### PR TITLE
Expose Stripe method configuration readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,9 +463,12 @@ card, credit card, wallet, or PayPal where the hosted Stripe account and
 Dashboard configuration support those methods.
 
 Agents and operators should check them before posting or funding bounties that
-expect live Stripe fiat or Base mainnet USDC movement. Indexer status is
-monitoring evidence only; settlement still requires decoded escrow logs to
-reconcile into platform state.
+expect live Stripe fiat or Base mainnet USDC movement. The live-money readiness
+response includes only whether an optional Stripe Payment Method Configuration
+is configured, not the Stripe object id, so PayPal-capable Checkout setup can be
+checked without leaking Stripe configuration. Indexer status is monitoring
+evidence only; settlement still requires decoded escrow logs to reconcile into
+platform state.
 
 `service-smoke-spawn` starts the compiled API and MCP binaries on local
 high-numbered ports, checks health/discovery/tool listing, posts a Base public

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -831,6 +831,10 @@ fn live_money_readiness_config(state: &SharedState, network: &str) -> LiveMoneyR
             state.stripe_secret_key.as_deref(),
         ),
         stripe_live_execution_enabled: state.stripe_live_execution_enabled,
+        stripe_payment_method_configuration_configured: state
+            .stripe_payment_method_configuration
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
         stripe_webhook_secret_configured: state.stripe_webhook_secret.is_some(),
         allow_unsigned_stripe_webhooks: state.allow_unsigned_stripe_webhooks,
         operator_auth_configured: state.operator_api_token.is_some(),
