### PR TITLE
Strengthen constructive PR review workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## What Changed
+
+Describe the smallest useful product, docs, verifier, payment-trust, or agent
+distribution improvement in this PR.
+
+## Linked Bounty Or Issue
+
+Link the bounty, issue, or discussion this PR addresses. If there is no bounty,
+say so explicitly.
+
+## Acceptance Criteria
+
+- [ ] The PR has a clear verifier or review path.
+- [ ] Deterministic behavior has tests or a documented manual check.
+- [ ] Payment, settlement, and payout behavior is unchanged or explicitly
+      covered by tests and docs.
+
+## Local Checks
+
+List the commands you ran, for example:
+
+```bash
+cargo run -p cli -- docs-contract-check
+cargo test -p <crate>
+```
+
+## Review Lane
+
+- [ ] I believe this is ready for `main`.
+- [ ] If useful but not main-ready, I am comfortable with maintainers preserving
+      this work on a `collab/pr-<number>-<topic>` branch for follow-up PRs.
+- [ ] This touches risky paths and needs manual maintainer security review.
+
+Code review, CI approval, and collaboration-branch preservation do not approve
+bounty acceptance, payout, or payment settlement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,18 @@ digital work, and receive settlement through trusted payment rails.
 5. Run the narrowest meaningful checks first, then broader gates when disk and
    local services allow it.
 
+## PR Review Loop
+
+- Treat external PRs as untrusted input until `scripts/review-external-pr.ps1`
+  or `scripts/review-external-pr.sh` and maintainer review say otherwise.
+- Every approve, request-changes, reject, close, or supersede response must be
+  constructive: say what passed, what blocks `main`, what command or file fixes
+  it, and whether a collaboration branch is appropriate.
+- Preserve useful but not-main-ready work on `collab/pr-<number>-<topic>` when
+  it is safe to do so. A collaboration branch lets contributors keep iterating,
+  but it is not merge approval, bounty acceptance, payout approval, or payment
+  settlement.
+
 ## Payment Invariants
 
 - A paid bounty must be funded before claim.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ whether the work belongs on a collaboration branch such as
 docs/spec work that is not main-ready, maintainers can opt in to preserving the
 PR head with `-CreateCollaborationBranch` or `--create-collaboration-branch`;
 that branch is not a merge approval, bounty acceptance, or payout approval.
+The PR template asks contributors which review lane they expect and whether a
+safe collaboration branch is acceptable if the work needs more iteration.
 
 The local demo uses simulated credits and deterministic verifiers. Base Sepolia,
 Stripe, and GitHub adapters are present as integration boundaries and are gated

--- a/docs/secure-pr-review.md
+++ b/docs/secure-pr-review.md
@@ -35,6 +35,9 @@ executing code from the PR.
   next steps. Tell the contributor what passed, what blocked main, the exact
   command to run locally, and whether the work is suitable for a collaboration
   branch.
+- Close or reject a PR only after leaving a public repair path. The repair path
+  should say whether the contributor should update the same PR, open a smaller
+  replacement PR, or continue against a collaboration branch.
 - Changes under `.github/workflows/`, `scripts/`, `contracts/`, `migrations/`,
   `crates/`, dependency manifests, or lockfiles require manual review.
 - Automation can post review comments or request changes, but it must not merge,
@@ -62,10 +65,38 @@ A collaboration branch is not a bounty acceptance, payment approval, or merge
 approval. It is a staging lane for useful work that should remain visible while
 main stays production-safe.
 
+## Reviewer Feedback Standard
+
+Every public PR response must be useful to a future contributor, not just the
+current author. Use this structure for approvals, change requests, declined PRs,
+and collaboration-branch acceptance:
+
+- **Decision**: `main-candidate`, `request-changes`,
+  `collaboration-branch-candidate`, `manual-security-review`, or
+  `declined/superseded`.
+- **What passed**: name the useful contribution, trusted checks, or safe files.
+  If nothing passed, say that directly and keep the explanation factual.
+- **What blocks main**: list the first concrete blocker, stale contract, risky
+  path, missing test, failing check, or product-scope mismatch.
+- **Repair path**: give the exact local command, file, test, or smaller PR split
+  that would make the next submission easier to accept.
+- **Branch path**: say whether the work should stay on the same PR, move to a
+  collaboration branch, or be restarted as a new focused PR.
+- **Payment boundary**: state that code review, branch preservation, and CI
+  approval do not authorize bounty acceptance, settlement, payout, or payment.
+
+Do not leave a contributor with only "not approved" or "closed as stale". If the
+work is useful but not safe for `main`, prefer preserving the idea on a
+collaboration branch when the branch rules allow it. If the work is unsafe or
+out of scope, explain the smallest safe version that could be reconsidered.
+
 ### Collaboration Branch Rules
 
 - Prefer collaboration branches for docs/spec/template work that is valuable but
   fails a contract check, or for larger feature drafts that need multiple PRs.
