### PR TITLE
Expose GitHub claim planner in SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ The MCP server exposes matching local tools on port `8090`, including
 `reconcile_stripe_checkout_webhook`, `reconcile_stripe_connect_snapshot`,
 `reconcile_stripe_transfer_event`,
 `plan_github_issue_bounty`, `plan_github_funding_comment`,
-`plan_github_proof_comment`, and
+`plan_github_claim_comment`, `plan_github_proof_comment`, and
 `plan_github_proof_comment_for_proof`.
 It also serves the same discovery manifest at
 `/.well-known/agent-bounties.json` so autonomous agents can find the API, MCP

--- a/crates/sdk-python/agent_bounties/client.py
+++ b/crates/sdk-python/agent_bounties/client.py
@@ -704,6 +704,36 @@ class AgentBountiesClient:
             },
         )
 
+    def plan_github_claim_comment(
+        self,
+        repository: str,
+        issue_url: str,
+        title: str,
+        body: str,
+        comment_body: str,
+        contributor_login: str | None = None,
+        comment_id: str | None = None,
+        claim_age_minutes: int | None = None,
+        progress_signal_count: int = 0,
+        active_claim_login: str | None = None,
+    ):
+        return self._request(
+            "POST",
+            "/v1/github/claim-comment-plan",
+            json={
+                "repository": repository,
+                "issue_url": issue_url,
+                "title": title,
+                "body": body,
+                "comment_body": comment_body,
+                "contributor_login": contributor_login,
+                "comment_id": comment_id,
+                "claim_age_minutes": claim_age_minutes,
+                "progress_signal_count": progress_signal_count,
+                "active_claim_login": active_claim_login,
+            },
+        )
+
     def plan_github_proof_comment(
         self,
         bounty_id: str,

--- a/crates/sdk-python/agent_bounties/smoke.py
+++ b/crates/sdk-python/agent_bounties/smoke.py
@@ -18,6 +18,17 @@ def _github_ci_evidence() -> dict:
     return {
         "repository": "example/repo",
         "pull_request_url": "https://github.com/example/repo/pull/1",
+        "pull_request": {
+            "author_login": "solver-agent",
+            "merged": True,
+            "merged_by_login": "maintainer",
+            "reviews": [
+                {
+                    "author_login": "maintainer",
+                    "state": "APPROVED",
+                }
+            ],
+        },
         "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "check_run": {
             "id": 123456789,
@@ -107,6 +118,10 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
         "discovery schema must require the GitHub funding comment planner endpoint",
     )
     _require(
+        "github_claim_comment_plan" in endpoint_required,
+        "discovery schema must require the GitHub claim comment planner endpoint",
+    )
+    _require(
         "base_escrow_events" in endpoint_required,
         "discovery schema must require the Base escrow event endpoint",
     )
@@ -172,6 +187,10 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
     _require(
         isinstance(discovery.get("endpoints", {}).get("github_funding_comment_plan"), str),
         "discovery manifest missing GitHub funding comment planner endpoint",
+    )
+    _require(
+        isinstance(discovery.get("endpoints", {}).get("github_claim_comment_plan"), str),
+        "discovery manifest missing GitHub claim comment planner endpoint",
     )
     _require(
         isinstance(discovery.get("endpoints", {}).get("github_proof_comment_plan"), str),
@@ -430,6 +449,33 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
     _require(
         github_funding_plan["signal"]["requires_operator_reconciliation"] is True,
         "GitHub funding comment planner must require operator reconciliation",
+    )
+    github_claim_plan = client.plan_github_claim_comment(
+        "agent-bounties/agent-bounties",
+        "https://github.com/agent-bounties/agent-bounties/issues/1",
+        "[bounty]: Fix CI",
+        "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n",
+        "/agent-bounty claim\nPlan: open a focused PR and run cargo test -p github-app.",
+        contributor_login="python-sdk-smoke",
+        comment_id="12346",
+        claim_age_minutes=5,
+        progress_signal_count=1,
+    )
+    _require(
+        github_claim_plan["ready"] is True,
+        "GitHub claim comment planner rejected progress-backed claim",
+    )
+    _require(
+        github_claim_plan["signal"]["decision"] == "Reserved",
+        "GitHub claim comment planner did not reserve progress-backed claim",
+    )
+    _require(
+        github_claim_plan["signal"]["settlement_authority"] is False,
+        "GitHub claim comment planner must not authorize payment settlement",
+    )
+    _require(
+        "How did you find Agent Bounties?" in github_claim_plan["check"]["text"],
+        "GitHub claim comment planner must carry the distribution feedback prompt",
     )
     github_proof_plan = client.plan_github_proof_comment(
         solver["id"],

--- a/crates/sdk-python/examples/cofund_claim.py
+++ b/crates/sdk-python/examples/cofund_claim.py
@@ -25,6 +25,10 @@ def run_example(client: AgentBountiesClient) -> dict:
         isinstance(endpoints.get("base_funding_plan"), str),
         "discovery missing Base funding planner endpoint",
     )
+    require(
+        isinstance(endpoints.get("github_claim_comment_plan"), str),
+        "discovery missing GitHub claim comment planner endpoint",
+    )
 
     solver = client.register_agent(
         f"python-example-solver-{suffix}",
@@ -74,6 +78,23 @@ def run_example(client: AgentBountiesClient) -> dict:
     claimed = client.claim_bounty(bounty_id, solver["id"])
     require(claimed["status"] == "Claimed", "claim did not move bounty to Claimed")
 
+    claim_plan = client.plan_github_claim_comment(
+        "agent-bounties/agent-bounties",
+        "https://github.com/agent-bounties/agent-bounties/issues/1",
+        "[bounty]: Fix CI",
+        "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n",
+        "/agent-bounty claim\nPlan: run the SDK co-funding example and open a focused PR.",
+        contributor_login="python-example-agent",
+        comment_id="12346",
+        claim_age_minutes=5,
+        progress_signal_count=1,
+    )
+    require(claim_plan["ready"] is True, "claim planner rejected progress-backed claim")
+    require(
+        claim_plan["signal"]["settlement_authority"] is False,
+        "claim planner must not authorize payment",
+    )
+
     artifact_body = json.dumps({"sdk": "python", "cofunded": True}, separators=(",", ":"))
     submission = client.submit_result(
         bounty_id,
@@ -119,6 +140,7 @@ def run_example(client: AgentBountiesClient) -> dict:
     return {
         "example": "python-cofund-claim",
         "bounty_id": bounty_id,
+        "claim_decision": claim_plan["signal"]["decision"],
         "status": status["bounty"]["status"],
         "settlements": len(paid["settlements"]),
         "base_plan_network": base_plan["network"]["name"],

--- a/crates/sdk-typescript/examples/cofund-claim.ts
+++ b/crates/sdk-typescript/examples/cofund-claim.ts
@@ -56,6 +56,10 @@ async function runExample(client: AgentBountiesClient): Promise<JsonObject> {
     typeof endpoints.base_funding_plan === "string",
     "discovery missing Base funding planner endpoint",
   );
+  requireCondition(
+    typeof endpoints.github_claim_comment_plan === "string",
+    "discovery missing GitHub claim comment planner endpoint",
+  );
 
   const solver = asObject(
     await client.registerAgent(
@@ -139,6 +143,28 @@ async function runExample(client: AgentBountiesClient): Promise<JsonObject> {
   );
   requireCondition(claimed.status === "Claimed", "claim did not move bounty to Claimed");
 
+  const claimPlan = asObject(
+    await client.planGitHubClaimComment({
+      repository: "agent-bounties/agent-bounties",
+      issue_url: "https://github.com/agent-bounties/agent-bounties/issues/1",
+      title: "[bounty]: Fix CI",
+      body:
+        "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n",
+      comment_body: "/agent-bounty claim\nPlan: run the SDK co-funding example and open a focused PR.",
+      contributor_login: "typescript-example-agent",
+      comment_id: "12346",
+      claim_age_minutes: 5,
+      progress_signal_count: 1,
+    }),
+    "claimPlan",
+  );
+  requireCondition(claimPlan.ready === true, "claim planner rejected progress-backed claim");
+  const claimSignal = asObject(claimPlan.signal, "claimPlan.signal");
+  requireCondition(
+    claimSignal.settlement_authority === false,
+    "claim planner must not authorize payment",
+  );
+
   const artifactBody = JSON.stringify({ sdk: "typescript", cofunded: true });
   const submission = asObject(
     await client.submitResult(bountyId, {
@@ -199,6 +225,7 @@ async function runExample(client: AgentBountiesClient): Promise<JsonObject> {
   return {
     example: "typescript-cofund-claim",
     bounty_id: bountyId,
+    claim_decision: claimSignal.decision,
     status: statusBounty.status,
     settlements: settlements.length,
     base_plan_network: asObject(basePlan.network, "basePlan.network").name,

--- a/crates/sdk-typescript/src/index.ts
+++ b/crates/sdk-typescript/src/index.ts
@@ -213,6 +213,19 @@ export interface PlanGitHubFundingCommentRequest {
   existing_idempotency_keys?: string[] | null;
 }
 
+export interface PlanGitHubClaimCommentRequest {
+  repository: string;
+  issue_url: string;
+  title: string;
+  body: string;
+  comment_body: string;
+  contributor_login?: string | null;
+  comment_id?: string | null;
+  claim_age_minutes?: number | null;
+  progress_signal_count?: number | null;
+  active_claim_login?: string | null;
+}
+
 export interface PlanGitHubProofCommentRequest {
   bounty_id: string;
   proof_url: string;
@@ -708,6 +721,24 @@ export class AgentBountiesClient {
         contributor_login: request.contributor_login ?? null,
         comment_id: request.comment_id ?? null,
         existing_idempotency_keys: request.existing_idempotency_keys ?? [],
+      }),
+    });
+  }
+
+  async planGitHubClaimComment(request: PlanGitHubClaimCommentRequest): Promise<unknown> {
+    return this.request("/v1/github/claim-comment-plan", {
+      method: "POST",
+      body: JSON.stringify({
+        repository: request.repository,
+        issue_url: request.issue_url,
+        title: request.title,
+        body: request.body,
+        comment_body: request.comment_body,
+        contributor_login: request.contributor_login ?? null,
+        comment_id: request.comment_id ?? null,
+        claim_age_minutes: request.claim_age_minutes ?? null,
+        progress_signal_count: request.progress_signal_count ?? 0,
+        active_claim_login: request.active_claim_login ?? null,
       }),
     });
   }

--- a/crates/sdk-typescript/src/smoke.ts
+++ b/crates/sdk-typescript/src/smoke.ts
@@ -56,6 +56,17 @@ function githubCiEvidence(): JsonObject {
   return {
     repository: "example/repo",
     pull_request_url: "https://github.com/example/repo/pull/1",
+    pull_request: {
+      author_login: "solver-agent",
+      merged: true,
+      merged_by_login: "maintainer",
+      reviews: [
+        {
+          author_login: "maintainer",
+          state: "APPROVED",
+        },
+      ],
+    },
     commit_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     check_run: {
       id: 123456789,
@@ -161,6 +172,10 @@ async function main(): Promise<void> {
     "discovery schema must require the GitHub funding comment planner endpoint",
   );
   requireCondition(
+    endpointRequired.includes("github_claim_comment_plan"),
+    "discovery schema must require the GitHub claim comment planner endpoint",
+  );
+  requireCondition(
     endpointRequired.includes("base_escrow_events"),
     "discovery schema must require the Base escrow event endpoint",
   );
@@ -223,6 +238,10 @@ async function main(): Promise<void> {
   requireCondition(
     typeof endpoints.github_funding_comment_plan === "string",
     "discovery manifest missing GitHub funding comment planner endpoint",
+  );
+  requireCondition(
+    typeof endpoints.github_claim_comment_plan === "string",
+    "discovery manifest missing GitHub claim comment planner endpoint",
   );
   requireCondition(
     typeof endpoints.github_proof_comment_plan === "string",
@@ -540,6 +559,40 @@ async function main(): Promise<void> {
   requireCondition(
     githubFundingSignal.requires_operator_reconciliation === true,
     "GitHub funding comment planner must require operator reconciliation",
+  );
+  const githubClaimPlan = asObject(
+    await client.planGitHubClaimComment({
+      repository: "agent-bounties/agent-bounties",
+      issue_url: "https://github.com/agent-bounties/agent-bounties/issues/1",
+      title: "[bounty]: Fix CI",
+      body:
+        "### Goal\nFix the failing CI check.\n\n### Acceptance criteria\nThe test job is green and the patch explains the failure.\n\n### Template\nfix-ci-failure\n\n### Suggested amount\n10 USDC\n",
+      comment_body: "/agent-bounty claim\nPlan: open a focused PR and run cargo test -p github-app.",
+      contributor_login: "typescript-sdk-smoke",
+      comment_id: "12346",
+      claim_age_minutes: 5,
+      progress_signal_count: 1,
+    }),
+    "githubClaimPlan",
+  );
+  requireCondition(
+    githubClaimPlan.ready === true,
+    "GitHub claim comment planner rejected progress-backed claim",
+  );
+  const githubClaimSignal = asObject(githubClaimPlan.signal, "githubClaimPlan.signal");
+  requireCondition(
+    githubClaimSignal.decision === "Reserved",
+    "GitHub claim comment planner did not reserve progress-backed claim",
+  );
+  requireCondition(
+    githubClaimSignal.settlement_authority === false,
+    "GitHub claim comment planner must not authorize payment settlement",
+  );
+  requireCondition(
+    stringField(asObject(githubClaimPlan.check, "githubClaimPlan.check"), "text").includes(
+      "How did you find Agent Bounties?",
+    ),
+    "GitHub claim comment planner must carry the distribution feedback prompt",
   );
   const githubProofPlan = asObject(
     await client.planGitHubProofComment({


### PR DESCRIPTION
﻿## Summary
- Exposes `plan_github_claim_comment` in the Python SDK and `planGitHubClaimComment` in the TypeScript SDK.
- Adds live SDK smoke coverage that verifies the claim planner is discoverable, reserves progress-backed claims, carries the distribution feedback prompt, and never authorizes settlement.
- Updates SDK co-funding examples to demonstrate the claim-reservation planner alongside pooled funding, claiming, verification, paid status, and Base Sepolia funding plans.
- Refreshes SDK GitHub CI evidence fixtures with merged PR metadata and independent approval so payment-grade verifier checks match the hardened verifier contract.

## Verification
- `python -m py_compile crates\\sdk-python\\agent_bounties\\client.py crates\\sdk-python\\agent_bounties\\smoke.py crates\\sdk-python\\examples\\cofund_claim.py`
- `npm run build` in `crates/sdk-typescript`
- `npm run check:examples` in `crates/sdk-typescript`
- `cargo run -p cli -- docs-contract-check`
- `cargo test -p github-app claim_comment`
- `cargo test -p api github_claim_comment_plan`
- `cargo run -p cli -- github-claim-comment-plan --repository agent-bounties/agent-bounties --issue-url https://github.com/agent-bounties/agent-bounties/issues/1 --title "[bounty]: Fix CI" --body-file examples/github-paid-bounty-issue.md --comment-body "/agent-bounty claim`nPlan: open a focused PR and run cargo test -p github-app." --contributor-login check-script --comment-id 12346 --claim-age-minutes 5`
- `scripts\\check-sdk-live.ps1`
- `cargo run -p cli -- funding-rehearsal-demo`
- `scripts\\check.ps1`

## Distribution Follow-Up
Posted the consolidated prior-participant discovery request on #55: https://github.com/NSPG13/agent-bounties/issues/55#issuecomment-4915739007

This PR does not approve bounty work, release funds, or alter settlement authority. Claim planner output remains coordination evidence only.
