### PR TITLE
Add funding comment planner and mixed funding rehearsal

### DIFF
--- a/.github/ISSUE_TEMPLATE/paid-bounty.yml
+++ b/.github/ISSUE_TEMPLATE/paid-bounty.yml
@@ -53,7 +53,15 @@ body:
     attributes:
       label: Co-funding note
       description: Optional instructions for people or agents who want to add funds to this bounty.
-      placeholder: "Additional supporters can comment `/agent-bounty fund <amount> USDC` or ask for a Base funding plan once the hosted rail is enabled."
+      placeholder: "Additional supporters can comment `/agent-bounty fund <amount> USDC via BaseUsdcEscrow` or `/agent-bounty fund <amount> USD via StripeFiatLedger`."
+    validations:
+      required: false
+  - type: textarea
+    id: discovery
+    attributes:
+      label: Discovery feedback
+      description: Help improve distribution. How did you find Agent Bounties, and what made this bounty worth posting or funding?
+      placeholder: "Example: saw a public proof page from another agent; posted because the acceptance criteria and payout path were explicit."
     validations:
       required: false
   - type: dropdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,11 @@ distribution improvement in this PR.
 Link the bounty, issue, or discussion this PR addresses. If there is no bounty,
 say so explicitly.
 
+## Discovery Feedback
+
+- How did you find Agent Bounties?
+- What made this bounty or project worth participating in?
+
 ## Acceptance Criteria
 
 - [ ] The PR has a clear verifier or review path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,15 @@ Good first contributions:
 - Improve MCP/OpenAPI agent ergonomics.
 - Add GitHub dogfooding bounties.
 
+Every issue, bounty, and PR should answer two distribution questions when
+possible:
+
+- How did you find Agent Bounties?
+- What made this bounty or project worth participating in?
+
+Those answers help improve agent discovery, public proof pages, bounty wording,
+and payout trust. They are not part of bounty acceptance or payout approval.
+
 If your PR is useful but not ready for `main`, maintainers may copy it to a
 `collab/pr-<number>-<topic>` branch so other contributors can target follow-up
 PRs there. That keeps iteration moving while protected payment, workflow,

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ way to recover before rerunning the check.
 cargo test --workspace
 cargo run -p cli -- demo
 cargo run -p cli -- pooled-funding-demo
+cargo run -p cli -- funding-rehearsal-demo
 cargo run -p cli -- base-plan --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --token 0x3333333333333333333333333333333333333333
 cargo run -p cli -- base-decode-demo
 cargo run -p cli -- base-log-query --escrow-contract 0x1111111111111111111111111111111111111111 --from-block 0
@@ -67,6 +68,7 @@ cargo run -p cli -- base-dispute-plan --escrow-contract 0x1111111111111111111111
 cargo run -p cli -- base-sepolia-runbook --settlement-signer 0x5555555555555555555555555555555555555555 --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x3333333333333333333333333333333333333333
 cargo run -p cli -- stripe-plan --organization-id 00000000-0000-0000-0000-000000000001
 cargo run -p cli -- github-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md
+cargo run -p cli -- github-funding-comment-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow" --contributor-login example-agent --comment-id 12345
 cargo run -p cli -- risk-policy
 cargo run -p cli -- risk-events --action NeedsReview --surface Bounty
 cargo run -p cli -- risk-approve-bounty --risk-event-id 00000000-0000-0000-0000-000000000001 --title "Reviewed bounty" --template-slug fix-ci-failure --amount-minor 25000000 --operator-id local-operator --note "Approved after manual review"
@@ -230,6 +232,7 @@ Useful REST paths:
 - `POST /v1/stripe/checkout-webhooks`
 - `POST /v1/stripe/connect-snapshots`
 - `POST /v1/github/issue-bounty-plan`
+- `POST /v1/github/funding-comment-plan`
 - `POST /v1/github/proof-comment-plan`
 - `POST /v1/github/proof-comment-plan-from-proof`
 - `GET /v1/evals/loops`
@@ -254,6 +257,7 @@ status, plan Stripe Checkout top-ups and Accounts v2 onboarding requests, plan
 Base USDC funding/release/refund/dispute transactions, call
 operator-gated live Stripe execution endpoints when a hosted service has Stripe
 secrets configured, plan GitHub paid-bounty issue checks and
+public funding-comment reconciliation signals, plan
 manual or proof-record-backed proof comments, and run `BountyBench`, `AbuseBench`, `JudgeBench`, or the
 combined eval-loop gate. Eval endpoints append compact `EvalRun` records that
 can be read from `/v1/evals/runs` or MCP `get_eval_runs` as hosted quality
@@ -306,7 +310,8 @@ The MCP server exposes matching local tools on port `8090`, including
 `plan_stripe_checkout_top_up`, `plan_stripe_connect_account`,
 `execute_stripe_checkout_top_up`, `execute_stripe_connect_account`,
 `reconcile_stripe_checkout_webhook`, `reconcile_stripe_connect_snapshot`,
-`plan_github_issue_bounty`, `plan_github_proof_comment`, and
+`plan_github_issue_bounty`, `plan_github_funding_comment`,
+`plan_github_proof_comment`, and
 `plan_github_proof_comment_for_proof`.
 It also serves the same discovery manifest at
 `/.well-known/agent-bounties.json` so autonomous agents can find the API, MCP
@@ -380,9 +385,11 @@ GitHub dogfooding starts from `.github/ISSUE_TEMPLATE/paid-bounty.yml`. The
 `github-app` crate parses issue-form bodies, validates bounty templates and
 amounts, carries optional funding/privacy terms, emits check-run output, and renders proof comments with stable
 fingerprints. API and MCP planner surfaces expose the same behavior at
-`/v1/github/issue-bounty-plan`, `/v1/github/proof-comment-plan`,
+`/v1/github/issue-bounty-plan`, `/v1/github/funding-comment-plan`,
+`/v1/github/proof-comment-plan`,
 `/v1/github/proof-comment-plan-from-proof`, `plan_github_issue_bounty`,
-`plan_github_proof_comment`, and `plan_github_proof_comment_for_proof`.
+`plan_github_funding_comment`, `plan_github_proof_comment`, and
+`plan_github_proof_comment_for_proof`.
 The `Paid Bounty Issues` workflow runs the planner on bounty-looking issue
 events and updates a sticky validation comment so contributors get immediate
 feedback before the issue is funded. The `Paid Bounty Proofs` workflow can be
@@ -393,7 +400,12 @@ publishes a sticky accepted-proof comment. Configure
 proof path.
 The paid-bounty issue form includes an optional co-funding note so supporters
 can publicly signal added demand while operators keep actual funding and payout
-state in the platform ledger/Base escrow flow.
+state in the platform ledger/Base escrow flow. Supporters can comment
+`/agent-bounty fund <amount> <currency> via <rail>`; the deterministic planner
+returns an idempotency key and `requires_operator_reconciliation`, so comments
+queue operator work without crediting balances. Contributor and bounty templates
+ask how participants found the project and why they participated so
+distribution learning compounds with the public proof graph.
 
 Run all local checks:
 
@@ -415,6 +427,7 @@ fixtures, `JudgeBench` for product-quality AI-judge filter regressions,
 operator planners including the risk-policy descriptor and Base
 release/refund/dispute transaction plans,
 the GitHub paid-bounty issue workflow dry-run,
+the GitHub funding-comment planner, the mixed Stripe/Base funding rehearsal,
 Python/TypeScript SDK compilation, SDK eval-run history checks, and Foundry
 escrow tests.
 GitHub Actions runs the same `scripts/check.sh` gate on pushes and pull

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -34,7 +34,8 @@ use eval_harness::{
     BountyBench, EvalSuiteResult, JudgeBench, LoopSuiteResult,
 };
 use github_app::{
-    bounty_check_output, parse_issue_form_bounty, proof_comment_plan, GitHubCheckRunOutput,
+    bounty_check_output, funding_comment_plan, parse_issue_form_bounty, proof_comment_plan,
+    GitHubCheckRunOutput, GitHubFundingCommentInput, GitHubFundingCommentPlan,
     GitHubIssueFormBounty, GitHubProofComment, GitHubProofCommentPlan,
 };
 use ledger::Ledger;
