### PR TITLE
Check Base indexer heartbeat in smoke

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3182,20 +3182,7 @@ async fn production_smoke_check(
             .is_some(),
         "Base indexer status must expose an indexer_ready boolean",
     )?;
-    require(
-        base_indexer_status
-            .pointer("/evidence_boundaries")
-            .and_then(|value| value.as_array())
-            .map(|boundaries| {
-                boundaries.iter().any(|boundary| {
-                    boundary
-                        .as_str()
-                        .is_some_and(|text| text.contains("does not fund"))
-                })
-            })
-            .unwrap_or(false),
-        "Base indexer status must state that status evidence is not settlement",
-    )?;
+    require_base_indexer_status_contract(&base_indexer_status, "Base indexer status")?;
 
     let bounty_feed_url =
         value_str(&discovery, "/endpoints/bounty_feed").context("bounty feed url missing")?;
@@ -4062,6 +4049,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             .is_some(),
         "API Base indexer status must expose indexer_ready boolean",
     )?;
+    require_base_indexer_status_contract(&api_base_indexer_status, "API Base indexer status")?;
     let mcp_base_indexer_status = mcp_tool_post(
         mcp,
         "get_base_indexer_status",
@@ -4071,20 +4059,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
         mcp_base_indexer_status.pointer("/network_chain_id") == Some(&serde_json::json!(8_453)),
         "MCP get_base_indexer_status must expose Base mainnet chain id",
     )?;
