### PR TITLE
Strengthen GitHub CI verifier evidence

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -3438,7 +3438,7 @@ mod tests {
             .submit_result(SubmitResultRequest {
                 bounty_id: approval.bounty.id,
                 solver_agent_id: solver.id,
-                artifact_uri: "https://github.com/example/repo/actions/runs/1".to_string(),
+                artifact_uri: "https://github.com/example/repo/pull/1".to_string(),
                 artifact_body: "{\"check\":\"green\"}".to_string(),
             })
             .unwrap();
@@ -3449,10 +3449,7 @@ mod tests {
                 expected_artifact_digest: "not-used-by-github-ci".to_string(),
                 verifier_kind: None,
                 rubric: None,
-                evidence: Some(serde_json::json!({
-                    "check_conclusion": "success",
-                    "check_name": "test"
-                })),
+                evidence: Some(github_ci_evidence()),
                 approved_risk_event_id: None,
             })
             .await;
@@ -4259,6 +4256,25 @@ mod tests {
             timestamp,
             hex::encode(mac.finalize().into_bytes())
         )
+    }
+
+    fn github_ci_evidence() -> serde_json::Value {
+        serde_json::json!({
+            "repository": "example/repo",
+            "pull_request_url": "https://github.com/example/repo/pull/1",
+            "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "check_run": {
+                "id": 123456789_u64,
+                "name": "full-check",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "html_url": "https://github.com/example/repo/actions/runs/123456789",
+                "repository": {
+                    "full_name": "example/repo"
+                }
+            }
+        })
     }
 
     fn valid_github_issue_body() -> String {

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -3312,7 +3312,7 @@ mod tests {
             .submit_result(SubmitResultRequest {
                 bounty_id: bounty.id,
                 solver_agent_id: solver.id,
-                artifact_uri: "https://github.com/example/repo/actions/runs/1".to_string(),
+                artifact_uri: "https://github.com/example/repo/pull/1".to_string(),
                 artifact_body: "{\"check\":\"green\"}".to_string(),
             })
             .unwrap();
@@ -3324,10 +3324,7 @@ mod tests {
                 expected_artifact_digest: "not-used-by-github-ci".to_string(),
                 verifier_kind: None,
                 rubric: None,
-                evidence: Some(serde_json::json!({
-                    "check_conclusion": "success",
-                    "check_name": "test"
-                })),
+                evidence: Some(github_ci_evidence()),
                 approved_risk_event_id: None,
             })
             .await
@@ -3687,7 +3684,7 @@ mod tests {
             .submit_result(SubmitResultRequest {
                 bounty_id: approval.bounty.id,
                 solver_agent_id: solver.id,
-                artifact_uri: "https://github.com/example/repo/actions/runs/1".to_string(),
+                artifact_uri: "https://github.com/example/repo/pull/1".to_string(),
                 artifact_body: "{\"check\":\"green\"}".to_string(),
             })
             .unwrap();
@@ -3699,10 +3696,7 @@ mod tests {
                 expected_artifact_digest: "not-used-by-github-ci".to_string(),
                 verifier_kind: None,
                 rubric: None,
-                evidence: Some(serde_json::json!({
-                    "check_conclusion": "success",
-                    "check_name": "test"
-                })),
+                evidence: Some(github_ci_evidence()),
                 approved_risk_event_id: None,
             })
             .await
@@ -3741,10 +3735,7 @@ mod tests {
                 expected_artifact_digest: "not-used-by-github-ci".to_string(),
                 verifier_kind: None,
                 rubric: None,
-                evidence: Some(serde_json::json!({
-                    "check_conclusion": "success",
-                    "check_name": "test"
-                })),
+                evidence: Some(github_ci_evidence()),
                 approved_risk_event_id: Some(payout_event.id),
             })
             .await
@@ -4016,5 +4007,24 @@ mod tests {
         assert_eq!(refund_report.bounty.status, BountyStatus::Refunded);
         assert_eq!(refund_report.escrow.status, EscrowStatus::Refunded);
         assert_eq!(refund_report.ledger_entries.len(), 1);
+    }
+
+    fn github_ci_evidence() -> serde_json::Value {
+        serde_json::json!({
+            "repository": "example/repo",
+            "pull_request_url": "https://github.com/example/repo/pull/1",
+            "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "check_run": {
+                "id": 123456789_u64,
+                "name": "full-check",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "html_url": "https://github.com/example/repo/actions/runs/123456789",
+                "repository": {
+                    "full_name": "example/repo"
+                }
+            }
+        })
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2552,7 +2552,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         serde_json::json!({
             "bounty_id": mcp_reviewed_bounty_id,
             "solver_agent_id": mcp_review_solver_id,
-            "artifact_uri": "https://github.com/example/repo/actions/runs/1",
+            "artifact_uri": "https://github.com/example/repo/pull/1",
             "artifact_body": reviewed_artifact_body
         }),
     )?;
@@ -2566,10 +2566,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             "expected_artifact_digest": "not-used-by-github-ci",
             "verifier_kind": null,
             "rubric": null,
-            "evidence": {
-                "check_conclusion": "success",
-                "check_name": "test"
-            },
+            "evidence": github_ci_evidence(),
             "approved_risk_event_id": null
         }),
     )?;