@@ -102,6 +103,7 @@ use worker::BaseEscrowLogWorker;
         reconcile_stripe_connect_snapshot,
         reconcile_stripe_checkout_webhook,
         plan_github_issue_bounty,
+        plan_github_funding_comment,
         plan_github_proof_comment,
         plan_github_proof_comment_from_proof,
         post_bounty,
@@ -124,6 +126,7 @@ use worker::BaseEscrowLogWorker;
         PlanStripeCheckoutTopUpRequest,
         PlanStripeConnectAccountRequest,
         PlanGitHubIssueBountyRequest,
+        PlanGitHubFundingCommentRequest,
         PlanGitHubProofCommentRequest,
         PlanGitHubProofCommentFromProofRequest,
         PlanBaseLogQueryRequest,
@@ -263,6 +266,19 @@ struct PlanGitHubIssueBountyRequest {
     issue_url: String,
     title: String,
     body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct PlanGitHubFundingCommentRequest {
+    repository: String,
+    issue_url: String,
+    title: String,
+    body: String,
+    comment_body: String,
+    contributor_login: Option<String>,
+    comment_id: Option<String>,
+    #[serde(default)]
+    existing_idempotency_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -497,6 +513,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/v1/github/issue-bounty-plan",
             post(plan_github_issue_bounty),
+        )
+        .route(
+            "/v1/github/funding-comment-plan",
+            post(plan_github_funding_comment),
         )
         .route(
             "/v1/github/proof-comment-plan",
@@ -1914,6 +1934,27 @@ fn github_issue_bounty_plan(request: PlanGitHubIssueBountyRequest) -> GitHubIssu
 
 #[utoipa::path(
     post,
+    path = "/v1/github/funding-comment-plan",
+    request_body = PlanGitHubFundingCommentRequest,
+    responses((status = 200, description = "GitHub public funding-comment signal plan"))
+)]
+async fn plan_github_funding_comment(
+    Json(request): Json<PlanGitHubFundingCommentRequest>,
+) -> Json<GitHubFundingCommentPlan> {
+    Json(funding_comment_plan(GitHubFundingCommentInput {
+        repository: request.repository,
+        issue_url: request.issue_url,
+        title: request.title,
+        body: request.body,
+        comment_body: request.comment_body,
+        contributor_login: request.contributor_login,
+        comment_id: request.comment_id,
+        existing_idempotency_keys: request.existing_idempotency_keys,
+    }))
+}
+
+#[utoipa::path(
+    post,
     path = "/v1/github/proof-comment-plan",
     request_body = PlanGitHubProofCommentRequest,
     responses((status = 200, description = "GitHub proof comment markdown and check-run plan"))
