### PR TITLE
Prefill public Stripe funding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,11 @@ create a `StripeFiat` bounty funding intent and then calls
 `POST /v1/stripe/live/funding-intents/{id}/checkout-session` to
 open Stripe Checkout when public Checkout is enabled. The stored funding intent
 preserves the page's success and cancel return URLs for Checkout UX only.
+Hosted public bounty and funding pages can link to the same form with
+`apiBaseUrl`, `bountyId`, `amountMinor`, `currency`, `rail`, and `source` query
+parameters so human funders do not need to copy IDs by hand. Those query
+parameters are UI defaults only; they do not credit funding or make a bounty
+claimable.
 Checkout may show debit card, credit card, wallet, or PayPal where the hosted
 Stripe account and Dashboard configuration support those methods.
 The funding page also includes a read-only hosted readiness check for

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 const DISCOVERY_SCHEMA: &str = "https://agentbounties.org/schemas/discovery-manifest.v1.json";
 const GITHUB_ISSUE_TEMPLATE_URL: &str =
     "https://github.com/NSPG13/agent-bounties/issues/new?template=paid-bounty.yml";
+const STATIC_FUNDING_PAGE_URL: &str = "https://nspg13.github.io/agent-bounties/funding.html";
 const AGENT_QUICKSTART_URL: &str =
     "https://github.com/NSPG13/agent-bounties/blob/main/docs/agent-quickstart.md";
 const REAL_FUNDING_REHEARSAL_URL: &str =
@@ -1216,6 +1217,15 @@ pub fn render_funding_feed_page(items: &[PublicFundingFeedItem]) -> String {
                         escape_html(&item.funding_intent_url)
                     )
                 };
+                let stripe_checkout_funding_action =
+                    stripe_checkout_funding_page_url_for_feed(item, "public-funding-feed")
+                        .map(|href| {
+                            format!(
+                                r#"<a data-agent-action="open_stripe_checkout_funding_page" href="{}">Open Stripe Checkout funding page</a> "#,
+                                escape_html(&href)
+                            )
+                        })
+                        .unwrap_or_default();
                 format!(
                     r#"<li>
         <h2><a href="{}">{}</a></h2>
@@ -1225,7 +1235,7 @@ pub fn render_funding_feed_page(items: &[PublicFundingFeedItem]) -> String {
         <p><code>{}</code></p>
         <h3>Funding intent payloads</h3>
         <ul>{}</ul>
-        <p>{}<a data-agent-action="add_funding_evidence" href="{}">Add funding evidence</a> <a data-agent-action="status" href="{}">Machine status</a> <a data-agent-action="template" href="{}">Template</a></p>
+        <p>{}{}<a data-agent-action="add_funding_evidence" href="{}">Add funding evidence</a> <a data-agent-action="status" href="{}">Machine status</a> <a data-agent-action="template" href="{}">Template</a></p>
       </li>"#,
                     escape_html(&item.public_url),
                     escape_html(&item.title),
@@ -1243,6 +1253,7 @@ pub fn render_funding_feed_page(items: &[PublicFundingFeedItem]) -> String {
                     partition_rows,
                     escape_html(&command),
                     funding_intent_example_rows,
+                    stripe_checkout_funding_action,
                     funding_intent_action,
                     escape_html(&item.funding_contribution_url),
                     escape_html(&item.status_url),
@@ -1659,6 +1670,95 @@ pub fn public_funding_feed_cofunding_command(item: &PublicFundingFeedItem) -> Op
     ))
 }
 
