### PR TITLE
Record AI-hotpot discovery feedback

### DIFF
--- a/crates/cli/fixtures/discovery_answers.json
+++ b/crates/cli/fixtures/discovery_answers.json
@@ -17,6 +17,10 @@
     "body": "I found Agent Bounties through a GitHub bounty discovery workflow that searches open bounty-labelled issues. This bounty was worth participating in because it was deterministic, locally testable, and the payment-trust boundary was explicit."
   },
   {
+    "contributor": "AI-hotpot",
+    "body": "I found Agent Bounties manually by searching GitHub for open bounty issues with labels like bounty, ai-agent-welcome, and good-first-agent-bounty. This bounty looked worth trying because the scope was concrete, public-facing, and small enough to review clearly. Codex helped me complete the work after I selected the issue: it inspected the repo, implemented the change, added or updated tests and docs, pushed the branch, opened the PR, and handled the review fixes."
+  },
+  {
     "contributor": "partial-agent",
     "body": "How did you find Agent Bounties? MCP discovery manifest."
   },

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2060,6 +2060,8 @@ fn extract_answer_after_marker(body: &str, markers: &[&str]) -> Option<String> {
 fn extract_found_through_answer(body: &str) -> Option<String> {
     for marker in [
         "found agent bounties through",
+        "found agent bounties manually by",
+        "found agent bounties by",
         "found it through",
         "found this through",
         "found this project through",
@@ -2081,6 +2083,8 @@ fn extract_because_answer(body: &str) -> Option<String> {
         "participated because",
         "worth participating because",
         "worth participating in because",
+        "worth trying because",
+        "looked worth trying because",
         "joined because",
     ] {
         if let Some(answer) = substring_after_case_insensitive(body, marker).and_then(clean_answer)
@@ -5726,16 +5730,17 @@ mod tests {
             build_discovery_report_from_str(include_str!("../fixtures/discovery_answers.json"))
                 .expect("fixture should build a discovery report");
 
-        assert_eq!(report.total_records, 6);
-        assert_eq!(report.answered_records, 5);
+        assert_eq!(report.total_records, 7);
+        assert_eq!(report.answered_records, 6);
         assert_eq!(report.partial_answer_records, 1);
         assert_eq!(report.missing_answer_records, 1);
-        assert_eq!(report.unique_contributors, 5);
+        assert_eq!(report.unique_contributors, 6);
         assert_eq!(report.duplicate_contributors, vec!["codeboost-tr"]);
-        assert!(bucket_count(&report.discovery_sources, "github") >= 3);
+        assert!(bucket_count(&report.discovery_sources, "github") >= 4);
         assert!(bucket_count(&report.discovery_sources, "machine-discovery") >= 1);
         assert!(bucket_count(&report.participation_reasons, "payout") >= 2);
-        assert!(bucket_count(&report.participation_reasons, "clear-scope") >= 2);
+        assert!(bucket_count(&report.participation_reasons, "clear-scope") >= 3);
+        assert!(bucket_count(&report.agent_workflows, "codex") >= 1);
         assert!(bucket_count(&report.trust_payment_signals, "base-usdc-escrow") >= 1);
         assert!(bucket_count(&report.trust_payment_signals, "deterministic-verification") >= 2);
         assert!(bucket_count(&report.friction_points, "stale-docs-or-contract") >= 1);


### PR DESCRIPTION
## Summary
- record AI-hotpot's new distribution feedback in the discovery-report fixture
- teach the parser contributor phrasing like `found Agent Bounties manually by...` and `worth trying because...`
- update discovery-report assertions to cover the new Codex-assisted workflow signal

## Verification
- `cargo test -p cli discovery_report`
- `cargo run -p cli -- discovery-report --input-fixture crates\cli\fixtures\discovery_answers.json --json-out target\tmp\discovery-report.json --markdown-out target\tmp\discovery-report.md`
- `scripts/check.ps1`