### PR TITLE
Handle force-pushed external PR reviews

### DIFF
--- a/scripts/review-external-pr.ps1
+++ b/scripts/review-external-pr.ps1
@@ -71,7 +71,15 @@ try {
     $safeForMaintainerCi = $docsOnly -and $riskyFiles.Count -eq 0
 
     $refName = "refs/remotes/origin/pr-$Pr-review"
-    Invoke-Checked { git fetch origin "pull/$Pr/head:$refName" }
+    Invoke-Checked { git fetch origin "+pull/$Pr/head:$refName" }
+    $fetchedOid = (& git rev-parse $refName).Trim()
+    if ($global:LASTEXITCODE -ne 0) {
+        throw "Unable to resolve fetched review ref: $refName"
+    }
+    if ($fetchedOid -ne $prJson.headRefOid) {
+        throw "Fetched PR head $fetchedOid did not match GitHub head $($prJson.headRefOid); rerun review"
+    }
+    $global:LASTEXITCODE = 0
 
     $worktreePath = Join-Path $targetRoot "pr-$Pr"
     $targetRootFull = [System.IO.Path]::GetFullPath($targetRoot)

--- a/scripts/review-external-pr.sh
+++ b/scripts/review-external-pr.sh
@@ -91,8 +91,14 @@ if [[ "${#non_docs_files[@]}" -ne 0 ]]; then
   docs_only=false
 fi
 
+head_oid="$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq '.headRefOid')"
 ref_name="refs/remotes/origin/pr-${pr}-review"
-git fetch origin "pull/${pr}/head:${ref_name}"
+git fetch origin "+pull/${pr}/head:${ref_name}"
+fetched_oid="$(git rev-parse "$ref_name")"
+if [[ "$fetched_oid" != "$head_oid" ]]; then
+  echo "fetched PR head $fetched_oid did not match GitHub head $head_oid; rerun review" >&2
+  exit 1
+fi
 
 tmp_root="$(mktemp -d)"
 worktree="$tmp_root/worktree"


### PR DESCRIPTION
## Summary
- force-update the disposable external PR review ref so rewritten PR heads can be reviewed cleanly
- verify the fetched ref matches GitHub's current PR head SHA before creating the worktree
- keep the same docs-only and docs-contract gating semantics

## Verification
- PowerShell parser check for scripts/review-external-pr.ps1
- bash -n scripts/review-external-pr.sh
- cargo run -p cli -- docs-contract-check
- scripts/review-external-pr.ps1 -Pr 7 passes as a safe docs PR
- scripts/review-external-pr.ps1 -Pr 6 fails closed as expected with docs-contract issues