### PR TITLE
Add Base indexer heartbeat status

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ available when the Base RPC URL is configured.
 The `worker` binary can run a one-shot or continuous Base USDC indexer against
 Postgres. Set `DATABASE_URL`, `BASE_INDEXER_NETWORK`,
 `BASE_INDEXER_START_BLOCK`, and RPC/escrow contract env vars before running it;
-in production compose, enable the optional `base-indexer` profile.
+in production compose, enable the optional `base-indexer` profile. Each poll
+persists a non-secret worker heartbeat with the last Success, Skipped, or Failed
+outcome so API/MCP status callers can distinguish cursor progress from worker
+freshness.
 
 Hosted API and MCP operator mutation surfaces can require
 `OPERATOR_API_TOKEN`. When set, risk approvals/rejections, Base settlement log

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1,16 +1,16 @@
 use app::{
     build_base_indexer_status_report, build_live_money_readiness_report, hash_artifact,
     stripe_secret_key_mode_from_secret, AddFundingContributionRequest, ApproveRiskBountyRequest,
-    ApproveRiskPayoutRequest, BaseEscrowReconciliation, BaseIndexerScanCursor,
-    BaseIndexerStatusConfig, BaseIndexerStatusReport, BaseReleaseQueueRequest, BountyNetwork,
-    BountyStatusResponse, ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest,
-    FundQuoteRequest, FundingIntentReport, LiveMoneyReadinessConfig, LiveMoneyReadinessReport,
-    OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest,
-    PlanBaseReleaseRequest, PlanStripeTransferRequest as AppPlanStripeTransferRequest,
-    PooledFundingReport, PostBountyRequest, QuoteSet, RegisterAgentRequest,
-    RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
-    ReviewedBountyApproval, RiskEventFilter, StripeTransferPlan, StripeTransferReconciliation,
-    SubmitResultRequest, VerifySubmissionRequest,
+    ApproveRiskPayoutRequest, BaseEscrowReconciliation, BaseIndexerHeartbeatStatus,
+    BaseIndexerScanCursor, BaseIndexerStatusConfig, BaseIndexerStatusReport,
+    BaseReleaseQueueRequest, BountyNetwork, BountyStatusResponse, ClaimBountyRequest,
+    CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport,
+    LiveMoneyReadinessConfig, LiveMoneyReadinessReport, OpenPooledBountyRequest,
+    PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
+    PlanStripeTransferRequest as AppPlanStripeTransferRequest, PooledFundingReport,
+    PostBountyRequest, QuoteSet, RegisterAgentRequest, RegisterCapabilityRequest,
+    RejectRiskEventRequest, RequestQuotesRequest, ReviewedBountyApproval, RiskEventFilter,
+    StripeTransferPlan, StripeTransferReconciliation, SubmitResultRequest, VerifySubmissionRequest,
 };
 use axum::{
     body::Bytes,
@@ -737,12 +737,21 @@ async fn base_indexer_status(
             .map(base_indexer_scan_cursor_from_db),
         _ => None,
     };
+    let heartbeat = match (&state.store, escrow_contract.as_deref()) {
+        (Some(store), Some(escrow_contract)) => store
+            .get_base_indexer_heartbeat(&network, escrow_contract)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .map(base_indexer_heartbeat_from_db),
+        _ => None,
+    };
 
     build_base_indexer_status_report(BaseIndexerStatusConfig {
         network,
         escrow_contract,
         database_configured: state.store.is_some(),
         cursor,
+        heartbeat,
     })
     .map(Json)
     .map_err(|_| StatusCode::BAD_REQUEST)
@@ -755,6 +764,27 @@ fn base_indexer_scan_cursor_from_db(cursor: db::BaseLogScanCursor) -> BaseIndexe
         last_scanned_block: cursor.last_scanned_block,
         last_log_key: cursor.last_log_key,
         updated_at: cursor.updated_at,
+    }
+}
+
+fn base_indexer_heartbeat_from_db(
+    heartbeat: db::BaseIndexerHeartbeat,
+) -> BaseIndexerHeartbeatStatus {
+    BaseIndexerHeartbeatStatus {
+        network: heartbeat.network,
+        escrow_contract: heartbeat.escrow_contract,
+        status: heartbeat.status,
+        started_at: heartbeat.started_at,
+        completed_at: heartbeat.completed_at,
+        latest_block: heartbeat.latest_block,
+        confirmed_to_block: heartbeat.confirmed_to_block,
+        from_block: heartbeat.from_block,
+        to_block: heartbeat.to_block,
+        fetched_logs: heartbeat.fetched_logs,
+        persisted_cursor_block: heartbeat.persisted_cursor_block,
+        skipped_reason: heartbeat.skipped_reason,
+        error_message: heartbeat.error_message,
+        updated_at: heartbeat.updated_at,
     }
 }
 
