### PR TITLE
Harden mixed Base refund handling

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -861,16 +861,22 @@ impl BountyNetwork {
             return Err(AppError::AgentNotFound);
         }
 
-        let requires_base_escrow = self
+        let bounty_snapshot = self
             .bounties
             .get(&request.bounty_id)
             .ok_or(AppError::BountyNotFound)?
-            .funding_mode
-            == FundingMode::BaseUsdcEscrow;
+            .clone();
+        let requires_base_escrow = self
+            .effective_funding_targets(&bounty_snapshot)?
+            .iter()
+            .any(|target| target.rail == PaymentRail::BaseUsdc);
         if requires_base_escrow && !self.has_funded_base_escrow(request.bounty_id) {
             return Err(AppError::InvalidBaseEscrowEvent(
                 "Base USDC bounty cannot be claimed before funded escrow is indexed".to_string(),
             ));
+        }
+        if !self.funding_targets_claimable(&bounty_snapshot)? {
+            return Err(domain::DomainError::UnfundedBounty.into());
         }
 
         let bounty = self
@@ -1110,6 +1116,7 @@ impl BountyNetwork {
                     escrow.bounty_id == event.bounty_id
                         && escrow.rail == PaymentRail::BaseUsdc
                         && escrow.id != escrow_id
+                        && escrow.status != EscrowStatus::Refunded
                 }) {
                     return Err(AppError::InvalidBaseEscrowEvent(
                         "bounty already has a different indexed Base USDC escrow".to_string(),
@@ -2330,7 +2337,7 @@ impl BountyNetwork {
             return Ok(None);
         }
 
-        let amount = self
+        let escrow = self
             .escrows
             .values()
             .find(|escrow| {
@@ -2338,20 +2345,19 @@ impl BountyNetwork {
                     && escrow.rail == PaymentRail::BaseUsdc
                     && is_refundable_base_escrow_status(&escrow.status)
             })
-            .map(|escrow| escrow.amount.clone())
-            .or_else(|| {
-                self.bounties
-                    .get(&bounty_id)
-                    .map(|bounty| bounty.amount.clone())
-            })
-            .ok_or(AppError::BountyNotFound)?;
-        let status = self
+            .cloned()
+            .ok_or_else(|| {
+                AppError::InvalidBaseEscrowEvent(
+                    "refunded event has no funded or disputed Base escrow".to_string(),
+                )
+            })?;
+        let amount = escrow.amount.clone();
+        let bounty_snapshot = self
             .bounties
             .get(&bounty_id)
             .ok_or(AppError::BountyNotFound)?
-            .status
             .clone();
-        if status == BountyStatus::Refunded {
+        if bounty_snapshot.status == BountyStatus::Refunded {
             return Ok(None);
         }
 
@@ -2360,8 +2366,35 @@ impl BountyNetwork {
                 .bounties
                 .get_mut(&bounty_id)
                 .ok_or(AppError::BountyNotFound)?;
-            if bounty.status != BountyStatus::Refunding {
-                bounty.refunding()?;
+            if bounty.funding_mode == FundingMode::MixedRails {
+                match bounty.status {
+                    BountyStatus::Unfunded | BountyStatus::Funded | BountyStatus::Claimable => {
+                        bounty.reopen_for_funding()?;
+                    }
+                    BountyStatus::Claimed
+                    | BountyStatus::Submitted
+                    | BountyStatus::Verifying
+                    | BountyStatus::Disputed => {
+                        bounty.mark_payment_disputed()?;
+                    }
+                    BountyStatus::Accepted
+                    | BountyStatus::Payable
+                    | BountyStatus::Paid
+                    | BountyStatus::Refunding
+                    | BountyStatus::Refunded
+                    | BountyStatus::Expired => {
+                        return Err(domain::DomainError::InvalidTransition {
+                            from: format!("{:?}", bounty.status),
+                            to: "Refunded".to_string(),
+                        }
+                        .into());
+                    }
+                }
+            } else {
+                if bounty.status != BountyStatus::Refunding {
+                    bounty.refunding()?;
+                }
+                bounty.mark_refunded()?;
             }
         }
 
@@ -2374,10 +2407,6 @@ impl BountyNetwork {
             ],
         )?;
         self.ledger.append(entry.clone())?;
-        self.bounties
-            .get_mut(&bounty_id)
-            .ok_or(AppError::BountyNotFound)?
-            .mark_refunded()?;
 
         Ok(Some(entry))
     }
@@ -3017,12 +3046,7 @@ impl BountyNetwork {
                         .filter(|escrow| escrow.rail == target.rail)
                         .filter(|escrow| escrow.amount.currency == target.amount.currency)
                         .filter(|escrow| {
-                            matches!(
-                                escrow.status,
-                                EscrowStatus::Funded
-                                    | EscrowStatus::Disputed
-                                    | EscrowStatus::Released
-                            )
+                            matches!(escrow.status, EscrowStatus::Funded | EscrowStatus::Released)
                         })
                         .count(),
                     claimable: confirmed >= target.amount.amount,
@@ -3068,12 +3092,7 @@ impl BountyNetwork {
             .filter(|escrow| escrow.bounty_id == bounty_id)
             .filter(|escrow| escrow.rail == *rail)
             .filter(|escrow| escrow.amount.currency == currency)
-            .filter(|escrow| {
-                matches!(
-                    escrow.status,
-                    EscrowStatus::Funded | EscrowStatus::Disputed | EscrowStatus::Released
-                )
-            })
+            .filter(|escrow| matches!(escrow.status, EscrowStatus::Funded | EscrowStatus::Released))
             .map(|escrow| escrow.amount.amount)
             .sum::<i64>();
         contribution_total + escrow_total
@@ -4370,6 +4389,130 @@ mod tests {
             .iter()
             .flat_map(|settlement| &settlement.payout_intents)
             .all(|intent| intent.status == PayoutStatus::Paid));
+    }
+
+    #[test]
+    fn mixed_base_refund_reopens_base_partition_without_refunding_stripe_partition() {
+        let mut network = BountyNetwork::default();
+        let organization_id = Uuid::new_v4();
+        let solver = network.register_agent(RegisterAgentRequest {
+            handle: "mixed-refund-solver".to_string(),
+            payout_wallet: Some("0x2222222222222222222222222222222222222222".to_string()),
+        });
+        let bounty = network
+            .open_pooled_bounty(OpenPooledBountyRequest {
+                title: "Recover mixed funding after Base refund".to_string(),
+                template_slug: "extract-data-to-schema".to_string(),
+                target_amount_minor: 500,
+                currency: "usd".to_string(),
+                funding_mode: FundingMode::MixedRails,
+                privacy: PrivacyLevel::Public,
+                funding_targets: vec![
+                    FundingPartitionTargetRequest {
+                        rail: PaymentRail::StripeFiat,
+                        amount_minor: 500,
+                        currency: "usd".to_string(),
+                    },
+                    FundingPartitionTargetRequest {
+                        rail: PaymentRail::BaseUsdc,
+                        amount_minor: 1_000,
+                        currency: "usdc".to_string(),
+                    },
+                ],
+            })
+            .unwrap();
+
+        network
+            .apply_stripe_funding_credit(stripe_funding_credit(
+                organization_id,
+                500,
+                "usd",
+                "evt_mixed_refund_topup",
+            ))
+            .unwrap();
+        network
+            .add_funding_contribution(AddFundingContributionRequest {
+                bounty_id: bounty.id,
+                contributor_agent_id: None,
+                source_organization_id: Some(organization_id),
+                amount_minor: 500,
+                currency: "usd".to_string(),
+                rail: PaymentRail::StripeFiat,
+                external_reference: Some("mixed-refund-stripe-500".to_string()),
+            })
+            .unwrap();
+        network
+            .apply_base_escrow_event(chain_base::simulated_created_event(
+                bounty.id,
+                42,
+                "0x3333333333333333333333333333333333333333",
+                Money::new(1_000, "usdc").unwrap(),
+                bounty.terms_hash.clone().unwrap(),
+            ))
+            .unwrap();
+        assert_eq!(
+            network.status(bounty.id).unwrap().bounty.status,
+            BountyStatus::Claimable
+        );
+        assert_eq!(network.list_claimable_bounties().len(), 1);
+
+        let refunded = network
+            .apply_base_escrow_event(chain_base::simulated_refunded_event(
+                bounty.id,
+                42,
+                format!("0x{}", "ab".repeat(32)),
+            ))
+            .unwrap();
+        assert_eq!(refunded.bounty.status, BountyStatus::Unfunded);
+        assert_eq!(refunded.escrow.status, EscrowStatus::Refunded);
+        assert_eq!(refunded.ledger_entries.len(), 1);
+        assert!(network.list_claimable_bounties().is_empty());
+
+        let status = network.status(bounty.id).unwrap();
+        let stripe_partition = status
+            .funding_summary
+            .partitions
+            .iter()
+            .find(|partition| partition.rail == PaymentRail::StripeFiat)
+            .unwrap();
+        let base_partition = status
+            .funding_summary
+            .partitions
+            .iter()
+            .find(|partition| partition.rail == PaymentRail::BaseUsdc)
+            .unwrap();
+        assert_eq!(stripe_partition.remaining.amount, 0);
+        assert_eq!(base_partition.remaining.amount, 1_000);
+        assert!(!status.funding_summary.claimable);
+        assert_eq!(
+            status.funding_contributions[0].status,
+            FundingContributionStatus::Applied
+        );
+        assert!(status
+            .escrows
+            .iter()
+            .any(|escrow| escrow.status == EscrowStatus::Refunded));
+
+        let err = network
+            .claim_bounty(ClaimBountyRequest {
+                bounty_id: bounty.id,
+                solver_agent_id: solver.id,
+            })
+            .unwrap_err();
+        assert!(matches!(err, AppError::InvalidBaseEscrowEvent(_)));
+
+        let refilled = network
+            .apply_base_escrow_event(chain_base::simulated_created_event(
+                bounty.id,
+                43,
+                "0x3333333333333333333333333333333333333333",
+                Money::new(1_000, "usdc").unwrap(),
+                bounty.terms_hash.clone().unwrap(),
+            ))
+            .unwrap();
+        assert_eq!(refilled.bounty.status, BountyStatus::Claimable);
+        assert_eq!(network.list_claimable_bounties().len(), 1);
+        assert_eq!(network.status(bounty.id).unwrap().escrows.len(), 2);
     }
 
     #[test]

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -296,6 +296,37 @@ impl Bounty {
         self.transition(BountyStatus::Refunded)
     }
 
+    pub fn reopen_for_funding(&mut self) -> DomainResult<()> {
+        if matches!(
+            self.status,
+            BountyStatus::Unfunded | BountyStatus::Funded | BountyStatus::Claimable
+        ) {
+            self.status = BountyStatus::Unfunded;
+            return Ok(());
+        }
+        Err(DomainError::InvalidTransition {
+            from: format!("{:?}", self.status),
+            to: "Unfunded".to_string(),
+        })
+    }
+
+    pub fn mark_payment_disputed(&mut self) -> DomainResult<()> {
+        if matches!(
+            self.status,
+            BountyStatus::Claimed
+                | BountyStatus::Submitted
+                | BountyStatus::Verifying
+                | BountyStatus::Disputed
+        ) {
+            self.status = BountyStatus::Disputed;
+            return Ok(());
+        }
+        Err(DomainError::InvalidTransition {
+            from: format!("{:?}", self.status),
+            to: "Disputed".to_string(),
+        })
+    }
+
     pub fn dispute(&mut self) -> DomainResult<()> {
         if matches!(
             self.status,
@@ -668,5 +699,40 @@ mod tests {
         bounty.mark_refunded().unwrap();
 
         assert_eq!(bounty.status, BountyStatus::Refunded);
+    }
+
+    #[test]
+    fn funded_bounty_can_reopen_after_partition_refund_before_claim() {
+        let mut bounty = Bounty::new(
+            "Fix CI",
+            "fix-ci",
+            Money::new(1_000_000, "usdc").unwrap(),
+            FundingMode::MixedRails,
+            PrivacyLevel::Public,
+        );
+        bounty.mark_funded("terms").unwrap();
+        bounty.make_claimable().unwrap();
+
+        bounty.reopen_for_funding().unwrap();
+
+        assert_eq!(bounty.status, BountyStatus::Unfunded);
+    }
+
+    #[test]
+    fn claimed_bounty_can_be_marked_payment_disputed() {
+        let mut bounty = Bounty::new(
+            "Fix CI",
+            "fix-ci",
+            Money::new(1_000_000, "usdc").unwrap(),
+            FundingMode::MixedRails,
+            PrivacyLevel::Public,
+        );
+        bounty.mark_funded("terms").unwrap();
+        bounty.make_claimable().unwrap();
+        bounty.claim().unwrap();
+
+        bounty.mark_payment_disputed().unwrap();
+
+        assert_eq!(bounty.status, BountyStatus::Disputed);
     }
 }

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -122,6 +122,9 @@ insufficient.
 For mixed real-money funding, create a `MixedRails` bounty with explicit
 partition targets. Stripe partitions are funded through verified platform
 balance reservations; Base partitions are confirmed only by indexed escrow logs.
+If a Base escrow is refunded before work starts, only the Base partition is
+reopened; the bounty is removed from claimable feeds until a replacement Base
+escrow is indexed.
 
 ```bash
 curl -X POST http://127.0.0.1:8090/tools/open_pooled_bounty \

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -33,6 +33,15 @@ broadcast the escrow funding transaction, then wait for the indexed
 escrow support still requires a contract and ABI upgrade, so the MVP supports
 one Base escrow target per mixed bounty.
 
+Mixed funding is partition-aware during refund handling. If an indexed
+`EscrowRefunded` event arrives for the Base partition before work starts, the
+platform reverses only the Base escrow liability and reopens the bounty for
+replacement Base funding; the Stripe partition remains reserved and visible in
+the funding summary. The bounty does not become claimable again until every
+partition is funded at claim time. If the Base partition is refunded after work
+has started, the bounty moves to dispute review instead of pretending the fiat
+partition was also refunded.
+
 For `StripeFiatLedger` pooled bounties, each `StripeFiat` contribution must
 include `source_organization_id`. The platform accepts the contribution only
 when that organization has enough verified Stripe Checkout top-up balance in the
@@ -150,8 +159,10 @@ and testnet development.
 The API accepts normalized chain events at `POST /v1/base/escrow-events`.
 `EscrowCreated` records durable escrow state, `EscrowReleased` marks pending
 payout intents paid and appends the settlement ledger entry, `EscrowRefunded`
-reverses the bounty liability, and replayed release/refund events cannot create
-duplicate ledger entries.
+reverses the relevant Base escrow liability, and replayed release/refund events
+cannot create duplicate ledger entries. For single-rail Base bounties, a
+refunded escrow makes the bounty `Refunded`; for mixed bounties, it reopens or
+disputes the bounty according to whether work has already started.
 For provider-facing workers and agents, the API also accepts raw EVM logs at
 `POST /v1/base/evm-logs`. That endpoint runs the same decoder/indexer pipeline
 used by the worker crate, returns the cursor/report, and persists affected


### PR DESCRIPTION
## Summary
- make mixed Base refunds reopen only the Base funding partition instead of terminally refunding the whole bounty
- revalidate funding partitions and funded Base escrow state at claim time
- allow replacement Base escrow indexing after a prior Base escrow was refunded
- document mixed refund behavior for agents and operators

## Validation
- scripts/preflight.ps1 -Mode core
- cargo test -p domain
- cargo test -p app --lib
- cargo run -p cli -- docs-contract-check
- cargo test --workspace
- scripts/check.ps1
- scripts/check-production-compose.ps1

Follow-up to #26.