@@ -4267,12 +4271,46 @@ mod tests {
         assert_eq!(report.network, "Base");
         assert_eq!(report.network_chain_id, 8_453);
         assert_eq!(report.stripe_secret_key_mode, "unset");
+        assert!(!report.stripe_payment_method_configuration_configured);
         assert_eq!(report.supplied_usdc_token_matches_native, Some(true));
         assert!(!report.live_money_ready);
         assert!(report
             .checks
             .iter()
             .any(|check| check.name == "Stripe live-money execution gate"));
+        assert!(report
+            .checks
+            .iter()
+            .any(|check| check.name == "Stripe Checkout payment-method configuration"));
+        assert!(!serde_json::to_string(&report)
+            .unwrap()
+            .contains("pmc_paypal_enabled"));
+    }
+
+    #[tokio::test]
+    async fn live_money_readiness_endpoint_reports_payment_method_configuration_without_id() {
+        let state = test_state_with_stripe_payment_method_configuration(
+            BountyNetwork::default(),
+            "pmc_paypal_enabled",
+        );
+        let report = live_money_readiness(
+            State(state),
+            Query(LiveMoneyReadinessQuery {
+                network: Some("base-mainnet".to_string()),
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        let json = serde_json::to_string(&report).unwrap();
+
+        assert!(report.stripe_payment_method_configuration_configured);
+        assert!(report.checks.iter().any(|check| {
+            check.name == "Stripe Checkout payment-method configuration"
+                && check.configured
+                && check.env_vars == vec!["STRIPE_PAYMENT_METHOD_CONFIGURATION".to_string()]
+        }));
+        assert!(!json.contains("pmc_paypal_enabled"));
     }
 
     #[tokio::test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -90,6 +90,7 @@ pub struct LiveMoneyReadinessConfig {
     pub usdc_token: Option<String>,
     pub stripe_secret_key_mode: String,
     pub stripe_live_execution_enabled: bool,
+    pub stripe_payment_method_configuration_configured: bool,
     pub stripe_webhook_secret_configured: bool,
     pub allow_unsigned_stripe_webhooks: bool,
     pub operator_auth_configured: bool,
@@ -122,6 +123,7 @@ pub struct LiveMoneyReadinessReport {
     pub network_rpc_url_env: String,
     pub network_native_usdc_token_address: String,
     pub stripe_secret_key_mode: String,
+    pub stripe_payment_method_configuration_configured: bool,
     pub supplied_usdc_token_matches_native: Option<bool>,
     pub checks: Vec<LiveMoneyReadinessCheck>,
     pub evidence_boundaries: Vec<String>,
@@ -422,6 +424,17 @@ pub fn build_live_money_readiness_report(
             },
         ),
         readiness_check(
+            "Stripe Checkout payment-method configuration",
+            config.stripe_payment_method_configuration_configured,
+            "optional Dashboard-managed Checkout payment-method sets such as PayPal-capable configurations",
+            vec!["STRIPE_PAYMENT_METHOD_CONFIGURATION".to_string()],
+            if config.stripe_payment_method_configuration_configured {
+                "Optional Stripe Payment Method Configuration is set; readiness reports only this boolean and not the configuration id."
+            } else {
+                "Optional Stripe Payment Method Configuration is unset; Checkout remains Dashboard-managed by default."
+            },
+        ),
+        readiness_check(
             "Stripe webhook evidence gate",
             stripe_webhook_secret || unsigned_stripe_webhooks,
             "crediting fiat balances and marking fiat transfer evidence in local/test environments",
@@ -536,10 +549,13 @@ pub fn build_live_money_readiness_report(
         network_rpc_url_env: network_descriptor.rpc_url_env,
         network_native_usdc_token_address: network_descriptor.native_usdc_token_address,
         stripe_secret_key_mode,
+        stripe_payment_method_configuration_configured: config
+            .stripe_payment_method_configuration_configured,
         supplied_usdc_token_matches_native,
         checks,
         evidence_boundaries: vec![
             "Stripe Checkout Session creation is not funding; only a verified checkout.session.completed webhook credits balance.".to_string(),
+            "Stripe Payment Method Configuration only changes eligible Checkout methods; it is not funding, payout, or settlement evidence.".to_string(),
             "Base approve/createEscrow transaction planning is not funding; only an indexed EscrowCreated log makes Base funding applied.".to_string(),
             "Deterministic verifier acceptance creates settlement intents; it does not pay by itself.".to_string(),
             "Base release transaction hashes are not payout; only an indexed EscrowReleased log marks USDC payout paid.".to_string(),
@@ -4326,6 +4342,7 @@ mod tests {
             usdc_token: Some(chain_base::BASE_MAINNET_USDC_TOKEN_ADDRESS.to_string()),
             stripe_secret_key_mode: "live".to_string(),
             stripe_live_execution_enabled: true,
+            stripe_payment_method_configuration_configured: true,
             stripe_webhook_secret_configured: true,
             allow_unsigned_stripe_webhooks: false,
             operator_auth_configured: true,
@@ -4338,6 +4355,7 @@ mod tests {
         assert!(report.base_mainnet_ready);
         assert!(report.live_money_ready);
         assert_eq!(report.network_chain_id, 8_453);
+        assert!(report.stripe_payment_method_configuration_configured);
         assert_eq!(
             report.network_native_usdc_token_address,
             chain_base::BASE_MAINNET_USDC_TOKEN_ADDRESS
@@ -4347,6 +4365,15 @@ mod tests {
             .evidence_boundaries
             .iter()
             .any(|boundary| boundary.contains("checkout.session.completed")));
+        assert!(report.evidence_boundaries.iter().any(|boundary| {
+            boundary.contains("Payment Method Configuration")
+                && boundary.contains("not funding, payout, or settlement evidence")
+        }));
+        assert!(report.checks.iter().any(|check| {
+            check.name == "Stripe Checkout payment-method configuration"
+                && check.configured
+                && check.env_vars == vec!["STRIPE_PAYMENT_METHOD_CONFIGURATION".to_string()]
+        }));
     }
 
     #[test]
@@ -4357,6 +4384,7 @@ mod tests {
             usdc_token: Some("0x3333333333333333333333333333333333333333".to_string()),
             stripe_secret_key_mode: "test".to_string(),
             stripe_live_execution_enabled: true,
+            stripe_payment_method_configuration_configured: false,
             stripe_webhook_secret_configured: true,
             allow_unsigned_stripe_webhooks: false,
             operator_auth_configured: true,
@@ -4366,6 +4394,7 @@ mod tests {
         .unwrap();
 
         assert!(!report.base_testnet_ready);
+        assert!(!report.stripe_payment_method_configuration_configured);
         assert_eq!(report.supplied_usdc_token_matches_native, Some(false));
         assert!(report
             .warnings

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1099,6 +1099,9 @@ fn real_funding_readiness(
         usdc_token,
         stripe_secret_key_mode: stripe_secret_key_mode_from_secret(stripe_secret_key.as_deref()),
         stripe_live_execution_enabled: env_flag("ENABLE_STRIPE_LIVE_EXECUTION"),
+        stripe_payment_method_configuration_configured: env_nonempty(
+            "STRIPE_PAYMENT_METHOD_CONFIGURATION",
+        ),
         stripe_webhook_secret_configured: env_nonempty("STRIPE_WEBHOOK_SECRET"),
         allow_unsigned_stripe_webhooks: env_flag("ALLOW_UNSIGNED_STRIPE_WEBHOOKS"),
         operator_auth_configured: env_nonempty("OPERATOR_API_TOKEN"),
@@ -3156,6 +3159,13 @@ async fn production_smoke_check(
     )?;
     require(
         live_money_readiness
+            .pointer("/stripe_payment_method_configuration_configured")
+            .and_then(|value| value.as_bool())
+            .is_some(),
+        "live-money readiness must expose a non-secret Stripe payment-method configuration boolean",
+    )?;
+    require(
+        live_money_readiness
             .pointer("/evidence_boundaries")
             .and_then(|value| value.as_array())
             .map(|boundaries| {
@@ -4035,6 +4045,13 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             .unwrap_or(false),
         "API live-money readiness must not expose Stripe secret material",
     )?;
+    require(
+        api_live_money_readiness
+            .pointer("/stripe_payment_method_configuration_configured")
+            .and_then(|value| value.as_bool())
+            .is_some(),
+        "API live-money readiness must expose a non-secret Stripe payment-method configuration boolean",
+    )?;
     let mcp_live_money_readiness = mcp_tool_post(
         mcp,
         "get_live_money_readiness",
@@ -4050,6 +4067,13 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             .and_then(|value| value.as_bool())
             .is_some(),
         "MCP get_live_money_readiness must expose live_money_ready boolean",
+    )?;
+    require(
+        mcp_live_money_readiness
+            .pointer("/stripe_payment_method_configuration_configured")
+            .and_then(|value| value.as_bool())
+            .is_some(),
+        "MCP get_live_money_readiness must expose a non-secret Stripe payment-method configuration boolean",
     )?;
     let api_base_indexer_status = get_json(&format!(
         "{api}/v1/base/indexer-status?network=base-mainnet"

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -2862,6 +2862,10 @@ fn live_money_readiness_config(state: &SharedState, network: &str) -> LiveMoneyR
             state.stripe_secret_key.as_deref(),
         ),
         stripe_live_execution_enabled: state.stripe_live_execution_enabled,
+        stripe_payment_method_configuration_configured: state
+            .stripe_payment_method_configuration
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty()),
         stripe_webhook_secret_configured: env_nonempty_value("STRIPE_WEBHOOK_SECRET").is_some(),
         allow_unsigned_stripe_webhooks: env_flag("ALLOW_UNSIGNED_STRIPE_WEBHOOKS"),
         operator_auth_configured: state.operator_api_token.is_some(),
@@ -3656,6 +3660,10 @@ mod tests {
         assert_eq!(body["network"], "Base");
         assert_eq!(body["network_chain_id"], 8_453);
         assert_eq!(body["stripe_secret_key_mode"], "unset");
+        assert_eq!(
+            body["stripe_payment_method_configuration_configured"],
+            false
+        );
         assert_eq!(body["supplied_usdc_token_matches_native"], true);
         assert_eq!(body["live_money_ready"], false);
         assert!(body["checks"].as_array().unwrap().iter().any(|check| {
@@ -3664,6 +3672,35 @@ mod tests {
                 .unwrap()
                 .contains("Stripe live-money execution")
         }));
+        assert!(body["checks"].as_array().unwrap().iter().any(|check| {
+            check["name"]
+                .as_str()
+                .unwrap()
+                .contains("payment-method configuration")
+        }));
+    }
+
+    #[tokio::test]
+    async fn live_money_readiness_tool_reports_payment_method_configuration_without_id() {
+        let response = get_live_money_readiness(
+            State(test_state_with_stripe_payment_method_configuration(
+                "pmc_paypal_enabled",
+            )),
+            Json(LiveMoneyReadinessArgs {
+                network: Some("base-mainnet".to_string()),
+            }),
+        )
+        .await
+        .0;
+        let body = &response["content"][0]["json"];
+        let text = serde_json::to_string(body).unwrap();
+
+        assert_eq!(body["stripe_payment_method_configuration_configured"], true);
+        assert!(body["checks"].as_array().unwrap().iter().any(|check| {
+            check["name"] == "Stripe Checkout payment-method configuration"
+                && check["configured"] == true
+        }));
+        assert!(!text.contains("pmc_paypal_enabled"));
     }
 
     #[tokio::test]

--- a/crates/sdk-python/agent_bounties/smoke.py
+++ b/crates/sdk-python/agent_bounties/smoke.py
@@ -282,6 +282,13 @@ def exercise_surface(client: AgentBountiesClient) -> dict:
         "live-money readiness did not expose a boolean live_money_ready gate",
     )
     _require(
+        isinstance(
+            live_money_readiness["stripe_payment_method_configuration_configured"],
+            bool,
+        ),
+        "live-money readiness did not expose a boolean Stripe payment-method configuration indicator",
+    )
+    _require(
         not live_money_readiness["stripe_secret_key_mode"].startswith(("sk_", "rk_")),
         "live-money readiness exposed Stripe secret material",
     )

--- a/crates/sdk-typescript/src/smoke.ts
+++ b/crates/sdk-typescript/src/smoke.ts
@@ -388,6 +388,10 @@ async function main(): Promise<void> {
     "live-money readiness did not expose a boolean live_money_ready gate",
   );
   requireCondition(
+    typeof liveMoneyReadiness.stripe_payment_method_configuration_configured === "boolean",
+    "live-money readiness did not expose a boolean Stripe payment-method configuration indicator",
+  );
+  requireCondition(
     !String(liveMoneyReadiness.stripe_secret_key_mode).startsWith("sk_")
       && !String(liveMoneyReadiness.stripe_secret_key_mode).startsWith("rk_"),
     "live-money readiness exposed Stripe secret material",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -144,8 +144,10 @@ The compose file sets:
 
 The API and MCP containers receive the same live-money environment contract so
 `GET /v1/readiness/live-money` and MCP `get_live_money_readiness` agree about
-Stripe webhook readiness, Base escrow addresses, native USDC tokens, and
-operator mutation protection.
+Stripe webhook readiness, the non-secret Stripe payment-method configuration
+indicator, Base escrow addresses, native USDC tokens, and operator mutation
+protection. These readiness responses expose only whether
+`STRIPE_PAYMENT_METHOD_CONFIGURATION` is configured, not the Stripe object id.
 
 To run the Base USDC indexer alongside API and MCP, set the indexer variables
 and opt into its compose profile:

--- a/docs/live-money-activation.md
+++ b/docs/live-money-activation.md
@@ -96,11 +96,14 @@ curl "$env:MCP_BASE_URL/tools/get_base_indexer_status" `
 ```
 
 These reports intentionally expose only Stripe key mode, configured gates, chain
-metadata, native USDC address, indexer cursor state, last worker heartbeat
+metadata, native USDC address, whether an optional Stripe Payment Method
+Configuration is configured, indexer cursor state, last worker heartbeat
 outcome, warnings, and settlement evidence boundaries. They must not expose
-Stripe secrets, webhook secrets, RPC URLs, or operator tokens. Indexer status is
-monitoring evidence only; it does not fund, release, refund, dispute, or
-authorize settlement.
+Stripe secrets, Payment Method Configuration ids, webhook secrets, RPC URLs, or
+operator tokens. The payment-method configuration indicator is Checkout UX
+readiness only; it does not fund, pay out, or authorize settlement. Indexer
+status is monitoring evidence only; it does not fund, release, refund, dispute,
+or authorize settlement.
 
 ## Automated Base Indexing
 

--- a/docs/production-smoke.md
+++ b/docs/production-smoke.md
@@ -36,8 +36,10 @@ The gate checks:
 - Discovery fields for Base funding plans and normalized escrow event
   reconciliation, so indexed `EscrowCreated` remains discoverable before claim.
 - Live-money readiness and Base indexer status reporting for Base mainnet USDC
-  and Stripe mode, including the indexer's nullable heartbeat fields, without
-  exposing secret keys, webhook secrets, RPC URLs, or operator tokens.
+  and Stripe mode, including the optional Stripe Checkout payment-method
+  configuration boolean and the indexer's nullable heartbeat fields, without
+  exposing secret keys, Payment Method Configuration ids, webhook secrets, RPC
+  URLs, or operator tokens.
 - MCP tool descriptors, JSON input schemas, and operator auth metadata for
   protected tools.
 - Public bounty, capability, template, and verifier pages.

--- a/docs/real-funding-rehearsal.md
+++ b/docs/real-funding-rehearsal.md
@@ -89,8 +89,9 @@ cargo run -p cli -- real-funding-readiness `
 
 The readiness report does not call Stripe or Base. It checks whether local
 simulation, Stripe test-mode execution, Stripe webhook evidence, Base Sepolia
-log reconciliation, optional signed transaction broadcast, and hosted operator
-auth are configured. Missing readiness only blocks the external rail step; the
+log reconciliation, optional signed transaction broadcast, the non-secret
+Stripe payment-method configuration indicator, and hosted operator auth are
+configured. Missing readiness only blocks the external rail step; the
 deterministic local rehearsal remains runnable.
 
 Expected evidence boundary in the JSON output:
@@ -141,6 +142,8 @@ It then validates that:
 - Base funding applies only after `EscrowCreated`,
 - Base payout applies only after `EscrowReleased`,
 - Stripe payout applies only after `transfer.created`,
+- readiness reports whether `STRIPE_PAYMENT_METHOD_CONFIGURATION` is configured
+  without exposing the Stripe object id,
 - final settlements contain paid solver payouts and platform fees for both
   rails.
 

--- a/scripts/validate_real_funding_rehearsal.py
+++ b/scripts/validate_real_funding_rehearsal.py
@@ -170,6 +170,10 @@ def check_readiness(readiness: dict[str, Any]) -> None:
         readiness["supplied_usdc_token_matches_native"] is True,
         "readiness must validate supplied Base Sepolia USDC token",
     )
+    expect(
+        isinstance(readiness["stripe_payment_method_configuration_configured"], bool),
+        "readiness must expose a boolean Stripe payment-method configuration indicator",
+    )
     checks = {check["name"]: check for check in readiness["checks"]}
     expect(
         checks["local deterministic rehearsal"]["configured"] is True,
@@ -179,9 +183,14 @@ def check_readiness(readiness: dict[str, Any]) -> None:
         checks["Base escrow addresses"]["configured"] is True,
         "Base Sepolia escrow and native token addresses must be accepted for planning",
     )
+    expect(
+        "Stripe Checkout payment-method configuration" in checks,
+        "readiness must include the optional Stripe Checkout payment-method configuration check",
+    )
     boundaries = "\n".join(readiness["evidence_boundaries"])
     for phrase in (
         "Checkout Session creation is not funding",
+        "Payment Method Configuration only changes eligible Checkout methods",
         "approve/createEscrow transaction planning is not funding",
         "verifier acceptance creates settlement intents",
         "EscrowReleased log marks USDC payout paid",


### PR DESCRIPTION
## Summary
- expose `stripe_payment_method_configuration_configured` on live-money readiness reports without revealing the Stripe Payment Method Configuration id
- add the optional Checkout method-configuration check to API, MCP, CLI, production smoke, SDK smoke, and real-funding artifact validation
- document that PayPal-capable Checkout setup is observable readiness metadata only, not funding, payout, or settlement evidence

## Contributor impact
Open PR queue was checked before edits. PR #24 remains in `CHANGES_REQUESTED` with no newer contributor commits, and this change is additive metadata only: no route names, request payloads, settlement states, SDK example flows, or Stripe Checkout creation behavior changed.

## Validation
- `cargo test -p app live_money_readiness`
- `cargo test -p api live_money_readiness`
- `cargo test -p mcp-server live_money_readiness`
- `cargo fmt --all -- --check`
- `cargo run -p cli -- real-funding-readiness --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x036CbD53842c5426634e7929541eC2318f3dCF7e`
- `./scripts/check.ps1`