@@ -3118,6 +3159,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn github_funding_comment_plan_flags_operator_reconciliation() {
+        let plan = plan_github_funding_comment(Json(PlanGitHubFundingCommentRequest {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Co-funding".to_string(),
+            body: valid_github_issue_body(),
+            comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
+            contributor_login: Some("solver-agent".to_string()),
+            comment_id: Some("123".to_string()),
+            existing_idempotency_keys: vec![],
+        }))
+        .await
+        .0;
+
+        assert!(plan.ready);
+        let signal = plan.signal.expect("funding signal");
+        assert!(signal.requires_operator_reconciliation);
+        assert_eq!(signal.amount.currency, "usdc");
+        assert!(signal.idempotency_key.ends_with(":comment:123"));
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::Success);
+    }
+
+    #[tokio::test]
+    async fn github_funding_comment_plan_rejects_duplicate_signal() {
+        let existing_key =
+            "github-funding-comment:agent-bounties/agent-bounties:https://github.com/agent-bounties/agent-bounties/issues/20:comment:123";
+        let plan = plan_github_funding_comment(Json(PlanGitHubFundingCommentRequest {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Co-funding".to_string(),
+            body: valid_github_issue_body(),
+            comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
+            contributor_login: None,
+            comment_id: Some("123".to_string()),
+            existing_idempotency_keys: vec![existing_key.to_string()],
+        }))
+        .await
+        .0;
+
+        assert!(!plan.ready);
+        assert!(plan.error.unwrap().contains("duplicate funding signal"));
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+    }
+
+    #[tokio::test]
     async fn github_proof_comment_plan_returns_markdown_and_fingerprint() {
         let bounty_id = Uuid::new_v4();
         let plan = plan_github_proof_comment(Json(PlanGitHubProofCommentRequest {
@@ -3242,6 +3328,10 @@ mod tests {
             manifest.endpoints.github_proof_comment_from_proof_plan,
             "http://127.0.0.1:8080/v1/github/proof-comment-plan-from-proof"
         );
+        assert_eq!(
+            manifest.endpoints.github_funding_comment_plan,
+            "http://127.0.0.1:8080/v1/github/funding-comment-plan"
+        );
         assert_eq!(manifest.risk_policy.low_value_usdc_cap_minor, 10_000_000);
         assert!(manifest
             .agent_entrypoints
@@ -3294,6 +3384,7 @@ mod tests {
         assert!(paths.contains_key("/v1/stripe/connect-snapshots"));
         assert!(paths.contains_key("/v1/stripe/checkout-webhooks"));
         assert!(paths.contains_key("/v1/github/issue-bounty-plan"));
+        assert!(paths.contains_key("/v1/github/funding-comment-plan"));
         assert!(paths.contains_key("/v1/github/proof-comment-plan"));
         assert!(paths.contains_key("/v1/github/proof-comment-plan-from-proof"));
         assert!(paths.contains_key("/v1/evals/loops"));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,9 +1,10 @@
 use anyhow::{bail, Context, Result};
 use app::{
     hash_artifact, AddFundingContributionRequest, BaseReleaseQueueRequest, BountyNetwork,
-    ClaimBountyRequest, CreateHelpRequestRequest, FundQuoteRequest, OpenPooledBountyRequest,
-    PostBountyRequest, RegisterAgentRequest, RegisterCapabilityRequest, RequestQuotesRequest,
-    SubmitResultRequest, VerifySubmissionRequest,
+    ClaimBountyRequest, CreateHelpRequestRequest, FundQuoteRequest, FundingPartitionTargetRequest,
+    OpenPooledBountyRequest, PlanBaseFundingRequest, PlanBaseReleaseRequest, PostBountyRequest,
+    RegisterAgentRequest, RegisterCapabilityRequest, RequestQuotesRequest, SubmitResultRequest,
+    VerifySubmissionRequest,
 };
 use chain_base::{
     base_network_descriptor, broadcast_signed_transaction, eth_get_transaction_receipt_request,
@@ -21,10 +22,12 @@ use eval_harness::{
     BountyBench, JudgeBench,
 };
 use github_app::{
-    bounty_check_output, parse_issue_form_bounty, proof_comment_plan, GitHubProofComment,
+    bounty_check_output, funding_comment_plan, parse_issue_form_bounty, proof_comment_plan,
+    GitHubFundingCommentInput, GitHubProofComment,
 };
 use payments_stripe::{
-    execute_stripe_request, CheckoutTopUpRequest, StripePlanner, STRIPE_API_BASE_URL,
+    execute_stripe_request, CheckoutTopUpRequest, ConnectAccountSnapshot, StripeEventDeduper,
+    StripePlanner, StripeWebhookEvent, STRIPE_API_BASE_URL,
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -46,10 +49,23 @@ struct Args {
     command: Command,
 }
 
+#[derive(Debug)]
+struct GithubFundingCommentPlanCli {
+    repository: String,
+    issue_url: String,
+    title: String,
+    body_file: String,
+    comment_body: String,
+    contributor_login: Option<String>,
+    comment_id: Option<String>,
+    existing_idempotency_keys: Vec<String>,
+}
+
 #[derive(Subcommand)]
 enum Command {
     Demo,
     PooledFundingDemo,
+    FundingRehearsalDemo,
     Bountybench,
     Abusebench,
     Judgebench,
@@ -254,6 +270,24 @@ enum Command {
         #[arg(long)]
         body_file: String,
     },
+    GithubFundingCommentPlan {
+        #[arg(long)]
+        repository: String,
+        #[arg(long)]
+        issue_url: String,
+        #[arg(long)]
+        title: String,
+        #[arg(long)]
+        body_file: String,
+        #[arg(long)]
+        comment_body: String,
+        #[arg(long)]
+        contributor_login: Option<String>,
+        #[arg(long)]
+        comment_id: Option<String>,
+        #[arg(long = "existing-idempotency-key")]
+        existing_idempotency_keys: Vec<String>,
+    },
     GithubProofCommentPlan {
         #[arg(long)]
         bounty_id: Uuid,
@@ -308,6 +342,7 @@ async fn main() -> Result<()> {
     match args.command {
         Command::Demo => demo().await,
         Command::PooledFundingDemo => pooled_funding_demo(),
+        Command::FundingRehearsalDemo => funding_rehearsal_demo().await,
         Command::Bountybench => bountybench(),
         Command::Abusebench => abusebench(),
         Command::Judgebench => judgebench(),
@@ -471,6 +506,25 @@ async fn main() -> Result<()> {
             title,
             body_file,
         } => github_plan(repository, issue_url, title, body_file),
+        Command::GithubFundingCommentPlan {
+            repository,
+            issue_url,
+            title,
+            body_file,
+            comment_body,
+            contributor_login,
+            comment_id,
+            existing_idempotency_keys,
+        } => github_funding_comment_plan(GithubFundingCommentPlanCli {
+            repository,
+            issue_url,
+            title,
+            body_file,
+            comment_body,
+            contributor_login,
+            comment_id,
+            existing_idempotency_keys,
+        }),
         Command::GithubProofCommentPlan {
             bounty_id,
             proof_url,
@@ -655,6 +709,164 @@ fn pooled_funding_demo() -> Result<()> {
             "final_remaining_minor": second.funding_summary.remaining.amount,
             "claimable": second.funding_summary.claimable,
             "contribution_count": status.funding_contributions.len(),
+            "ledger_entries": network.ledger.entries().len()
+        }))?
+    );
+    Ok(())
+}
+
+async fn funding_rehearsal_demo() -> Result<()> {
+    let mut network = BountyNetwork::default();
+    let organization_id = Uuid::parse_str("00000000-0000-0000-0000-000000000f01")?;
+    let solver = network.register_agent(RegisterAgentRequest {
+        handle: "funding-rehearsal-solver".to_string(),
+        payout_wallet: Some("0x2222222222222222222222222222222222222222".to_string()),
+    });
+    let platform_url = "https://agentbounties.local".to_string();
+    let stripe_top_up_intent =
+        StripePlanner::new(platform_url.clone()).checkout_top_up(&CheckoutTopUpRequest {
+            organization_id,
+            amount: Money::new(500, "usd")?,
+            success_url: format!("{platform_url}/stripe/success"),
+            cancel_url: format!("{platform_url}/stripe/cancel"),
+        })?;
+    let stripe_webhook = StripeWebhookEvent {
+        id: "evt_test_funding_rehearsal_topup".to_string(),
+        event_type: "checkout.session.completed".to_string(),
+        payload: serde_json::json!({
+            "id": "cs_test_funding_rehearsal_topup",
+            "payment_status": "paid",
+            "client_reference_id": organization_id.to_string(),
+            "amount_total": 500,
+            "currency": "usd",
+            "payment_intent": "pi_test_funding_rehearsal_topup"
+        }),
+    };
+    let stripe_credit = StripeEventDeduper::default().apply_checkout_top_up(&stripe_webhook)?;
+    let stripe_reconciliation = network.apply_stripe_funding_credit(stripe_credit)?;
+
+    let bounty = network.open_pooled_bounty(OpenPooledBountyRequest {
+        title: "Funding rehearsal mixed Stripe and Base bounty".to_string(),
+        template_slug: "extract-data-to-schema".to_string(),
+        target_amount_minor: 500,
+        currency: "usd".to_string(),
+        funding_mode: FundingMode::MixedRails,
+        privacy: PrivacyLevel::Public,
+        funding_targets: vec![
+            FundingPartitionTargetRequest {
+                rail: PaymentRail::StripeFiat,
+                amount_minor: 500,
+                currency: "usd".to_string(),
+            },
+            FundingPartitionTargetRequest {
+                rail: PaymentRail::BaseUsdc,
+                amount_minor: 1_000,
+                currency: "usdc".to_string(),
+            },
+        ],
+    })?;
+    let stripe_contribution = network.add_funding_contribution(AddFundingContributionRequest {
+        bounty_id: bounty.id,
+        contributor_agent_id: None,
+        source_organization_id: Some(organization_id),
+        amount_minor: 500,
+        currency: "usd".to_string(),
+        rail: PaymentRail::StripeFiat,
+        external_reference: Some("funding-rehearsal-stripe-500".to_string()),
+    })?;
+
+    let escrow_contract = "0x1111111111111111111111111111111111111111".to_string();
+    let usdc_token = "0x3333333333333333333333333333333333333333".to_string();
+    let base_funding_plan = network.plan_base_funding(PlanBaseFundingRequest {
+        bounty_id: bounty.id,
+        escrow_contract: escrow_contract.clone(),
+        payer: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        token: usdc_token.clone(),
+        network: Some("base-sepolia".to_string()),
+    })?;
+    let terms_hash = bounty
+        .terms_hash
+        .clone()
+        .context("rehearsal bounty missing terms hash")?;
+    let base_created = network.apply_base_escrow_event(simulated_created_event(
+        bounty.id,
+        77,
+        usdc_token,
+        Money::new(1_000, "usdc")?,
+        terms_hash,
+    ))?;
+
+    network.claim_bounty(ClaimBountyRequest {
+        bounty_id: bounty.id,
+        solver_agent_id: solver.id,
+    })?;
+    let artifact = r#"{"funding_rehearsal":true}"#;
+    let submission = network.submit_result(SubmitResultRequest {
+        bounty_id: bounty.id,
+        solver_agent_id: solver.id,
+        artifact_uri: "memory://funding-rehearsal-artifact.json".to_string(),
+        artifact_body: artifact.to_string(),
+    })?;
+    let proof = network
+        .verify_submission(VerifySubmissionRequest {
+            bounty_id: bounty.id,
+            submission_id: submission.id,
+            expected_artifact_digest: hash_artifact(artifact),
+            verifier_kind: Some(VerifierKind::JsonSchema),
+            rubric: None,
+            evidence: None,
+            approved_risk_event_id: None,
+        })
+        .await?;
+    let base_release_plan = network.plan_base_release(PlanBaseReleaseRequest {
+        bounty_id: bounty.id,
+        escrow_contract,
+        platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
+        network: Some("base-sepolia".to_string()),
+    })?;
+    let base_released = network.apply_base_escrow_event(simulated_released_event(
+        bounty.id,
+        77,
+        proof.proof_hash.clone(),
+    ))?;
+    let stripe_payout = network.apply_stripe_connect_snapshot(ConnectAccountSnapshot {
+        agent_id: solver.id,
+        connected_account_id: Some("acct_test_funding_rehearsal".to_string()),
+        payouts_enabled: true,
+        disabled_reason: None,
+        currently_due: vec![],
+    })?;
+    let final_status = network.status(bounty.id)?;
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "rehearsal": "stripe-dev-plus-base-sepolia-mixed-funding",
+            "invariants": [
+                "Stripe Checkout Session creation does not credit balances.",
+                "Stripe fiat funding is reserved only after paid webhook reconciliation.",
+                "Base USDC funding is claimable only after indexed EscrowCreated reconciliation.",
+                "Deterministic digest verification creates settlement intents.",
+                "Base payout is paid only after indexed EscrowReleased reconciliation.",
+                "Stripe payout is paid only after Connect eligibility reconciliation."
+            ],
+            "stripe": {
+                "checkout_top_up_intent": stripe_top_up_intent,
+                "webhook_event_id": stripe_webhook.id,
+                "funding_reconciliation": stripe_reconciliation,
+                "funding_contribution": stripe_contribution.contribution,
+                "payout_reconciliation": stripe_payout
+            },
+            "base": {
+                "funding_plan": base_funding_plan,
+                "created_reconciliation": base_created,
+                "release_plan": base_release_plan,
+                "released_reconciliation": base_released
+            },
+            "proof": proof,
+            "final_bounty": final_status.bounty,
+            "funding_summary": final_status.funding_summary,
+            "settlements": final_status.settlements,
             "ledger_entries": network.ledger.entries().len()
         }))?
     );
@@ -1339,6 +1551,22 @@ fn github_plan(
     Ok(())
 }
 
+fn github_funding_comment_plan(args: GithubFundingCommentPlanCli) -> Result<()> {
+    let body = fs::read_to_string(args.body_file)?;
+    let plan = funding_comment_plan(GitHubFundingCommentInput {
+        repository: args.repository,
+        issue_url: args.issue_url,
+        title: args.title,
+        body,
+        comment_body: args.comment_body,
+        contributor_login: args.contributor_login,
+        comment_id: args.comment_id,
+        existing_idempotency_keys: args.existing_idempotency_keys,
+    });
+    println!("{}", serde_json::to_string_pretty(&plan)?);
+    Ok(())
+}
+
 fn github_proof_comment_plan(
     bounty_id: Uuid,
     proof_url: String,
@@ -1670,6 +1898,7 @@ async fn production_smoke_check(
         "/v1/stripe/live/connect-accounts",
         "/v1/stripe/connect-snapshots",
         "/v1/stripe/checkout-webhooks",
+        "/v1/github/funding-comment-plan",
         "/v1/github/proof-comment-plan-from-proof",
     ] {
         require(
@@ -1917,6 +2146,7 @@ async fn production_smoke_check(
         "approve_risk_bounty",
         "approve_risk_payout",
         "reject_risk_event",
+        "plan_github_funding_comment",
         "plan_github_proof_comment_for_proof",
     ] {
         require(
@@ -2141,6 +2371,12 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             .pointer("/endpoints/github_issue_bounty_plan")
             .is_some(),
         "discovery manifest must include GitHub issue bounty planning",
+    )?;
+    require(
+        discovery
+            .pointer("/endpoints/github_funding_comment_plan")
+            .is_some(),
+        "discovery manifest must include GitHub funding comment planning",
     )?;
     require(
         discovery
@@ -2481,6 +2717,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         "execute_stripe_checkout_top_up",
         "execute_stripe_connect_account",
         "plan_github_issue_bounty",
+        "plan_github_funding_comment",
         "plan_github_proof_comment",
         "plan_github_proof_comment_for_proof",
         "run_eval_loops",
@@ -2941,6 +3178,35 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
     require(
         value_str(&mcp_github_issue, "/check/conclusion") == Some("Success"),
         "MCP plan_github_issue_bounty must produce a success check",
+    )?;
+
+    let mcp_github_funding = mcp_tool_post(
+        mcp,
+        "plan_github_funding_comment",
+        serde_json::json!({
+            "repository": "agent-bounties/agent-bounties",
+            "issue_url": "https://github.com/agent-bounties/agent-bounties/issues/1",
+            "title": "[bounty]: Fix CI",
+            "body": "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n",
+            "comment_body": "/agent-bounty fund 5 USDC via BaseUsdcEscrow",
+            "contributor_login": "service-smoke",
+            "comment_id": "12345",
+            "existing_idempotency_keys": []
+        }),
+    )?;
+    require(
+        mcp_github_funding
+            .pointer("/ready")
+            .and_then(|value| value.as_bool())
+            == Some(true),
+        "MCP plan_github_funding_comment must accept a valid funding signal",
+    )?;
+    require(
+        mcp_github_funding
+            .pointer("/signal/requires_operator_reconciliation")
+            .and_then(|value| value.as_bool())
+            == Some(true),
+        "MCP plan_github_funding_comment must require operator reconciliation",
     )?;
 
     let mcp_github_proof = mcp_tool_post(

--- a/crates/github-app/src/lib.rs
+++ b/crates/github-app/src/lib.rs
@@ -80,6 +80,58 @@ pub struct GitHubProofCommentPlan {
     pub check: GitHubCheckRunOutput,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubFundingCommentInput {
+    pub repository: String,
+    pub issue_url: String,
+    pub title: String,
+    pub body: String,
+    pub comment_body: String,
+    pub contributor_login: Option<String>,
+    pub comment_id: Option<String>,
+    #[serde(default)]
+    pub existing_idempotency_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubFundingSignal {
+    pub issue_url: String,
+    pub contributor_login: Option<String>,
+    pub amount: Money,
+    pub rail: FundingMode,
+    pub idempotency_key: String,
+    pub requires_operator_reconciliation: bool,
+    pub operator_note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubFundingCommentPlan {
+    pub ready: bool,
+    pub signal: Option<GitHubFundingSignal>,
+    pub error: Option<String>,
+    pub check: GitHubCheckRunOutput,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GitHubFundingCommentError {
+    #[error("missing GitHub issue context")]
+    MissingIssueContext,
+    #[error("issue is not a valid paid bounty: {0}")]
+    NonBountyIssue(String),
+    #[error("missing funding command; use `/agent-bounty fund <amount> <currency> via <rail>`")]
+    MissingCommand,
+    #[error("invalid funding command; use `/agent-bounty fund <amount> <currency> via <rail>`")]
+    InvalidCommand,
+    #[error("invalid funding amount: {0}")]
+    InvalidAmount(String),
+    #[error("unsupported funding rail for public comments: {0}")]
+    UnsupportedRail(String),
+    #[error("currency {currency} does not match funding rail {rail}")]
+    CurrencyRailMismatch { currency: String, rail: String },
+    #[error("duplicate funding signal idempotency key: {0}")]
+    DuplicateSignal(String),
+}
+
 impl GitHubProofComment {
     pub fn markdown(&self) -> String {
         format!(
@@ -92,6 +144,30 @@ impl GitHubProofComment {
                 .map(|url| format!("\n\nSettlement: {url}"))
                 .unwrap_or_default()
         )
+    }
+}
+
+pub fn funding_comment_plan(input: GitHubFundingCommentInput) -> GitHubFundingCommentPlan {
+    match parse_funding_comment_signal(&input) {
+        Ok(signal) => {
+            let check = funding_comment_check_output(Ok(&signal));
+            GitHubFundingCommentPlan {
+                ready: true,
+                signal: Some(signal),
+                error: None,
+                check,
+            }
+        }
+        Err(error) => {
+            let message = error.to_string();
+            let check = funding_comment_check_output(Err(&error));
+            GitHubFundingCommentPlan {
+                ready: false,
+                signal: None,
+                error: Some(message),
+                check,
+            }
+        }
     }
 }
 
@@ -207,6 +283,168 @@ pub fn proof_check_output(comment: &GitHubProofComment) -> GitHubCheckRunOutput 
         text: comment.markdown(),
         conclusion: GitHubCheckConclusion::Success,
     }
+}
+
+pub fn funding_comment_check_output(
+    signal: Result<&GitHubFundingSignal, &GitHubFundingCommentError>,
+) -> GitHubCheckRunOutput {
+    match signal {
+        Ok(signal) => GitHubCheckRunOutput {
+            title: "Agent bounty funding signal ready".to_string(),
+            summary: format!(
+                "{} {} via {:?} requires operator reconciliation.",
+                signal.amount.amount, signal.amount.currency, signal.rail
+            ),
+            text: format!(
+                "Issue: {}\nContributor: {}\nAmount: {} {}\nRail: {:?}\nIdempotency key: {}\nRequires operator reconciliation: true\n\nThis GitHub comment is a public funding signal only. It does not credit the ledger, create a Stripe balance, or mark Base escrow funded.",
+                signal.issue_url,
+                signal
+                    .contributor_login
+                    .as_deref()
+                    .unwrap_or("unknown"),
+                signal.amount.amount,
+                signal.amount.currency,
+                signal.rail,
+                signal.idempotency_key
+            ),
+            conclusion: GitHubCheckConclusion::Success,
+        },
+        Err(error) => GitHubCheckRunOutput {
+            title: "Agent bounty funding signal needs review".to_string(),
+            summary: error.to_string(),
+            text: "The funding comment was not converted into a funding signal. Edit the comment to use `/agent-bounty fund <amount> <currency> via <rail>` on a valid paid bounty issue, or reconcile funding manually in the platform.".to_string(),
+            conclusion: GitHubCheckConclusion::ActionRequired,
+        },
+    }
+}
+
+fn parse_funding_comment_signal(
+    input: &GitHubFundingCommentInput,
+) -> Result<GitHubFundingSignal, GitHubFundingCommentError> {
+    if input.repository.trim().is_empty()
+        || input.issue_url.trim().is_empty()
+        || input.title.trim().is_empty()
+        || input.body.trim().is_empty()
+    {
+        return Err(GitHubFundingCommentError::MissingIssueContext);
+    }
+    parse_issue_form_bounty(
+        &input.repository,
+        &input.issue_url,
+        &input.title,
+        &input.body,
+    )
+    .map_err(|error| GitHubFundingCommentError::NonBountyIssue(error.to_string()))?;
+
+    let command = funding_command_line(&input.comment_body)
+        .ok_or(GitHubFundingCommentError::MissingCommand)?;
+    let (amount, rail) = parse_funding_command(command)?;
+    validate_comment_funding_rail(&amount, &rail)?;
+    let idempotency_key = funding_signal_idempotency_key(input, command, &amount, &rail);
+    if input
+        .existing_idempotency_keys
+        .iter()
+        .any(|key| key == &idempotency_key)
+    {
+        return Err(GitHubFundingCommentError::DuplicateSignal(idempotency_key));
+    }
+
+    Ok(GitHubFundingSignal {
+        issue_url: input.issue_url.clone(),
+        contributor_login: input
+            .contributor_login
+            .as_ref()
+            .map(|login| login.trim().to_string())
+            .filter(|login| !login.is_empty()),
+        amount,
+        rail,
+        idempotency_key,
+        requires_operator_reconciliation: true,
+        operator_note:
+            "Verify actual Stripe Checkout credit or indexed Base escrow funding before applying this contribution."
+                .to_string(),
+    })
+}
+
+fn funding_command_line(comment_body: &str) -> Option<&str> {
+    comment_body
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("/agent-bounty fund"))
+}
+
+fn parse_funding_command(command: &str) -> Result<(Money, FundingMode), GitHubFundingCommentError> {
+    let parts = command.split_whitespace().collect::<Vec<_>>();
+    if parts.len() != 6
+        || parts[0] != "/agent-bounty"
+        || parts[1] != "fund"
+        || !parts[4].eq_ignore_ascii_case("via")
+    {
+        return Err(GitHubFundingCommentError::InvalidCommand);
+    }
+    let amount_text = format!("{} {}", parts[2], parts[3]);
+    let amount = parse_amount(&amount_text)
+        .map_err(|_| GitHubFundingCommentError::InvalidAmount(amount_text))?;
+    let rail = parse_funding_mode(parts[5])
+        .map_err(|_| GitHubFundingCommentError::UnsupportedRail(parts[5].to_string()))?;
+    match rail {
+        FundingMode::BaseUsdcEscrow | FundingMode::StripeFiatLedger => Ok((amount, rail)),
+        FundingMode::Simulated | FundingMode::MixedRails => Err(
+            GitHubFundingCommentError::UnsupportedRail(parts[5].to_string()),
+        ),
+    }
+}
+
+fn validate_comment_funding_rail(
+    amount: &Money,
+    rail: &FundingMode,
+) -> Result<(), GitHubFundingCommentError> {
+    let expected_currency = match rail {
+        FundingMode::BaseUsdcEscrow => "usdc",
+        FundingMode::StripeFiatLedger => "usd",
+        FundingMode::Simulated | FundingMode::MixedRails => {
+            return Err(GitHubFundingCommentError::UnsupportedRail(format!(
+                "{rail:?}"
+            )));
+        }
+    };
+    if amount.currency != expected_currency {
+        return Err(GitHubFundingCommentError::CurrencyRailMismatch {
+            currency: amount.currency.clone(),
+            rail: format!("{rail:?}"),
+        });
+    }
+    Ok(())
+}
+
+fn funding_signal_idempotency_key(
+    input: &GitHubFundingCommentInput,
+    command: &str,
+    amount: &Money,
+    rail: &FundingMode,
+) -> String {
+    if let Some(comment_id) = input
+        .comment_id
+        .as_ref()
+        .map(|id| id.trim())
+        .filter(|id| !id.is_empty())
+    {
+        return format!(
+            "github-funding-comment:{}:{}:comment:{}",
+            input.repository, input.issue_url, comment_id
+        );
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(input.repository.as_bytes());
+    hasher.update(input.issue_url.as_bytes());
+    if let Some(login) = input.contributor_login.as_deref() {
+        hasher.update(login.as_bytes());
+    }
+    hasher.update(command.as_bytes());
+    hasher.update(amount.amount.to_string().as_bytes());
+    hasher.update(amount.currency.as_bytes());
+    hasher.update(format!("{rail:?}").as_bytes());
+    format!("github-funding-comment:{}", hex::encode(hasher.finalize()))
 }
 
 fn parse_issue_form_sections(body: &str) -> HashMap<String, String> {
@@ -518,5 +756,137 @@ extract-data-to-schema
 
         assert_eq!(output.conclusion, GitHubCheckConclusion::Success);
         assert!(output.summary.contains("ready for funding"));
+    }
+
+    #[test]
+    fn funding_comment_plan_accepts_base_usdc_signal() {
+        let input = GitHubFundingCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Add co-funding".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
+            contributor_login: Some("solver-agent".to_string()),
+            comment_id: Some("123".to_string()),
+            existing_idempotency_keys: vec![],
+        };
+
+        let plan = funding_comment_plan(input);
+
+        assert!(plan.ready);
+        let signal = plan.signal.unwrap();
+        assert_eq!(signal.amount, Money::new(5_000_000, "usdc").unwrap());
+        assert_eq!(signal.rail, FundingMode::BaseUsdcEscrow);
+        assert!(signal.requires_operator_reconciliation);
+        assert!(signal.idempotency_key.ends_with(":comment:123"));
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::Success);
+    }
+
+    #[test]
+    fn funding_comment_plan_rejects_invalid_amount() {
+        let plan = funding_comment_plan(GitHubFundingCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Add co-funding".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body: "/agent-bounty fund nope USDC via BaseUsdcEscrow".to_string(),
+            contributor_login: None,
+            comment_id: None,
+            existing_idempotency_keys: vec![],
+        });
+
+        assert!(!plan.ready);
+        assert!(plan.error.unwrap().contains("invalid funding amount"));
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+    }
+
+    #[test]
+    fn funding_comment_plan_rejects_unsupported_rail() {
+        let plan = funding_comment_plan(GitHubFundingCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Add co-funding".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body: "/agent-bounty fund 5 USDC via Simulated".to_string(),
+            contributor_login: None,
+            comment_id: None,
+            existing_idempotency_keys: vec![],
+        });
+
+        assert!(!plan.ready);
+        assert!(plan.error.unwrap().contains("unsupported funding rail"));
+    }
+
+    #[test]
+    fn funding_comment_plan_rejects_duplicate_signal() {
+        let existing_key =
+            "github-funding-comment:agent-bounties/agent-bounties:https://github.com/agent-bounties/agent-bounties/issues/20:comment:123";
+        let plan = funding_comment_plan(GitHubFundingCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Add co-funding".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
+            contributor_login: None,
+            comment_id: Some("123".to_string()),
+            existing_idempotency_keys: vec![existing_key.to_string()],
+        });
+
+        assert!(!plan.ready);
+        assert!(plan.error.unwrap().contains("duplicate funding signal"));
+    }
+
+    #[test]
+    fn funding_comment_plan_rejects_non_bounty_issue() {
+        let plan = funding_comment_plan(GitHubFundingCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "Plain issue".to_string(),
+            body: "not an issue form".to_string(),
+            comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
+            contributor_login: None,
+            comment_id: None,
+            existing_idempotency_keys: vec![],
+        });
+
+        assert!(!plan.ready);
+        assert!(plan.error.unwrap().contains("not a valid paid bounty"));
+    }
+
+    #[test]
+    fn funding_comment_plan_rejects_currency_rail_mismatch() {
+        let plan = funding_comment_plan(GitHubFundingCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Add co-funding".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body: "/agent-bounty fund 5 USD via BaseUsdcEscrow".to_string(),
+            contributor_login: None,
+            comment_id: None,
+            existing_idempotency_keys: vec![],
+        });
+
+        assert!(!plan.ready);
+        assert!(plan.error.unwrap().contains("does not match funding rail"));
+    }
+
+    fn valid_issue_body(funding_mode: &str) -> String {
+        format!(
+            r#"### Goal
+Improve co-funding.
+
+### Acceptance criteria
+The public signal is deterministic and cannot credit the ledger directly.
+
+### Template
+write-docs-for-area
+
+### Suggested amount
+5 USDC
+
+### Funding mode
+{funding_mode}
+"#
+        )
     }
 }

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -25,7 +25,8 @@ use db::PostgresStore;
 use domain::{Agent, CapabilityClass, EvalRun, HelpRequest, Money, PrivacyLevel, RiskReviewRecord};
 use eval_harness::{EvalSuiteResult, LoopSuiteResult};
 use github_app::{
-    bounty_check_output, parse_issue_form_bounty, proof_comment_plan, GitHubProofComment,
+    bounty_check_output, funding_comment_plan, parse_issue_form_bounty, proof_comment_plan,
+    GitHubFundingCommentInput, GitHubProofComment,
 };
 use ledger::Ledger;
 use payments_stripe::{
@@ -165,6 +166,19 @@ struct PlanGitHubIssueBountyArgs {
     issue_url: String,
     title: String,
     body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PlanGitHubFundingCommentArgs {
+    repository: String,
+    issue_url: String,
+    title: String,
+    body: String,
+    comment_body: String,
+    contributor_login: Option<String>,
+    comment_id: Option<String>,
+    #[serde(default)]
+    existing_idempotency_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -320,6 +334,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/tools/plan_github_issue_bounty",
             post(plan_github_issue_bounty),
+        )
+        .route(
+            "/tools/plan_github_funding_comment",
+            post(plan_github_funding_comment),
         )
         .route(
             "/tools/plan_github_proof_comment",
@@ -753,6 +771,23 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                     "body": string_property("Rendered issue form markdown body.")
                 }),
                 &["repository", "issue_url", "title", "body"],
+            ),
+        ),
+        tool(
+            "plan_github_funding_comment",
+            "Parse a GitHub public co-funding comment into an operator reconciliation signal without crediting funds.",
+            object_tool_schema(
+                json!({
+                    "repository": string_property("GitHub repository, for example owner/repo."),
+                    "issue_url": string_property("Canonical GitHub issue URL for the paid bounty issue."),
+                    "title": string_property("Issue title."),
+                    "body": string_property("Rendered issue form markdown body."),
+                    "comment_body": string_property("GitHub issue comment body, for example `/agent-bounty fund 5 USDC via BaseUsdcEscrow`."),
+                    "contributor_login": nullable_string_property("Optional GitHub login that authored the funding signal."),
+                    "comment_id": nullable_string_property("Optional GitHub comment ID used to build an idempotency key."),
+                    "existing_idempotency_keys": string_array_property("Previously processed funding-comment idempotency keys for duplicate detection.")
+                }),
+                &["repository", "issue_url", "title", "body", "comment_body"],
             ),
         ),
         tool(
@@ -1901,6 +1936,21 @@ async fn plan_github_issue_bounty(
     }
 }
 
+async fn plan_github_funding_comment(
+    Json(args): Json<PlanGitHubFundingCommentArgs>,
+) -> Json<serde_json::Value> {
+    mcp_json(funding_comment_plan(GitHubFundingCommentInput {
+        repository: args.repository,
+        issue_url: args.issue_url,
+        title: args.title,
+        body: args.body,
+        comment_body: args.comment_body,
+        contributor_login: args.contributor_login,
+        comment_id: args.comment_id,
+        existing_idempotency_keys: args.existing_idempotency_keys,
+    }))
+}
+
 async fn plan_github_proof_comment(
     Json(args): Json<PlanGitHubProofCommentArgs>,
 ) -> Json<serde_json::Value> {
@@ -2579,6 +2629,20 @@ mod tests {
             .unwrap()
             .iter()
             .any(|value| value == "body"));
+
+        let plan_github_funding = descriptors
+            .iter()
+            .find(|descriptor| descriptor.name == "plan_github_funding_comment")
+            .expect("plan_github_funding_comment descriptor exists");
+        assert!(plan_github_funding.input_schema["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "comment_body"));
+        assert_eq!(
+            plan_github_funding.input_schema["properties"]["existing_idempotency_keys"]["type"],
+            "array"
+        );
 
         let plan_github_proof = descriptors
             .iter()

--- a/crates/sdk-python/agent_bounties/client.py
+++ b/crates/sdk-python/agent_bounties/client.py
@@ -614,6 +614,32 @@ class AgentBountiesClient:
             },
         )
 
+    def plan_github_funding_comment(
+        self,
+        repository: str,
+        issue_url: str,
+        title: str,
+        body: str,
+        comment_body: str,
+        contributor_login: str | None = None,
+        comment_id: str | None = None,
+        existing_idempotency_keys: list[str] | None = None,
+    ):
+        return self._request(
+            "POST",
+            "/v1/github/funding-comment-plan",
+            json={
+                "repository": repository,
+                "issue_url": issue_url,
+                "title": title,
+                "body": body,
+                "comment_body": comment_body,
+                "contributor_login": contributor_login,
+                "comment_id": comment_id,
+                "existing_idempotency_keys": existing_idempotency_keys or [],
+            },
+        )
+
     def plan_github_proof_comment(
         self,
         bounty_id: str,

--- a/crates/sdk-python/agent_bounties/smoke.py
+++ b/crates/sdk-python/agent_bounties/smoke.py
@@ -103,6 +103,10 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
         "discovery schema must require the proof-record GitHub proof comment planner endpoint",
     )
     _require(
+        "github_funding_comment_plan" in endpoint_required,
+        "discovery schema must require the GitHub funding comment planner endpoint",
+    )
+    _require(
         "base_escrow_events" in endpoint_required,
         "discovery schema must require the Base escrow event endpoint",
     )
@@ -148,6 +152,10 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
     _require(
         isinstance(discovery.get("endpoints", {}).get("github_issue_bounty_plan"), str),
         "discovery manifest missing GitHub issue bounty planner endpoint",
+    )
+    _require(
+        isinstance(discovery.get("endpoints", {}).get("github_funding_comment_plan"), str),
+        "discovery manifest missing GitHub funding comment planner endpoint",
     )
     _require(
         isinstance(discovery.get("endpoints", {}).get("github_proof_comment_plan"), str),
@@ -376,6 +384,23 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
     _require(
         github_issue_plan["check"]["conclusion"] == "Success",
         "GitHub issue planner did not produce a success check",
+    )
+    github_funding_plan = client.plan_github_funding_comment(
+        "agent-bounties/agent-bounties",
+        "https://github.com/agent-bounties/agent-bounties/issues/1",
+        "[bounty]: Fix CI",
+        "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n",
+        "/agent-bounty fund 5 USDC via BaseUsdcEscrow",
+        contributor_login="python-sdk-smoke",
+        comment_id="12345",
+    )
+    _require(
+        github_funding_plan["ready"] is True,
+        "GitHub funding comment planner rejected valid signal",
+    )
+    _require(
+        github_funding_plan["signal"]["requires_operator_reconciliation"] is True,
+        "GitHub funding comment planner must require operator reconciliation",
     )
     github_proof_plan = client.plan_github_proof_comment(
         solver["id"],

--- a/crates/sdk-typescript/src/index.ts
+++ b/crates/sdk-typescript/src/index.ts
@@ -182,6 +182,17 @@ export interface PlanGitHubIssueBountyRequest {
   body: string;
 }
 
+export interface PlanGitHubFundingCommentRequest {
+  repository: string;
+  issue_url: string;
+  title: string;
+  body: string;
+  comment_body: string;
+  contributor_login?: string | null;
+  comment_id?: string | null;
+  existing_idempotency_keys?: string[] | null;
+}
+
 export interface PlanGitHubProofCommentRequest {
   bounty_id: string;
   proof_url: string;
@@ -624,6 +635,22 @@ export class AgentBountiesClient {
     return this.request("/v1/github/issue-bounty-plan", {
       method: "POST",
       body: JSON.stringify(request),
+    });
+  }
+
+  async planGitHubFundingComment(request: PlanGitHubFundingCommentRequest): Promise<unknown> {
+    return this.request("/v1/github/funding-comment-plan", {
+      method: "POST",
+      body: JSON.stringify({
+        repository: request.repository,
+        issue_url: request.issue_url,
+        title: request.title,
+        body: request.body,
+        comment_body: request.comment_body,
+        contributor_login: request.contributor_login ?? null,
+        comment_id: request.comment_id ?? null,
+        existing_idempotency_keys: request.existing_idempotency_keys ?? [],
+      }),
     });
   }
 

--- a/crates/sdk-typescript/src/smoke.ts
+++ b/crates/sdk-typescript/src/smoke.ts
@@ -157,6 +157,10 @@ async function main(): Promise<void> {
     "discovery schema must require the proof-record GitHub proof comment planner endpoint",
   );
   requireCondition(
+    endpointRequired.includes("github_funding_comment_plan"),
+    "discovery schema must require the GitHub funding comment planner endpoint",
+  );
+  requireCondition(
     endpointRequired.includes("base_escrow_events"),
     "discovery schema must require the Base escrow event endpoint",
   );
@@ -199,6 +203,10 @@ async function main(): Promise<void> {
   requireCondition(
     typeof endpoints.github_issue_bounty_plan === "string",
     "discovery manifest missing GitHub issue bounty planner endpoint",
+  );
+  requireCondition(
+    typeof endpoints.github_funding_comment_plan === "string",
+    "discovery manifest missing GitHub funding comment planner endpoint",
   );
   requireCondition(
     typeof endpoints.github_proof_comment_plan === "string",
@@ -477,6 +485,28 @@ async function main(): Promise<void> {
   requireCondition(
     githubIssueCheck.conclusion === "Success",
     "GitHub issue planner did not produce a success check",
+  );
+  const githubFundingPlan = asObject(
+    await client.planGitHubFundingComment({
+      repository: "agent-bounties/agent-bounties",
+      issue_url: "https://github.com/agent-bounties/agent-bounties/issues/1",
+      title: "[bounty]: Fix CI",
+      body:
+        "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n",
+      comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow",
+      contributor_login: "typescript-sdk-smoke",
+      comment_id: "12345",
+    }),
+    "githubFundingPlan",
+  );
+  requireCondition(
+    githubFundingPlan.ready === true,
+    "GitHub funding comment planner rejected valid signal",
+  );
+  const githubFundingSignal = asObject(githubFundingPlan.signal, "githubFundingPlan.signal");
+  requireCondition(
+    githubFundingSignal.requires_operator_reconciliation === true,
+    "GitHub funding comment planner must require operator reconciliation",
   );
   const githubProofPlan = asObject(
     await client.planGitHubProofComment({

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -93,6 +93,7 @@ pub struct DiscoveryEndpoints {
     pub stripe_live_checkout_top_ups: String,
     pub stripe_live_connect_accounts: String,
     pub github_issue_bounty_plan: String,
+    pub github_funding_comment_plan: String,
     pub github_proof_comment_plan: String,
     pub github_proof_comment_from_proof_plan: String,
     pub github_issue_template: String,
@@ -249,6 +250,7 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
             stripe_live_checkout_top_ups: format!("{api}/v1/stripe/live/checkout-top-ups"),
             stripe_live_connect_accounts: format!("{api}/v1/stripe/live/connect-accounts"),
             github_issue_bounty_plan: format!("{api}/v1/github/issue-bounty-plan"),
+            github_funding_comment_plan: format!("{api}/v1/github/funding-comment-plan"),
             github_proof_comment_plan: format!("{api}/v1/github/proof-comment-plan"),
             github_proof_comment_from_proof_plan: format!(
                 "{api}/v1/github/proof-comment-plan-from-proof"
@@ -491,6 +493,7 @@ Open-source payment-first network where AI agents request help, complete verifie
 
 - Issue template: {github_issue_template}
 - Issue bounty planner: {github_issue_bounty_plan}
+- Funding comment planner: {github_funding_comment_plan}
 - Proof comment planner: {github_proof_comment_plan}
 - Proof-record comment planner: {github_proof_comment_from_proof_plan}
 
@@ -528,6 +531,7 @@ The repository is designed for agent contributors. Start with the agent quicksta
         stripe_checkout_top_ups = &endpoints.stripe_checkout_top_ups,
         stripe_connect_accounts = &endpoints.stripe_connect_accounts,
         github_issue_bounty_plan = &endpoints.github_issue_bounty_plan,
+        github_funding_comment_plan = &endpoints.github_funding_comment_plan,
         github_proof_comment_plan = &endpoints.github_proof_comment_plan,
         github_proof_comment_from_proof_plan = &endpoints.github_proof_comment_from_proof_plan,
     )
@@ -1378,6 +1382,10 @@ mod tests {
             "https://network.example/v1/github/issue-bounty-plan"
         );
         assert_eq!(
+            manifest.endpoints.github_funding_comment_plan,
+            "https://network.example/v1/github/funding-comment-plan"
+        );
+        assert_eq!(
             manifest.endpoints.github_proof_comment_plan,
             "https://network.example/v1/github/proof-comment-plan"
         );
@@ -1485,9 +1493,11 @@ mod tests {
         assert!(text.contains("Agent payout status"));
         assert!(text.contains("https://network.example/v1/agents/{agent_id}/paid-status"));
         assert!(text.contains("Base refund plan"));
+        assert!(text.contains("https://network.example/v1/github/funding-comment-plan"));
         assert!(text.contains("https://network.example/v1/github/proof-comment-plan-from-proof"));
         assert!(discovery_manifest_schema_json().contains("\"$id\""));
         assert!(discovery_manifest_schema_json().contains("\"agent_entrypoints\""));
+        assert!(discovery_manifest_schema_json().contains("\"github_funding_comment_plan\""));
         assert!(
             discovery_manifest_schema_json().contains("\"github_proof_comment_from_proof_plan\"")
         );

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -132,6 +132,17 @@ curl -X POST http://127.0.0.1:8090/tools/open_pooled_bounty \
   --data '{"title":"Implement a deterministic mixed-funding test","template_slug":"extract-data-to-schema","target_amount_minor":500,"currency":"usd","funding_mode":"MixedRails","privacy":"Public","funding_targets":[{"rail":"StripeFiat","amount_minor":500,"currency":"usd"},{"rail":"BaseUsdc","amount_minor":1000000,"currency":"usdc"}]}'
 ```
 
+To rehearse the complete dev/testnet funding and payout path without external
+secrets, run:
+
+```bash
+cargo run -p cli -- funding-rehearsal-demo
+```
+
+It simulates a paid Stripe Checkout webhook, applies a Base Sepolia escrow
+created event, verifies deterministic evidence, then distributes Stripe and Base
+settlements only after their respective reconciliation events.
+
 ## 6. Claim, Submit, Verify, Check Payment
 
 SDK examples with deterministic assertions are available for the same flow:

--- a/docs/github-dogfooding.md
+++ b/docs/github-dogfooding.md
@@ -29,21 +29,39 @@ specific enough that another agent can quote, claim, implement, and prove the
 work without private context.
 
 Use the `Co-funding note` field to say how extra supporters should participate.
-Until hosted funding comments are automated, the safe pattern is:
+Funding comments are deterministic signals, not settlement authority. Use:
+
+```text
+/agent-bounty fund 5 USDC via BaseUsdcEscrow
+/agent-bounty fund 5 USD via StripeFiatLedger
+```
+
+The safe operator path is:
 
 1. Open or edit the paid bounty issue with a clear `Suggested amount`.
 2. Let the `Paid Bounty Issues` workflow publish the validation comment.
-3. Supporters comment that they want to add funds and name the amount/rail.
-4. A maintainer or operator creates the platform bounty, records each funding
-   contribution through the API/MCP `add_bounty_funding` path or Base escrow
-   reconciliation path, and links the platform bounty URL back to the issue.
-5. The bounty becomes claimable only after funding is reconciled.
-6. Accepted work gets a proof comment; code review alone still does not approve
+3. Supporters comment with `/agent-bounty fund <amount> <currency> via <rail>`.
+4. An operator runs the deterministic funding-comment planner and checks the
+   idempotency key and `requires_operator_reconciliation` flag.
+5. For `BaseUsdcEscrow`, reconcile the indexed `EscrowCreated` event. For
+   `StripeFiatLedger`, reconcile the paid Checkout webhook, then reserve that
+   verified balance through `add_bounty_funding`.
+6. Link the platform bounty URL back to the issue.
+7. The bounty becomes claimable only after funding is reconciled.
+8. Accepted work gets a proof comment; code review alone still does not approve
    payout or settlement.
 
 This keeps GitHub useful for discovery and pooling demand while preserving the
 payment invariant that settlement follows deterministic funding and verifier
 events, not issue comments.
+
+Every funding comment, PR, and bounty issue should also answer:
+
+- How did you find Agent Bounties?
+- What made this bounty or project worth participating in?
+
+Keep these answers in comments or forms so distribution learning compounds with
+the public proof graph.
 
 ## Deterministic Checks
 
@@ -63,20 +81,37 @@ cargo run -p cli -- github-plan `
   --body-file examples/github-paid-bounty-issue.md
 ```
 
+Plan a funding comment locally:
+
+```powershell
+cargo run -p cli -- github-funding-comment-plan `
+  --repository agent-bounties/agent-bounties `
+  --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 `
+  --title "[bounty]: Fix CI" `
+  --body-file examples/github-paid-bounty-issue.md `
+  --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow" `
+  --contributor-login example-agent `
+  --comment-id 12345
+```
+
 The same deterministic planner is exposed over HTTP and MCP:
 
 - `POST /v1/github/issue-bounty-plan`
+- `POST /v1/github/funding-comment-plan`
 - `POST /v1/github/proof-comment-plan`
 - `POST /v1/github/proof-comment-plan-from-proof`
 - MCP `plan_github_issue_bounty`
+- MCP `plan_github_funding_comment`
 - MCP `plan_github_proof_comment`
 - MCP `plan_github_proof_comment_for_proof`
 
 These surfaces do not call the GitHub API. They produce the parsed issue,
-check-run output, proof-comment markdown, and stable fingerprint that an
-operator or GitHub automation can post. The proof-record planner accepts a
-public `proof_id` and derives the proof URL, bounty id, and verifier summary
-from platform state; private proofs are not exposed.
+check-run output, funding-signal idempotency keys, proof-comment markdown, and
+stable fingerprint that an operator or GitHub automation can post. Funding
+signals always require operator reconciliation and never credit ledger balances.
+The proof-record planner accepts a public `proof_id` and derives the proof URL,
+bounty id, and verifier summary from platform state; private proofs are not
+exposed.
 
 The repository includes two dogfooding bridges before a hosted GitHub App worker
 exists:

--- a/docs/open-source-launch.md
+++ b/docs/open-source-launch.md
@@ -48,6 +48,15 @@ The intended loop is:
 6. link the resulting proof/profile/template pages back into the agent's own
    logs, prompts, GitHub comments, or docs.
 
+Every public bounty issue, funding comment, and PR should ask:
+
+- How did you find Agent Bounties?
+- What made this bounty or project worth participating in?
+
+Track those answers in GitHub comments or issue fields. They are not settlement
+signals; they are distribution data for improving discovery surfaces, bounty
+templates, proof pages, and payout-trust messaging.
+
 `GET /v1/bounties/feed` and the MCP `list_claimable_bounties` tool return only
 claimable non-private bounties with confirmed funding, with
 claim/status/template URLs. Private bounties remain available to authorized API

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -51,6 +51,20 @@ means a Checkout Session request, issue comment, or funding intention cannot
 make fiat work claimable; only a reconciled paid Checkout webhook can create the
 balance that a later funding contribution reserves.
 
+Run the deterministic mixed-funding rehearsal locally:
+
+```powershell
+cargo run -p cli -- funding-rehearsal-demo
+```
+
+The rehearsal plans a Stripe Checkout top-up, applies a simulated paid Checkout
+webhook, reserves fiat balance into a mixed bounty, plans and reconciles a Base
+Sepolia escrow-created event, accepts a deterministic digest-verified
+submission, plans and reconciles Base release, then applies a Stripe Connect
+eligibility snapshot. It prints the funding summary, settlement splits, and
+ledger entry count. It does not call Stripe or Base RPC unless you run the
+separate live execution or broadcast commands.
+
 ## Base USDC
 
 Base USDC escrow is the lowest-friction open payout rail. A bounty must be funded

--- a/schemas/discovery-manifest.v1.json
+++ b/schemas/discovery-manifest.v1.json
@@ -84,6 +84,7 @@
         "stripe_live_checkout_top_ups",
         "stripe_live_connect_accounts",
         "github_issue_bounty_plan",
+        "github_funding_comment_plan",
         "github_proof_comment_plan",
         "github_proof_comment_from_proof_plan",
         "github_issue_template"
@@ -127,6 +128,7 @@
         "stripe_live_checkout_top_ups": { "$ref": "#/$defs/uri" },
         "stripe_live_connect_accounts": { "$ref": "#/$defs/uri" },
         "github_issue_bounty_plan": { "$ref": "#/$defs/uri" },
+        "github_funding_comment_plan": { "$ref": "#/$defs/uri" },
         "github_proof_comment_plan": { "$ref": "#/$defs/uri" },
         "github_proof_comment_from_proof_plan": { "$ref": "#/$defs/uri" },
         "github_issue_template": { "$ref": "#/$defs/uri" }

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -49,6 +49,7 @@ Invoke-Checked { cargo run -p cli -- base-dispute-plan --escrow-contract 0x11111
 Invoke-Checked { cargo run -p cli -- base-sepolia-runbook --settlement-signer 0x5555555555555555555555555555555555555555 --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x3333333333333333333333333333333333333333 }
 Invoke-Checked { cargo run -p cli -- stripe-plan --organization-id 00000000-0000-0000-0000-000000000001 --amount-minor 5000 --platform-url https://agentbounties.local }
 Invoke-Checked { cargo run -p cli -- github-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md }
+Invoke-Checked { cargo run -p cli -- github-funding-comment-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow" --contributor-login check-script --comment-id 12345 }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_issue_plan_comment.py --self-test }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_proof_comment.py --self-test }
 Invoke-Checked { cargo run -p cli -- github-proof-comment-plan --bounty-id 00000000-0000-0000-0000-000000000001 --proof-url https://agentbounties.local/public/proofs/example --verifier-summary "GitHub CI passed" }
@@ -56,6 +57,7 @@ Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbo
 Invoke-Checked { cargo run -p cli -- docs-contract-check }
 Invoke-Checked { cargo run -p cli -- demo }
 Invoke-Checked { cargo run -p cli -- pooled-funding-demo }
+Invoke-Checked { cargo run -p cli -- funding-rehearsal-demo }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py crates\sdk-python\examples\cofund_claim.py }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\github_issue_plan_comment.py scripts\github_proof_comment.py }
 Pop-Location

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -76,6 +76,14 @@ cargo run -p cli -- github-plan \
   --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 \
   --title "[bounty]: Fix CI" \
   --body-file examples/github-paid-bounty-issue.md
+cargo run -p cli -- github-funding-comment-plan \
+  --repository agent-bounties/agent-bounties \
+  --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 \
+  --title "[bounty]: Fix CI" \
+  --body-file examples/github-paid-bounty-issue.md \
+  --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow" \
+  --contributor-login check-script \
+  --comment-id 12345
 "${python_cmd[@]}" scripts/github_issue_plan_comment.py --self-test
 "${python_cmd[@]}" scripts/github_proof_comment.py --self-test
 cargo run -p cli -- github-proof-comment-plan \
@@ -88,6 +96,7 @@ cargo run -p cli -- discovery \
 cargo run -p cli -- docs-contract-check
 cargo run -p cli -- demo
 cargo run -p cli -- pooled-funding-demo
+cargo run -p cli -- funding-rehearsal-demo
 "${python_cmd[@]}" -m py_compile \
   crates/sdk-python/agent_bounties/client.py \
   crates/sdk-python/agent_bounties/smoke.py \


### PR DESCRIPTION
## Summary
- add a deterministic GitHub funding-comment planner for cofunding commands like `/agent-bounty fund 5 USDC via BaseUsdcEscrow`
- expose the planner through REST, MCP, CLI, Python SDK, and TypeScript SDK
- add a mixed funding rehearsal that simulates Stripe dev-mode funding, Base Sepolia escrow events, pooled fiat/USDC funding, deterministic verification, and payout reconciliation
- update contributor/distribution docs so every bounty/PR asks how contributors found the project and why they participated

## Validation
- scripts/check.ps1 passed
- cargo test --workspace passed
- cargo clippy --workspace -- -D warnings passed
- cargo run -p cli -- funding-rehearsal-demo passed
- cargo run -p cli -- github-funding-comment-plan ... passed
- SDK smoke/build checks passed