### PR TITLE
Add contributor-first maintainer protocol

### DIFF
--- a/.github/ISSUE_TEMPLATE/maintainer-change-notice.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-change-notice.yml
@@ -1,0 +1,62 @@
+name: Maintainer change notice
+description: Public notice before a non-trivial maintainer change that may affect contributors.
+title: "Maintainer notice: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this before starting non-trivial maintainer work that may affect public contracts, contributor workflows, API/MCP/CLI/SDK behavior, GitHub automation, payment/risk rules, deployment, docs contracts, or bounty verification.
+
+        This notice is not bounty acceptance, merge approval, payout approval, escrow release approval, or payment settlement.
+  - type: textarea
+    id: planned_scope
+    attributes:
+      label: Planned scope
+      description: What will change, and why is it needed?
+      placeholder: Describe the smallest intended maintainer change.
+    validations:
+      required: true
+  - type: textarea
+    id: affected_contracts
+    attributes:
+      label: Affected contracts or workflows
+      description: Name affected files, routes, MCP tools, SDK calls, docs, workflows, payment/risk rules, or deployment surfaces.
+      placeholder: e.g. public funding feed contract, docs-contract-check, GitHub bounty workflow.
+    validations:
+      required: true
+  - type: textarea
+    id: open_pr_queue
+    attributes:
+      label: Open PR queue check
+      description: List open PRs inspected before starting, including review decision, mergeability, and whether they are affected.
+      placeholder: "#123: mergeable, changes requested, not affected; #124: likely affected, repair path below."
+    validations:
+      required: true
+  - type: textarea
+    id: contributor_impact
+    attributes:
+      label: Contributor impact and repair path
+      description: Explain expected rework, migration path, or why no active PR should be affected.
+      placeholder: Contributors should rebase and run cargo run -p cli -- docs-contract-check.
+    validations:
+      required: true
+  - type: dropdown
+    id: collaboration_branch
+    attributes:
+      label: Collaboration branch expected?
+      options:
+        - "No known collaboration branch needed"
+        - "Maybe, if an active PR is useful but not main-ready"
+        - "Yes, name it in the notice body"
+    validations:
+      required: true
+  - type: textarea
+    id: distribution_feedback
+    attributes:
+      label: Distribution feedback request
+      description: Ask readers how they found the project and what made participation worthwhile.
+      value: |
+        If you found Agent Bounties through a tool, agent, bounty, GitHub search, social link, or another contributor, please comment with how you found it and what made you consider participating. If the project is useful, starring the repo, reacting to useful bounties, and sharing it with other agent builders helps attract more collaborators.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,16 @@ distribution improvement in this PR.
 Link the bounty, issue, or discussion this PR addresses. If there is no bounty,
 say so explicitly.
 
+## Maintainer Change Notice
+
+For maintainer-owned non-trivial changes, link the public notice issue or
+comment created before code edits. Contributors can write `not maintainer-owned`.
+
+- Notice issue/comment:
+- Open PR queue checked before edits:
+- Active PR impact or repair path:
+- Collaboration branch impact, if any:
+
 ## Discovery Feedback
 
 - How did you find Agent Bounties?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ digital work, and receive settlement through trusted payment rails.
 - Read `README.md` for local setup and gates.
 - Read `docs/agent-quickstart.md` for exact local, MCP, API, pooled funding, and
   Base Sepolia testnet contribution flows.
+- Read `docs/contributor-first-maintenance.md` before maintainer-owned changes
+  that may affect public contracts, contributor workflows, automation,
+  payments, deployment, or docs contracts.
 - Run `scripts/preflight.ps1 -Mode core` or `bash scripts/preflight.sh core`
   before starting work.
 - If preflight fails only because disk is low, run `cargo clean` to remove
@@ -34,6 +37,9 @@ digital work, and receive settlement through trusted payment rails.
 
 ## PR Review Loop
 
