### PR TITLE
Add safe public funding status CTAs

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -2258,6 +2258,60 @@ fn public_bounty_page_model(
         .filter(|proof| proof.privacy != PrivacyLevel::Private)
         .map(|proof| format!("{api}/public/proofs/{}", proof.id))
         .collect();
+    let public_url = format!("{api}/public/bounties/{}", bounty.id);
+    let funding_partitions = status
+        .funding_summary
+        .partitions
+        .iter()
+        .map(|partition| web_public::PublicFundingPartition {
+            rail: format!("{:?}", partition.rail),
+            target_minor: partition.target.amount,
+            confirmed_minor: partition.confirmed.amount,
+            remaining_minor: partition.remaining.amount,
+            currency: partition.target.currency.clone(),
+            contribution_count: partition.contribution_count,
+            escrow_count: partition.escrow_count,
+            claimable: partition.claimable,
+        })
+        .collect();
+    let verifier_result_links = status
+        .verifier_results
+        .iter()
+        .map(|result| web_public::PublicBountyRecordLink {
+            label: format!(
+                "{:?} {:?} verifier result {}",
+                result.kind, result.decision, result.id
+            ),
+            url: format!("{public_url}#verifier-results"),
+        })
+        .collect();
+    let settlement_links = status
+        .settlements
+        .iter()
+        .map(|settlement| {
+            let paid_payouts = settlement
+                .payout_intents
+                .iter()
+                .filter(|intent| intent.status == PayoutStatus::Paid)
+                .count();
+            let total_payouts = settlement.payout_intents.len();
+            web_public::PublicBountyRecordLink {
+                label: format!(
+                    "{:?} settlement {} ({paid_payouts}/{total_payouts} payouts paid)",
+                    settlement.rail, settlement.id
+                ),
+                url: format!("{public_url}#settlements"),
+            }
+        })
+        .collect();
+    let template_signal_links = status
+        .template_signals
+        .iter()
+        .map(|signal| web_public::PublicBountyRecordLink {
+            label: format!("{} template signal {}", signal.template_slug, signal.id),
+            url: format!("{api}/public/templates/{}", signal.template_slug),
+        })
+        .collect();
     web_public::PublicBountyPage {
         bounty_id: bounty.id.to_string(),
         title: bounty.title.clone(),
@@ -2275,12 +2329,16 @@ fn public_bounty_page_model(
         funding_applied_minor: status.funding_summary.applied.amount,
         funding_remaining_minor: status.funding_summary.remaining.amount,
         contribution_count: status.funding_summary.contribution_count,
-        public_url: format!("{api}/public/bounties/{}", bounty.id),
+        public_url,
         claim_url: format!("{api}/v1/bounties/{}/claim", bounty.id),
         status_url: format!("{api}/v1/bounties/{}", bounty.id),
         template_url: format!("{api}/public/templates/{}", bounty.template_slug),
         funding_contribution_url: format!("{api}/v1/bounties/{}/funding-contributions", bounty.id),
         proof_urls,
+        funding_partitions,
+        verifier_result_links,
+        settlement_links,
+        template_signal_links,
     }
 }
 
@@ -3878,12 +3936,67 @@ mod tests {
 
         assert!(html.contains("Fix public &lt;CI&gt;"));
         assert!(html.contains("Funding State"));
+        assert!(html.contains("Funding partitions"));
         assert!(html.contains("application/ld+json"));
+        assert!(html.contains("agent-bounty-public-status"));
         assert!(html.contains("Machine status"));
-        assert!(html.contains("Add funding"));
+        assert!(html.contains(r#"data-agent-action="claim""#));
+        assert!(!html.contains("Add funding"));
+        assert!(!html.contains(r#"rel="payment""#));
         assert!(html.contains(&format!("/public/bounties/{}", bounty.id)));
         assert!(html.contains(&format!("/v1/bounties/{}/claim", bounty.id)));
+        assert!(!html.contains(&format!("/v1/bounties/{}/funding-contributions", bounty.id)));
+    }
+
+    #[tokio::test]
+    async fn public_bounty_detail_exposes_cofunding_while_target_remains() {
+        let state = test_state(BountyNetwork::default());
+        let bounty = open_pooled_bounty(
+            State(state.clone()),
+            Json(OpenPooledBountyRequest {
+                title: "Fund shared public work".to_string(),
+                template_slug: "write-docs-for-area".to_string(),
+                target_amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::Simulated,
+                privacy: PrivacyLevel::Public,
+                funding_targets: vec![],
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        let partial = add_funding_contribution(
+            State(state.clone()),
+            Path(bounty.id),
+            Json(AddFundingContributionRequest {
+                bounty_id: bounty.id,
+                contributor_agent_id: None,
+                source_organization_id: None,
+                amount_minor: 400_000,
+                currency: "USDC".to_string(),
+                rail: PaymentRail::Simulated,
+                external_reference: Some("partial-public-page".to_string()),
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        assert_eq!(partial.bounty.status, BountyStatus::Unfunded);
+        assert_eq!(partial.funding_summary.remaining.amount, 600_000);
+
+        let html = public_bounty_page(State(state), Path(bounty.id))
+            .await
+            .unwrap()
+            .0;
+
+        assert!(html.contains("partially funded"));
+        assert!(html.contains("Co-funding command:"));
+        assert!(html.contains("/agent-bounty fund 0.6 USDC via Simulated"));
+        assert!(html.contains(r#"rel="payment""#));
+        assert!(html.contains(r#"data-agent-action="add_funding""#));
         assert!(html.contains(&format!("/v1/bounties/{}/funding-contributions", bounty.id)));
+        assert!(!html.contains(r#"data-agent-action="claim""#));
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3599,9 +3599,12 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
     require(
         public_bounty_page.contains("Funding State")
             && public_bounty_page.contains("application/ld+json")
+            && public_bounty_page.contains("agent-bounty-public-status")
             && public_bounty_page.contains("Machine status")
-            && public_bounty_page.contains("Add funding"),
-        "public bounty detail page must expose funding state and machine-readable actions",
+            && public_bounty_page.contains(r#"data-agent-action="claim""#)
+            && !public_bounty_page.contains("Add funding")
+            && !public_bounty_page.contains(r#"rel="payment""#),
+        "public funded bounty detail page must expose claim/status actions without unsafe funding links",
     )?;
 
     let mcp_discovery = get_json(&format!("{mcp}/.well-known/agent-bounties.json"))?;

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -176,6 +176,35 @@ pub struct PublicBountyPage {
     pub template_url: String,
     pub funding_contribution_url: String,
     pub proof_urls: Vec<String>,
+    pub funding_partitions: Vec<PublicFundingPartition>,
+    pub verifier_result_links: Vec<PublicBountyRecordLink>,
+    pub settlement_links: Vec<PublicBountyRecordLink>,
+    pub template_signal_links: Vec<PublicBountyRecordLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PublicFundingPartition {
+    pub rail: String,
+    pub target_minor: i64,
+    pub confirmed_minor: i64,
+    pub remaining_minor: i64,
+    pub currency: String,
+    pub contribution_count: usize,
+    pub escrow_count: usize,
+    pub claimable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PublicBountyRecordLink {
+    pub label: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PublicBountyNextAction {
+    pub kind: String,
+    pub label: String,
+    pub href: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -831,7 +860,7 @@ pub fn render_bounty_feed_page(items: &[PublicBountyFeedItem]) -> String {
   <main>
     <h1>Claimable Agent Bounties</h1>
     <p><a href="/v1/bounties/feed">Machine-readable feed</a></p>
-    <p>Each bounty detail page exposes Claim, Machine status, Template, Proof, and Add funding links for autonomous agents.</p>
+    <p>Each bounty detail page exposes Claim, Machine status, Template, Proof, and conditional Add funding links for autonomous agents.</p>
     <ul>
       {}
     </ul>
@@ -843,6 +872,47 @@ pub fn render_bounty_feed_page(items: &[PublicBountyFeedItem]) -> String {
 }
 
 pub fn render_public_bounty_page(item: &PublicBountyPage) -> String {
+    let funding_state = public_funding_state_label(item);
+    let cofunding_command = public_cofunding_command(item);
+    let next_actions = public_bounty_next_actions(item, cofunding_command.is_some());
+    let payment_link = cofunding_command
+        .as_ref()
+        .map(|_| {
+            format!(
+                r#"<link rel="payment" href="{}">"#,
+                escape_html(&item.funding_contribution_url)
+            )
+        })
+        .unwrap_or_default();
+    let cofunding_command_html = cofunding_command
+        .as_deref()
+        .map(|command| {
+            format!(
+                r#"<p>Co-funding command: <code>{}</code></p>"#,
+                escape_html(command)
+            )
+        })
+        .unwrap_or_else(|| "<p>No co-funding action is currently available.</p>".to_string());
+    let partition_rows = render_funding_partition_rows(item);
+    let next_action_links = next_actions
+        .iter()
+        .map(|action| {
+            format!(
+                r#"<li><a data-agent-action="{}" href="{}">{}</a></li>"#,
+                escape_html(&action.kind),
+                escape_html(&action.href),
+                escape_html(&action.label)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let verifier_result_links =
+        render_record_links(&item.verifier_result_links, "No public verifier result yet");
+    let settlement_links = render_record_links(&item.settlement_links, "No settlement state yet");
+    let template_signal_links = render_record_links(
+        &item.template_signal_links,
+        "No reusable template signal yet",
+    );
     let proof_links = if item.proof_urls.is_empty() {
         "<li>No public proof yet</li>".to_string()
     } else {
@@ -857,6 +927,15 @@ pub fn render_public_bounty_page(item: &PublicBountyPage) -> String {
             .collect::<Vec<_>>()
             .join("\n")
     };
+    let potential_actions = next_actions
+        .iter()
+        .map(|action| {
+            serde_json::json!({
+                "name": action.kind,
+                "target": action.href
+            })
+        })
+        .collect::<Vec<_>>();
     let metadata = serde_json::json!({
         "@context": "https://schema.org",
         "@type": "Action",
@@ -880,18 +959,38 @@ pub fn render_public_bounty_page(item: &PublicBountyPage) -> String {
                 "target_minor": item.funding_target_minor,
                 "applied_minor": item.funding_applied_minor,
                 "remaining_minor": item.funding_remaining_minor,
-                "contribution_count": item.contribution_count
+                "contribution_count": item.contribution_count,
+                "state": funding_state,
+                "partitions": item.funding_partitions,
+                "cofunding_command": cofunding_command.as_deref()
             }
         },
-        "potentialAction": [
-            { "name": "claim", "target": item.claim_url },
-            { "name": "status", "target": item.status_url },
-            { "name": "template", "target": item.template_url },
-            { "name": "funding_contribution", "target": item.funding_contribution_url }
-        ],
+        "potentialAction": potential_actions,
         "proof": item.proof_urls
     });
+    let public_status = serde_json::json!({
+        "type": "agent-bounty-public-status",
+        "bounty_id": item.bounty_id,
+        "status": item.status,
+        "funding_state": funding_state,
+        "funding": {
+            "target_minor": item.funding_target_minor,
+            "applied_minor": item.funding_applied_minor,
+            "remaining_minor": item.funding_remaining_minor,
+            "contribution_count": item.contribution_count,
+            "partitions": item.funding_partitions,
+            "cofunding_command": cofunding_command.as_deref()
+        },
+        "evidence": {
+            "proof_urls": item.proof_urls,
+            "verifier_results": item.verifier_result_links,
+            "settlements": item.settlement_links,
+            "template_signals": item.template_signal_links
+        },
+        "next_actions": next_actions
+    });
     let metadata_json = json_script(&metadata);
+    let public_status_json = json_script(&public_status);
     format!(
         r#"<!doctype html>
 <html lang="en">
@@ -911,8 +1010,9 @@ pub fn render_public_bounty_page(item: &PublicBountyPage) -> String {
   <meta name="agent-bounty:verification_type" content="{}">
   <link rel="canonical" href="{}">
   <link rel="alternate" type="application/json" href="{}">
-  <link rel="payment" href="{}">
+  {}
   <script type="application/ld+json">{}</script>
+  <script type="application/json" id="agent-bounty-public-status">{}</script>
 </head>
 <body>
   <main>
@@ -932,21 +1032,44 @@ pub fn render_public_bounty_page(item: &PublicBountyPage) -> String {
     <section>
       <h2>Funding State</h2>
       <dl>
+        <dt>State</dt><dd>{}</dd>
         <dt>Target</dt><dd>{} {}</dd>
         <dt>Applied</dt><dd>{} {}</dd>
         <dt>Remaining</dt><dd>{} {}</dd>
         <dt>Contributions</dt><dd>{}</dd>
       </dl>
+      <h3>Funding partitions</h3>
+      <ul>
+        {}
+      </ul>
+      {}
     </section>
     <nav aria-label="Agent actions">
-      <a href="{}">Claim</a>
-      <a href="{}">Machine status</a>
-      <a href="{}">Template</a>
-      <a href="{}">Add funding</a>
-      <a href="/public/bounties">Back to public bounties</a>
+      <ul>
+        {}
+        <li><a href="/public/bounties">Back to public bounties</a></li>
+      </ul>
     </nav>
-    <section>
+    <section id="proof-links">
       <h2>Proof Links</h2>
+      <ul>
+        {}
+      </ul>
+    </section>
+    <section id="verifier-results">
+      <h2>Verifier Results</h2>
+      <ul>
+        {}
+      </ul>
+    </section>
+    <section id="settlements">
+      <h2>Settlement State</h2>
+      <ul>
+        {}
+      </ul>
+    </section>
+    <section id="template-signals">
+      <h2>Reusable Template Signals</h2>
       <ul>
         {}
       </ul>
@@ -967,8 +1090,9 @@ pub fn render_public_bounty_page(item: &PublicBountyPage) -> String {
         escape_html(&item.verification_type),
         escape_html(&item.public_url),
         escape_html(&item.status_url),
-        escape_html(&item.funding_contribution_url),
+        payment_link,
         metadata_json,
+        public_status_json,
         escape_html(&item.title),
         escape_html(&item.bounty_id),
         escape_html(&item.template_url),
@@ -982,6 +1106,7 @@ pub fn render_public_bounty_page(item: &PublicBountyPage) -> String {
         escape_html(&item.verification_type),
         escape_html(item.terms_hash.as_deref().unwrap_or("pending")),
         escape_html(&item.created_at),
+        escape_html(&funding_state),
         item.funding_target_minor,
         escape_html(&item.currency),
         item.funding_applied_minor,
@@ -989,12 +1114,170 @@ pub fn render_public_bounty_page(item: &PublicBountyPage) -> String {
         item.funding_remaining_minor,
         escape_html(&item.currency),
         item.contribution_count,
-        escape_html(&item.claim_url),
-        escape_html(&item.status_url),
-        escape_html(&item.template_url),
-        escape_html(&item.funding_contribution_url),
+        partition_rows,
+        cofunding_command_html,
+        next_action_links,
         proof_links,
+        verifier_result_links,
+        settlement_links,
+        template_signal_links,
     )
+}
+
+pub fn public_funding_state_label(item: &PublicBountyPage) -> String {
+    match item.status.as_str() {
+        "Paid" => "paid".to_string(),
+        "Refunded" => "refunded".to_string(),
+        "Disputed" => "disputed".to_string(),
+        "Expired" => "expired".to_string(),
+        _ if item.claimable => "claimable".to_string(),
+        _ if item.funding_remaining_minor == 0 && item.funding_applied_minor > 0 => {
+            "funded".to_string()
+        }
+        _ if item.funding_applied_minor > 0 => "partially funded".to_string(),
+        _ => "unfunded".to_string(),
+    }
+}
+
+pub fn public_cofunding_command(item: &PublicBountyPage) -> Option<String> {
+    if item.funding_remaining_minor <= 0 || is_terminal_public_status(&item.status) {
+        return None;
+    }
+    let partition = item
+        .funding_partitions
+        .iter()
+        .find(|partition| partition.remaining_minor > 0);
+    let rail = partition
+        .map(|partition| partition.rail.as_str())
+        .unwrap_or(item.funding_mode.as_str());
+    let currency = partition
+        .map(|partition| partition.currency.as_str())
+        .unwrap_or(item.currency.as_str());
+    let amount_minor = partition
+        .map(|partition| partition.remaining_minor)
+        .unwrap_or(item.funding_remaining_minor);
+    Some(format!(
+        "/agent-bounty fund {} {} via {}",
+        format_command_amount(amount_minor, currency),
+        currency.to_ascii_uppercase(),
+        rail
+    ))
+}
+
+pub fn public_bounty_next_actions(
+    item: &PublicBountyPage,
+    can_add_funding: bool,
+) -> Vec<PublicBountyNextAction> {
+    let mut actions = Vec::new();
+    if item.claimable && !is_terminal_public_status(&item.status) {
+        actions.push(PublicBountyNextAction {
+            kind: "claim".to_string(),
+            label: "Claim".to_string(),
+            href: item.claim_url.clone(),
+        });
+    }
+    actions.push(PublicBountyNextAction {
+        kind: "status".to_string(),
+        label: "Machine status".to_string(),
+        href: item.status_url.clone(),
+    });
+    actions.push(PublicBountyNextAction {
+        kind: "template".to_string(),
+        label: "Template".to_string(),
+        href: item.template_url.clone(),
+    });
+    if can_add_funding {
+        actions.push(PublicBountyNextAction {
+            kind: "add_funding".to_string(),
+            label: "Add funding".to_string(),
+            href: item.funding_contribution_url.clone(),
+        });
+    }
+    if let Some(proof_url) = item.proof_urls.first() {
+        actions.push(PublicBountyNextAction {
+            kind: "proof".to_string(),
+            label: "Public proof".to_string(),
+            href: proof_url.clone(),
+        });
+    }
+    actions
+}
+
+fn render_funding_partition_rows(item: &PublicBountyPage) -> String {
+    let partitions = if item.funding_partitions.is_empty() {
+        vec![PublicFundingPartition {
+            rail: item.funding_mode.clone(),
+            target_minor: item.funding_target_minor,
+            confirmed_minor: item.funding_applied_minor,
+            remaining_minor: item.funding_remaining_minor,
+            currency: item.currency.clone(),
+            contribution_count: item.contribution_count,
+            escrow_count: 0,
+            claimable: item.claimable,
+        }]
+    } else {
+        item.funding_partitions.clone()
+    };
+    partitions
+        .iter()
+        .map(|partition| {
+            format!(
+                r#"<li><span>{}</span><span>{} {}</span><span>{} confirmed</span><span>{} remaining</span><span>{} contributions</span><span>{} escrows</span><span>claimable: {}</span></li>"#,
+                escape_html(&partition.rail),
+                partition.target_minor,
+                escape_html(&partition.currency),
+                partition.confirmed_minor,
+                partition.remaining_minor,
+                partition.contribution_count,
+                partition.escrow_count,
+                partition.claimable
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_record_links(links: &[PublicBountyRecordLink], empty_label: &str) -> String {
+    if links.is_empty() {
+        return format!("<li>{}</li>", escape_html(empty_label));
+    }
+    links
+        .iter()
+        .map(|link| {
+            format!(
+                r#"<li><a href="{}">{}</a></li>"#,
+                escape_html(&link.url),
+                escape_html(&link.label)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn is_terminal_public_status(status: &str) -> bool {
+    matches!(status, "Paid" | "Refunded" | "Disputed" | "Expired")
+}
+
+fn format_command_amount(amount_minor: i64, currency: &str) -> String {
+    let scale = match currency.to_ascii_lowercase().as_str() {
+        "usdc" => 1_000_000,
+        "usd" => 100,
+        _ => 1,
+    };
+    if scale == 1 {
+        return amount_minor.to_string();
+    }
+    let whole = amount_minor / scale;
+    let fraction = amount_minor.abs() % scale;
+    if fraction == 0 {
+        return whole.to_string();
+    }
+    let width = if scale == 1_000_000 { 6 } else { 2 };
+    let mut fraction_text = format!("{:0width$}", fraction, width = width);
+    while fraction_text.ends_with('0') {
+        fraction_text.pop();
+    }
+    format!("{whole}.{fraction_text}")
 }
 
 pub fn render_capability_feed_page(items: &[PublicCapabilityFeedItem]) -> String {
@@ -1740,20 +2023,130 @@ mod tests {
             funding_contribution_url: "https://network.example/v1/bounties/1/funding-contributions"
                 .to_string(),
             proof_urls: vec!["https://network.example/public/proofs/1".to_string()],
+            funding_partitions: vec![PublicFundingPartition {
+                rail: "BaseUsdc".to_string(),
+                target_minor: 1_000,
+                confirmed_minor: 1_000,
+                remaining_minor: 0,
+                currency: "usdc".to_string(),
+                contribution_count: 1,
+                escrow_count: 1,
+                claimable: true,
+            }],
+            verifier_result_links: vec![PublicBountyRecordLink {
+                label: "GitHubCi Accepted verifier result".to_string(),
+                url: "https://network.example/public/bounties/1#verifier-results".to_string(),
+            }],
+            settlement_links: vec![PublicBountyRecordLink {
+                label: "BaseUsdc settlement".to_string(),
+                url: "https://network.example/public/bounties/1#settlements".to_string(),
+            }],
+            template_signal_links: vec![PublicBountyRecordLink {
+                label: "fix-ci-failure template signal".to_string(),
+                url: "https://network.example/public/templates/fix-ci-failure".to_string(),
+            }],
         };
 
         let html = render_public_bounty_page(&item);
 
         assert!(html.contains("application/ld+json"));
+        assert!(html.contains("agent-bounty-public-status"));
         assert!(html.contains("agent-bounty:title"));
         assert!(html.contains("agent-bounty:verification_type"));
         assert!(html.contains("Funding State"));
+        assert!(html.contains("Funding partitions"));
         assert!(html.contains("Machine status"));
-        assert!(html.contains("Add funding"));
+        assert!(html.contains(r#"data-agent-action="claim""#));
+        assert!(!html.contains("Add funding"));
+        assert!(!html.contains(r#"rel="payment""#));
+        assert!(html.contains("No co-funding action is currently available"));
+        assert!(html.contains("BaseUsdc"));
+        assert!(html.contains("Verifier Results"));
+        assert!(html.contains("Settlement State"));
+        assert!(html.contains("Reusable Template Signals"));
         assert!(html.contains("https://network.example/public/proofs/1"));
-        assert!(html.contains("https://network.example/v1/bounties/1/funding-contributions"));
+        assert!(html.contains("https://network.example/public/bounties/1#verifier-results"));
+        assert!(!html.contains("https://network.example/v1/bounties/1/funding-contributions"));
         assert!(!html.contains("</script><script>"));
         assert!(html.contains("&lt;/script&gt;&lt;script&gt;"));
+    }
+
+    #[test]
+    fn public_bounty_page_exposes_cofunding_only_when_funding_remains() {
+        let item = public_bounty_page_fixture("Unfunded", 500_000, 500_000, false);
+
+        let html = render_public_bounty_page(&item);
+
+        assert!(html.contains("partially funded"));
+        assert!(html.contains("Co-funding command:"));
+        assert!(html.contains("/agent-bounty fund 0.5 USDC via BaseUsdc"));
+        assert!(html.contains(r#"rel="payment""#));
+        assert!(html.contains(r#"data-agent-action="add_funding""#));
+        assert!(html.contains("https://network.example/v1/bounties/1/funding-contributions"));
+        assert!(!html.contains(r#"data-agent-action="claim""#));
+    }
+
+    #[test]
+    fn public_bounty_page_suppresses_unsafe_payment_actions_for_terminal_states() {
+        for status in ["Paid", "Refunded", "Disputed", "Expired"] {
+            let item = public_bounty_page_fixture(status, 500_000, 500_000, false);
+
+            let html = render_public_bounty_page(&item);
+
+            assert!(!html.contains("Co-funding command:"), "{status}");
+            assert!(!html.contains(r#"rel="payment""#), "{status}");
+            assert!(
+                !html.contains(r#"data-agent-action="add_funding""#),
+                "{status}"
+            );
+            assert!(!html.contains(r#"data-agent-action="claim""#), "{status}");
+        }
+    }
+
+    fn public_bounty_page_fixture(
+        status: &str,
+        applied_minor: i64,
+        remaining_minor: i64,
+        claimable: bool,
+    ) -> PublicBountyPage {
+        PublicBountyPage {
+            bounty_id: Uuid::new_v4().to_string(),
+            title: "Public fix".to_string(),
+            template_slug: "fix-ci-failure".to_string(),
+            amount_minor: applied_minor + remaining_minor,
+            currency: "usdc".to_string(),
+            funding_mode: "BaseUsdcEscrow".to_string(),
+            privacy: "Public".to_string(),
+            status: status.to_string(),
+            terms_hash: Some("terms".to_string()),
+            created_at: Utc::now().to_rfc3339(),
+            verification_type: "GitHubCi".to_string(),
+            claimable,
+            funding_target_minor: applied_minor + remaining_minor,
+            funding_applied_minor: applied_minor,
+            funding_remaining_minor: remaining_minor,
+            contribution_count: usize::from(applied_minor > 0),
+            public_url: "https://network.example/public/bounties/1".to_string(),
+            claim_url: "https://network.example/v1/bounties/1/claim".to_string(),
+            status_url: "https://network.example/v1/bounties/1".to_string(),
+            template_url: "https://network.example/public/templates/fix-ci-failure".to_string(),
+            funding_contribution_url: "https://network.example/v1/bounties/1/funding-contributions"
+                .to_string(),
+            proof_urls: vec![],
+            funding_partitions: vec![PublicFundingPartition {
+                rail: "BaseUsdc".to_string(),
+                target_minor: applied_minor + remaining_minor,
+                confirmed_minor: applied_minor,
+                remaining_minor,
+                currency: "usdc".to_string(),
+                contribution_count: usize::from(applied_minor > 0),
+                escrow_count: usize::from(applied_minor > 0),
+                claimable,
+            }],
+            verifier_result_links: vec![],
+            settlement_links: vec![],
+            template_signal_links: vec![],
+        }
     }
 
     fn claimable_bounty(title: &str, amount_minor: i64, privacy: PrivacyLevel) -> Bounty {

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -64,6 +64,28 @@ means a Checkout Session request, issue comment, or funding intention cannot
 make fiat work claimable; only a reconciled paid Checkout webhook can create the
 balance that a later funding contribution reserves.
 
+## Public Bounty Funding Status
+
+Public bounty pages are a distribution surface for humans and agents, so they
+publish a machine-readable funding status without exposing private payment
+records. Each public page includes target, applied, and remaining amounts,
+per-rail funding partitions, contribution and escrow counts, public proof links,
+verifier result anchors, settlement anchors, template-signal links, and
+`agent-bounty-public-status` JSON for autonomous clients.
+
+Co-funding calls to action are conditional. The page emits `rel="payment"`,
+`data-agent-action="add_funding"`, and an `/agent-bounty fund ...` command only
+while funding remains and the bounty is not terminal. Fully funded, paid,
+refunded, disputed, and expired bounties suppress payment links even when the
+funding-contribution API route exists. Agents should treat the public page as a
+routing and discovery document, not as settlement evidence.
+
+The public page must not leak private payer identity, source organization IDs,
+Stripe customer or Checkout Session IDs, webhook payloads, internal operator
+review notes, or private proof material. Verifier, settlement, and template
+signals are public pointers that help agents decide whether to claim, fund, or
+reuse a bounty pattern; they never authorize payment by themselves.
+
 Run the deterministic mixed-funding rehearsal locally:
 
 ```powershell


### PR DESCRIPTION
## Summary
- expose partition-aware public bounty funding status and machine-readable `agent-bounty-public-status` JSON
- show co-funding/payment actions only while funding remains and the bounty is non-terminal
- surface public proof, verifier, settlement, and template signal links without leaking private payment details
- update service smoke coverage and payment model docs for the new public-page contract

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p web-public -p api public_bounty`
- `cargo run -p cli -- docs-contract-check`
- `cargo run -p cli -- service-smoke-spawn --api-base-url http://127.0.0.1:18080 --mcp-base-url http://127.0.0.1:18090`
- `scripts\check.ps1`

Closes #34.