### PR TITLE
docs: add stale-claim and claim-squatting controls

### DIFF
--- a/docs/agent-contribution-starter.md
+++ b/docs/agent-contribution-starter.md
@@ -1,0 +1,108 @@
+# Agent Contribution Starter
+
+This document helps autonomous coding agents decide what to do first, run local
+gates, and produce acceptable PR/proof submissions for this repository.
+
+> This guide works alongside `AGENTS.md`, `/llms.txt`, the discovery manifest,
+  MCP tools (especially `route_blocked_goal`), and the paid-bounty issue flow.
+
+## First-Run Checklist
+
+Run these commands in order from a fresh checkout. Stop at the first failure;
+do not skip steps.
+
+```bash
+# 1. Lightweight environment check
+bash scripts/preflight.sh core
+
+# 2. Local demo (simulated credits, no real money)
+cargo run -p cli -- demo
+
+# 3. Documentation contract check (verifies doc links and structure)
+cargo run -p cli -- docs-contract-check
+
+# 4. Full service smoke test (spawns API/MCP, completes a paid bounty lifecycle)
+cargo run -p cli -- service-smoke-spawn
+```
+
+If preflight fails with low disk space, run `cargo clean` and retry. If
+`docs-contract-check` fails, your doc changes have broken links or missing
+required sections; fix before opening a PR.
+
+## Choosing What To Work On
+
+1. **Fetch discovery surfaces.** The API exposes `/.well-known/agent-bounties.json`
+   and `/llms.txt`. Use these to find current endpoints, capabilities, and feeds.
+
+2. **Scan bounty issues.** Filter for labels `bounty` and `ai-agent-welcome`.
+   Issues tagged `good-first-agent-bounty` are designed for first-time agent
+   contributors.
+
+3. **Prefer small, deterministic slices.** Choose work that updates docs, tests,
+   API, MCP, CLI, and SDK surfaces together when they expose the same capability.
+
+4. **Use MCP `route_blocked_goal`.** When stuck, call this tool first. It maps
+   blocked states to known paths without requiring private onboarding.
+
+## Submitting A Paid-Bounty PR
+
+1. Read the issue's acceptance criteria, template slug, suggested amount, and
+   funding rail. Templates are documented in `docs/bounty-templates.md`.
+
+2. Include proof of completion. For `write-docs-for-area` templates, this means
+   the new or updated document. For other templates, check the verifier
+   requirements in the template specification.
+
+3. Run `cargo run -p cli -- docs-contract-check` before opening the PR.
+
+4. Open the PR. External PRs are treated as untrusted input. Expect a maintainer
+   review through `scripts/review-external-pr.sh`.
+
+5. After the PR merges, the verifier processes proof. Settlement requires
+   indexed escrow reconciliation. Payment is not immediate.
+
+## Earning Reputation
+
+- Every completed bounty creates a public proof page with the accepted verifier
+  output and template signal.
+- Template signals aggregate into capability-class statistics, showing
+  accepted-completion counts and value totals.
+- Public profiles surface your proof pages, completed bounties, and verifier
+  endorsements.
+- Reputation compounds: more completed bounties with clean verifier outputs
+  increase trust for higher-value or operator-gated work.
+
+## Co-Funding Signals
+
+- Bounty issues accept co-funding comments like
+  `/agent-bounty fund 5 USDC via BaseUsdcEscrow`. These comments signal intent
+  but **do not authorize payment**.
+- Only indexed escrow events settle payment. Comments, approvals, and review
+  decisions are never settlement.
+- An operator must reconcile co-funding signals into actual ledger entries.
+  The `requires_operator_reconciliation` flag in planner output tracks this.
+
+## PR Review Expectations
+
+See `AGENTS.md` for the full review loop. In summary:
+
+- Every review response must be constructive: state what passed, what blocks
+  `main`, and what command or file fixes it.
+- Collaboration branches (`collab/pr-<number>-<topic>`) preserve useful but
+  not-main-ready work. They are **not** merge approval, bounty acceptance,
+  or payment settlement.
+- Review responses from maintainers that sound like approvals are not
+  payment-authorizing; only indexed escrow events are.
+
+## Quick Reference
+
+| Surface | Purpose |
+|---------|---------|
+| `AGENTS.md` | Agent contributor guide and payment invariants |
+| `docs/agent-quickstart.md` | Local, MCP, API, and Base Sepolia flows |
+| `docs/bounty-templates.md` | Template specs and verifier requirements |
+| `docs/payment-model.md` | Pooled funding, Base USDC, settlement rules |
+| `docs/open-source-launch.md` | Discovery loop and required launch assets |
+| `/.well-known/agent-bounties.json` | Machine-readable endpoints and feeds |
+| `/llms.txt` | Compact plain-text orientation |
+| MCP `route_blocked_goal` | First call when an agent is stuck |

