### PR TITLE
Add funding page readiness preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,10 @@ create a `StripeFiat` bounty funding intent and then calls
 open Stripe Checkout when public Checkout is enabled. Checkout may show debit
 card, credit card, wallet, or PayPal where the hosted Stripe account and
 Dashboard configuration support those methods.
+The funding page also includes a read-only hosted readiness check for
+`/v1/readiness/live-money?network=base-mainnet` so funders can see non-secret
+Stripe live, signed-webhook, Base mainnet, and PayPal-capable
+method-configuration signals before creating a funding intent.
 
 Agents and operators should check them before posting or funding bounties that
 expect live Stripe fiat or Base mainnet USDC movement. The live-money readiness

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -104,6 +104,9 @@ def main() -> int:
         "/v1/stripe/live/funding-intents/",
         "No payment credentials were collected here",
         "STRIPE_PAYMENT_METHOD_CONFIGURATION",
+        "Check readiness",
+        "/v1/readiness/live-money?network=base-mainnet",
+        "stripe_payment_method_configuration_configured",
     ]
     for phrase in required_funding_phrases:
         if phrase not in funding and phrase not in main_js:
@@ -118,6 +121,13 @@ def main() -> int:
     questions = discovery.get("distribution_feedback", {}).get("questions", [])
     if len(questions) < 4:
         fail("static discovery manifest must include distribution feedback questions")
+    hosted_readiness = discovery.get("hosted_readiness", {})
+    if (
+        hosted_readiness.get("funding_page_action") != "check_readiness"
+        or "stripe_payment_method_configuration_configured"
+        not in hosted_readiness.get("non_secret_fields", [])
+    ):
+        fail("static discovery manifest must advertise hosted readiness preflight fields")
 
     print("site check ok")
     return 0

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -8,6 +8,19 @@
   "website": "https://nspg13.github.io/agent-bounties/",
   "funding_guide": "https://nspg13.github.io/agent-bounties/funding.html",
   "llms_txt": "https://nspg13.github.io/agent-bounties/llms.txt",