+- Use collaboration branches to keep useful contribution energy visible without
+  relaxing the `main` gate. They are for continued iteration, not for running
+  privileged automation on unreviewed code.
 - Do not put changes to `.github/workflows/`, release scripts, deployment
   automation, secrets handling, payment settlement, escrow contracts, or
   dependency locks on a collaboration branch unless the maintainer explicitly
@@ -76,6 +107,8 @@ main stays production-safe.
   until the branch has a clean path back through the normal gates.
 - When the branch becomes main-ready, open a maintainer-owned PR from the
   collaboration branch to `main` and run the full gates again.
+- If closing the original PR after creating a collaboration branch, link the
+  branch in the close comment and state what follow-up PR should target.
 
 To post a GitHub review result:
 
@@ -130,12 +163,14 @@ Every review outcome should leave the contributor with a repair path:
   payout approval.
 - **Manual security review**: state which risky paths triggered the lane and ask
   for a smaller split if that would help review.
+- **Decline or close**: state why the PR is being closed, name any superseding
+  PR/issue/branch, and describe the smallest revised PR that would be welcome.
 
 Suggested "not main-ready yet" comment:
 
 ```text
-Thanks for the contribution. I cannot approve this for main yet, but the repair
-path is concrete.
+Thanks for the contribution. Decision: request-changes. I cannot approve this
+for main yet, but the repair path is concrete.
 
 What passed:
 - <docs-only / useful topic / no risky paths, when true>
@@ -154,6 +189,28 @@ Collaboration branch:
 
 This review does not approve bounty acceptance, merge, payout, or payment
 settlement.
+```
+
+Suggested "accepted for collaboration branch" comment:
+
+```text
+Thanks for the contribution. Decision: collaboration-branch-candidate.
+
+What passed:
+- <useful docs/spec/template/feature direction>
+
+What blocks main:
+- <contract mismatch / incomplete acceptance criteria / larger split still in progress>
+
+Collaboration branch:
+- <collab/pr-number-topic>
+- Please target follow-up PRs at that branch until it has a clean path back to main.
+
+Repair path:
+- <exact command or files to update before a maintainer-owned PR back to main>
+
+This branch preserves iteration space. It is not merge approval, bounty
+acceptance, payout approval, or payment settlement.
 ```
 
 ## Docs Contract Check

