### PR TITLE
Add constructive PR review lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ cargo run -p cli -- docs-contract-check
 Before approving gated Actions on an external PR, run
 `scripts\review-external-pr.ps1 -Pr <number>` or
 `bash scripts/review-external-pr.sh --pr <number>`. See
-[docs/secure-pr-review.md](docs/secure-pr-review.md).
+[docs/secure-pr-review.md](docs/secure-pr-review.md). Review responses must be
+constructive: explain what passed, what blocked `main`, what command to run, and
+whether the work belongs on a collaboration branch such as
+`collab/pr-<number>-<topic>` while contributors continue iterating.
 
 The local demo uses simulated credits and deterministic verifiers. Base Sepolia,
 Stripe, and GitHub adapters are present as integration boundaries and are gated

--- a/docs/secure-pr-review.md
+++ b/docs/secure-pr-review.md
@@ -31,10 +31,51 @@ executing code from the PR.
   and passes the docs contract check. A maintainer may still inspect semantics
   before approving CI.
 - `safe_for_maintainer_ci=false` means do not approve CI yet.
+- Every approval, rejection, or "not yet" response must include constructive
+  next steps. Tell the contributor what passed, what blocked main, the exact
+  command to run locally, and whether the work is suitable for a collaboration
+  branch.
 - Changes under `.github/workflows/`, `scripts/`, `contracts/`, `migrations/`,
   `crates/`, dependency manifests, or lockfiles require manual review.
 - Automation can post review comments or request changes, but it must not merge,
   approve payment, or approve a bounty payout.
+
+## Review Lanes
+
+Use three lanes instead of treating every PR as merge-or-reject:
+
+- **Main candidate**: the PR passes the trusted intake gate, passes required CI,
+  and a maintainer agrees the semantics are correct. It can be approved for
+  merge to `main`.
+- **Collaboration branch candidate**: the work is useful but not main-ready,
+  usually because docs examples are stale, acceptance criteria are incomplete,
+  or a feature slice needs more contributors. A maintainer may preserve it on a
+  branch such as `collab/pr-6-agent-quickstart` so others can open follow-up PRs
+  against that branch without slowing main.
+- **Manual security review**: the PR changes workflows, scripts, crates,
+  contracts, migrations, dependency manifests, or other risky paths. Do not
+  create an upstream collaboration branch until a maintainer has reviewed the
+  diff line by line and decided the branch will not become a privileged
+  execution surface.
+
+A collaboration branch is not a bounty acceptance, payment approval, or merge
+approval. It is a staging lane for useful work that should remain visible while
+main stays production-safe.
+
+### Collaboration Branch Rules
+
+- Prefer collaboration branches for docs/spec/template work that is valuable but
+  fails a contract check, or for larger feature drafts that need multiple PRs.
+- Do not put changes to `.github/workflows/`, release scripts, deployment
+  automation, secrets handling, payment settlement, escrow contracts, or
+  dependency locks on a collaboration branch unless the maintainer explicitly
+  accepts the security risk.
+- Name branches `collab/pr-<number>-<short-topic>` or
+  `collab/<bounty-id>-<short-topic>`.
+- Ask follow-up contributors to target the collaboration branch, not `main`,
+  until the branch has a clean path back through the normal gates.
+- When the branch becomes main-ready, open a maintainer-owned PR from the
+  collaboration branch to `main` and run the full gates again.
 
 To post a GitHub review result:
 

--- a/scripts/review-external-pr.ps1
+++ b/scripts/review-external-pr.ps1
@@ -57,6 +57,62 @@ function Test-RiskyPath {
     )
 }
 
