### PR TITLE
Expose Stripe funding handoff in discovery

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -4248,6 +4248,15 @@ mod tests {
             manifest.endpoints.github_claim_comment_plan,
             "http://127.0.0.1:8080/v1/github/claim-comment-plan"
         );
+        assert_eq!(
+            manifest.funding_handoff.page,
+            "https://nspg13.github.io/agent-bounties/funding.html"
+        );
+        assert_eq!(manifest.funding_handoff.supported_rail, "StripeFiat");
+        assert!(manifest
+            .funding_handoff
+            .settlement_authority
+            .contains("verified Stripe webhook"));
         assert_eq!(manifest.risk_policy.low_value_usdc_cap_minor, 10_000_000);
         assert!(manifest
             .agent_entrypoints
@@ -4782,6 +4791,7 @@ mod tests {
         assert!(text.contains("docs/agent-quickstart.md"));
         assert!(text.contains("http://127.0.0.1:8090/tools"));
         assert!(text.contains("route_blocked_goal"));
+        assert!(text.contains("Prefilled Stripe funding handoff"));
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -44,6 +44,8 @@ use std::{
 };
 use uuid::Uuid;
 
+const STATIC_FUNDING_PAGE_URL: &str = "https://nspg13.github.io/agent-bounties/funding.html";
+
 #[derive(Parser)]
 #[command(name = "agent-bounties")]
 #[command(about = "Open-source agent bounty network CLI")]
@@ -2799,9 +2801,12 @@ async fn production_smoke_check(
                     && required
                         .iter()
                         .any(|value| value.as_str() == Some("payment_rails"))
+                    && required
+                        .iter()
+                        .any(|value| value.as_str() == Some("funding_handoff"))
             })
             .unwrap_or(false),
-        "discovery schema must require agent entrypoints and payment rails",
+        "discovery schema must require agent entrypoints, payment rails, and funding handoff",
     )?;
     require(
         discovery_schema
@@ -2900,6 +2905,50 @@ async fn production_smoke_check(
                 == Some(true)
         }),
         "all advertised payment rails must require funding before claim",
+    )?;
+    let funding_handoff = discovery
+        .pointer("/funding_handoff")
+        .and_then(|value| value.as_object())
+        .context("discovery manifest must expose a funding_handoff object")?;
+    require(
+        funding_handoff.get("page").and_then(|value| value.as_str())
+            == Some(STATIC_FUNDING_PAGE_URL),
+        "funding handoff must point to the static public funding page",
+    )?;
+    require(
+        funding_handoff
+            .get("supported_rail")
+            .and_then(|value| value.as_str())
+            == Some("StripeFiat"),
+        "funding handoff must advertise StripeFiat support",
+    )?;
+    let funding_handoff_params = funding_handoff
+        .get("query_params")
+        .and_then(|value| value.as_array())
+        .context("funding handoff must expose query_params")?;
+    for param in [
+        "apiBaseUrl",
+        "bountyId",
+        "amountMinor",
+        "currency",
+        "rail",
+        "source",
+        "externalReference",
+    ] {
+        require(
+            funding_handoff_params
+                .iter()
+                .any(|value| value.as_str() == Some(param)),
+            &format!("funding handoff missing query parameter {param}"),
+        )?;
+    }
+    require(
+        funding_handoff
+            .get("settlement_authority")
+            .and_then(|value| value.as_str())
+            .map(|authority| authority.contains("verified Stripe webhook"))
+            .unwrap_or(false),
+        "funding handoff must keep verified Stripe webhook reconciliation as settlement authority",
     )?;
 
     let trust_tiers = discovery

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -4075,6 +4075,7 @@ mod tests {
         assert!(text.contains("route_blocked_goal"));
         assert!(text.contains("/.well-known/agent-bounties.json"));
         assert!(text.contains("docs/agent-quickstart.md"));
+        assert!(text.contains("Prefilled Stripe funding handoff"));
     }
 
     #[tokio::test]

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -54,6 +54,7 @@ pub struct DiscoveryManifest {
     pub templates: Vec<DiscoveryTemplate>,
     pub proof_surfaces: Vec<String>,
     pub risk_controls: Vec<String>,
+    pub funding_handoff: FundingHandoffDescriptor,
     pub real_money_rehearsal: RealMoneyRehearsalDescriptor,
     pub distribution_feedback: DistributionFeedbackPrompt,
     pub risk_policy: RiskPolicyDescriptor,
@@ -149,6 +150,15 @@ pub struct RealMoneyRehearsalDescriptor {
     pub payout_evidence: Vec<String>,
     pub pooled_and_mixed_funding: bool,
     pub test_mode_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FundingHandoffDescriptor {
+    pub page: String,
+    pub purpose: String,
+    pub query_params: Vec<String>,
+    pub supported_rail: String,
+    pub settlement_authority: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -586,9 +596,33 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
             "Hosted operator mutation surfaces can require OPERATOR_API_TOKEN.".to_string(),
             "MixedRails bounties require explicit funding targets and settle each rail/currency partition separately.".to_string(),
         ],
+        funding_handoff: funding_handoff_descriptor(),
         real_money_rehearsal: real_money_rehearsal_descriptor(),
         distribution_feedback: distribution_feedback_prompt(&endpoints),
         risk_policy,
+    }
+}
+
+fn funding_handoff_descriptor() -> FundingHandoffDescriptor {
+    FundingHandoffDescriptor {
+        page: STATIC_FUNDING_PAGE_URL.to_string(),
+        purpose:
+            "Prefill the public Stripe Checkout funding form from a hosted public bounty or funding feed."
+                .to_string(),
+        query_params: vec![
+            "apiBaseUrl".to_string(),
+            "bountyId".to_string(),
+            "organizationId".to_string(),
+            "amountMinor".to_string(),
+            "currency".to_string(),
+            "rail".to_string(),
+            "source".to_string(),
+            "externalReference".to_string(),
+        ],
+        supported_rail: "StripeFiat".to_string(),
+        settlement_authority:
+            "Query parameters are UI defaults only; funding still requires verified Stripe webhook reconciliation."
+                .to_string(),
     }
 }
 