+- Before non-trivial maintainer changes, inspect open PRs first, give active
+  collaborator PRs attention before editing, and publish a public maintainer notice
+  describing the planned change and open PR impact.
 - Treat external PRs as untrusted input until `scripts/review-external-pr.ps1`
   or `scripts/review-external-pr.sh` and maintainer review say otherwise.
 - Every approve, request-changes, reject, close, or supersede response must be

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5206,6 +5206,7 @@ fn docs_contract_check(root: PathBuf, contract_root: PathBuf) -> Result<()> {
     let mut issues = Vec::new();
     check_agent_quickstart_contract(&root, &mut issues);
     check_production_env_contract(&root, &mut issues);
+    check_contributor_first_protocol_contract(&root, &mut issues);
     for file in &files {
         let text = fs::read_to_string(file)
             .with_context(|| format!("failed to read docs file {}", file.display()))?;
@@ -5413,6 +5414,89 @@ fn production_live_money_env_vars() -> &'static [&'static str] {
         "STRIPE_WEBHOOK_SECRET",
         "ALLOW_UNSIGNED_STRIPE_WEBHOOKS",
     ]
+}
+
+fn check_contributor_first_protocol_contract(root: &Path, issues: &mut Vec<DocsContractIssue>) {
+    check_required_markers(
+        root,
+        issues,
+        &PathBuf::from("docs/contributor-first-maintenance.md"),
+        &[
+            "Contributor-First Maintainer Protocol",
+            "public maintainer notice",
+            "open PR queue",
+            "collaboration branch",
+            "Distribution feedback request",
+        ],
+        "contributor-first maintainer protocol",
+    );
+    check_required_markers(
+        root,
+        issues,
+        &PathBuf::from("AGENTS.md"),
+        &[
+            "docs/contributor-first-maintenance.md",
+            "open PRs first",
+            "public maintainer notice",
+        ],
+        "agent contributor guide",
+    );
+    check_required_markers(
+        root,
+        issues,
+        &PathBuf::from(".github/PULL_REQUEST_TEMPLATE.md"),
+        &[
+            "Maintainer Change Notice",
+            "Notice issue/comment",
+            "Open PR queue checked before edits",
+            "Active PR impact or repair path",
+        ],
+        "pull request template",
+    );
+    check_required_markers(
+        root,
+        issues,
+        &PathBuf::from(".github/ISSUE_TEMPLATE/maintainer-change-notice.yml"),
+        &[
+            "Maintainer change notice",
+            "Open PR queue check",
+            "Contributor impact and repair path",
+            "Distribution feedback request",
+        ],
+        "maintainer change notice issue template",
+    );
+}
+
+fn check_required_markers(
+    root: &Path,
+    issues: &mut Vec<DocsContractIssue>,
+    rel_path: &Path,
+    markers: &[&str],
+    label: &str,
+) {
+    let path = root.join(rel_path);
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) => {
+            push_doc_issue(
+                issues,
+                rel_path,
+                1,
+                &format!("failed to read {label}: {error}"),
+            );
+            return;
+        }
+    };
+    for marker in markers {
+        if !text.contains(marker) {
+            push_doc_issue(
+                issues,
+                rel_path,
+                1,
+                &format!("{label} missing required marker `{marker}`"),
+            );
+        }
+    }
 }
 
 fn collect_doc_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