@@ -4075,6 +4105,9 @@ mod tests {
         assert!(report.escrow_contract_configured);
         assert_eq!(report.network_chain_id, 8_453);
         assert!(report.last_scanned_block.is_none());
+        assert!(!report.heartbeat_found);
+        assert_eq!(report.worker_healthy, None);
+        assert_eq!(report.last_poll_status, None);
         assert!(report.evidence_boundaries.iter().any(|boundary| {
             boundary.contains("does not fund, release, refund, dispute, or authorize settlement")
         }));

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -135,6 +135,7 @@ pub struct BaseIndexerStatusConfig {
     pub escrow_contract: Option<String>,
     pub database_configured: bool,
     pub cursor: Option<BaseIndexerScanCursor>,
+    pub heartbeat: Option<BaseIndexerHeartbeatStatus>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -147,12 +148,32 @@ pub struct BaseIndexerScanCursor {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BaseIndexerHeartbeatStatus {
+    pub network: String,
+    pub escrow_contract: String,
+    pub status: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub latest_block: Option<u64>,
+    pub confirmed_to_block: Option<u64>,
+    pub from_block: Option<u64>,
+    pub to_block: Option<u64>,
+    pub fetched_logs: u64,
+    pub persisted_cursor_block: Option<u64>,
+    pub skipped_reason: Option<String>,
+    pub error_message: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BaseIndexerStatusReport {
     pub status: String,
     pub indexer_ready: bool,
     pub database_configured: bool,
     pub escrow_contract_configured: bool,
     pub cursor_found: bool,
+    pub heartbeat_found: bool,
+    pub worker_healthy: Option<bool>,
     pub network: String,
     pub network_chain_id: u64,
     pub network_rpc_url_env: String,
@@ -160,6 +181,18 @@ pub struct BaseIndexerStatusReport {
     pub last_scanned_block: Option<u64>,
     pub last_log_key: Option<String>,
     pub cursor_updated_at: Option<DateTime<Utc>>,
+    pub last_poll_status: Option<String>,
+    pub last_poll_started_at: Option<DateTime<Utc>>,
+    pub last_poll_completed_at: Option<DateTime<Utc>>,
+    pub last_poll_latest_block: Option<u64>,
+    pub last_poll_confirmed_to_block: Option<u64>,
+    pub last_poll_from_block: Option<u64>,
+    pub last_poll_to_block: Option<u64>,
+    pub last_poll_fetched_logs: Option<u64>,
+    pub last_poll_persisted_cursor_block: Option<u64>,
+    pub last_poll_skipped_reason: Option<String>,
+    pub last_poll_error_message: Option<String>,
+    pub heartbeat_updated_at: Option<DateTime<Utc>>,
     pub warnings: Vec<String>,
     pub evidence_boundaries: Vec<String>,
     pub commands: Vec<String>,
@@ -201,6 +234,23 @@ pub fn build_base_indexer_status_report(
         && escrow_contract_configured
         && cursor_found
         && cursor_matches_request;
+    let heartbeat = config.heartbeat.as_ref();
+    let heartbeat_found = heartbeat.is_some();
+    let heartbeat_matches_request = match (heartbeat, escrow_contract.as_deref()) {
+        (Some(heartbeat), Some(escrow_contract)) => {
+            heartbeat.network == config.network
+                && heartbeat
+                    .escrow_contract
+                    .eq_ignore_ascii_case(escrow_contract)
+        }
+        (Some(_), None) => false,
+        (None, _) => true,
+    };
+    let worker_healthy = heartbeat.and_then(|heartbeat| match heartbeat.status.as_str() {
+        "Success" | "Skipped" => Some(true),
+        "Failed" => Some(false),
+        _ => None,
+    });
     let status = if !config.database_configured {
         "persistence_unavailable"
     } else if !escrow_contract_configured {
@@ -237,6 +287,25 @@ pub fn build_base_indexer_status_report(
                 .to_string(),
         );
     }
+    if config.database_configured && escrow_contract_configured && cursor_found && !heartbeat_found
+    {
+        warnings.push(
+            "No Base indexer heartbeat was found; run the worker to persist the latest poll outcome."
+                .to_string(),
+        );
+    }
+    if !heartbeat_matches_request {
+        warnings.push(
+            "The persisted worker heartbeat does not match the requested network and escrow contract."
+                .to_string(),
+        );
+    }
+    if worker_healthy == Some(false) {
+        warnings.push(
+            "The most recent Base indexer worker poll failed; inspect last_poll_error_message before trusting worker freshness."
+                .to_string(),
+        );
+    }
 
     Ok(BaseIndexerStatusReport {
         status: status.to_string(),
@@ -244,6 +313,8 @@ pub fn build_base_indexer_status_report(
         database_configured: config.database_configured,
         escrow_contract_configured,
         cursor_found,
+        heartbeat_found,
+        worker_healthy,
         network: network_descriptor.name,
         network_chain_id: network_descriptor.chain_id,
         network_rpc_url_env: network_descriptor.rpc_url_env,
@@ -251,11 +322,24 @@ pub fn build_base_indexer_status_report(
         last_scanned_block: cursor.map(|cursor| cursor.last_scanned_block),
         last_log_key: cursor.and_then(|cursor| cursor.last_log_key.clone()),
         cursor_updated_at: cursor.map(|cursor| cursor.updated_at),
+        last_poll_status: heartbeat.map(|heartbeat| heartbeat.status.clone()),
+        last_poll_started_at: heartbeat.map(|heartbeat| heartbeat.started_at),
+        last_poll_completed_at: heartbeat.and_then(|heartbeat| heartbeat.completed_at),
+        last_poll_latest_block: heartbeat.and_then(|heartbeat| heartbeat.latest_block),
+        last_poll_confirmed_to_block: heartbeat.and_then(|heartbeat| heartbeat.confirmed_to_block),
+        last_poll_from_block: heartbeat.and_then(|heartbeat| heartbeat.from_block),
+        last_poll_to_block: heartbeat.and_then(|heartbeat| heartbeat.to_block),
+        last_poll_fetched_logs: heartbeat.map(|heartbeat| heartbeat.fetched_logs),
+        last_poll_persisted_cursor_block: heartbeat
+            .and_then(|heartbeat| heartbeat.persisted_cursor_block),
+        last_poll_skipped_reason: heartbeat.and_then(|heartbeat| heartbeat.skipped_reason.clone()),
+        last_poll_error_message: heartbeat.and_then(|heartbeat| heartbeat.error_message.clone()),
+        heartbeat_updated_at: heartbeat.map(|heartbeat| heartbeat.updated_at),
         warnings,
         evidence_boundaries: vec![
             "Indexer status is operational evidence only; it does not fund, release, refund, dispute, or authorize settlement.".to_string(),
             "Base USDC state changes still require decoded escrow logs to be reconciled into platform state.".to_string(),
-            "A cursor proves the worker persisted scan progress for this contract; it does not prove the worker is currently running.".to_string(),
+            "A cursor proves the worker persisted scan progress for this contract; heartbeat proves only the last recorded poll outcome, not current liveness.".to_string(),
         ],
         commands: vec![
             "cargo run -p worker -- --once".to_string(),
@@ -4246,6 +4330,7 @@ mod tests {
             escrow_contract: Some("0x1111111111111111111111111111111111111111".to_string()),
             database_configured: false,
             cursor: None,
+            heartbeat: None,
         })
         .unwrap();
 
@@ -4254,6 +4339,7 @@ mod tests {
         assert!(!report.database_configured);
         assert!(report.escrow_contract_configured);
         assert!(!report.cursor_found);
+        assert!(!report.heartbeat_found);
         assert_eq!(report.network_chain_id, 8_453);
         assert!(report
             .warnings
@@ -4267,6 +4353,7 @@ mod tests {
     #[test]
     fn base_indexer_status_reports_matching_cursor() {
         let updated_at = Utc::now();
+        let heartbeat_at = Utc::now();
         let report = build_base_indexer_status_report(BaseIndexerStatusConfig {
             network: "base-sepolia".to_string(),
             escrow_contract: Some("0x1111111111111111111111111111111111111111".to_string()),
@@ -4278,6 +4365,22 @@ mod tests {
                 last_log_key: Some("0xabc:0".to_string()),
                 updated_at,
             }),
+            heartbeat: Some(BaseIndexerHeartbeatStatus {
+                network: "base-sepolia".to_string(),
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                status: "Success".to_string(),
+                started_at: heartbeat_at,
+                completed_at: Some(heartbeat_at),
+                latest_block: Some(12_360),
+                confirmed_to_block: Some(12_358),
+                from_block: Some(12_345),
+                to_block: Some(12_358),
+                fetched_logs: 3,
+                persisted_cursor_block: Some(12_358),
+                skipped_reason: None,
+                error_message: None,
+                updated_at: heartbeat_at,
+            }),
         })
         .unwrap();
 
@@ -4285,11 +4388,61 @@ mod tests {
         assert!(report.indexer_ready);
         assert!(report.database_configured);
         assert!(report.cursor_found);
+        assert!(report.heartbeat_found);
+        assert_eq!(report.worker_healthy, Some(true));
         assert_eq!(report.network_chain_id, 84_532);
         assert_eq!(report.last_scanned_block, Some(12_345));
         assert_eq!(report.last_log_key.as_deref(), Some("0xabc:0"));
         assert_eq!(report.cursor_updated_at, Some(updated_at));
+        assert_eq!(report.last_poll_status.as_deref(), Some("Success"));
+        assert_eq!(report.last_poll_fetched_logs, Some(3));
+        assert_eq!(report.heartbeat_updated_at, Some(heartbeat_at));
         assert!(report.warnings.is_empty());
+    }
+
+    #[test]
+    fn base_indexer_status_warns_on_failed_heartbeat() {
+        let updated_at = Utc::now();
+        let report = build_base_indexer_status_report(BaseIndexerStatusConfig {
+            network: "base-sepolia".to_string(),
+            escrow_contract: Some("0x1111111111111111111111111111111111111111".to_string()),
+            database_configured: true,
+            cursor: Some(BaseIndexerScanCursor {
+                network: "base-sepolia".to_string(),
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                last_scanned_block: 12_345,
+                last_log_key: Some("0xabc:0".to_string()),
+                updated_at,
+            }),
+            heartbeat: Some(BaseIndexerHeartbeatStatus {
+                network: "base-sepolia".to_string(),
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                status: "Failed".to_string(),
+                started_at: updated_at,
+                completed_at: Some(updated_at),
+                latest_block: None,
+                confirmed_to_block: None,
+                from_block: None,
+                to_block: None,
+                fetched_logs: 0,
+                persisted_cursor_block: None,
+                skipped_reason: None,
+                error_message: Some("rpc timeout".to_string()),
+                updated_at,
+            }),
+        })
+        .unwrap();
+
+        assert_eq!(report.status, "cursor_persisted");
+        assert_eq!(report.worker_healthy, Some(false));
+        assert_eq!(
+            report.last_poll_error_message.as_deref(),
+            Some("rpc timeout")
+        );
+        assert!(report
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("most recent Base indexer worker poll failed")));
     }
 
     fn fund_base_bounty(

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -62,6 +62,24 @@ pub struct BaseLogScanCursor {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseIndexerHeartbeat {
+    pub network: String,
+    pub escrow_contract: String,
+    pub status: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub latest_block: Option<u64>,
+    pub confirmed_to_block: Option<u64>,
+    pub from_block: Option<u64>,
+    pub to_block: Option<u64>,
+    pub fetched_logs: u64,
+    pub persisted_cursor_block: Option<u64>,
+    pub skipped_reason: Option<String>,
+    pub error_message: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Default)]
 pub struct InMemoryStore {
     pub agents: HashMap<Id, Agent>,
@@ -753,6 +771,94 @@ impl PostgresStore {
         .bind(normalize_key_address(escrow_contract))
         .bind(i64_from_u64(last_scanned_block)?)
         .bind(last_log_key)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_base_indexer_heartbeat(
+        &self,
+        network: &str,
+        escrow_contract: &str,
+    ) -> DbResult<Option<BaseIndexerHeartbeat>> {
+        let row = sqlx::query(
+            r#"
+            SELECT network, escrow_contract, status, started_at, completed_at,
+                   latest_block, confirmed_to_block, from_block, to_block,
+                   fetched_logs, persisted_cursor_block, skipped_reason,
+                   error_message, updated_at
+            FROM base_indexer_heartbeats
+            WHERE network = $1 AND escrow_contract = $2
+            "#,
+        )
+        .bind(network)
+        .bind(normalize_key_address(escrow_contract))
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(|row| {
+            Ok(BaseIndexerHeartbeat {
+                network: row.try_get("network")?,
+                escrow_contract: row.try_get("escrow_contract")?,
+                status: row.try_get("status")?,
+                started_at: row.try_get("started_at")?,
+                completed_at: row.try_get("completed_at")?,
+                latest_block: optional_u64_from_i64(row.try_get("latest_block")?)?,
+                confirmed_to_block: optional_u64_from_i64(row.try_get("confirmed_to_block")?)?,
+                from_block: optional_u64_from_i64(row.try_get("from_block")?)?,
+                to_block: optional_u64_from_i64(row.try_get("to_block")?)?,
+                fetched_logs: u64_from_i64(row.try_get("fetched_logs")?)?,
+                persisted_cursor_block: optional_u64_from_i64(
+                    row.try_get("persisted_cursor_block")?,
+                )?,
+                skipped_reason: row.try_get("skipped_reason")?,
+                error_message: row.try_get("error_message")?,
+                updated_at: row.try_get("updated_at")?,
+            })
+        })
+        .transpose()
+    }
+
+    pub async fn upsert_base_indexer_heartbeat(
+        &self,
+        heartbeat: &BaseIndexerHeartbeat,
+    ) -> DbResult<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO base_indexer_heartbeats
+              (network, escrow_contract, status, started_at, completed_at,
+               latest_block, confirmed_to_block, from_block, to_block,
+               fetched_logs, persisted_cursor_block, skipped_reason,
+               error_message, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, now())
+            ON CONFLICT (network, escrow_contract) DO UPDATE SET
+              status = EXCLUDED.status,
+              started_at = EXCLUDED.started_at,
+              completed_at = EXCLUDED.completed_at,
+              latest_block = EXCLUDED.latest_block,
+              confirmed_to_block = EXCLUDED.confirmed_to_block,
+              from_block = EXCLUDED.from_block,
+              to_block = EXCLUDED.to_block,
+              fetched_logs = EXCLUDED.fetched_logs,
+              persisted_cursor_block = EXCLUDED.persisted_cursor_block,
+              skipped_reason = EXCLUDED.skipped_reason,
+              error_message = EXCLUDED.error_message,
+              updated_at = now()
+            "#,
+        )
+        .bind(&heartbeat.network)
+        .bind(normalize_key_address(&heartbeat.escrow_contract))
+        .bind(&heartbeat.status)
+        .bind(heartbeat.started_at)
+        .bind(heartbeat.completed_at)
+        .bind(optional_i64_from_u64(heartbeat.latest_block)?)
+        .bind(optional_i64_from_u64(heartbeat.confirmed_to_block)?)
+        .bind(optional_i64_from_u64(heartbeat.from_block)?)
+        .bind(optional_i64_from_u64(heartbeat.to_block)?)
+        .bind(i64_from_u64(heartbeat.fetched_logs)?)
+        .bind(optional_i64_from_u64(heartbeat.persisted_cursor_block)?)
+        .bind(&heartbeat.skipped_reason)
+        .bind(&heartbeat.error_message)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -1482,6 +1588,14 @@ fn u64_from_i64(value: i64) -> DbResult<u64> {
     u64::try_from(value).map_err(|_| DbError::IntegerOverflow(value.to_string()))
 }
 
+fn optional_i64_from_u64(value: Option<u64>) -> DbResult<Option<i64>> {
+    value.map(i64_from_u64).transpose()
+}
+
+fn optional_u64_from_i64(value: Option<i64>) -> DbResult<Option<u64>> {
+    value.map(u64_from_i64).transpose()
+}
+
 fn normalize_key_address(address: &str) -> String {
     address.trim().to_ascii_lowercase()
 }
@@ -1583,6 +1697,7 @@ mod tests {
             "ledger_entries",
             "payment_events",
             "eval_runs",
+            "base_indexer_heartbeats",
         ] {
             assert!(CORE_MIGRATION.contains(table), "missing {table}");
         }

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -1,12 +1,13 @@
 use app::{
     build_base_indexer_status_report, build_live_money_readiness_report,
     stripe_secret_key_mode_from_secret, AddFundingContributionRequest, ApproveRiskBountyRequest,
-    ApproveRiskPayoutRequest, BaseIndexerScanCursor, BaseIndexerStatusConfig,
-    BaseReleaseQueueRequest, BountyNetwork, ClaimBountyRequest, CreateFundingIntentRequest,
-    CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport, LiveMoneyReadinessConfig,
-    OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest,
-    PlanBaseReleaseRequest, PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest,
-    RegisterAgentRequest, RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
+    ApproveRiskPayoutRequest, BaseIndexerHeartbeatStatus, BaseIndexerScanCursor,
+    BaseIndexerStatusConfig, BaseReleaseQueueRequest, BountyNetwork, ClaimBountyRequest,
+    CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport,
+    LiveMoneyReadinessConfig, OpenPooledBountyRequest, PlanBaseDisputeRequest,
+    PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
+    PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest, RegisterAgentRequest,
+    RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
     ReviewedBountyApproval, RiskEventFilter, SubmitResultRequest, VerifySubmissionRequest,
 };
 use axum::{
@@ -2756,12 +2757,25 @@ async fn get_base_indexer_status(
         }
         _ => None,
     };
+    let heartbeat = match (&state.store, escrow_contract.as_deref()) {
+        (Some(store), Some(escrow_contract)) => {
+            match store
+                .get_base_indexer_heartbeat(&network, escrow_contract)
+                .await
+            {
+                Ok(heartbeat) => heartbeat.map(base_indexer_heartbeat_from_db),
+                Err(error) => return mcp_error(error.to_string()),
+            }
+        }
+        _ => None,
+    };
 
     match build_base_indexer_status_report(BaseIndexerStatusConfig {
         network,
         escrow_contract,
         database_configured: state.store.is_some(),
         cursor,
+        heartbeat,
     }) {
         Ok(report) => mcp_json(report),
         Err(error) => mcp_error(error.to_string()),
@@ -2775,6 +2789,27 @@ fn base_indexer_scan_cursor_from_db(cursor: db::BaseLogScanCursor) -> BaseIndexe
         last_scanned_block: cursor.last_scanned_block,
         last_log_key: cursor.last_log_key,
         updated_at: cursor.updated_at,
+    }
+}
+
+fn base_indexer_heartbeat_from_db(
+    heartbeat: db::BaseIndexerHeartbeat,
+) -> BaseIndexerHeartbeatStatus {
+    BaseIndexerHeartbeatStatus {
+        network: heartbeat.network,
+        escrow_contract: heartbeat.escrow_contract,
+        status: heartbeat.status,
+        started_at: heartbeat.started_at,
+        completed_at: heartbeat.completed_at,
+        latest_block: heartbeat.latest_block,
+        confirmed_to_block: heartbeat.confirmed_to_block,
+        from_block: heartbeat.from_block,
+        to_block: heartbeat.to_block,
+        fetched_logs: heartbeat.fetched_logs,
+        persisted_cursor_block: heartbeat.persisted_cursor_block,
+        skipped_reason: heartbeat.skipped_reason,
+        error_message: heartbeat.error_message,
+        updated_at: heartbeat.updated_at,
     }
 }
 
@@ -3615,6 +3650,9 @@ mod tests {
         assert_eq!(body["database_configured"], false);
         assert_eq!(body["network_chain_id"], 8_453);
         assert_eq!(body["last_scanned_block"], serde_json::Value::Null);
+        assert_eq!(body["heartbeat_found"], false);
+        assert_eq!(body["worker_healthy"], serde_json::Value::Null);
+        assert_eq!(body["last_poll_status"], serde_json::Value::Null);
         assert!(body["evidence_boundaries"]
             .as_array()
             .unwrap()

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 app = { path = "../app" }
 async-trait.workspace = true
 chain-base = { path = "../chain-base" }
+chrono.workspace = true
 db = { path = "../db" }
 domain = { path = "../domain" }
 ledger = { path = "../ledger" }
@@ -20,4 +21,3 @@ tokio.workspace = true
 verifier-sdk = { path = "../verifier-sdk" }
 
 [dev-dependencies]
-chrono.workspace = true

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -5,7 +5,8 @@ use chain_base::{
     BaseEscrowEvent, BaseEscrowEventKind, BaseEscrowLogDecoder, BaseEscrowLogQuery,
     BaseNetworkDescriptor, ChainEventIndexer, EvmLog,
 };
-use db::PostgresStore;
+use chrono::{DateTime, Utc};
+use db::{BaseIndexerHeartbeat, PostgresStore};
 use domain::{Id, Submission, VerifierResult};
 use ledger::{Ledger, LedgerEntry};
 use serde::{Deserialize, Serialize};
@@ -344,6 +345,117 @@ pub struct BaseIndexerPollReport {
     pub reconciliation: Option<BaseLogPipelineReport>,
     pub persisted_cursor_block: Option<u64>,
     pub skipped_reason: Option<String>,
+}
+
+pub const BASE_INDEXER_HEARTBEAT_SUCCESS: &str = "Success";
+pub const BASE_INDEXER_HEARTBEAT_SKIPPED: &str = "Skipped";
+pub const BASE_INDEXER_HEARTBEAT_FAILED: &str = "Failed";
+
+pub async fn poll_base_indexer_once_with_heartbeat(
+    store: &PostgresStore,
+    config: &BaseIndexerConfig,
+) -> anyhow::Result<BaseIndexerPollReport> {
+    let started_at = Utc::now();
+    match poll_base_indexer_once(store, config).await {
+        Ok(report) => {
+            let completed_at = Utc::now();
+            let heartbeat =
+                base_indexer_heartbeat_from_report(config, started_at, completed_at, &report);
+            store.upsert_base_indexer_heartbeat(&heartbeat).await?;
+            Ok(report)
+        }
+        Err(error) => {
+            let completed_at = Utc::now();
+            let error_message = error.to_string();
+            let heartbeat = base_indexer_heartbeat_from_error(
+                config,
+                started_at,
+                completed_at,
+                error_message.as_str(),
+            );
+            if let Err(heartbeat_error) = store.upsert_base_indexer_heartbeat(&heartbeat).await {
+                return Err(error).context(format!(
+                    "failed to persist Base indexer failure heartbeat: {heartbeat_error}"
+                ));
+            }
+            Err(error)
+        }
+    }
+}
+
+pub fn base_indexer_heartbeat_from_report(
+    config: &BaseIndexerConfig,
+    started_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+    report: &BaseIndexerPollReport,
+) -> BaseIndexerHeartbeat {
+    let failure_summary = report.reconciliation.as_ref().and_then(|reconciliation| {
+        if reconciliation.failures.is_empty() {
+            None
+        } else {
+            Some(
+                reconciliation
+                    .failures
+                    .iter()
+                    .map(|failure| {
+                        format!(
+                            "{}:{} {}",
+                            failure.block_number, failure.log_index, failure.reason
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            )
+        }
+    });
+    let status = if failure_summary.is_some() {
+        BASE_INDEXER_HEARTBEAT_FAILED
+    } else if report.skipped_reason.is_some() {
+        BASE_INDEXER_HEARTBEAT_SKIPPED
+    } else {
+        BASE_INDEXER_HEARTBEAT_SUCCESS
+    };
+
+    BaseIndexerHeartbeat {
+        network: config.network.clone(),
+        escrow_contract: config.escrow_contract.clone(),
+        status: status.to_string(),
+        started_at,
+        completed_at: Some(completed_at),
+        latest_block: Some(report.latest_block),
+        confirmed_to_block: report.confirmed_to_block,
+        from_block: report.from_block,
+        to_block: report.to_block,
+        fetched_logs: report.fetched_logs as u64,
+        persisted_cursor_block: report.persisted_cursor_block,
+        skipped_reason: report.skipped_reason.clone(),
+        error_message: failure_summary,
+        updated_at: completed_at,
+    }
+}
+
+pub fn base_indexer_heartbeat_from_error(
+    config: &BaseIndexerConfig,
+    started_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+    error_message: &str,
+) -> BaseIndexerHeartbeat {
+    BaseIndexerHeartbeat {
+        network: config.network.clone(),
+        escrow_contract: config.escrow_contract.clone(),
+        status: BASE_INDEXER_HEARTBEAT_FAILED.to_string(),
+        started_at,
+        completed_at: Some(completed_at),
+        latest_block: None,
+        confirmed_to_block: None,
+        from_block: None,
+        to_block: None,
+        fetched_logs: 0,
+        persisted_cursor_block: None,
+        skipped_reason: None,
+        error_message: Some(error_message.to_string()),
+        updated_at: completed_at,
+    }
 }
 
 pub async fn poll_base_indexer_once(
@@ -839,6 +951,85 @@ mod tests {
         assert_eq!(bounded_to_block(100, 500, 50), 149);
         assert_eq!(bounded_to_block(100, 120, 50), 120);
         assert_eq!(bounded_to_block(100, 120, 0), 100);
+    }
+
+    fn test_base_indexer_config() -> BaseIndexerConfig {
+        BaseIndexerConfig {
+            network: "base-sepolia".to_string(),
+            rpc_url: "https://base-sepolia.example".to_string(),
+            escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+            start_block: Some(1),
+            poll_seconds: 15,
+            confirmations: 2,
+            max_blocks_per_query: 2_000,
+            request_id: 1,
+        }
+    }
+
+    #[test]
+    fn base_indexer_heartbeat_marks_skipped_poll() {
+        let config = test_base_indexer_config();
+        let now = Utc::now();
+        let report = BaseIndexerPollReport {
+            network: base_network_descriptor("base-sepolia").unwrap(),
+            escrow_contract: config.escrow_contract.clone(),
+            latest_block: 10,
+            confirmations: 2,
+            confirmed_to_block: Some(8),
+            from_block: Some(9),
+            to_block: None,
+            fetched_logs: 0,
+            reconciliation: None,
+            persisted_cursor_block: Some(8),
+            skipped_reason: Some("no confirmed blocks are ready to scan".to_string()),
+        };
+
+        let heartbeat = base_indexer_heartbeat_from_report(&config, now, now, &report);
+
+        assert_eq!(heartbeat.status, BASE_INDEXER_HEARTBEAT_SKIPPED);
+        assert_eq!(
+            heartbeat.skipped_reason.as_deref(),
+            Some("no confirmed blocks are ready to scan")
+        );
+        assert_eq!(heartbeat.latest_block, Some(10));
+        assert_eq!(heartbeat.persisted_cursor_block, Some(8));
+    }
+
+    #[test]
+    fn base_indexer_heartbeat_marks_reconciliation_failure() {
+        let config = test_base_indexer_config();
+        let now = Utc::now();
+        let report = BaseIndexerPollReport {
+            network: base_network_descriptor("base-sepolia").unwrap(),
+            escrow_contract: config.escrow_contract.clone(),
+            latest_block: 10,
+            confirmations: 2,
+            confirmed_to_block: Some(8),
+            from_block: Some(7),
+            to_block: Some(8),
+            fetched_logs: 1,
+            reconciliation: Some(BaseLogPipelineReport {
+                failures: vec![BaseLogFailure {
+                    block_number: 8,
+                    log_index: 0,
+                    log_key: "0xabc:0".to_string(),
+                    reason: "terminal event before create".to_string(),
+                }],
+                ..BaseLogPipelineReport::default()
+            }),
+            persisted_cursor_block: Some(7),
+            skipped_reason: None,
+        };
+
+        let heartbeat = base_indexer_heartbeat_from_report(&config, now, now, &report);
+
+        assert_eq!(heartbeat.status, BASE_INDEXER_HEARTBEAT_FAILED);
+        assert_eq!(heartbeat.fetched_logs, 1);
+        assert!(heartbeat
+            .error_message
+            .as_deref()
+            .unwrap()
+            .contains("terminal event before create"));
     }
 
     async fn payable_base_bounty() -> (BountyNetwork, Bounty, ProofRecord) {

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use db::PostgresStore;
 use std::{env, time::Duration};
 use tokio::time::sleep;
-use worker::{poll_base_indexer_once, BaseIndexerConfig};
+use worker::{poll_base_indexer_once_with_heartbeat, BaseIndexerConfig};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
     store.migrate().await?;
 
     loop {
-        let report = poll_base_indexer_once(&store, &config).await?;
+        let report = poll_base_indexer_once_with_heartbeat(&store, &config).await?;
         println!("{}", serde_json::to_string(&report)?);
         if once {
             return Ok(());

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -95,10 +95,13 @@ The worker uses `DATABASE_URL`, `BASE_INDEXER_NETWORK`, RPC/escrow contract
 configuration, and `BASE_INDEXER_START_BLOCK` on first run. After it scans a
 range, it persists a Postgres cursor keyed by network and escrow contract, so
 later polls continue from the last confirmed scanned block even when no escrow
-events were found. Money state still changes only when decoded escrow logs are
-persisted. Check `GET /v1/base/indexer-status?network=<network>` or MCP
-`get_base_indexer_status` after startup to confirm the cursor is being written;
-the status response is monitoring evidence, not settlement authorization.
+events were found. Each poll also persists a heartbeat with the last Success,
+Skipped, or Failed outcome, block range, fetched log count, skipped reason, and
+error message when present. Money state still changes only when decoded escrow
+logs are persisted. Check `GET /v1/base/indexer-status?network=<network>` or
+MCP `get_base_indexer_status` after startup to confirm the cursor and heartbeat
+are being written; the status response is monitoring evidence, not settlement
+authorization.
 
 `DATABASE_URL` should point at the compose service hostname, for example
 `postgres://agent_bounties:change-me@postgres:5432/agent_bounties`. If

--- a/docs/live-money-activation.md
+++ b/docs/live-money-activation.md
@@ -91,10 +91,11 @@ curl "$env:MCP_BASE_URL/tools/get_base_indexer_status" `
 ```
 
 These reports intentionally expose only Stripe key mode, configured gates, chain
-metadata, native USDC address, indexer cursor state, warnings, and settlement
-evidence boundaries. They must not expose Stripe secrets, webhook secrets, RPC
-URLs, or operator tokens. Indexer status is monitoring evidence only; it does
-not fund, release, refund, dispute, or authorize settlement.
+metadata, native USDC address, indexer cursor state, last worker heartbeat
+outcome, warnings, and settlement evidence boundaries. They must not expose
+Stripe secrets, webhook secrets, RPC URLs, or operator tokens. Indexer status is
+monitoring evidence only; it does not fund, release, refund, dispute, or
+authorize settlement.
 
 ## Automated Base Indexing
 
@@ -113,10 +114,12 @@ subtracts `BASE_INDEXER_CONFIRMATIONS`, scans up to
 `BASE_INDEXER_MAX_BLOCKS_PER_QUERY` confirmed blocks, applies decoded escrow
 logs through the same deterministic state machine as the API/MCP reconciliation
 endpoints, and persists a Postgres scan cursor. Empty ranges advance the scan
-cursor; failed ranges do not.
+cursor; failed ranges do not. Every poll writes a heartbeat row so operators
+and agents can see the latest Success, Skipped, or Failed poll outcome without
+granting that heartbeat settlement authority.
 Check `GET /v1/base/indexer-status?network=<network>` after startup to confirm
-Postgres persistence is configured and a cursor is being written for the escrow
-contract.
+Postgres persistence is configured and cursor plus heartbeat records are being
+written for the escrow contract.
 
 For a one-shot rehearsal without a long-running container, run:
 

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -266,7 +266,9 @@ that pipeline: it fetches `eth_blockNumber`, waits for a configurable
 confirmation depth, scans bounded block ranges for the configured escrow
 contract, persists a Postgres scan cursor even for empty ranges, and writes
 only decoded escrow evidence into bounty, escrow, settlement, Base event, and
-ledger state.
+ledger state. It also persists a heartbeat for the last poll outcome, including
+Success, Skipped, or Failed status, block range, fetched log count, skipped
+reason, and error message when present.
 
 Run a one-shot local indexer pass after setting `DATABASE_URL`,
 `BASE_INDEXER_NETWORK`, `BASE_INDEXER_START_BLOCK`, and either
@@ -281,8 +283,8 @@ Hosted deployments can run the same binary through the production compose
 `base-indexer` profile. The worker does not sign transactions, broadcast
 transactions, or treat transaction hashes as settlement evidence. API
 `GET /v1/base/indexer-status` and MCP `get_base_indexer_status` expose the
-non-secret persisted cursor for monitoring, but that status is not settlement
-authorization.
+non-secret persisted cursor and heartbeat for monitoring, but that status is
+not settlement authorization.
 
 Generate a local sample plan:
 

--- a/migrations/0001_core.sql
+++ b/migrations/0001_core.sql
@@ -136,6 +136,24 @@ CREATE TABLE IF NOT EXISTS base_log_cursors (
   PRIMARY KEY (network, escrow_contract)
 );
 
+CREATE TABLE IF NOT EXISTS base_indexer_heartbeats (
+  network TEXT NOT NULL,
+  escrow_contract TEXT NOT NULL,
+  status TEXT NOT NULL,
+  started_at TIMESTAMPTZ NOT NULL,
+  completed_at TIMESTAMPTZ,
+  latest_block BIGINT CHECK (latest_block IS NULL OR latest_block >= 0),
+  confirmed_to_block BIGINT CHECK (confirmed_to_block IS NULL OR confirmed_to_block >= 0),
+  from_block BIGINT CHECK (from_block IS NULL OR from_block >= 0),
+  to_block BIGINT CHECK (to_block IS NULL OR to_block >= 0),
+  fetched_logs BIGINT NOT NULL DEFAULT 0 CHECK (fetched_logs >= 0),
+  persisted_cursor_block BIGINT CHECK (persisted_cursor_block IS NULL OR persisted_cursor_block >= 0),
+  skipped_reason TEXT,
+  error_message TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (network, escrow_contract)
+);
+
 CREATE TABLE IF NOT EXISTS claims (
   id UUID PRIMARY KEY,
   bounty_id UUID NOT NULL REFERENCES bounties(id),


### PR DESCRIPTION
## Summary
- Add a durable `base_indexer_heartbeats` Postgres record keyed by Base network and escrow contract.
- Make the Base indexer worker persist the last Success, Skipped, or Failed poll outcome.
- Expose heartbeat fields through `GET /v1/base/indexer-status` and MCP `get_base_indexer_status` without changing settlement authority.
- Update operator docs and deterministic tests.

## Public notice and PR queue
- Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/78
- Open PR queue checked before edits: #63, #37, #24.
- Active PR impact: none known. All three open contributor PRs were already in `CHANGES_REQUESTED` state before this change, and this slice only extends Base indexer status/persistence surfaces.
- Collaboration branch path: not needed for this slice; no contributor PR is being superseded.

## Distribution improvement
Agents and operators can now tell whether hosted Base settlement indexing has a persisted cursor only, or whether the worker has also recently recorded a successful/skipped/failed poll. This makes real-money operations easier to trust without treating monitoring data as payment evidence.

## Payment boundary
Heartbeat status is monitoring evidence only. Bounties still become `Paid`, `Refunded`, or `Disputed` only through decoded and reconciled Base escrow logs.

## Verification
- `scripts/preflight.ps1 -Mode core`
- `cargo fmt --all -- --check`
- `cargo test -p worker -p app -p api -p mcp-server`
- `cargo test -p db`
- `cargo run -p cli -- docs-contract-check`
- `cargo run -p cli -- service-smoke-spawn`