### PR TITLE
Add checked SDK co-funding examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.log
 node_modules/
 dist/
+dist-examples/
 coverage/
 *.tsbuildinfo
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Rust and Cargo 1.88 or newer are required to run the workspace.
 Agents should start with [docs/agent-quickstart.md](docs/agent-quickstart.md)
 for the local no-money path, MCP/API calls, pooled funding, and Base Sepolia
 testnet rehearsal.
+Copy-paste SDK examples for local co-funding, claiming, verification, paid
+status checks, and Base Sepolia funding plans live at
+[crates/sdk-python/examples/cofund_claim.py](crates/sdk-python/examples/cofund_claim.py)
+and
+[crates/sdk-typescript/examples/cofund-claim.ts](crates/sdk-typescript/examples/cofund-claim.ts).
 
 Run the lightweight preflight first. `core` checks the required local tooling for
 normal development and basic SDK work; `full` also checks Foundry and disk

--- a/crates/sdk-python/examples/cofund_claim.py
+++ b/crates/sdk-python/examples/cofund_claim.py
@@ -1,0 +1,138 @@
+import argparse
+import json
+import time
+import uuid
+
+from agent_bounties import AgentBountiesClient, hash_artifact
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def run_example(client: AgentBountiesClient) -> dict:
+    suffix = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+    discovery = client.get_discovery_manifest()
+    endpoints = discovery.get("endpoints", {})
+    require(isinstance(endpoints.get("llms_txt"), str), "discovery missing llms.txt")
+    require(
+        isinstance(endpoints.get("pooled_bounties"), str),
+        "discovery missing pooled bounty endpoint",
+    )
+    require(
+        isinstance(endpoints.get("base_funding_plan"), str),
+        "discovery missing Base funding planner endpoint",
+    )
+
+    solver = client.register_agent(
+        f"python-example-solver-{suffix}",
+        "0x2222222222222222222222222222222222222222",
+    )
+    first_funder = client.register_agent(f"python-example-funder-a-{suffix}")
+    second_funder = client.register_agent(f"python-example-funder-b-{suffix}")
+
+    bounty = client.open_pooled_bounty(
+        title=f"Python SDK co-funded local bounty {suffix}",
+        template_slug="extract-data-to-schema",
+        target_amount_minor=1_000_000,
+        currency="usdc",
+        funding_mode="Simulated",
+        privacy="Public",
+    )
+    bounty_id = bounty["id"]
+
+    partial = client.add_funding_contribution(
+        bounty_id,
+        amount_minor=400_000,
+        currency="usdc",
+        rail="Simulated",
+        contributor_agent_id=first_funder["id"],
+        external_reference=f"python-example-{suffix}-funding-a",
+    )
+    require(partial["bounty"]["status"] == "Unfunded", "partial funding became claimable")
+    require(
+        partial["funding_summary"]["remaining"]["amount"] == 600_000,
+        "partial funding remaining amount drifted",
+    )
+
+    funded = client.add_funding_contribution(
+        bounty_id,
+        amount_minor=600_000,
+        currency="usdc",
+        rail="Simulated",
+        contributor_agent_id=second_funder["id"],
+        external_reference=f"python-example-{suffix}-funding-b",
+    )
+    require(funded["bounty"]["status"] == "Claimable", "fully funded bounty is not claimable")
+    require(funded["funding_summary"]["claimable"] is True, "funding summary is not claimable")
+
+    claimable = client.list_claimable_bounties()
+    require(any(item["id"] == bounty_id for item in claimable), "bounty missing from claimable feed")
+
+    claimed = client.claim_bounty(bounty_id, solver["id"])
+    require(claimed["status"] == "Claimed", "claim did not move bounty to Claimed")
+
+    artifact_body = json.dumps({"sdk": "python", "cofunded": True}, separators=(",", ":"))
+    submission = client.submit_result(
+        bounty_id,
+        solver["id"],
+        "memory://python-sdk-cofund-claim.json",
+        artifact_body,
+    )
+    proof = client.request_verification(
+        bounty_id,
+        submission["id"],
+        hash_artifact(artifact_body),
+        verifier_kind="JsonSchema",
+    )
+    require("proof_hash" in proof, "verification did not return proof_hash")
+
+    status = client.get_bounty_status(bounty_id)
+    require(status["bounty"]["status"] == "Paid", "simulated bounty did not settle as paid")
+    paid = client.get_paid_status(bounty_id)
+    require(len(paid["settlements"]) == 1, "paid status missing simulated settlement")
+
+    base_bounty = client.open_pooled_bounty(
+        title=f"Python SDK Base Sepolia funding plan {suffix}",
+        template_slug="fix-ci-failure",
+        target_amount_minor=1_000_000,
+        currency="usdc",
+        funding_mode="BaseUsdcEscrow",
+        privacy="Public",
+    )
+    base_plan = client.plan_base_funding(
+        base_bounty["id"],
+        "0x1111111111111111111111111111111111111111",
+        "0x2222222222222222222222222222222222222222",
+        "0x3333333333333333333333333333333333333333",
+        network="base-sepolia",
+    )
+    require(base_plan["network"]["chain_id"] == 84_532, "Base plan did not use Base Sepolia")
+    require(
+        base_plan["funding"]["create_escrow"]["function"]
+        == "createEscrow(bytes32,address,uint256,bytes32)",
+        "Base plan createEscrow function drifted",
+    )
+
+    return {
+        "example": "python-cofund-claim",
+        "bounty_id": bounty_id,
+        "status": status["bounty"]["status"],
+        "settlements": len(paid["settlements"]),
+        "base_plan_network": base_plan["network"]["name"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Agent Bounties Python SDK co-funding example.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8080")
+    args = parser.parse_args()
+
+    result = run_example(AgentBountiesClient(args.base_url))
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/sdk-typescript/examples/cofund-claim.ts
+++ b/crates/sdk-typescript/examples/cofund-claim.ts
@@ -1,0 +1,209 @@
+import { AgentBountiesClient, hashArtifact } from "../src/index.js";
+
+declare const process: {
+  argv: string[];
+};
+
+type JsonObject = Record<string, unknown>;
+
+function requireCondition(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function asObject(value: unknown, label: string): JsonObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function asArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  return value;
+}
+
+function stringField(value: JsonObject, field: string): string {
+  const result = value[field];
+  if (typeof result !== "string") {
+    throw new Error(`${field} must be a string`);
+  }
+  return result;
+}
+
+function baseUrlFromArgs(): string {
+  const index = process.argv.indexOf("--base-url");
+  if (index >= 0 && process.argv[index + 1]) {
+    return process.argv[index + 1];
+  }
+  return "http://127.0.0.1:8080";
+}
+
+async function runExample(client: AgentBountiesClient): Promise<JsonObject> {
+  const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  const discovery = asObject(await client.getDiscoveryManifest(), "discovery");
+  const endpoints = asObject(discovery.endpoints, "discovery.endpoints");
+  requireCondition(typeof endpoints.llms_txt === "string", "discovery missing llms.txt");
+  requireCondition(
+    typeof endpoints.pooled_bounties === "string",
+    "discovery missing pooled bounty endpoint",
+  );
+  requireCondition(
+    typeof endpoints.base_funding_plan === "string",
+    "discovery missing Base funding planner endpoint",
+  );
+
+  const solver = asObject(
+    await client.registerAgent(
+      `typescript-example-solver-${suffix}`,
+      "0x2222222222222222222222222222222222222222",
+    ),
+    "solver",
+  );
+  const firstFunder = asObject(
+    await client.registerAgent(`typescript-example-funder-a-${suffix}`),
+    "firstFunder",
+  );
+  const secondFunder = asObject(
+    await client.registerAgent(`typescript-example-funder-b-${suffix}`),
+    "secondFunder",
+  );
+
+  const bounty = asObject(
+    await client.openPooledBounty({
+      title: `TypeScript SDK co-funded local bounty ${suffix}`,
+      template_slug: "extract-data-to-schema",
+      target_amount_minor: 1_000_000,
+      currency: "usdc",
+      funding_mode: "Simulated",
+      privacy: "Public",
+    }),
+    "bounty",
+  );
+  const bountyId = stringField(bounty, "id");
+
+  const partial = asObject(
+    await client.addFundingContribution(bountyId, {
+      amount_minor: 400_000,
+      currency: "usdc",
+      rail: "Simulated",
+      contributor_agent_id: stringField(firstFunder, "id"),
+      external_reference: `typescript-example-${suffix}-funding-a`,
+    }),
+    "partial",
+  );
+  requireCondition(
+    asObject(partial.bounty, "partial.bounty").status === "Unfunded",
+    "partial funding became claimable",
+  );
+  requireCondition(
+    asObject(asObject(partial.funding_summary, "partial.funding_summary").remaining, "partial.remaining")
+      .amount === 600_000,
+    "partial funding remaining amount drifted",
+  );
+
+  const funded = asObject(
+    await client.addFundingContribution(bountyId, {
+      amount_minor: 600_000,
+      currency: "usdc",
+      rail: "Simulated",
+      contributor_agent_id: stringField(secondFunder, "id"),
+      external_reference: `typescript-example-${suffix}-funding-b`,
+    }),
+    "funded",
+  );
+  requireCondition(
+    asObject(funded.bounty, "funded.bounty").status === "Claimable",
+    "fully funded bounty is not claimable",
+  );
+  requireCondition(
+    asObject(funded.funding_summary, "funded.funding_summary").claimable === true,
+    "funding summary is not claimable",
+  );
+
+  const claimable = asArray(await client.listClaimableBounties(), "claimable").map((item) =>
+    asObject(item, "claimable item"),
+  );
+  requireCondition(
+    claimable.some((item) => item.id === bountyId),
+    "bounty missing from claimable feed",
+  );
+
+  const claimed = asObject(
+    await client.claimBounty(bountyId, { solver_agent_id: stringField(solver, "id") }),
+    "claimed",
+  );
+  requireCondition(claimed.status === "Claimed", "claim did not move bounty to Claimed");
+
+  const artifactBody = JSON.stringify({ sdk: "typescript", cofunded: true });
+  const submission = asObject(
+    await client.submitResult(bountyId, {
+      solver_agent_id: stringField(solver, "id"),
+      artifact_uri: "memory://typescript-sdk-cofund-claim.json",
+      artifact_body: artifactBody,
+    }),
+    "submission",
+  );
+  const proof = asObject(
+    await client.requestVerification(bountyId, {
+      submission_id: stringField(submission, "id"),
+      expected_artifact_digest: await hashArtifact(artifactBody),
+      verifier_kind: "JsonSchema",
+    }),
+    "proof",
+  );
+  requireCondition("proof_hash" in proof, "verification did not return proof_hash");
+
+  const status = asObject(await client.getBountyStatus(bountyId), "status");
+  const statusBounty = asObject(status.bounty, "status.bounty");
+  requireCondition(statusBounty.status === "Paid", "simulated bounty did not settle as paid");
+  const paid = asObject(await client.getPaidStatus(bountyId), "paid");
+  const settlements = asArray(paid.settlements, "paid.settlements");
+  requireCondition(settlements.length === 1, "paid status missing simulated settlement");
+
+  const baseBounty = asObject(
+    await client.openPooledBounty({
+      title: `TypeScript SDK Base Sepolia funding plan ${suffix}`,
+      template_slug: "fix-ci-failure",
+      target_amount_minor: 1_000_000,
+      currency: "usdc",
+      funding_mode: "BaseUsdcEscrow",
+      privacy: "Public",
+    }),
+    "baseBounty",
+  );
+  const basePlan = asObject(
+    await client.planBaseFunding({
+      bounty_id: stringField(baseBounty, "id"),
+      escrow_contract: "0x1111111111111111111111111111111111111111",
+      payer: "0x2222222222222222222222222222222222222222",
+      token: "0x3333333333333333333333333333333333333333",
+      network: "base-sepolia",
+    }),
+    "basePlan",
+  );
+  requireCondition(
+    asObject(basePlan.network, "basePlan.network").chain_id === 84_532,
+    "Base plan did not use Base Sepolia",
+  );
+  requireCondition(
+    asObject(asObject(basePlan.funding, "basePlan.funding").create_escrow, "basePlan.create_escrow")
+      .function === "createEscrow(bytes32,address,uint256,bytes32)",
+    "Base plan createEscrow function drifted",
+  );
+
+  return {
+    example: "typescript-cofund-claim",
+    bounty_id: bountyId,
+    status: statusBounty.status,
+    settlements: settlements.length,
+    base_plan_network: asObject(basePlan.network, "basePlan.network").name,
+  };
+}
+
+const result = await runExample(new AgentBountiesClient({ baseUrl: baseUrlFromArgs() }));
+console.log(JSON.stringify(result, null, 2));

--- a/crates/sdk-typescript/package.json
+++ b/crates/sdk-typescript/package.json
@@ -6,10 +6,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "build:examples": "tsc -p tsconfig.examples.json",
+    "check:examples": "tsc -p tsconfig.examples.json --noEmit"
   },
   "devDependencies": {
     "typescript": "^5.5.0"
   }
 }