+  "hosted_readiness": {
+    "endpoint_template": "{api_base_url}/v1/readiness/live-money?network=base-mainnet",
+    "funding_page_action": "check_readiness",
+    "settlement_authority": "informational only; funding still requires verified webhook or indexed chain evidence",
+    "non_secret_fields": [
+      "stripe_secret_key_mode",
+      "stripe_payment_method_configuration_configured",
+      "live_money_ready",
+      "stripe_live_mode_ready",
+      "stripe_webhook_ready",
+      "base_mainnet_ready"
+    ]
+  },
   "payment_invariants": [
     "Stripe Checkout funding can show card, wallet, or PayPal-capable payment methods where the hosted Stripe account supports them.",
     "Funding is credited only after verified webhook or indexed chain evidence.",

--- a/site/funding.html
+++ b/site/funding.html
@@ -36,6 +36,14 @@
               Hosted API base URL
               <input name="apiBaseUrl" type="url" placeholder="https://api.example.com" required>
             </label>
+            <div class="readiness-panel" aria-labelledby="readiness-title">
+              <div>
+                <h3 id="readiness-title">Hosted readiness</h3>
+                <p class="fine">Check live-money readiness before creating a funding intent. This only reads <code>/v1/readiness/live-money?network=base-mainnet</code>; it does not create a Checkout Session or move funds.</p>
+              </div>
+              <button id="readiness-button" class="button secondary" type="button">Check readiness</button>
+              <output id="readiness-output" class="output readiness-output" aria-live="polite">Enter a hosted API URL, then check readiness.</output>
+            </div>
             <label>
               Bounty ID
               <input name="bountyId" placeholder="00000000-0000-0000-0000-000000000001" required>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -8,6 +8,9 @@ Start here:
 - Public website: https://nspg13.github.io/agent-bounties/
 - Static discovery manifest: https://nspg13.github.io/agent-bounties/.well-known/agent-bounties.json
 - Funding guide: https://nspg13.github.io/agent-bounties/funding.html
+- Hosted readiness preflight: enter an API base URL on the funding page and run
+  the read-only check_readiness action for
+  /v1/readiness/live-money?network=base-mainnet
 
 Payment invariants:
 

--- a/site/main.js
+++ b/site/main.js
@@ -70,6 +70,8 @@
 
   const form = document.getElementById("funding-form");
   const output = document.getElementById("funding-output");
+  const readinessButton = document.getElementById("readiness-button");
+  const readinessOutput = document.getElementById("readiness-output");
   if (!form || !output) return;
 
   function randomUuid() {
@@ -95,6 +97,63 @@
     if (!organizationField.value) {
       organizationField.value = funderId;
     }
+  }
+
+  function configuredLabel(value) {
+    return value ? "ready" : "needs setup";
+  }
+
+  function formatReadiness(report) {
+    const checks = Array.isArray(report.checks) ? report.checks : [];
+    const methodConfig = report.stripe_payment_method_configuration_configured === true;
+    const checkoutMethodCheck = checks.find(
+      (check) => check && check.name === "Stripe Checkout payment-method configuration",
+    );
+    const webhookBoundary = Array.isArray(report.evidence_boundaries)
+      && report.evidence_boundaries.some((boundary) =>
+        String(boundary).includes("checkout.session.completed webhook")
+      );
+
+    return [
+      `Network: ${report.network || "unknown"} (${report.network_chain_id || "unknown"})`,
+      `Live-money gate: ${configuredLabel(report.live_money_ready === true)}`,
+      `Stripe live execution: ${configuredLabel(report.stripe_live_mode_ready === true)}`,
+      `Signed webhook evidence: ${configuredLabel(report.stripe_webhook_ready === true)}`,
+      `Checkout method configuration: ${configuredLabel(methodConfig)}`,
+      `PayPal-capable setup indicator: ${methodConfig ? "configured" : "not configured"}`,
+      `Base mainnet escrow: ${configuredLabel(report.base_mainnet_ready === true)}`,
+      `Webhook settlement boundary: ${webhookBoundary ? "present" : "missing"}`,
+      checkoutMethodCheck && checkoutMethodCheck.detail
+        ? `Method detail: ${checkoutMethodCheck.detail}`
+        : "Method detail: no readiness detail returned",
+      "This readiness check is informational. Funding still requires Stripe Checkout completion and a verified webhook.",
+    ].join("\n");
+  }
+
+  if (readinessButton && readinessOutput) {
+    readinessButton.addEventListener("click", async () => {
+      const apiBaseUrlField = form.elements.namedItem("apiBaseUrl");
+      const apiBaseUrl = apiBaseUrlField instanceof HTMLInputElement
+        ? apiBaseUrlField.value.replace(/\/+$/, "")
+        : "";
+      if (!apiBaseUrl) {
+        readinessOutput.textContent = "Enter a hosted API base URL before checking readiness.";
+        return;
+      }
+
+      readinessOutput.textContent = "Checking hosted live-money readiness...";
+      try {
+        const response = await fetch(`${apiBaseUrl}/v1/readiness/live-money?network=base-mainnet`, {
+          headers: { accept: "application/json" },
+        });
+        if (!response.ok) {
+          throw new Error(`Readiness check failed with ${response.status}`);
+        }
+        readinessOutput.textContent = formatReadiness(await response.json());
+      } catch (error) {
+        readinessOutput.textContent = `${error.message}\n\nNo funding intent or Checkout Session was created. Confirm the hosted API URL, CORS settings, and live-money readiness endpoint.`;
+      }
+    });
   }
 
   form.addEventListener("submit", async (event) => {

--- a/site/styles.css
+++ b/site/styles.css
@@ -335,6 +335,23 @@ input {
   gap: 14px;
 }
 
+.readiness-panel {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--wash);
+}
+
+.readiness-panel h3 {
+  margin-bottom: 6px;
+}
+
+.readiness-panel .button {
+  justify-self: start;
+}
+
 .fine {
   color: var(--muted);
   line-height: 1.7;
@@ -349,10 +366,17 @@ input {
   white-space: pre-wrap;
 }
 
+.readiness-output {
+  max-height: 260px;
+  overflow: auto;
+  background: rgba(255, 255, 255, 0.62);
+}
+
 code {
   padding: 0.1em 0.3em;
   border-radius: 4px;
   background: rgba(16, 20, 23, 0.08);
+  overflow-wrap: anywhere;
 }
 
 .reveal {
@@ -402,5 +426,9 @@ code {
 
   .process > div {
     min-height: auto;
+  }
+
+  .readiness-output {
+    max-height: none;
   }
 }


### PR DESCRIPTION
## Summary
- add a read-only hosted readiness check to the static funding page before public Checkout creation
- advertise the readiness preflight in `llms.txt` and the static discovery manifest for agents
- tighten the site validator so the endpoint and non-secret Stripe method configuration field stay visible

## Contributor impact
Open PR queue was checked before edits. PR #24 remains in `CHANGES_REQUESTED`; this change is isolated to the static website, README, and site validator. It does not change API routes, SDK examples, settlement states, or Stripe Checkout creation behavior.

## Validation
- `python scripts/check-site.py`
- `python -m py_compile scripts/check-site.py`
- browser screenshot via `npx --yes playwright screenshot --full-page file:///.../site/funding.html output/playwright/funding-readiness-full.png`
- browser interaction smoke with mocked `/v1/readiness/live-money?network=base-mainnet`
- `./scripts/check.ps1`