### PR TITLE
Require Stripe balance for fiat bounty funding

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,8 @@ Useful REST paths:
 The Python and TypeScript SDKs cover the same core agent loop: read `/llms.txt`
 or the machine-discovery manifest and schema, route a blocked goal, register agents/capabilities,
 create help requests, request quotes, fund quotes, open pooled bounty targets,
-add funding contributions, post Base funding-ready bounties, reconcile Base funding events, claim/submit/verify bounties, inspect
+add funding contributions, reserve verified Stripe Checkout top-up balance into
+pooled fiat bounties, post Base funding-ready bounties, reconcile Base funding events, claim/submit/verify bounties, inspect
 the public claimable bounty and capability feeds, check bounty and agent paid
 status, plan Stripe Checkout top-ups and Accounts v2 onboarding requests, plan
 Base USDC funding/release/refund/dispute transactions, call

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -4027,6 +4027,7 @@ mod tests {
             Json(AddFundingContributionRequest {
                 bounty_id: bounty.id,
                 contributor_agent_id: None,
+                source_organization_id: None,
                 amount_minor: 400,
                 currency: "USDC".to_string(),
                 rail: PaymentRail::Simulated,
@@ -4045,6 +4046,7 @@ mod tests {
             Json(AddFundingContributionRequest {
                 bounty_id: bounty.id,
                 contributor_agent_id: None,
+                source_organization_id: None,
                 amount_minor: 600,
                 currency: "usdc".to_string(),
                 rail: PaymentRail::Simulated,

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -13,7 +13,7 @@ use domain::{
     RiskReviewRecord, RiskSurface, Settlement, Submission, TemplateSignal, VerificationDecision,
     VerifierKind, VerifierResult,
 };
-use ledger::{credit, debit, Ledger, LedgerEntry};
+use ledger::{credit, debit, AccountCode, Ledger, LedgerEntry};
 use payments_stripe::{
     evaluate_connect_payout, ConnectAccountSnapshot, ConnectPayoutState, StripeFundingCredit,
 };
@@ -109,6 +109,7 @@ pub struct OpenPooledBountyRequest {
 pub struct AddFundingContributionRequest {
     pub bounty_id: Id,
     pub contributor_agent_id: Option<Id>,
+    pub source_organization_id: Option<Id>,
     pub amount_minor: i64,
     pub currency: String,
     pub rail: PaymentRail,
@@ -644,6 +645,7 @@ impl BountyNetwork {
             id: Uuid::new_v4(),
             bounty_id: bounty.id,
             contributor_agent_id: None,
+            source_organization_id: None,
             rail: payment_rail_for_funding_mode(&funding_mode),
             amount,
             status: FundingContributionStatus::Applied,
@@ -715,6 +717,21 @@ impl BountyNetwork {
                 request.rail, bounty.funding_mode
             )));
         }
+        match (request.rail.clone(), request.source_organization_id) {
+            (PaymentRail::StripeFiat, None) => {
+                return Err(AppError::InvalidFundingContribution(
+                    "Stripe fiat bounty funding must name a source organization with verified platform balance".to_string(),
+                ));
+            }
+            (PaymentRail::StripeFiat, Some(_)) => {}
+            (_, Some(_)) => {
+                return Err(AppError::InvalidFundingContribution(
+                    "source organization balance is only valid for Stripe fiat contributions"
+                        .to_string(),
+                ));
+            }
+            _ => {}
+        }
         let amount = Money::new(request.amount_minor, request.currency)?;
         if amount.currency != bounty.amount.currency {
             return Err(AppError::InvalidFundingContribution(format!(
@@ -753,9 +770,22 @@ impl BountyNetwork {
         let contributor_agent_id = request.contributor_agent_id;
         let rail = request.rail;
         let external_reference = request.external_reference;
-        let contributor_account = contributor_agent_id
-            .map(|id| format!("contributor_funds:{id}"))
-            .unwrap_or_else(|| "external_contributor_funds".to_string());
+        let source_organization_id = request.source_organization_id;
+        let contributor_account = if let Some(organization_id) = source_organization_id {
+            let available =
+                self.stripe_platform_balance_available_minor(organization_id, &amount.currency);
+            if available < amount.amount {
+                return Err(AppError::InvalidFundingContribution(format!(
+                    "insufficient Stripe platform balance for organization {organization_id}: available {} {}, requested {} {}",
+                    available, amount.currency, amount.amount, amount.currency
+                )));
+            }
+            stripe_platform_balance_account(organization_id)
+        } else {
+            contributor_agent_id
+                .map(|id| format!("contributor_funds:{id}"))
+                .unwrap_or_else(|| "external_contributor_funds".to_string())
+        };
         let entry = LedgerEntry::new(
             "pooled bounty funding contribution",
             Some(format!("fund-contribution:{contribution_id}")),
@@ -769,6 +799,7 @@ impl BountyNetwork {
             id: contribution_id,
             bounty_id: bounty.id,
             contributor_agent_id,
+            source_organization_id,
             rail,
             amount: amount.clone(),
             status: FundingContributionStatus::Applied,
@@ -2723,6 +2754,14 @@ impl BountyNetwork {
             .sum()
     }
 
+    fn stripe_platform_balance_available_minor(&self, organization_id: Id, currency: &str) -> i64 {
+        let balance = self.ledger.balance(
+            &AccountCode::new(stripe_platform_balance_account(organization_id)),
+            currency,
+        );
+        (-balance).max(0)
+    }
+
     fn has_funded_base_escrow(&self, bounty_id: Id) -> bool {
         self.escrows.values().any(|escrow| {
             escrow.bounty_id == bounty_id
@@ -2741,6 +2780,10 @@ fn base_escrow_uuid(bounty_id: Id, onchain_escrow_id: u128) -> Id {
 
 fn base_escrow_reference(onchain_escrow_id: u128) -> String {
     format!("base:{onchain_escrow_id}")
+}
+
+fn stripe_platform_balance_account(organization_id: Id) -> String {
+    format!("platform_balance:{organization_id}")
 }
 
 fn parse_base_escrow_reference(reference: &Option<String>) -> AppResult<u128> {
@@ -2833,6 +2876,28 @@ mod tests {
                 bounty.terms_hash.clone().unwrap(),
             ))
             .unwrap()
+    }
+
+    fn stripe_funding_credit(
+        organization_id: Id,
+        amount_minor: i64,
+        currency: &str,
+        event_id: &str,
+    ) -> StripeFundingCredit {
+        StripeFundingCredit {
+            organization_id,
+            amount: Money::new(amount_minor, currency).unwrap(),
+            checkout_session_id: format!("cs_{event_id}"),
+            payment_intent_id: Some(format!("pi_{event_id}")),
+            payment_event: PaymentEvent {
+                id: Uuid::new_v4(),
+                rail: PaymentRail::StripeFiat,
+                external_id: event_id.to_string(),
+                status: PaymentEventStatus::Applied,
+                payload_hash: hash_artifact(event_id),
+                received_at: Utc::now(),
+            },
+        }
     }
 
     #[tokio::test]
@@ -3113,6 +3178,7 @@ mod tests {
             .add_funding_contribution(AddFundingContributionRequest {
                 bounty_id: bounty.id,
                 contributor_agent_id: Some(sponsor_a.id),
+                source_organization_id: None,
                 amount_minor: 400,
                 currency: "USDC".to_string(),
                 rail: PaymentRail::Simulated,
@@ -3135,6 +3201,7 @@ mod tests {
             .add_funding_contribution(AddFundingContributionRequest {
                 bounty_id: bounty.id,
                 contributor_agent_id: Some(sponsor_b.id),
+                source_organization_id: None,
                 amount_minor: 600,
                 currency: "usdc".to_string(),
                 rail: PaymentRail::Simulated,
@@ -3187,6 +3254,7 @@ mod tests {
             .add_funding_contribution(AddFundingContributionRequest {
                 bounty_id: bounty.id,
                 contributor_agent_id: Some(sponsor.id),
+                source_organization_id: None,
                 amount_minor: 1_000,
                 currency: "usdc".to_string(),
                 rail: PaymentRail::Simulated,
@@ -3252,6 +3320,7 @@ mod tests {
             .add_funding_contribution(AddFundingContributionRequest {
                 bounty_id: bounty.id,
                 contributor_agent_id: None,
+                source_organization_id: None,
                 amount_minor: 700,
                 currency: "usdc".to_string(),
                 rail: PaymentRail::Simulated,
@@ -3263,6 +3332,7 @@ mod tests {
                 .add_funding_contribution(AddFundingContributionRequest {
                     bounty_id: bounty.id,
                     contributor_agent_id: None,
+                    source_organization_id: None,
                     amount_minor: 100,
                     currency: "usdc".to_string(),
                     rail: PaymentRail::Simulated,
@@ -3276,6 +3346,7 @@ mod tests {
                 .add_funding_contribution(AddFundingContributionRequest {
                     bounty_id: bounty.id,
                     contributor_agent_id: None,
+                    source_organization_id: None,
                     amount_minor: 400,
                     currency: "usdc".to_string(),
                     rail: PaymentRail::Simulated,
@@ -3290,6 +3361,128 @@ mod tests {
         assert_eq!(status.funding_summary.applied.amount, 700);
         assert_eq!(status.funding_summary.remaining.amount, 300);
         assert!(!status.funding_summary.claimable);
+    }
+
+    #[test]
+    fn stripe_pooled_funding_requires_verified_platform_balance() {
+        let mut network = BountyNetwork::default();
+        let organization_id = Uuid::new_v4();
+        let bounty = network
+            .open_pooled_bounty(OpenPooledBountyRequest {
+                title: "Fund fiat-backed docs work".to_string(),
+                template_slug: "write-docs-for-area".to_string(),
+                target_amount_minor: 1_000,
+                currency: "usd".to_string(),
+                funding_mode: FundingMode::StripeFiatLedger,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+
+        assert!(matches!(
+            network
+                .add_funding_contribution(AddFundingContributionRequest {
+                    bounty_id: bounty.id,
+                    contributor_agent_id: None,
+                    source_organization_id: None,
+                    amount_minor: 500,
+                    currency: "usd".to_string(),
+                    rail: PaymentRail::StripeFiat,
+                    external_reference: Some("unbacked".to_string()),
+                })
+                .unwrap_err(),
+            AppError::InvalidFundingContribution(_)
+        ));
+        assert!(matches!(
+            network
+                .add_funding_contribution(AddFundingContributionRequest {
+                    bounty_id: bounty.id,
+                    contributor_agent_id: None,
+                    source_organization_id: Some(organization_id),
+                    amount_minor: 500,
+                    currency: "usd".to_string(),
+                    rail: PaymentRail::StripeFiat,
+                    external_reference: Some("insufficient".to_string()),
+                })
+                .unwrap_err(),
+            AppError::InvalidFundingContribution(_)
+        ));
+
+        network
+            .apply_stripe_funding_credit(stripe_funding_credit(
+                organization_id,
+                700,
+                "usd",
+                "evt_topup_700",
+            ))
+            .unwrap();
+        assert_eq!(
+            network.stripe_platform_balance_available_minor(organization_id, "usd"),
+            700
+        );
+
+        let partial = network
+            .add_funding_contribution(AddFundingContributionRequest {
+                bounty_id: bounty.id,
+                contributor_agent_id: None,
+                source_organization_id: Some(organization_id),
+                amount_minor: 700,
+                currency: "usd".to_string(),
+                rail: PaymentRail::StripeFiat,
+                external_reference: Some("stripe-700".to_string()),
+            })
+            .unwrap();
+        assert_eq!(partial.bounty.status, BountyStatus::Unfunded);
+        assert_eq!(partial.funding_summary.remaining.amount, 300);
+        assert_eq!(
+            partial.contribution.source_organization_id,
+            Some(organization_id)
+        );
+        assert_eq!(
+            network.stripe_platform_balance_available_minor(organization_id, "usd"),
+            0
+        );
+
+        assert!(matches!(
+            network
+                .add_funding_contribution(AddFundingContributionRequest {
+                    bounty_id: bounty.id,
+                    contributor_agent_id: None,
+                    source_organization_id: Some(organization_id),
+                    amount_minor: 300,
+                    currency: "usd".to_string(),
+                    rail: PaymentRail::StripeFiat,
+                    external_reference: Some("stripe-300-before-topup".to_string()),
+                })
+                .unwrap_err(),
+            AppError::InvalidFundingContribution(_)
+        ));
+
+        network
+            .apply_stripe_funding_credit(stripe_funding_credit(
+                organization_id,
+                300,
+                "usd",
+                "evt_topup_300",
+            ))
+            .unwrap();
+        let funded = network
+            .add_funding_contribution(AddFundingContributionRequest {
+                bounty_id: bounty.id,
+                contributor_agent_id: None,
+                source_organization_id: Some(organization_id),
+                amount_minor: 300,
+                currency: "usd".to_string(),
+                rail: PaymentRail::StripeFiat,
+                external_reference: Some("stripe-300".to_string()),
+            })
+            .unwrap();
+
+        assert_eq!(funded.bounty.status, BountyStatus::Claimable);
+        assert!(funded.funding_summary.claimable);
+        assert_eq!(
+            network.stripe_platform_balance_available_minor(organization_id, "usd"),
+            0
+        );
     }
 
     #[tokio::test]
@@ -3537,18 +3730,38 @@ mod tests {
     #[tokio::test]
     async fn stripe_fiat_settlement_blocks_payout_until_connect_eligible() {
         let mut network = BountyNetwork::default();
+        let organization_id = Uuid::new_v4();
         let solver = network.register_agent(RegisterAgentRequest {
             handle: "solver".to_string(),
             payout_wallet: None,
         });
         let bounty = network
-            .post_funded_bounty(PostBountyRequest {
+            .open_pooled_bounty(OpenPooledBountyRequest {
                 title: "Summarize private notes".to_string(),
                 template_slug: "write-docs-for-area".to_string(),
-                amount_minor: 5_000,
+                target_amount_minor: 5_000,
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::StripeFiatLedger,
                 privacy: PrivacyLevel::Private,
+            })
+            .unwrap();
+        network
+            .apply_stripe_funding_credit(stripe_funding_credit(
+                organization_id,
+                5_000,
+                "usd",
+                "evt_private_notes_topup",
+            ))
+            .unwrap();
+        network
+            .add_funding_contribution(AddFundingContributionRequest {
+                bounty_id: bounty.id,
+                contributor_agent_id: None,
+                source_organization_id: Some(organization_id),
+                amount_minor: 5_000,
+                currency: "usd".to_string(),
+                rail: PaymentRail::StripeFiat,
+                external_reference: Some("stripe-private-notes".to_string()),
             })
             .unwrap();
 
@@ -3587,7 +3800,12 @@ mod tests {
             status.settlements[0].payout_intents[0].status,
             PayoutStatus::Blocked
         );
-        assert_eq!(network.ledger.entries().len(), 1);
+        assert_eq!(status.funding_contributions.len(), 1);
+        assert_eq!(
+            status.funding_contributions[0].source_organization_id,
+            Some(organization_id)
+        );
+        assert_eq!(network.ledger.entries().len(), 2);
 
         let blocked = network
             .apply_stripe_connect_snapshot(ConnectAccountSnapshot {
@@ -3623,7 +3841,7 @@ mod tests {
             status.settlements[0].payout_intents[0].status,
             PayoutStatus::Paid
         );
-        assert_eq!(network.ledger.entries().len(), 3);
+        assert_eq!(network.ledger.entries().len(), 4);
 
         let replay = network
             .apply_stripe_connect_snapshot(ConnectAccountSnapshot {
@@ -3635,7 +3853,7 @@ mod tests {
             })
             .unwrap();
         assert!(replay.ledger_entries.is_empty());
-        assert_eq!(network.ledger.entries().len(), 3);
+        assert_eq!(network.ledger.entries().len(), 4);
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -627,6 +627,7 @@ fn pooled_funding_demo() -> Result<()> {
     let first = network.add_funding_contribution(AddFundingContributionRequest {
         bounty_id: bounty.id,
         contributor_agent_id: Some(sponsor_a.id),
+        source_organization_id: None,
         amount_minor: 400_000,
         currency: "usdc".to_string(),
         rail: PaymentRail::Simulated,
@@ -635,6 +636,7 @@ fn pooled_funding_demo() -> Result<()> {
     let second = network.add_funding_contribution(AddFundingContributionRequest {
         bounty_id: bounty.id,
         contributor_agent_id: Some(sponsor_b.id),
+        source_organization_id: None,
         amount_minor: 600_000,
         currency: "usdc".to_string(),
         rail: PaymentRail::Simulated,
@@ -2327,6 +2329,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         serde_json::json!({
             "bounty_id": pooled_bounty_id.as_str(),
             "contributor_agent_id": null,
+            "source_organization_id": null,
             "amount_minor": 1_000,
             "currency": "usdc",
             "rail": "Simulated",

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -410,10 +410,11 @@ impl PostgresStore {
         sqlx::query(
             r#"
             INSERT INTO funding_contributions
-              (id, bounty_id, contributor_agent_id, rail, amount, currency, status, funding_ledger_entry_id, refund_ledger_entry_id, settlement_id, external_reference, created_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+              (id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, funding_ledger_entry_id, refund_ledger_entry_id, settlement_id, external_reference, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             ON CONFLICT (id) DO UPDATE SET
               contributor_agent_id = EXCLUDED.contributor_agent_id,
+              source_organization_id = EXCLUDED.source_organization_id,
               rail = EXCLUDED.rail,
               amount = EXCLUDED.amount,
               currency = EXCLUDED.currency,
@@ -427,6 +428,7 @@ impl PostgresStore {
         .bind(contribution.id)
         .bind(contribution.bounty_id)
         .bind(contribution.contributor_agent_id)
+        .bind(contribution.source_organization_id)
         .bind(format!("{:?}", contribution.rail))
         .bind(contribution.amount.amount)
         .bind(&contribution.amount.currency)
@@ -444,7 +446,7 @@ impl PostgresStore {
     pub async fn list_funding_contributions(&self) -> DbResult<Vec<FundingContribution>> {
         let rows = sqlx::query(
             r#"
-            SELECT id, bounty_id, contributor_agent_id, rail, amount, currency, status, funding_ledger_entry_id, refund_ledger_entry_id, settlement_id, external_reference, created_at
+            SELECT id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, funding_ledger_entry_id, refund_ledger_entry_id, settlement_id, external_reference, created_at
             FROM funding_contributions
             ORDER BY created_at
             "#,
@@ -458,6 +460,7 @@ impl PostgresStore {
                     id: row.try_get("id")?,
                     bounty_id: row.try_get("bounty_id")?,
                     contributor_agent_id: row.try_get("contributor_agent_id")?,
+                    source_organization_id: row.try_get("source_organization_id")?,
                     rail: parse_payment_rail(row.try_get::<String, _>("rail")?)?,
                     amount: Money::new(
                         row.try_get::<i64, _>("amount")?,
@@ -1438,6 +1441,7 @@ mod tests {
             assert!(CORE_MIGRATION.contains(table), "missing {table}");
         }
         assert!(CORE_MIGRATION.contains("idx_funding_contributions_external_reference"));
+        assert!(CORE_MIGRATION.contains("source_organization_id UUID"));
         assert!(CORE_MIGRATION.contains("funding_ledger_entry_id UUID"));
         assert!(CORE_MIGRATION.contains("refund_ledger_entry_id UUID"));
         assert!(CORE_MIGRATION.contains("settlement_id UUID"));

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -491,6 +491,7 @@ pub struct FundingContribution {
     pub id: Id,
     pub bounty_id: Id,
     pub contributor_agent_id: Option<Id>,
+    pub source_organization_id: Option<Id>,
     pub rail: PaymentRail,
     pub amount: Money,
     pub status: FundingContributionStatus,

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -507,9 +507,10 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                 json!({
                     "bounty_id": uuid_property("Pooled bounty UUID."),
                     "contributor_agent_id": nullable_uuid_property("Optional contributor agent UUID."),
+                    "source_organization_id": nullable_uuid_property("Stripe-funded organization balance to reserve from when rail is StripeFiat."),
                     "amount_minor": integer_property("Contribution amount in minor units."),
                     "currency": string_property("Currency code."),
-                    "rail": enum_property(&["Simulated", "StripeFiat"], "Funding rail for this contribution."),
+                    "rail": enum_property(&["Simulated", "StripeFiat"], "Funding rail for this contribution. StripeFiat requires source_organization_id and verified Checkout top-up balance."),
                     "external_reference": nullable_string_property("Optional per-bounty idempotency reference from the funding rail.")
                 }),
                 &["bounty_id", "amount_minor", "currency", "rail"],
@@ -2604,6 +2605,10 @@ mod tests {
             .expect("add_bounty_funding descriptor exists");
         assert_eq!(
             add_funding.input_schema["properties"]["bounty_id"]["format"],
+            "uuid"
+        );
+        assert_eq!(
+            add_funding.input_schema["properties"]["source_organization_id"]["format"],
             "uuid"
         );
         assert!(add_funding.input_schema["required"]

--- a/crates/sdk-python/agent_bounties/client.py
+++ b/crates/sdk-python/agent_bounties/client.py
@@ -266,6 +266,7 @@ class AgentBountiesClient:
         currency: str,
         rail: str,
         contributor_agent_id: str | None = None,
+        source_organization_id: str | None = None,
         external_reference: str | None = None,
     ):
         return self._request(
@@ -274,6 +275,7 @@ class AgentBountiesClient:
             json={
                 "bounty_id": bounty_id,
                 "contributor_agent_id": contributor_agent_id,
+                "source_organization_id": source_organization_id,
                 "amount_minor": amount_minor,
                 "currency": currency,
                 "rail": rail,

--- a/crates/sdk-typescript/src/index.ts
+++ b/crates/sdk-typescript/src/index.ts
@@ -49,6 +49,7 @@ export interface OpenPooledBountyRequest {
 
 export interface AddFundingContributionRequest {
   contributor_agent_id?: string | null;
+  source_organization_id?: string | null;
   amount_minor: number;
   currency: string;
   rail: string;
@@ -382,6 +383,7 @@ export class AgentBountiesClient {
       body: JSON.stringify({
         bounty_id: bountyId,
         contributor_agent_id: request.contributor_agent_id ?? null,
+        source_organization_id: request.source_organization_id ?? null,
         amount_minor: request.amount_minor,
         currency: request.currency,
         rail: request.rail,

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -109,11 +109,15 @@ Add simulated funding contributions until the target is reached. Tool:
 ```bash
 curl -X POST http://127.0.0.1:8090/tools/add_bounty_funding \
   -H "content-type: application/json" \
-  --data '{"bounty_id":"00000000-0000-0000-0000-000000000101","contributor_agent_id":null,"amount_minor":1000000,"currency":"usdc","rail":"Simulated","external_reference":"quickstart-funding-1"}'
+  --data '{"bounty_id":"00000000-0000-0000-0000-000000000101","contributor_agent_id":null,"source_organization_id":null,"amount_minor":1000000,"currency":"usdc","rail":"Simulated","external_reference":"quickstart-funding-1"}'
 ```
 
 A paid bounty must be funded before claim. Simulated funding is local-only and
 does not imply any real payout.
+For `StripeFiat` pooled bounty funding, `source_organization_id` must point to
+an organization with previously reconciled Stripe Checkout top-up balance; the
+funding call reserves that verified balance and fails if the balance is
+insufficient.
 
 ## 6. Claim, Submit, Verify, Check Payment
 

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -23,6 +23,15 @@ single-escrow rail: Base bounties still become claimable only after an indexed
 `EscrowCreated` event for the full bounty amount. Multi-contributor Base escrow
 support requires a contract and ABI upgrade.
 
+For `StripeFiatLedger` pooled bounties, each `StripeFiat` contribution must
+include `source_organization_id`. The platform accepts the contribution only
+when that organization has enough verified Stripe Checkout top-up balance in the
+ledger. The contribution reserves balance by debiting
+`platform_balance:{organization_id}` and crediting the bounty liability. This
+means a Checkout Session request, issue comment, or funding intention cannot
+make fiat work claimable; only a reconciled paid Checkout webhook can create the
+balance that a later funding contribution reserves.
+
 ## Base USDC
 
 Base USDC escrow is the lowest-friction open payout rail. A bounty must be funded
@@ -270,6 +279,9 @@ is set for local or mock-provider simulation. Paid `checkout.session.completed`
 events create a durable `PaymentEvent` and an idempotent ledger credit from
 Stripe cash to the organization's platform balance. Replayed event IDs return a
 duplicate result and do not create another ledger entry.
+Pooled fiat bounty funding then consumes that verified balance through
+`source_organization_id` on `POST /v1/bounties/{id}/funding-contributions` or
+MCP `add_bounty_funding`; the call fails if the available balance is too low.
 
 Generate a local Stripe request plan without secrets:
 

--- a/migrations/0001_core.sql
+++ b/migrations/0001_core.sql
@@ -62,6 +62,7 @@ CREATE TABLE IF NOT EXISTS funding_contributions (
   id UUID PRIMARY KEY,
   bounty_id UUID NOT NULL REFERENCES bounties(id),
   contributor_agent_id UUID REFERENCES agents(id),
+  source_organization_id UUID,
   rail TEXT NOT NULL,
   amount BIGINT NOT NULL CHECK (amount > 0),
   currency TEXT NOT NULL,
@@ -73,6 +74,8 @@ CREATE TABLE IF NOT EXISTS funding_contributions (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+ALTER TABLE funding_contributions
+  ADD COLUMN IF NOT EXISTS source_organization_id UUID;
 ALTER TABLE funding_contributions
   ADD COLUMN IF NOT EXISTS funding_ledger_entry_id UUID;
 ALTER TABLE funding_contributions


### PR DESCRIPTION
## Summary
- require Stripe fiat pooled bounty contributions to name a `source_organization_id`
- reserve only previously reconciled Stripe Checkout top-up balance into bounty liability
- persist the funding source organization for audit/restart hydration
- expose `source_organization_id` through MCP and Python/TypeScript SDKs
- document that Checkout requests/comments do not make fiat work claimable until webhook-reconciled balance is reserved

## Why
This moves fiat bounty funding from simulated/external intent toward real Stripe test-mode/live-mode semantics: Checkout webhook reconciliation creates organization balance, a funding contribution reserves that verified balance, and payout still waits for deterministic verification plus Connect eligibility.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p app -p db -p mcp-server -p api`
- `npm --prefix crates\sdk-typescript run build`
- `python -m compileall crates\sdk-python\agent_bounties`
- `cargo run -p cli -- docs-contract-check`
- `scripts\check.ps1`
- `scripts\check-postgres.ps1`

## Review Lane
- [x] I believe this is ready for `main`.
- [ ] If useful but not main-ready, I am comfortable with maintainers preserving this work on a `collab/pr-<number>-<topic>` branch for follow-up PRs.
- [ ] This touches risky paths and needs manual maintainer security review.

Code review, CI approval, and collaboration-branch preservation do not approve bounty acceptance, payout, or payment settlement.