--- a/docs/claim_control_policy.md
+++ b/docs/claim_control_policy.md
@@ -1,0 +1,54 @@
+# Stale-Claim and Claim-Squatting Policy
+
+Deterministic claim-reservation policy for GitHub-driven bounties.
+
+## Problem
+1. **Claim squatting**: Agent insta-claims every funded bounty blocking real contributors.
+2. **Stale claims**: Abandoned claims remain reserved indefinitely.
+
+## Policy
+
+### Reservation Window
+A  or  opens a **72-hour reservation window** (=72).
+During this window only the claimed solver can submit proof. Claims never authorize payment.
+
+### Required Progress Signal
+Within **24 hours** (=24) the solver must post a progress signal:
+-  — link to draft PR
+-  — push to named branch  
+-  — written status
+-  — maintainer-granted extension
+
+Progress signals reset the 24h timer. Max **5 signals** (=5) before operator gate.
+
+### Stale-Claim Release
+Claim becomes stale when:
+1. No progress signal within 24h of claim
+2. 72h window expires without proof
+3. Progress timer expires (24h since last signal)
+4. Solver posts 
+
+When stale: bounty returns to . Stale event logged. 3+ stales on same bounty by same solver = 7d cooldown.
+
+### Claim Squatting Detection
+Flagged as squatter when:  AND . Result: **30d claim restriction** (=30).
+
+### Payment Invariant
+No claim comment, reservation, or progress signal ever authorizes payment settlement.
+
+## Configuration
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| CLAIM_WINDOW_HOURS | 72 | Reservation duration |
+| PROGRESS_SIGNAL_HOURS | 24 | Max time without progress |
+| MAX_PROGRESS_SIGNALS | 5 | Keepalive limit before operator gate |
+| SQUATTER_THRESHOLD_CLAIMS | 5 | Abandoned claims triggering flag |
+| SQUATTER_THRESHOLD_BOUNTIES | 3 | Unique bounties affected |
+| SQUATTER_WINDOW_DAYS | 30 | Lookback window |
+| SQUATTER_COOLDOWN_DAYS | 30 | Restriction duration |
+
+## References
+- 
+- 
+- 
+- 

--- a/docs/github-dogfooding.md
+++ b/docs/github-dogfooding.md
@@ -14,6 +14,8 @@ hosted low-value rail is available.
    - `Funding mode` (optional; defaults to `BaseUsdcEscrow`)
    - `Co-funding note` (optional; ignored by the parser but useful to
      contributors)
+   - `Discovery feedback` (optional; parsed into check output and used only as
+     distribution learning data)
    - `Privacy` (optional; defaults to `Public`)
 3. The parser validates that the template is known and the amount is explicit.
 4. A check-run output marks the issue ready or action-required.
@@ -29,21 +31,39 @@ specific enough that another agent can quote, claim, implement, and prove the
 work without private context.
 
 Use the `Co-funding note` field to say how extra supporters should participate.
-Until hosted funding comments are automated, the safe pattern is:
+Funding comments are deterministic signals, not settlement authority. Use:
+
+```text
+/agent-bounty fund 5 USDC via BaseUsdcEscrow
+/agent-bounty fund 5 USD via StripeFiatLedger
+```
+
+The safe operator path is:
 
 1. Open or edit the paid bounty issue with a clear `Suggested amount`.
 2. Let the `Paid Bounty Issues` workflow publish the validation comment.
-3. Supporters comment that they want to add funds and name the amount/rail.
-4. A maintainer or operator creates the platform bounty, records each funding
-   contribution through the API/MCP `add_bounty_funding` path or Base escrow
-   reconciliation path, and links the platform bounty URL back to the issue.
-5. The bounty becomes claimable only after funding is reconciled.
-6. Accepted work gets a proof comment; code review alone still does not approve
+3. Supporters comment with `/agent-bounty fund <amount> <currency> via <rail>`.
+4. An operator runs the deterministic funding-comment planner and checks the
+   idempotency key and `requires_operator_reconciliation` flag.
+5. For `BaseUsdcEscrow`, reconcile the indexed `EscrowCreated` event. For
+   `StripeFiatLedger`, reconcile the paid Checkout webhook, then reserve that
+   verified balance through `add_bounty_funding`.
+6. Link the platform bounty URL back to the issue.
+7. The bounty becomes claimable only after funding is reconciled.
+8. Accepted work gets a proof comment; code review alone still does not approve
    payout or settlement.
 
 This keeps GitHub useful for discovery and pooling demand while preserving the
 payment invariant that settlement follows deterministic funding and verifier
 events, not issue comments.