-

--- a/crates/sdk-typescript/tsconfig.examples.json
+++ b/crates/sdk-typescript/tsconfig.examples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "dist-examples"
+  },
+  "include": ["src/**/*.ts", "examples/**/*.ts"]
+}

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -134,6 +134,13 @@ curl -X POST http://127.0.0.1:8090/tools/open_pooled_bounty \
 
 ## 6. Claim, Submit, Verify, Check Payment
 
+SDK examples with deterministic assertions are available for the same flow:
+`crates/sdk-python/examples/cofund_claim.py` and
+`crates/sdk-typescript/examples/cofund-claim.ts`. They read the discovery
+manifest, run a local simulated co-funded bounty through claim, submit,
+verification, and paid-status checks, then plan a Base Sepolia funding
+transaction without treating the plan as settlement.
+
 Find claimable public work:
 
 ```bash

--- a/scripts/check-sdk-live.ps1
+++ b/scripts/check-sdk-live.ps1
@@ -75,11 +75,14 @@ try {
         }
 
         Invoke-Checked { & $pythonCommand.Source @pythonArgs -m agent_bounties.smoke --base-url $apiBaseUrl }
+        Invoke-Checked { & $pythonCommand.Source @pythonArgs crates\sdk-python\examples\cofund_claim.py --base-url $apiBaseUrl }
 
         Push-Location (Join-Path $repoRoot "crates\sdk-typescript")
         Invoke-Checked { npm ci }
         Invoke-Checked { npm run build }
+        Invoke-Checked { npm run build:examples }
         Invoke-Checked { node dist/smoke.js --base-url $apiBaseUrl }
+        Invoke-Checked { node dist-examples/examples/cofund-claim.js --base-url $apiBaseUrl }
         Pop-Location
     }
     finally {

--- a/scripts/check-sdk-live.sh
+++ b/scripts/check-sdk-live.sh
@@ -76,8 +76,13 @@ if [[ "$ready" != "1" ]]; then
 fi
 
 PYTHONPATH="$sdk_python_path" "${python_cmd[@]}" -m agent_bounties.smoke --base-url "$api_base_url"
+PYTHONPATH="$sdk_python_path" "${python_cmd[@]}" \
+  crates/sdk-python/examples/cofund_claim.py \
+  --base-url "$api_base_url"
 
 cd "$repo_root/crates/sdk-typescript"
 npm ci
 npm run build
+npm run build:examples
 node dist/smoke.js --base-url "$api_base_url"
+node dist-examples/examples/cofund-claim.js --base-url "$api_base_url"

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -56,13 +56,14 @@ Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbo
 Invoke-Checked { cargo run -p cli -- docs-contract-check }
 Invoke-Checked { cargo run -p cli -- demo }
 Invoke-Checked { cargo run -p cli -- pooled-funding-demo }
-Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py crates\sdk-python\examples\cofund_claim.py }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\github_issue_plan_comment.py scripts\github_proof_comment.py }
 Pop-Location
 
 Push-Location (Join-Path $repoRoot "crates\sdk-typescript")
 Invoke-Checked { npm ci }
 Invoke-Checked { npm run build }
+Invoke-Checked { npm run check:examples }
 Pop-Location
 
 Push-Location (Join-Path $repoRoot "contracts\base-escrow")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -92,12 +92,14 @@ cargo run -p cli -- pooled-funding-demo
   crates/sdk-python/agent_bounties/client.py \
   crates/sdk-python/agent_bounties/smoke.py \
   crates/sdk-python/agent_bounties/__init__.py \
+  crates/sdk-python/examples/cofund_claim.py \
   scripts/github_issue_plan_comment.py \
   scripts/github_proof_comment.py
 
 cd "$repo_root/crates/sdk-typescript"
 npm ci
 npm run build
+npm run check:examples
 
 cd "$repo_root/contracts/base-escrow"
 forge test


### PR DESCRIPTION
## Summary
- add Python and TypeScript SDK examples for local simulated co-funding, claim, submit, verify, and paid-status checks
- show Base Sepolia as the hosted/testnet rail through real funding-plan calls without treating the plan as settlement
- add TypeScript example typecheck/build scripts and wire Python/TypeScript examples into local gates
- update README and agent quickstart links so autonomous agents can find the examples

## Validation
- python -m py_compile crates/sdk-python/agent_bounties/client.py crates/sdk-python/agent_bounties/smoke.py crates/sdk-python/agent_bounties/__init__.py crates/sdk-python/examples/cofund_claim.py
- npm --prefix crates/sdk-typescript run build
- npm --prefix crates/sdk-typescript run check:examples
- npm --prefix crates/sdk-typescript run build:examples
- scripts/check-sdk-live.ps1
- cargo run -p cli -- docs-contract-check
- scripts/check.ps1

Advances #21.