-    require(
-        mcp_base_indexer_status
-            .pointer("/evidence_boundaries")
-            .and_then(|value| value.as_array())
-            .map(|boundaries| {
-                boundaries.iter().any(|boundary| {
-                    boundary
-                        .as_str()
-                        .is_some_and(|text| text.contains("does not fund"))
-                })
-            })
-            .unwrap_or(false),
-        "MCP get_base_indexer_status must state that status evidence is not settlement",
-    )?;
+    require_base_indexer_status_contract(&mcp_base_indexer_status, "MCP get_base_indexer_status")?;
 
     let mcp_risk_bounty = post_json(
         &format!("{mcp}/tools/post_bounty"),
@@ -6254,6 +6229,70 @@ fn require(condition: bool, message: &str) -> Result<()> {
         bail!("{message}");
     }
     Ok(())
+}
+
+fn require_base_indexer_status_contract(value: &serde_json::Value, context: &str) -> Result<()> {
+    require(
+        value
+            .pointer("/heartbeat_found")
+            .and_then(|field| field.as_bool())
+            .is_some(),
+        &format!("{context} must expose heartbeat_found boolean"),
+    )?;
+    require(
+        value
+            .pointer("/worker_healthy")
+            .is_some_and(|field| field.is_boolean() || field.is_null()),
+        &format!("{context} must expose nullable worker_healthy boolean"),
+    )?;
+    for field in [
+        "/last_poll_status",
+        "/last_poll_started_at",
+        "/last_poll_completed_at",
+        "/last_poll_skipped_reason",
+        "/last_poll_error_message",
+        "/heartbeat_updated_at",
+    ] {
+        require(
+            value
+                .pointer(field)
+                .is_some_and(|field| field.is_string() || field.is_null()),
+            &format!("{context} must expose nullable string field {field}"),
+        )?;
+    }
+    for field in [
+        "/last_poll_latest_block",
+        "/last_poll_confirmed_to_block",
+        "/last_poll_from_block",
+        "/last_poll_to_block",
+        "/last_poll_fetched_logs",
+        "/last_poll_persisted_cursor_block",
+    ] {
+        require(
+            value
+                .pointer(field)
+                .is_some_and(|field| field.as_u64().is_some() || field.is_null()),
+            &format!("{context} must expose nullable numeric field {field}"),
+        )?;
+    }
+    require(
+        value
+            .pointer("/evidence_boundaries")
+            .and_then(|field| field.as_array())
+            .map(|boundaries| {
+                boundaries.iter().any(|boundary| {
+                    boundary
+                        .as_str()
+                        .is_some_and(|text| text.contains("does not fund"))
+                }) && boundaries.iter().any(|boundary| {
+                    boundary.as_str().is_some_and(|text| {
+                        text.contains("heartbeat proves only the last recorded poll outcome")
+                    })
+                })
+            })
+            .unwrap_or(false),
+        &format!("{context} must state cursor and heartbeat status are not settlement"),
+    )
 }
 
 fn require_agent_paid_status(value: &serde_json::Value, message: &str) -> Result<()> {

--- a/crates/sdk-python/agent_bounties/smoke.py
+++ b/crates/sdk-python/agent_bounties/smoke.py
@@ -288,8 +288,50 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
         "Base indexer status did not expose an indexer_ready boolean",
     )
     _require(
+        isinstance(base_indexer_status.get("heartbeat_found"), bool),
+        "Base indexer status did not expose a heartbeat_found boolean",
+    )
+    _require(
+        base_indexer_status.get("worker_healthy") is None
+        or isinstance(base_indexer_status.get("worker_healthy"), bool),
+        "Base indexer status did not expose nullable worker_healthy",
+    )
+    for field in (
+        "last_poll_status",
+        "last_poll_started_at",
+        "last_poll_completed_at",
+        "last_poll_skipped_reason",
+        "last_poll_error_message",
+        "heartbeat_updated_at",
+    ):
+        value = base_indexer_status.get(field)
+        _require(
+            value is None or isinstance(value, str),
+            f"Base indexer status did not expose nullable string field {field}",
+        )
+    for field in (
+        "last_poll_latest_block",
+        "last_poll_confirmed_to_block",
+        "last_poll_from_block",
+        "last_poll_to_block",
+        "last_poll_fetched_logs",
+        "last_poll_persisted_cursor_block",
+    ):
+        value = base_indexer_status.get(field)
+        _require(
+            value is None or type(value) is int,
+            f"Base indexer status did not expose nullable numeric field {field}",
+        )
+    _require(
         any("does not fund" in boundary for boundary in base_indexer_status["evidence_boundaries"]),
         "Base indexer status did not explain that status evidence is not settlement",
+    )
+    _require(
+        any(
+            "heartbeat proves only the last recorded poll outcome" in boundary
+            for boundary in base_indexer_status["evidence_boundaries"]
+        ),
+        "Base indexer status did not explain the heartbeat evidence boundary",
     )
     try:
         client.post_bounty(

--- a/docs/production-smoke.md
+++ b/docs/production-smoke.md
@@ -36,8 +36,8 @@ The gate checks:
 - Discovery fields for Base funding plans and normalized escrow event
   reconciliation, so indexed `EscrowCreated` remains discoverable before claim.
 - Live-money readiness and Base indexer status reporting for Base mainnet USDC
-  and Stripe mode, without exposing secret keys, webhook secrets, RPC URLs, or
-  operator tokens.
+  and Stripe mode, including the indexer's nullable heartbeat fields, without
+  exposing secret keys, webhook secrets, RPC URLs, or operator tokens.
 - MCP tool descriptors, JSON input schemas, and operator auth metadata for
   protected tools.
 - Public bounty, capability, template, and verifier pages.


### PR DESCRIPTION
## Summary
- Tighten hosted `production-smoke` so Base indexer status must expose the new heartbeat fields.
- Apply the same heartbeat response-shape checks to local `service-smoke-spawn` and the Python SDK smoke surface.
- Document that production smoke covers nullable Base indexer heartbeat fields.

## Public notice and PR queue
- Maintainer notice/comment: https://github.com/NSPG13/agent-bounties/issues/78#issuecomment-4918333671
- Open PR queue checked before edits: #63, #37, #24.
- Active PR impact: none known. All open contributor PRs were already `CHANGES_REQUESTED`, and this does not rename API/MCP routes or change settlement behavior.
- Collaboration branch path: not needed for this smoke-gate-only follow-up.

## Distribution improvement
This makes the hosted readiness signal more reliable for autonomous agents and operators: if `/v1/base/indexer-status` or MCP `get_base_indexer_status` drifts and stops exposing worker heartbeat evidence, deploy smoke fails before agents trust stale real-money monitoring surfaces.

## Payment boundary
The new checks explicitly preserve the boundary that cursor and heartbeat status are monitoring evidence only; they cannot authorize funding, release, refund, dispute, or payout settlement.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p cli`
- `python -m py_compile crates\\sdk-python\\agent_bounties\\smoke.py crates\\sdk-python\\agent_bounties\\client.py`
- `cargo run -p cli -- docs-contract-check`
- `cargo build -p api -p mcp-server`
- `cargo run -p cli -- service-smoke-spawn`