@@ -2635,10 +2632,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             "expected_artifact_digest": "not-used-by-github-ci",
             "verifier_kind": null,
             "rubric": null,
-            "evidence": {
-                "check_conclusion": "success",
-                "check_name": "test"
-            },
+            "evidence": github_ci_evidence(),
             "approved_risk_event_id": mcp_payout_risk_event_id.as_str()
         }),
     )?;
@@ -3273,6 +3267,25 @@ fn post_json(url: &str, body: serde_json::Value) -> Result<serde_json::Value> {
         url,
         Some(body.to_string()),
     )?)?)
+}
+
+fn github_ci_evidence() -> serde_json::Value {
+    serde_json::json!({
+        "repository": "example/repo",
+        "pull_request_url": "https://github.com/example/repo/pull/1",
+        "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "check_run": {
+            "id": 123456789_u64,
+            "name": "full-check",
+            "status": "completed",
+            "conclusion": "success",
+            "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "html_url": "https://github.com/example/repo/actions/runs/123456789",
+            "repository": {
+                "full_name": "example/repo"
+            }
+        }
+    })
 }
 
 fn mcp_tool_get(mcp_base_url: &str, tool_name: &str) -> Result<serde_json::Value> {

--- a/crates/eval-harness/src/lib.rs
+++ b/crates/eval-harness/src/lib.rs
@@ -948,7 +948,10 @@ async fn verifier_suite() -> Result<EvalSuiteResult, EvalError> {
             "abc123abc123abc123",
             None,
             None,
-            Some(serde_json::json!({ "check_conclusion": "success" })),
+            Some(github_ci_evidence(
+                "success",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )),
             VerificationDecision::Accepted,
         )
         .await?,
@@ -958,7 +961,10 @@ async fn verifier_suite() -> Result<EvalSuiteResult, EvalError> {
             "abc123abc123abc123",
             None,
             None,
-            Some(serde_json::json!({ "check_conclusion": "failure" })),
+            Some(github_ci_evidence(
+                "failure",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )),
             VerificationDecision::Rejected,
         )
         .await?,
@@ -1055,7 +1061,11 @@ async fn verifier_case(
         bounty_id,
         solver_agent_id: Uuid::new_v4(),
         artifact_digest: artifact_digest.to_string(),
-        artifact_uri: format!("s3://eval-harness/{name}.json"),
+        artifact_uri: if kind == VerifierKind::GitHubCi {
+            "https://github.com/agent-bounties/agent-bounties/pull/42".to_string()
+        } else {
+            format!("s3://eval-harness/{name}.json")
+        },
         submitted_at: Utc::now(),
     };
     let result = verify_with_builtin(
@@ -1089,6 +1099,25 @@ async fn verifier_case(
         passed: failures.is_empty(),
         score: if failures.is_empty() { 1.0 } else { 0.0 },
         failures,
+    })
+}
+
+fn github_ci_evidence(conclusion: &str, head_sha: &str) -> serde_json::Value {
+    serde_json::json!({
+        "repository": "agent-bounties/agent-bounties",
+        "pull_request_url": "https://github.com/agent-bounties/agent-bounties/pull/42",
+        "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "check_run": {
+            "id": 123456789_u64,
+            "name": "full-check",
+            "status": "completed",
+            "conclusion": conclusion,
+            "head_sha": head_sha,
+            "html_url": "https://github.com/agent-bounties/agent-bounties/actions/runs/123456789",
+            "repository": {
+                "full_name": "agent-bounties/agent-bounties"
+            }
+        }
     })
 }
 

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -581,7 +581,7 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                         "AiJudgeFilter"
                     ], "Optional verifier kind."),
                     "rubric": nullable_string_property("Optional human or AI-judge rubric."),
-                    "evidence": nullable_object_property("Optional verifier evidence payload."),
+                    "evidence": nullable_object_property("Optional verifier evidence payload. For GitHubCi, include repository, pull_request_url, commit_sha, and check_run { id, name, status, conclusion, head_sha, html_url, repository.full_name }."),
                     "approved_risk_event_id": nullable_uuid_property("Optional approved payout risk event UUID that permits verification to continue after operator review.")
                 }),
                 &["bounty_id", "submission_id", "expected_artifact_digest"],
@@ -3130,7 +3130,7 @@ mod tests {
             .submit_result(SubmitResultRequest {
                 bounty_id: approval.bounty.id,
                 solver_agent_id: solver.id,
-                artifact_uri: "https://github.com/example/repo/actions/runs/1".to_string(),
+                artifact_uri: "https://github.com/example/repo/pull/1".to_string(),
                 artifact_body: "{\"check\":\"green\"}".to_string(),
             })
             .unwrap();
@@ -3141,10 +3141,7 @@ mod tests {
                 expected_artifact_digest: "not-used-by-github-ci".to_string(),
                 verifier_kind: None,
                 rubric: None,
-                evidence: Some(json!({
-                    "check_conclusion": "success",
-                    "check_name": "test"
-                })),
+                evidence: Some(github_ci_evidence()),
                 approved_risk_event_id: None,
             })
             .await;