--- a/scripts/review-external-pr.ps1
+++ b/scripts/review-external-pr.ps1
@@ -38,6 +38,7 @@ function Test-DocsPath {
         $Path -eq "README.md" -or
         $Path -eq "AGENTS.md" -or
         $Path -eq "llms.txt" -or
+        $Path -eq ".github/PULL_REQUEST_TEMPLATE.md" -or
         $Path.StartsWith("docs/") -or
         $Path.StartsWith("examples/") -or
         $Path.StartsWith(".github/ISSUE_TEMPLATE/")
@@ -317,19 +318,34 @@ try {
     $result | ConvertTo-Json -Depth 6
 
     if ($PostReview) {
+        $passedItems = @()
+        if ($docsOnly) {
+            $passedItems += "The changed files are limited to documentation or contributor-facing metadata."
+        }
+        if ($riskyFiles.Count -eq 0) {
+            $passedItems += "No risky paths were changed by the PR head reviewed here."
+        }
+        if ($docsCheckOk) {
+            $passedItems += "`docs-contract-check` passed against the trusted maintainer checkout."
+        }
+        if ($passedItems.Count -eq 0) {
+            $passedItems += "The PR head was fetched and matched against GitHub before review; no merge-ready checks passed yet."
+        }
+
         if ($mainCandidate) {
             $body = @"
 Automated external PR intake passed.
 
-What passed:
-- The changed files are docs-only.
-- No risky paths were changed.
-- `docs-contract-check` passed against the trusted maintainer checkout.
+Decision: main-candidate.
 
-Recommended lane: main-candidate.
+What passed:
+$(Format-MarkdownList $passedItems)
+
+What blocks main:
+- Nothing from the automated external intake gate. A maintainer still needs to review semantics before merge.
 
 Next steps:
-- A maintainer should still review the semantics before merging.
+- A maintainer should review the content and required checks before merging to `main`.
 - This review does not approve bounty acceptance, payout, or payment settlement.
 "@
             Invoke-Checked { gh pr review $Pr --repo $Repo --comment --body $body }
@@ -354,11 +370,14 @@ Next steps:
                 "Do not move this to an upstream collaboration branch automatically. The risky or non-doc paths need manual maintainer security review first."
             }
             $body = @"
-Thanks for the contribution. I cannot approve this for `main` yet, but the next repair steps are concrete.
+Thanks for the contribution. Decision: request-changes for `main`. The next repair steps are concrete.
 
 Recommended lane: $recommendedLane.
 
-Why it is blocked:
+What passed:
+$(Format-MarkdownList $passedItems)
+
+What blocks main:
 $(($blockers | ForEach-Object { $_ }) -join "`n`n")
 
 How to fix:
@@ -372,6 +391,8 @@ cargo run -p cli -- docs-contract-check
 
 Collaboration branch guidance:
 $branchGuidance
+
+This review does not approve bounty acceptance, merge, payout, or payment settlement.
 "@
             Invoke-Checked { gh pr review $Pr --repo $Repo --request-changes --body $body }
         }

--- a/scripts/review-external-pr.sh
+++ b/scripts/review-external-pr.sh
@@ -61,6 +61,7 @@ is_docs_path() {
   [[ "$path" == "README.md" ]] ||
     [[ "$path" == "AGENTS.md" ]] ||
     [[ "$path" == "llms.txt" ]] ||
+    [[ "$path" == ".github/PULL_REQUEST_TEMPLATE.md" ]] ||
     [[ "$path" == docs/* ]] ||
     [[ "$path" == examples/* ]] ||
     [[ "$path" == .github/ISSUE_TEMPLATE/* ]]
@@ -250,6 +251,20 @@ if [[ "${#feedback_items[@]}" -eq 0 ]]; then
   feedback_items+=("Perform semantic review before approving merge, and keep payment or bounty acceptance separate from code review.")
 fi
 
+passed_items=()
+if [[ "$docs_only" == true ]]; then
+  passed_items+=("The changed files are limited to documentation or contributor-facing metadata.")
+fi
+if [[ "${#risky_files[@]}" -eq 0 ]]; then
+  passed_items+=("No risky paths were changed by the PR head reviewed here.")
+fi
+if [[ "$docs_contract_check" == "ok" ]]; then
+  passed_items+=("docs-contract-check passed against the trusted maintainer checkout.")
+fi
+if [[ "${#passed_items[@]}" -eq 0 ]]; then
+  passed_items+=("The PR head was fetched and matched against GitHub before review; no merge-ready checks passed yet.")
+fi
+
 printf '{\n'
 printf '  "pr": %s,\n' "$pr"
 printf '  "docs_only": %s,\n' "$docs_only"
@@ -266,29 +281,27 @@ printf '}\n'
 
 if [[ "$post_review" == true ]]; then
   if [[ "$safe_for_maintainer_ci" == true ]]; then
-    body="$(
-      cat <<'EOF'
-Automated external PR intake passed.
-
-What passed:
-- The changed files are docs-only.
-- No risky paths were changed.
-- docs-contract-check passed against the trusted maintainer checkout.
-
-Recommended lane: main-candidate.
-
-Next steps:
-- A maintainer should still review the semantics before merging.
-- This review does not approve bounty acceptance, payout, or payment settlement.
-EOF
-    )"
-    gh pr review "$pr" --repo "$repo" --comment --body "$body"
+    body_file="$tmp_root/review-body.md"
+    {
+      printf 'Automated external PR intake passed.\n\n'
+      printf 'Decision: main-candidate.\n\n'
+      printf 'What passed:\n'
+      markdown_list "- None" "${passed_items[@]}"
+      printf '\nWhat blocks main:\n'
+      printf -- '- Nothing from the automated external intake gate. A maintainer still needs to review semantics before merge.\n'
+      printf '\nNext steps:\n'
+      printf -- '- A maintainer should review the content and required checks before merging to main.\n'
+      printf -- '- This review does not approve bounty acceptance, payout, or payment settlement.\n'
+    } >"$body_file"
+    gh pr review "$pr" --repo "$repo" --comment --body "$(cat "$body_file")"
   else
     body_file="$tmp_root/review-body.md"
     {
-      printf 'Thanks for the contribution. I cannot approve this for main yet, but the next repair steps are concrete.\n\n'
+      printf 'Thanks for the contribution. Decision: request-changes for main. The next repair steps are concrete.\n\n'
       printf 'Recommended lane: %s.\n\n' "$recommended_lane"
-      printf 'Why it is blocked:\n'
+      printf 'What passed:\n'
+      markdown_list "- None" "${passed_items[@]}"
+      printf '\nWhat blocks main:\n'
       if [[ "${#non_docs_files[@]}" -gt 0 ]]; then
         printf '\nNon-doc files changed:\n'
         markdown_list "- None" "${non_docs_files[@]}"
@@ -315,6 +328,7 @@ EOF
       else
         printf 'Do not move this to an upstream collaboration branch automatically. The risky or non-doc paths need manual maintainer security review first.\n'
       fi
+      printf '\nThis review does not approve bounty acceptance, merge, payout, or payment settlement.\n'
     } >"$body_file"
     gh pr review "$pr" --repo "$repo" --request-changes --body "$(cat "$body_file")"
   fi


### PR DESCRIPTION
## Summary
- add a PR template that asks contributors to declare checks, bounty linkage, and expected review lane
- expand the secure PR review guide with constructive feedback and collaboration branch requirements
- update external PR review helpers so posted reviews include decision, what passed, main blockers, repair path, branch guidance, and payment boundary

## Validation
- `scripts/preflight.ps1 -Mode core`
- `git diff --check`
- `cargo run -p cli -- docs-contract-check`
- PowerShell parser check for `scripts/review-external-pr.ps1`
- `bash -n scripts/review-external-pr.sh`
- dry-run `scripts/review-external-pr.ps1 -Pr 17` without posting a review