### PR TITLE
Publish real funding rehearsal artifacts

### DIFF
--- a/.github/workflows/real-funding-rehearsal.yml
+++ b/.github/workflows/real-funding-rehearsal.yml
@@ -1,0 +1,68 @@
+name: Real Funding Rehearsal
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * *"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/real-funding-rehearsal.yml"
+      - "crates/domain/**"
+      - "crates/chain-base/**"
+      - "crates/ledger/**"
+      - "crates/payments-stripe/**"
+      - "crates/cli/**"
+      - "scripts/real-funding-rehearsal.*"
+      - "scripts/validate_real_funding_rehearsal.py"
+  pull_request:
+    paths:
+      - ".github/workflows/real-funding-rehearsal.yml"
+      - "crates/domain/**"
+      - "crates/chain-base/**"
+      - "crates/ledger/**"
+      - "crates/payments-stripe/**"
+      - "crates/cli/**"
+      - "scripts/real-funding-rehearsal.*"
+      - "scripts/validate_real_funding_rehearsal.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: real-funding-rehearsal-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate and validate real-funding rehearsal artifacts
+        run: bash scripts/real-funding-rehearsal.sh target/real-funding-rehearsal
+
+      - name: Add rehearsal summary
+        run: |
+          {
+            echo "## Real Funding Rehearsal"
+            echo
+            echo "- Generated funding-rehearsal-demo.json"
+            echo "- Generated real-funding-readiness.json"
+            echo "- Validated StripeFiat and BaseUsdc settlement after deterministic evidence reconciliation"
+            echo
+            echo "This workflow does not execute live Stripe or Base transactions. It proves the evidence boundary that operators use before testnet or hosted low-value money movement."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: real-funding-rehearsal
+          path: target/real-funding-rehearsal/*.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ cargo run -p cli -- demo
 cargo run -p cli -- pooled-funding-demo
 cargo run -p cli -- funding-rehearsal-demo
 cargo run -p cli -- real-funding-readiness --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x3333333333333333333333333333333333333333
+.\scripts\real-funding-rehearsal.ps1
 cargo run -p cli -- base-plan --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --token 0x3333333333333333333333333333333333333333
 cargo run -p cli -- base-decode-demo
 cargo run -p cli -- base-log-query --escrow-contract 0x1111111111111111111111111111111111111111 --from-block 0
@@ -115,6 +116,10 @@ For an operator runbook that combines Stripe test-mode Checkout, Base Sepolia
 USDC escrow, pooled funding, mixed funding, deterministic verification, and
 post-evidence distribution, see
 [docs/real-funding-rehearsal.md](docs/real-funding-rehearsal.md).
+The `Real Funding Rehearsal` workflow publishes public JSON artifacts for the
+deterministic StripeFiat plus BaseUsdc mixed-funding path. It does not execute
+live Stripe or Base transactions; it proves the evidence boundary used before
+operators run Stripe test-mode Checkout or Base Sepolia signing/reconciliation.
 `base-fetch-logs`, `base-broadcast-signed-transaction`, and
 `base-transaction-receipt` perform live JSON-RPC calls and require either
 `BASE_SEPOLIA_RPC_URL`/`BASE_MAINNET_RPC_URL` for the selected network or an
@@ -464,11 +469,15 @@ operator planners including the risk-policy descriptor and Base
 release/refund/dispute transaction plans and Stripe Connect transfer plans,
 the GitHub paid-bounty issue workflow dry-run,
 the GitHub funding-comment planner, the mixed Stripe/Base funding rehearsal,
+the real-funding rehearsal artifact validator,
 Python/TypeScript SDK compilation, SDK eval-run history checks, and Foundry
 escrow tests.
 GitHub Actions runs the same `scripts/check.sh` gate on pushes and pull
 requests. The Docker-backed `scripts/check-postgres.*` smoke is separate so the
 default contributor gate remains fast and does not require Docker.
+The separate `Real Funding Rehearsal` workflow publishes the validated
+`funding-rehearsal-demo.json` and `real-funding-readiness.json` artifacts on
+manual runs, scheduled runs, and payment-path changes.
 The separate `Containers` workflow runs `scripts/check-production-compose.sh`
 when production packaging files change or when manually dispatched.
 The optional `scripts/check-containers.*` gate builds production API and MCP

--- a/docs/real-funding-rehearsal.md
+++ b/docs/real-funding-rehearsal.md
@@ -109,6 +109,43 @@ Expected evidence boundary in the JSON output:
 - `stripe.transfer_reconciliation` applies only after the simulated
   `transfer.created` event with matching payout metadata.
 
+## Public Rehearsal Artifacts
+
+Use the checked runner when you want shareable JSON evidence instead of terminal
+output:
+
+```powershell
+.\scripts\real-funding-rehearsal.ps1
+```
+
+On Unix-like shells:
+
+```bash
+bash scripts/real-funding-rehearsal.sh
+```
+
+The runner writes:
+
+- `target/real-funding-rehearsal/funding-rehearsal-demo.json`
+- `target/real-funding-rehearsal/real-funding-readiness.json`
+
+It then validates that:
+
+- the mixed bounty has separate `StripeFiat` and `BaseUsdc` funding targets,
+- Stripe Checkout and Base escrow plans start as `AwaitingEvidence`,
+- Stripe funding applies only after `checkout.session.completed`,
+- Base funding applies only after `EscrowCreated`,
+- Base payout applies only after `EscrowReleased`,
+- Stripe payout applies only after `transfer.created`,
+- final settlements contain paid solver payouts and platform fees for both
+  rails.
+
+The `Real Funding Rehearsal` GitHub Actions workflow runs the same script on
+manual dispatch, schedule, main-branch payment-path changes, and PRs that touch
+payment-path code. The uploaded artifacts are public proof that the repository
+still supports pooled and mixed funding semantics without exposing live Stripe
+keys, private wallets, or signed Base transactions.
+
 ## Stripe Test Mode Funding
 
 Use funding intents when a contributor wants to assign real fiat funding to a

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -63,8 +63,9 @@ Invoke-Checked { cargo run -p cli -- demo }
 Invoke-Checked { cargo run -p cli -- pooled-funding-demo }
 Invoke-Checked { cargo run -p cli -- funding-rehearsal-demo }
 Invoke-Checked { cargo run -p cli -- real-funding-readiness --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x3333333333333333333333333333333333333333 }
+Invoke-Checked { & (Join-Path $repoRoot "scripts\real-funding-rehearsal.ps1") }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py crates\sdk-python\examples\cofund_claim.py }
-Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py scripts\validate_real_funding_rehearsal.py }
 Pop-Location
 
 Push-Location (Join-Path $repoRoot "crates\sdk-typescript")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -116,6 +116,7 @@ cargo run -p cli -- real-funding-readiness \
   --network base-sepolia \
   --escrow-contract 0x1111111111111111111111111111111111111111 \
   --usdc-token 0x3333333333333333333333333333333333333333
+bash scripts/real-funding-rehearsal.sh
 "${python_cmd[@]}" -m py_compile \
   crates/sdk-python/agent_bounties/client.py \
   crates/sdk-python/agent_bounties/smoke.py \
@@ -124,7 +125,8 @@ cargo run -p cli -- real-funding-readiness \
   scripts/github_issue_plan_comment.py \
   scripts/github_funding_comment.py \
   scripts/github_claim_comment.py \
-  scripts/github_proof_comment.py
+  scripts/github_proof_comment.py \
+  scripts/validate_real_funding_rehearsal.py
 
 cd "$repo_root/crates/sdk-typescript"
 npm ci

--- a/scripts/real-funding-rehearsal.ps1
+++ b/scripts/real-funding-rehearsal.ps1
@@ -1,0 +1,48 @@
+param(
+    [string] $OutDir = "target\real-funding-rehearsal"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
+
+$pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+$pythonArgs = @()
+if (-not $pythonCommand) {
+    $pythonCommand = Get-Command py -ErrorAction SilentlyContinue
+    $pythonArgs = @("-3")
+}
+if (-not $pythonCommand) {
+    throw "python or py is required to validate real funding rehearsal artifacts"
+}
+
+Push-Location $repoRoot
+try {
+    New-Item -ItemType Directory -Force $OutDir | Out-Null
+    $resolvedOutDir = (Resolve-Path $OutDir).Path
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+
+    $fundingJson = cargo run -q -p cli -- funding-rehearsal-demo | Out-String
+    [System.IO.File]::WriteAllText(
+        (Join-Path $resolvedOutDir "funding-rehearsal-demo.json"),
+        $fundingJson,
+        $utf8NoBom
+    )
+
+    $readinessJson = cargo run -q -p cli -- real-funding-readiness `
+        --network base-sepolia `
+        --escrow-contract 0x1111111111111111111111111111111111111111 `
+        --usdc-token 0x3333333333333333333333333333333333333333 |
+        Out-String
+    [System.IO.File]::WriteAllText(
+        (Join-Path $resolvedOutDir "real-funding-readiness.json"),
+        $readinessJson,
+        $utf8NoBom
+    )
+
+    & $pythonCommand.Source @pythonArgs scripts\validate_real_funding_rehearsal.py $OutDir
+}
+finally {
+    Pop-Location
+}

--- a/scripts/real-funding-rehearsal.sh
+++ b/scripts/real-funding-rehearsal.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+out_dir="${1:-target/real-funding-rehearsal}"
+
+if command -v cygpath >/dev/null 2>&1 && [[ -n "${USERPROFILE:-}" ]]; then
+  export PATH="$(cygpath -u "$USERPROFILE")/.cargo/bin:$PATH"
+fi
+if [[ -d "${HOME:-}/.cargo/bin" ]]; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+fi
+if [[ -d "/mnt/c/Users/${USER:-}/.cargo/bin" ]]; then
+  export PATH="/mnt/c/Users/${USER}/.cargo/bin:$PATH"
+fi
+if ! command -v cargo >/dev/null 2>&1 && command -v cargo.exe >/dev/null 2>&1; then
+  cargo() { cargo.exe "$@"; }
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  python_cmd=(python3)
+elif command -v python >/dev/null 2>&1; then
+  python_cmd=(python)
+elif command -v py >/dev/null 2>&1; then
+  python_cmd=(py -3)
+elif command -v py.exe >/dev/null 2>&1; then
+  python_cmd=(py.exe -3)
+else
+  echo "python3, python, or py is required to validate real funding rehearsal artifacts" >&2
+  exit 127
+fi
+
+cd "$repo_root"
+mkdir -p "$out_dir"
+
+cargo run -q -p cli -- funding-rehearsal-demo > "$out_dir/funding-rehearsal-demo.json"
+cargo run -q -p cli -- real-funding-readiness \
+  --network base-sepolia \
+  --escrow-contract 0x1111111111111111111111111111111111111111 \
+  --usdc-token 0x3333333333333333333333333333333333333333 \
+  > "$out_dir/real-funding-readiness.json"
+
+"${python_cmd[@]}" scripts/validate_real_funding_rehearsal.py "$out_dir"

--- a/scripts/validate_real_funding_rehearsal.py
+++ b/scripts/validate_real_funding_rehearsal.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Validate deterministic real-funding rehearsal artifacts.
+
+The rehearsal artifacts are intentionally strict: they prove that Stripe and
+Base plans do not mutate payment state until webhook/log evidence is reconciled.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_STRIPE_API_VERSION = "2026-02-25.clover"
+EXPECTED_BASE_CHAIN_ID = 84532
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8-sig"))
+    except FileNotFoundError:
+        fail(f"missing artifact: {path}")
+    except json.JSONDecodeError as error:
+        fail(f"invalid JSON in {path}: {error}")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"real funding rehearsal validation failed: {message}")
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def money(value: dict[str, Any]) -> tuple[int, str]:
+    return int(value["amount"]), str(value["currency"])
+
+
+def settlement_for(report: dict[str, Any], rail: str) -> dict[str, Any]:
+    for settlement in report.get("settlements", []):
+        if settlement.get("rail") == rail:
+            return settlement
+    fail(f"missing final settlement for {rail}")
+
+
+def first_payout(settlement: dict[str, Any]) -> dict[str, Any]:
+    payouts = settlement.get("payout_intents", [])
+    expect(len(payouts) == 1, f"{settlement.get('rail')} must have one payout intent")
+    return payouts[0]
+
+
+def check_funding_targets(report: dict[str, Any]) -> None:
+    targets = {
+        (target["rail"], target["amount"]["currency"]): target["amount"]["amount"]
+        for target in report["final_bounty"]["funding_targets"]
+    }
+    expect(targets.get(("StripeFiat", "usd")) == 500, "missing USD Stripe funding target")
+    expect(targets.get(("BaseUsdc", "usdc")) == 1000, "missing USDC Base funding target")
+
+    partitions = {
+        (partition["rail"], partition["target"]["currency"]): partition
+        for partition in report["funding_summary"]["partitions"]
+    }
+    for key in (("StripeFiat", "usd"), ("BaseUsdc", "usdc")):
+        partition = partitions.get(key)
+        expect(partition is not None, f"missing funding partition {key}")
+        expect(partition["claimable"] is True, f"partition {key} must be claimable")
+        expect(money(partition["remaining"])[0] == 0, f"partition {key} must be fully funded")
+
+
+def check_stripe(report: dict[str, Any]) -> None:
+    stripe = report["stripe"]
+    checkout = stripe["checkout_request"]
+    expect(checkout["method"] == "POST", "Stripe checkout request must use POST")
+    expect(checkout["endpoint"] == "/v1/checkout/sessions", "Stripe funding must use Checkout Sessions")
+    expect(checkout["api_version"] == EXPECTED_STRIPE_API_VERSION, "Stripe API version drifted")
+    expect(checkout["body"]["mode"] == "payment", "Stripe checkout must be one-time payment mode")
+    expect(
+        checkout["body"]["metadata"]["bounty_id"] == report["final_bounty"]["id"],
+        "Stripe checkout metadata must bind bounty_id",
+    )
+    expect(
+        checkout["body"]["metadata"]["funding_intent_id"] == stripe["funding_intent"]["id"],
+        "Stripe checkout metadata must bind funding_intent_id",
+    )
+    expect(
+        stripe["funding_intent"]["status"] == "AwaitingEvidence",
+        "Stripe funding intent must start awaiting evidence",
+    )
+    expect(
+        stripe["funding_reconciliation"]["funding_intent"]["status"] == "Applied",
+        "Stripe funding must apply only after checkout webhook reconciliation",
+    )
+    expect(
+        stripe["connect_eligibility"]["payout_state"]["status"] == "Pending",
+        "Stripe Connect eligibility should only unblock the payout intent",
+    )
+    expect(
+        stripe["transfer_plan"]["requires_reconciliation"] is True,
+        "Stripe transfer plan must require transfer.created reconciliation",
+    )
+    expect(
+        stripe["transfer_reconciliation"]["settlement"]["payout_intents"][0]["status"] == "Paid",
+        "Stripe payout must become paid after transfer.created reconciliation",
+    )
+
+
+def check_base(report: dict[str, Any]) -> None:
+    base = report["base"]
+    expect(
+        base["funding_intent"]["status"] == "AwaitingEvidence",
+        "Base funding intent must start awaiting evidence",
+    )
+    expect(
+        base["funding_plan"]["network"]["chain_id"] == EXPECTED_BASE_CHAIN_ID,
+        "Base funding plan must target Base Sepolia",
+    )
+    expect(
+        base["created_reconciliation"]["event"]["kind"] == "Created",
+        "Base funding must reconcile an EscrowCreated event",
+    )
+    expect(
+        base["created_reconciliation"]["bounty"]["status"] == "Claimable",
+        "Base EscrowCreated reconciliation must make mixed bounty claimable",
+    )
+    expect(
+        base["release_plan"]["transaction"]["function"] == "release(uint256,address[],uint256[],bytes32)",
+        "Base release plan must be an escrow release call",
+    )
+    recipients = base["release_plan"]["release_call"]["recipients"]
+    expect(len(recipients) == 2, "Base release must split solver payout and platform fee")
+    expect(
+        base["released_reconciliation"]["event"]["kind"] == "Released",
+        "Base payout must reconcile an EscrowReleased event",
+    )
+    released_base = settlement_for(base["released_reconciliation"], "BaseUsdc")
+    expect(
+        first_payout(released_base)["status"] == "Paid",
+        "Base payout intent must be paid only after EscrowReleased reconciliation",
+    )
+
+
+def check_final_settlements(report: dict[str, Any]) -> None:
+    stripe = settlement_for(report, "StripeFiat")
+    base = settlement_for(report, "BaseUsdc")
+    stripe_payout = first_payout(stripe)
+    base_payout = first_payout(base)
+
+    expect(stripe_payout["status"] == "Paid", "final Stripe payout must be paid")
+    expect(base_payout["status"] == "Paid", "final Base payout must be paid")
+    expect(money(stripe_payout["amount"]) == (450, "usd"), "unexpected Stripe solver payout")
+    expect(money(stripe["platform_fee"]) == (50, "usd"), "unexpected Stripe platform fee")
+    expect(money(base_payout["amount"]) == (900, "usdc"), "unexpected Base solver payout")
+    expect(money(base["platform_fee"]) == (100, "usdc"), "unexpected Base platform fee")
+
+
+def check_readiness(readiness: dict[str, Any]) -> None:
+    expect(readiness["local_rehearsal_ready"] is True, "local rehearsal must be ready")
+    expect(readiness["network"] == "Base Sepolia", "readiness must describe Base Sepolia")
+    checks = {check["name"]: check for check in readiness["checks"]}
+    expect(
+        checks["local deterministic rehearsal"]["configured"] is True,
+        "local deterministic rehearsal check must be configured",
+    )
+    expect(
+        checks["Base Sepolia escrow addresses"]["configured"] is True,
+        "dummy Base Sepolia escrow/token addresses must be accepted for planning",
+    )
+    boundaries = "\n".join(readiness["evidence_boundaries"])
+    for phrase in (
+        "Checkout Session creation is not funding",
+        "approve/createEscrow transaction planning is not funding",
+        "verifier acceptance creates settlement intents",
+        "EscrowReleased log marks USDC payout paid",
+        "transfer planning are not payout",
+    ):
+        expect(phrase in boundaries, f"missing evidence boundary: {phrase}")
+
+
+def main() -> None:
+    out_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "target/real-funding-rehearsal")
+    report = load_json(out_dir / "funding-rehearsal-demo.json")
+    readiness = load_json(out_dir / "real-funding-readiness.json")
+
+    expect(
+        report["rehearsal"] == "stripe-dev-plus-base-sepolia-mixed-funding",
+        "unexpected rehearsal id",
+    )
+    expect(report["final_bounty"]["status"] == "Paid", "final mixed bounty must be paid")
+    expect(report["final_bounty"]["funding_mode"] == "MixedRails", "must rehearse mixed funding")
+    expect(report["ledger_entries"] >= 6, "expected funding and payout ledger entries")
+    for invariant in (
+        "Stripe Checkout Session creation does not credit balances.",
+        "Base payout is paid only after indexed EscrowReleased reconciliation.",
+        "Stripe payout is paid only after transfer.created reconciliation.",
+    ):
+        expect(invariant in report["invariants"], f"missing invariant: {invariant}")
+
+    check_funding_targets(report)
+    check_stripe(report)
+    check_base(report)
+    check_final_settlements(report)
+    check_readiness(readiness)
+
+    print(
+        "validated real funding rehearsal: "
+        "mixed bounty paid with StripeFiat and BaseUsdc settlements after evidence reconciliation"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add cross-platform real-funding rehearsal runners that write JSON artifacts for the mixed StripeFiat plus BaseUsdc path
- validate that funding and payout state only change after deterministic webhook/log evidence reconciliation
- publish a Real Funding Rehearsal workflow artifact and document the operator/discovery path

## Verification
- scripts/preflight.ps1 -Mode core
- scripts/real-funding-rehearsal.ps1
- bash scripts/real-funding-rehearsal.sh target/real-funding-rehearsal-bash
- python -m py_compile scripts/validate_real_funding_rehearsal.py
- scripts/check.ps1