### PR TITLE
Add secure external PR review gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ COPY schemas ./schemas
 
 ARG APP_PACKAGE=api
 ARG APP_BINARY=api
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/workspace/target \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/workspace/target,sharing=locked \
     cargo build --locked --release -p "${APP_PACKAGE}" \
     && cp "target/release/${APP_BINARY}" /tmp/agent-bounties-service
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ cargo run -p cli -- discovery
 cargo run -p cli -- production-smoke --api-base-url https://api.example.com --mcp-base-url https://mcp.example.com
 cargo build -p api -p mcp-server
 cargo run -p cli -- service-smoke-spawn
+cargo run -p cli -- docs-contract-check
 ```
+
+Before approving gated Actions on an external PR, run
+`scripts\review-external-pr.ps1 -Pr <number>` or
+`bash scripts/review-external-pr.sh --pr <number>`. See
+[docs/secure-pr-review.md](docs/secure-pr-review.md).
 
 The local demo uses simulated credits and deterministic verifiers. Base Sepolia,
 Stripe, and GitHub adapters are present as integration boundaries and are gated

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,6 +26,7 @@ use payments_stripe::{
     execute_stripe_request, CheckoutTopUpRequest, StripePlanner, STRIPE_API_BASE_URL,
 };
 use std::{
+    collections::{BTreeMap, BTreeSet},
     env, fs,
     io::{Read, Write},
     net::TcpStream,
@@ -267,6 +268,12 @@ enum Command {
         #[arg(long, default_value = "http://127.0.0.1:8090")]
         mcp_base_url: String,
     },
+    DocsContractCheck {
+        #[arg(long, default_value = ".")]
+        root: String,
+        #[arg(long, default_value = ".")]
+        contract_root: String,
+    },
     ProductionSmoke {
         #[arg(long, env = "PRODUCTION_API_BASE_URL")]
         api_base_url: String,
@@ -471,6 +478,10 @@ async fn main() -> Result<()> {
             public_base_url,
             mcp_base_url,
         } => discovery(public_base_url, mcp_base_url),
+        Command::DocsContractCheck {
+            root,
+            contract_root,
+        } => docs_contract_check(PathBuf::from(root), PathBuf::from(contract_root)),
         Command::ProductionSmoke {
             api_base_url,
             mcp_base_url,
@@ -3396,6 +3407,730 @@ fn decode_chunked_body(body: &str) -> Result<String> {
         rest = &after_size[size + 2..];
     }
     Ok(decoded)
+}
+
+#[derive(Debug)]
+struct DocsContractIssue {
+    file: PathBuf,
+    line: usize,
+    message: String,
+}
+
+#[derive(Debug, Clone)]
+struct RequestContract {
+    required: Vec<&'static str>,
+    allowed: Vec<&'static str>,
+    numeric_fields: Vec<&'static str>,
+}
+
+fn docs_contract_check(root: PathBuf, contract_root: PathBuf) -> Result<()> {
+    let root = fs::canonicalize(&root)
+        .with_context(|| format!("docs root does not exist: {}", root.display()))?;
+    let contract_root = fs::canonicalize(&contract_root)
+        .with_context(|| format!("contract root does not exist: {}", contract_root.display()))?;
+    let api_routes = load_api_routes(&contract_root)?;
+    let mcp_tools = load_mcp_tools(&contract_root)?;
+    let request_contracts = request_contracts();
+    let mut files = Vec::new();
+    collect_doc_files(&root, &mut files)?;
+
+    let mut issues = Vec::new();
+    for file in &files {
+        let text = fs::read_to_string(file)
+            .with_context(|| format!("failed to read docs file {}", file.display()))?;
+        let rel = file.strip_prefix(&root).unwrap_or(file.as_path());
+        check_doc_text(
+            rel,
+            &text,
+            &api_routes,
+            &mcp_tools,
+            &request_contracts,
+            &mut issues,
+        );
+    }
+
+    if !issues.is_empty() {
+        for issue in &issues {
+            eprintln!("{}:{}: {}", issue.file.display(), issue.line, issue.message);
+        }
+        bail!("docs contract check failed with {} issue(s)", issues.len());
+    }
+
+    println!(
+        "docs_contract_check=ok files={} api_routes={} mcp_tools={}",
+        files.len(),
+        api_routes.len(),
+        mcp_tools.len()
+    );
+    Ok(())
+}
+
+fn collect_doc_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default();
+        if path.is_dir() {
+            if matches!(
+                file_name,
+                ".git" | "target" | "node_modules" | ".next" | "__pycache__"
+            ) {
+                continue;
+            }
+            collect_doc_files(&path, files)?;
+        } else if is_doc_contract_file(&path) {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(())
+}
+
+fn is_doc_contract_file(path: &Path) -> bool {
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    if matches!(file_name, "README.md" | "AGENTS.md" | "llms.txt") {
+        return true;
+    }
+    matches!(
+        path.extension().and_then(|value| value.to_str()),
+        Some("md" | "txt")
+    )
+}
+
+fn load_api_routes(contract_root: &Path) -> Result<BTreeSet<String>> {
+    let source_path = contract_root.join("crates/api/src/main.rs");
+    let source = fs::read_to_string(&source_path)
+        .with_context(|| format!("failed to read {}", source_path.display()))?;
+    let mut routes = BTreeSet::new();
+    let mut expecting_route = false;
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if let Some(route_start) = trimmed.find(".route(") {
+            if let Some(route) = first_string_literal(&trimmed[route_start..]) {
+                routes.insert(normalize_route(route));
+                expecting_route = false;
+            } else {
+                expecting_route = true;
+            }
+            continue;
+        }
+        if expecting_route {
+            if let Some(route) = first_string_literal(trimmed) {
+                routes.insert(normalize_route(route));
+                expecting_route = false;
+            }
+        }
+    }
+    Ok(routes)
+}
+
+fn load_mcp_tools(contract_root: &Path) -> Result<BTreeSet<String>> {
+    let source_path = contract_root.join("crates/mcp-server/src/main.rs");
+    let source = fs::read_to_string(&source_path)
+        .with_context(|| format!("failed to read {}", source_path.display()))?;
+    let mut tools = BTreeSet::new();
+    let mut expecting_name = false;
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed == "tool(" || trimmed == "operator_tool(" {
+            expecting_name = true;
+            continue;
+        }
+        if expecting_name {
+            if let Some(name) = first_string_literal(trimmed) {
+                tools.insert(name.to_string());
+                expecting_name = false;
+            }
+        }
+    }
+    Ok(tools)
+}
+
+fn check_doc_text(
+    file: &Path,
+    text: &str,
+    api_routes: &BTreeSet<String>,
+    mcp_tools: &BTreeSet<String>,
+    request_contracts: &BTreeMap<String, RequestContract>,
+    issues: &mut Vec<DocsContractIssue>,
+) {
+    for (line_index, line) in text.lines().enumerate() {
+        let line_number = line_index + 1;
+        if line_mentions_mcp_port_for_api(line) {
+            push_doc_issue(
+                issues,
+                file,
+                line_number,
+                "REST/API path is pointed at port 8090; API defaults to 8080 and MCP defaults to 8090",
+            );
+        }
+        for alias in stale_discovery_aliases() {
+            if line.contains(alias) {
+                push_doc_issue(
+                    issues,
+                    file,
+                    line_number,
+                    &format!(
+                        "stale discovery endpoint `{alias}`; use the manifest `endpoints` object keys"
+                    ),
+                );
+            }
+        }
+        for tool in tool_names_from_line(line) {
+            if !mcp_tools.contains(&tool) {
+                push_doc_issue(
+                    issues,
+                    file,
+                    line_number,
+                    &format!("unknown MCP tool `{tool}`"),
+                );
+            }
+        }
+        for path in api_paths_from_line(line) {
+            let normalized = normalize_route(&path);
+            if is_checked_api_path(&normalized)
+                && !is_external_api_path(&normalized)
+                && !api_routes.contains(&normalized)
+            {
+                push_doc_issue(
+                    issues,
+                    file,
+                    line_number,
+                    &format!("unknown API route `{path}`"),
+                );
+            }
+        }
+    }
+
+    for (start_line, block) in markdown_code_blocks(text) {
+        check_curl_payload_block(file, start_line, &block, request_contracts, issues);
+    }
+}
+
+fn check_curl_payload_block(
+    file: &Path,
+    start_line: usize,
+    block: &str,
+    request_contracts: &BTreeMap<String, RequestContract>,
+    issues: &mut Vec<DocsContractIssue>,
+) {
+    if !block.contains("curl") || !(block.contains("--data") || block.contains(" -d ")) {
+        return;
+    }
+    let Some(path) = block.lines().flat_map(api_paths_from_line).next() else {
+        return;
+    };
+    let normalized = normalize_route(&path);
+    let Some(contract) = request_contracts.get(&normalized) else {
+        return;
+    };
+    let Some(json_text) = extract_first_json_object(block) else {
+        push_doc_issue(
+            issues,
+            file,
+            start_line,
+            &format!("curl payload for `{path}` does not contain a JSON object"),
+        );
+        return;
+    };
+    let value: serde_json::Value = match serde_json::from_str(&json_text) {
+        Ok(value) => value,
+        Err(error) => {
+            push_doc_issue(
+                issues,
+                file,
+                start_line,
+                &format!("curl payload for `{path}` is not valid JSON: {error}"),
+            );
+            return;
+        }
+    };
+    let Some(object) = value.as_object() else {
+        push_doc_issue(
+            issues,
+            file,
+            start_line,
+            &format!("curl payload for `{path}` must be a JSON object"),
+        );
+        return;
+    };
+
+    for field in &contract.required {
+        if !object.contains_key(*field) {
+            push_doc_issue(
+                issues,
+                file,
+                start_line,
+                &format!("curl payload for `{path}` is missing required field `{field}`"),
+            );
+        }
+    }
+    for field in object.keys() {
+        if !contract.allowed.iter().any(|allowed| allowed == field) {
+            push_doc_issue(
+                issues,
+                file,
+                start_line,
+                &format!("curl payload for `{path}` contains unknown field `{field}`"),
+            );
+        }
+    }
+    for field in &contract.numeric_fields {
+        if let Some(value) = object.get(*field) {
+            if !value.is_number() {
+                push_doc_issue(
+                    issues,
+                    file,
+                    start_line,
+                    &format!("curl payload for `{path}` field `{field}` must be numeric"),
+                );
+            }
+        }
+    }
+}
+
+fn request_contracts() -> BTreeMap<String, RequestContract> {
+    let mut contracts = BTreeMap::new();
+    insert_request_contract(
+        &mut contracts,
+        "/v1/agents",
+        &["handle"],
+        &["handle", "payout_wallet"],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/capabilities",
+        &[
+            "agent_id",
+            "class",
+            "template_slugs",
+            "min_price_minor",
+            "max_price_minor",
+            "currency",
+            "latency_seconds",
+            "supported_verifiers",
+        ],
+        &[
+            "agent_id",
+            "class",
+            "template_slugs",
+            "min_price_minor",
+            "max_price_minor",
+            "currency",
+            "latency_seconds",
+            "supported_verifiers",
+        ],
+        &["min_price_minor", "max_price_minor", "latency_seconds"],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/capabilities/search",
+        &["query"],
+        &["query"],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/bounties/{param}/claim",
+        &["bounty_id", "solver_agent_id"],
+        &["bounty_id", "solver_agent_id"],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/bounties/{param}/submit",
+        &[
+            "bounty_id",
+            "solver_agent_id",
+            "artifact_uri",
+            "artifact_body",
+        ],
+        &[
+            "bounty_id",
+            "solver_agent_id",
+            "artifact_uri",
+            "artifact_body",
+        ],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/bounties/{param}/verify",
+        &["bounty_id", "submission_id", "expected_artifact_digest"],
+        &[
+            "bounty_id",
+            "submission_id",
+            "expected_artifact_digest",
+            "verifier_kind",
+            "rubric",
+            "evidence",
+            "approved_risk_event_id",
+        ],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/base/funding-plan",
+        &["bounty_id", "escrow_contract", "payer", "token"],
+        &["bounty_id", "escrow_contract", "payer", "token", "network"],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/base/fetch-rpc-logs",
+        &["escrow_contract", "from_block"],
+        &[
+            "escrow_contract",
+            "from_block",
+            "to_block",
+            "request_id",
+            "network",
+        ],
+        &["from_block", "to_block", "request_id"],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/base/release-queue",
+        &[],
+        &["escrow_contract", "platform_fee_wallet", "network"],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/base/release-plan",
+        &["bounty_id", "escrow_contract", "platform_fee_wallet"],
+        &[
+            "bounty_id",
+            "escrow_contract",
+            "platform_fee_wallet",
+            "network",
+        ],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/base/refund-plan",
+        &["bounty_id", "escrow_contract", "reason_hash"],
+        &["bounty_id", "escrow_contract", "reason_hash", "network"],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/base/dispute-plan",
+        &["bounty_id", "escrow_contract", "dispute_hash"],
+        &["bounty_id", "escrow_contract", "dispute_hash", "network"],
+        &[],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/base/broadcast-signed-transaction",
+        &["signed_transaction"],
+        &["signed_transaction", "request_id", "network"],
+        &["request_id"],
+    );
+    insert_request_contract(
+        &mut contracts,
+        "/v1/base/transaction-receipt",
+        &["tx_hash"],
+        &["tx_hash", "request_id", "network", "reconcile_logs"],
+        &["request_id"],
+    );
+    contracts
+}
+
+fn insert_request_contract(
+    contracts: &mut BTreeMap<String, RequestContract>,
+    path: &str,
+    required: &'static [&'static str],
+    allowed: &'static [&'static str],
+    numeric_fields: &'static [&'static str],
+) {
+    contracts.insert(
+        normalize_route(path),
+        RequestContract {
+            required: required.to_vec(),
+            allowed: allowed.to_vec(),
+            numeric_fields: numeric_fields.to_vec(),
+        },
+    );
+}
+
+fn line_mentions_mcp_port_for_api(line: &str) -> bool {
+    (line.contains("localhost:8090") || line.contains("127.0.0.1:8090"))
+        && (line.contains("/v1/") || line.contains("/api-docs/") || line.contains("/public/"))
+}
+
+fn stale_discovery_aliases() -> &'static [&'static str] {
+    &[
+        "openapi_url",
+        "mcp_url",
+        "templates_url",
+        "claimable_bounties_url",
+        "capabilities_feed_url",
+        "public_proofs_url",
+    ]
+}
+
+fn tool_names_from_line(line: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    if let Some((_, after)) = line.split_once("Tool:") {
+        if let Some(name) = first_identifier(after) {
+            names.push(name);
+        }
+    }
+
+    let lower = line.to_ascii_lowercase();
+    if lower.contains("mcp") || lower.contains("tool") {
+        for name in backtick_identifiers(line) {
+            if looks_like_tool_reference(&name) {
+                names.push(name);
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn looks_like_tool_reference(value: &str) -> bool {
+    const VERBS: &[&str] = &[
+        "route_",
+        "request_",
+        "post_",
+        "claim_",
+        "submit_",
+        "get_",
+        "register_",
+        "list_",
+        "search_",
+        "plan_",
+        "reconcile_",
+        "fetch_",
+        "broadcast_",
+        "approve_",
+        "reject_",
+        "execute_",
+        "run_",
+        "fund_",
+    ];
+    VERBS.iter().any(|prefix| value.starts_with(prefix))
+}
+
+fn backtick_identifiers(line: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut rest = line;
+    while let Some(start) = rest.find('`') {
+        let after_start = &rest[start + 1..];
+        let Some(end) = after_start.find('`') else {
+            break;
+        };
+        let value = &after_start[..end];
+        if is_snake_identifier(value) {
+            values.push(value.to_string());
+        }
+        rest = &after_start[end + 1..];
+    }
+    values
+}
+
+fn is_snake_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.contains('_')
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+}
+
+fn first_identifier(value: &str) -> Option<String> {
+    let mut chars = value.trim_start().chars().peekable();
+    let mut ident = String::new();
+    while let Some(ch) = chars.peek().copied() {
+        if ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_' {
+            ident.push(ch);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    if ident.is_empty() {
+        None
+    } else {
+        Some(ident)
+    }
+}
+
+fn first_string_literal(line: &str) -> Option<&str> {
+    let start = line.find('"')?;
+    let after_start = &line[start + 1..];
+    let end = after_start.find('"')?;
+    Some(&after_start[..end])
+}
+
+fn api_paths_from_line(line: &str) -> Vec<String> {
+    let chars = line.char_indices().collect::<Vec<_>>();
+    let mut paths = Vec::new();
+    let mut index = 0;
+    while index < chars.len() {
+        let (byte_index, ch) = chars[index];
+        if ch != '/' {
+            index += 1;
+            continue;
+        }
+        let prev = if index == 0 {
+            None
+        } else {
+            Some(chars[index - 1].1)
+        };
+        let next = chars.get(index + 1).map(|(_, ch)| *ch);
+        if prev == Some(':') || next == Some('/') {
+            index += 1;
+            continue;
+        }
+        let mut end = byte_index + ch.len_utf8();
+        let mut cursor = index + 1;
+        while let Some((next_byte, next_ch)) = chars.get(cursor).copied() {
+            if is_path_char(next_ch) {
+                end = next_byte + next_ch.len_utf8();
+                cursor += 1;
+            } else {
+                break;
+            }
+        }
+        let path = trim_path_token(&line[byte_index..end]);
+        if is_checked_api_path(&normalize_route(path)) {
+            paths.push(path.to_string());
+        }
+        index = cursor.max(index + 1);
+    }
+    paths
+}
+
+fn is_path_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric()
+        || matches!(
+            ch,
+            '/' | '{' | '}' | ':' | '_' | '-' | '.' | '?' | '=' | '&'
+        )
+}
+
+fn trim_path_token(value: &str) -> &str {
+    value
+        .trim_end_matches(['.', ',', ')', ']', '>', ';', ':'])
+        .split('?')
+        .next()
+        .unwrap_or(value)
+}
+
+fn is_checked_api_path(path: &str) -> bool {
+    path.starts_with("/v1/")
+        || path.starts_with("/public/")
+        || path.starts_with("/api-docs/")
+        || path.starts_with("/.well-known/")
+        || path.starts_with("/schemas/")
+        || matches!(path, "/llms.txt" | "/docs" | "/health")
+}
+
+fn is_external_api_path(path: &str) -> bool {
+    matches!(path, "/v1/checkout/sessions")
+}
+
+fn normalize_route(path: &str) -> String {
+    let trimmed = trim_path_token(path.trim()).trim_end_matches('/');
+    if trimmed.is_empty() {
+        return "/".to_string();
+    }
+    let mut normalized = String::new();
+    for segment in trimmed.split('/') {
+        if segment.is_empty() {
+            continue;
+        }
+        normalized.push('/');
+        if segment.starts_with(':') || (segment.starts_with('{') && segment.ends_with('}')) {
+            normalized.push_str("{param}");
+        } else {
+            normalized.push_str(segment);
+        }
+    }
+    if normalized.is_empty() {
+        "/".to_string()
+    } else {
+        normalized
+    }
+}
+
+fn markdown_code_blocks(text: &str) -> Vec<(usize, String)> {
+    let mut blocks = Vec::new();
+    let mut in_block = false;
+    let mut start_line = 0;
+    let mut current = String::new();
+    for (index, line) in text.lines().enumerate() {
+        if line.trim_start().starts_with("```") {
+            if in_block {
+                blocks.push((start_line, current.clone()));
+                current.clear();
+                in_block = false;
+            } else {
+                in_block = true;
+                start_line = index + 2;
+            }
+            continue;
+        }
+        if in_block {
+            current.push_str(line);
+            current.push('\n');
+        }
+    }
+    blocks
+}
+
+fn extract_first_json_object(text: &str) -> Option<String> {
+    let start = text.find('{')?;
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (offset, ch) in text[start..].char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    let end = start + offset + ch.len_utf8();
+                    return Some(text[start..end].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn push_doc_issue(issues: &mut Vec<DocsContractIssue>, file: &Path, line: usize, message: &str) {
+    issues.push(DocsContractIssue {
+        file: file.to_path_buf(),
+        line,
+        message: message.to_string(),
+    });
 }
 
 fn require(condition: bool, message: &str) -> Result<()> {

--- a/docs/secure-pr-review.md
+++ b/docs/secure-pr-review.md
@@ -1,0 +1,59 @@
+# Secure External PR Review
+
+External PRs are untrusted input. Do not approve a gated Actions run until the
+changed files and static contracts have been reviewed.
+
+## Intake Command
+
+Run the trusted checker from a clean maintainer checkout:
+
+```powershell
+scripts\review-external-pr.ps1 -Pr 6
+```
+
+```bash
+bash scripts/review-external-pr.sh --pr 6
+```
+
+The wrapper fetches the PR into a temporary worktree, classifies changed files,
+and runs:
+
+```bash
+cargo run -p cli -- docs-contract-check --root <pr-worktree> --contract-root <trusted-checkout>
+```
+
+The checker validates docs against the trusted API and MCP contracts without
+executing code from the PR.
+
+## Decision Rules
+
+- `safe_for_maintainer_ci=true` means the PR is docs-only, avoids risky paths,
+  and passes the docs contract check. A maintainer may still inspect semantics
+  before approving CI.
+- `safe_for_maintainer_ci=false` means do not approve CI yet.
+- Changes under `.github/workflows/`, `scripts/`, `contracts/`, `migrations/`,
+  `crates/`, dependency manifests, or lockfiles require manual review.
+- Automation can post review comments or request changes, but it must not merge,
+  approve payment, or approve a bounty payout.
+
+To post a GitHub review result:
+
+```powershell
+scripts\review-external-pr.ps1 -Pr 6 -PostReview
+```
+
+```bash
+bash scripts/review-external-pr.sh --pr 6 --post-review
+```
+
+## Docs Contract Check
+
+`docs-contract-check` fails when docs reference:
+
+- REST paths served from the MCP port,
+- API routes not present in the trusted Axum router,
+- MCP tool names not present in the trusted MCP descriptor source,
+- stale discovery endpoint aliases instead of the manifest `endpoints` object,
+- key curl JSON examples whose fields do not match request contracts.
+
+This gate is also part of `scripts/check.ps1` and `scripts/check.sh`.

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -53,6 +53,7 @@ Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_issue_plan_c
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_proof_comment.py --self-test }
 Invoke-Checked { cargo run -p cli -- github-proof-comment-plan --bounty-id 00000000-0000-0000-0000-000000000001 --proof-url https://agentbounties.local/public/proofs/example --verifier-summary "GitHub CI passed" }
 Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbounties.local --mcp-base-url https://agentbounties.local/mcp }
+Invoke-Checked { cargo run -p cli -- docs-contract-check }
 Invoke-Checked { cargo run -p cli -- demo }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\github_issue_plan_comment.py scripts\github_proof_comment.py }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -85,6 +85,7 @@ cargo run -p cli -- github-proof-comment-plan \
 cargo run -p cli -- discovery \
   --public-base-url https://agentbounties.local \
   --mcp-base-url https://agentbounties.local/mcp
+cargo run -p cli -- docs-contract-check
 cargo run -p cli -- demo
 "${python_cmd[@]}" -m py_compile \
   crates/sdk-python/agent_bounties/client.py \

--- a/scripts/review-external-pr.ps1
+++ b/scripts/review-external-pr.ps1
@@ -1,0 +1,145 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [int] $Pr,
+    [string] $Repo = "NSPG13/agent-bounties",
+    [switch] $PostReview
+)
+
+$ErrorActionPreference = "Stop"
+if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$targetRoot = Join-Path $repoRoot "target\pr-review"
+New-Item -ItemType Directory -Force -Path $targetRoot | Out-Null
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock] $Command
+    )
+
+    $global:LASTEXITCODE = 0
+    & $Command
+    $commandSucceeded = $?
+    $exitCode = $global:LASTEXITCODE
+    if (-not $commandSucceeded -or $exitCode -ne 0) {
+        throw "Command failed with exit code $exitCode`: $Command"
+    }
+    $global:LASTEXITCODE = 0
+}
+
+function Test-DocsPath {
+    param([string] $Path)
+    return (
+        $Path -eq "README.md" -or
+        $Path -eq "AGENTS.md" -or
+        $Path -eq "llms.txt" -or
+        $Path.StartsWith("docs/") -or
+        $Path.StartsWith("examples/") -or
+        $Path.StartsWith(".github/ISSUE_TEMPLATE/")
+    )
+}
+
+function Test-RiskyPath {
+    param([string] $Path)
+    return (
+        $Path.StartsWith(".github/workflows/") -or
+        $Path.StartsWith("scripts/") -or
+        $Path.StartsWith("contracts/") -or
+        $Path.StartsWith("migrations/") -or
+        $Path.StartsWith("crates/") -or
+        $Path -eq "Cargo.toml" -or
+        $Path -eq "Cargo.lock" -or
+        $Path.EndsWith("package.json") -or
+        $Path.EndsWith("package-lock.json")
+    )
+}
+
+Push-Location $repoRoot
+try {
+    $prJson = gh pr view $Pr --repo $Repo --json number,title,url,author,headRefOid,files | ConvertFrom-Json
+    $changedFiles = @($prJson.files | ForEach-Object { $_.path })
+    if ($changedFiles.Count -eq 0) {
+        throw "PR #$Pr has no changed files"
+    }
+
+    $riskyFiles = @($changedFiles | Where-Object { Test-RiskyPath $_ })
+    $nonDocsFiles = @($changedFiles | Where-Object { -not (Test-DocsPath $_) })
+    $docsOnly = $nonDocsFiles.Count -eq 0
+    $safeForMaintainerCi = $docsOnly -and $riskyFiles.Count -eq 0
+
+    $refName = "refs/remotes/origin/pr-$Pr-review"
+    Invoke-Checked { git fetch origin "pull/$Pr/head:$refName" }
+
+    $worktreePath = Join-Path $targetRoot "pr-$Pr"
+    $targetRootFull = [System.IO.Path]::GetFullPath($targetRoot)
+    $worktreeFull = [System.IO.Path]::GetFullPath($worktreePath)
+    if (-not $worktreeFull.StartsWith($targetRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to use unsafe worktree path: $worktreeFull"
+    }
+    if (Test-Path $worktreeFull) {
+        Invoke-Checked { git worktree remove --force $worktreeFull }
+    }
+    Invoke-Checked { git worktree add --detach $worktreeFull $refName }
+
+    $docsCheckOk = $false
+    $docsCheckOutput = ""
+    try {
+        $docsCheckStdout = Join-Path $targetRoot "pr-$Pr-docs-contract-check.stdout.log"
+        $docsCheckStderr = Join-Path $targetRoot "pr-$Pr-docs-contract-check.stderr.log"
+        foreach ($path in @($docsCheckStdout, $docsCheckStderr)) {
+            if (Test-Path $path) {
+                Remove-Item -LiteralPath $path -Force
+            }
+        }
+        $process = Start-Process `
+            -FilePath "cargo" `
+            -ArgumentList @("run", "-p", "cli", "--", "docs-contract-check", "--root", $worktreeFull, "--contract-root", $repoRoot) `
+            -RedirectStandardOutput $docsCheckStdout `
+            -RedirectStandardError $docsCheckStderr `
+            -Wait `
+            -PassThru `
+            -WindowStyle Hidden
+        $docsCheckExitCode = $process.ExitCode
+        $stdoutText = if (Test-Path $docsCheckStdout) { Get-Content -Raw $docsCheckStdout } else { "" }
+        $stderrText = if (Test-Path $docsCheckStderr) { Get-Content -Raw $docsCheckStderr } else { "" }
+        $docsCheckOutput = (@($stdoutText, $stderrText) -join "`n").Trim()
+        if ($docsCheckExitCode -eq 0) {
+            $docsCheckOk = $true
+        }
+    } finally {
+        Invoke-Checked { git worktree remove --force $worktreeFull }
+    }
+
+    $result = [ordered]@{
+        pr = $prJson.number
+        title = $prJson.title
+        url = $prJson.url
+        author = $prJson.author.login
+        docs_only = $docsOnly
+        safe_for_maintainer_ci = ($safeForMaintainerCi -and $docsCheckOk)
+        risky_files = $riskyFiles
+        non_docs_files = $nonDocsFiles
+        docs_contract_check = if ($docsCheckOk) { "ok" } else { "failed" }
+        docs_contract_output = $docsCheckOutput
+    }
+    $result | ConvertTo-Json -Depth 6
+
+    if ($PostReview) {
+        if ($safeForMaintainerCi -and $docsCheckOk) {
+            $body = "Automated external PR intake passed static docs-only review and docs-contract-check. This does not approve merge or payment; a maintainer still needs to review semantics and decide whether to approve CI."
+            Invoke-Checked { gh pr review $Pr --repo $Repo --comment --body $body }
+        } else {
+            $body = "Automated external PR intake failed. risky_files=$($riskyFiles -join ', ') non_docs_files=$($nonDocsFiles -join ', ') docs_contract_check=$($result.docs_contract_check). Maintainer review required; do not approve CI yet."
+            Invoke-Checked { gh pr review $Pr --repo $Repo --request-changes --body $body }
+        }
+    }
+
+    if (-not ($safeForMaintainerCi -and $docsCheckOk)) {
+        exit 1
+    }
+} finally {
+    Pop-Location
+}

--- a/scripts/review-external-pr.sh
+++ b/scripts/review-external-pr.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="NSPG13/agent-bounties"
+post_review=false
+pr=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --post-review)
+      post_review=true
+      shift
+      ;;
+    --pr)
+      pr="$2"
+      shift 2
+      ;;
+    *)
+      if [[ -z "$pr" ]]; then
+        pr="$1"
+        shift
+      else
+        echo "unknown argument: $1" >&2
+        exit 64
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$pr" ]]; then
+  echo "usage: scripts/review-external-pr.sh --pr <number> [--repo owner/name] [--post-review]" >&2
+  exit 64
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+for tool in gh git cargo; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "$tool is required for external PR review" >&2
+    exit 127
+  fi
+done
+
+is_docs_path() {
+  local path="$1"
+  [[ "$path" == "README.md" ]] ||
+    [[ "$path" == "AGENTS.md" ]] ||
+    [[ "$path" == "llms.txt" ]] ||
+    [[ "$path" == docs/* ]] ||
+    [[ "$path" == examples/* ]] ||
+    [[ "$path" == .github/ISSUE_TEMPLATE/* ]]
+}
+
+is_risky_path() {
+  local path="$1"
+  [[ "$path" == .github/workflows/* ]] ||
+    [[ "$path" == scripts/* ]] ||
+    [[ "$path" == contracts/* ]] ||
+    [[ "$path" == migrations/* ]] ||
+    [[ "$path" == crates/* ]] ||
+    [[ "$path" == "Cargo.toml" ]] ||
+    [[ "$path" == "Cargo.lock" ]] ||
+    [[ "$path" == *package.json ]] ||
+    [[ "$path" == *package-lock.json ]]
+}
+
+mapfile -t changed_files < <(gh pr view "$pr" --repo "$repo" --json files --jq '.files[].path')
+if [[ "${#changed_files[@]}" -eq 0 ]]; then
+  echo "PR #$pr has no changed files" >&2
+  exit 1
+fi
+
+risky_files=()
+non_docs_files=()
+for file in "${changed_files[@]}"; do
+  if is_risky_path "$file"; then
+    risky_files+=("$file")
+  fi
+  if ! is_docs_path "$file"; then
+    non_docs_files+=("$file")
+  fi
+done
+
+docs_only=true
+if [[ "${#non_docs_files[@]}" -ne 0 ]]; then
+  docs_only=false
+fi
+
+ref_name="refs/remotes/origin/pr-${pr}-review"
+git fetch origin "pull/${pr}/head:${ref_name}"
+
+tmp_root="$(mktemp -d)"
+worktree="$tmp_root/worktree"
+cleanup() {
+  if git worktree list --porcelain | grep -Fqx "worktree $worktree"; then
+    git worktree remove --force "$worktree" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp_root"
+}
+trap cleanup EXIT
+
+git worktree add --detach "$worktree" "$ref_name" >/dev/null
+
+docs_contract_check="failed"
+if cargo run -p cli -- docs-contract-check --root "$worktree" --contract-root "$repo_root"; then
+  docs_contract_check="ok"
+fi
+
+safe_for_maintainer_ci=false
+if [[ "$docs_only" == true && "${#risky_files[@]}" -eq 0 && "$docs_contract_check" == "ok" ]]; then
+  safe_for_maintainer_ci=true
+fi
+
+printf '{\n'
+printf '  "pr": %s,\n' "$pr"
+printf '  "docs_only": %s,\n' "$docs_only"
+printf '  "safe_for_maintainer_ci": %s,\n' "$safe_for_maintainer_ci"
+printf '  "docs_contract_check": "%s",\n' "$docs_contract_check"
+printf '  "risky_files": [%s],\n' "$(printf '"%s",' "${risky_files[@]}" | sed 's/,$//')"
+printf '  "non_docs_files": [%s]\n' "$(printf '"%s",' "${non_docs_files[@]}" | sed 's/,$//')"
+printf '}\n'
+
+if [[ "$post_review" == true ]]; then
+  if [[ "$safe_for_maintainer_ci" == true ]]; then
+    gh pr review "$pr" --repo "$repo" --comment --body \
+      "Automated external PR intake passed static docs-only review and docs-contract-check. This does not approve merge or payment; a maintainer still needs to review semantics and decide whether to approve CI."
+  else
+    gh pr review "$pr" --repo "$repo" --request-changes --body \
+      "Automated external PR intake failed. risky_files=${risky_files[*]} non_docs_files=${non_docs_files[*]} docs_contract_check=${docs_contract_check}. Maintainer review required; do not approve CI yet."
+  fi
+fi
+
+if [[ "$safe_for_maintainer_ci" != true ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `cargo run -p cli -- docs-contract-check` to validate docs against trusted API/MCP contracts
- add PowerShell and Bash external PR review wrappers that fetch PRs into temporary worktrees without executing PR code
- document the maintainer intake policy for external PRs
- lock Docker BuildKit Cargo caches to avoid parallel API/MCP build races in production compose smoke

## Verification
- `cargo run -p cli -- docs-contract-check`
- `cargo test -p cli`
- `cargo clippy -p cli -- -D warnings`
- `bash -n scripts/check.sh scripts/preflight.sh scripts/review-external-pr.sh`
- PowerShell scriptblock parse for `scripts/review-external-pr.ps1`
- `scripts/review-external-pr.ps1 -Pr 6` fails closed on known-bad quickstart PR
- `scripts/review-external-pr.ps1 -Pr 7` passes on corrected docs-only Base runbook PR
- `scripts/check-production-compose.ps1 -ProjectName agent-bounties-prod-smoke-locktest -ApiPort 18280 -McpPort 18290`
- `scripts/check.ps1`