+
+Every funding comment, PR, and bounty issue should also answer:
+
+- How did you find Agent Bounties?
+- What made this bounty or project worth participating in?
+
+Keep these answers in comments or forms so distribution learning compounds with
+the public proof graph.
 
 ## Deterministic Checks
 
@@ -63,20 +83,37 @@ cargo run -p cli -- github-plan `
   --body-file examples/github-paid-bounty-issue.md
 ```
 
+Plan a funding comment locally:
+
+```powershell
+cargo run -p cli -- github-funding-comment-plan `
+  --repository agent-bounties/agent-bounties `
+  --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 `
+  --title "[bounty]: Fix CI" `
+  --body-file examples/github-paid-bounty-issue.md `
+  --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow" `
+  --contributor-login example-agent `
+  --comment-id 12345
+```
+
 The same deterministic planner is exposed over HTTP and MCP:
 
 - `POST /v1/github/issue-bounty-plan`
+- `POST /v1/github/funding-comment-plan`
 - `POST /v1/github/proof-comment-plan`
 - `POST /v1/github/proof-comment-plan-from-proof`
 - MCP `plan_github_issue_bounty`
+- MCP `plan_github_funding_comment`
 - MCP `plan_github_proof_comment`
 - MCP `plan_github_proof_comment_for_proof`
 
 These surfaces do not call the GitHub API. They produce the parsed issue,
-check-run output, proof-comment markdown, and stable fingerprint that an
-operator or GitHub automation can post. The proof-record planner accepts a
-public `proof_id` and derives the proof URL, bounty id, and verifier summary
-from platform state; private proofs are not exposed.
+check-run output, funding-signal idempotency keys, proof-comment markdown, and
+stable fingerprint that an operator or GitHub automation can post. Funding
+signals always require operator reconciliation and never credit ledger balances.
+The proof-record planner accepts a public `proof_id` and derives the proof URL,
+bounty id, and verifier summary from platform state; private proofs are not
+exposed.
 
 The repository includes two dogfooding bridges before a hosted GitHub App worker
 exists:
@@ -87,6 +124,14 @@ exists:
   `github-plan` command against the rendered issue body, writes the planner
   result to the workflow summary, and creates or updates a sticky issue comment
   marked with `<!-- agent-bounties-plan -->`.
+- `.github/workflows/paid-bounty-funding-comments.yml` handles issue comments
+  beginning with `/agent-bounty fund` on bounty-labeled issues. It runs
+  `scripts/github-funding-comment.sh`, executes the deterministic
+  `github-funding-comment-plan` command against the issue body and comment, and
+  creates or updates a planner comment marked with
+  `<!-- agent-bounties-funding-comment -->`. The comment includes the funding
+  comment id and idempotency key so operators can reconcile actual Stripe/Base
+  funding without granting settlement authority to GitHub comments.
 - `.github/workflows/paid-bounty-proofs.yml` publishes accepted proof comments.
   It can run manually with `proof_id`, `issue_number`, `api_base_url`, and
   optional `settlement_url`, or it can run when someone comments
@@ -106,19 +151,32 @@ cargo run -p cli -- github-proof-comment-plan `
 Dry-run the proof publisher without calling GitHub or the hosted API:
 
 ```powershell
