### PR TITLE
Add worker image to container gates

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -11,7 +11,9 @@ on:
       - "docker-compose.production.yml"
       - "docs/deployment.md"
       - "migrations/**"
+      - "scripts/check-containers.ps1"
       - "scripts/check-containers.sh"
+      - "scripts/check-production-compose.ps1"
       - "scripts/check-production-compose.sh"
       - "scripts/check-production-smoke.sh"
   push:
@@ -25,7 +27,9 @@ on:
       - "docker-compose.production.yml"
       - "docs/deployment.md"
       - "migrations/**"
+      - "scripts/check-containers.ps1"
       - "scripts/check-containers.sh"
+      - "scripts/check-production-compose.ps1"
       - "scripts/check-production-compose.sh"
       - "scripts/check-production-smoke.sh"
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ bash scripts/check-postgres.sh
 ```
 
 For container packaging and deployment, see [docs/deployment.md](docs/deployment.md).
-The optional container gate builds separate API and MCP images from the same
-Dockerfile:
+The optional container gate builds separate API, MCP, and Base indexer worker
+images from the same Dockerfile:
 
 ```powershell
 .\scripts\check-containers.ps1
@@ -501,9 +501,11 @@ The separate `Real Funding Rehearsal` workflow publishes the validated
 `funding-rehearsal-demo.json` and `real-funding-readiness.json` artifacts on
 manual runs, scheduled runs, and payment-path changes.
 The separate `Containers` workflow runs `scripts/check-production-compose.sh`
-when production packaging files change or when manually dispatched.
-The optional `scripts/check-containers.*` gate builds production API and MCP
-images and is separate for the same reason.
+when production packaging files change or when manually dispatched. That gate
+validates and builds the optional Base indexer worker service before starting
+the API/MCP/Postgres smoke topology.
+The optional `scripts/check-containers.*` gate builds production API, MCP, and
+worker images and is separate for the same reason.
 The optional `scripts/check-production-compose.*` gate runs the production
 API/MCP/Postgres topology locally and executes the read-only production smoke
 against the temporary stack.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,14 +1,14 @@
 # Deployment
 
 The production package is one Dockerfile with build arguments for the service
-binary. API and MCP containers use the same image recipe and differ only by
-`APP_PACKAGE`, `APP_BINARY`, bind address, and public URL configuration.
+binary. API, MCP, and worker containers use the same image recipe and differ by
+`APP_PACKAGE`, `APP_BINARY`, bind address, and service-specific configuration.
 Rust and Cargo 1.88 or newer are required for local builds because the locked
 dependency graph includes crates with that minimum supported Rust version.
 
 ## Container Images
 
-Build both images locally:
+Build the deployable API, MCP, and Base indexer worker images locally:
 
 ```powershell
 .\scripts\check-containers.ps1
@@ -44,8 +44,9 @@ docker compose --env-file .env -f docker-compose.production.yml up -d --build
 ```
 
 To rehearse the production compose topology locally without leaving containers
-running, use the compose smoke. It binds API/MCP to high local ports, runs the
-read-only production smoke, and tears the stack down:
+running, use the compose smoke. It validates and builds the optional
+`base-indexer` profile, binds API/MCP to high local ports, runs the read-only
+production smoke, and tears the stack down:
 
 ```powershell
 .\scripts\check-production-compose.ps1

--- a/docs/development-methodology.md
+++ b/docs/development-methodology.md
@@ -109,7 +109,8 @@ has persisted at least one eval run.
 
 `scripts/check-production-compose.ps1` and
 `scripts/check-production-compose.sh` are the local production-container gate.
-They build the production API/MCP/Postgres compose topology, run the read-only
-production smoke against high local ports, and tear the stack down. The separate
-GitHub Actions `Containers` workflow runs this gate for production packaging
-changes and on manual dispatch.
+They validate and build the optional Base indexer worker service, build the
+production API/MCP/Postgres compose topology, run the read-only production smoke
+against high local ports, and tear the stack down. The separate GitHub Actions
+`Containers` workflow runs this gate for production packaging changes and on
+manual dispatch.

--- a/scripts/check-containers.ps1
+++ b/scripts/check-containers.ps1
@@ -1,6 +1,7 @@
 param(
     [string] $ApiImage = "agent-bounties-api:local",
-    [string] $McpImage = "agent-bounties-mcp:local"
+    [string] $McpImage = "agent-bounties-mcp:local",
+    [string] $WorkerImage = "agent-bounties-worker:local"
 )
 
 $ErrorActionPreference = "Stop"
@@ -36,6 +37,13 @@ try {
             --build-arg APP_PACKAGE=mcp-server `
             --build-arg APP_BINARY=mcp-server `
             -t $McpImage `
