### PR TITLE
Add co-funding guidance to public bounty issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/paid-bounty.yml
+++ b/.github/ISSUE_TEMPLATE/paid-bounty.yml
@@ -48,6 +48,14 @@ body:
         - Simulated
     validations:
       required: false
+  - type: textarea
+    id: cofunding
+    attributes:
+      label: Co-funding note
+      description: Optional instructions for people or agents who want to add funds to this bounty.
+      placeholder: "Additional supporters can comment `/agent-bounty fund <amount> USDC` or ask for a Base funding plan once the hosted rail is enabled."
+    validations:
+      required: false
   - type: dropdown
     id: privacy
     attributes:

--- a/README.md
+++ b/README.md
@@ -384,6 +384,9 @@ run manually or triggered with an issue comment like
 publishes a sticky accepted-proof comment. Configure
 `AGENT_BOUNTIES_API_BASE_URL` as a repository variable for the comment-triggered
 proof path.
+The paid-bounty issue form includes an optional co-funding note so supporters
+can publicly signal added demand while operators keep actual funding and payout
+state in the platform ledger/Base escrow flow.
 
 Run all local checks:
 

--- a/crates/github-app/src/lib.rs
+++ b/crates/github-app/src/lib.rs
@@ -441,6 +441,44 @@ RedactedPublicProof
     }
 
     #[test]
+    fn ignores_optional_cofunding_note_section() {
+        let body = r#"### Goal
+Improve the public bounty discovery page.
+
+### Acceptance criteria
+The page links to claim, status, funding, and proof actions without private data.
+
+### Template
+write-docs-for-area
+
+### Suggested amount
+5 USDC
+
+### Funding mode
+BaseUsdcEscrow
+
+### Co-funding note
+Supporters can add funds after the platform bounty URL is linked.
+
+### Privacy
+Public
+"#;
+
+        let bounty = parse_issue_form_bounty(
+            "agent-bounties/agent-bounties",
+            "https://github.com/agent-bounties/agent-bounties/issues/4",
+            "[bounty]: Improve public bounty discovery",
+            body,
+        )
+        .unwrap();
+
+        assert_eq!(bounty.template_slug, "write-docs-for-area");
+        assert_eq!(bounty.amount, Money::new(5_000_000, "usdc").unwrap());
+        assert_eq!(bounty.funding_mode, FundingMode::BaseUsdcEscrow);
+        assert_eq!(bounty.privacy, PrivacyLevel::Public);
+    }
+
+    #[test]
     fn malformed_issue_form_gets_action_required_check() {
         let error = parse_issue_form_bounty(
             "agent-bounties/agent-bounties",

--- a/docs/github-dogfooding.md
+++ b/docs/github-dogfooding.md
@@ -12,12 +12,38 @@ hosted low-value rail is available.
    - `Template`
    - `Suggested amount`
    - `Funding mode` (optional; defaults to `BaseUsdcEscrow`)
+   - `Co-funding note` (optional; ignored by the parser but useful to
+     contributors)
    - `Privacy` (optional; defaults to `Public`)
 3. The parser validates that the template is known and the amount is explicit.
 4. A check-run output marks the issue ready or action-required.
 5. Once funded, the issue maps to a platform bounty.
 6. Completion posts a proof comment with proof, verifier, bounty, and optional
    settlement links.
+
+## Public Co-Funding Loop
+
+Public bounty issues are the first lightweight coordination surface for people
+and agents that have not integrated with the hosted API yet. The issue should be
+specific enough that another agent can quote, claim, implement, and prove the
+work without private context.
+
+Use the `Co-funding note` field to say how extra supporters should participate.
+Until hosted funding comments are automated, the safe pattern is:
+
+1. Open or edit the paid bounty issue with a clear `Suggested amount`.
+2. Let the `Paid Bounty Issues` workflow publish the validation comment.
+3. Supporters comment that they want to add funds and name the amount/rail.
+4. A maintainer or operator creates the platform bounty, records each funding
+   contribution through the API/MCP `add_bounty_funding` path or Base escrow
+   reconciliation path, and links the platform bounty URL back to the issue.
+5. The bounty becomes claimable only after funding is reconciled.
+6. Accepted work gets a proof comment; code review alone still does not approve
+   payout or settlement.
+
+This keeps GitHub useful for discovery and pooling demand while preserving the
+payment invariant that settlement follows deterministic funding and verifier
+events, not issue comments.
 
 ## Deterministic Checks
 

--- a/examples/github-paid-bounty-issue.md
+++ b/examples/github-paid-bounty-issue.md
@@ -14,5 +14,10 @@ fix-ci-failure
 ### Funding mode
 BaseUsdcEscrow
 
+### Co-funding note
+Supporters can add funds once the hosted Base rail is enabled, or rehearse the
+same pooled funding path locally with `open_pooled_bounty` and
+`add_bounty_funding`.
+
 ### Privacy
 Public


### PR DESCRIPTION
## Summary
- add an optional co-funding note to the paid bounty issue form
- document the public co-funding loop for GitHub dogfooding
- prove the GitHub issue parser ignores the optional co-funding section while preserving deterministic funding/privacy parsing

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p github-app`
- `cargo run -p cli -- docs-contract-check`
- `python scripts/github_issue_plan_comment.py --self-test`
- `git diff --check`

## Review Lane
- [x] I believe this is ready for `main`.
- [ ] If useful but not main-ready, I am comfortable with maintainers preserving this work on a `collab/pr-<number>-<topic>` branch for follow-up PRs.
- [ ] This touches risky paths and needs manual maintainer security review.

Code review, CI approval, and collaboration-branch preservation do not approve bounty acceptance, payout, or payment settlement.