+function Format-MarkdownList {
+    param(
+        [object[]] $Items,
+        [int] $Limit = 12,
+        [string] $Empty = "- None"
+    )
+
+    $values = @($Items | Where-Object { $_ } | Select-Object -First $Limit)
+    if ($values.Count -eq 0) {
+        return $Empty
+    }
+    return (($values | ForEach-Object { "- $_" }) -join "`n")
+}
+
+function Get-DocsContractIssues {
+    param([string] $Output)
+
+    if ([string]::IsNullOrWhiteSpace($Output)) {
+        return @()
+    }
+    return @(
+        $Output -split "`r?`n" |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ -match '^[^\s:][^:]+:\d+:' } |
+            Select-Object -First 20
+    )
+}
+
+function New-ConstructiveFeedback {
+    param(
+        [bool] $DocsOnly,
+        [object[]] $RiskyFiles,
+        [object[]] $NonDocsFiles,
+        [bool] $DocsCheckOk,
+        [object[]] $DocsIssues
+    )
+
+    $items = @()
+    if (-not $DocsOnly) {
+        $items += "Split docs-only changes from code or infrastructure changes, or wait for manual maintainer review of the non-doc paths."
+    }
+    if ($RiskyFiles.Count -gt 0) {
+        $items += "Risky paths need line-by-line maintainer review before CI or any upstream collaboration branch is approved."
+    }
+    if (-not $DocsCheckOk) {
+        $items += "Run `cargo run -p cli -- docs-contract-check` locally and update examples to match the current API routes, MCP tools, discovery manifest shape, and request payloads."
+    }
+    if ($DocsIssues.Count -gt 0) {
+        $items += "Start with the first docs-contract issue listed below, then rerun the checker until it reports `docs_contract_check=ok`."
+    }
+    if ($items.Count -eq 0) {
+        $items += "Perform semantic review before approving merge, and keep payment or bounty acceptance separate from code review."
+    }
+    return $items
+}
+
 Push-Location $repoRoot
 try {
     $prJson = gh pr view $Pr --repo $Repo --json number,title,url,author,headRefOid,files | ConvertFrom-Json
@@ -121,6 +177,23 @@ try {
         Invoke-Checked { git worktree remove --force $worktreeFull }
     }
 
+    $docsIssues = Get-DocsContractIssues $docsCheckOutput
+    $collaborationBranchCandidate = $docsOnly -and $riskyFiles.Count -eq 0
+    $mainCandidate = $safeForMaintainerCi -and $docsCheckOk
+    $recommendedLane = if ($mainCandidate) {
+        "main-candidate"
+    } elseif ($collaborationBranchCandidate) {
+        "collaboration-branch-candidate"
+    } else {
+        "manual-security-review"
+    }
+    $feedbackItems = New-ConstructiveFeedback `
+        -DocsOnly $docsOnly `
+        -RiskyFiles $riskyFiles `
+        -NonDocsFiles $nonDocsFiles `
+        -DocsCheckOk $docsCheckOk `
+        -DocsIssues $docsIssues
+
     $result = [ordered]@{
         pr = $prJson.number
         title = $prJson.title
@@ -128,24 +201,76 @@ try {
         author = $prJson.author.login
         docs_only = $docsOnly
         safe_for_maintainer_ci = ($safeForMaintainerCi -and $docsCheckOk)
-        risky_files = $riskyFiles
-        non_docs_files = $nonDocsFiles
+        main_candidate = $mainCandidate
+        collaboration_branch_candidate = $collaborationBranchCandidate
+        recommended_lane = $recommendedLane
+        risky_files = [string[]]@($riskyFiles)
+        non_docs_files = [string[]]@($nonDocsFiles)
         docs_contract_check = if ($docsCheckOk) { "ok" } else { "failed" }
+        docs_contract_issues = [string[]]@($docsIssues)
+        constructive_feedback = [string[]]@($feedbackItems)
         docs_contract_output = $docsCheckOutput
     }
     $result | ConvertTo-Json -Depth 6
 
     if ($PostReview) {
-        if ($safeForMaintainerCi -and $docsCheckOk) {
-            $body = "Automated external PR intake passed static docs-only review and docs-contract-check. This does not approve merge or payment; a maintainer still needs to review semantics and decide whether to approve CI."
+        if ($mainCandidate) {
+            $body = @"
+Automated external PR intake passed.
+
+What passed:
+- The changed files are docs-only.
+- No risky paths were changed.
+- `docs-contract-check` passed against the trusted maintainer checkout.
+
+Recommended lane: main-candidate.
+
+Next steps:
+- A maintainer should still review the semantics before merging.
+- This review does not approve bounty acceptance, payout, or payment settlement.
+"@
             Invoke-Checked { gh pr review $Pr --repo $Repo --comment --body $body }
         } else {
-            $body = "Automated external PR intake failed. risky_files=$($riskyFiles -join ', ') non_docs_files=$($nonDocsFiles -join ', ') docs_contract_check=$($result.docs_contract_check). Maintainer review required; do not approve CI yet."
+            $blockers = @()
+            if ($nonDocsFiles.Count -gt 0) {
+                $blockers += "Non-doc files changed:`n$(Format-MarkdownList $nonDocsFiles)"
+            }
+            if ($riskyFiles.Count -gt 0) {
+                $blockers += "Risky files changed:`n$(Format-MarkdownList $riskyFiles)"
+            }
+            if (-not $docsCheckOk) {
+                $blockers += "Docs contract check failed:`n$(Format-MarkdownList $docsIssues -Empty '- The checker failed without line-specific issues. Run the command below for full output.')"
+            }
+            $branchGuidance = if ($collaborationBranchCandidate) {
+                "This looks suitable for a collaboration branch such as `collab/pr-$Pr-<short-topic>` if a maintainer wants others to iterate on it without merging to `main` yet. That branch would not imply bounty acceptance or payment approval."
+            } else {
+                "Do not move this to an upstream collaboration branch automatically. The risky or non-doc paths need manual maintainer security review first."
+            }
+            $body = @"
+Thanks for the contribution. I cannot approve this for `main` yet, but the next repair steps are concrete.
+
+Recommended lane: $recommendedLane.
+
+Why it is blocked:
+$(($blockers | ForEach-Object { $_ }) -join "`n`n")
+
+How to fix:
+$(Format-MarkdownList $feedbackItems)
+
+Local command to run before pushing an update:
+
+~~~bash
+cargo run -p cli -- docs-contract-check
+~~~
+
+Collaboration branch guidance:
+$branchGuidance
+"@
             Invoke-Checked { gh pr review $Pr --repo $Repo --request-changes --body $body }
         }
     }
 