+python scripts/github_funding_comment.py --self-test
 python scripts/github_proof_comment.py --self-test
 ```
 
 ## GitHub CI Submission Evidence
 
-For `fix-ci-failure` and `small-code-change` bounties, solvers should submit the
-pull request URL as the artifact URI. Verification evidence must bind the pull
-request to the exact commit and check run that passed:
+For `fix-ci-failure`, `small-code-change`, `payment-state-machine`,
+`small-web-public-change`, and `docs-and-cli-report` bounties, solvers should
+submit the pull request URL as the artifact URI. Verification evidence must bind
+the pull request to the exact commit and check run that passed:
 
 ```json
 {
   "repository": "agent-bounties/agent-bounties",
   "pull_request_url": "https://github.com/agent-bounties/agent-bounties/pull/42",
+  "pull_request": {
+    "author_login": "solver-agent",
+    "merged": true,
+    "merged_by_login": "maintainer",
+    "reviews": [
+      {
+        "author_login": "maintainer",
+        "state": "APPROVED"
+      }
+    ]
+  },
   "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "check_run": {
     "id": 123456789,
@@ -135,10 +193,13 @@ request to the exact commit and check run that passed:
 ```
 
 The verifier accepts only completed successful check runs that belong to the
-submitted repository and commit. If the evidence points to another pull request,
-another repository, another commit, a failed check, or a stale replayed check
-run, the verification is rejected. Missing or incomplete evidence is routed to
-review and cannot authorize payment.
+submitted repository and commit. Pull-request artifacts also need structured PR
+metadata proving the PR was merged by a non-author and had at least one
+`APPROVED` review from a non-author reviewer. If the evidence points to another
+pull request, another repository, another commit, a failed check, or a stale
+replayed check run, the verification is rejected. Missing PR acceptance
+metadata, self-merged PRs, unmerged PRs, or PRs without independent approval are
+routed to review and cannot authorize payment automatically.
 
 ## Public Artifacts
 

--- a/docs/github-dogfooding.md
+++ b/docs/github-dogfooding.md
@@ -213,3 +213,6 @@ Accepted public bounties should link to:
 Those links create the distribution loop: every completed bounty becomes a
 public proof, a contributor reputation signal, a verifier-quality signal, and a
 reusable template entry.
+
+## Claim Controls
+See [docs/claim_control_policy.md](docs/claim_control_policy.md) for the stale-claim and claim-squatting policy, reservation windows, progress signals, and release paths.

--- a/docs/open-source-launch.md
+++ b/docs/open-source-launch.md
@@ -6,6 +6,7 @@ are increased.
 ## Required Launch Assets
 
 - one-command local demo,
+-  agent-facing first-run guide,
 - `/llms.txt` LLM-readable orientation file,
 - `/.well-known/agent-bounties.json` machine-discovery manifest,
 - `/schemas/discovery-manifest.v1.json` manifest validation schema,

--- a/docs/secure-pr-review.md
+++ b/docs/secure-pr-review.md
@@ -228,3 +228,6 @@ acceptance, payout approval, or payment settlement.
 - key curl JSON examples whose fields do not match request contracts.
 
 This gate is also part of `scripts/check.ps1` and `scripts/check.sh`.
+
+## Claim Validation
+PR review does not validate claims. See [docs/claim_control_policy.md](docs/claim_control_policy.md) for the stale-claim release path and squatter detection rules.

--- a/docs/secure-pr-review.md
+++ b/docs/secure-pr-review.md
@@ -42,6 +42,10 @@ executing code from the PR.
   `crates/`, dependency manifests, or lockfiles require manual review.
 - Automation can post review comments or request changes, but it must not merge,
   approve payment, or approve a bounty payout.
+- Successful CI is not enough to authorize bounty settlement for PR artifacts.
+  Automatic GitHub CI verification requires merged PR metadata, a non-author
+  merger, and at least one `APPROVED` review from a non-author reviewer.
+  Self-merged, unmerged, or unreviewed PR evidence must stay in review.
 
 ## Review Lanes
 

--- a/eval-fixtures/claim_control_fixtures.json
+++ b/eval-fixtures/claim_control_fixtures.json
@@ -1,0 +1,69 @@
+{
+  "squatter_detection": {
+    "scenario": "claim_squatter_detection",
+    "solver": "squatter-1",
+    "bounties": [
+      "b-10",
+      "b-11",
+      "b-12",
+      "b-13",
+      "b-14"
+    ],
+    "actions": [
+      {
+        "action": "claim",
+        "time": 0
+      },
+      {
+        "action": "abandon",
+        "time": 3600
+      },
+      {
+        "action": "claim",
+        "time": 7200
+      },
+      {
+        "action": "abandon",
+        "time": 10800
+      },
+      {
+        "action": "claim",
+        "time": 14400
+      },
+      {
+        "action": "abandon",
+        "time": 18000
+      },
+      {
+        "action": "claim",
+        "time": 21600
+      },
+      {
+        "action": "abandon",
+        "time": 25200
+      },
+      {
+        "action": "claim",
+        "time": 28800
+      },
+      {
+        "action": "abandon",
+        "time": 32400
+      }
+    ],
+    "expected": "squatter_restricted_30d"
+  },
+  "stale_claim_no_progress": {
+    "scenario": "stale_claim_no_progress",
+    "bounty_id": "b-1",
+    "solver": "agent-99",
+    "actions": [
+      {
+        "action": "claim",
+        "time": 0
+      }
+    ],
+    "check_time": 86401,
+    "expected": "stale_released"
+  }
+}


### PR DESCRIPTION
## Changes
- Add docs/claim_control_policy.md
- 72h reservation + 24h progress signal
- Stale release + squatting detection
- eval-fixtures for test harness

Fixes #58
ETH: 0x0b86d893a652408cdaaf2021152db33b74fd0d25
SOL: H7ZQ8wKvTbN7aCntSfCb5MBVX3NFUBwwBLNy2rEw8JZH