@@ -3308,6 +3305,25 @@ mod tests {
             stripe_api_base_url: STRIPE_API_BASE_URL.to_string(),
             operator_api_token: Some(token.to_string()),
             store: None,
+        })
+    }
+
+    fn github_ci_evidence() -> serde_json::Value {
+        json!({
+            "repository": "example/repo",
+            "pull_request_url": "https://github.com/example/repo/pull/1",
+            "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "check_run": {
+                "id": 123456789_u64,
+                "name": "full-check",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "html_url": "https://github.com/example/repo/actions/runs/123456789",
+                "repository": {
+                    "full_name": "example/repo"
+                }
+            }
         })
     }
 

--- a/crates/sdk-python/agent_bounties/smoke.py
+++ b/crates/sdk-python/agent_bounties/smoke.py
@@ -14,6 +14,23 @@ def _require(condition: bool, message: str) -> None:
         raise AssertionError(message)
 
 
+def _github_ci_evidence() -> dict:
+    return {
+        "repository": "example/repo",
+        "pull_request_url": "https://github.com/example/repo/pull/1",
+        "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "check_run": {
+            "id": 123456789,
+            "name": "full-check",
+            "status": "completed",
+            "conclusion": "success",
+            "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "html_url": "https://github.com/example/repo/actions/runs/123456789",
+            "repository": {"full_name": "example/repo"},
+        },
+    }
+
+
 def exercise_surface(client: AgentBountiesClient) -> dict:
     suffix = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
 
@@ -247,10 +264,10 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
     reviewed_submission = client.submit_result(
         reviewed_bounty_id,
         review_solver["id"],
-        "https://github.com/example/repo/actions/runs/1",
+        "https://github.com/example/repo/pull/1",
         json.dumps({"check": "green"}, separators=(",", ":")),
     )