-    if (-not ($safeForMaintainerCi -and $docsCheckOk)) {
+    if (-not $mainCandidate) {
         exit 1
     }
 } finally {

--- a/scripts/review-external-pr.sh
+++ b/scripts/review-external-pr.sh
@@ -69,6 +69,37 @@ is_risky_path() {
     [[ "$path" == *package-lock.json ]]
 }
 
+markdown_list() {
+  local empty="$1"
+  shift || true
+  if [[ "$#" -eq 0 ]]; then
+    printf '%s\n' "$empty"
+    return
+  fi
+  local item
+  for item in "$@"; do
+    printf -- '- %s\n' "$item"
+  done
+}
+
+json_array() {
+  if [[ "$#" -eq 0 ]]; then
+    return
+  fi
+  local first=true
+  local item escaped
+  for item in "$@"; do
+    escaped="${item//\\/\\\\}"
+    escaped="${escaped//\"/\\\"}"
+    if [[ "$first" == true ]]; then
+      first=false
+    else
+      printf ','
+    fi
+    printf '"%s"' "$escaped"
+  done
+}
+
 mapfile -t changed_files < <(gh pr view "$pr" --repo "$repo" --json files --jq '.files[].path')
 if [[ "${#changed_files[@]}" -eq 0 ]]; then
   echo "PR #$pr has no changed files" >&2
@@ -113,31 +144,106 @@ trap cleanup EXIT
 git worktree add --detach "$worktree" "$ref_name" >/dev/null
 
 docs_contract_check="failed"
-if cargo run -p cli -- docs-contract-check --root "$worktree" --contract-root "$repo_root"; then
+docs_output="$tmp_root/docs-contract-check.log"
+if cargo run -p cli -- docs-contract-check --root "$worktree" --contract-root "$repo_root" >"$docs_output" 2>&1; then
   docs_contract_check="ok"
 fi
+cat "$docs_output"
+mapfile -t docs_contract_issues < <(grep -E '^[^[:space:]:][^:]+:[0-9]+:' "$docs_output" | head -n 20 || true)
 
 safe_for_maintainer_ci=false
 if [[ "$docs_only" == true && "${#risky_files[@]}" -eq 0 && "$docs_contract_check" == "ok" ]]; then
   safe_for_maintainer_ci=true
+fi
+collaboration_branch_candidate=false
+if [[ "$docs_only" == true && "${#risky_files[@]}" -eq 0 ]]; then
+  collaboration_branch_candidate=true
+fi
+recommended_lane="manual-security-review"
+if [[ "$safe_for_maintainer_ci" == true ]]; then
+  recommended_lane="main-candidate"
+elif [[ "$collaboration_branch_candidate" == true ]]; then
+  recommended_lane="collaboration-branch-candidate"
+fi
+
+feedback_items=()
+if [[ "$docs_only" != true ]]; then
+  feedback_items+=("Split docs-only changes from code or infrastructure changes, or wait for manual maintainer review of the non-doc paths.")
+fi
+if [[ "${#risky_files[@]}" -gt 0 ]]; then
+  feedback_items+=("Risky paths need line-by-line maintainer review before CI or any upstream collaboration branch is approved.")
+fi
+if [[ "$docs_contract_check" != "ok" ]]; then
+  feedback_items+=("Run cargo run -p cli -- docs-contract-check locally and update examples to match the current API routes, MCP tools, discovery manifest shape, and request payloads.")
+fi
+if [[ "${#docs_contract_issues[@]}" -gt 0 ]]; then
+  feedback_items+=("Start with the first docs-contract issue listed below, then rerun the checker until it reports docs_contract_check=ok.")
+fi
+if [[ "${#feedback_items[@]}" -eq 0 ]]; then
+  feedback_items+=("Perform semantic review before approving merge, and keep payment or bounty acceptance separate from code review.")
 fi
 
 printf '{\n'
 printf '  "pr": %s,\n' "$pr"
 printf '  "docs_only": %s,\n' "$docs_only"
 printf '  "safe_for_maintainer_ci": %s,\n' "$safe_for_maintainer_ci"
+printf '  "main_candidate": %s,\n' "$safe_for_maintainer_ci"
+printf '  "collaboration_branch_candidate": %s,\n' "$collaboration_branch_candidate"
+printf '  "recommended_lane": "%s",\n' "$recommended_lane"
 printf '  "docs_contract_check": "%s",\n' "$docs_contract_check"
-printf '  "risky_files": [%s],\n' "$(printf '"%s",' "${risky_files[@]}" | sed 's/,$//')"
-printf '  "non_docs_files": [%s]\n' "$(printf '"%s",' "${non_docs_files[@]}" | sed 's/,$//')"
+printf '  "risky_files": [%s],\n' "$(json_array "${risky_files[@]}")"
+printf '  "non_docs_files": [%s]\n' "$(json_array "${non_docs_files[@]}")"
 printf '}\n'
 
 if [[ "$post_review" == true ]]; then
   if [[ "$safe_for_maintainer_ci" == true ]]; then
-    gh pr review "$pr" --repo "$repo" --comment --body \
-      "Automated external PR intake passed static docs-only review and docs-contract-check. This does not approve merge or payment; a maintainer still needs to review semantics and decide whether to approve CI."
+    body="$(
+      cat <<'EOF'
+Automated external PR intake passed.
+
+What passed:
+- The changed files are docs-only.
+- No risky paths were changed.
+- docs-contract-check passed against the trusted maintainer checkout.
+
+Recommended lane: main-candidate.
+
+Next steps:
+- A maintainer should still review the semantics before merging.
+- This review does not approve bounty acceptance, payout, or payment settlement.
+EOF
+    )"
+    gh pr review "$pr" --repo "$repo" --comment --body "$body"
   else
