### PR TITLE
Expose Stripe transfer settlement in SDKs

### DIFF
--- a/crates/sdk-python/agent_bounties/client.py
+++ b/crates/sdk-python/agent_bounties/client.py
@@ -605,6 +605,20 @@ class AgentBountiesClient:
             json={"agent_id": agent_id},
         )
 
+    def plan_stripe_connect_transfer(
+        self,
+        payout_intent_id: str,
+        connected_account_id: str,
+    ):
+        return self._request(
+            "POST",
+            "/v1/stripe/connect-transfers",
+            json={
+                "payout_intent_id": payout_intent_id,
+                "connected_account_id": connected_account_id,
+            },
+        )
+
     def execute_stripe_checkout_top_up(
         self,
         organization_id: str,
@@ -630,6 +644,20 @@ class AgentBountiesClient:
             "POST",
             "/v1/stripe/live/connect-accounts",
             json={"agent_id": agent_id},
+        )
+
+    def execute_stripe_connect_transfer(
+        self,
+        payout_intent_id: str,
+        connected_account_id: str,
+    ):
+        return self._request(
+            "POST",
+            "/v1/stripe/live/connect-transfers",
+            json={
+                "payout_intent_id": payout_intent_id,
+                "connected_account_id": connected_account_id,
+            },
         )
 
     def plan_github_issue_bounty(
@@ -722,6 +750,24 @@ class AgentBountiesClient:
         response = httpx.request(
             "POST",
             f"{self.base_url}/v1/stripe/checkout-webhooks",
+            json=event,
+            headers=headers or None,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def reconcile_stripe_transfer_event(
+        self,
+        event: dict,
+        stripe_signature: str | None = None,
+    ):
+        headers = self._headers() or {}
+        if stripe_signature:
+            headers["stripe-signature"] = stripe_signature
+        response = httpx.request(
+            "POST",
+            f"{self.base_url}/v1/stripe/transfer-events",
             json=event,
             headers=headers or None,
             timeout=30,

--- a/crates/sdk-python/agent_bounties/smoke.py
+++ b/crates/sdk-python/agent_bounties/smoke.py
@@ -146,8 +146,24 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
         "discovery manifest missing live Stripe Checkout execution endpoint",
     )
     _require(
+        isinstance(discovery.get("endpoints", {}).get("stripe_connect_transfers"), str),
+        "discovery manifest missing Stripe Connect transfer planner endpoint",
+    )
+    _require(
+        isinstance(discovery.get("endpoints", {}).get("stripe_connect_snapshots"), str),
+        "discovery manifest missing Stripe Connect snapshot reconciliation endpoint",
+    )
+    _require(
         isinstance(discovery.get("endpoints", {}).get("stripe_live_connect_accounts"), str),
         "discovery manifest missing live Stripe Connect execution endpoint",
+    )
+    _require(
+        isinstance(discovery.get("endpoints", {}).get("stripe_live_connect_transfers"), str),
+        "discovery manifest missing live Stripe Connect transfer execution endpoint",
+    )
+    _require(
+        isinstance(discovery.get("endpoints", {}).get("stripe_transfer_events"), str),
+        "discovery manifest missing Stripe transfer event reconciliation endpoint",
     )
     _require(
         isinstance(discovery.get("endpoints", {}).get("github_issue_bounty_plan"), str),
@@ -378,6 +394,15 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
         stripe_connect["request"]["endpoint"] == "/v2/core/accounts",
         "Stripe Connect account planner used the wrong endpoint",
     )
+    try:
+        client.plan_stripe_connect_transfer(str(uuid.uuid4()), "acct_test_sdk_smoke")
+    except httpx.HTTPStatusError as error:
+        _require(
+            error.response.status_code == 400,
+            "unknown Stripe transfer payout intent should return 400",
+        )
+    else:
+        raise AssertionError("unknown Stripe transfer payout intent should fail")
     github_issue_plan = client.plan_github_issue_bounty(
         "agent-bounties/agent-bounties",
         "https://github.com/agent-bounties/agent-bounties/issues/1",

--- a/crates/sdk-typescript/src/index.ts
+++ b/crates/sdk-typescript/src/index.ts
@@ -190,6 +190,11 @@ export interface PlanStripeConnectAccountRequest {
   agent_id: string;
 }
 
+export interface PlanStripeConnectTransferRequest {
+  payout_intent_id: string;
+  connected_account_id: string;
+}
+
 export interface PlanGitHubIssueBountyRequest {
   repository: string;
   issue_url: string;
@@ -650,6 +655,13 @@ export class AgentBountiesClient {
     });
   }
 
+  async planStripeConnectTransfer(request: PlanStripeConnectTransferRequest): Promise<unknown> {
+    return this.request("/v1/stripe/connect-transfers", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  }
+
   async executeStripeCheckoutTopUp(request: PlanStripeCheckoutTopUpRequest): Promise<unknown> {
     return this.request("/v1/stripe/live/checkout-top-ups", {
       method: "POST",
@@ -665,6 +677,13 @@ export class AgentBountiesClient {
 
   async executeStripeConnectAccount(request: PlanStripeConnectAccountRequest): Promise<unknown> {
     return this.request("/v1/stripe/live/connect-accounts", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  }
+
+  async executeStripeConnectTransfer(request: PlanStripeConnectTransferRequest): Promise<unknown> {
+    return this.request("/v1/stripe/live/connect-transfers", {
       method: "POST",
       body: JSON.stringify(request),
     });
@@ -729,6 +748,17 @@ export class AgentBountiesClient {
     stripeSignature?: string,
   ): Promise<unknown> {
     return this.request("/v1/stripe/checkout-webhooks", {
+      method: "POST",
+      headers: stripeSignature ? { "stripe-signature": stripeSignature } : undefined,
+      body: JSON.stringify(event),
+    });
+  }
+
+  async reconcileStripeTransferEvent(
+    event: StripeWebhookEvent,
+    stripeSignature?: string,
+  ): Promise<unknown> {
+    return this.request("/v1/stripe/transfer-events", {
       method: "POST",
       headers: stripeSignature ? { "stripe-signature": stripeSignature } : undefined,
       body: JSON.stringify(event),

--- a/crates/sdk-typescript/src/smoke.ts
+++ b/crates/sdk-typescript/src/smoke.ts
@@ -197,8 +197,24 @@ async function main(): Promise<void> {
     "discovery manifest missing live Stripe Checkout execution endpoint",
   );
   requireCondition(
+    typeof endpoints.stripe_connect_transfers === "string",
+    "discovery manifest missing Stripe Connect transfer planner endpoint",
+  );
+  requireCondition(
+    typeof endpoints.stripe_connect_snapshots === "string",
+    "discovery manifest missing Stripe Connect snapshot reconciliation endpoint",
+  );
+  requireCondition(
     typeof endpoints.stripe_live_connect_accounts === "string",
     "discovery manifest missing live Stripe Connect execution endpoint",
+  );
+  requireCondition(
+    typeof endpoints.stripe_live_connect_transfers === "string",
+    "discovery manifest missing live Stripe Connect transfer execution endpoint",
+  );
+  requireCondition(
+    typeof endpoints.stripe_transfer_events === "string",
+    "discovery manifest missing Stripe transfer event reconciliation endpoint",
   );
   requireCondition(
     typeof endpoints.github_issue_bounty_plan === "string",
@@ -473,6 +489,19 @@ async function main(): Promise<void> {
   requireCondition(
     stripeConnectRequest.endpoint === "/v2/core/accounts",
     "Stripe Connect account planner used the wrong endpoint",
+  );
+  let unknownTransferRejected = false;
+  try {
+    await client.planStripeConnectTransfer({
+      payout_intent_id: crypto.randomUUID(),
+      connected_account_id: "acct_test_sdk_smoke",
+    });
+  } catch (error) {
+    unknownTransferRejected = error instanceof Error && error.message.includes("400");
+  }
+  requireCondition(
+    unknownTransferRejected,
+    "unknown Stripe transfer payout intent should return 400",
   );
   const githubIssuePlan = asObject(
     await client.planGitHubIssueBounty({


### PR DESCRIPTION
## Summary
- add Python SDK methods for Stripe Connect transfer planning, live execution, and transfer-event reconciliation
- add TypeScript SDK request type and methods for the same Stripe transfer settlement surfaces
- extend Python and TypeScript SDK smoke tests to assert discovery manifest coverage and route wiring for the transfer planner

## Validation
- `python -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py`
- `npm run build` in `crates/sdk-typescript`
- `scripts\check-sdk-live.ps1`
- `scripts\check.ps1`