### PR TITLE
Add SDK live smoke workflow

### DIFF
--- a/.github/workflows/sdk-live-smoke.yml
+++ b/.github/workflows/sdk-live-smoke.yml
@@ -1,0 +1,71 @@
+name: SDK Live Smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/sdk-live-smoke.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/api/**"
+      - "crates/app/**"
+      - "crates/chain-base/**"
+      - "crates/domain/**"
+      - "crates/github-app/**"
+      - "crates/ledger/**"
+      - "crates/payments-stripe/**"
+      - "crates/risk/**"
+      - "crates/sdk-python/**"
+      - "crates/sdk-typescript/**"
+      - "crates/verifier-sdk/**"
+      - "crates/web-public/**"
+      - "scripts/check-sdk-live.ps1"
+      - "scripts/check-sdk-live.sh"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/sdk-live-smoke.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/api/**"
+      - "crates/app/**"
+      - "crates/chain-base/**"
+      - "crates/domain/**"
+      - "crates/github-app/**"
+      - "crates/ledger/**"
+      - "crates/payments-stripe/**"
+      - "crates/risk/**"
+      - "crates/sdk-python/**"
+      - "crates/sdk-typescript/**"
+      - "crates/verifier-sdk/**"
+      - "crates/web-public/**"
+      - "scripts/check-sdk-live.ps1"
+      - "scripts/check-sdk-live.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-live-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sdk-live-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: crates/sdk-typescript/package-lock.json
+
+      - run: bash scripts/check-sdk-live.sh

--- a/README.md
+++ b/README.md
@@ -522,8 +522,10 @@ worker images and is separate for the same reason.
 The optional `scripts/check-production-compose.*` gate runs the production
 API/MCP/Postgres topology locally and executes the read-only production smoke
 against the temporary stack.
-The optional `scripts/check-sdk-live.*` smoke is separate for the same reason:
-it runs live Python and TypeScript SDK requests against a local API service.
+The separate `SDK Live Smoke` workflow runs `scripts/check-sdk-live.sh` for SDK
+and API public-surface changes. The optional local `scripts/check-sdk-live.*`
+smoke remains available for maintainers because it runs live Python and
+TypeScript SDK requests against a local API service.
 
 If Foundry is not installed globally, place the Windows Foundry binaries in
 `.tools\foundry` or install Foundry through the official `foundryup` flow.

--- a/docs/development-methodology.md
+++ b/docs/development-methodology.md
@@ -99,7 +99,9 @@ adoption gate. They start the API in in-memory mode and run the Python and
 TypeScript SDKs through the same agent bounty lifecycle that external agent
 developers are expected to copy. If `OPERATOR_API_TOKEN` is set, the spawned API
 requires it for hosted mutation surfaces and both SDK smoke clients send it, so
-the same gate covers authenticated operator flows.
+the same gate covers authenticated operator flows. The separate GitHub Actions
+`SDK Live Smoke` workflow runs this gate for SDK and API public-surface changes
+and on manual dispatch.
 
 `scripts/check-production-smoke.ps1` and `scripts/check-production-smoke.sh`
 are the hosted read-only release gate. They run against public API and MCP URLs

--- a/scripts/check-sdk-live.ps1
+++ b/scripts/check-sdk-live.ps1
@@ -28,6 +28,12 @@ if (-not $pythonCommand) {
     throw "python or py is required to run the Python SDK smoke"
 }
 
+& $pythonCommand.Source @pythonArgs -c "import httpx" *> $null
+if ($LASTEXITCODE -ne 0) {
+    Invoke-Checked { & $pythonCommand.Source @pythonArgs -m pip install "httpx>=0.27" }
+}
+$global:LASTEXITCODE = 0
+
 Push-Location $repoRoot
 try {
     Invoke-Checked { cargo build -p api }

--- a/scripts/check-sdk-live.sh
+++ b/scripts/check-sdk-live.sh
@@ -25,6 +25,10 @@ else
   exit 127
 fi
 
+if ! "${python_cmd[@]}" -c "import httpx" >/dev/null 2>&1; then
+  "${python_cmd[@]}" -m pip install "httpx>=0.27"
+fi
+
 cd "$repo_root"
 cargo build -p api
 


### PR DESCRIPTION
## Summary
- Add a path-scoped `SDK Live Smoke` GitHub Actions workflow.
- The workflow runs the existing `scripts/check-sdk-live.sh` gate on SDK and API public-surface changes.
- Update README and development methodology docs to describe the automated SDK runtime gate.

## Public notice and PR queue
- Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/82
- Open PR queue checked before edits: #24.
- Active PR impact: low. #24 is SDK-example related and already `CHANGES_REQUESTED`; this PR does not change SDK client method signatures, example command inputs, API routes, or payment semantics. If #24 is revived, the repair path is to make the SDK examples pass the existing `scripts/check-sdk-live.*` gate.
- Collaboration branch path: not needed for this maintainer slice.

## Distribution improvement
This makes SDK runtime confidence visible on GitHub before merge. Agent builders copying the Python or TypeScript SDK examples get a stronger signal that discovery, routing, funding, claiming, verification, and payout-status flows still work against a real local API process.

## Payment boundary
This workflow uses local in-memory/simulated flows only. It does not execute live Stripe, broadcast Base transactions, reconcile chain logs, approve bounty acceptance, or authorize payout settlement.

## Verification
- `cargo fmt --all -- --check`
- `cargo run -p cli -- docs-contract-check`
- `git diff --check`
- `scripts/check-sdk-live.ps1`
- `bash scripts/check-sdk-live.sh` was attempted locally, but correctly refused this Windows/WSL-mixed toolchain because the script requires a native Unix API binary; the GitHub workflow runs it on Ubuntu.