-    gh pr review "$pr" --repo "$repo" --request-changes --body \
-      "Automated external PR intake failed. risky_files=${risky_files[*]} non_docs_files=${non_docs_files[*]} docs_contract_check=${docs_contract_check}. Maintainer review required; do not approve CI yet."
+    body_file="$tmp_root/review-body.md"
+    {
+      printf 'Thanks for the contribution. I cannot approve this for main yet, but the next repair steps are concrete.\n\n'
+      printf 'Recommended lane: %s.\n\n' "$recommended_lane"
+      printf 'Why it is blocked:\n'
+      if [[ "${#non_docs_files[@]}" -gt 0 ]]; then
+        printf '\nNon-doc files changed:\n'
+        markdown_list "- None" "${non_docs_files[@]}"
+      fi
+      if [[ "${#risky_files[@]}" -gt 0 ]]; then
+        printf '\nRisky files changed:\n'
+        markdown_list "- None" "${risky_files[@]}"
+      fi
+      if [[ "$docs_contract_check" != "ok" ]]; then
+        printf '\nDocs contract check failed:\n'
+        markdown_list "- The checker failed without line-specific issues. Run the command below for full output." "${docs_contract_issues[@]}"
+      fi
+      printf '\nHow to fix:\n'
+      markdown_list "- Rerun the trusted review command and address each blocker." "${feedback_items[@]}"
+      printf '\nLocal command to run before pushing an update:\n\n'
+      printf '```bash\ncargo run -p cli -- docs-contract-check\n```\n\n'
+      printf 'Collaboration branch guidance:\n'
+      if [[ "$collaboration_branch_candidate" == true ]]; then
+        printf 'This looks suitable for a collaboration branch such as collab/pr-%s-<short-topic> if a maintainer wants others to iterate on it without merging to main yet. That branch would not imply bounty acceptance or payment approval.\n' "$pr"
+      else
+        printf 'Do not move this to an upstream collaboration branch automatically. The risky or non-doc paths need manual maintainer security review first.\n'
+      fi
+    } >"$body_file"
+    gh pr review "$pr" --repo "$repo" --request-changes --body "$(cat "$body_file")"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- require constructive accept/reject feedback in the secure external PR review docs
- add explicit main, collaboration-branch, and manual-security-review lanes
- teach the external PR review scripts to emit lane recommendations and repair-focused feedback
- preserve main safety while allowing promising docs/spec work to continue on `collab/*` branches

## Verification
- PowerShell parser check for `scripts/review-external-pr.ps1`
- `bash -n scripts/review-external-pr.sh`
- `cargo run -p cli -- docs-contract-check`
- `scripts/review-external-pr.ps1 -Pr 7` passes as a main candidate
- `scripts/review-external-pr.ps1 -Pr 6` fails closed while recommending the collaboration branch lane
- `scripts/check.ps1`

## External PR handling
- Posted constructive feedback on PR #6
- Created `collab/pr-6-agent-quickstart` from the reviewed PR #6 head so contributors can iterate without merging to main