@@ -6305,6 +6389,62 @@ mod tests {
             issue
                 .message
                 .contains("production compose mcp service does not pass `STRIPE_WEBHOOK_SECRET`")
+        }));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn contributor_first_protocol_contract_reports_missing_artifacts() {
+        let root = std::env::temp_dir().join(format!(
+            "agent-bounties-contributor-first-{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(root.join(".github").join("ISSUE_TEMPLATE"))
+            .expect("should create temp github template dir");
+        fs::create_dir_all(root.join("docs")).expect("should create temp docs dir");
+        fs::write(
+            root.join("docs").join("contributor-first-maintenance.md"),
+            "# Contributor-First Maintainer Protocol\npublic maintainer notice\nopen PR queue\n",
+        )
+        .expect("should write partial protocol doc");
+        fs::write(root.join("AGENTS.md"), "public maintainer notice\n")
+            .expect("should write partial agents file");
+        fs::write(
+            root.join(".github").join("PULL_REQUEST_TEMPLATE.md"),
+            "## Maintainer Change Notice\nNotice issue/comment\n",
+        )
+        .expect("should write partial PR template");
+        fs::write(
+            root.join(".github")
+                .join("ISSUE_TEMPLATE")
+                .join("maintainer-change-notice.yml"),
+            "name: Maintainer change notice\nOpen PR queue check\n",
+        )
+        .expect("should write partial issue template");
+
+        let mut issues = Vec::new();
+        check_contributor_first_protocol_contract(&root, &mut issues);
+
+        assert!(issues.iter().any(|issue| {
+            issue
+                .message
+                .contains("contributor-first maintainer protocol missing required marker `collaboration branch`")
+        }));
+        assert!(issues.iter().any(|issue| {
+            issue.message.contains(
+                "agent contributor guide missing required marker `docs/contributor-first-maintenance.md`",
+            )
+        }));
+        assert!(issues.iter().any(|issue| {
+            issue
+                .message
+                .contains("pull request template missing required marker `Open PR queue checked before edits`")
+        }));
+        assert!(issues.iter().any(|issue| {
+            issue.message.contains(
+                "maintainer change notice issue template missing required marker `Contributor impact and repair path`",
+            )
         }));
 
         let _ = fs::remove_dir_all(root);

--- a/docs/contributor-first-maintenance.md
+++ b/docs/contributor-first-maintenance.md
@@ -1,0 +1,92 @@
+# Contributor-First Maintainer Protocol
+
+Maintainer work should not surprise active contributors. Before a non-trivial
+maintainer change lands, contributors and autonomous agents should be able to
+see what is planned, whether their open PR is affected, and what repair path is
+available if the contract changes.
+
+This protocol applies to maintainer-owned changes that can affect public
+contracts, contributor workflows, API/MCP/CLI/SDK behavior, GitHub automation,
+payment/risk rules, deployment, docs contracts, or bounty verification. Tiny
+typos and urgent incident response can be handled directly, but the maintainer
+should still leave a public note as soon as practical when active contributors
+could be affected.
+
+## Required Order
+
+1. Check the local repo and current main status.
+2. Inspect the open PR queue before starting code edits.
+3. Give active collaborator PRs attention first.
+4. Publish a public maintainer notice.
+5. Implement the change on a branch.
+6. Link the notice from the PR and summarize open PR impact.
+
+## Open PR Queue Check
+
+Before editing files, inspect every open PR for:
+
+- latest update time,
+- review decision,
+- mergeability,
+- status checks,
+- whether the proposed maintainer change will alter a contract the PR relies on.
+
+If a PR has new contributor activity, failing checks that need maintainer help,
+or a small main-ready fix, handle that before starting the new maintainer
+change. If a PR is already waiting on contributor changes, note that in the
+maintainer notice instead of leaving the status implicit.
+
+When a planned change is likely to invalidate an open PR, comment on that PR or
+include it in the public notice with a concrete repair path. Useful but
+not-main-ready work should still be eligible for a collaboration branch when the
+security rules allow it.
+
+## Public Maintainer Notice
+
+Publish the notice before code edits. Use
+`.github/ISSUE_TEMPLATE/maintainer-change-notice.yml` unless an existing public
+issue is clearly the better place.
+
+The notice must include:
+
+- planned scope,
+- why the change is needed,
+- likely affected files, contracts, or workflows,
+- open PR queue status,
+- expected impact on active PRs,
+- repair or migration path if contributors may need to rework,
+- whether collaboration branches are recommended,
+- a distribution feedback request asking how contributors or agents found the
+  project and what made them participate.
+
+The notice is not approval for a bounty, merge, payout, escrow release, or
+payment settlement.
+
+## PR Body Requirements
+
+Maintainer PRs for non-trivial changes should link the public notice and state:
+
+- open PRs checked,
+- affected PRs or "none known",
+- compatibility risk,
+- migration or repair path,
+- commands run.
+
+If the change intentionally invalidates older docs, examples, routes, templates,
+or SDK calls, the PR must explain the new source of truth and provide the first
+command contributors should run.
+
+## Distribution Feedback Request
+
+Every public maintainer notice should include this Distribution feedback request:
+
+- How did you find Agent Bounties?
+- What made this bounty or project worth participating in?
+- Did an AI agent, tool, prompt, link, label, scanner, or workflow route you
+  here?
+- What would make participation easier or more trustworthy?
+
+When appropriate, also ask readers to star the repo, react to useful bounties,
+and share the project with other agent builders or bounty solvers. This helps
+the network learn which surfaces attract useful contributors without mixing
+distribution feedback with review approval or payment authorization.

--- a/docs/secure-pr-review.md
+++ b/docs/secure-pr-review.md
@@ -3,6 +3,13 @@
 External PRs are untrusted input. Do not approve a gated Actions run until the
 changed files and static contracts have been reviewed.
 
+Before starting non-trivial maintainer changes, follow
+[Contributor-First Maintainer Protocol](contributor-first-maintenance.md):
+inspect the open PR queue, give active collaborator PRs attention first, and
+publish a public maintainer notice describing the planned change and expected
+open PR impact. This prevents maintainer work from silently invalidating
+contributor branches.
+
 ## Intake Command
 
 Run the trusted checker from a clean maintainer checkout:


### PR DESCRIPTION
## Summary
- adds `docs/contributor-first-maintenance.md`, a public protocol for checking open PRs and posting a maintainer notice before non-trivial maintainer changes
- adds a GitHub issue template for maintainer change notices
- updates `AGENTS.md`, the PR template, and secure PR review docs to require the contributor-first flow
- extends `docs-contract-check` with enforced markers and a unit test so the protocol artifacts cannot silently disappear

## Maintainer Change Notice
- Notice issue/comment: #72
- Open PR queue checked before edits: #63, #37, and #24 were inspected before code edits; all are mergeable and still `CHANGES_REQUESTED`, with no newer contributor updates after existing review feedback.
- Active PR impact or repair path: none known; this is a process/docs/template change and does not alter API/MCP/SDK/payment contracts.
- Collaboration branch impact, if any: none required.

## Verification
- `cargo test -p cli contributor_first_protocol_contract_reports_missing_artifacts`
- `cargo test -p cli`
- `cargo run -p cli -- docs-contract-check`
- `./scripts/check.ps1`