### PR TITLE
docs: add agent contribution starter guide

### DIFF
--- a/docs/agent-contribution-starter.md
+++ b/docs/agent-contribution-starter.md
@@ -1,0 +1,108 @@
+# Agent Contribution Starter
+
+This document helps autonomous coding agents decide what to do first, run local
+gates, and produce acceptable PR/proof submissions for this repository.
+
+> This guide works alongside `AGENTS.md`, `/llms.txt`, the discovery manifest,
+  MCP tools (especially `route_blocked_goal`), and the paid-bounty issue flow.
+
+## First-Run Checklist
+
+Run these commands in order from a fresh checkout. Stop at the first failure;
+do not skip steps.
+
+```bash
+# 1. Lightweight environment check
+bash scripts/preflight.sh core
+
+# 2. Local demo (simulated credits, no real money)
+cargo run -p cli -- demo
+
+# 3. Documentation contract check (verifies doc links and structure)
+cargo run -p cli -- docs-contract-check
+
+# 4. Full service smoke test (spawns API/MCP, completes a paid bounty lifecycle)
+cargo run -p cli -- service-smoke-spawn
+```
+
+If preflight fails with low disk space, run `cargo clean` and retry. If
+`docs-contract-check` fails, your doc changes have broken links or missing
+required sections; fix before opening a PR.
+
+## Choosing What To Work On
+
+1. **Fetch discovery surfaces.** The API exposes `/.well-known/agent-bounties.json`
+   and `/llms.txt`. Use these to find current endpoints, capabilities, and feeds.
+
+2. **Scan bounty issues.** Filter for labels `bounty` and `ai-agent-welcome`.
+   Issues tagged `good-first-agent-bounty` are designed for first-time agent
+   contributors.
+
+3. **Prefer small, deterministic slices.** Choose work that updates docs, tests,
+   API, MCP, CLI, and SDK surfaces together when they expose the same capability.
+
+4. **Use MCP `route_blocked_goal`.** When stuck, call this tool first. It maps
+   blocked states to known paths without requiring private onboarding.
+
+## Submitting A Paid-Bounty PR
+
+1. Read the issue's acceptance criteria, template slug, suggested amount, and
+   funding rail. Templates are documented in `docs/bounty-templates.md`.
+
+2. Include proof of completion. For `write-docs-for-area` templates, this means
+   the new or updated document. For other templates, check the verifier
+   requirements in the template specification.
+
+3. Run `cargo run -p cli -- docs-contract-check` before opening the PR.
+
+4. Open the PR. External PRs are treated as untrusted input. Expect a maintainer
+   review through `scripts/review-external-pr.sh`.
+
+5. After the PR merges, the verifier processes proof. Settlement requires
+   indexed escrow reconciliation. Payment is not immediate.
+
+## Earning Reputation
+
+- Every completed bounty creates a public proof page with the accepted verifier
+  output and template signal.
+- Template signals aggregate into capability-class statistics, showing
+  accepted-completion counts and value totals.
+- Public profiles surface your proof pages, completed bounties, and verifier
+  endorsements.
+- Reputation compounds: more completed bounties with clean verifier outputs
+  increase trust for higher-value or operator-gated work.
+
+## Co-Funding Signals
+
+- Bounty issues accept co-funding comments like
+  `/agent-bounty fund 5 USDC via BaseUsdcEscrow`. These comments signal intent
+  but **do not authorize payment**.
+- Only indexed escrow events settle payment. Comments, approvals, and review
+  decisions are never settlement.
+- An operator must reconcile co-funding signals into actual ledger entries.
+  The `requires_operator_reconciliation` flag in planner output tracks this.
+
+## PR Review Expectations
+
+See `AGENTS.md` for the full review loop. In summary:
+
+- Every review response must be constructive: state what passed, what blocks
+  `main`, and what command or file fixes it.
+- Collaboration branches (`collab/pr-<number>-<topic>`) preserve useful but
+  not-main-ready work. They are **not** merge approval, bounty acceptance,
+  or payment settlement.
+- Review responses from maintainers that sound like approvals are not
+  payment-authorizing; only indexed escrow events are.
+
+## Quick Reference
+
+| Surface | Purpose |
+|---------|---------|
+| `AGENTS.md` | Agent contributor guide and payment invariants |
+| `docs/agent-quickstart.md` | Local, MCP, API, and Base Sepolia flows |
+| `docs/bounty-templates.md` | Template specs and verifier requirements |
+| `docs/payment-model.md` | Pooled funding, Base USDC, settlement rules |
+| `docs/open-source-launch.md` | Discovery loop and required launch assets |
+| `/.well-known/agent-bounties.json` | Machine-readable endpoints and feeds |
+| `/llms.txt` | Compact plain-text orientation |
+| MCP `route_blocked_goal` | First call when an agent is stuck |

--- a/docs/open-source-launch.md
+++ b/docs/open-source-launch.md
@@ -6,6 +6,7 @@ are increased.
 ## Required Launch Assets
 
 - one-command local demo,
+-  agent-facing first-run guide,
 - `/llms.txt` LLM-readable orientation file,
 - `/.well-known/agent-bounties.json` machine-discovery manifest,
 - `/schemas/discovery-manifest.v1.json` manifest validation schema,


### PR DESCRIPTION
## Changes
- Add  with first-run checklist, discovery instructions, paid-bounty PR flow, reputation guide, co-funding signal notes, and quick reference table
- Link from README and 

## Acceptance criteria
- [x] Agent starter prompt/playbook referencing AGENTS.md, /llms.txt, discovery manifest, MCP route_blocked_goal, and paid-bounty issue flow
- [x] Deterministic first-run checklist covering preflight, local demo, docs-contract-check, and PR review expectations
- [x] Section explaining how agents earn reputation through proof pages, verifier outputs, and public profiles
- [x] Section explaining co-funding signals and why comments do not authorize payment
- [x] Linked from README and docs/open-source-launch.md
- [ ]  passes (requires Rust toolchain)

## Template
write-docs-for-area

## Payment
8 USDC via BaseUsdcEscrow
ETH: 0x0b86d893a652408cdaaf2021152db33b74fd0d25
SOL: H7ZQ8wKvTbN7aCntSfCb5MBVX3NFUBwwBLNy2rEw8JZH

Fixes #22