### PR TITLE
Preserve funding Checkout redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,9 +458,10 @@ The static website includes a Stripe Checkout funding form at
 https://nspg13.github.io/agent-bounties/funding.html. It calls the hosted API to
 create a `StripeFiat` bounty funding intent and then calls
 `POST /v1/stripe/live/funding-intents/{id}/checkout-session` to
-open Stripe Checkout when public Checkout is enabled. Checkout may show debit
-card, credit card, wallet, or PayPal where the hosted Stripe account and
-Dashboard configuration support those methods.
+open Stripe Checkout when public Checkout is enabled. The stored funding intent
+preserves the page's success and cancel return URLs for Checkout UX only.
+Checkout may show debit card, credit card, wallet, or PayPal where the hosted
+Stripe account and Dashboard configuration support those methods.
 The funding page also includes a read-only hosted readiness check for
 `/v1/readiness/live-money?network=base-mainnet` so funders can see non-secret
 Stripe live, signed-webhook, Base mainnet, and PayPal-capable

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -3878,8 +3878,12 @@ mod tests {
                     currency: "usd".to_string(),
                     rail: domain::PaymentRail::StripeFiat,
                     external_reference: Some("card-funding-test".to_string()),
-                    stripe_success_url: None,
-                    stripe_cancel_url: None,
+                    stripe_success_url: Some(
+                        "https://nspg13.github.io/agent-bounties/success.html".to_string(),
+                    ),
+                    stripe_cancel_url: Some(
+                        "https://nspg13.github.io/agent-bounties/cancel.html".to_string(),
+                    ),
                     base_escrow_contract: None,
                     base_payer: None,
                     base_token: None,
@@ -3911,6 +3915,14 @@ mod tests {
         assert_eq!(
             report.request.idempotency_key,
             format!("bounty_funding_intent:{}", funding_intent.id)
+        );
+        assert_eq!(
+            report.request.body["success_url"],
+            "https://nspg13.github.io/agent-bounties/success.html"
+        );
+        assert_eq!(
+            report.request.body["cancel_url"],
+            "https://nspg13.github.io/agent-bounties/cancel.html"
         );
         assert_eq!(
             report.request.body["metadata"]["bounty_id"],

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1577,6 +1577,8 @@ impl BountyNetwork {
         }
 
         let intent_id = funding_intent_uuid(bounty.id, &external_reference);
+        let stripe_success_url = request.stripe_success_url.clone();
+        let stripe_cancel_url = request.stripe_cancel_url.clone();
         let mut intent = FundingIntent {
             id: intent_id,
             bounty_id: bounty.id,
@@ -1586,6 +1588,8 @@ impl BountyNetwork {
             amount: amount.clone(),
             status: FundingIntentStatus::AwaitingEvidence,
             external_reference: Some(external_reference.clone()),
+            stripe_success_url,
+            stripe_cancel_url,
             created_at: Utc::now(),
         };
 
@@ -1596,8 +1600,8 @@ impl BountyNetwork {
                     &bounty,
                     &intent,
                     &platform_base_url,
-                    request.stripe_success_url,
-                    request.stripe_cancel_url,
+                    intent.stripe_success_url.clone(),
+                    intent.stripe_cancel_url.clone(),
                 )?;
                 (
                     FundingIntentNextAction::StripeCheckout { request: checkout },
@@ -1667,7 +1671,13 @@ impl BountyNetwork {
             .bounties
             .get(&intent.bounty_id)
             .ok_or(AppError::BountyNotFound)?;
-        stripe_checkout_for_funding_intent(bounty, intent, &platform_base_url.into(), None, None)
+        stripe_checkout_for_funding_intent(
+            bounty,
+            intent,
+            &platform_base_url.into(),
+            intent.stripe_success_url.clone(),
+            intent.stripe_cancel_url.clone(),
+        )
     }
 
     pub fn claim_bounty(&mut self, request: ClaimBountyRequest) -> AppResult<Bounty> {
@@ -4627,8 +4637,12 @@ mod tests {
                     currency: "usd".to_string(),
                     rail: PaymentRail::StripeFiat,
                     external_reference: Some("intent-stripe-500".to_string()),
-                    stripe_success_url: None,
-                    stripe_cancel_url: None,
+                    stripe_success_url: Some(
+                        "https://fund.example/success.html?intent=stripe".to_string(),
+                    ),
+                    stripe_cancel_url: Some(
+                        "https://fund.example/cancel.html?intent=stripe".to_string(),
+                    ),
                     base_escrow_contract: None,
                     base_payer: None,
                     base_token: None,
@@ -4641,6 +4655,14 @@ mod tests {
             stripe_intent.intent.status,
             FundingIntentStatus::AwaitingEvidence
         );
+        assert_eq!(
+            stripe_intent.intent.stripe_success_url.as_deref(),
+            Some("https://fund.example/success.html?intent=stripe")
+        );
+        assert_eq!(
+            stripe_intent.intent.stripe_cancel_url.as_deref(),
+            Some("https://fund.example/cancel.html?intent=stripe")
+        );
         assert!(stripe_intent.requires_reconciliation);
         assert!(!stripe_intent.funding_summary.claimable);
         let checkout = match &stripe_intent.next_action {
@@ -4648,8 +4670,27 @@ mod tests {
             FundingIntentNextAction::BaseEscrowFunding { .. } => panic!("expected Stripe action"),
         };
         assert_eq!(
+            checkout.body["success_url"],
+            "https://fund.example/success.html?intent=stripe"
+        );
+        assert_eq!(
+            checkout.body["cancel_url"],
+            "https://fund.example/cancel.html?intent=stripe"
+        );
+        assert_eq!(
             checkout.idempotency_key,
             format!("bounty_funding_intent:{}", stripe_intent.intent.id)
+        );
+        let executed_checkout = network
+            .stripe_checkout_for_funding_intent(stripe_intent.intent.id, "https://api.example")
+            .unwrap();
+        assert_eq!(
+            executed_checkout.body["success_url"],
+            "https://fund.example/success.html?intent=stripe"
+        );
+        assert_eq!(
+            executed_checkout.body["cancel_url"],
+            "https://fund.example/cancel.html?intent=stripe"
         );
         assert_eq!(
             checkout.body["metadata"]["funding_intent_id"],

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -512,8 +512,8 @@ impl PostgresStore {
         sqlx::query(
             r#"
             INSERT INTO funding_intents
-              (id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, external_reference, created_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+              (id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, external_reference, stripe_success_url, stripe_cancel_url, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             ON CONFLICT (id) DO UPDATE SET
               contributor_agent_id = EXCLUDED.contributor_agent_id,
               source_organization_id = EXCLUDED.source_organization_id,
@@ -521,7 +521,9 @@ impl PostgresStore {
               amount = EXCLUDED.amount,
               currency = EXCLUDED.currency,
               status = EXCLUDED.status,
-              external_reference = EXCLUDED.external_reference
+              external_reference = EXCLUDED.external_reference,
+              stripe_success_url = EXCLUDED.stripe_success_url,
+              stripe_cancel_url = EXCLUDED.stripe_cancel_url
             "#,
         )
         .bind(intent.id)
@@ -533,6 +535,8 @@ impl PostgresStore {
         .bind(&intent.amount.currency)
         .bind(format!("{:?}", intent.status))
         .bind(&intent.external_reference)
+        .bind(&intent.stripe_success_url)
+        .bind(&intent.stripe_cancel_url)
         .bind(intent.created_at)
         .execute(&self.pool)
         .await?;
@@ -542,7 +546,7 @@ impl PostgresStore {
     pub async fn list_funding_intents(&self) -> DbResult<Vec<FundingIntent>> {
         let rows = sqlx::query(
             r#"
-            SELECT id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, external_reference, created_at
+            SELECT id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, external_reference, stripe_success_url, stripe_cancel_url, created_at
             FROM funding_intents
             ORDER BY created_at
             "#,
@@ -564,6 +568,8 @@ impl PostgresStore {
                     )?,
                     status: parse_funding_intent_status(row.try_get::<String, _>("status")?)?,
                     external_reference: row.try_get("external_reference")?,
+                    stripe_success_url: row.try_get("stripe_success_url")?,
+                    stripe_cancel_url: row.try_get("stripe_cancel_url")?,
                     created_at: row.try_get("created_at")?,
                 })
             })
@@ -1707,6 +1713,8 @@ mod tests {
         assert!(CORE_MIGRATION.contains("funding_ledger_entry_id UUID"));
         assert!(CORE_MIGRATION.contains("refund_ledger_entry_id UUID"));
         assert!(CORE_MIGRATION.contains("settlement_id UUID"));
+        assert!(CORE_MIGRATION.contains("stripe_success_url TEXT"));
+        assert!(CORE_MIGRATION.contains("stripe_cancel_url TEXT"));
         assert!(CORE_MIGRATION.contains("fund-contribution:"));
     }
 

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -534,6 +534,10 @@ pub struct FundingIntent {
     pub amount: Money,
     pub status: FundingIntentStatus,
     pub external_reference: Option<String>,
+    #[serde(default)]
+    pub stripe_success_url: Option<String>,
+    #[serde(default)]
+    pub stripe_cancel_url: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -368,8 +368,10 @@ API can create a Stripe-hosted Checkout Session through
 `POST /v1/stripe/live/funding-intents/{id}/checkout-session`.
 That endpoint only executes stored `StripeFiat` funding intents and preserves
 `bounty_id`, `funding_intent_id`, and `funding_intent_reference` metadata for
-webhook reconciliation. It does not credit balances or make the bounty
-claimable.
+webhook reconciliation. If the funding intent carried public success and cancel
+URLs, those return URLs are preserved for Stripe Checkout so funders land back
+on the intended website after payment or cancellation. Redirect URLs are UX
+only: they do not credit balances or make the bounty claimable.
 The optional `STRIPE_API_BASE_URL` or `--api-base-url` can target a sandbox or
 mock provider. The optional `STRIPE_PAYMENT_METHOD_CONFIGURATION` can target a
 Dashboard-managed Checkout method set without changing ledger reconciliation.

--- a/docs/real-funding-rehearsal.md
+++ b/docs/real-funding-rehearsal.md
@@ -197,8 +197,9 @@ curl.exe -sS -X POST http://127.0.0.1:8080/v1/stripe/live/funding-intents/{id}/c
 
 The endpoint requires `ENABLE_STRIPE_LIVE_EXECUTION=true`,
 `ENABLE_STRIPE_PUBLIC_CHECKOUT=true`, and Stripe credentials on the hosted API.
-It returns a Stripe Checkout URL for the specific funding intent. The bounty is
-still funded only after the signed webhook is reconciled.
+It returns a Stripe Checkout URL for the specific funding intent and preserves
+the funding intent's optional success/cancel return URLs. The bounty is still
+funded only after the signed webhook is reconciled.
 
 If `STRIPE_PAYMENT_METHOD_CONFIGURATION` is set, the Checkout Session request
 includes that Stripe Dashboard configuration id. This is useful for rehearsing

--- a/migrations/0001_core.sql
+++ b/migrations/0001_core.sql
@@ -100,8 +100,15 @@ CREATE TABLE IF NOT EXISTS funding_intents (
   currency TEXT NOT NULL,
   status TEXT NOT NULL,
   external_reference TEXT,
+  stripe_success_url TEXT,
+  stripe_cancel_url TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+ALTER TABLE funding_intents
+  ADD COLUMN IF NOT EXISTS stripe_success_url TEXT;
+ALTER TABLE funding_intents
+  ADD COLUMN IF NOT EXISTS stripe_cancel_url TEXT;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_funding_intents_external_reference
   ON funding_intents (bounty_id, external_reference)


### PR DESCRIPTION
## Summary
- persist optional Stripe Checkout success/cancel return URLs on bounty funding intents
- reuse those stored return URLs when executing public funding-intent Checkout sessions
- document that redirects are UX only and webhook reconciliation remains the funding authority

## Why
The static funding page creates a funding intent with public `success.html` / `cancel.html` URLs, then asks the hosted API to execute Checkout for that stored funding intent. The execution path reconstructed the Stripe Checkout request from stored state, so custom return URLs could be dropped and funders could land on API fallback pages instead of the public website.

## Safety
- Adds nullable funding-intent fields with serde defaults for old JSON compatibility.
- Keeps Checkout Session creation separate from funding credit.
- Keeps `checkout.session.completed` webhook reconciliation as the only Stripe funding-credit authority.
- Does not change route names, request field names, payout settlement, or PayPal-capable Checkout configuration behavior.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p app funding_intents_assign_stripe_after_webhook_and_base_after_escrow_log`
- `cargo test -p api public_stripe_funding_intent_checkout_executes_bounty_checkout`
- `cargo test -p db migration_contains_durable_market_tables`
- `./scripts/check.ps1`
- `./scripts/check-postgres.ps1`