+pub fn stripe_checkout_funding_page_url_for_feed(
+    item: &PublicFundingFeedItem,
+    source: &str,
+) -> Option<String> {
+    public_stripe_checkout_funding_page_url(
+        &item.bounty_id,
+        &item.funding_intent_url,
+        &item.funding_mode,
+        item.funding_remaining_minor,
+        &item.currency,
+        &item.funding_partitions,
+        source,
+    )
+}
+
+pub fn stripe_checkout_funding_page_url_for_bounty(
+    item: &PublicBountyPage,
+    source: &str,
+) -> Option<String> {
+    public_stripe_checkout_funding_page_url(
+        &item.bounty_id,
+        &item.funding_intent_url,
+        &item.funding_mode,
+        item.funding_remaining_minor,
+        &item.currency,
+        &item.funding_partitions,
+        source,
+    )
+}
+
+fn public_stripe_checkout_funding_page_url(
+    bounty_id: &str,
+    funding_intent_url: &str,
+    funding_mode: &str,
+    fallback_amount_minor: i64,
+    fallback_currency: &str,
+    funding_partitions: &[PublicFundingPartition],
+    source: &str,
+) -> Option<String> {
+    let (amount_minor, currency) = funding_partitions
+        .iter()
+        .find(|partition| partition.rail == "StripeFiat" && partition.remaining_minor > 0)
+        .map(|partition| (partition.remaining_minor, partition.currency.as_str()))
+        .or_else(|| {
+            if funding_mode == "StripeFiatLedger" && fallback_amount_minor > 0 {
+                Some((fallback_amount_minor, fallback_currency))
+            } else {
+                None
+            }
+        })?;
+    let api_base_url = api_base_url_from_funding_intent_url(funding_intent_url)?;
+    let query = vec![
+        ("apiBaseUrl", api_base_url.to_string()),
+        ("bountyId", bounty_id.to_string()),
+        ("amountMinor", amount_minor.to_string()),
+        ("currency", currency.to_lowercase()),
+        ("rail", "StripeFiat".to_string()),
+        ("source", source.to_string()),
+    ]
+    .into_iter()
+    .map(|(key, value)| format!("{key}={}", encode_query_component(&value)))
+    .collect::<Vec<_>>()
+    .join("&");
+    Some(format!("{STATIC_FUNDING_PAGE_URL}?{query}"))
+}
+
+fn api_base_url_from_funding_intent_url(funding_intent_url: &str) -> Option<&str> {
+    let marker = "/v1/bounties/";
+    let index = funding_intent_url.find(marker)?;
+    let api_base_url = &funding_intent_url[..index];
+    if api_base_url.starts_with("https://") || api_base_url.starts_with("http://") {
+        Some(api_base_url.trim_end_matches('/'))
+    } else {
+        None
+    }
+}
+
+fn encode_query_component(value: &str) -> String {
+    value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                vec![byte as char]
+            }
+            _ => format!("%{byte:02X}").chars().collect::<Vec<_>>(),
+        })
+        .collect()
+}
+
 fn cofunding_command_for(bounty_id: &str, amount_minor: i64, currency: &str, rail: &str) -> String {
     format!(
         "/agent-bounty fund {} {} {} via {}",
@@ -1821,6 +1921,13 @@ pub fn public_bounty_next_actions(
         href: item.template_url.clone(),
     });
     if can_add_funding {
+        if let Some(href) = stripe_checkout_funding_page_url_for_bounty(item, "public-bounty") {
+            actions.push(PublicBountyNextAction {
+                kind: "open_stripe_checkout_funding_page".to_string(),
+                label: "Open Stripe Checkout funding page".to_string(),
+                href,
+            });
+        }
         if !item.funding_intent_examples.is_empty() {
             actions.push(PublicBountyNextAction {
                 kind: "create_funding_intent".to_string(),
@@ -2921,6 +3028,7 @@ mod tests {
         assert!(html.contains("agent-bounty-funding-feed"));
         assert!(html.contains(r#"data-agent-action="create_funding_intent""#));
         assert!(html.contains(r#"data-agent-action="add_funding_evidence""#));
+        assert!(!html.contains(r#"data-agent-action="open_stripe_checkout_funding_page""#));
         assert!(html.contains(r#"data-agent-action="distribution_feedback""#));
         assert!(html.contains("How did you find Agent Bounties?"));
         assert!(html.contains("What would make the project easier or more trustworthy"));
@@ -2934,6 +3042,23 @@ mod tests {
             "/agent-bounty fund {} 0.5 USDC via BaseUsdc",
             item.bounty_id
         )));
+    }
+
+    #[test]
+    fn funding_feed_page_exposes_prefilled_stripe_checkout_funding_link() {
+        let item = public_stripe_funding_feed_item_fixture();
+
+        let html = render_funding_feed_page(&[item.clone()]);
+
+        assert!(html.contains(r#"data-agent-action="open_stripe_checkout_funding_page""#));
+        assert!(html.contains("Open Stripe Checkout funding page"));
+        assert!(html.contains("https://nspg13.github.io/agent-bounties/funding.html?"));
+        assert!(html.contains("apiBaseUrl=https%3A%2F%2Fnetwork.example"));
+        assert!(html.contains(&format!("bountyId={}", item.bounty_id)));
+        assert!(html.contains("amountMinor=500"));
+        assert!(html.contains("currency=usd"));
+        assert!(html.contains("rail=StripeFiat"));
+        assert!(html.contains("source=public-funding-feed"));
     }
 
     #[test]
@@ -3122,10 +3247,50 @@ mod tests {
         assert!(html.contains(r#"rel="payment""#));
         assert!(html.contains(r#"data-agent-action="create_funding_intent""#));
         assert!(html.contains(r#"data-agent-action="add_funding_evidence""#));
+        assert!(!html.contains(r#"data-agent-action="open_stripe_checkout_funding_page""#));
         assert!(html.contains("base_network"));
         assert!(html.contains("https://network.example/v1/bounties/1/funding-contributions"));
         assert!(html.contains("https://network.example/v1/bounties/1/funding-intents"));
         assert!(!html.contains(r#"data-agent-action="claim""#));
+    }
+
+    #[test]
+    fn public_bounty_page_exposes_prefilled_stripe_checkout_funding_link() {
+        let mut item = public_bounty_page_fixture("Unfunded", 0, 500, false);
+        item.currency = "usd".to_string();
+        item.funding_mode = "StripeFiatLedger".to_string();
+        item.funding_target_minor = 500;
+        item.funding_remaining_minor = 500;
+        item.funding_partitions = vec![PublicFundingPartition {
+            rail: "StripeFiat".to_string(),
+            target_minor: 500,
+            confirmed_minor: 0,
+            remaining_minor: 500,
+            currency: "usd".to_string(),
+            contribution_count: 0,
+            escrow_count: 0,
+            claimable: false,
+        }];
+        item.funding_intent_examples = public_funding_intent_examples(
+            &item.bounty_id,
+            &item.funding_intent_url,
+            &item.public_url,
+            &item.funding_mode,
+            item.funding_remaining_minor,
+            &item.currency,
+            &item.funding_partitions,
+        );
+
+        let html = render_public_bounty_page(&item);
+
+        assert!(html.contains(r#"data-agent-action="open_stripe_checkout_funding_page""#));
+        assert!(html.contains("Open Stripe Checkout funding page"));
+        assert!(html.contains("apiBaseUrl=https%3A%2F%2Fnetwork.example"));
+        assert!(html.contains(&format!("bountyId={}", item.bounty_id)));
+        assert!(html.contains("amountMinor=500"));
+        assert!(html.contains("currency=usd"));
+        assert!(html.contains("source=public-bounty"));
+        assert!(html.contains("open_stripe_checkout_funding_page"));
     }
 
     #[test]
@@ -3340,6 +3505,32 @@ mod tests {
             funding_partitions,
             funding_intent_examples,
         }
+    }
+
+    fn public_stripe_funding_feed_item_fixture() -> PublicFundingFeedItem {
+        let mut item = public_funding_feed_item_fixture(0, 500, "StripeFiat");
+        item.currency = "usd".to_string();
+        item.funding_mode = "StripeFiatLedger".to_string();
+        item.funding_partitions = vec![PublicFundingPartition {
+            rail: "StripeFiat".to_string(),
+            target_minor: 500,
+            confirmed_minor: 0,
+            remaining_minor: 500,
+            currency: "usd".to_string(),
+            contribution_count: 0,
+            escrow_count: 0,
+            claimable: false,
+        }];
+        item.funding_intent_examples = public_funding_intent_examples(
+            &item.bounty_id,
+            &item.funding_intent_url,
+            &item.public_url,
+            &item.funding_mode,
+            item.funding_remaining_minor,
+            &item.currency,
+            &item.funding_partitions,
+        );
+        item
     }
 
     fn claimable_bounty(title: &str, amount_minor: i64, privacy: PrivacyLevel) -> Bounty {

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -375,6 +375,11 @@ only: they do not credit balances or make the bounty claimable.
 The optional `STRIPE_API_BASE_URL` or `--api-base-url` can target a sandbox or
 mock provider. The optional `STRIPE_PAYMENT_METHOD_CONFIGURATION` can target a
 Dashboard-managed Checkout method set without changing ledger reconciliation.
+Public bounty pages may link human funders to the static funding page with
+prefilled `apiBaseUrl`, `bountyId`, `amountMinor`, `currency`, `rail`, and
+`source` query parameters. Those links only reduce copy-paste friction for
+StripeFiat Checkout funding. They are not ledger evidence, do not authorize
+settlement, and are not offered for Base-only funding partitions.
 The live surfaces are:
 
 - `POST /v1/stripe/live/checkout-top-ups`, which creates the planned Checkout

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -107,6 +107,11 @@ def main() -> int:
         "Check readiness",
         "/v1/readiness/live-money?network=base-mainnet",
         "stripe_payment_method_configuration_configured",
+        "Prefilled funding request",
+        "apiBaseUrl",
+        "bountyId",
+        "amountMinor",
+        "funding_source",
     ]
     for phrase in required_funding_phrases:
         if phrase not in funding and phrase not in main_js:
@@ -128,6 +133,14 @@ def main() -> int:
         not in hosted_readiness.get("non_secret_fields", [])
     ):
         fail("static discovery manifest must advertise hosted readiness preflight fields")
+    funding_handoff = discovery.get("funding_handoff", {})
+    if (
+        funding_handoff.get("page") != "https://nspg13.github.io/agent-bounties/funding.html"
+        or "apiBaseUrl" not in funding_handoff.get("query_params", [])
+        or "bountyId" not in funding_handoff.get("query_params", [])
+        or "amountMinor" not in funding_handoff.get("query_params", [])
+    ):
+        fail("static discovery manifest must advertise public funding handoff query params")
 
     print("site check ok")
     return 0

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -7,6 +7,22 @@
   "repository": "https://github.com/NSPG13/agent-bounties",
   "website": "https://nspg13.github.io/agent-bounties/",
   "funding_guide": "https://nspg13.github.io/agent-bounties/funding.html",
+  "funding_handoff": {
+    "page": "https://nspg13.github.io/agent-bounties/funding.html",
+    "purpose": "Prefill the public Stripe Checkout funding form from a hosted public bounty or funding feed.",
+    "query_params": [
+      "apiBaseUrl",
+      "bountyId",
+      "organizationId",
+      "amountMinor",
+      "currency",
+      "rail",
+      "source",
+      "externalReference"
+    ],
+    "supported_rail": "StripeFiat",
+    "settlement_authority": "query parameters are UI defaults only; funding still requires verified Stripe webhook reconciliation"
+  },
   "llms_txt": "https://nspg13.github.io/agent-bounties/llms.txt",
   "hosted_readiness": {
     "endpoint_template": "{api_base_url}/v1/readiness/live-money?network=base-mainnet",

--- a/site/funding.html
+++ b/site/funding.html
@@ -36,6 +36,7 @@
               Hosted API base URL
               <input name="apiBaseUrl" type="url" placeholder="https://api.example.com" required>
             </label>
+            <output id="prefill-output" class="output prefill-output" aria-live="polite">Open this page from a public bounty funding link to prefill the hosted API, bounty, amount, and source.</output>
             <div class="readiness-panel" aria-labelledby="readiness-title">
               <div>
                 <h3 id="readiness-title">Hosted readiness</h3>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -8,6 +8,8 @@ Start here:
 - Public website: https://nspg13.github.io/agent-bounties/
 - Static discovery manifest: https://nspg13.github.io/agent-bounties/.well-known/agent-bounties.json
 - Funding guide: https://nspg13.github.io/agent-bounties/funding.html
+- Prefilled Stripe funding handoff:
+  https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&amountMinor={amount_minor}&currency=usd&rail=StripeFiat&source={source}
 - Hosted readiness preflight: enter an API base URL on the funding page and run
   the read-only check_readiness action for
   /v1/readiness/live-money?network=base-mainnet
@@ -16,6 +18,8 @@ Payment invariants:
 
 - A paid bounty must be funded before claim.
 - Stripe Checkout funding can show card, wallet, or PayPal-capable payment methods where the hosted Stripe account supports them.
+- Funding page query parameters are UI defaults only; they do not create funding
+  or settlement.
 - Stripe funding is credited only after a verified checkout.session.completed webhook.
 - Base USDC funding and payouts require indexed escrow logs.
 - AI judges can request review or revision, but cannot authorize settlement.

--- a/site/main.js
+++ b/site/main.js
@@ -70,6 +70,7 @@
 
   const form = document.getElementById("funding-form");
   const output = document.getElementById("funding-output");
+  const prefillOutput = document.getElementById("prefill-output");
   const readinessButton = document.getElementById("readiness-button");
   const readinessOutput = document.getElementById("readiness-output");
   if (!form || !output) return;
@@ -86,6 +87,25 @@
     return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
   }
 
+  function firstQueryParam(searchParams, names) {
+    for (const name of names) {
+      const value = searchParams.get(name);
+      if (value && value.trim()) {
+        return value.trim();
+      }
+    }
+    return "";
+  }
+
+  function setInputValue(name, value) {
+    const field = form.elements.namedItem(name);
+    if (field instanceof HTMLInputElement && value) {
+      field.value = value;
+      return true;
+    }
+    return false;
+  }
+
   const organizationField = form.elements.namedItem("organizationId");
   if (organizationField instanceof HTMLInputElement) {
     const storageKey = "agent-bounties-public-funder-id";
@@ -96,6 +116,40 @@
     }
     if (!organizationField.value) {
       organizationField.value = funderId;
+    }
+  }
+
+  const query = new URLSearchParams(window.location.search);
+  const prefillValues = {
+    apiBaseUrl: firstQueryParam(query, ["apiBaseUrl", "api_base_url", "api"]),
+    bountyId: firstQueryParam(query, ["bountyId", "bounty_id"]),
+    organizationId: firstQueryParam(query, ["organizationId", "organization_id", "sourceOrganizationId", "source_organization_id"]),
+    amountMinor: firstQueryParam(query, ["amountMinor", "amount_minor"]),
+    currency: firstQueryParam(query, ["currency"]),
+    externalReference: firstQueryParam(query, ["externalReference", "external_reference"]),
+    source: firstQueryParam(query, ["source", "funding_source"]),
+    rail: firstQueryParam(query, ["rail"]),
+  };
+
+  const prefilledFields = [
+    setInputValue("apiBaseUrl", prefillValues.apiBaseUrl) && "hosted API",
+    setInputValue("bountyId", prefillValues.bountyId) && "bounty id",
+    setInputValue("organizationId", prefillValues.organizationId) && "funder ledger id",
+    setInputValue("amountMinor", prefillValues.amountMinor) && "amount",
+    setInputValue("currency", prefillValues.currency.toLowerCase()) && "currency",
+    setInputValue("externalReference", prefillValues.externalReference) && "external reference",
+  ].filter(Boolean);
+  const fundingSource = prefillValues.source || "funding-page";
+  form.dataset.fundingSource = fundingSource;
+  form.dataset.fundingRail = prefillValues.rail || "StripeFiat";
+  if (prefillOutput) {
+    if (prefilledFields.length > 0) {
+      const railNotice = prefillValues.rail && prefillValues.rail !== "StripeFiat"
+        ? `\nRail warning: this page creates StripeFiat Checkout only; use the API/Base funding plan for ${prefillValues.rail}.`
+        : "";
+      prefillOutput.textContent = `Prefilled funding request from ${fundingSource}: ${prefilledFields.join(", ")}.${railNotice}\nReview the values and readiness before opening Checkout. Query parameters are UI defaults only; funding still requires a verified Stripe webhook.`;
+    } else {
+      prefillOutput.textContent = "Open this page from a public bounty funding link to prefill the hosted API, bounty, amount, and source.";
     }
   }
 
@@ -165,9 +219,12 @@
     const organizationId = String(data.get("organizationId") || "").trim();
     const amountMinor = Number(data.get("amountMinor"));
     const currency = String(data.get("currency") || "usd").trim().toLowerCase();
+    const source = form.dataset.fundingSource || "funding-page";
     const externalReference =
       String(data.get("externalReference") || "").trim() ||
-      `checkout-funding-${Date.now()}`;
+      `${source}-checkout-${Date.now()}`;
+    const pageBase = `${window.location.origin}${window.location.pathname.replace(/funding\.html$/, "")}`;
+    const returnQuery = `?bountyId=${encodeURIComponent(bountyId)}&source=${encodeURIComponent(source)}`;
 
     try {
       const intentResponse = await fetch(`${apiBaseUrl}/v1/bounties/${bountyId}/funding-intents`, {
@@ -181,8 +238,8 @@
           currency,
           rail: "StripeFiat",
           external_reference: externalReference,
-          stripe_success_url: `${window.location.origin}${window.location.pathname.replace(/funding\.html$/, "success.html")}`,
-          stripe_cancel_url: `${window.location.origin}${window.location.pathname.replace(/funding\.html$/, "cancel.html")}`,
+          stripe_success_url: `${pageBase}success.html${returnQuery}`,
+          stripe_cancel_url: `${pageBase}cancel.html${returnQuery}`,
           base_escrow_contract: null,
           base_payer: null,
           base_token: null,

--- a/site/styles.css
+++ b/site/styles.css
@@ -372,6 +372,10 @@ input {
   background: rgba(255, 255, 255, 0.62);
 }
 
+.prefill-output {
+  background: rgba(255, 255, 255, 0.62);
+}
+
 code {
   padding: 0.1em 0.3em;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- add human-facing Stripe Checkout funding-page links for public bounties that have remaining `StripeFiat` funding partitions
- make `site/funding.html` read query params such as `apiBaseUrl`, `bountyId`, `amountMinor`, `currency`, `rail`, and `source`
- document and validate that these query params are UI defaults only and do not create funding or settlement evidence

## Why
PayPal-capable Stripe Checkout is now available through Stripe Dashboard-managed Checkout configuration, and the public funding flow preserves website return URLs. The remaining adoption friction is copy-paste: funders should be able to move from a public bounty/funding page to a prefilled card, wallet, or PayPal-capable Checkout form without manually copying a bounty id and amount.

## Safety
- Only emits the static Checkout funding-page handoff for `StripeFiat` remaining partitions.
- Does not add Stripe Checkout links for Base-only funding partitions.
- Keeps API/MCP funding endpoints, request payload names, settlement states, webhook authority, and Base escrow reconciliation unchanged.
- Query params are browser UI defaults only; Stripe funding still requires a verified `checkout.session.completed` webhook.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `python scripts/check-site.py`
- `cargo test -p web-public prefilled_stripe_checkout`
- `cargo test -p web-public funding_feed_page_exposes_machine_readable_funding_actions`
- `cargo test -p web-public public_bounty_page_exposes_cofunding_only_when_funding_remains`
- `cargo test -p api public_funding_feed`
- `cargo test -p api public_bounty_detail_exposes_cofunding_while_target_remains`
- `./scripts/check.ps1`