@@ -682,6 +716,7 @@ fn markdown_bullets(items: &[String]) -> String {
 pub fn render_llms_txt(api_base_url: &str, mcp_base_url: &str) -> String {
     let manifest = discovery_manifest(api_base_url, mcp_base_url);
     let endpoints = &manifest.endpoints;
+    let funding_handoff = &manifest.funding_handoff;
     let rehearsal = &manifest.real_money_rehearsal;
     let feedback = &manifest.distribution_feedback;
     let feedback_questions = markdown_bullets(&feedback.questions);
@@ -704,6 +739,7 @@ Open-source payment-first network where AI agents request help, complete verifie
 - Public funding opportunities: {public_funding}
 - Public bounty feed: {bounty_feed}
 - Public funding feed: {funding_feed}
+- Prefilled Stripe funding handoff: {funding_handoff_page}
 - Open pooled bounty: {pooled_bounties}
 - Create real-rail funding intent: {bounty_funding_intents}
 - Add pooled bounty funding: {bounty_funding_contributions}
@@ -745,6 +781,7 @@ Open-source payment-first network where AI agents request help, complete verifie
 - Paid/refunded/disputed state changes only after indexed escrow logs are reconciled.
 - Stripe live execution is gated by operator secrets and compliance state.
 - Stripe Checkout funding can show cards, wallets, or PayPal where the hosted Stripe account supports and enables them.
+- Use the prefilled funding handoff for human StripeFiat funding; its query parameters are UI defaults only and verified webhooks remain the funding authority.
 - Stripe Connect eligibility does not mark fiat payouts paid; transfer.created evidence does.
 - Hosted operator mutation calls may require `Authorization: Bearer <token>` or `x-operator-token: <token>`.
 - AI judges can request review or revision, but cannot authorize settlement.
@@ -820,6 +857,7 @@ The repository is designed for agent contributors. Start with the agent quicksta
         public_funding = &endpoints.public_funding,
         bounty_feed = &endpoints.bounty_feed,
         funding_feed = &endpoints.funding_feed,
+        funding_handoff_page = &funding_handoff.page,
         pooled_bounties = &endpoints.pooled_bounties,
         bounty_funding_intents = &endpoints.bounty_funding_intents,
         bounty_funding_contributions = &endpoints.bounty_funding_contributions,
@@ -2727,6 +2765,27 @@ mod tests {
             .payment_rails
             .iter()
             .any(|rail| rail.name.contains("Mixed Stripe fiat")));
+        assert_eq!(manifest.funding_handoff.page, STATIC_FUNDING_PAGE_URL);
+        assert_eq!(manifest.funding_handoff.supported_rail, "StripeFiat");
+        assert!(manifest
+            .funding_handoff
+            .query_params
+            .iter()
+            .any(|param| param == "apiBaseUrl"));
+        assert!(manifest
+            .funding_handoff
+            .query_params
+            .iter()
+            .any(|param| param == "bountyId"));
+        assert!(manifest
+            .funding_handoff
+            .query_params
+            .iter()
+            .any(|param| param == "amountMinor"));
+        assert!(manifest
+            .funding_handoff
+            .settlement_authority
+            .contains("verified Stripe webhook"));
         assert_eq!(
             manifest.real_money_rehearsal.command,
             "cargo run -p cli -- funding-rehearsal-demo"
@@ -2790,6 +2849,8 @@ mod tests {
         assert!(text.contains("https://network.example/public/bounties/{bounty_id}"));
         assert!(text.contains("https://network.example/public/funding"));
         assert!(text.contains("https://network.example/v1/bounties/funding-feed"));
+        assert!(text.contains(STATIC_FUNDING_PAGE_URL));
+        assert!(text.contains("Prefilled Stripe funding handoff"));
         assert!(text.contains("route_blocked_goal"));
         assert!(text.contains("Open pooled bounty"));
         assert!(text.contains("https://network.example/v1/bounties/pooled"));
@@ -2842,6 +2903,8 @@ mod tests {
         assert!(discovery_manifest_schema_json().contains("\"funding_feed\""));
         assert!(discovery_manifest_schema_json().contains("\"public_funding\""));
         assert!(discovery_manifest_schema_json().contains("\"public_bounty\""));
+        assert!(discovery_manifest_schema_json().contains("\"funding_handoff\""));
+        assert!(discovery_manifest_schema_json().contains("\"supported_rail\""));
         assert!(discovery_manifest_schema_json().contains("\"real_money_rehearsal\""));
         assert!(discovery_manifest_schema_json().contains("\"live_money_readiness\""));
         assert!(discovery_manifest_schema_json().contains("\"base_indexer_status\""));

--- a/docs/production-smoke.md
+++ b/docs/production-smoke.md
@@ -35,6 +35,9 @@ The gate checks:
   operation metadata.
 - Discovery fields for Base funding plans and normalized escrow event
   reconciliation, so indexed `EscrowCreated` remains discoverable before claim.
+- Discovery fields for the public StripeFiat funding handoff, including the
+  static funding page URL, prefill query parameters, and the rule that verified
+  Stripe webhook reconciliation remains the funding authority.
 - Live-money readiness and Base indexer status reporting for Base mainnet USDC
   and Stripe mode, including the optional Stripe Checkout payment-method
   configuration boolean and the indexer's nullable heartbeat fields, without

--- a/schemas/discovery-manifest.v1.json
+++ b/schemas/discovery-manifest.v1.json
@@ -18,6 +18,7 @@
     "templates",
     "proof_surfaces",
     "risk_controls",
+    "funding_handoff",
     "real_money_rehearsal",
     "distribution_feedback",
     "risk_policy"
@@ -192,6 +193,7 @@
       }
     },
     "real_money_rehearsal": { "$ref": "#/$defs/real_money_rehearsal" },
+    "funding_handoff": { "$ref": "#/$defs/funding_handoff" },
     "distribution_feedback": { "$ref": "#/$defs/distribution_feedback" },
     "risk_policy": {
       "type": "object",
@@ -319,6 +321,35 @@
         },
         "pooled_and_mixed_funding": { "type": "boolean" },
         "test_mode_only": { "type": "boolean" }
+      }
+    },
+    "funding_handoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "page",
+        "purpose",
+        "query_params",
+        "supported_rail",
+        "settlement_authority"
+      ],
+      "properties": {
+        "page": { "$ref": "#/$defs/uri" },
+        "purpose": { "type": "string", "minLength": 1 },
+        "query_params": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "contains": { "const": "bountyId" }
+        },
+        "supported_rail": {
+          "type": "string",
+          "const": "StripeFiat"
+        },
+        "settlement_authority": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "distribution_feedback": {


### PR DESCRIPTION
## What
- Adds a typed `funding_handoff` descriptor to hosted API/MCP discovery manifests.
- Points agents and humans to the static public Stripe Checkout funding page and its prefill query params.
- Extends read-only `production-smoke` to assert the handoff contract, supported `StripeFiat` rail, and verified-webhook settlement authority.
- Updates API/MCP `/llms.txt` discovery tests and production smoke docs.

## Why
PayPal support for non-enterprise human funders is intentionally provided through Stripe-hosted Checkout and the optional Dashboard-managed `STRIPE_PAYMENT_METHOD_CONFIGURATION` path. The remaining risk is discovery drift: a hosted API could be healthy while agents/humans no longer have a machine-readable route to the debit-card, wallet, or PayPal-capable Checkout handoff.

## Payment boundary
This PR is read-only/discovery-only. It does not create funding intents, create Checkout Sessions, call PayPal directly, credit balances, change payout rails, or alter Base escrow reconciliation. Stripe funding credit still requires verified `checkout.session.completed` webhook evidence.

## Contributor queue
Checked before edits: open PR #24 remains `CHANGES_REQUESTED` with no new commits after review; no active mergeable contributor PR needed attention first. Recent external comments on #55 have already been answered with safe contribution guidance and distribution questions.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p web-public discovery_manifest_exposes_agent_distribution_entrypoints`
- `cargo test -p web-public llms_txt_points_agents_to_machine_readable_surfaces`
- `cargo test -p cli`
- `cargo run -p cli -- docs-contract-check`
- `cargo test -p api discovery_endpoint_advertises_mcp_and_payment_entrypoints`
- `cargo test -p api llms_txt_endpoint_points_agents_to_discovery_and_mcp`
- `cargo test -p mcp-server llms_txt_exposes_agent_orientation`
- `python scripts/check-site.py`
- `./scripts/check.ps1`