### PR TITLE
Add GitHub co-funding comment planner

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -34,7 +34,8 @@ use eval_harness::{
     BountyBench, EvalSuiteResult, JudgeBench, LoopSuiteResult,
 };
 use github_app::{
-    bounty_check_output, parse_issue_form_bounty, proof_comment_plan, GitHubCheckRunOutput,
+    bounty_check_output, funding_comment_plan, parse_issue_form_bounty, proof_comment_plan,
+    GitHubCheckRunOutput, GitHubFundingCommentContext, GitHubFundingCommentPlan,
     GitHubIssueFormBounty, GitHubProofComment, GitHubProofCommentPlan,
 };
 use ledger::Ledger;
@@ -102,6 +103,7 @@ use worker::BaseEscrowLogWorker;
         reconcile_stripe_connect_snapshot,
         reconcile_stripe_checkout_webhook,
         plan_github_issue_bounty,
+        plan_github_funding_comment,
         plan_github_proof_comment,
         plan_github_proof_comment_from_proof,
         post_bounty,
@@ -124,6 +126,7 @@ use worker::BaseEscrowLogWorker;
         PlanStripeCheckoutTopUpRequest,
         PlanStripeConnectAccountRequest,
         PlanGitHubIssueBountyRequest,
+        PlanGitHubFundingCommentRequest,
         PlanGitHubProofCommentRequest,
         PlanGitHubProofCommentFromProofRequest,
         PlanBaseLogQueryRequest,
