### PR TITLE
Add collaboration branch PR review action

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ Good first contributions:
 - Improve MCP/OpenAPI agent ergonomics.
 - Add GitHub dogfooding bounties.
 
+If your PR is useful but not ready for `main`, maintainers may copy it to a
+`collab/pr-<number>-<topic>` branch so other contributors can target follow-up
+PRs there. That keeps iteration moving while protected payment, workflow,
+contract, and release paths stay out of `main` until they pass the normal gates.
+Collaboration branches are not bounty acceptance or payout approval.
+
 Before running expensive checks, run the preflight:
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ Before approving gated Actions on an external PR, run
 [docs/secure-pr-review.md](docs/secure-pr-review.md). Review responses must be
 constructive: explain what passed, what blocked `main`, what command to run, and
 whether the work belongs on a collaboration branch such as
-`collab/pr-<number>-<topic>` while contributors continue iterating.
+`collab/pr-<number>-<topic>` while contributors continue iterating. For useful
+docs/spec work that is not main-ready, maintainers can opt in to preserving the
+PR head with `-CreateCollaborationBranch` or `--create-collaboration-branch`;
+that branch is not a merge approval, bounty acceptance, or payout approval.
 
 The local demo uses simulated credits and deterministic verifiers. Base Sepolia,
 Stripe, and GitHub adapters are present as integration boundaries and are gated

--- a/docs/secure-pr-review.md
+++ b/docs/secure-pr-review.md
@@ -87,6 +87,75 @@ scripts\review-external-pr.ps1 -Pr 6 -PostReview
 bash scripts/review-external-pr.sh --pr 6 --post-review
 ```
 
+To preserve useful work for continued iteration without merging it into
+`main`, opt in to creating or reusing a collaboration branch:
+
+```powershell
+scripts\review-external-pr.ps1 -Pr 6 -CreateCollaborationBranch -PostReview
+```
+
+```bash
+bash scripts/review-external-pr.sh --pr 6 --create-collaboration-branch --post-review
+```
+
+Use an explicit branch name when a maintainer has already announced one:
+
+```powershell
+scripts\review-external-pr.ps1 -Pr 6 -CreateCollaborationBranch -CollaborationBranch collab/pr-6-agent-quickstart
+```
+
+```bash
+bash scripts/review-external-pr.sh --pr 6 --create-collaboration-branch --collaboration-branch collab/pr-6-agent-quickstart
+```
+
+The branch creation flag is intentionally narrow. It refuses PRs that touch
+risky paths, will reuse an existing `collab/pr-<number>-...` branch when exactly
+one exists, and will not overwrite an existing branch that points at a different
+commit. A maintainer can still make a manual branch after deeper review, but the
+automation should not turn untrusted code into an upstream execution surface.
+
+## Constructive Review Format
+
+Every review outcome should leave the contributor with a repair path:
+
+- **Approve for main**: state what passed, list the checks that were trusted,
+  and remind readers that code review does not approve bounty payout or payment
+  settlement.
+- **Request changes**: state the blocker, give the exact local command to run,
+  point at the first failing file or contract mismatch, and explain what would
+  make the PR main-ready.
+- **Accept for collaboration branch**: state that the work is useful but not
+  main-ready, name the branch, invite follow-up PRs against that branch, and
+  say clearly that the branch is not a merge approval, bounty acceptance, or
+  payout approval.
+- **Manual security review**: state which risky paths triggered the lane and ask
+  for a smaller split if that would help review.
+
+Suggested "not main-ready yet" comment:
+
+```text
+Thanks for the contribution. I cannot approve this for main yet, but the repair
+path is concrete.
+
+What passed:
+- <docs-only / useful topic / no risky paths, when true>
+
+What blocks main:
+- <first failing check or risky path>
+
+Please run:
+`cargo run -p cli -- docs-contract-check`
+
+Recommended lane:
+<main-candidate | collaboration-branch-candidate | manual-security-review>
+
+Collaboration branch:
+<branch name or why one is not safe yet>
+
+This review does not approve bounty acceptance, merge, payout, or payment
+settlement.
+```
+
 ## Docs Contract Check
 
 `docs-contract-check` fails when docs reference:

--- a/scripts/review-external-pr.ps1
+++ b/scripts/review-external-pr.ps1
@@ -2,6 +2,8 @@ param(
     [Parameter(Mandatory = $true)]
     [int] $Pr,
     [string] $Repo = "NSPG13/agent-bounties",
+    [string] $CollaborationBranch,
+    [switch] $CreateCollaborationBranch,
     [switch] $PostReview
 )
 
@@ -85,6 +87,62 @@ function Get-DocsContractIssues {
     )
 }
 
+function New-CollaborationBranchName {
+    param(
+        [int] $Pr,
+        [string] $Topic
+    )
+
+    $slug = $Topic.ToLowerInvariant()
+    $slug = [regex]::Replace($slug, "[^a-z0-9]+", "-").Trim("-")
+    if ($slug.Length -gt 48) {
+        $slug = $slug.Substring(0, 48).Trim("-")
+    }
+    if ([string]::IsNullOrWhiteSpace($slug)) {
+        $slug = "contribution"
+    }
+    return "collab/pr-$Pr-$slug"
+}
+
+function Get-ExistingCollaborationBranch {
+    param([int] $Pr)
+
+    $prefix = "refs/heads/collab/pr-$Pr-"
+    $matches = @(
+        & git ls-remote --heads origin "$prefix*" |
+            ForEach-Object {
+                $parts = $_ -split "\s+", 2
+                if ($parts.Count -eq 2 -and $parts[1].StartsWith("refs/heads/")) {
+                    [pscustomobject]@{
+                        oid = $parts[0]
+                        name = $parts[1].Substring("refs/heads/".Length)
+                    }
+                }
+            }
+    )
+    if ($global:LASTEXITCODE -ne 0) {
+        throw "Unable to list existing collaboration branches"
+    }
+    $global:LASTEXITCODE = 0
+    if ($matches.Count -eq 1) {
+        return $matches[0]
+    }
+    return $null
+}
+
+function Assert-SafeCollaborationBranch {
+    param([string] $Name)
+
+    if ([string]::IsNullOrWhiteSpace($Name) -or -not $Name.StartsWith("collab/")) {
+        throw "Collaboration branches must be named collab/<topic>: $Name"
+    }
+    & git check-ref-format --branch $Name | Out-Null
+    if ($global:LASTEXITCODE -ne 0) {
+        throw "Invalid collaboration branch name: $Name"
+    }
+    $global:LASTEXITCODE = 0
+}
+
 function New-ConstructiveFeedback {
     param(
         [bool] $DocsOnly,
@@ -115,7 +173,7 @@ function New-ConstructiveFeedback {
 
 Push-Location $repoRoot
 try {
-    $prJson = gh pr view $Pr --repo $Repo --json number,title,url,author,headRefOid,files | ConvertFrom-Json
+    $prJson = gh pr view $Pr --repo $Repo --json number,title,url,author,headRefName,headRefOid,files | ConvertFrom-Json
     $changedFiles = @($prJson.files | ForEach-Object { $_.path })
     if ($changedFiles.Count -eq 0) {
         throw "PR #$Pr has no changed files"
@@ -194,6 +252,49 @@ try {
         -DocsCheckOk $docsCheckOk `
         -DocsIssues $docsIssues
 