-    reviewed_evidence = {"check_conclusion": "success", "check_name": "test"}
+    reviewed_evidence = _github_ci_evidence()
     try:
         client.request_verification(
             reviewed_bounty_id,

--- a/crates/sdk-typescript/src/smoke.ts
+++ b/crates/sdk-typescript/src/smoke.ts
@@ -52,6 +52,23 @@ function operatorApiTokenFromArgs(): string | undefined {
   return token && token.trim() ? token : undefined;
 }
 
+function githubCiEvidence(): JsonObject {
+  return {
+    repository: "example/repo",
+    pull_request_url: "https://github.com/example/repo/pull/1",
+    commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    check_run: {
+      id: 123456789,
+      name: "full-check",
+      status: "completed",
+      conclusion: "success",
+      head_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      html_url: "https://github.com/example/repo/actions/runs/123456789",
+      repository: { full_name: "example/repo" },
+    },
+  };
+}
+
 async function main(): Promise<void> {
   const client = new AgentBountiesClient({
     baseUrl: baseUrlFromArgs(),
@@ -310,12 +327,12 @@ async function main(): Promise<void> {
   const reviewedSubmission = asObject(
     await client.submitResult(reviewedBountyId, {
       solver_agent_id: stringField(reviewSolver, "id"),
-      artifact_uri: "https://github.com/example/repo/actions/runs/1",
+      artifact_uri: "https://github.com/example/repo/pull/1",
       artifact_body: JSON.stringify({ check: "green" }),
     }),
     "reviewedSubmission",
   );
-  const reviewedEvidence = { check_conclusion: "success", check_name: "test" };
+  const reviewedEvidence = githubCiEvidence();
   try {
     await client.requestVerification(reviewedBountyId, {
       submission_id: stringField(reviewedSubmission, "id"),

--- a/crates/verifier-sdk/src/lib.rs
+++ b/crates/verifier-sdk/src/lib.rs
@@ -125,35 +125,269 @@ impl Verifier for GitHubCiVerifier {
     }
 
     async fn verify(&self, input: VerificationInput) -> VerifierResultType<VerifierResult> {
-        let evidence = required_evidence(&input)?;
-        let conclusion = evidence_string(evidence, "check_conclusion")
-            .or_else(|| evidence_string(evidence, "conclusion"))
-            .unwrap_or_default()
-            .to_ascii_lowercase();
-        let status = evidence_string(evidence, "status")
-            .unwrap_or_default()
-            .to_ascii_lowercase();
-        let accepted = matches!(conclusion.as_str(), "success" | "passed")
-            || matches!(status.as_str(), "success" | "passed" | "completed");
+        let Some(evidence) = input.evidence.as_ref() else {
+            return Ok(make_result(
+                input.bounty_id,
+                input.submission.id,
+                None,
+                VerifierKind::GitHubCi,
+                VerificationDecision::NeedsReview,
+                "GitHub CI evidence needs review: structured evidence is required",
+                0.35,
+            ));
+        };
 
-        Ok(make_result(
-            input.bounty_id,
-            input.submission.id,
-            None,
-            VerifierKind::GitHubCi,
-            if accepted {
+        let parsed = match GitHubCiEvidence::from_value(evidence, &input.submission) {
+            Ok(parsed) => parsed,
+            Err(message) => {
+                return Ok(make_result(
+                    input.bounty_id,
+                    input.submission.id,
+                    None,
+                    VerifierKind::GitHubCi,
+                    VerificationDecision::NeedsReview,
+                    format!("GitHub CI evidence needs review: {message}"),
+                    0.35,
+                ));
+            }
+        };
+
+        if let Err(reason) = parsed.validate_ownership(&input.submission) {
+            return Ok(make_result_with_payload(ResultSeed {
+                bounty_id: input.bounty_id,
+                submission_id: input.submission.id,
+                verifier_agent_id: None,
+                kind: VerifierKind::GitHubCi,
+                decision: VerificationDecision::Rejected,
+                summary: format!("GitHub CI evidence rejected: {reason}"),
+                confidence: 0.0,
+                payload: Some(&parsed.canonical_payload()),
+            }));
+        }
+
+        let status = parsed.check_status.to_ascii_lowercase();
+        let conclusion = parsed.check_conclusion.to_ascii_lowercase();
+        let completed = matches!(status.as_str(), "completed" | "success" | "passed");
+        let succeeded = matches!(conclusion.as_str(), "success" | "passed");
+        let accepted = completed && succeeded;
+        let short_sha = short_sha(&parsed.commit_sha);
+        let summary = if accepted {
+            format!(
+                "GitHub CI evidence accepted: {} {} commit {} check {}#{} succeeded",
+                parsed.repository,
+                parsed
+                    .pull_request_number()
+                    .map(|number| format!("PR #{number}"))
+                    .unwrap_or_else(|| "repository evidence".to_string()),
+                short_sha,
+                parsed.check_name,
+                parsed.check_run_id
+            )
+        } else {
+            format!(
+                "GitHub CI evidence rejected: check {}#{} for {} commit {} ended with status `{}` and conclusion `{}`",
+                parsed.check_name,
+                parsed.check_run_id,
+                parsed.repository,
+                short_sha,
+                parsed.check_status,
+                parsed.check_conclusion
+            )
+        };
+
+        Ok(make_result_with_payload(ResultSeed {
+            bounty_id: input.bounty_id,
+            submission_id: input.submission.id,
+            verifier_agent_id: None,
+            kind: VerifierKind::GitHubCi,
+            decision: if accepted {
                 VerificationDecision::Accepted
             } else {
                 VerificationDecision::Rejected
             },
-            if accepted {
-                "GitHub CI evidence passed"
-            } else {
-                "GitHub CI evidence did not pass"
-            },
-            if accepted { 0.98 } else { 0.0 },
-        ))
+            summary,
+            confidence: if accepted { 0.98 } else { 0.0 },
+            payload: Some(&parsed.canonical_payload()),
+        }))
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitHubCiEvidence {
+    repository: String,
+    pull_request_url: Option<String>,
+    commit_sha: String,
+    check_run_id: String,
+    check_name: String,
+    check_status: String,
+    check_conclusion: String,
+    check_head_sha: String,
+    check_repository: String,
+    check_html_url: Option<String>,
+}
+
+impl GitHubCiEvidence {
+    fn from_value(evidence: &Value, submission: &Submission) -> Result<Self, String> {
+        let check_run = evidence.get("check_run").filter(|value| value.is_object());
+        let repository = evidence_string(evidence, "repository")
+            .or_else(|| evidence_string(evidence, "repo"))
+            .or_else(|| {
+                check_run.and_then(|value| nested_string(value, &["repository", "full_name"]))
+            })
+            .or_else(|| github_pr_reference(&submission.artifact_uri).map(|pr| pr.repository))
+            .ok_or_else(|| "repository is required".to_string())?;
+        let repository = normalize_repository(&repository)
+            .ok_or_else(|| "repository must be in owner/name form".to_string())?;
+
+        let pull_request_url = evidence_string(evidence, "pull_request_url")
+            .or_else(|| evidence_string(evidence, "pr_url"))
+            .or_else(|| github_pr_reference(&submission.artifact_uri).map(|pr| pr.url));
+        if let Some(url) = &pull_request_url {
+            let pr = github_pr_reference(url)
+                .ok_or_else(|| "pull_request_url must be a GitHub pull request URL".to_string())?;
+            if pr.repository != repository {
+                return Err("pull_request_url repository does not match repository".to_string());
+            }
+        }
+
+        let commit_sha = evidence_string(evidence, "commit_sha")
+            .or_else(|| evidence_string(evidence, "head_sha"))
+            .or_else(|| check_run.and_then(|value| evidence_string(value, "head_sha")))
+            .ok_or_else(|| "commit_sha is required".to_string())?;
+        let commit_sha = normalize_git_sha(&commit_sha)
+            .ok_or_else(|| "commit_sha must be a 7-64 character hex Git SHA".to_string())?;
+
+        let check_run_id = evidence_string(evidence, "check_run_id")
+            .or_else(|| check_run.and_then(|value| evidence_string(value, "id")))
+            .or_else(|| {
+                check_run.and_then(|value| evidence_i64(value, "id").map(|id| id.to_string()))
+            })
+            .ok_or_else(|| "check_run_id is required".to_string())?;
+        if check_run_id.trim().is_empty() {
+            return Err("check_run_id is required".to_string());
+        }
+
+        let check_name = evidence_string(evidence, "check_name")
+            .or_else(|| check_run.and_then(|value| evidence_string(value, "name")))
+            .ok_or_else(|| "check_name is required".to_string())?;
+        if check_name.trim().is_empty() {
+            return Err("check_name is required".to_string());
+        }
+
+        let check_status = evidence_string(evidence, "check_status")
+            .or_else(|| evidence_string(evidence, "status"))
+            .or_else(|| check_run.and_then(|value| evidence_string(value, "status")))
+            .ok_or_else(|| "check_status is required".to_string())?;
+
+        let check_conclusion = evidence_string(evidence, "check_conclusion")
+            .or_else(|| evidence_string(evidence, "conclusion"))
+            .or_else(|| check_run.and_then(|value| evidence_string(value, "conclusion")))
+            .ok_or_else(|| "check_conclusion is required".to_string())?;
+
+        let check_head_sha = evidence_string(evidence, "check_head_sha")
+            .or_else(|| check_run.and_then(|value| evidence_string(value, "head_sha")))
+            .or_else(|| {
+                check_run.and_then(|value| nested_string(value, &["check_suite", "head_sha"]))
+            })
+            .ok_or_else(|| "check_head_sha is required".to_string())?;
+        let check_head_sha = normalize_git_sha(&check_head_sha)
+            .ok_or_else(|| "check_head_sha must be a 7-64 character hex Git SHA".to_string())?;
+
+        let check_repository = evidence_string(evidence, "check_repository")
+            .or_else(|| {
+                check_run.and_then(|value| nested_string(value, &["repository", "full_name"]))
+            })
+            .unwrap_or_else(|| repository.clone());
+        let check_repository = normalize_repository(&check_repository)
+            .ok_or_else(|| "check_repository must be in owner/name form".to_string())?;
+
+        let check_html_url = evidence_string(evidence, "check_html_url")
+            .or_else(|| check_run.and_then(|value| evidence_string(value, "html_url")));
+
+        Ok(Self {
+            repository,
+            pull_request_url,
+            commit_sha,
+            check_run_id: check_run_id.trim().to_string(),
+            check_name: check_name.trim().to_string(),
+            check_status: check_status.trim().to_string(),
+            check_conclusion: check_conclusion.trim().to_string(),
+            check_head_sha,
+            check_repository,
+            check_html_url,
+        })
+    }
+
+    fn validate_ownership(&self, submission: &Submission) -> Result<(), String> {
+        if self.check_repository != self.repository {
+            return Err(format!(
+                "check run repository `{}` does not match submitted repository `{}`",
+                self.check_repository, self.repository
+            ));
+        }
+        if self.check_head_sha != self.commit_sha {
+            return Err(format!(
+                "check run head SHA `{}` does not match submitted commit `{}`",
+                self.check_head_sha, self.commit_sha
+            ));
+        }
+        if let Some(submission_pr) = github_pr_reference(&submission.artifact_uri) {
+            if submission_pr.repository != self.repository {
+                return Err(format!(
+                    "submission artifact repository `{}` does not match evidence repository `{}`",
+                    submission_pr.repository, self.repository
+                ));
+            }
+            if let Some(evidence_pr_url) = &self.pull_request_url {
+                let evidence_pr =
+                    github_pr_reference(evidence_pr_url).expect("validated pull request URL");
+                if evidence_pr.number != submission_pr.number {
+                    return Err(format!(
+                        "evidence PR #{} does not match submitted PR #{}",
+                        evidence_pr.number, submission_pr.number
+                    ));
+                }
+            }
+        }
+        if let Some(url) = &self.check_html_url {
+            if !github_url_belongs_to_repository(url, &self.repository) {
+                return Err(format!(
+                    "check run URL does not belong to repository `{}`",
+                    self.repository
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn canonical_payload(&self) -> String {
+        format!(
+            "github-ci:{}:{}:{}:{}:{}:{}:{}:{}:{}",
+            self.repository,
+            self.pull_request_url.as_deref().unwrap_or(""),
+            self.commit_sha,
+            self.check_run_id,
+            self.check_name,
+            self.check_status.to_ascii_lowercase(),
+            self.check_conclusion.to_ascii_lowercase(),
+            self.check_head_sha,
+            self.check_repository
+        )
+    }
+
+    fn pull_request_number(&self) -> Option<u64> {
+        self.pull_request_url
+            .as_deref()
+            .and_then(github_pr_reference)
+            .map(|pr| pr.number)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitHubPullRequestRef {
+    repository: String,
+    number: u64,
+    url: String,
 }
 
 #[derive(Debug, Clone)]
@@ -261,21 +495,49 @@ fn make_result(
     summary: impl Into<String>,
     confidence: f32,
 ) -> VerifierResult {
-    let summary = summary.into();
-    let mut hasher = Sha256::new();
-    hasher.update(format!(
-        "{bounty_id}:{submission_id}:{kind:?}:{decision:?}:{summary}:{confidence}"
-    ));
-
-    VerifierResult {
-        id: Uuid::new_v4(),
+    make_result_with_payload(ResultSeed {
         bounty_id,
         submission_id,
         verifier_agent_id,
         kind,
         decision,
-        summary,
+        summary: summary.into(),
         confidence,
+        payload: None,
+    })
+}
+
+struct ResultSeed<'a> {
+    bounty_id: Id,
+    submission_id: Id,
+    verifier_agent_id: Option<Id>,
+    kind: VerifierKind,
+    decision: VerificationDecision,
+    summary: String,
+    confidence: f32,
+    payload: Option<&'a str>,
+}
+
+fn make_result_with_payload(seed: ResultSeed<'_>) -> VerifierResult {
+    let mut hasher = Sha256::new();
+    hasher.update(format!(
+        "{}:{}:{:?}:{:?}:{}:{}",
+        seed.bounty_id, seed.submission_id, seed.kind, seed.decision, seed.summary, seed.confidence
+    ));
+    if let Some(payload) = seed.payload {
+        hasher.update(":");
+        hasher.update(payload);
+    }
+
+    VerifierResult {
+        id: Uuid::new_v4(),
+        bounty_id: seed.bounty_id,
+        submission_id: seed.submission_id,
+        verifier_agent_id: seed.verifier_agent_id,
+        kind: seed.kind,
+        decision: seed.decision,
+        summary: seed.summary,
+        confidence: seed.confidence,
         signed_payload_hash: hex::encode(hasher.finalize()),
         created_at: Utc::now(),
     }
@@ -289,7 +551,11 @@ fn required_evidence(input: &VerificationInput) -> VerifierResultType<&Value> {
 }
 
 fn evidence_string(evidence: &Value, key: &str) -> Option<String> {
-    evidence.get(key)?.as_str().map(ToString::to_string)
+    let value = evidence.get(key)?;
+    if let Some(text) = value.as_str() {
+        return Some(text.to_string());
+    }
+    value.as_u64().map(|number| number.to_string())
 }
 
 fn evidence_i64(evidence: &Value, key: &str) -> Option<i64> {
@@ -298,6 +564,89 @@ fn evidence_i64(evidence: &Value, key: &str) -> Option<i64> {
 
 fn evidence_bool(evidence: &Value, key: &str) -> Option<bool> {
     evidence.get(key)?.as_bool()
+}
+
+fn nested_string(value: &Value, path: &[&str]) -> Option<String> {
+    let mut cursor = value;
+    for key in path {
+        cursor = cursor.get(*key)?;
+    }
+    if let Some(text) = cursor.as_str() {
+        return Some(text.to_string());
+    }
+    cursor.as_u64().map(|number| number.to_string())
+}
+
+fn normalize_repository(value: &str) -> Option<String> {
+    let trimmed = value.trim().trim_matches('/');
+    let parts = trimmed.split('/').collect::<Vec<_>>();
+    if parts.len() != 2 || parts.iter().any(|part| part.is_empty()) {
+        return None;
+    }
+    if parts.iter().any(|part| {
+        !part
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    }) {
+        return None;
+    }
+    Some(format!(
+        "{}/{}",
+        parts[0].to_ascii_lowercase(),
+        parts[1].to_ascii_lowercase()
+    ))
+}
+
+fn normalize_git_sha(value: &str) -> Option<String> {
+    let sha = value.trim().to_ascii_lowercase();
+    if (7..=64).contains(&sha.len()) && sha.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        Some(sha)
+    } else {
+        None
+    }
+}
+
+fn github_pr_reference(url: &str) -> Option<GitHubPullRequestRef> {
+    let trimmed = url.trim();
+    let path = trimmed
+        .strip_prefix("https://github.com/")
+        .or_else(|| trimmed.strip_prefix("http://github.com/"))?;
+    let path = path.trim_end_matches('/');
+    let parts = path.split('/').collect::<Vec<_>>();
+    if parts.len() < 4 || parts[2] != "pull" {
+        return None;
+    }
+    let repository = normalize_repository(&format!("{}/{}", parts[0], parts[1]))?;
+    let number = parts[3].parse::<u64>().ok()?;
+    Some(GitHubPullRequestRef {
+        repository,
+        number,
+        url: format!(
+            "https://github.com/{}/{}/pull/{}",
+            parts[0].to_ascii_lowercase(),
+            parts[1].to_ascii_lowercase(),
+            number
+        ),
+    })
+}
+
+fn github_url_belongs_to_repository(url: &str, repository: &str) -> bool {
+    let Some(path) = url
+        .trim()
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.trim().strip_prefix("http://github.com/"))
+    else {
+        return false;
+    };
+    let parts = path.split('/').collect::<Vec<_>>();
+    if parts.len() < 2 {
+        return false;
+    }
+    normalize_repository(&format!("{}/{}", parts[0], parts[1])).as_deref() == Some(repository)
+}
+
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
 }
 
 #[cfg(test)]
@@ -361,6 +710,82 @@ mod tests {
     #[tokio::test]
     async fn github_ci_verifier_accepts_success_evidence() {
         let bounty_id = Uuid::new_v4();
+        let submission = Submission {
+            artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/42".to_string(),
+            ..submission_for(bounty_id, "abc123abc123abc123")
+        };
+
+        let result = GitHubCiVerifier
+            .verify(VerificationInput {
+                bounty_id,
+                submission,
+                expected_artifact_digest: None,
+                rubric: None,
+                evidence: Some(github_ci_evidence()),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.kind, VerifierKind::GitHubCi);
+        assert_eq!(result.decision, VerificationDecision::Accepted);
+        assert!(result.summary.contains("PR #42"));
+        assert_eq!(result.signed_payload_hash.len(), 64);
+    }
+
+    #[tokio::test]
+    async fn github_ci_verifier_rejects_mismatched_commit_evidence() {
+        let bounty_id = Uuid::new_v4();
+        let submission = Submission {
+            artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/42".to_string(),
+            ..submission_for(bounty_id, "abc123abc123abc123")
+        };
+        let mut evidence = github_ci_evidence();
+        evidence["check_run"]["head_sha"] =
+            serde_json::json!("ffffffffffffffffffffffffffffffffffffffff");
+
+        let result = GitHubCiVerifier
+            .verify(VerificationInput {
+                bounty_id,
+                submission,
+                expected_artifact_digest: None,
+                rubric: None,
+                evidence: Some(evidence),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.decision, VerificationDecision::Rejected);
+        assert!(result.summary.contains("does not match submitted commit"));
+    }
+
+    #[tokio::test]
+    async fn github_ci_verifier_rejects_failed_check_evidence() {
+        let bounty_id = Uuid::new_v4();
+        let submission = Submission {
+            artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/42".to_string(),
+            ..submission_for(bounty_id, "abc123abc123abc123")
+        };
+        let mut evidence = github_ci_evidence();
+        evidence["check_run"]["conclusion"] = serde_json::json!("failure");
+
+        let result = GitHubCiVerifier
+            .verify(VerificationInput {
+                bounty_id,
+                submission,
+                expected_artifact_digest: None,
+                rubric: None,
+                evidence: Some(evidence),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.decision, VerificationDecision::Rejected);
+        assert!(result.summary.contains("conclusion `failure`"));
+    }
+
+    #[tokio::test]
+    async fn github_ci_verifier_needs_review_for_missing_evidence() {
+        let bounty_id = Uuid::new_v4();
         let submission = submission_for(bounty_id, "abc123abc123abc123");
 
         let result = GitHubCiVerifier
@@ -369,16 +794,72 @@ mod tests {
                 submission,
                 expected_artifact_digest: None,
                 rubric: None,
-                evidence: Some(serde_json::json!({
-                    "check_conclusion": "success",
-                    "check_name": "test"
-                })),
+                evidence: None,
             })
             .await
             .unwrap();
 
-        assert_eq!(result.kind, VerifierKind::GitHubCi);
-        assert_eq!(result.decision, VerificationDecision::Accepted);
+        assert_eq!(result.decision, VerificationDecision::NeedsReview);
+        assert!(result.summary.contains("structured evidence is required"));
+    }
+
+    #[tokio::test]
+    async fn github_ci_verifier_rejects_replayed_pr_evidence() {
+        let bounty_id = Uuid::new_v4();
+        let submission = Submission {
+            artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/43".to_string(),
+            ..submission_for(bounty_id, "abc123abc123abc123")
+        };
+
+        let result = GitHubCiVerifier
+            .verify(VerificationInput {
+                bounty_id,
+                submission,
+                expected_artifact_digest: None,
+                rubric: None,
+                evidence: Some(github_ci_evidence()),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.decision, VerificationDecision::Rejected);
+        assert!(result.summary.contains("does not match submitted PR"));
+    }
+
+    #[tokio::test]
+    async fn github_ci_verifier_hash_binds_check_run_payload() {
+        let bounty_id = Uuid::new_v4();
+        let submission = Submission {
+            artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/42".to_string(),
+            ..submission_for(bounty_id, "abc123abc123abc123")
+        };
+        let mut replayed = github_ci_evidence();
+        replayed["check_run"]["id"] = serde_json::json!(123456790_u64);
+
+        let first = GitHubCiVerifier
+            .verify(VerificationInput {
+                bounty_id,
+                submission: submission.clone(),
+                expected_artifact_digest: None,
+                rubric: None,
+                evidence: Some(github_ci_evidence()),
+            })
+            .await
+            .unwrap();
+        let second = GitHubCiVerifier
+            .verify(VerificationInput {
+                bounty_id,
+                submission,
+                expected_artifact_digest: None,
+                rubric: None,
+                evidence: Some(replayed),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(first.decision, VerificationDecision::Accepted);
+        assert_eq!(second.decision, VerificationDecision::Accepted);
+        assert_ne!(first.signed_payload_hash, second.signed_payload_hash);
     }
 
     #[tokio::test]
@@ -434,5 +915,24 @@ mod tests {
             artifact_uri: "s3://bucket/artifact".to_string(),
             submitted_at: Utc::now(),
         }
+    }
+
+    fn github_ci_evidence() -> Value {
+        serde_json::json!({
+            "repository": "agent-bounties/agent-bounties",
+            "pull_request_url": "https://github.com/agent-bounties/agent-bounties/pull/42",
+            "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "check_run": {
+                "id": 123456789_u64,
+                "name": "full-check",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "html_url": "https://github.com/agent-bounties/agent-bounties/actions/runs/123456789",
+                "repository": {
+                    "full_name": "agent-bounties/agent-bounties"
+                }
+            }
+        })
     }
 }

--- a/docs/bounty-templates.md
+++ b/docs/bounty-templates.md
@@ -8,12 +8,16 @@ into distribution data for future agents.
 
 ## fix-ci-failure
 
-Input: repository, failing check URL, expected branch.
+Input: repository, pull request URL, commit SHA, failing check URL, expected
+branch.
 
-Verifier: GitHub CI evidence. The built-in verifier accepts structured evidence
-with a successful check conclusion.
+Verifier: GitHub CI evidence. The built-in verifier accepts only structured
+evidence that binds the repository, pull request, submitted commit SHA, and
+check run. The check run must belong to the same repository and commit, have a
+completed status, and have a successful conclusion.
 
-Output: passing check and concise failure explanation.
+Output: passing check, submitted pull request URL, commit SHA, and concise
+failure explanation.
 
 ## extract-data-to-schema
 
@@ -51,8 +55,36 @@ Output: logs, screenshot/artifact digest, observed result.
 ## Verifier Evidence
 
 `JsonSchema` verifies the submitted artifact digest against the expected digest.
-`GitHubCi` accepts successful GitHub check evidence. `DockerCommand` accepts a
-zero exit code and, when provided, a matching artifact digest. `HttpCallback`
-requires a 2xx callback, an `accepted` decision, and a valid signature flag.
-`Manual` and `AiJudgeFilter` are review-only and never authorize payment
-directly.
+`GitHubCi` accepts structured successful GitHub check evidence. `DockerCommand`
+accepts a zero exit code and, when provided, a matching artifact digest.
+`HttpCallback` requires a 2xx callback, an `accepted` decision, and a valid
+signature flag. `Manual` and `AiJudgeFilter` are review-only and never authorize
+payment directly.
+
+### GitHub CI Evidence Shape
+
+For `fix-ci-failure` and `small-code-change` bounties, set the submission
+`artifact_uri` to the pull request URL and pass evidence like:
+
+```json
+{
+  "repository": "owner/repo",
+  "pull_request_url": "https://github.com/owner/repo/pull/123",
+  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "check_run": {
+    "id": 123456789,
+    "name": "full-check",
+    "status": "completed",
+    "conclusion": "success",
+    "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "html_url": "https://github.com/owner/repo/actions/runs/123456789",
+    "repository": {
+      "full_name": "owner/repo"
+    }
+  }
+}
+```
+
+The verifier rejects evidence when the check-run repository, check-run head SHA,
+or pull request number does not match the submitted work. Missing structured
+evidence returns `NeedsReview` rather than authorizing payment.

--- a/docs/github-dogfooding.md
+++ b/docs/github-dogfooding.md
@@ -83,6 +83,37 @@ Dry-run the proof publisher without calling GitHub or the hosted API:
 python scripts/github_proof_comment.py --self-test
 ```
 
+## GitHub CI Submission Evidence
+
+For `fix-ci-failure` and `small-code-change` bounties, solvers should submit the
+pull request URL as the artifact URI. Verification evidence must bind the pull
+request to the exact commit and check run that passed:
+
+```json
+{
+  "repository": "agent-bounties/agent-bounties",
+  "pull_request_url": "https://github.com/agent-bounties/agent-bounties/pull/42",
+  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "check_run": {
+    "id": 123456789,
+    "name": "full-check",
+    "status": "completed",
+    "conclusion": "success",
+    "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "html_url": "https://github.com/agent-bounties/agent-bounties/actions/runs/123456789",
+    "repository": {
+      "full_name": "agent-bounties/agent-bounties"
+    }
+  }
+}
+```
+
+The verifier accepts only completed successful check runs that belong to the
+submitted repository and commit. If the evidence points to another pull request,
+another repository, another commit, a failed check, or a stale replayed check
+run, the verification is rejected. Missing or incomplete evidence is routed to
+review and cannot authorize payment.
+
 ## Public Artifacts
 
 Accepted public bounties should link to:


### PR DESCRIPTION
## Summary
- require structured GitHub CI evidence for `GitHubCi` verification: repository, pull request URL, commit SHA, and check-run metadata
- reject check evidence when repository, PR number, or check-run head SHA does not match the submitted work
- return deterministic `Accepted`, `Rejected`, or `NeedsReview` results with payload-bound hashes
- update API, MCP, CLI, eval-loop, Python SDK, and TypeScript SDK smoke paths to use the stricter evidence shape
- document the evidence contract for AI agents submitting `fix-ci-failure` and `small-code-change` bounties

## Verification
- `cargo test -p verifier-sdk`
- `cargo test -p verifier-sdk -p app -p api -p mcp-server -p eval-harness`
- `npm --prefix crates/sdk-typescript run build`
- `python -m compileall crates/sdk-python/agent_bounties`
- `cargo fmt --all --check`
- `cargo clippy -p verifier-sdk -p app -p api -p mcp-server -p eval-harness -p cli -- -D warnings`
- `cargo run -p cli -- docs-contract-check`
- `scripts/check.ps1`
- `scripts/check-production-compose.ps1 -ProjectName agent-bounties-prod-smoke-githubci -ApiPort 18380 -McpPort 18390`

Closes #4 when merged.