### PR TITLE
Link funding contributions to ledger and settlement records

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1127,6 +1127,7 @@ async fn verify_submission(
         bounty,
         verifier_result,
         settlements,
+        funding_contributions,
         reputation_events,
         template_signals,
         ledger_entries,
@@ -1148,6 +1149,12 @@ async fn verify_submission(
                 .filter(|settlement| settlement.bounty_id == proof.bounty_id)
                 .cloned()
                 .collect::<Vec<_>>();
+            let funding_contributions = network
+                .funding_contributions
+                .values()
+                .filter(|contribution| contribution.bounty_id == proof.bounty_id)
+                .cloned()
+                .collect::<Vec<_>>();
             let reputation_events = network
                 .reputation_events
                 .values()
@@ -1166,6 +1173,7 @@ async fn verify_submission(
                 bounty,
                 verifier_result,
                 settlements,
+                funding_contributions,
                 reputation_events,
                 template_signals,
                 ledger_entries,
@@ -1201,6 +1209,12 @@ async fn verify_submission(
         for settlement in &settlements {
             store
                 .upsert_settlement(settlement)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        }
+        for contribution in &funding_contributions {
+            store
+                .upsert_funding_contribution(contribution)
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -630,25 +630,29 @@ impl BountyNetwork {
 
         bounty.mark_funded(terms_hash)?;
         bounty.make_claimable()?;
+        let entry = LedgerEntry::new(
+            "fund bounty",
+            Some(format!("fund:{}", bounty.id)),
+            vec![
+                debit("escrow_asset", amount.clone()),
+                credit("bounty_liability", amount.clone()),
+            ],
+        )?;
+        self.ledger.append(entry.clone())?;
+
         let contribution = FundingContribution {
             id: Uuid::new_v4(),
             bounty_id: bounty.id,
             contributor_agent_id: None,
             rail: payment_rail_for_funding_mode(&funding_mode),
-            amount: amount.clone(),
+            amount,
             status: FundingContributionStatus::Applied,
+            funding_ledger_entry_id: Some(entry.id),
+            refund_ledger_entry_id: None,
+            settlement_id: None,
             external_reference: Some(format!("initial:{}", bounty.id)),
             created_at: Utc::now(),
         };
-
-        self.ledger.append(LedgerEntry::new(
-            "fund bounty",
-            Some(format!("fund:{}", bounty.id)),
-            vec![
-                debit("escrow_asset", amount.clone()),
-                credit("bounty_liability", amount),
-            ],
-        )?)?;
 
         self.funding_contributions
             .insert(contribution.id, contribution);
@@ -745,29 +749,35 @@ impl BountyNetwork {
             )));
         }
 
-        let contribution = FundingContribution {
-            id: Uuid::new_v4(),
-            bounty_id: bounty.id,
-            contributor_agent_id: request.contributor_agent_id,
-            rail: request.rail,
-            amount: amount.clone(),
-            status: FundingContributionStatus::Applied,
-            external_reference: request.external_reference,
-            created_at: Utc::now(),
-        };
-        let contributor_account = contribution
-            .contributor_agent_id
+        let contribution_id = Uuid::new_v4();
+        let contributor_agent_id = request.contributor_agent_id;
+        let rail = request.rail;
+        let external_reference = request.external_reference;
+        let contributor_account = contributor_agent_id
             .map(|id| format!("contributor_funds:{id}"))
             .unwrap_or_else(|| "external_contributor_funds".to_string());
         let entry = LedgerEntry::new(
             "pooled bounty funding contribution",
-            Some(format!("fund-contribution:{}", contribution.id)),
+            Some(format!("fund-contribution:{contribution_id}")),
             vec![
                 debit(contributor_account, amount.clone()),
-                credit(format!("bounty_liability:{}", bounty.id), amount),
+                credit(format!("bounty_liability:{}", bounty.id), amount.clone()),
             ],
         )?;
         self.ledger.append(entry.clone())?;
+        let contribution = FundingContribution {
+            id: contribution_id,
+            bounty_id: bounty.id,
+            contributor_agent_id,
+            rail,
+            amount: amount.clone(),
+            status: FundingContributionStatus::Applied,
+            funding_ledger_entry_id: Some(entry.id),
+            refund_ledger_entry_id: None,
+            settlement_id: None,
+            external_reference,
+            created_at: Utc::now(),
+        };
         self.funding_contributions
             .insert(contribution.id, contribution.clone());
 
@@ -963,6 +973,7 @@ impl BountyNetwork {
             submission.solver_agent_id,
             result.verifier_agent_id,
         )?;
+        self.link_funding_contributions_to_settlement(request.bounty_id, settlement.id);
         let reputation_reason = if settlement
             .payout_intents
             .iter()
@@ -2103,6 +2114,18 @@ impl BountyNetwork {
         })
     }
 
+    fn link_funding_contributions_to_settlement(&mut self, bounty_id: Id, settlement_id: Id) {
+        for contribution in self
+            .funding_contributions
+            .values_mut()
+            .filter(|contribution| contribution.bounty_id == bounty_id)
+        {
+            if contribution.status == FundingContributionStatus::Applied {
+                contribution.settlement_id = Some(settlement_id);
+            }
+        }
+    }
+
     fn update_base_escrow_status(&mut self, escrow_id: Id, status: EscrowStatus) -> AppResult<()> {
         let escrow = self.escrows.get_mut(&escrow_id).ok_or_else(|| {
             AppError::InvalidBaseEscrowEvent(
@@ -3023,6 +3046,32 @@ mod tests {
     }
 
     #[test]
+    fn initial_non_base_funding_contribution_links_to_ledger_entry() {
+        let mut network = BountyNetwork::default();
+        let bounty = network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Write onboarding docs".to_string(),
+                template_slug: "write-docs-for-area".to_string(),
+                amount_minor: 1_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::Simulated,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+
+        let status = network.status(bounty.id).unwrap();
+        let contribution = status.funding_contributions.first().unwrap();
+
+        assert_eq!(network.ledger.entries().len(), 1);
+        assert_eq!(
+            contribution.funding_ledger_entry_id,
+            Some(network.ledger.entries()[0].id)
+        );
+        assert_eq!(contribution.settlement_id, None);
+        assert_eq!(contribution.refund_ledger_entry_id, None);
+    }
+
+    #[test]
     fn pooled_simulated_funding_becomes_claimable_only_at_target() {
         let mut network = BountyNetwork::default();
         let solver = network.register_agent(RegisterAgentRequest {
@@ -3074,6 +3123,12 @@ mod tests {
         assert_eq!(partial.funding_summary.applied.amount, 400);
         assert_eq!(partial.funding_summary.remaining.amount, 600);
         assert!(!partial.funding_summary.claimable);
+        assert_eq!(
+            partial.contribution.funding_ledger_entry_id,
+            Some(partial.ledger_entries[0].id)
+        );
+        assert_eq!(partial.contribution.settlement_id, None);
+        assert_eq!(partial.contribution.refund_ledger_entry_id, None);
         assert!(network.list_claimable_bounties().is_empty());
 
         let funded = network
@@ -3091,6 +3146,10 @@ mod tests {
         assert_eq!(funded.funding_summary.remaining.amount, 0);
         assert_eq!(funded.funding_summary.contribution_count, 2);
         assert!(funded.funding_summary.claimable);
+        assert_eq!(
+            funded.contribution.funding_ledger_entry_id,
+            Some(funded.ledger_entries[0].id)
+        );
         assert_eq!(network.list_claimable_bounties().len(), 1);
         assert_eq!(network.ledger.entries().len(), 2);
 
@@ -3101,6 +3160,78 @@ mod tests {
             })
             .unwrap();
         assert_eq!(claimed.status, BountyStatus::Claimed);
+    }
+
+    #[tokio::test]
+    async fn pooled_contributions_link_to_settlement_after_verification() {
+        let mut network = BountyNetwork::default();
+        let solver = network.register_agent(RegisterAgentRequest {
+            handle: "solver".to_string(),
+            payout_wallet: None,
+        });
+        let sponsor = network.register_agent(RegisterAgentRequest {
+            handle: "sponsor".to_string(),
+            payout_wallet: None,
+        });
+        let bounty = network
+            .open_pooled_bounty(OpenPooledBountyRequest {
+                title: "Extract public data".to_string(),
+                template_slug: "extract-data-to-schema".to_string(),
+                target_amount_minor: 1_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::Simulated,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+        network
+            .add_funding_contribution(AddFundingContributionRequest {
+                bounty_id: bounty.id,
+                contributor_agent_id: Some(sponsor.id),
+                amount_minor: 1_000,
+                currency: "usdc".to_string(),
+                rail: PaymentRail::Simulated,
+                external_reference: Some("sponsor-full".to_string()),
+            })
+            .unwrap();
+        network
+            .claim_bounty(ClaimBountyRequest {
+                bounty_id: bounty.id,
+                solver_agent_id: solver.id,
+            })
+            .unwrap();
+        let artifact = "{\"ok\":true}";
+        let submission = network
+            .submit_result(SubmitResultRequest {
+                bounty_id: bounty.id,
+                solver_agent_id: solver.id,
+                artifact_uri: "memory://pooled-artifact".to_string(),
+                artifact_body: artifact.to_string(),
+            })
+            .unwrap();
+
+        network
+            .verify_submission(VerifySubmissionRequest {
+                bounty_id: bounty.id,
+                submission_id: submission.id,
+                expected_artifact_digest: hash_artifact(artifact),
+                verifier_kind: Some(VerifierKind::JsonSchema),
+                rubric: None,
+                evidence: None,
+                approved_risk_event_id: None,
+            })
+            .await
+            .unwrap();
+
+        let status = network.status(bounty.id).unwrap();
+        let settlement = status.settlements.first().unwrap();
+
+        assert_eq!(status.funding_contributions.len(), 1);
+        assert_eq!(
+            status.funding_contributions[0].settlement_id,
+            Some(settlement.id)
+        );
+        assert_eq!(status.funding_contributions[0].refund_ledger_entry_id, None);
+        assert_eq!(status.bounty.status, BountyStatus::Paid);
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2012,6 +2012,7 @@ struct ServiceSmokeReport {
     bounty_id: String,
     feed_items: usize,
     mcp_tools: usize,
+    pooled_bounty_id: String,
     mcp_reviewed_bounty_id: String,
     mcp_bounty_id: String,
     mcp_solver_id: String,
@@ -2305,6 +2306,94 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         api_risk_policy.pointer("/ai_judges_can_authorize_payment")
             == Some(&serde_json::json!(false)),
         "API risk policy must state that AI judges cannot authorize payment",
+    )?;
+
+    let pooled_bounty = post_json(
+        &format!("{api}/v1/bounties/pooled"),
+        serde_json::json!({
+            "title": "Service smoke pooled bounty",
+            "template_slug": "extract-data-to-schema",
+            "target_amount_minor": 1_000,
+            "currency": "usdc",
+            "funding_mode": "Simulated",
+            "privacy": "Public"
+        }),
+    )?;
+    let pooled_bounty_id = value_str(&pooled_bounty, "/id")
+        .context("pooled bounty id missing")?
+        .to_string();
+    let pooled_funding = post_json(
+        &format!("{api}/v1/bounties/{pooled_bounty_id}/funding-contributions"),
+        serde_json::json!({
+            "bounty_id": pooled_bounty_id.as_str(),
+            "contributor_agent_id": null,
+            "amount_minor": 1_000,
+            "currency": "usdc",
+            "rail": "Simulated",
+            "external_reference": format!("service-smoke-pooled-{smoke_id}")
+        }),
+    )?;
+    require(
+        value_str(&pooled_funding, "/bounty/status") == Some("Claimable"),
+        "pooled simulated funding must make the bounty claimable at target",
+    )?;
+    require(
+        pooled_funding
+            .pointer("/contribution/funding_ledger_entry_id")
+            .and_then(|value| value.as_str())
+            .is_some(),
+        "pooled funding contribution must link to its funding ledger entry",
+    )?;
+    let pooled_claim = post_json(
+        &format!("{api}/v1/bounties/{pooled_bounty_id}/claim"),
+        serde_json::json!({
+            "bounty_id": pooled_bounty_id.as_str(),
+            "solver_agent_id": solver_id.as_str()
+        }),
+    )?;
+    require(
+        value_str(&pooled_claim, "/status") == Some("Claimed"),
+        "pooled bounty claim must move bounty to Claimed",
+    )?;
+    let pooled_artifact_body = "{\"pooled_smoke\":true}";
+    let pooled_submission = post_json(
+        &format!("{api}/v1/bounties/{pooled_bounty_id}/submit"),
+        serde_json::json!({
+            "bounty_id": pooled_bounty_id.as_str(),
+            "solver_agent_id": solver_id.as_str(),
+            "artifact_uri": "memory://service-smoke-pooled-artifact",
+            "artifact_body": pooled_artifact_body
+        }),
+    )?;
+    let pooled_submission_id =
+        value_str(&pooled_submission, "/id").context("pooled submission id missing")?;
+    let pooled_proof = post_json(
+        &format!("{api}/v1/bounties/{pooled_bounty_id}/verify"),
+        serde_json::json!({
+            "bounty_id": pooled_bounty_id.as_str(),
+            "submission_id": pooled_submission_id,
+            "expected_artifact_digest": hash_artifact(pooled_artifact_body),
+            "verifier_kind": "JsonSchema",
+            "rubric": null,
+            "evidence": null,
+            "approved_risk_event_id": null
+        }),
+    )?;
+    require(
+        value_str(&pooled_proof, "/proof_hash").is_some(),
+        "pooled bounty verification must return a proof hash",
+    )?;
+    let pooled_status = get_json(&format!("{api}/v1/bounties/{pooled_bounty_id}"))?;
+    let pooled_settlement_id =
+        value_str(&pooled_status, "/settlements/0/id").context("pooled settlement id missing")?;
+    require(
+        value_str(&pooled_status, "/bounty/status") == Some("Paid"),
+        "pooled simulated bounty must settle to Paid",
+    )?;
+    require(
+        value_str(&pooled_status, "/funding_contributions/0/settlement_id")
+            == Some(pooled_settlement_id),
+        "pooled funding contribution must link to the settlement after verification",
     )?;
 
     let bounty = post_json(
@@ -3042,6 +3131,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         bounty_id,
         feed_items: feed_items.len(),
         mcp_tools: tool_list.len(),
+        pooled_bounty_id,
         mcp_reviewed_bounty_id: mcp_reviewed_bounty_id.to_string(),
         mcp_bounty_id,
         mcp_solver_id: mcp_solver_id.to_string(),
@@ -3061,6 +3151,7 @@ fn print_service_smoke_report(report: &ServiceSmokeReport) -> Result<()> {
             "bounty_id": report.bounty_id,
             "feed_items": report.feed_items,
             "mcp_tools": report.mcp_tools,
+            "pooled_bounty_id": report.pooled_bounty_id,
             "mcp_reviewed_bounty_id": report.mcp_reviewed_bounty_id,
             "mcp_bounty_id": report.mcp_bounty_id,
             "mcp_solver_id": report.mcp_solver_id,
@@ -3200,6 +3291,29 @@ fn verify_service_smoke_restart_persistence(
                 .map(|settlements| !settlements.is_empty())
                 .unwrap_or(false),
             "restarted API must hydrate MCP-created settlement records",
+        )?;
+
+        let pooled_bounty_status =
+            get_json(&format!("{api}/v1/bounties/{}", report.pooled_bounty_id))?;
+        let pooled_settlement_id = value_str(&pooled_bounty_status, "/settlements/0/id")
+            .context("restarted pooled bounty settlement id missing")?;
+        require(
+            value_str(&pooled_bounty_status, "/bounty/status") == Some("Paid"),
+            "restarted API must hydrate paid pooled bounty from Postgres",
+        )?;
+        require(
+            pooled_bounty_status
+                .pointer("/funding_contributions/0/funding_ledger_entry_id")
+                .and_then(|value| value.as_str())
+                .is_some(),
+            "restarted API must hydrate pooled contribution funding ledger linkage",
+        )?;
+        require(
+            value_str(
+                &pooled_bounty_status,
+                "/funding_contributions/0/settlement_id",
+            ) == Some(pooled_settlement_id),
+            "restarted API must hydrate pooled contribution settlement linkage",
         )?;
 
         let reviewed_bounty_status = get_json(&format!(

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -410,14 +410,17 @@ impl PostgresStore {
         sqlx::query(
             r#"
             INSERT INTO funding_contributions
-              (id, bounty_id, contributor_agent_id, rail, amount, currency, status, external_reference, created_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+              (id, bounty_id, contributor_agent_id, rail, amount, currency, status, funding_ledger_entry_id, refund_ledger_entry_id, settlement_id, external_reference, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             ON CONFLICT (id) DO UPDATE SET
               contributor_agent_id = EXCLUDED.contributor_agent_id,
               rail = EXCLUDED.rail,
               amount = EXCLUDED.amount,
               currency = EXCLUDED.currency,
               status = EXCLUDED.status,
+              funding_ledger_entry_id = EXCLUDED.funding_ledger_entry_id,
+              refund_ledger_entry_id = EXCLUDED.refund_ledger_entry_id,
+              settlement_id = EXCLUDED.settlement_id,
               external_reference = EXCLUDED.external_reference
             "#,
         )
@@ -428,6 +431,9 @@ impl PostgresStore {
         .bind(contribution.amount.amount)
         .bind(&contribution.amount.currency)
         .bind(format!("{:?}", contribution.status))
+        .bind(contribution.funding_ledger_entry_id)
+        .bind(contribution.refund_ledger_entry_id)
+        .bind(contribution.settlement_id)
         .bind(&contribution.external_reference)
         .bind(contribution.created_at)
         .execute(&self.pool)
@@ -438,7 +444,7 @@ impl PostgresStore {
     pub async fn list_funding_contributions(&self) -> DbResult<Vec<FundingContribution>> {
         let rows = sqlx::query(
             r#"
-            SELECT id, bounty_id, contributor_agent_id, rail, amount, currency, status, external_reference, created_at
+            SELECT id, bounty_id, contributor_agent_id, rail, amount, currency, status, funding_ledger_entry_id, refund_ledger_entry_id, settlement_id, external_reference, created_at
             FROM funding_contributions
             ORDER BY created_at
             "#,
@@ -458,6 +464,9 @@ impl PostgresStore {
                         row.try_get::<String, _>("currency")?,
                     )?,
                     status: parse_funding_contribution_status(row.try_get::<String, _>("status")?)?,
+                    funding_ledger_entry_id: row.try_get("funding_ledger_entry_id")?,
+                    refund_ledger_entry_id: row.try_get("refund_ledger_entry_id")?,
+                    settlement_id: row.try_get("settlement_id")?,
                     external_reference: row.try_get("external_reference")?,
                     created_at: row.try_get("created_at")?,
                 })
@@ -1429,6 +1438,10 @@ mod tests {
             assert!(CORE_MIGRATION.contains(table), "missing {table}");
         }
         assert!(CORE_MIGRATION.contains("idx_funding_contributions_external_reference"));
+        assert!(CORE_MIGRATION.contains("funding_ledger_entry_id UUID"));
+        assert!(CORE_MIGRATION.contains("refund_ledger_entry_id UUID"));
+        assert!(CORE_MIGRATION.contains("settlement_id UUID"));
+        assert!(CORE_MIGRATION.contains("fund-contribution:"));
     }
 
     #[test]

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -494,6 +494,9 @@ pub struct FundingContribution {
     pub rail: PaymentRail,
     pub amount: Money,
     pub status: FundingContributionStatus,
+    pub funding_ledger_entry_id: Option<Id>,
+    pub refund_ledger_entry_id: Option<Id>,
+    pub settlement_id: Option<Id>,
     pub external_reference: Option<String>,
     pub created_at: DateTime<Utc>,
 }

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -1532,6 +1532,7 @@ async fn request_verification(
         bounty,
         verifier_result,
         settlements,
+        funding_contributions,
         reputation_events,
         template_signals,
         ledger_entries,
@@ -1553,6 +1554,12 @@ async fn request_verification(
                 .filter(|settlement| settlement.bounty_id == proof.bounty_id)
                 .cloned()
                 .collect::<Vec<_>>();
+            let funding_contributions = network
+                .funding_contributions
+                .values()
+                .filter(|contribution| contribution.bounty_id == proof.bounty_id)
+                .cloned()
+                .collect::<Vec<_>>();
             let reputation_events = network
                 .reputation_events
                 .values()
@@ -1571,6 +1578,7 @@ async fn request_verification(
                 bounty,
                 verifier_result,
                 settlements,
+                funding_contributions,
                 reputation_events,
                 template_signals,
                 ledger_entries,
@@ -1603,6 +1611,11 @@ async fn request_verification(
         }
         for settlement in &settlements {
             if let Err(error) = store.upsert_settlement(settlement).await {
+                return mcp_error(error);
+            }
+        }
+        for contribution in &funding_contributions {
+            if let Err(error) = store.upsert_funding_contribution(contribution).await {
                 return mcp_error(error);
             }
         }

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -9,9 +9,13 @@ solver can claim it. `POST /v1/bounties/pooled` and MCP
 `open_pooled_bounty` create an unfunded target with a terms hash. Contributors
 then call `POST /v1/bounties/{id}/funding-contributions` or MCP
 `add_bounty_funding`. Each applied contribution writes a balanced ledger entry,
-updates the bounty funding summary, and leaves the bounty unclaimable until the
-applied total exactly reaches the target amount. Overfunding and duplicate
-external contribution references are rejected deterministically.
+stores the funding ledger entry id on new contribution records, updates the
+bounty funding summary, and leaves the bounty unclaimable until the applied
+total exactly reaches the target amount. Contribution records also carry nullable
+refund ledger entry and settlement ids so later payout or refund review can bind
+back to the exact funding source. Legacy hydrated rows without an older ledger
+link remain readable but new funding events populate the link. Overfunding and
+duplicate external contribution references are rejected deterministically.
 
 This first pooled path is implemented for internal ledger rails such as
 `Simulated` and `StripeFiatLedger`. The current Base escrow contract remains a

--- a/migrations/0001_core.sql
+++ b/migrations/0001_core.sql
@@ -66,9 +66,19 @@ CREATE TABLE IF NOT EXISTS funding_contributions (
   amount BIGINT NOT NULL CHECK (amount > 0),
   currency TEXT NOT NULL,
   status TEXT NOT NULL,
+  funding_ledger_entry_id UUID,
+  refund_ledger_entry_id UUID,
+  settlement_id UUID,
   external_reference TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+ALTER TABLE funding_contributions
+  ADD COLUMN IF NOT EXISTS funding_ledger_entry_id UUID;
+ALTER TABLE funding_contributions
+  ADD COLUMN IF NOT EXISTS refund_ledger_entry_id UUID;
+ALTER TABLE funding_contributions
+  ADD COLUMN IF NOT EXISTS settlement_id UUID;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_funding_contributions_external_reference
   ON funding_contributions (bounty_id, external_reference)
@@ -216,6 +226,15 @@ CREATE TABLE IF NOT EXISTS ledger_entries (
   postings JSONB NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+UPDATE funding_contributions fc
+SET funding_ledger_entry_id = le.id
+FROM ledger_entries le
+WHERE fc.funding_ledger_entry_id IS NULL
+  AND (
+    le.external_event_id = 'fund-contribution:' || fc.id::text
+    OR le.external_event_id = 'fund:' || fc.bounty_id::text
+  );
 
 CREATE TABLE IF NOT EXISTS payment_events (
   id UUID PRIMARY KEY,


### PR DESCRIPTION
Closes #1.

## Summary
- Add durable audit linkage fields to `FundingContribution`: funding ledger entry id, refund ledger entry id, and settlement id.
- Populate funding ledger links for initial and pooled contributions, and link applied contributions to the settlement created during verification.
- Persist and hydrate the new fields through Postgres, including compatibility `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migration behavior for existing local volumes.
- Extend API/MCP verification persistence so updated contribution settlement links are stored.
- Expand service smoke and restart persistence checks with a simulated pooled bounty lifecycle that verifies funding ledger and settlement linkage after restart.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p cli -p api -p mcp-server -p app -p db`
- `cargo run -p cli -- service-smoke-spawn --api-base-url http://127.0.0.1:18080 --mcp-base-url http://127.0.0.1:18090`
- `scripts/check-postgres.ps1`
- `scripts/check.ps1`

## Notes
- Existing hydrated contribution rows without a historical ledger link remain readable; new funding events populate the link.
- This is not a payout approval or payment settlement decision.