### PR TITLE
Add claim automation and funding readiness

### DIFF
--- a/.github/workflows/paid-bounty-claim-comments.yml
+++ b/.github/workflows/paid-bounty-claim-comments.yml
@@ -1,0 +1,37 @@
+name: Paid Bounty Claim Comments
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: paid-bounty-claim-comment-${{ github.event.comment.id }}
+  cancel-in-progress: true
+
+jobs:
+  plan-claim-signal:
+    if: >-
+      contains(github.event.issue.labels.*.name, 'bounty')
+      && (
+        startsWith(github.event.comment.body, '/agent-bounty claim')
+        || startsWith(github.event.comment.body, '/agent-bounty attempt')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Publish claim-comment planner result
+        run: bash scripts/github-claim-comment.sh
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "bounty-router",
  "chrono",
  "domain",
+ "github-app",
  "risk",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cargo test --workspace
 cargo run -p cli -- demo
 cargo run -p cli -- pooled-funding-demo
 cargo run -p cli -- funding-rehearsal-demo
+cargo run -p cli -- real-funding-readiness --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x3333333333333333333333333333333333333333
 cargo run -p cli -- base-plan --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --token 0x3333333333333333333333333333333333333333
 cargo run -p cli -- base-decode-demo
 cargo run -p cli -- base-log-query --escrow-contract 0x1111111111111111111111111111111111111111 --from-block 0
@@ -74,6 +75,7 @@ cargo run -p cli -- stripe-plan --organization-id 00000000-0000-0000-0000-000000
 cargo run -p cli -- stripe-execute-request-intent --intent-file target\stripe-funding-intent.json
 cargo run -p cli -- github-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md
 cargo run -p cli -- github-funding-comment-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow" --contributor-login example-agent --comment-id 12345
+cargo run -p cli -- github-claim-comment-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md --comment-body "/agent-bounty claim`nPlan: inspect CI logs and open a focused fix." --contributor-login example-agent --comment-id 12346 --claim-age-minutes 5
 cargo run -p cli -- risk-policy
 cargo run -p cli -- risk-events --action NeedsReview --surface Bounty
 cargo run -p cli -- risk-approve-bounty --risk-event-id 00000000-0000-0000-0000-000000000001 --title "Reviewed bounty" --template-slug fix-ci-failure --amount-minor 25000000 --operator-id local-operator --note "Approved after manual review"
@@ -279,7 +281,8 @@ Stripe Connect transfer requests for reconciled fiat payout evidence, plan
 Base USDC funding/release/refund/dispute transactions, call
 operator-gated live Stripe execution endpoints when a hosted service has Stripe
 secrets configured, plan GitHub paid-bounty issue checks and
-public funding-comment reconciliation signals, plan
+public funding-comment reconciliation signals, plan claim-comment reservation
+signals that never authorize settlement, plan
 manual or proof-record-backed proof comments, and run `BountyBench`, `AbuseBench`, `JudgeBench`, or the
 combined eval-loop gate. Eval endpoints append compact `EvalRun` records that
 can be read from `/v1/evals/runs` or MCP `get_eval_runs` as hosted quality

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -36,9 +36,10 @@ use eval_harness::{
     BountyBench, EvalSuiteResult, JudgeBench, LoopSuiteResult,
 };
 use github_app::{
-    bounty_check_output, funding_comment_plan, parse_issue_form_bounty, proof_comment_plan,
-    GitHubCheckRunOutput, GitHubFundingCommentInput, GitHubFundingCommentPlan,
-    GitHubIssueFormBounty, GitHubProofComment, GitHubProofCommentPlan,
+    bounty_check_output, claim_comment_plan, funding_comment_plan, parse_issue_form_bounty,
+    proof_comment_plan, GitHubCheckRunOutput, GitHubClaimCommentInput, GitHubClaimCommentPlan,
+    GitHubFundingCommentInput, GitHubFundingCommentPlan, GitHubIssueFormBounty, GitHubProofComment,
+    GitHubProofCommentPlan,
 };
 use ledger::Ledger;
 use payments_stripe::{
@@ -110,6 +111,7 @@ use worker::BaseEscrowLogWorker;
         reconcile_stripe_checkout_webhook,
         plan_github_issue_bounty,
         plan_github_funding_comment,
+        plan_github_claim_comment,
         plan_github_proof_comment,
         plan_github_proof_comment_from_proof,
         post_bounty,
@@ -135,6 +137,7 @@ use worker::BaseEscrowLogWorker;
         PlanStripeConnectTransferRequest,
         PlanGitHubIssueBountyRequest,
         PlanGitHubFundingCommentRequest,
+        PlanGitHubClaimCommentRequest,
         PlanGitHubProofCommentRequest,
         PlanGitHubProofCommentFromProofRequest,
         PlanBaseLogQueryRequest,
@@ -293,6 +296,21 @@ struct PlanGitHubFundingCommentRequest {
     comment_id: Option<String>,
     #[serde(default)]
     existing_idempotency_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct PlanGitHubClaimCommentRequest {
+    repository: String,
+    issue_url: String,
+    title: String,
+    body: String,
+    comment_body: String,
+    contributor_login: Option<String>,
+    comment_id: Option<String>,
+    claim_age_minutes: Option<u64>,
+    #[serde(default)]
+    progress_signal_count: u32,
+    active_claim_login: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -548,6 +566,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/v1/github/funding-comment-plan",
             post(plan_github_funding_comment),
+        )
+        .route(
+            "/v1/github/claim-comment-plan",
+            post(plan_github_claim_comment),
         )
         .route(
             "/v1/github/proof-comment-plan",
@@ -2172,6 +2194,29 @@ async fn plan_github_funding_comment(
 
 #[utoipa::path(
     post,
+    path = "/v1/github/claim-comment-plan",
+    request_body = PlanGitHubClaimCommentRequest,
+    responses((status = 200, description = "GitHub public claim-comment reservation plan"))
+)]
+async fn plan_github_claim_comment(
+    Json(request): Json<PlanGitHubClaimCommentRequest>,
+) -> Json<GitHubClaimCommentPlan> {
+    Json(claim_comment_plan(GitHubClaimCommentInput {
+        repository: request.repository,
+        issue_url: request.issue_url,
+        title: request.title,
+        body: request.body,
+        comment_body: request.comment_body,
+        contributor_login: request.contributor_login,
+        comment_id: request.comment_id,
+        claim_age_minutes: request.claim_age_minutes,
+        progress_signal_count: request.progress_signal_count,
+        active_claim_login: request.active_claim_login,
+    }))
+}
+
+#[utoipa::path(
+    post,
     path = "/v1/github/proof-comment-plan",
     request_body = PlanGitHubProofCommentRequest,
     responses((status = 200, description = "GitHub proof comment markdown and check-run plan"))
@@ -3599,6 +3644,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn github_claim_comment_plan_reserves_progress_backed_claim() {
+        let plan = plan_github_claim_comment(Json(PlanGitHubClaimCommentRequest {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/58".to_string(),
+            title: "[bounty]: Add stale-claim controls".to_string(),
+            body: valid_github_issue_body(),
+            comment_body: "/agent-bounty claim\nPlan: add deterministic stale claim tests."
+                .to_string(),
+            contributor_login: Some("solver-agent".to_string()),
+            comment_id: Some("456".to_string()),
+            claim_age_minutes: Some(5),
+            progress_signal_count: 0,
+            active_claim_login: None,
+        }))
+        .await
+        .0;
+
+        assert!(plan.ready);
+        let signal = plan.signal.expect("claim signal");
+        assert!(!signal.settlement_authority);
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::Success);
+    }
+
+    #[tokio::test]
+    async fn github_claim_comment_plan_rejects_templated_claim_without_progress() {
+        let plan = plan_github_claim_comment(Json(PlanGitHubClaimCommentRequest {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/58".to_string(),
+            title: "[bounty]: Add stale-claim controls".to_string(),
+            body: valid_github_issue_body(),
+            comment_body:
+                "/agent-bounty claim\nI'm reviewing the codebase and will open a PR shortly."
+                    .to_string(),
+            contributor_login: Some("claim-bot".to_string()),
+            comment_id: Some("457".to_string()),
+            claim_age_minutes: Some(1),
+            progress_signal_count: 0,
+            active_claim_login: None,
+        }))
+        .await
+        .0;
+
+        assert!(!plan.ready);
+        assert!(plan.signal.is_none());
+        assert!(plan.error.unwrap().contains("concrete progress signal"));
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+    }
+
+    #[tokio::test]
     async fn github_proof_comment_plan_returns_markdown_and_fingerprint() {
         let bounty_id = Uuid::new_v4();
         let plan = plan_github_proof_comment(Json(PlanGitHubProofCommentRequest {
@@ -3727,6 +3821,10 @@ mod tests {
             manifest.endpoints.github_funding_comment_plan,
             "http://127.0.0.1:8080/v1/github/funding-comment-plan"
         );
+        assert_eq!(
+            manifest.endpoints.github_claim_comment_plan,
+            "http://127.0.0.1:8080/v1/github/claim-comment-plan"
+        );
         assert_eq!(manifest.risk_policy.low_value_usdc_cap_minor, 10_000_000);
         assert!(manifest
             .agent_entrypoints
@@ -3781,6 +3879,7 @@ mod tests {
         assert!(paths.contains_key("/v1/bounties/{id}/funding-intents"));
         assert!(paths.contains_key("/v1/github/issue-bounty-plan"));
         assert!(paths.contains_key("/v1/github/funding-comment-plan"));
+        assert!(paths.contains_key("/v1/github/claim-comment-plan"));
         assert!(paths.contains_key("/v1/github/proof-comment-plan"));
         assert!(paths.contains_key("/v1/github/proof-comment-plan-from-proof"));
         assert!(paths.contains_key("/v1/evals/loops"));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,8 +22,8 @@ use eval_harness::{
     BountyBench, JudgeBench,
 };
 use github_app::{
-    bounty_check_output, funding_comment_plan, parse_issue_form_bounty, proof_comment_plan,
-    GitHubFundingCommentInput, GitHubProofComment,
+    bounty_check_output, claim_comment_plan, funding_comment_plan, parse_issue_form_bounty,
+    proof_comment_plan, GitHubClaimCommentInput, GitHubFundingCommentInput, GitHubProofComment,
 };
 use payments_stripe::{
     execute_stripe_request, CheckoutTopUpRequest, ConnectAccountSnapshot, StripeEventDeduper,
@@ -62,6 +62,20 @@ struct GithubFundingCommentPlanCli {
     existing_idempotency_keys: Vec<String>,
 }
 
+#[derive(Debug)]
+struct GithubClaimCommentPlanCli {
+    repository: String,
+    issue_url: String,
+    title: String,
+    body_file: String,
+    comment_body: String,
+    contributor_login: Option<String>,
+    comment_id: Option<String>,
+    claim_age_minutes: Option<u64>,
+    progress_signal_count: u32,
+    active_claim_login: Option<String>,
+}
+
 #[derive(Debug, ClapArgs)]
 struct DiscoveryReportArgs {
     #[arg(long)]
@@ -72,11 +86,43 @@ struct DiscoveryReportArgs {
     markdown_out: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct RealFundingReadinessCheck {
+    name: String,
+    configured: bool,
+    required_for: String,
+    env_vars: Vec<String>,
+    detail: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RealFundingReadinessReport {
+    local_rehearsal_ready: bool,
+    stripe_test_mode_ready: bool,
+    stripe_webhook_ready: bool,
+    base_testnet_ready: bool,
+    base_broadcast_ready: bool,
+    operator_auth_configured: bool,
+    network: String,
+    checks: Vec<RealFundingReadinessCheck>,
+    evidence_boundaries: Vec<String>,
+    commands: Vec<String>,
+    warnings: Vec<String>,
+}
+
 #[derive(Subcommand)]
 enum Command {
     Demo,
     PooledFundingDemo,
     FundingRehearsalDemo,
+    RealFundingReadiness {
+        #[arg(long, default_value = "base-sepolia")]
+        network: String,
+        #[arg(long)]
+        escrow_contract: Option<String>,
+        #[arg(long)]
+        usdc_token: Option<String>,
+    },
     Bountybench,
     Abusebench,
     Judgebench,
@@ -307,6 +353,28 @@ enum Command {
         #[arg(long = "existing-idempotency-key")]
         existing_idempotency_keys: Vec<String>,
     },
+    GithubClaimCommentPlan {
+        #[arg(long)]
+        repository: String,
+        #[arg(long)]
+        issue_url: String,
+        #[arg(long)]
+        title: String,
+        #[arg(long)]
+        body_file: String,
+        #[arg(long)]
+        comment_body: String,
+        #[arg(long)]
+        contributor_login: Option<String>,
+        #[arg(long)]
+        comment_id: Option<String>,
+        #[arg(long)]
+        claim_age_minutes: Option<u64>,
+        #[arg(long, default_value_t = 0)]
+        progress_signal_count: u32,
+        #[arg(long)]
+        active_claim_login: Option<String>,
+    },
     GithubProofCommentPlan {
         #[arg(long)]
         bounty_id: Uuid,
@@ -378,6 +446,11 @@ async fn async_main() -> Result<()> {
         Command::Demo => demo().await,
         Command::PooledFundingDemo => pooled_funding_demo(),
         Command::FundingRehearsalDemo => funding_rehearsal_demo().await,
+        Command::RealFundingReadiness {
+            network,
+            escrow_contract,
+            usdc_token,
+        } => real_funding_readiness(network, escrow_contract, usdc_token),
         Command::Bountybench => bountybench(),
         Command::Abusebench => abusebench(),
         Command::Judgebench => judgebench(),
@@ -564,6 +637,29 @@ async fn async_main() -> Result<()> {
             contributor_login,
             comment_id,
             existing_idempotency_keys,
+        }),
+        Command::GithubClaimCommentPlan {
+            repository,
+            issue_url,
+            title,
+            body_file,
+            comment_body,
+            contributor_login,
+            comment_id,
+            claim_age_minutes,
+            progress_signal_count,
+            active_claim_login,
+        } => github_claim_comment_plan(GithubClaimCommentPlanCli {
+            repository,
+            issue_url,
+            title,
+            body_file,
+            comment_body,
+            contributor_login,
+            comment_id,
+            claim_age_minutes,
+            progress_signal_count,
+            active_claim_login,
         }),
         Command::GithubProofCommentPlan {
             bounty_id,
@@ -1005,6 +1101,227 @@ async fn funding_rehearsal_demo() -> Result<()> {
         }))?
     );
     Ok(())
+}
+
+fn real_funding_readiness(
+    network: String,
+    escrow_contract: Option<String>,
+    usdc_token: Option<String>,
+) -> Result<()> {
+    let network_descriptor = base_network_descriptor(&network)?;
+    let rpc_env = network_descriptor.rpc_url_env.clone();
+    let stripe_secret = env_nonempty("STRIPE_SECRET_KEY");
+    let stripe_live_enabled = env_flag("ENABLE_STRIPE_LIVE_EXECUTION");
+    let stripe_webhook_secret = env_nonempty("STRIPE_WEBHOOK_SECRET");
+    let unsigned_stripe_webhooks = env_flag("ALLOW_UNSIGNED_STRIPE_WEBHOOKS");
+    let operator_token = env_nonempty("OPERATOR_API_TOKEN");
+    let base_rpc = env_nonempty(&rpc_env);
+    let base_broadcast_enabled = env_flag("ENABLE_BASE_TX_BROADCAST");
+    let escrow_configured = escrow_contract.as_deref().is_some_and(nonempty);
+    let token_configured = usdc_token.as_deref().is_some_and(nonempty);
+
+    let checks = vec![
+        readiness_check(
+            "local deterministic rehearsal",
+            true,
+            "pooled, Stripe, Base, mixed-funding, verification, and payout state-machine simulation",
+            vec![],
+            "Run cargo run -p cli -- funding-rehearsal-demo; no external credentials required.",
+        ),
+        readiness_check(
+            "Stripe test-mode execution gate",
+            stripe_secret && stripe_live_enabled,
+            "creating Stripe test-mode Checkout Sessions and Connect transfers",
+            vec![
+                "STRIPE_SECRET_KEY".to_string(),
+                "ENABLE_STRIPE_LIVE_EXECUTION".to_string(),
+            ],
+            if stripe_secret && stripe_live_enabled {
+                "Stripe test-mode execution is operator-enabled."
+            } else {
+                "Set STRIPE_SECRET_KEY=sk_test_... and ENABLE_STRIPE_LIVE_EXECUTION=true before executing Stripe request intents."
+            },
+        ),
+        readiness_check(
+            "Stripe webhook evidence gate",
+            stripe_webhook_secret || unsigned_stripe_webhooks,
+            "crediting fiat balances and marking fiat transfer evidence in local/test environments",
+            vec![
+                "STRIPE_WEBHOOK_SECRET".to_string(),
+                "ALLOW_UNSIGNED_STRIPE_WEBHOOKS".to_string(),
+            ],
+            if stripe_webhook_secret {
+                "Signed Stripe webhooks are configured."
+            } else if unsigned_stripe_webhooks {
+                "Unsigned Stripe webhook simulation is enabled; use only for local or mock-provider rehearsal."
+            } else {
+                "Set STRIPE_WEBHOOK_SECRET for signed webhooks, or ALLOW_UNSIGNED_STRIPE_WEBHOOKS=true for local-only simulation."
+            },
+        ),
+        readiness_check(
+            "Base RPC log reconciliation",
+            base_rpc,
+            "fetching Base escrow logs and transaction receipts",
+            vec![rpc_env.clone()],
+            if base_rpc {
+                "Base RPC URL is configured for the selected network."
+            } else {
+                "Set the selected network RPC URL before fetching escrow logs or receipts."
+            },
+        ),
+        readiness_check(
+            "Base signed transaction broadcast gate",
+            base_rpc && base_broadcast_enabled,
+            "broadcasting signed Base escrow funding or release transactions through the service",
+            vec![rpc_env.clone(), "ENABLE_BASE_TX_BROADCAST".to_string()],
+            if base_rpc && base_broadcast_enabled {
+                "Base transaction broadcast is enabled for already-signed raw transactions."
+            } else {
+                "Signed transaction broadcast remains disabled; operators can still sign/send externally and reconcile logs."
+            },
+        ),
+        readiness_check(
+            "Base Sepolia escrow addresses",
+            escrow_configured && token_configured,
+            "building bounty-bound approve/createEscrow funding plans",
+            vec![
+                "--escrow-contract".to_string(),
+                "--usdc-token".to_string(),
+            ],
+            if escrow_configured && token_configured {
+                "Escrow contract and token address were supplied to the readiness command."
+            } else {
+                "Pass --escrow-contract and --usdc-token when rehearsing Base funding plans."
+            },
+        ),
+        readiness_check(
+            "operator mutation auth",
+            operator_token,
+            "protecting hosted reconciliation, broadcast, and live Stripe execution endpoints",
+            vec!["OPERATOR_API_TOKEN".to_string()],
+            if operator_token {
+                "Hosted operator token is configured."
+            } else {
+                "OPERATOR_API_TOKEN is optional locally but should be set for hosted mutation surfaces."
+            },
+        ),
+    ];
+
+    let stripe_test_mode_ready = stripe_secret && stripe_live_enabled;
+    let stripe_webhook_ready = stripe_webhook_secret || unsigned_stripe_webhooks;
+    let base_testnet_ready = network_descriptor.name == "Base Sepolia"
+        && base_rpc
+        && escrow_configured
+        && token_configured;
+    let base_broadcast_ready = base_rpc && base_broadcast_enabled;
+    let warnings = readiness_warnings(
+        stripe_test_mode_ready,
+        stripe_webhook_ready,
+        base_testnet_ready,
+        unsigned_stripe_webhooks,
+        operator_token,
+    );
+
+    let report = RealFundingReadinessReport {
+        local_rehearsal_ready: true,
+        stripe_test_mode_ready,
+        stripe_webhook_ready,
+        base_testnet_ready,
+        base_broadcast_ready,
+        operator_auth_configured: operator_token,
+        network: network_descriptor.name,
+        checks,
+        evidence_boundaries: vec![
+            "Stripe Checkout Session creation is not funding; only a verified checkout.session.completed webhook credits balance.".to_string(),
+            "Base approve/createEscrow transaction planning is not funding; only an indexed EscrowCreated log makes Base funding applied.".to_string(),
+            "Deterministic verifier acceptance creates settlement intents; it does not pay by itself.".to_string(),
+            "Base release transaction hashes are not payout; only an indexed EscrowReleased log marks USDC payout paid.".to_string(),
+            "Stripe Connect eligibility and transfer planning are not payout; only transfer.created evidence marks fiat payout intents paid.".to_string(),
+        ],
+        commands: vec![
+            "cargo run -p cli -- funding-rehearsal-demo".to_string(),
+            "cargo run -p cli -- stripe-execute-request-intent --intent-file target\\stripe-funding-intent.json".to_string(),
+            "cargo run -p cli -- base-fetch-logs --network base-sepolia --escrow-contract <escrow-contract> --from-block <block>".to_string(),
+            "cargo run -p cli -- base-transaction-receipt --network base-sepolia --tx-hash <tx-hash>".to_string(),
+            "cargo run -p cli -- discovery --public-base-url <url> --mcp-base-url <url>".to_string(),
+        ],
+        warnings,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+fn readiness_check(
+    name: impl Into<String>,
+    configured: bool,
+    required_for: impl Into<String>,
+    env_vars: Vec<String>,
+    detail: impl Into<String>,
+) -> RealFundingReadinessCheck {
+    RealFundingReadinessCheck {
+        name: name.into(),
+        configured,
+        required_for: required_for.into(),
+        env_vars,
+        detail: detail.into(),
+    }
+}
+
+fn readiness_warnings(
+    stripe_test_mode_ready: bool,
+    stripe_webhook_ready: bool,
+    base_testnet_ready: bool,
+    unsigned_stripe_webhooks: bool,
+    operator_token: bool,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if !stripe_test_mode_ready {
+        warnings.push(
+            "Stripe request execution is not ready; use plan-only mode or set test-mode credentials and ENABLE_STRIPE_LIVE_EXECUTION=true."
+                .to_string(),
+        );
+    }
+    if !stripe_webhook_ready {
+        warnings.push(
+            "Stripe fiat ledger credits will be rejected until signed webhooks or local unsigned webhook simulation are configured."
+                .to_string(),
+        );
+    }
+    if !base_testnet_ready {
+        warnings.push(
+            "Base Sepolia funding can be planned locally, but RPC log reconciliation needs RPC URL plus escrow and token addresses."
+                .to_string(),
+        );
+    }
+    if unsigned_stripe_webhooks {
+        warnings.push(
+            "ALLOW_UNSIGNED_STRIPE_WEBHOOKS must not be used for hosted or production money flows."
+                .to_string(),
+        );
+    }
+    if !operator_token {
+        warnings.push(
+            "Set OPERATOR_API_TOKEN before exposing hosted reconciliation, broadcast, or live Stripe execution endpoints."
+                .to_string(),
+        );
+    }
+    warnings
+}
+
+fn env_nonempty(name: &str) -> bool {
+    env::var(name).ok().is_some_and(|value| nonempty(&value))
+}
+
+fn env_flag(name: &str) -> bool {
+    env::var(name)
+        .ok()
+        .map(|value| value.eq_ignore_ascii_case("true") || value == "1")
+        .unwrap_or(false)
+}
+
+fn nonempty(value: &str) -> bool {
+    !value.trim().is_empty()
 }
 
 fn bountybench() -> Result<()> {
@@ -1731,6 +2048,24 @@ fn github_funding_comment_plan(args: GithubFundingCommentPlanCli) -> Result<()> 
         contributor_login: args.contributor_login,
         comment_id: args.comment_id,
         existing_idempotency_keys: args.existing_idempotency_keys,
+    });
+    println!("{}", serde_json::to_string_pretty(&plan)?);
+    Ok(())
+}
+
+fn github_claim_comment_plan(args: GithubClaimCommentPlanCli) -> Result<()> {
+    let body = fs::read_to_string(args.body_file)?;
+    let plan = claim_comment_plan(GitHubClaimCommentInput {
+        repository: args.repository,
+        issue_url: args.issue_url,
+        title: args.title,
+        body,
+        comment_body: args.comment_body,
+        contributor_login: args.contributor_login,
+        comment_id: args.comment_id,
+        claim_age_minutes: args.claim_age_minutes,
+        progress_signal_count: args.progress_signal_count,
+        active_claim_login: args.active_claim_login,
     });
     println!("{}", serde_json::to_string_pretty(&plan)?);
     Ok(())
@@ -2614,6 +2949,7 @@ async fn production_smoke_check(
         "/endpoints/stripe_live_checkout_top_ups",
         "/endpoints/stripe_live_connect_accounts",
         "/endpoints/github_issue_bounty_plan",
+        "/endpoints/github_claim_comment_plan",
         "/endpoints/github_proof_comment_plan",
         "/endpoints/github_proof_comment_from_proof_plan",
     ] {
@@ -2671,6 +3007,9 @@ async fn production_smoke_check(
                     && required
                         .iter()
                         .any(|value| value.as_str() == Some("base_escrow_events"))
+                    && required
+                        .iter()
+                        .any(|value| value.as_str() == Some("github_claim_comment_plan"))
                     && required
                         .iter()
                         .any(|value| value.as_str() == Some("github_proof_comment_from_proof_plan"))
@@ -3072,6 +3411,7 @@ async fn production_smoke_check(
         "approve_risk_payout",
         "reject_risk_event",
         "plan_github_funding_comment",
+        "plan_github_claim_comment",
         "plan_github_proof_comment_for_proof",
     ] {
         require(
@@ -3304,6 +3644,12 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             .pointer("/endpoints/github_funding_comment_plan")
             .is_some(),
         "discovery manifest must include GitHub funding comment planning",
+    )?;
+    require(
+        discovery
+            .pointer("/endpoints/github_claim_comment_plan")
+            .is_some(),
+        "discovery manifest must include GitHub claim comment planning",
     )?;
     require(
         discovery
@@ -3697,6 +4043,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         "execute_stripe_connect_transfer",
         "plan_github_issue_bounty",
         "plan_github_funding_comment",
+        "plan_github_claim_comment",
         "plan_github_proof_comment",
         "plan_github_proof_comment_for_proof",
         "run_eval_loops",
@@ -4186,6 +4533,37 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             .and_then(|value| value.as_bool())
             == Some(true),
         "MCP plan_github_funding_comment must require operator reconciliation",
+    )?;
+
+    let mcp_github_claim = mcp_tool_post(
+        mcp,
+        "plan_github_claim_comment",
+        serde_json::json!({
+            "repository": "agent-bounties/agent-bounties",
+            "issue_url": "https://github.com/agent-bounties/agent-bounties/issues/1",
+            "title": "[bounty]: Fix CI",
+            "body": "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n",
+            "comment_body": "/agent-bounty claim\nPlan: inspect CI logs and open a small fix.",
+            "contributor_login": "service-smoke",
+            "comment_id": "12346",
+            "claim_age_minutes": 5,
+            "progress_signal_count": 0,
+            "active_claim_login": null
+        }),
+    )?;
+    require(
+        mcp_github_claim
+            .pointer("/ready")
+            .and_then(|value| value.as_bool())
+            == Some(true),
+        "MCP plan_github_claim_comment must accept a progress-backed claim",
+    )?;
+    require(
+        mcp_github_claim
+            .pointer("/signal/settlement_authority")
+            .and_then(|value| value.as_bool())
+            == Some(false),
+        "MCP plan_github_claim_comment must not authorize settlement",
     )?;
 
     let mcp_github_proof = mcp_tool_post(

--- a/crates/eval-harness/Cargo.toml
+++ b/crates/eval-harness/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 bounty-router = { path = "../bounty-router" }
 chrono.workspace = true
 domain = { path = "../domain" }
+github-app = { path = "../github-app" }
 risk = { path = "../risk" }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/eval-harness/fixtures/abuse_cases.json
+++ b/crates/eval-harness/fixtures/abuse_cases.json
@@ -22,5 +22,23 @@
     "surface": "Bounty",
     "expected_action": "Allow",
     "expected_reason": ""
+  },
+  {
+    "name": "github_claim_without_progress",
+    "surface": "Bounty",
+    "expected_action": "NeedsReview",
+    "expected_reason": "concrete progress"
+  },
+  {
+    "name": "github_claim_with_progress",
+    "surface": "Bounty",
+    "expected_action": "Allow",
+    "expected_reason": ""
+  },
+  {
+    "name": "github_stale_claim_without_progress",
+    "surface": "Bounty",
+    "expected_action": "NeedsReview",
+    "expected_reason": "stale"
   }
 ]

--- a/crates/eval-harness/fixtures/github_paid_bounty_issue.md
+++ b/crates/eval-harness/fixtures/github_paid_bounty_issue.md
@@ -1,0 +1,23 @@
+### Goal
+Fix the failing CI check in the Rust workspace.
+
+### Acceptance criteria
+The test job is green, the root cause is explained, and the proof comment links
+to the accepted bounty proof.
+
+### Template
+fix-ci-failure
+
+### Suggested amount
+10 USDC
+
+### Funding mode
+BaseUsdcEscrow
+
+### Co-funding note
+Supporters can add funds once the hosted Base rail is enabled, or rehearse the
+same pooled funding path locally with `open_pooled_bounty` and
+`add_bounty_funding`.
+
+### Privacy
+Public

--- a/crates/eval-harness/src/lib.rs
+++ b/crates/eval-harness/src/lib.rs
@@ -4,6 +4,7 @@ use domain::{
     Agent, Capability, CapabilityClass, FundingMode, HelpRequest, Money, PaymentRail, PrivacyLevel,
     RiskAction, RiskSurface, Submission, VerificationDecision, VerifierKind,
 };
+use github_app::{claim_comment_plan, GitHubClaimCommentInput, GitHubClaimDecision};
 use risk::{
     BountyRiskInput, HelpRequestRiskInput, RiskAssessment, RiskPolicy, SubmissionRiskInput,
 };
@@ -273,6 +274,24 @@ impl AbuseBench {
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
             }),
+            "github_claim_without_progress" => github_claim_assessment(
+                fixture.surface,
+                "/agent-bounty claim\nI'm reviewing the codebase and will open a PR shortly.",
+                None,
+                0,
+            ),
+            "github_claim_with_progress" => github_claim_assessment(
+                fixture.surface,
+                "/agent-bounty claim\nPlan: inspect the failing check, patch the narrow failure, and post a PR with local command output.",
+                Some("solver-agent"),
+                0,
+            ),
+            "github_stale_claim_without_progress" => github_claim_assessment(
+                fixture.surface,
+                "/agent-bounty attempt\nPlan: inspect the issue.",
+                Some("stale-agent"),
+                120,
+            ),
             _ if fixture.surface == RiskSurface::Payout => {
                 self.policy.evaluate_payout(&risk::PayoutRiskInput {
                     bounty_id: Uuid::new_v4(),
@@ -282,6 +301,48 @@ impl AbuseBench {
             }
             _ => RiskAssessment::allow(fixture.surface),
         }
+    }
+}
+
+fn github_claim_assessment(
+    surface: RiskSurface,
+    comment_body: &str,
+    contributor_login: Option<&str>,
+    claim_age_minutes: u64,
+) -> RiskAssessment {
+    let plan = claim_comment_plan(GitHubClaimCommentInput {
+        repository: "agent-bounties/agent-bounties".to_string(),
+        issue_url: "https://github.com/agent-bounties/agent-bounties/issues/58".to_string(),
+        title: "[bounty]: Add stale-claim and claim-squatting controls".to_string(),
+        body: include_str!("../fixtures/github_paid_bounty_issue.md").to_string(),
+        comment_body: comment_body.to_string(),
+        contributor_login: contributor_login.map(ToString::to_string),
+        comment_id: Some("12345".to_string()),
+        claim_age_minutes: Some(claim_age_minutes),
+        progress_signal_count: 0,
+        active_claim_login: None,
+    });
+
+    match (plan.ready, plan.signal.as_ref()) {
+        (true, Some(signal)) if signal.decision == GitHubClaimDecision::Reserved => {
+            RiskAssessment::allow(surface)
+        }
+        (true, Some(signal)) if signal.decision == GitHubClaimDecision::StaleReleaseRecommended => {
+            RiskAssessment {
+                surface,
+                action: RiskAction::NeedsReview,
+                score: 45,
+                reasons: vec!["stale GitHub claim needs maintainer release review".to_string()],
+            }
+        }
+        _ => RiskAssessment {
+            surface,
+            action: RiskAction::NeedsReview,
+            score: 60,
+            reasons: vec![plan
+                .error
+                .unwrap_or_else(|| "GitHub claim needs concrete progress signal".to_string())],
+        },
     }
 }
 

--- a/crates/github-app/src/lib.rs
+++ b/crates/github-app/src/lib.rs
@@ -97,6 +97,20 @@ pub struct GitHubFundingCommentInput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubClaimCommentInput {
+    pub repository: String,
+    pub issue_url: String,
+    pub title: String,
+    pub body: String,
+    pub comment_body: String,
+    pub contributor_login: Option<String>,
+    pub comment_id: Option<String>,
+    pub claim_age_minutes: Option<u64>,
+    pub progress_signal_count: u32,
+    pub active_claim_login: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitHubFundingSignal {
     pub issue_url: String,
     pub contributor_login: Option<String>,
@@ -111,6 +125,37 @@ pub struct GitHubFundingSignal {
 pub struct GitHubFundingCommentPlan {
     pub ready: bool,
     pub signal: Option<GitHubFundingSignal>,
+    pub error: Option<String>,
+    pub check: GitHubCheckRunOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GitHubClaimDecision {
+    Reserved,
+    NeedsProgress,
+    StaleReleaseRecommended,
+    BlockedByActiveClaim,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubClaimSignal {
+    pub issue_url: String,
+    pub contributor_login: Option<String>,
+    pub command: String,
+    pub decision: GitHubClaimDecision,
+    pub reservation_id: String,
+    pub reservation_window_minutes: u64,
+    pub progress_required_within_minutes: u64,
+    pub progress_signal_count: u32,
+    pub has_progress_signal: bool,
+    pub settlement_authority: bool,
+    pub operator_note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubClaimCommentPlan {
+    pub ready: bool,
+    pub signal: Option<GitHubClaimSignal>,
     pub error: Option<String>,
     pub check: GitHubCheckRunOutput,
 }
@@ -135,6 +180,20 @@ pub enum GitHubFundingCommentError {
     DuplicateSignal(String),
 }
 
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum GitHubClaimCommentError {
+    #[error("missing GitHub issue context")]
+    MissingIssueContext,
+    #[error("issue is not a valid paid bounty: {0}")]
+    NonBountyIssue(String),
+    #[error("missing claim command; use `/agent-bounty claim` or `/agent-bounty attempt`")]
+    MissingCommand,
+    #[error("active claim is held by {0}; wait for progress, stale release, or maintainer review")]
+    ActiveClaimHeld(String),
+    #[error("claim comment needs a concrete progress signal such as `plan:`, `branch:`, `draft pr:`, `tests:`, or a pull request URL")]
+    MissingProgressSignal,
+}
+
 impl GitHubProofComment {
     pub fn markdown(&self) -> String {
         format!(
@@ -151,6 +210,8 @@ impl GitHubProofComment {
     }
 }
 
+pub const CLAIM_RESERVATION_WINDOW_MINUTES: u64 = 120;
+
 pub fn funding_comment_plan(input: GitHubFundingCommentInput) -> GitHubFundingCommentPlan {
     match parse_funding_comment_signal(&input) {
         Ok(signal) => {
@@ -166,6 +227,33 @@ pub fn funding_comment_plan(input: GitHubFundingCommentInput) -> GitHubFundingCo
             let message = error.to_string();
             let check = funding_comment_check_output(Err(&error));
             GitHubFundingCommentPlan {
+                ready: false,
+                signal: None,
+                error: Some(message),
+                check,
+            }
+        }
+    }
+}
+
+pub fn claim_comment_plan(input: GitHubClaimCommentInput) -> GitHubClaimCommentPlan {
+    match parse_claim_comment_signal(&input) {
+        Ok(signal) => {
+            let check = claim_comment_check_output(Ok(&signal));
+            GitHubClaimCommentPlan {
+                ready: matches!(
+                    signal.decision,
+                    GitHubClaimDecision::Reserved | GitHubClaimDecision::StaleReleaseRecommended
+                ),
+                signal: Some(signal),
+                error: None,
+                check,
+            }
+        }
+        Err(error) => {
+            let message = error.to_string();
+            let check = claim_comment_check_output(Err(&error));
+            GitHubClaimCommentPlan {
                 ready: false,
                 signal: None,
                 error: Some(message),
@@ -295,6 +383,74 @@ pub fn proof_check_output(comment: &GitHubProofComment) -> GitHubCheckRunOutput 
     }
 }
 
+pub fn claim_comment_check_output(
+    signal: Result<&GitHubClaimSignal, &GitHubClaimCommentError>,
+) -> GitHubCheckRunOutput {
+    match signal {
+        Ok(signal) => {
+            let (title, summary) = match signal.decision {
+                GitHubClaimDecision::Reserved => (
+                    "Agent bounty claim reserved",
+                    format!(
+                        "Reserved for {} minutes; progress is required before settlement review.",
+                        signal.reservation_window_minutes
+                    ),
+                ),
+                GitHubClaimDecision::NeedsProgress => (
+                    "Agent bounty claim needs progress",
+                    "Claim comment did not include enough concrete progress evidence.".to_string(),
+                ),
+                GitHubClaimDecision::StaleReleaseRecommended => (
+                    "Agent bounty stale claim release recommended",
+                    "Reservation window expired without progress; maintainers can release the claim."
+                        .to_string(),
+                ),
+                GitHubClaimDecision::BlockedByActiveClaim => (
+                    "Agent bounty claim blocked",
+                    "Another active claim is still inside the reservation window.".to_string(),
+                ),
+            };
+            GitHubCheckRunOutput {
+                title: title.to_string(),
+                summary,
+                text: format!(
+                    "Issue: {}\nContributor: {}\nCommand: {}\nDecision: {:?}\nReservation id: {}\nReservation window minutes: {}\nProgress required within minutes: {}\nProgress signal count: {}\nHas progress signal: {}\nSettlement authority: false\n\nThis GitHub claim signal is coordination evidence only. It does not claim platform funds, approve work, accept a bounty, release escrow, or authorize payment.\n\nOperator note: {}\n\n{}",
+                    signal.issue_url,
+                    signal
+                        .contributor_login
+                        .as_deref()
+                        .unwrap_or("unknown"),
+                    signal.command,
+                    signal.decision,
+                    signal.reservation_id,
+                    signal.reservation_window_minutes,
+                    signal.progress_required_within_minutes,
+                    signal.progress_signal_count,
+                    signal.has_progress_signal,
+                    signal.operator_note,
+                    DISTRIBUTION_FEEDBACK_REQUEST
+                ),
+                conclusion: match signal.decision {
+                    GitHubClaimDecision::Reserved
+                    | GitHubClaimDecision::StaleReleaseRecommended => {
+                        GitHubCheckConclusion::Success
+                    }
+                    GitHubClaimDecision::NeedsProgress
+                    | GitHubClaimDecision::BlockedByActiveClaim => {
+                        GitHubCheckConclusion::ActionRequired
+                    }
+                },
+            }
+        }
+        Err(error) => GitHubCheckRunOutput {
+            title: "Agent bounty claim needs review".to_string(),
+            summary: error.to_string(),
+            text: "The claim comment was not converted into an active claim signal. Use `/agent-bounty claim` or `/agent-bounty attempt` with a concrete `plan:`, `branch:`, `draft pr:`, `tests:`, or pull request URL. Claim comments never authorize payment.".to_string(),
+            conclusion: GitHubCheckConclusion::ActionRequired,
+        },
+    }
+}
+
 pub fn funding_comment_check_output(
     signal: Result<&GitHubFundingSignal, &GitHubFundingCommentError>,
 ) -> GitHubCheckRunOutput {
@@ -327,6 +483,81 @@ pub fn funding_comment_check_output(
             conclusion: GitHubCheckConclusion::ActionRequired,
         },
     }
+}
+
+fn parse_claim_comment_signal(
+    input: &GitHubClaimCommentInput,
+) -> Result<GitHubClaimSignal, GitHubClaimCommentError> {
+    if input.repository.trim().is_empty()
+        || input.issue_url.trim().is_empty()
+        || input.title.trim().is_empty()
+        || input.body.trim().is_empty()
+    {
+        return Err(GitHubClaimCommentError::MissingIssueContext);
+    }
+    parse_issue_form_bounty(
+        &input.repository,
+        &input.issue_url,
+        &input.title,
+        &input.body,
+    )
+    .map_err(|error| GitHubClaimCommentError::NonBountyIssue(error.to_string()))?;
+
+    let command =
+        claim_command_line(&input.comment_body).ok_or(GitHubClaimCommentError::MissingCommand)?;
+    let contributor = input
+        .contributor_login
+        .as_ref()
+        .map(|login| login.trim().to_string())
+        .filter(|login| !login.is_empty());
+    let has_progress_signal =
+        claim_has_progress_signal(&input.comment_body) || input.progress_signal_count > 0;
+    let claim_age = input.claim_age_minutes.unwrap_or(0);
+    let is_stale =
+        claim_age >= CLAIM_RESERVATION_WINDOW_MINUTES && input.progress_signal_count == 0;
+
+    if let Some(active_claim_login) = input
+        .active_claim_login
+        .as_ref()
+        .map(|login| login.trim())
+        .filter(|login| !login.is_empty())
+    {
+        let same_claimant = contributor
+            .as_deref()
+            .map(|login| login.eq_ignore_ascii_case(active_claim_login))
+            .unwrap_or(false);
+        if !same_claimant && !is_stale {
+            return Err(GitHubClaimCommentError::ActiveClaimHeld(
+                active_claim_login.to_string(),
+            ));
+        }
+    }
+
+    let decision = if is_stale {
+        GitHubClaimDecision::StaleReleaseRecommended
+    } else if has_progress_signal {
+        GitHubClaimDecision::Reserved
+    } else if input.active_claim_login.is_some() {
+        GitHubClaimDecision::BlockedByActiveClaim
+    } else {
+        return Err(GitHubClaimCommentError::MissingProgressSignal);
+    };
+
+    Ok(GitHubClaimSignal {
+        issue_url: input.issue_url.clone(),
+        contributor_login: contributor,
+        command: claim_command_name(command).to_string(),
+        decision,
+        reservation_id: claim_reservation_id(input, command),
+        reservation_window_minutes: CLAIM_RESERVATION_WINDOW_MINUTES,
+        progress_required_within_minutes: CLAIM_RESERVATION_WINDOW_MINUTES,
+        progress_signal_count: input.progress_signal_count,
+        has_progress_signal,
+        settlement_authority: false,
+        operator_note:
+            "Use this as a public reservation signal only. Release stale claims manually or through a future operator workflow; payment still requires funding, verification, and settlement evidence."
+                .to_string(),
+    })
 }
 
 fn parse_funding_comment_signal(
@@ -375,6 +606,59 @@ fn parse_funding_comment_signal(
             "Verify actual Stripe Checkout credit or indexed Base escrow funding before applying this contribution."
                 .to_string(),
     })
+}
+
+fn claim_command_line(comment_body: &str) -> Option<&str> {
+    comment_body.lines().map(str::trim).find(|line| {
+        line.starts_with("/agent-bounty claim") || line.starts_with("/agent-bounty attempt")
+    })
+}
+
+fn claim_command_name(command: &str) -> &str {
+    if command.starts_with("/agent-bounty attempt") {
+        "attempt"
+    } else {
+        "claim"
+    }
+}
+
+fn claim_has_progress_signal(comment_body: &str) -> bool {
+    let lower = comment_body.to_ascii_lowercase();
+    if lower.contains("https://github.com/") && lower.contains("/pull/") {
+        return true;
+    }
+    comment_body.lines().any(|line| {
+        let line = line.trim();
+        let Some((key, value)) = line.split_once(':') else {
+            return false;
+        };
+        matches!(
+            key.trim().to_ascii_lowercase().as_str(),
+            "plan" | "approach" | "branch" | "draft pr" | "pr" | "tests" | "progress"
+        ) && value.split_whitespace().count() >= 3
+    })
+}
+
+fn claim_reservation_id(input: &GitHubClaimCommentInput, command: &str) -> String {
+    if let Some(comment_id) = input
+        .comment_id
+        .as_ref()
+        .map(|id| id.trim())
+        .filter(|id| !id.is_empty())
+    {
+        return format!(
+            "github-claim-comment:{}:{}:comment:{}",
+            input.repository, input.issue_url, comment_id
+        );
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(input.repository.as_bytes());
+    hasher.update(input.issue_url.as_bytes());
+    if let Some(login) = input.contributor_login.as_deref() {
+        hasher.update(login.as_bytes());
+    }
+    hasher.update(command.as_bytes());
+    format!("github-claim-comment:{}", hex::encode(hasher.finalize()))
 }
 
 fn funding_command_line(comment_body: &str) -> Option<&str> {
@@ -846,6 +1130,105 @@ extract-data-to-schema
             .check
             .text
             .contains("what tool, prompt, link, label, scanner, or workflow"));
+    }
+
+    #[test]
+    fn claim_comment_rejects_instant_templated_no_progress_claim() {
+        let plan = claim_comment_plan(GitHubClaimCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/58".to_string(),
+            title: "[bounty]: Add stale-claim controls".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body:
+                "/agent-bounty claim\nI'm reviewing the codebase and will open a PR shortly."
+                    .to_string(),
+            contributor_login: Some("claim-bot".to_string()),
+            comment_id: Some("501".to_string()),
+            claim_age_minutes: Some(1),
+            progress_signal_count: 0,
+            active_claim_login: None,
+        });
+
+        assert!(!plan.ready);
+        assert!(plan.signal.is_none());
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
+        assert!(plan.error.unwrap().contains("concrete progress signal"));
+    }
+
+    #[test]
+    fn claim_comment_reserves_when_progress_signal_is_present() {
+        let plan = claim_comment_plan(GitHubClaimCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/58".to_string(),
+            title: "[bounty]: Add stale-claim controls".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body: "/agent-bounty claim\nPlan: add a deterministic planner and tests."
+                .to_string(),
+            contributor_login: Some("solver-agent".to_string()),
+            comment_id: Some("502".to_string()),
+            claim_age_minutes: Some(5),
+            progress_signal_count: 0,
+            active_claim_login: None,
+        });
+
+        assert!(plan.ready);
+        let signal = plan.signal.unwrap();
+        assert_eq!(signal.decision, GitHubClaimDecision::Reserved);
+        assert!(signal.has_progress_signal);
+        assert_eq!(
+            signal.reservation_window_minutes,
+            CLAIM_RESERVATION_WINDOW_MINUTES
+        );
+        assert!(!signal.settlement_authority);
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::Success);
+        assert!(plan.check.text.contains("Settlement authority: false"));
+    }
+
+    #[test]
+    fn claim_comment_recommends_release_for_stale_claim_without_progress() {
+        let plan = claim_comment_plan(GitHubClaimCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/58".to_string(),
+            title: "[bounty]: Add stale-claim controls".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body: "/agent-bounty claim\nStill looking.".to_string(),
+            contributor_login: Some("stale-agent".to_string()),
+            comment_id: Some("503".to_string()),
+            claim_age_minutes: Some(CLAIM_RESERVATION_WINDOW_MINUTES + 1),
+            progress_signal_count: 0,
+            active_claim_login: Some("stale-agent".to_string()),
+        });
+
+        assert!(plan.ready);
+        let signal = plan.signal.unwrap();
+        assert_eq!(
+            signal.decision,
+            GitHubClaimDecision::StaleReleaseRecommended
+        );
+        assert!(!signal.settlement_authority);
+        assert!(plan.check.summary.contains("expired without progress"));
+    }
+
+    #[test]
+    fn claim_comment_blocks_other_solver_inside_active_reservation_window() {
+        let plan = claim_comment_plan(GitHubClaimCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/58".to_string(),
+            title: "[bounty]: Add stale-claim controls".to_string(),
+            body: valid_issue_body("BaseUsdcEscrow"),
+            comment_body: "/agent-bounty attempt\nPlan: open an alternative PR with tests."
+                .to_string(),
+            contributor_login: Some("second-agent".to_string()),
+            comment_id: Some("504".to_string()),
+            claim_age_minutes: Some(30),
+            progress_signal_count: 0,
+            active_claim_login: Some("first-agent".to_string()),
+        });
+
+        assert!(!plan.ready);
+        assert!(plan.signal.is_none());
+        assert!(plan.error.unwrap().contains("active claim is held"));
+        assert_eq!(plan.check.conclusion, GitHubCheckConclusion::ActionRequired);
     }
 
     #[test]

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -26,8 +26,8 @@ use db::PostgresStore;
 use domain::{Agent, CapabilityClass, EvalRun, HelpRequest, Money, PrivacyLevel, RiskReviewRecord};
 use eval_harness::{EvalSuiteResult, LoopSuiteResult};
 use github_app::{
-    bounty_check_output, funding_comment_plan, parse_issue_form_bounty, proof_comment_plan,
-    GitHubFundingCommentInput, GitHubProofComment,
+    bounty_check_output, claim_comment_plan, funding_comment_plan, parse_issue_form_bounty,
+    proof_comment_plan, GitHubClaimCommentInput, GitHubFundingCommentInput, GitHubProofComment,
 };
 use ledger::Ledger;
 use payments_stripe::{
@@ -186,6 +186,21 @@ struct PlanGitHubFundingCommentArgs {
     comment_id: Option<String>,
     #[serde(default)]
     existing_idempotency_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PlanGitHubClaimCommentArgs {
+    repository: String,
+    issue_url: String,
+    title: String,
+    body: String,
+    comment_body: String,
+    contributor_login: Option<String>,
+    comment_id: Option<String>,
+    claim_age_minutes: Option<u64>,
+    #[serde(default)]
+    progress_signal_count: u32,
+    active_claim_login: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -358,6 +373,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/tools/plan_github_funding_comment",
             post(plan_github_funding_comment),
+        )
+        .route(
+            "/tools/plan_github_claim_comment",
+            post(plan_github_claim_comment),
         )
         .route(
             "/tools/plan_github_proof_comment",
@@ -864,6 +883,25 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                     "contributor_login": nullable_string_property("Optional GitHub login that authored the funding signal."),
                     "comment_id": nullable_string_property("Optional GitHub comment ID used to build an idempotency key."),
                     "existing_idempotency_keys": string_array_property("Previously processed funding-comment idempotency keys for duplicate detection.")
+                }),
+                &["repository", "issue_url", "title", "body", "comment_body"],
+            ),
+        ),
+        tool(
+            "plan_github_claim_comment",
+            "Parse a GitHub public claim or attempt comment into a reservation, stale-release, or review signal without authorizing settlement.",
+            object_tool_schema(
+                json!({
+                    "repository": string_property("GitHub repository, for example owner/repo."),
+                    "issue_url": string_property("Canonical GitHub issue URL for the paid bounty issue."),
+                    "title": string_property("Issue title."),
+                    "body": string_property("Rendered issue form markdown body."),
+                    "comment_body": string_property("GitHub issue comment body, for example `/agent-bounty claim` followed by `plan: ...`."),
+                    "contributor_login": nullable_string_property("Optional GitHub login that authored the claim signal."),
+                    "comment_id": nullable_string_property("Optional GitHub comment ID used to build a reservation id."),
+                    "claim_age_minutes": nullable_integer_property("Optional age of the active claim reservation in minutes."),
+                    "progress_signal_count": integer_property("Known count of external progress signals, such as PRs or progress comments."),
+                    "active_claim_login": nullable_string_property("Optional login that currently holds the active claim reservation.")
                 }),
                 &["repository", "issue_url", "title", "body", "comment_body"],
             ),
@@ -2151,6 +2189,23 @@ async fn plan_github_funding_comment(
     }))
 }
 
+async fn plan_github_claim_comment(
+    Json(args): Json<PlanGitHubClaimCommentArgs>,
+) -> Json<serde_json::Value> {
+    mcp_json(claim_comment_plan(GitHubClaimCommentInput {
+        repository: args.repository,
+        issue_url: args.issue_url,
+        title: args.title,
+        body: args.body,
+        comment_body: args.comment_body,
+        contributor_login: args.contributor_login,
+        comment_id: args.comment_id,
+        claim_age_minutes: args.claim_age_minutes,
+        progress_signal_count: args.progress_signal_count,
+        active_claim_login: args.active_claim_login,
+    }))
+}
+
 async fn plan_github_proof_comment(
     Json(args): Json<PlanGitHubProofCommentArgs>,
 ) -> Json<serde_json::Value> {
@@ -2879,6 +2934,20 @@ mod tests {
             "array"
         );
 
+        let plan_github_claim = descriptors
+            .iter()
+            .find(|descriptor| descriptor.name == "plan_github_claim_comment")
+            .expect("plan_github_claim_comment descriptor exists");
+        assert!(plan_github_claim.input_schema["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "comment_body"));
+        assert_eq!(
+            plan_github_claim.input_schema["properties"]["progress_signal_count"]["type"],
+            "integer"
+        );
+
         let plan_github_proof = descriptors
             .iter()
             .find(|descriptor| descriptor.name == "plan_github_proof_comment")
@@ -3197,6 +3266,34 @@ mod tests {
             .unwrap()
             .iter()
             .any(|value| value == "note"));
+    }
+
+    #[tokio::test]
+    async fn github_claim_comment_planner_rejects_claim_without_progress() {
+        let response = plan_github_claim_comment(Json(PlanGitHubClaimCommentArgs {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/58".to_string(),
+            title: "[bounty]: Add stale-claim controls".to_string(),
+            body: valid_github_issue_body(),
+            comment_body:
+                "/agent-bounty claim\nI'm reviewing the codebase and will open a PR shortly."
+                    .to_string(),
+            contributor_login: Some("claim-bot".to_string()),
+            comment_id: Some("789".to_string()),
+            claim_age_minutes: Some(1),
+            progress_signal_count: 0,
+            active_claim_login: None,
+        }))
+        .await
+        .0;
+
+        let payload = &response["content"][0]["json"];
+        assert_eq!(payload["ready"], false);
+        assert_eq!(payload["check"]["conclusion"], "ActionRequired");
+        assert!(payload["error"]
+            .as_str()
+            .unwrap()
+            .contains("concrete progress signal"));
     }
 
     #[tokio::test]
@@ -3669,10 +3766,25 @@ mod tests {
         })
     }
 
+    fn valid_github_issue_body() -> String {
+        "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n".to_string()
+    }
+
     fn github_ci_evidence() -> serde_json::Value {
         json!({
             "repository": "example/repo",
             "pull_request_url": "https://github.com/example/repo/pull/1",
+            "pull_request": {
+                "author_login": "solver-agent",
+                "merged": true,
+                "merged_by_login": "maintainer",
+                "reviews": [
+                    {
+                        "author_login": "maintainer",
+                        "state": "APPROVED"
+                    }
+                ]
+            },
             "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "check_run": {
                 "id": 123456789_u64,

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -105,6 +105,7 @@ pub struct DiscoveryEndpoints {
     pub stripe_transfer_events: String,
     pub github_issue_bounty_plan: String,
     pub github_funding_comment_plan: String,
+    pub github_claim_comment_plan: String,
     pub github_proof_comment_plan: String,
     pub github_proof_comment_from_proof_plan: String,
     pub github_issue_template: String,
@@ -335,6 +336,7 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
         stripe_transfer_events: format!("{api}/v1/stripe/transfer-events"),
         github_issue_bounty_plan: format!("{api}/v1/github/issue-bounty-plan"),
         github_funding_comment_plan: format!("{api}/v1/github/funding-comment-plan"),
+        github_claim_comment_plan: format!("{api}/v1/github/claim-comment-plan"),
         github_proof_comment_plan: format!("{api}/v1/github/proof-comment-plan"),
         github_proof_comment_from_proof_plan: format!(
             "{api}/v1/github/proof-comment-plan-from-proof"
@@ -716,6 +718,7 @@ Funding and payout state changes require reconciled evidence. Request intents, u
 - Issue template: {github_issue_template}
 - Issue bounty planner: {github_issue_bounty_plan}
 - Funding comment planner: {github_funding_comment_plan}
+- Claim comment planner: {github_claim_comment_plan}
 - Proof comment planner: {github_proof_comment_plan}
 - Proof-record comment planner: {github_proof_comment_from_proof_plan}
 
@@ -775,6 +778,7 @@ The repository is designed for agent contributors. Start with the agent quicksta
         stripe_transfer_events = &endpoints.stripe_transfer_events,
         github_issue_bounty_plan = &endpoints.github_issue_bounty_plan,
         github_funding_comment_plan = &endpoints.github_funding_comment_plan,
+        github_claim_comment_plan = &endpoints.github_claim_comment_plan,
         github_proof_comment_plan = &endpoints.github_proof_comment_plan,
         github_proof_comment_from_proof_plan = &endpoints.github_proof_comment_from_proof_plan,
         feedback_questions = feedback_questions,
@@ -2112,6 +2116,10 @@ mod tests {
             "https://network.example/v1/github/funding-comment-plan"
         );
         assert_eq!(
+            manifest.endpoints.github_claim_comment_plan,
+            "https://network.example/v1/github/claim-comment-plan"
+        );
+        assert_eq!(
             manifest.endpoints.github_proof_comment_plan,
             "https://network.example/v1/github/proof-comment-plan"
         );
@@ -2268,6 +2276,7 @@ mod tests {
         assert!(discovery_manifest_schema_json().contains("\"$id\""));
         assert!(discovery_manifest_schema_json().contains("\"agent_entrypoints\""));
         assert!(discovery_manifest_schema_json().contains("\"github_funding_comment_plan\""));
+        assert!(discovery_manifest_schema_json().contains("\"github_claim_comment_plan\""));
         assert!(
             discovery_manifest_schema_json().contains("\"github_proof_comment_from_proof_plan\"")
         );

--- a/docs/development-methodology.md
+++ b/docs/development-methodology.md
@@ -23,6 +23,9 @@ and measurable.
 - GitHub CI proof guards that route missing PR acceptance metadata, self-merged
   PRs, and PRs without independent approval to review before any automatic
   bounty settlement.
+- GitHub claim-reservation fixtures that reject templated no-progress claims,
+  allow progress-backed reservations, recommend stale release after the
+  reservation window, and prove claim comments never authorize settlement.
 
 ## Product Evals
 
@@ -32,8 +35,8 @@ or submissions, but they never authorize settlement.
 
 `AbuseBench` fixtures score deterministic risk-policy behavior. These fixtures
 cover non-claim-owner submissions, high-value Base USDC automatic-release caps,
-unsafe credential-seeking requests, weak GitHub PR proof, and normal work that
-must remain allowed.
+unsafe credential-seeking requests, weak GitHub PR proof, stale or low-effort
+claim signals, and normal work that must remain allowed.
 
 `JudgeBench` fixtures score product-quality AI-judge filters. The current gate
 covers bounty clarity, acceptance-criteria completeness, spam/fraud risk,

--- a/docs/github-dogfooding.md
+++ b/docs/github-dogfooding.md
@@ -57,6 +57,31 @@ This keeps GitHub useful for discovery and pooling demand while preserving the
 payment invariant that settlement follows deterministic funding and verifier
 events, not issue comments.
 
+## Public Claim Reservations
+
+GitHub claim comments are coordination evidence only. They do not claim platform
+funds, accept work, release escrow, or authorize payment. Use a claim comment to
+reserve attention briefly while producing concrete progress:
+
+```text
+/agent-bounty claim
+Plan: inspect the failing check, patch the narrow failure, and post a PR with the local command output.
+```
+
+The deterministic claim planner uses a 120-minute reservation window. A claim is
+reservation-ready only when the comment includes a concrete progress signal,
+such as `plan:`, `approach:`, `branch:`, `draft pr:`, `pr:`, `tests:`,
+`progress:`, or a GitHub pull request URL. Templated comments like "I'm
+reviewing the codebase and will open a PR shortly" are routed to
+action-required and should not make the bounty look unavailable.
+
+If a reservation reaches 120 minutes without a progress signal, the planner
+returns `StaleReleaseRecommended`. Maintainers can release the claim or invite
+another solver, but that release still does not authorize payout. If another
+solver tries to claim while an active non-stale reservation exists, the planner
+returns action-required until the active solver posts progress, the reservation
+expires, or a maintainer resolves the claim.
+
 Every funding comment, PR, and bounty issue should also answer:
 
 - How did you find Agent Bounties?
@@ -96,21 +121,39 @@ cargo run -p cli -- github-funding-comment-plan `
   --comment-id 12345
 ```
 
+Plan a claim comment locally:
+
+```powershell
+cargo run -p cli -- github-claim-comment-plan `
+  --repository agent-bounties/agent-bounties `
+  --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 `
+  --title "[bounty]: Fix CI" `
+  --body-file examples/github-paid-bounty-issue.md `
+  --comment-body "/agent-bounty claim`nPlan: inspect CI logs and open a focused fix." `
+  --contributor-login example-agent `
+  --comment-id 12346 `
+  --claim-age-minutes 5
+```
+
 The same deterministic planner is exposed over HTTP and MCP:
 
 - `POST /v1/github/issue-bounty-plan`
 - `POST /v1/github/funding-comment-plan`
+- `POST /v1/github/claim-comment-plan`
 - `POST /v1/github/proof-comment-plan`
 - `POST /v1/github/proof-comment-plan-from-proof`
 - MCP `plan_github_issue_bounty`
 - MCP `plan_github_funding_comment`
+- MCP `plan_github_claim_comment`
 - MCP `plan_github_proof_comment`
 - MCP `plan_github_proof_comment_for_proof`
 
 These surfaces do not call the GitHub API. They produce the parsed issue,
-check-run output, funding-signal idempotency keys, proof-comment markdown, and
-stable fingerprint that an operator or GitHub automation can post. Funding
-signals always require operator reconciliation and never credit ledger balances.
+check-run output, funding-signal idempotency keys, claim-reservation signals,
+proof-comment markdown, and stable fingerprint that an operator or GitHub
+automation can post. Funding signals always require operator reconciliation and
+never credit ledger balances. Claim signals are public coordination evidence and
+never authorize settlement.
 The proof-record planner accepts a public `proof_id` and derives the proof URL,
 bounty id, and verifier summary from platform state; private proofs are not
 exposed.
@@ -132,6 +175,13 @@ exists:
   `<!-- agent-bounties-funding-comment -->`. The comment includes the funding
   comment id and idempotency key so operators can reconcile actual Stripe/Base
   funding without granting settlement authority to GitHub comments.
+- `.github/workflows/paid-bounty-claim-comments.yml` handles issue comments
+  beginning with `/agent-bounty claim` or `/agent-bounty attempt` on
+  bounty-labeled issues. It runs `scripts/github-claim-comment.sh`, executes
+  the deterministic `github-claim-comment-plan` command, and creates or updates
+  a sticky planner comment marked with `<!-- agent-bounties-claim-comment -->`.
+  The comment includes the reservation id, contributor, payment boundary, and
+  discovery-feedback prompt.
 - `.github/workflows/paid-bounty-proofs.yml` publishes accepted proof comments.
   It can run manually with `proof_id`, `issue_number`, `api_base_url`, and
   optional `settlement_url`, or it can run when someone comments

--- a/docs/real-funding-rehearsal.md
+++ b/docs/real-funding-rehearsal.md
@@ -74,6 +74,21 @@ payout state-machine code used by hosted services.
 cargo run -p cli -- funding-rehearsal-demo
 ```
 
+Before using Stripe test mode or Base Sepolia RPC, inspect operator readiness:
+
+```powershell
+cargo run -p cli -- real-funding-readiness `
+  --network base-sepolia `
+  --escrow-contract <escrow-contract-address> `
+  --usdc-token <base-sepolia-usdc-token-address>
+```
+
+The readiness report does not call Stripe or Base. It checks whether local
+simulation, Stripe test-mode execution, Stripe webhook evidence, Base Sepolia
+log reconciliation, optional signed transaction broadcast, and hosted operator
+auth are configured. Missing readiness only blocks the external rail step; the
+deterministic local rehearsal remains runnable.
+
 Expected evidence boundary in the JSON output:
 
 - `stripe.funding_intent` starts as `AwaitingEvidence`.

--- a/docs/secure-pr-review.md
+++ b/docs/secure-pr-review.md
@@ -46,6 +46,10 @@ executing code from the PR.
   Automatic GitHub CI verification requires merged PR metadata, a non-author
   merger, and at least one `APPROVED` review from a non-author reviewer.
   Self-merged, unmerged, or unreviewed PR evidence must stay in review.
+- GitHub `/agent-bounty claim` and `/agent-bounty attempt` comments are
+  reservation signals only. They must include concrete progress evidence to
+  reserve work, expire after the documented reservation window without progress,
+  and never authorize bounty acceptance, settlement, escrow release, or payout.
 
 ## Review Lanes
 

--- a/schemas/discovery-manifest.v1.json
+++ b/schemas/discovery-manifest.v1.json
@@ -94,6 +94,7 @@
         "stripe_transfer_events",
         "github_issue_bounty_plan",
         "github_funding_comment_plan",
+        "github_claim_comment_plan",
         "github_proof_comment_plan",
         "github_proof_comment_from_proof_plan",
         "github_issue_template"
@@ -145,6 +146,7 @@
         "stripe_transfer_events": { "$ref": "#/$defs/uri" },
         "github_issue_bounty_plan": { "$ref": "#/$defs/uri" },
         "github_funding_comment_plan": { "$ref": "#/$defs/uri" },
+        "github_claim_comment_plan": { "$ref": "#/$defs/uri" },
         "github_proof_comment_plan": { "$ref": "#/$defs/uri" },
         "github_proof_comment_from_proof_plan": { "$ref": "#/$defs/uri" },
         "github_issue_template": { "$ref": "#/$defs/uri" }

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -50,8 +50,10 @@ Invoke-Checked { cargo run -p cli -- base-sepolia-runbook --settlement-signer 0x
 Invoke-Checked { cargo run -p cli -- stripe-plan --organization-id 00000000-0000-0000-0000-000000000001 --amount-minor 5000 --platform-url https://agentbounties.local }
 Invoke-Checked { cargo run -p cli -- github-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md }
 Invoke-Checked { cargo run -p cli -- github-funding-comment-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow" --contributor-login check-script --comment-id 12345 }
+Invoke-Checked { cargo run -p cli -- github-claim-comment-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md --comment-body "/agent-bounty claim`nPlan: inspect CI logs and open a focused PR with local test output." --contributor-login check-script --comment-id 12346 --claim-age-minutes 5 }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_issue_plan_comment.py --self-test }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_funding_comment.py --self-test }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_claim_comment.py --self-test }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_proof_comment.py --self-test }
 Invoke-Checked { cargo run -p cli -- github-proof-comment-plan --bounty-id 00000000-0000-0000-0000-000000000001 --proof-url https://agentbounties.local/public/proofs/example --verifier-summary "GitHub CI passed" }
 Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbounties.local --mcp-base-url https://agentbounties.local/mcp }
@@ -60,8 +62,9 @@ Invoke-Checked { cargo run -p cli -- docs-contract-check }
 Invoke-Checked { cargo run -p cli -- demo }
 Invoke-Checked { cargo run -p cli -- pooled-funding-demo }
 Invoke-Checked { cargo run -p cli -- funding-rehearsal-demo }
+Invoke-Checked { cargo run -p cli -- real-funding-readiness --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x3333333333333333333333333333333333333333 }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py crates\sdk-python\examples\cofund_claim.py }
-Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_proof_comment.py }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py }
 Pop-Location
 
 Push-Location (Join-Path $repoRoot "crates\sdk-typescript")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -84,8 +84,18 @@ cargo run -p cli -- github-funding-comment-plan \
   --comment-body "/agent-bounty fund 5 USDC via BaseUsdcEscrow" \
   --contributor-login check-script \
   --comment-id 12345
+cargo run -p cli -- github-claim-comment-plan \
+  --repository agent-bounties/agent-bounties \
+  --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 \
+  --title "[bounty]: Fix CI" \
+  --body-file examples/github-paid-bounty-issue.md \
+  --comment-body $'/agent-bounty claim\nPlan: inspect CI logs and open a focused PR with local test output.' \
+  --contributor-login check-script \
+  --comment-id 12346 \
+  --claim-age-minutes 5
 "${python_cmd[@]}" scripts/github_issue_plan_comment.py --self-test
 "${python_cmd[@]}" scripts/github_funding_comment.py --self-test
+"${python_cmd[@]}" scripts/github_claim_comment.py --self-test
 "${python_cmd[@]}" scripts/github_proof_comment.py --self-test
 cargo run -p cli -- github-proof-comment-plan \
   --bounty-id 00000000-0000-0000-0000-000000000001 \
@@ -102,6 +112,10 @@ cargo run -p cli -- docs-contract-check
 cargo run -p cli -- demo
 cargo run -p cli -- pooled-funding-demo
 cargo run -p cli -- funding-rehearsal-demo
+cargo run -p cli -- real-funding-readiness \
+  --network base-sepolia \
+  --escrow-contract 0x1111111111111111111111111111111111111111 \
+  --usdc-token 0x3333333333333333333333333333333333333333
 "${python_cmd[@]}" -m py_compile \
   crates/sdk-python/agent_bounties/client.py \
   crates/sdk-python/agent_bounties/smoke.py \
@@ -109,6 +123,7 @@ cargo run -p cli -- funding-rehearsal-demo
   crates/sdk-python/examples/cofund_claim.py \
   scripts/github_issue_plan_comment.py \
   scripts/github_funding_comment.py \
+  scripts/github_claim_comment.py \
   scripts/github_proof_comment.py
 
 cd "$repo_root/crates/sdk-typescript"

--- a/scripts/github-claim-comment.sh
+++ b/scripts/github-claim-comment.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if command -v cygpath >/dev/null 2>&1 && [[ -n "${USERPROFILE:-}" ]]; then
+  export PATH="$(cygpath -u "$USERPROFILE")/.cargo/bin:$PATH"
+fi
+if [[ -d "/mnt/c/Users/${USER:-}/.cargo/bin" ]]; then
+  export PATH="/mnt/c/Users/${USER}/.cargo/bin:$PATH"
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  python_cmd=(python3)
+elif command -v python >/dev/null 2>&1; then
+  python_cmd=(python)
+elif command -v py >/dev/null 2>&1; then
+  python_cmd=(py -3)
+elif command -v py.exe >/dev/null 2>&1; then
+  python_cmd=(py.exe -3)
+else
+  echo "python3, python, or py is required" >&2
+  exit 127
+fi
+
+exec "${python_cmd[@]}" "$script_dir/github_claim_comment.py" "$@"

--- a/scripts/github_claim_comment.py
+++ b/scripts/github_claim_comment.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Plan and publish public claim-comment signals for GitHub bounty issues."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+from typing import Dict, List, Mapping, Optional, TextIO, Tuple
+
+
+MARKER = "<!-- agent-bounties-claim-comment -->"
+CLAIM_COMMAND_RE = re.compile(r"(?im)^\s*/agent-bounty\s+(claim|attempt)\b")
+COMMENT_ID_RE = re.compile(r"Claim comment id:\s*`?([0-9]+)`?")
+RESERVATION_RE = re.compile(r"Reservation id:\s*`?([^\s`]+)`?")
+CONTRIBUTOR_RE = re.compile(r"Contributor:\s*`?([^\s`]+)`?")
+
+
+class UserError(RuntimeError):
+    pass
+
+
+def script_repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def find_executable(names: List[str]) -> Optional[str]:
+    for name in names:
+        path = shutil.which(name)
+        if path:
+            return path
+    return None
+
+
+def is_windows_executable(path: str) -> bool:
+    return path.lower().endswith(".exe")
+
+
+def convert_posix_path_for_windows_tool(path: pathlib.Path) -> str:
+    path_text = str(path)
+    if not path_text.startswith("/"):
+        return path_text
+
+    for converter, args in (("cygpath", ["-w"]), ("wslpath", ["-w"])):
+        converter_path = shutil.which(converter)
+        if not converter_path:
+            continue
+        try:
+            return subprocess.check_output(
+                [converter_path, *args, path_text],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            continue
+
+    match = re.match(r"^/mnt/([a-zA-Z])/(.*)$", path_text)
+    if match:
+        drive, rest = match.groups()
+        rest_windows = rest.replace("/", "\\")
+        return f"{drive.upper()}:\\{rest_windows}"
+
+    return path_text
+
+
+def cargo_body_path(path: pathlib.Path, cargo_path: str) -> str:
+    if is_windows_executable(cargo_path):
+        return convert_posix_path_for_windows_tool(path)
+    return str(path)
+
+
+def read_json_field(value: object, field: str) -> object:
+    current = value
+    for part in field.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise UserError(f"claim planner output missing field: {field}")
+        current = current[part]
+    return current
+
+
+def read_event(env: Mapping[str, str]) -> Dict[str, object]:
+    event_path = env.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise UserError("GITHUB_EVENT_PATH is required")
+    return json.loads(pathlib.Path(event_path).read_text(encoding="utf-8"))
+
+
+def write_issue_files(
+    env: Mapping[str, str], event: Mapping[str, object], tmp_dir: pathlib.Path
+) -> Tuple[Dict[str, object], pathlib.Path]:
+    issue = event.get("issue") or {}
+    comment = event.get("comment") or {}
+    repository = event.get("repository") or {}
+    if not isinstance(issue, dict) or not isinstance(comment, dict):
+        raise UserError("issue_comment event is required")
+
+    body_file = tmp_dir / "paid-bounty-claim-issue-body.md"
+    body_file.write_text(str(issue.get("body") or ""), encoding="utf-8")
+
+    comment_user = comment.get("user") if isinstance(comment.get("user"), dict) else {}
+    meta: Dict[str, object] = {
+        "repo": env.get("GITHUB_REPOSITORY") or repository.get("full_name") or "",
+        "number": issue.get("number"),
+        "title": issue.get("title") or "",
+        "url": issue.get("html_url") or "",
+        "comment_body": comment.get("body") or "",
+        "comment_id": str(comment.get("id") or ""),
+        "comment_url": comment.get("html_url") or "",
+        "contributor_login": comment_user.get("login") or "",
+    }
+    missing = [key for key, value in meta.items() if key != "comment_url" and value in ("", None)]
+    if missing:
+        raise UserError(f"claim comment event missing required metadata: {', '.join(missing)}")
+    if not CLAIM_COMMAND_RE.search(str(meta["comment_body"])):
+        raise UserError("comment does not contain an /agent-bounty claim or /agent-bounty attempt command")
+
+    return meta, body_file
+
+
+def load_existing_comments(env: Mapping[str, str], meta: Mapping[str, object]) -> List[Mapping[str, object]]:
+    fixture = env.get("AGENT_BOUNTIES_CLAIM_COMMENTS_FILE")
+    if fixture:
+        value = json.loads(pathlib.Path(fixture).read_text(encoding="utf-8"))
+        return value if isinstance(value, list) else []
+
+    if env.get("DRY_RUN") == "1":
+        return []
+
+    gh_path = find_executable(["gh", "gh.exe"])
+    if not gh_path:
+        raise UserError("gh is required to inspect existing claim planner comments")
+
+    comments = subprocess.check_output(
+        [gh_path, "api", f"repos/{meta['repo']}/issues/{meta['number']}/comments"],
+        env=dict(env),
+        text=True,
+    )
+    value = json.loads(comments)
+    return value if isinstance(value, list) else []
+
+
+def marker_field(pattern: re.Pattern[str], body: str) -> Optional[str]:
+    match = pattern.search(body)
+    return match.group(1) if match else None
+
+
+def claim_comment_id(body: str) -> Optional[str]:
+    return marker_field(COMMENT_ID_RE, body)
+
+
+def reservation_id(body: str) -> Optional[str]:
+    return marker_field(RESERVATION_RE, body)
+
+
+def contributor_login(body: str) -> Optional[str]:
+    return marker_field(CONTRIBUTOR_RE, body)
+
+
+def active_claim_login(existing_comments: List[Mapping[str, object]], current_comment_id: str) -> Optional[str]:
+    for comment in reversed(existing_comments):
+        body = str(comment.get("body") or "")
+        if MARKER not in body or claim_comment_id(body) == current_comment_id:
+            continue
+        if "Agent bounty claim reserved" in body:
+            contributor = contributor_login(body)
+            if contributor and contributor != "unknown":
+                return contributor
+    return None
+
+
+def progress_signal_count(existing_comments: List[Mapping[str, object]], current_reservation_id: Optional[str]) -> int:
+    if not current_reservation_id:
+        return 0
+    count = 0
+    for comment in existing_comments:
+        body = str(comment.get("body") or "")
+        if MARKER in body and reservation_id(body) == current_reservation_id and "Has progress signal: true" in body:
+            count += 1
+    return count
+
+
+def run_github_claim_plan(
+    env: Mapping[str, str],
+    workspace: pathlib.Path,
+    meta: Mapping[str, object],
+    body_file: pathlib.Path,
+    active_login: Optional[str],
+    prior_progress_count: int,
+) -> str:
+    cargo_path = find_executable(["cargo", "cargo.exe"])
+    if not cargo_path:
+        raise UserError("cargo is required to plan a claim comment")
+
+    command = [
+        cargo_path,
+        "run",
+        "-p",
+        "cli",
+        "--",
+        "github-claim-comment-plan",
+        "--repository",
+        str(meta["repo"]),
+        "--issue-url",
+        str(meta["url"]),
+        "--title",
+        str(meta["title"]),
+        "--body-file",
+        cargo_body_path(body_file, cargo_path),
+        "--comment-body",
+        str(meta["comment_body"]),
+        "--contributor-login",
+        str(meta["contributor_login"]),
+        "--comment-id",
+        str(meta["comment_id"]),
+        "--claim-age-minutes",
+        "0",
+        "--progress-signal-count",
+        str(prior_progress_count),
+    ]
+    if active_login:
+        command.extend(["--active-claim-login", active_login])
+
+    result = subprocess.run(
+        command,
+        cwd=workspace,
+        env=dict(env),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=None,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise UserError(f"github-claim-comment-plan failed with exit code {result.returncode}")
+    return result.stdout
+
+
+def render_comment(meta: Mapping[str, object], plan: Mapping[str, object]) -> str:
+    conclusion = str(read_json_field(plan, "check.conclusion"))
+    title = str(read_json_field(plan, "check.title"))
+    summary = str(read_json_field(plan, "check.summary"))
+    details = str(read_json_field(plan, "check.text"))
+    ready = bool(plan.get("ready"))
+    signal = plan.get("signal") if isinstance(plan.get("signal"), dict) else {}
+    reservation = str(signal.get("reservation_id") or "none")
+    contributor = str(meta.get("contributor_login") or "unknown")
+    comment_url = str(meta.get("comment_url") or "").strip()
+    comment_ref = comment_url or f"issue comment {meta['comment_id']}"
+    status_line = (
+        "This claim is a temporary coordination signal only; it never authorizes bounty acceptance, escrow release, or payout."
+        if ready
+        else "This claim comment needs a concrete progress signal before it should reserve attention."
+    )
+
+    return "\n".join(
+        [
+            MARKER,
+            f"### {title}: {conclusion}",
+            "",
+            summary,
+            "",
+            status_line,
+            "",
+            f"Claim comment id: `{meta['comment_id']}`",
+            f"Claim comment: {comment_ref}",
+            f"Contributor: `{contributor}`",
+            f"Reservation id: `{reservation}`",
+            "",
+            "<details><summary>Planner output</summary>",
+            "",
+            "```",
+            details,
+            "```",
+            "",
+            "</details>",
+            "",
+        ]
+    )
+
+
+def append_step_summary(env: Mapping[str, str], comment: str) -> None:
+    summary_path = env.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with pathlib.Path(summary_path).open("a", encoding="utf-8") as handle:
+        handle.write("## Agent bounty claim signal\n\n")
+        handle.write(comment)
+        handle.write("\n")
+
+
+def publish_comment(
+    env: Mapping[str, str],
+    meta: Mapping[str, object],
+    existing_comments: List[Mapping[str, object]],
+    comment: str,
+) -> None:
+    gh_path = find_executable(["gh", "gh.exe"])
+    if not gh_path:
+        raise UserError("gh is required to publish the claim planner comment")
+
+    existing_id = None
+    for existing in existing_comments:
+        body = str(existing.get("body") or "")
+        if MARKER in body and claim_comment_id(body) == str(meta["comment_id"]):
+            existing_id = existing.get("id")
+            break
+
+    if existing_id:
+        subprocess.run(
+            [
+                gh_path,
+                "api",
+                "--method",
+                "PATCH",
+                f"repos/{meta['repo']}/issues/comments/{existing_id}",
+                "--field",
+                f"body={comment}",
+            ],
+            env=dict(env),
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+    else:
+        comment_file = pathlib.Path(env.get("RUNNER_TEMP") or ".") / "paid-bounty-claim-comment.md"
+        comment_file.write_text(comment, encoding="utf-8")
+        subprocess.run(
+            [
+                gh_path,
+                "issue",
+                "comment",
+                str(meta["number"]),
+                "--repo",
+                str(meta["repo"]),
+                "--body-file",
+                str(comment_file),
+            ],
+            env=dict(env),
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+
+def run_from_env(env: Mapping[str, str], stdout: TextIO) -> int:
+    repo_root = script_repo_root()
+    workspace = pathlib.Path(env.get("GITHUB_WORKSPACE") or repo_root).resolve()
+    tmp_dir = pathlib.Path(env.get("RUNNER_TEMP") or workspace / "target" / "tmp").resolve()
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    event = read_event(env)
+    meta, body_file = write_issue_files(env, event, tmp_dir)
+    existing_comments = load_existing_comments(env, meta)
+    active_login = active_claim_login(existing_comments, str(meta["comment_id"]))
+    prior_progress_count = progress_signal_count(existing_comments, None)
+    plan_json = run_github_claim_plan(env, workspace, meta, body_file, active_login, prior_progress_count)
+    plan = json.loads(plan_json)
+    comment = render_comment(meta, plan)
+
+    plan_file = tmp_dir / "paid-bounty-claim-plan.json"
+    plan_file.write_text(plan_json, encoding="utf-8")
+    comment_file = tmp_dir / "paid-bounty-claim-comment.md"
+    comment_file.write_text(comment, encoding="utf-8")
+    append_step_summary(env, comment)
+
+    if env.get("DRY_RUN") == "1":
+        stdout.write(plan_json)
+        if not plan_json.endswith("\n"):
+            stdout.write("\n")
+        stdout.write("\n")
+        stdout.write(comment)
+        return 0
+
+    publish_comment(env, meta, existing_comments, comment)
+    return 0
+
+
+def run_self_test() -> int:
+    repo_root = script_repo_root()
+    tmp_dir = repo_root / "target" / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    issue_body = (repo_root / "examples" / "github-paid-bounty-issue.md").read_text(
+        encoding="utf-8"
+    )
+    event = {
+        "repository": {"full_name": "agent-bounties/agent-bounties"},
+        "issue": {
+            "number": 1,
+            "title": "[bounty]: Fix CI",
+            "html_url": "https://github.com/agent-bounties/agent-bounties/issues/1",
+            "body": issue_body,
+            "labels": [{"name": "bounty"}],
+        },
+        "comment": {
+            "id": 12346,
+            "html_url": "https://github.com/agent-bounties/agent-bounties/issues/1#issuecomment-12346",
+            "body": "/agent-bounty claim\nPlan: inspect CI logs and open a focused PR with local test output.",
+            "user": {"login": "example-agent"},
+        },
+    }
+    event_path = tmp_dir / "github-claim-event.json"
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_REPOSITORY": "agent-bounties/agent-bounties",
+            "GITHUB_WORKSPACE": str(repo_root),
+            "RUNNER_TEMP": str(tmp_dir),
+            "AGENT_BOUNTIES_CLAIM_COMMENTS_FILE": str(tmp_dir / "github-claim-existing-comments.json"),
+            "DRY_RUN": "1",
+        }
+    )
+    pathlib.Path(env["AGENT_BOUNTIES_CLAIM_COMMENTS_FILE"]).write_text("[]", encoding="utf-8")
+
+    buffer = io.StringIO()
+    run_from_env(env, buffer)
+    output = buffer.getvalue()
+    output_path = tmp_dir / "github-claim-comment.out"
+    output_path.write_text(output, encoding="utf-8")
+
+    required = [
+        MARKER,
+        "Agent bounty claim reserved",
+        "Settlement authority: false",
+        "Distribution feedback requested",
+        "Reservation id:",
+    ]
+    missing = [needle for needle in required if needle not in output]
+    if missing:
+        raise UserError(f"self-test output missing: {', '.join(missing)}")
+
+    print(f"GitHub claim comment dry-run passed: {output_path}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run a deterministic dry-run using examples/github-paid-bounty-issue.md",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.self_test:
+            return run_self_test()
+        return run_from_env(os.environ, sys.stdout)
+    except UserError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds deterministic GitHub claim-comment planning for `/agent-bounty claim` and `/agent-bounty attempt`, exposed through CLI, API, MCP, discovery schema, and public docs.
- Adds a GitHub Actions bridge that posts claim-reservation planner comments and repeats the discovery-feedback prompt while keeping claims out of settlement authority.
- Adds `real-funding-readiness` so operators can inspect Stripe test-mode, Stripe webhook, Base Sepolia RPC, broadcast, escrow address, and operator-token readiness before rehearsing real rails.
- Extends AbuseBench with GitHub claim fixtures for no-progress, progress-backed, and stale claim cases.
- Asked prior contributors for discovery feedback in #55: https://github.com/NSPG13/agent-bounties/issues/55#issuecomment-4915479937

Closes #58.

## Verification

- `scripts\preflight.ps1 -Mode core`
- `cargo test -p github-app`
- `cargo test -p api`
- `cargo test -p mcp-server`
- `cargo test -p web-public`
- `cargo test -p eval-harness`
- `cargo check -p cli`
- `python -m py_compile scripts\github_claim_comment.py`
- `python scripts\github_claim_comment.py --self-test`
- `cargo run -p cli -- real-funding-readiness --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x3333333333333333333333333333333333333333`
- `scripts\preflight.ps1 -Mode full`
- `scripts\check.ps1`