+            .
+    }
+    Invoke-Checked {
+        docker build `
+            --build-arg APP_PACKAGE=worker `
+            --build-arg APP_BINARY=worker `
+            -t $WorkerImage `
             .
     }
 } finally {

--- a/scripts/check-containers.sh
+++ b/scripts/check-containers.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 api_image="${API_IMAGE:-agent-bounties-api:local}"
 mcp_image="${MCP_IMAGE:-agent-bounties-mcp:local}"
+worker_image="${WORKER_IMAGE:-agent-bounties-worker:local}"
 
 if ! docker version >/dev/null 2>&1 && command -v docker.exe >/dev/null 2>&1; then
   docker() { docker.exe "$@"; }
@@ -19,4 +20,9 @@ docker build \
   --build-arg APP_PACKAGE=mcp-server \
   --build-arg APP_BINARY=mcp-server \
   -t "$mcp_image" \
+  .
+docker build \
+  --build-arg APP_PACKAGE=worker \
+  --build-arg APP_BINARY=worker \
+  -t "$worker_image" \
   .

--- a/scripts/check-production-compose.ps1
+++ b/scripts/check-production-compose.ps1
@@ -57,8 +57,11 @@ $composeArgs = @(
     "-p", $ProjectName,
     "-f", "docker-compose.production.yml"
 )
+$baseIndexerComposeArgs = $composeArgs + @("--profile", "base-indexer")
 
 try {
+    Invoke-Checked { docker compose @baseIndexerComposeArgs config | Out-Null }
+    Invoke-Checked { docker compose @baseIndexerComposeArgs build base-indexer }
     Invoke-Checked { docker compose @composeArgs up -d --build }
     Wait-HttpOk "http://127.0.0.1:$ApiPort/health"
     Wait-HttpOk "http://127.0.0.1:$McpPort/health"

--- a/scripts/check-production-compose.sh
+++ b/scripts/check-production-compose.sh
@@ -48,6 +48,7 @@ grep -v -E '^(API_PORT|MCP_PORT|PUBLIC_BASE_URL|MCP_BASE_URL)=' "$env_file" > "$
   echo "MCP_BASE_URL=http://127.0.0.1:$mcp_port"
 } >> "$runtime_env_file"
 compose_args=(--env-file "$runtime_env_file" -p "$project_name" -f docker-compose.production.yml)
+base_indexer_compose_args=("${compose_args[@]}" --profile base-indexer)
 
 if ! docker version >/dev/null 2>&1 && command -v docker.exe >/dev/null 2>&1; then
   docker() { docker.exe "$@"; }
@@ -76,6 +77,8 @@ wait_http_ok() {
   return 1
 }
 
+docker compose "${base_indexer_compose_args[@]}" config >/dev/null
+docker compose "${base_indexer_compose_args[@]}" build base-indexer
 docker compose "${compose_args[@]}" up -d --build
 wait_http_ok "http://127.0.0.1:$api_port/health"
 wait_http_ok "http://127.0.0.1:$mcp_port/health"


### PR DESCRIPTION
## Summary

- Adds the deployable `worker` image to `scripts/check-containers.*`.
- Makes `scripts/check-production-compose.*` validate and build the optional `base-indexer` compose profile before starting the API/MCP/Postgres smoke stack.
- Updates container workflow path filters and docs so production packaging changes include the Base indexer worker.

Public maintainer notice: #74

## Verification

- `cargo run -p cli -- docs-contract-check`
- `bash -n scripts/check-containers.sh scripts/check-production-compose.sh`
- `bash scripts/check-production-compose.sh`
- `./scripts/check-containers.ps1`
- `./scripts/check-production-compose.ps1`
- `git diff --check`

## Payment safety

This only changes packaging gates and docs. It does not change bounty settlement state, live Stripe execution, Base transaction broadcasting, escrow reconciliation rules, or API/MCP payment contracts.