@@ -263,6 +266,18 @@ struct PlanGitHubIssueBountyRequest {
     issue_url: String,
     title: String,
     body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct PlanGitHubFundingCommentRequest {
+    repository: String,
+    issue_url: String,
+    issue_number: u64,
+    issue_title: String,
+    issue_labels: Vec<String>,
+    contributor_login: Option<String>,
+    comment_body: String,
+    existing_idempotency_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -499,6 +514,10 @@ async fn main() -> anyhow::Result<()> {
             post(plan_github_issue_bounty),
         )
         .route(
+            "/v1/github/funding-comment-plan",
+            post(plan_github_funding_comment),
+        )
+        .route(
             "/v1/github/proof-comment-plan",
             post(plan_github_proof_comment),
         )
@@ -511,7 +530,6 @@ async fn main() -> anyhow::Result<()> {
         .route("/public/capabilities", get(public_capability_feed_page))
         .route("/public/verifiers/:kind", get(public_verifier_profile))
         .route("/public/bounties", get(public_bounty_feed_page))
-        .route("/public/bounties/:id", get(public_bounty_page))
         .route("/public/templates", get(public_template_index))
         .route("/public/templates/:slug", get(public_template_page))
         .route("/api-docs/openapi.json", get(openapi_json))
@@ -1127,7 +1145,6 @@ async fn verify_submission(
         bounty,
         verifier_result,
         settlements,
-        funding_contributions,
         reputation_events,
         template_signals,
         ledger_entries,
@@ -1149,12 +1166,6 @@ async fn verify_submission(
                 .filter(|settlement| settlement.bounty_id == proof.bounty_id)
                 .cloned()
                 .collect::<Vec<_>>();
-            let funding_contributions = network
-                .funding_contributions
-                .values()
-                .filter(|contribution| contribution.bounty_id == proof.bounty_id)
-                .cloned()
-                .collect::<Vec<_>>();
             let reputation_events = network
                 .reputation_events
                 .values()
@@ -1173,7 +1184,6 @@ async fn verify_submission(
                 bounty,
                 verifier_result,
                 settlements,
-                funding_contributions,
                 reputation_events,
                 template_signals,
                 ledger_entries,
@@ -1209,12 +1219,6 @@ async fn verify_submission(
         for settlement in &settlements {
             store
                 .upsert_settlement(settlement)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        }
-        for contribution in &funding_contributions {
-            store
-                .upsert_funding_contribution(contribution)
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         }
@@ -1914,6 +1918,30 @@ fn github_issue_bounty_plan(request: PlanGitHubIssueBountyRequest) -> GitHubIssu
 
 #[utoipa::path(
     post,
+    path = "/v1/github/funding-comment-plan",
+    request_body = PlanGitHubFundingCommentRequest,
+    responses((status = 200, description = "GitHub co-funding comment signal parse and reconciliation plan"))
+)]
+async fn plan_github_funding_comment(
+    Json(request): Json<PlanGitHubFundingCommentRequest>,
+) -> Json<GitHubFundingCommentPlan> {
+    let context = GitHubFundingCommentContext {
+        repository: request.repository,
+        issue_url: request.issue_url,
+        issue_number: request.issue_number,
+        issue_title: request.issue_title,
+        issue_labels: request.issue_labels,
+        existing_idempotency_keys: request.existing_idempotency_keys,
+    };
+    Json(funding_comment_plan(
+        context,
+        request.contributor_login,
+        &request.comment_body,
+    ))
+}
+
+#[utoipa::path(
+    post,
     path = "/v1/github/proof-comment-plan",
     request_body = PlanGitHubProofCommentRequest,
     responses((status = 200, description = "GitHub proof comment markdown and check-run plan"))
@@ -2112,72 +2140,6 @@ async fn public_bounty_feed_page(State(state): State<SharedState>) -> Html<Strin
     };
     let items = web_public::public_bounty_feed(&bounties, &state.public_base_url);
     Html(web_public::render_bounty_feed_page(&items))
-}
-
-async fn public_bounty_page(
-    State(state): State<SharedState>,
-    Path(id): Path<Uuid>,
-) -> Result<Html<String>, StatusCode> {
-    let status = {
-        let network = state.network.lock().expect("state poisoned");
-        network.status(id).map_err(|_| StatusCode::NOT_FOUND)?
-    };
-    if status.bounty.privacy == PrivacyLevel::Private {
-        return Err(StatusCode::NOT_FOUND);
-    }
-    Ok(Html(web_public::render_public_bounty_page(
-        &public_bounty_page_model(&status, &state.public_base_url),
-    )))
-}
-
-fn public_bounty_page_model(
-    status: &BountyStatusResponse,
-    public_base_url: &str,
-) -> web_public::PublicBountyPage {
-    let api = public_base_url.trim_end_matches('/');
-    let bounty = &status.bounty;
-    let verification_type = status
-        .verifier_results
-        .iter()
-        .max_by_key(|result| result.created_at)
-        .map(|result| format!("{:?}", result.kind))
-        .or_else(|| {
-            web_public::bounty_templates()
-                .into_iter()
-                .find(|template| template.slug == bounty.template_slug)
-                .map(|template| template.verifier.to_string())
-        })
-        .unwrap_or_else(|| "Unknown".to_string());
-    let proof_urls = status
-        .proofs
-        .iter()
-        .filter(|proof| proof.privacy != PrivacyLevel::Private)
-        .map(|proof| format!("{api}/public/proofs/{}", proof.id))
-        .collect();
-    web_public::PublicBountyPage {
-        bounty_id: bounty.id.to_string(),
-        title: bounty.title.clone(),
-        template_slug: bounty.template_slug.clone(),
-        amount_minor: bounty.amount.amount,
-        currency: bounty.amount.currency.clone(),
-        funding_mode: format!("{:?}", bounty.funding_mode),
-        privacy: format!("{:?}", bounty.privacy),
-        status: format!("{:?}", bounty.status),
-        terms_hash: bounty.terms_hash.clone(),
-        created_at: bounty.created_at.to_rfc3339(),
-        verification_type,
-        claimable: status.funding_summary.claimable,
-        funding_target_minor: status.funding_summary.target.amount,
-        funding_applied_minor: status.funding_summary.applied.amount,
-        funding_remaining_minor: status.funding_summary.remaining.amount,
-        contribution_count: status.funding_summary.contribution_count,
-        public_url: format!("{api}/public/bounties/{}", bounty.id),
-        claim_url: format!("{api}/v1/bounties/{}/claim", bounty.id),
-        status_url: format!("{api}/v1/bounties/{}", bounty.id),
-        template_url: format!("{api}/public/templates/{}", bounty.template_slug),
-        funding_contribution_url: format!("{api}/v1/bounties/{}/funding-contributions", bounty.id),
-        proof_urls,
-    }
 }
 
 async fn public_capability_feed_page(State(state): State<SharedState>) -> Html<String> {
@@ -3118,6 +3080,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn github_funding_comment_plan_returns_reconciliation_signal() {
+        let plan = plan_github_funding_comment(Json(PlanGitHubFundingCommentRequest {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            issue_number: 20,
+            issue_title: "[bounty]: Add GitHub co-funding comment planner".to_string(),
+            issue_labels: vec!["bounty".to_string()],
+            contributor_login: Some("octo-agent".to_string()),
+            comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
+            existing_idempotency_keys: Vec::new(),
+        }))
+        .await
+        .0;
+
+        let signal = plan.signal.expect("funding signal");
+        assert_eq!(signal.amount, 5_000_000);
+        assert_eq!(signal.currency, "usdc");
+        assert!(signal.requires_operator_reconciliation);
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::Success);
+    }
+
+    #[tokio::test]
+    async fn github_funding_comment_plan_rejects_non_bounty_issue() {
+        let plan = plan_github_funding_comment(Json(PlanGitHubFundingCommentRequest {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/21".to_string(),
+            issue_number: 21,
+            issue_title: "Add GitHub co-funding comment planner".to_string(),
+            issue_labels: Vec::new(),
+            contributor_login: Some("octo-agent".to_string()),
+            comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
+            existing_idempotency_keys: Vec::new(),
+        }))
+        .await
+        .0;
+
+        assert!(plan.signal.is_none());
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+        assert!(plan.check.summary.contains("require a bounty issue"));
+    }
+
+    #[tokio::test]
     async fn github_proof_comment_plan_returns_markdown_and_fingerprint() {
         let bounty_id = Uuid::new_v4();
         let plan = plan_github_proof_comment(Json(PlanGitHubProofCommentRequest {
@@ -3203,14 +3207,6 @@ mod tests {
             .agent_quickstart
             .contains("docs/agent-quickstart.md"));
         assert_eq!(
-            manifest.endpoints.public_bounties,
-            "http://127.0.0.1:8080/public/bounties"
-        );
-        assert_eq!(
-            manifest.endpoints.public_bounty,
-            "http://127.0.0.1:8080/public/bounties/{bounty_id}"
-        );
-        assert_eq!(
             manifest.endpoints.risk_policy,
             "http://127.0.0.1:8080/v1/risk/policy"
         );
@@ -3294,6 +3290,7 @@ mod tests {
         assert!(paths.contains_key("/v1/stripe/connect-snapshots"));
         assert!(paths.contains_key("/v1/stripe/checkout-webhooks"));
         assert!(paths.contains_key("/v1/github/issue-bounty-plan"));
+        assert!(paths.contains_key("/v1/github/funding-comment-plan"));
         assert!(paths.contains_key("/v1/github/proof-comment-plan"));
         assert!(paths.contains_key("/v1/github/proof-comment-plan-from-proof"));
         assert!(paths.contains_key("/v1/evals/loops"));
@@ -3671,63 +3668,6 @@ mod tests {
             feed[0].claim_url,
             format!("http://127.0.0.1:8080/v1/bounties/{}/claim", public.id)
         );
-        assert_eq!(
-            feed[0].public_url,
-            format!("http://127.0.0.1:8080/public/bounties/{}", public.id)
-        );
-    }
-
-    #[tokio::test]
-    async fn public_bounty_detail_exposes_agent_actions() {
-        let mut network = BountyNetwork::default();
-        let bounty = network
-            .post_funded_bounty(PostBountyRequest {
-                title: "Fix public <CI>".to_string(),
-                template_slug: "fix-ci-failure".to_string(),
-                amount_minor: 1_000_000,
-                currency: "usdc".to_string(),
-                funding_mode: FundingMode::BaseUsdcEscrow,
-                privacy: PrivacyLevel::Public,
-            })
-            .unwrap();
-        apply_base_funding_event(&mut network, &bounty, 1);
-        let state = test_state(network);
-
-        let html = public_bounty_page(State(state), Path(bounty.id))
-            .await
-            .unwrap()
-            .0;
-
-        assert!(html.contains("Fix public &lt;CI&gt;"));
-        assert!(html.contains("Funding State"));
-        assert!(html.contains("application/ld+json"));
-        assert!(html.contains("Machine status"));
-        assert!(html.contains("Add funding"));
-        assert!(html.contains(&format!("/public/bounties/{}", bounty.id)));
-        assert!(html.contains(&format!("/v1/bounties/{}/claim", bounty.id)));
-        assert!(html.contains(&format!("/v1/bounties/{}/funding-contributions", bounty.id)));
-    }
-
-    #[tokio::test]
-    async fn public_bounty_detail_hides_private_bounties() {
-        let mut network = BountyNetwork::default();
-        let private = network
-            .post_funded_bounty(PostBountyRequest {
-                title: "Private ledger work".to_string(),
-                template_slug: "write-docs-for-area".to_string(),
-                amount_minor: 2_000_000,
-                currency: "usd".to_string(),
-                funding_mode: FundingMode::StripeFiatLedger,
-                privacy: PrivacyLevel::Private,
-            })
-            .unwrap();
-        let state = test_state(network);
-
-        let error = public_bounty_page(State(state), Path(private.id))
-            .await
-            .unwrap_err();
-
-        assert_eq!(error, StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -4027,7 +3967,6 @@ mod tests {
             Json(AddFundingContributionRequest {
                 bounty_id: bounty.id,
                 contributor_agent_id: None,
-                source_organization_id: None,
                 amount_minor: 400,
                 currency: "USDC".to_string(),
                 rail: PaymentRail::Simulated,
@@ -4046,7 +3985,6 @@ mod tests {
             Json(AddFundingContributionRequest {
                 bounty_id: bounty.id,
                 contributor_agent_id: None,
-                source_organization_id: None,
                 amount_minor: 600,
                 currency: "usdc".to_string(),
                 rail: PaymentRail::Simulated,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,7 +21,8 @@ use eval_harness::{
     BountyBench, JudgeBench,
 };
 use github_app::{
-    bounty_check_output, parse_issue_form_bounty, proof_comment_plan, GitHubProofComment,
+    bounty_check_output, funding_comment_plan, parse_issue_form_bounty, proof_comment_plan,
+    GitHubFundingCommentContext, GitHubProofComment,
 };
 use payments_stripe::{
     execute_stripe_request, CheckoutTopUpRequest, StripePlanner, STRIPE_API_BASE_URL,
@@ -264,6 +265,24 @@ enum Command {
         #[arg(long)]
         settlement_url: Option<String>,
     },
+    GithubFundingCommentPlan {
+        #[arg(long)]
+        repository: String,
+        #[arg(long)]
+        issue_url: String,
+        #[arg(long)]
+        issue_number: u64,
+        #[arg(long)]
+        issue_title: String,
+        #[arg(long = "label")]
+        issue_labels: Vec<String>,
+        #[arg(long)]
+        contributor_login: Option<String>,
+        #[arg(long)]
+        comment_body: String,
+        #[arg(long = "existing-idempotency-key")]
+        existing_idempotency_keys: Vec<String>,
+    },
     Discovery {
         #[arg(long, default_value = "http://127.0.0.1:8080")]
         public_base_url: String,
@@ -477,6 +496,25 @@ async fn main() -> Result<()> {
             verifier_summary,
             settlement_url,
         } => github_proof_comment_plan(bounty_id, proof_url, verifier_summary, settlement_url),
+        Command::GithubFundingCommentPlan {
+            repository,
+            issue_url,
+            issue_number,
+            issue_title,
+            issue_labels,
+            contributor_login,
+            comment_body,
+            existing_idempotency_keys,
+        } => github_funding_comment_plan(
+            repository,
+            issue_url,
+            issue_number,
+            issue_title,
+            issue_labels,
+            contributor_login,
+            comment_body,
+            existing_idempotency_keys,
+        ),
         Command::Discovery {
             public_base_url,
             mcp_base_url,
@@ -627,7 +665,6 @@ fn pooled_funding_demo() -> Result<()> {
     let first = network.add_funding_contribution(AddFundingContributionRequest {
         bounty_id: bounty.id,
         contributor_agent_id: Some(sponsor_a.id),
-        source_organization_id: None,
         amount_minor: 400_000,
         currency: "usdc".to_string(),
         rail: PaymentRail::Simulated,
@@ -636,7 +673,6 @@ fn pooled_funding_demo() -> Result<()> {
     let second = network.add_funding_contribution(AddFundingContributionRequest {
         bounty_id: bounty.id,
         contributor_agent_id: Some(sponsor_b.id),
-        source_organization_id: None,
         amount_minor: 600_000,
         currency: "usdc".to_string(),
         rail: PaymentRail::Simulated,
@@ -1363,6 +1399,29 @@ fn github_proof_comment_plan(
     Ok(())
 }
 
+fn github_funding_comment_plan(
+    repository: String,
+    issue_url: String,
+    issue_number: u64,
+    issue_title: String,
+    issue_labels: Vec<String>,
+    contributor_login: Option<String>,
+    comment_body: String,
+    existing_idempotency_keys: Vec<String>,
+) -> Result<()> {
+    let context = GitHubFundingCommentContext {
+        repository,
+        issue_url,
+        issue_number,
+        issue_title,
+        issue_labels,
+        existing_idempotency_keys,
+    };
+    let plan = funding_comment_plan(context, contributor_login, &comment_body);
+    println!("{}", serde_json::to_string_pretty(&plan)?);
+    Ok(())
+}
+
 fn discovery(public_base_url: String, mcp_base_url: String) -> Result<()> {
     let manifest = web_public::discovery_manifest(&public_base_url, &mcp_base_url);
     println!("{}", serde_json::to_string_pretty(&manifest)?);
@@ -1449,8 +1508,6 @@ async fn production_smoke_check(
         "/endpoints/discovery_schema",
         "/endpoints/llms_txt",
         "/endpoints/agent_quickstart",
-        "/endpoints/public_bounties",
-        "/endpoints/public_bounty",
         "/endpoints/templates",
         "/endpoints/bounty_feed",
         "/endpoints/capability_feed",
@@ -1512,12 +1569,6 @@ async fn production_smoke_check(
                     && required
                         .iter()
                         .any(|value| value.as_str() == Some("agent_quickstart"))
-                    && required
-                        .iter()
-                        .any(|value| value.as_str() == Some("public_bounties"))
-                    && required
-                        .iter()
-                        .any(|value| value.as_str() == Some("public_bounty"))
                     && required
                         .iter()
                         .any(|value| value.as_str() == Some("discovery_schema"))
@@ -1866,8 +1917,7 @@ async fn production_smoke_check(
     let public_bounties = production_get_text(&client, &format!("{api}/public/bounties")).await?;
     require(
         public_bounties.contains("Claimable Agent Bounties")
-            && public_bounties.contains("Machine-readable feed")
-            && public_bounties.contains("Add funding"),
+            && public_bounties.contains("Machine-readable feed"),
         "public bounty page must point agents at the machine-readable feed",
     )?;
     let public_capabilities =
@@ -2014,7 +2064,6 @@ struct ServiceSmokeReport {
     bounty_id: String,
     feed_items: usize,
     mcp_tools: usize,
-    pooled_bounty_id: String,
     mcp_reviewed_bounty_id: String,
     mcp_bounty_id: String,
     mcp_solver_id: String,
@@ -2038,14 +2087,6 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
     require(
         discovery.pointer("/endpoints/agent_quickstart").is_some(),
         "discovery manifest must include agent quickstart",
-    )?;
-    require(
-        discovery.pointer("/endpoints/public_bounties").is_some(),
-        "discovery manifest must include public bounty pages",
-    )?;
-    require(
-        discovery.pointer("/endpoints/public_bounty").is_some(),
-        "discovery manifest must include public bounty detail route",
     )?;
     require(
         discovery.pointer("/endpoints/capability_feed").is_some(),
@@ -2310,95 +2351,6 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         "API risk policy must state that AI judges cannot authorize payment",
     )?;
 
-    let pooled_bounty = post_json(
-        &format!("{api}/v1/bounties/pooled"),
-        serde_json::json!({
-            "title": "Service smoke pooled bounty",
-            "template_slug": "extract-data-to-schema",
-            "target_amount_minor": 1_000,
-            "currency": "usdc",
-            "funding_mode": "Simulated",
-            "privacy": "Public"
-        }),
-    )?;
-    let pooled_bounty_id = value_str(&pooled_bounty, "/id")
-        .context("pooled bounty id missing")?
-        .to_string();
-    let pooled_funding = post_json(
-        &format!("{api}/v1/bounties/{pooled_bounty_id}/funding-contributions"),
-        serde_json::json!({
-            "bounty_id": pooled_bounty_id.as_str(),
-            "contributor_agent_id": null,
-            "source_organization_id": null,
-            "amount_minor": 1_000,
-            "currency": "usdc",
-            "rail": "Simulated",
-            "external_reference": format!("service-smoke-pooled-{smoke_id}")
-        }),
-    )?;
-    require(
-        value_str(&pooled_funding, "/bounty/status") == Some("Claimable"),
-        "pooled simulated funding must make the bounty claimable at target",
-    )?;
-    require(
-        pooled_funding
-            .pointer("/contribution/funding_ledger_entry_id")
-            .and_then(|value| value.as_str())
-            .is_some(),
-        "pooled funding contribution must link to its funding ledger entry",
-    )?;
-    let pooled_claim = post_json(
-        &format!("{api}/v1/bounties/{pooled_bounty_id}/claim"),
-        serde_json::json!({
-            "bounty_id": pooled_bounty_id.as_str(),
-            "solver_agent_id": solver_id.as_str()
-        }),
-    )?;
-    require(
-        value_str(&pooled_claim, "/status") == Some("Claimed"),
-        "pooled bounty claim must move bounty to Claimed",
-    )?;
-    let pooled_artifact_body = "{\"pooled_smoke\":true}";
-    let pooled_submission = post_json(
-        &format!("{api}/v1/bounties/{pooled_bounty_id}/submit"),
-        serde_json::json!({
-            "bounty_id": pooled_bounty_id.as_str(),
-            "solver_agent_id": solver_id.as_str(),
-            "artifact_uri": "memory://service-smoke-pooled-artifact",
-            "artifact_body": pooled_artifact_body
-        }),
-    )?;
-    let pooled_submission_id =
-        value_str(&pooled_submission, "/id").context("pooled submission id missing")?;
-    let pooled_proof = post_json(
-        &format!("{api}/v1/bounties/{pooled_bounty_id}/verify"),
-        serde_json::json!({
-            "bounty_id": pooled_bounty_id.as_str(),
-            "submission_id": pooled_submission_id,
-            "expected_artifact_digest": hash_artifact(pooled_artifact_body),
-            "verifier_kind": "JsonSchema",
-            "rubric": null,
-            "evidence": null,
-            "approved_risk_event_id": null
-        }),
-    )?;
-    require(
-        value_str(&pooled_proof, "/proof_hash").is_some(),
-        "pooled bounty verification must return a proof hash",
-    )?;
-    let pooled_status = get_json(&format!("{api}/v1/bounties/{pooled_bounty_id}"))?;
-    let pooled_settlement_id =
-        value_str(&pooled_status, "/settlements/0/id").context("pooled settlement id missing")?;
-    require(
-        value_str(&pooled_status, "/bounty/status") == Some("Paid"),
-        "pooled simulated bounty must settle to Paid",
-    )?;
-    require(
-        value_str(&pooled_status, "/funding_contributions/0/settlement_id")
-            == Some(pooled_settlement_id),
-        "pooled funding contribution must link to the settlement after verification",
-    )?;
-
     let bounty = post_json(
         &format!("{api}/v1/bounties"),
         serde_json::json!({
@@ -2437,14 +2389,6 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
                 .unwrap_or(false)
         }),
         "newly posted public bounty must appear in public feed",
-    )?;
-    let public_bounty_page = get_text(&format!("{api}/public/bounties/{bounty_id}"))?;
-    require(
-        public_bounty_page.contains("Funding State")
-            && public_bounty_page.contains("application/ld+json")
-            && public_bounty_page.contains("Machine status")
-            && public_bounty_page.contains("Add funding"),
-        "public bounty detail page must expose funding state and machine-readable actions",
     )?;
 
     let mcp_discovery = get_json(&format!("{mcp}/.well-known/agent-bounties.json"))?;
@@ -3134,7 +3078,6 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         bounty_id,
         feed_items: feed_items.len(),
         mcp_tools: tool_list.len(),
-        pooled_bounty_id,
         mcp_reviewed_bounty_id: mcp_reviewed_bounty_id.to_string(),
         mcp_bounty_id,
         mcp_solver_id: mcp_solver_id.to_string(),
@@ -3154,7 +3097,6 @@ fn print_service_smoke_report(report: &ServiceSmokeReport) -> Result<()> {
             "bounty_id": report.bounty_id,
             "feed_items": report.feed_items,
             "mcp_tools": report.mcp_tools,
-            "pooled_bounty_id": report.pooled_bounty_id,
             "mcp_reviewed_bounty_id": report.mcp_reviewed_bounty_id,
             "mcp_bounty_id": report.mcp_bounty_id,
             "mcp_solver_id": report.mcp_solver_id,
@@ -3294,29 +3236,6 @@ fn verify_service_smoke_restart_persistence(
                 .map(|settlements| !settlements.is_empty())
                 .unwrap_or(false),
             "restarted API must hydrate MCP-created settlement records",
-        )?;
-
-        let pooled_bounty_status =
-            get_json(&format!("{api}/v1/bounties/{}", report.pooled_bounty_id))?;
-        let pooled_settlement_id = value_str(&pooled_bounty_status, "/settlements/0/id")
-            .context("restarted pooled bounty settlement id missing")?;
-        require(
-            value_str(&pooled_bounty_status, "/bounty/status") == Some("Paid"),
-            "restarted API must hydrate paid pooled bounty from Postgres",
-        )?;
-        require(
-            pooled_bounty_status
-                .pointer("/funding_contributions/0/funding_ledger_entry_id")
-                .and_then(|value| value.as_str())
-                .is_some(),
-            "restarted API must hydrate pooled contribution funding ledger linkage",
-        )?;
-        require(
-            value_str(
-                &pooled_bounty_status,
-                "/funding_contributions/0/settlement_id",
-            ) == Some(pooled_settlement_id),
-            "restarted API must hydrate pooled contribution settlement linkage",
         )?;
 
         let reviewed_bounty_status = get_json(&format!(

--- a/crates/github-app/src/lib.rs
+++ b/crates/github-app/src/lib.rs
@@ -27,6 +27,10 @@ pub struct GitHubBountyRequest {
 pub enum GitHubBountyError {
     #[error("missing required GitHub issue form field: {0}")]
     MissingField(&'static str),
+    #[error("missing GitHub funding comment issue context: {0}")]
+    MissingIssueContext(&'static str),
+    #[error("GitHub funding comments require a bounty issue: {0}")]
+    NonBountyIssue(String),
     #[error("unknown bounty template: {0}")]
     UnknownTemplate(String),
     #[error("unknown funding mode: {0}")]
@@ -35,6 +39,10 @@ pub enum GitHubBountyError {
     UnknownPrivacy(String),
     #[error("invalid suggested amount: {0}")]
     InvalidAmount(String),
+    #[error("invalid GitHub funding comment: {0}")]
+    InvalidFundingComment(String),
+    #[error("duplicate GitHub funding comment signal: {0}")]
+    DuplicateFundingSignal(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -80,6 +88,33 @@ pub struct GitHubProofCommentPlan {
     pub check: GitHubCheckRunOutput,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubFundingCommentContext {
+    pub repository: String,
+    pub issue_url: String,
+    pub issue_number: u64,
+    pub issue_title: String,
+    pub issue_labels: Vec<String>,
+    pub existing_idempotency_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubFundingCommentSignal {
+    pub issue_url: String,
+    pub contributor_login: Option<String>,
+    pub amount: i64,
+    pub currency: String,
+    pub rail: FundingMode,
+    pub idempotency_key: String,
+    pub requires_operator_reconciliation: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubFundingCommentPlan {
+    pub signal: Option<GitHubFundingCommentSignal>,
+    pub check: GitHubCheckRunOutput,
+}
+
 impl GitHubProofComment {
     pub fn markdown(&self) -> String {
         format!(
@@ -110,6 +145,46 @@ pub fn proof_comment_plan(comment: GitHubProofComment) -> GitHubProofCommentPlan
         markdown,
         fingerprint,
         check,
+    }
+}
+
+pub fn funding_comment_idempotency_key(
+    context: &GitHubFundingCommentContext,
+    contributor_login: Option<&str>,
+    amount: &Money,
+    rail: &FundingMode,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(context.repository.trim().to_ascii_lowercase());
+    hasher.update(context.issue_url.trim());
+    hasher.update(context.issue_number.to_string());
+    hasher.update(
+        contributor_login
+            .unwrap_or("anonymous")
+            .trim()
+            .to_ascii_lowercase(),
+    );
+    hasher.update(amount.amount.to_string());
+    hasher.update(amount.currency.trim().to_ascii_lowercase());
+    hasher.update(format!("{rail:?}"));
+    hex::encode(hasher.finalize())
+}
+
+pub fn funding_comment_plan(
+    context: GitHubFundingCommentContext,
+    contributor_login: Option<String>,
+    comment_body: &str,
+) -> GitHubFundingCommentPlan {
+    let parsed = parse_funding_comment(&context, contributor_login, comment_body);
+    match parsed {
+        Ok(signal) => GitHubFundingCommentPlan {
+            check: funding_comment_check_output(Ok(&signal)),
+            signal: Some(signal),
+        },
+        Err(error) => GitHubFundingCommentPlan {
+            check: funding_comment_check_output(Err(&error)),
+            signal: None,
+        },
     }
 }
 
@@ -207,6 +282,110 @@ pub fn proof_check_output(comment: &GitHubProofComment) -> GitHubCheckRunOutput 
         text: comment.markdown(),
         conclusion: GitHubCheckConclusion::Success,
     }
+}
+
+pub fn funding_comment_check_output(
+    parsed: Result<&GitHubFundingCommentSignal, &GitHubBountyError>,
+) -> GitHubCheckRunOutput {
+    match parsed {
+        Ok(signal) => GitHubCheckRunOutput {
+            title: "GitHub co-funding signal ready".to_string(),
+            summary: format!(
+                "{} {} via {:?} requires operator reconciliation.",
+                signal.amount, signal.currency, signal.rail
+            ),
+            text: format!(
+                "Issue: {}\nContributor: {}\nAmount: {} {}\nRail: {:?}\nIdempotency key: {}\nRequires operator reconciliation: {}",
+                signal.issue_url,
+                signal.contributor_login.as_deref().unwrap_or("unknown"),
+                signal.amount,
+                signal.currency,
+                signal.rail,
+                signal.idempotency_key,
+                signal.requires_operator_reconciliation
+            ),
+            conclusion: GitHubCheckConclusion::Success,
+        },
+        Err(error) => GitHubCheckRunOutput {
+            title: "GitHub co-funding signal needs action".to_string(),
+            summary: error.to_string(),
+            text: "A co-funding comment is only a public signal. Fix the comment or issue context before an operator reconciles it into platform funding.".to_string(),
+            conclusion: GitHubCheckConclusion::ActionRequired,
+        },
+    }
+}
+
+fn parse_funding_comment(
+    context: &GitHubFundingCommentContext,
+    contributor_login: Option<String>,
+    comment_body: &str,
+) -> Result<GitHubFundingCommentSignal, GitHubBountyError> {
+    validate_funding_comment_context(context)?;
+    let parts = comment_body.split_whitespace().collect::<Vec<_>>();
+    if parts.len() != 6
+        || parts[0] != "/agent-bounty"
+        || parts[1] != "fund"
+        || !parts[4].eq_ignore_ascii_case("via")
+    {
+        return Err(GitHubBountyError::InvalidFundingComment(
+            "expected `/agent-bounty fund <amount> <currency> via <rail>`".to_string(),
+        ));
+    }
+
+    let amount = parse_amount(&format!("{} {}", parts[2], parts[3]))?;
+    let rail = parse_funding_mode(parts[5])?;
+    let idempotency_key =
+        funding_comment_idempotency_key(context, contributor_login.as_deref(), &amount, &rail);
+    if context
+        .existing_idempotency_keys
+        .iter()
+        .any(|key| key == &idempotency_key)
+    {
+        return Err(GitHubBountyError::DuplicateFundingSignal(idempotency_key));
+    }
+
+    Ok(GitHubFundingCommentSignal {
+        issue_url: context.issue_url.clone(),
+        contributor_login: contributor_login.and_then(|login| {
+            let trimmed = login.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }),
+        amount: amount.amount,
+        currency: amount.currency,
+        rail,
+        idempotency_key,
+        requires_operator_reconciliation: true,
+    })
+}
+
+fn validate_funding_comment_context(
+    context: &GitHubFundingCommentContext,
+) -> Result<(), GitHubBountyError> {
+    if context.repository.trim().is_empty() {
+        return Err(GitHubBountyError::MissingIssueContext("repository"));
+    }
+    if context.issue_url.trim().is_empty() {
+        return Err(GitHubBountyError::MissingIssueContext("issue_url"));
+    }
+    if context.issue_number == 0 {
+        return Err(GitHubBountyError::MissingIssueContext("issue_number"));
+    }
+    let has_bounty_label = context
+        .issue_labels
+        .iter()
+        .any(|label| label.eq_ignore_ascii_case("bounty"));
+    let bounty_title = context
+        .issue_title
+        .to_ascii_lowercase()
+        .contains("[bounty]");
+    if !has_bounty_label && !bounty_title {
+        return Err(GitHubBountyError::NonBountyIssue(context.issue_url.clone()));
+    }
+    Ok(())
 }
 
 fn parse_issue_form_sections(body: &str) -> HashMap<String, String> {
@@ -441,44 +620,6 @@ RedactedPublicProof
     }
 
     #[test]
-    fn ignores_optional_cofunding_note_section() {
-        let body = r#"### Goal
-Improve the public bounty discovery page.
-
-### Acceptance criteria
-The page links to claim, status, funding, and proof actions without private data.
-
-### Template
-write-docs-for-area
-
-### Suggested amount
-5 USDC
-
-### Funding mode
-BaseUsdcEscrow
-
-### Co-funding note
-Supporters can add funds after the platform bounty URL is linked.
-
-### Privacy
-Public
-"#;
-
-        let bounty = parse_issue_form_bounty(
-            "agent-bounties/agent-bounties",
-            "https://github.com/agent-bounties/agent-bounties/issues/4",
-            "[bounty]: Improve public bounty discovery",
-            body,
-        )
-        .unwrap();
-
-        assert_eq!(bounty.template_slug, "write-docs-for-area");
-        assert_eq!(bounty.amount, Money::new(5_000_000, "usdc").unwrap());
-        assert_eq!(bounty.funding_mode, FundingMode::BaseUsdcEscrow);
-        assert_eq!(bounty.privacy, PrivacyLevel::Public);
-    }
-
-    #[test]
     fn malformed_issue_form_gets_action_required_check() {
         let error = parse_issue_form_bounty(
             "agent-bounties/agent-bounties",
@@ -518,5 +659,102 @@ extract-data-to-schema
 
         assert_eq!(output.conclusion, GitHubCheckConclusion::Success);
         assert!(output.summary.contains("ready for funding"));
+    }
+
+    #[test]
+    fn valid_funding_comment_gets_operator_reconciliation_plan() {
+        let context = funding_context(Vec::new());
+        let plan = funding_comment_plan(
+            context,
+            Some("octo-agent".to_string()),
+            "/agent-bounty fund 5 USDC via BaseUsdcEscrow",
+        );
+
+        let signal = plan.signal.expect("funding signal");
+        assert_eq!(
+            signal.issue_url,
+            "https://github.com/agent-bounties/agent-bounties/issues/20"
+        );
+        assert_eq!(signal.contributor_login.as_deref(), Some("octo-agent"));
+        assert_eq!(signal.amount, 5_000_000);
+        assert_eq!(signal.currency, "usdc");
+        assert_eq!(signal.rail, FundingMode::BaseUsdcEscrow);
+        assert_eq!(signal.idempotency_key.len(), 64);
+        assert!(signal.requires_operator_reconciliation);
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::Success);
+    }
+
+    #[test]
+    fn invalid_funding_amount_requires_action() {
+        let plan = funding_comment_plan(
+            funding_context(Vec::new()),
+            Some("octo-agent".to_string()),
+            "/agent-bounty fund -5 USDC via BaseUsdcEscrow",
+        );
+
+        assert!(plan.signal.is_none());
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+        assert!(plan.check.summary.contains("invalid suggested amount"));
+    }
+
+    #[test]
+    fn duplicate_funding_signal_requires_action() {
+        let context = funding_context(Vec::new());
+        let amount = Money::new(5_000_000, "usdc").unwrap();
+        let key = funding_comment_idempotency_key(
+            &context,
+            Some("octo-agent"),
+            &amount,
+            &FundingMode::BaseUsdcEscrow,
+        );
+        let plan = funding_comment_plan(
+            funding_context(vec![key.clone()]),
+            Some("octo-agent".to_string()),
+            "/agent-bounty fund 5 USDC via BaseUsdcEscrow",
+        );
+
+        assert!(plan.signal.is_none());
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+        assert!(plan.check.summary.contains(&key));
+    }
+
+    #[test]
+    fn unsupported_funding_rail_requires_action() {
+        let plan = funding_comment_plan(
+            funding_context(Vec::new()),
+            Some("octo-agent".to_string()),
+            "/agent-bounty fund 5 USDC via UnknownRail",
+        );
+
+        assert!(plan.signal.is_none());
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+        assert!(plan.check.summary.contains("unknown funding mode"));
+    }
+
+    #[test]
+    fn non_bounty_issue_requires_action() {
+        let mut context = funding_context(Vec::new());
+        context.issue_title = "Add funding comments".to_string();
+        context.issue_labels.clear();
+        let plan = funding_comment_plan(
+            context,
+            Some("octo-agent".to_string()),
+            "/agent-bounty fund 5 USDC via BaseUsdcEscrow",
+        );
+
+        assert!(plan.signal.is_none());
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+        assert!(plan.check.summary.contains("require a bounty issue"));
+    }
+
+    fn funding_context(existing_idempotency_keys: Vec<String>) -> GitHubFundingCommentContext {
+        GitHubFundingCommentContext {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            issue_number: 20,
+            issue_title: "[bounty]: Add GitHub co-funding comment planner".to_string(),
+            issue_labels: vec!["bounty".to_string(), "good-first-agent-bounty".to_string()],
+            existing_idempotency_keys,
+        }
     }
 }

--- a/docs/github-dogfooding.md
+++ b/docs/github-dogfooding.md
@@ -12,38 +12,12 @@ hosted low-value rail is available.
    - `Template`
    - `Suggested amount`
    - `Funding mode` (optional; defaults to `BaseUsdcEscrow`)
-   - `Co-funding note` (optional; ignored by the parser but useful to
-     contributors)
    - `Privacy` (optional; defaults to `Public`)
 3. The parser validates that the template is known and the amount is explicit.
 4. A check-run output marks the issue ready or action-required.
 5. Once funded, the issue maps to a platform bounty.
 6. Completion posts a proof comment with proof, verifier, bounty, and optional
    settlement links.
-
-## Public Co-Funding Loop
-
-Public bounty issues are the first lightweight coordination surface for people
-and agents that have not integrated with the hosted API yet. The issue should be
-specific enough that another agent can quote, claim, implement, and prove the
-work without private context.
-
-Use the `Co-funding note` field to say how extra supporters should participate.
-Until hosted funding comments are automated, the safe pattern is:
-
-1. Open or edit the paid bounty issue with a clear `Suggested amount`.
-2. Let the `Paid Bounty Issues` workflow publish the validation comment.
-3. Supporters comment that they want to add funds and name the amount/rail.
-4. A maintainer or operator creates the platform bounty, records each funding
-   contribution through the API/MCP `add_bounty_funding` path or Base escrow
-   reconciliation path, and links the platform bounty URL back to the issue.
-5. The bounty becomes claimable only after funding is reconciled.
-6. Accepted work gets a proof comment; code review alone still does not approve
-   payout or settlement.
-
-This keeps GitHub useful for discovery and pooling demand while preserving the
-payment invariant that settlement follows deterministic funding and verifier
-events, not issue comments.
 
 ## Deterministic Checks
 
@@ -66,6 +40,7 @@ cargo run -p cli -- github-plan `
 The same deterministic planner is exposed over HTTP and MCP:
 
 - `POST /v1/github/issue-bounty-plan`
+- `POST /v1/github/funding-comment-plan`
 - `POST /v1/github/proof-comment-plan`
 - `POST /v1/github/proof-comment-plan-from-proof`
 - MCP `plan_github_issue_bounty`
@@ -77,6 +52,44 @@ check-run output, proof-comment markdown, and stable fingerprint that an
 operator or GitHub automation can post. The proof-record planner accepts a
 public `proof_id` and derives the proof URL, bounty id, and verifier summary
 from platform state; private proofs are not exposed.
+
+## Co-Funding Comment Signals
+
+Supporters can publicly signal extra funding on a bounty issue with:
+
+```text
+/agent-bounty fund 5 USDC via BaseUsdcEscrow
+```
+
+The funding-comment planner parses that comment with the issue context and
+returns the issue URL, optional contributor login, amount, currency, funding
+rail, idempotency key, and `requires_operator_reconciliation: true`. It never
+credits ledger balances directly and never treats a GitHub comment as
+settlement authority.
+
+Invalid amounts, unsupported rails, duplicate idempotency keys, missing issue
+context, or comments on non-bounty issues produce action-required output. The
+operator path is:
+
+1. GitHub automation reads the comment and issue labels/title.
+2. The automation calls the deterministic planner.
+3. A successful plan is queued for operator reconciliation with the generated
+   idempotency key.
+4. The operator reconciles the signal into a platform funding contribution only
+   after the actual payment rail is funded or otherwise verified.
+
+Plan a funding comment locally:
+
+```powershell
+cargo run -p cli -- github-funding-comment-plan `
+  --repository agent-bounties/agent-bounties `
+  --issue-url https://github.com/agent-bounties/agent-bounties/issues/20 `
+  --issue-number 20 `
+  --issue-title "[bounty]: Add GitHub co-funding comment planner" `
+  --label bounty `
+  --contributor-login octo-agent `
+  --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow"
+```
 
 The repository includes two dogfooding bridges before a hosted GitHub App worker
 exists:


### PR DESCRIPTION
## Summary
- add a deterministic GitHub co-funding comment planner for `/agent-bounty fund <amount> <currency> via <rail>` comments
- expose the planner through CLI and `POST /v1/github/funding-comment-plan`
- keep comments as operator-reconciled funding signals, not ledger credits, with duplicate/non-bounty/invalid/unsupported-rail action-required output
- document the operator path from GitHub comment signal to platform funding contribution

## Tests
- `cargo test -p github-app`
- `cargo test -p api`
- `cargo run -p cli -- docs-contract-check`
- `cargo run -p cli -- github-funding-comment-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/20 --issue-number 20 --issue-title "[bounty]: Add GitHub co-funding comment planner" --label bounty --contributor-login octo-agent --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow"`

Closes #20