+    $collaborationBranchName = $null
+    $collaborationBranchStatus = "not_requested"
+    if ($CreateCollaborationBranch) {
+        if (-not $collaborationBranchCandidate) {
+            throw "Refusing to create an upstream collaboration branch for PR #$Pr because the changed files require manual security review."
+        }
+        $existingCollaborationBranch = if ([string]::IsNullOrWhiteSpace($CollaborationBranch)) {
+            Get-ExistingCollaborationBranch -Pr $Pr
+        } else {
+            $null
+        }
+        $collaborationBranchName = if (-not [string]::IsNullOrWhiteSpace($CollaborationBranch)) {
+            $CollaborationBranch
+        } elseif ($null -ne $existingCollaborationBranch) {
+            $existingCollaborationBranch.name
+        } else {
+            New-CollaborationBranchName -Pr $Pr -Topic $prJson.headRefName
+        }
+        Assert-SafeCollaborationBranch -Name $collaborationBranchName
+        $remoteRef = "refs/heads/$collaborationBranchName"
+        $existingBranchLine = & git ls-remote --heads origin $remoteRef
+        if ($global:LASTEXITCODE -ne 0) {
+            throw "Unable to inspect remote collaboration branch: $collaborationBranchName"
+        }
+        $global:LASTEXITCODE = 0
+        $existingBranchOid = if (-not [string]::IsNullOrWhiteSpace($existingBranchLine)) {
+            ($existingBranchLine -split "\s+", 2)[0]
+        } else {
+            $null
+        }
+        if ($existingBranchOid) {
+            $collaborationBranchStatus = if ($existingBranchOid -eq $fetchedOid) {
+                "exists_at_pr_head"
+            } else {
+                "exists_different_head"
+            }
+        } else {
+            $refspec = "${fetchedOid}:$remoteRef"
+            Invoke-Checked { git push origin $refspec }
+            $collaborationBranchStatus = "created"
+        }
+    }
+
     $result = [ordered]@{
         pr = $prJson.number
         title = $prJson.title
@@ -203,6 +304,8 @@ try {
         safe_for_maintainer_ci = ($safeForMaintainerCi -and $docsCheckOk)
         main_candidate = $mainCandidate
         collaboration_branch_candidate = $collaborationBranchCandidate
+        collaboration_branch = $collaborationBranchName
+        collaboration_branch_status = $collaborationBranchStatus
         recommended_lane = $recommendedLane
         risky_files = [string[]]@($riskyFiles)
         non_docs_files = [string[]]@($nonDocsFiles)
@@ -242,7 +345,11 @@ Next steps:
                 $blockers += "Docs contract check failed:`n$(Format-MarkdownList $docsIssues -Empty '- The checker failed without line-specific issues. Run the command below for full output.')"
             }
             $branchGuidance = if ($collaborationBranchCandidate) {
-                "This looks suitable for a collaboration branch such as `collab/pr-$Pr-<short-topic>` if a maintainer wants others to iterate on it without merging to `main` yet. That branch would not imply bounty acceptance or payment approval."
+                if ($CreateCollaborationBranch) {
+                    "This is suitable for a collaboration branch. Branch `$collaborationBranchName` status: `$collaborationBranchStatus`. That branch does not imply bounty acceptance, merge approval, or payment approval."
+                } else {
+                    "This looks suitable for a collaboration branch such as `collab/pr-$Pr-<short-topic>` if a maintainer wants others to iterate on it without merging to `main` yet. That branch would not imply bounty acceptance or payment approval."
+                }
             } else {
                 "Do not move this to an upstream collaboration branch automatically. The risky or non-doc paths need manual maintainer security review first."
             }

--- a/scripts/review-external-pr.sh
+++ b/scripts/review-external-pr.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 repo="NSPG13/agent-bounties"
 post_review=false
+create_collaboration_branch=false
+collaboration_branch=""
 pr=""
 
 while [[ $# -gt 0 ]]; do
@@ -14,6 +16,14 @@ while [[ $# -gt 0 ]]; do
     --post-review)
       post_review=true
       shift
+      ;;
+    --create-collaboration-branch)
+      create_collaboration_branch=true
+      shift
+      ;;
+    --collaboration-branch)
+      collaboration_branch="$2"
+      shift 2
       ;;
     --pr)
       pr="$2"
@@ -32,7 +42,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$pr" ]]; then
-  echo "usage: scripts/review-external-pr.sh --pr <number> [--repo owner/name] [--post-review]" >&2
+  echo "usage: scripts/review-external-pr.sh --pr <number> [--repo owner/name] [--post-review] [--create-collaboration-branch] [--collaboration-branch collab/name]" >&2
   exit 64
 fi
 
@@ -100,6 +110,36 @@ json_array() {
   done
 }
 
+slugify_branch_topic() {
+  local topic="$1"
+  local slug
+  slug="$(
+    printf '%s' "$topic" |
+      tr '[:upper:]' '[:lower:]' |
+      sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/^(.{0,48}).*$/\1/; s/-+$//'
+  )"
+  if [[ -z "$slug" ]]; then
+    slug="contribution"
+  fi
+  printf 'collab/pr-%s-%s' "$pr" "$slug"
+}
+
+existing_collaboration_branch() {
+  mapfile -t matches < <(git ls-remote --heads origin "refs/heads/collab/pr-${pr}-*" | awk '{print $2}' | sed 's#^refs/heads/##')
+  if [[ "${#matches[@]}" -eq 1 ]]; then
+    printf '%s' "${matches[0]}"
+  fi
+}
+
+assert_safe_collaboration_branch() {
+  local branch="$1"
+  if [[ -z "$branch" || "$branch" != collab/* ]]; then
+    echo "collaboration branches must be named collab/<topic>: $branch" >&2
+    exit 64
+  fi
+  git check-ref-format --branch "$branch" >/dev/null
+}
+
 mapfile -t changed_files < <(gh pr view "$pr" --repo "$repo" --json files --jq '.files[].path')
 if [[ "${#changed_files[@]}" -eq 0 ]]; then
   echo "PR #$pr has no changed files" >&2
@@ -123,6 +163,7 @@ if [[ "${#non_docs_files[@]}" -ne 0 ]]; then
 fi
 
 head_oid="$(gh pr view "$pr" --repo "$repo" --json headRefOid --jq '.headRefOid')"
+head_ref_name="$(gh pr view "$pr" --repo "$repo" --json headRefName --jq '.headRefName')"
 ref_name="refs/remotes/origin/pr-${pr}-review"
 git fetch origin "+pull/${pr}/head:${ref_name}"
 fetched_oid="$(git rev-parse "$ref_name")"
@@ -166,6 +207,32 @@ elif [[ "$collaboration_branch_candidate" == true ]]; then
   recommended_lane="collaboration-branch-candidate"
 fi
 
+collaboration_branch_status="not_requested"
+if [[ "$create_collaboration_branch" == true ]]; then
+  if [[ "$collaboration_branch_candidate" != true ]]; then
+    echo "refusing to create an upstream collaboration branch for PR #$pr because the changed files require manual security review" >&2
+    exit 1
+  fi
+  if [[ -z "$collaboration_branch" ]]; then
+    collaboration_branch="$(existing_collaboration_branch)"
+  fi
+  if [[ -z "$collaboration_branch" ]]; then
+    collaboration_branch="$(slugify_branch_topic "$head_ref_name")"
+  fi
+  assert_safe_collaboration_branch "$collaboration_branch"
+  existing_oid="$(git ls-remote --heads origin "refs/heads/${collaboration_branch}" | awk '{print $1}')"
+  if [[ -n "$existing_oid" ]]; then
+    if [[ "$existing_oid" == "$fetched_oid" ]]; then
+      collaboration_branch_status="exists_at_pr_head"
+    else
+      collaboration_branch_status="exists_different_head"
+    fi
+  else
+    git push origin "${fetched_oid}:refs/heads/${collaboration_branch}"
+    collaboration_branch_status="created"
+  fi
+fi
+
 feedback_items=()
 if [[ "$docs_only" != true ]]; then
   feedback_items+=("Split docs-only changes from code or infrastructure changes, or wait for manual maintainer review of the non-doc paths.")
@@ -189,6 +256,8 @@ printf '  "docs_only": %s,\n' "$docs_only"
 printf '  "safe_for_maintainer_ci": %s,\n' "$safe_for_maintainer_ci"
 printf '  "main_candidate": %s,\n' "$safe_for_maintainer_ci"
 printf '  "collaboration_branch_candidate": %s,\n' "$collaboration_branch_candidate"
+printf '  "collaboration_branch": "%s",\n' "$collaboration_branch"
+printf '  "collaboration_branch_status": "%s",\n' "$collaboration_branch_status"
 printf '  "recommended_lane": "%s",\n' "$recommended_lane"
 printf '  "docs_contract_check": "%s",\n' "$docs_contract_check"
 printf '  "risky_files": [%s],\n' "$(json_array "${risky_files[@]}")"
@@ -238,7 +307,11 @@ EOF
       printf '```bash\ncargo run -p cli -- docs-contract-check\n```\n\n'
       printf 'Collaboration branch guidance:\n'
       if [[ "$collaboration_branch_candidate" == true ]]; then
-        printf 'This looks suitable for a collaboration branch such as collab/pr-%s-<short-topic> if a maintainer wants others to iterate on it without merging to main yet. That branch would not imply bounty acceptance or payment approval.\n' "$pr"
+        if [[ "$create_collaboration_branch" == true ]]; then
+          printf 'This is suitable for a collaboration branch. Branch %s status: %s. That branch does not imply bounty acceptance, merge approval, or payment approval.\n' "$collaboration_branch" "$collaboration_branch_status"
+        else
+          printf 'This looks suitable for a collaboration branch such as collab/pr-%s-<short-topic> if a maintainer wants others to iterate on it without merging to main yet. That branch would not imply bounty acceptance or payment approval.\n' "$pr"
+        fi
       else
         printf 'Do not move this to an upstream collaboration branch automatically. The risky or non-doc paths need manual maintainer security review first.\n'
       fi


### PR DESCRIPTION
## Summary
- add an opt-in collaboration branch action to the trusted external PR review scripts
- reuse existing `collab/pr-<number>-...` branches when present and refuse risky-path PRs automatically
- document constructive feedback requirements for approve, request-changes, collaboration-branch, and manual-security lanes

## Validation
- `scripts/preflight.ps1 -Mode core`
- `bash -n scripts/review-external-pr.sh`
- `cargo run -p cli -- docs-contract-check`
- `scripts/review-external-pr.ps1 -Pr 6 -CreateCollaborationBranch -CollaborationBranch collab/pr-6-agent-quickstart` (no post)
- `scripts/review-external-pr.ps1 -Pr 6 -CreateCollaborationBranch` (no post)

PR #6 remains blocked from main because `docs-contract-check` reports stale discovery keys, API paths pointed at the MCP port, unknown MCP tool names, and an invalid `/v1/agents` payload. It is suitable for continued work on `collab/pr-6-agent-quickstart`.