### PR TITLE
Add Stripe handoff to funding comments

### DIFF
--- a/.github/workflows/paid-bounty-funding-comments.yml
+++ b/.github/workflows/paid-bounty-funding-comments.yml
@@ -32,3 +32,4 @@ jobs:
         run: bash scripts/github-funding-comment.sh
         env:
           GH_TOKEN: ${{ github.token }}
+          AGENT_BOUNTIES_API_BASE_URL: ${{ vars.AGENT_BOUNTIES_API_BASE_URL }}

--- a/README.md
+++ b/README.md
@@ -522,7 +522,11 @@ The maintainer follow-up loop and current adoption signals are documented in
 The `Paid Bounty Funding Comments` workflow runs the same Rust planner for
 funding comments and publishes a GitHub result comment keyed to the source
 comment id, which gives supporters fast feedback while keeping Stripe/Base
-reconciliation as the only funding authority.
+reconciliation as the only funding authority. For `StripeFiatLedger` funding
+comments, set repository variable `AGENT_BOUNTIES_API_BASE_URL` so the planner
+comment can include a prefilled public Stripe Checkout funding-page handoff;
+that link is a UI default only and verified Stripe webhooks remain the funding
+authority.
 
 Run all local checks:
 

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -313,6 +313,7 @@ struct PlanGitHubFundingCommentRequest {
     comment_body: String,
     contributor_login: Option<String>,
     comment_id: Option<String>,
+    funding_api_base_url: Option<String>,
     #[serde(default)]
     existing_idempotency_keys: Vec<String>,
 }
@@ -2441,6 +2442,7 @@ async fn plan_github_funding_comment(
         comment_body: request.comment_body,
         contributor_login: request.contributor_login,
         comment_id: request.comment_id,
+        funding_api_base_url: request.funding_api_base_url,
         existing_idempotency_keys: request.existing_idempotency_keys,
     }))
 }
@@ -4019,6 +4021,7 @@ mod tests {
             comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
             contributor_login: Some("solver-agent".to_string()),
             comment_id: Some("123".to_string()),
+            funding_api_base_url: None,
             existing_idempotency_keys: vec![],
         }))
         .await
@@ -4028,8 +4031,39 @@ mod tests {
         let signal = plan.signal.expect("funding signal");
         assert!(signal.requires_operator_reconciliation);
         assert_eq!(signal.amount.currency, "usdc");
+        assert!(signal.funding_handoff_url.is_none());
         assert!(signal.idempotency_key.ends_with(":comment:123"));
         assert_eq!(plan.check.conclusion, GitHubCheckConclusion::Success);
+    }
+
+    #[tokio::test]
+    async fn github_funding_comment_plan_returns_stripe_handoff_url() {
+        let plan = plan_github_funding_comment(Json(PlanGitHubFundingCommentRequest {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Co-funding".to_string(),
+            body: valid_github_issue_body_with_funding_mode("StripeFiatLedger"),
+            comment_body: "/agent-bounty fund 5 USD via StripeFiatLedger".to_string(),
+            contributor_login: Some("human-funder".to_string()),
+            comment_id: Some("124".to_string()),
+            funding_api_base_url: Some("https://api.agentbounties.example".to_string()),
+            existing_idempotency_keys: vec![],
+        }))
+        .await
+        .0;
+
+        assert!(plan.ready);
+        let signal = plan.signal.expect("funding signal");
+        let handoff = signal.funding_handoff_url.expect("handoff url");
+        assert!(handoff.contains("https://nspg13.github.io/agent-bounties/funding.html"));
+        assert!(handoff.contains("apiBaseUrl=https%3A%2F%2Fapi.agentbounties.example"));
+        assert!(handoff.contains("rail=StripeFiat"));
+        assert!(handoff.contains("externalReference=github-funding-comment%3A"));
+        assert!(plan.check.text.contains("Stripe Checkout funding handoff"));
+        assert!(plan
+            .check
+            .text
+            .contains("verified Stripe webhook reconciliation"));
     }
 
     #[tokio::test]
@@ -4044,6 +4078,7 @@ mod tests {
             comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
             contributor_login: None,
             comment_id: Some("123".to_string()),
+            funding_api_base_url: None,
             existing_idempotency_keys: vec![existing_key.to_string()],
         }))
         .await
@@ -5965,7 +6000,12 @@ mod tests {
     }
 
     fn valid_github_issue_body() -> String {
-        r#"### Goal
+        valid_github_issue_body_with_funding_mode("BaseUsdcEscrow")
+    }
+
+    fn valid_github_issue_body_with_funding_mode(funding_mode: &str) -> String {
+        format!(
+            r#"### Goal
 Fix the failing CI check.
 
 ### Acceptance criteria
@@ -5976,7 +6016,10 @@ fix-ci-failure
 
 ### Suggested amount
 10 USDC
+
+### Funding mode
+{funding_mode}
 "#
-        .to_string()
+        )
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -63,6 +63,7 @@ struct GithubFundingCommentPlanCli {
     comment_body: String,
     contributor_login: Option<String>,
     comment_id: Option<String>,
+    funding_api_base_url: Option<String>,
     existing_idempotency_keys: Vec<String>,
 }
 
@@ -332,6 +333,8 @@ enum Command {
         contributor_login: Option<String>,
         #[arg(long)]
         comment_id: Option<String>,
+        #[arg(long)]
+        funding_api_base_url: Option<String>,
         #[arg(long = "existing-idempotency-key")]
         existing_idempotency_keys: Vec<String>,
     },
@@ -610,6 +613,7 @@ async fn async_main() -> Result<()> {
             comment_body,
             contributor_login,
             comment_id,
+            funding_api_base_url,
             existing_idempotency_keys,
         } => github_funding_comment_plan(GithubFundingCommentPlanCli {
             repository,
@@ -619,6 +623,7 @@ async fn async_main() -> Result<()> {
             comment_body,
             contributor_login,
             comment_id,
+            funding_api_base_url,
             existing_idempotency_keys,
         }),
         Command::GithubClaimCommentPlan {
@@ -1858,6 +1863,7 @@ fn github_funding_comment_plan(args: GithubFundingCommentPlanCli) -> Result<()> 
         comment_body: args.comment_body,
         contributor_login: args.contributor_login,
         comment_id: args.comment_id,
+        funding_api_base_url: args.funding_api_base_url,
         existing_idempotency_keys: args.existing_idempotency_keys,
     });
     println!("{}", serde_json::to_string_pretty(&plan)?);

--- a/crates/github-app/src/lib.rs
+++ b/crates/github-app/src/lib.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 use uuid::Uuid;
 
+const STATIC_FUNDING_PAGE_URL: &str = "https://nspg13.github.io/agent-bounties/funding.html";
 const DISTRIBUTION_FEEDBACK_REQUEST: &str = "Distribution feedback requested, separate from review or payout decisions:\n\n- How did you find Agent Bounties?\n- What made this bounty or project worth participating in?\n- If an AI agent helped you find or complete this work, what tool, prompt, link, label, scanner, or workflow led it here?\n- What would make the project easier or more trustworthy before you participate again?\n\nIf Agent Bounties is useful, please star the repository, react/upvote useful issues or bounties, share it with other AI-agent builders or bounty solvers, and invite collaborators who can improve task liquidity, verifier quality, payment trust, or agent distribution.\n\nThese answers help improve agent discovery, bounty templates, proof pages, and payment-trust messaging.";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -92,6 +93,7 @@ pub struct GitHubFundingCommentInput {
     pub comment_body: String,
     pub contributor_login: Option<String>,
     pub comment_id: Option<String>,
+    pub funding_api_base_url: Option<String>,
     #[serde(default)]
     pub existing_idempotency_keys: Vec<String>,
 }
@@ -119,6 +121,7 @@ pub struct GitHubFundingSignal {
     pub idempotency_key: String,
     pub requires_operator_reconciliation: bool,
     pub operator_note: String,
+    pub funding_handoff_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -455,27 +458,38 @@ pub fn funding_comment_check_output(
     signal: Result<&GitHubFundingSignal, &GitHubFundingCommentError>,
 ) -> GitHubCheckRunOutput {
     match signal {
-        Ok(signal) => GitHubCheckRunOutput {
-            title: "Agent bounty funding signal ready".to_string(),
-            summary: format!(
-                "{} {} via {:?} requires operator reconciliation.",
-                signal.amount.amount, signal.amount.currency, signal.rail
-            ),
-            text: format!(
-                "Issue: {}\nContributor: {}\nAmount: {} {}\nRail: {:?}\nIdempotency key: {}\nRequires operator reconciliation: true\n\nThis GitHub comment is a public funding signal only. It does not credit the ledger, create a Stripe balance, or mark Base escrow funded.\n\n{}",
-                signal.issue_url,
-                signal
-                    .contributor_login
-                    .as_deref()
-                    .unwrap_or("unknown"),
-                signal.amount.amount,
-                signal.amount.currency,
-                signal.rail,
-                signal.idempotency_key,
-                DISTRIBUTION_FEEDBACK_REQUEST
-            ),
-            conclusion: GitHubCheckConclusion::Success,
-        },
+        Ok(signal) => {
+            let handoff_text = signal
+                .funding_handoff_url
+                .as_ref()
+                .map(|url| {
+                    format!(
+                        "\nStripe Checkout funding handoff: {url}\nHandoff boundary: opens the public funding form with UI defaults only; funding still requires verified Stripe webhook reconciliation.\n"
+                    )
+                })
+                .unwrap_or_default();
+            GitHubCheckRunOutput {
+                title: "Agent bounty funding signal ready".to_string(),
+                summary: format!(
+                    "{} {} via {:?} requires operator reconciliation.",
+                    signal.amount.amount, signal.amount.currency, signal.rail
+                ),
+                text: format!(
+                    "Issue: {}\nContributor: {}\nAmount: {} {}\nRail: {:?}\nIdempotency key: {}\nRequires operator reconciliation: true{handoff_text}\nThis GitHub comment is a public funding signal only. It does not credit the ledger, create a Stripe balance, or mark Base escrow funded.\n\n{}",
+                    signal.issue_url,
+                    signal
+                        .contributor_login
+                        .as_deref()
+                        .unwrap_or("unknown"),
+                    signal.amount.amount,
+                    signal.amount.currency,
+                    signal.rail,
+                    signal.idempotency_key,
+                    DISTRIBUTION_FEEDBACK_REQUEST
+                ),
+                conclusion: GitHubCheckConclusion::Success,
+            }
+        }
         Err(error) => GitHubCheckRunOutput {
             title: "Agent bounty funding signal needs review".to_string(),
             summary: error.to_string(),
@@ -570,7 +584,7 @@ fn parse_funding_comment_signal(
     {
         return Err(GitHubFundingCommentError::MissingIssueContext);
     }
-    parse_issue_form_bounty(
+    let bounty = parse_issue_form_bounty(
         &input.repository,
         &input.issue_url,
         &input.title,
@@ -591,6 +605,8 @@ fn parse_funding_comment_signal(
         return Err(GitHubFundingCommentError::DuplicateSignal(idempotency_key));
     }
 
+    let funding_handoff_url = funding_handoff_url(input, &bounty, &amount, &rail, &idempotency_key);
+
     Ok(GitHubFundingSignal {
         issue_url: input.issue_url.clone(),
         contributor_login: input
@@ -605,7 +621,59 @@ fn parse_funding_comment_signal(
         operator_note:
             "Verify actual Stripe Checkout credit or indexed Base escrow funding before applying this contribution."
                 .to_string(),
+        funding_handoff_url,
     })
+}
+
+fn funding_handoff_url(
+    input: &GitHubFundingCommentInput,
+    bounty: &GitHubIssueFormBounty,
+    amount: &Money,
+    rail: &FundingMode,
+    idempotency_key: &str,
+) -> Option<String> {
+    if !matches!(rail, FundingMode::StripeFiatLedger) {
+        return None;
+    }
+
+    let mut query = Vec::new();
+    if let Some(api_base_url) = input
+        .funding_api_base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        query.push(("apiBaseUrl", api_base_url.to_string()));
+    }
+    query.extend([
+        ("bountyId", bounty.request.id.to_string()),
+        ("amountMinor", amount.amount.to_string()),
+        ("currency", amount.currency.clone()),
+        ("rail", "StripeFiat".to_string()),
+        ("source", "github-funding-comment".to_string()),
+        ("externalReference", idempotency_key.to_string()),
+    ]);
+
+    Some(format!(
+        "{STATIC_FUNDING_PAGE_URL}?{}",
+        query
+            .into_iter()
+            .map(|(key, value)| format!("{key}={}", url_query_encode(&value)))
+            .collect::<Vec<_>>()
+            .join("&")
+    ))
+}
+
+fn url_query_encode(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
 }
 
 fn claim_command_line(comment_body: &str) -> Option<&str> {
@@ -1115,6 +1183,7 @@ extract-data-to-schema
             comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
             contributor_login: Some("solver-agent".to_string()),
             comment_id: Some("123".to_string()),
+            funding_api_base_url: None,
             existing_idempotency_keys: vec![],
         };
 
@@ -1125,14 +1194,51 @@ extract-data-to-schema
         assert_eq!(signal.amount, Money::new(5_000_000, "usdc").unwrap());
         assert_eq!(signal.rail, FundingMode::BaseUsdcEscrow);
         assert!(signal.requires_operator_reconciliation);
+        assert!(signal.funding_handoff_url.is_none());
         assert!(signal.idempotency_key.ends_with(":comment:123"));
         assert_eq!(plan.check.conclusion, GitHubCheckConclusion::Success);
+        assert!(!plan.check.text.contains("Stripe Checkout funding handoff"));
         assert!(plan.check.text.contains("Distribution feedback requested"));
         assert!(plan
             .check
             .text
             .contains("what tool, prompt, link, label, scanner, or workflow"));
         assert!(plan.check.text.contains("star the repository"));
+    }
+
+    #[test]
+    fn funding_comment_plan_adds_stripe_checkout_handoff_url() {
+        let input = GitHubFundingCommentInput {
+            repository: "agent-bounties/agent-bounties".to_string(),
+            issue_url: "https://github.com/agent-bounties/agent-bounties/issues/20".to_string(),
+            title: "[bounty]: Add co-funding".to_string(),
+            body: valid_issue_body("StripeFiatLedger"),
+            comment_body: "/agent-bounty fund 5 USD via StripeFiatLedger".to_string(),
+            contributor_login: Some("human-funder".to_string()),
+            comment_id: Some("124".to_string()),
+            funding_api_base_url: Some("https://api.agentbounties.example/".to_string()),
+            existing_idempotency_keys: vec![],
+        };
+
+        let plan = funding_comment_plan(input);
+
+        assert!(plan.ready);
+        let signal = plan.signal.unwrap();
+        let handoff = signal.funding_handoff_url.expect("handoff url");
+        assert_eq!(signal.amount, Money::new(500, "usd").unwrap());
+        assert_eq!(signal.rail, FundingMode::StripeFiatLedger);
+        assert!(handoff.starts_with(STATIC_FUNDING_PAGE_URL));
+        assert!(handoff.contains("apiBaseUrl=https%3A%2F%2Fapi.agentbounties.example"));
+        assert!(handoff.contains("amountMinor=500"));
+        assert!(handoff.contains("currency=usd"));
+        assert!(handoff.contains("rail=StripeFiat"));
+        assert!(handoff.contains("source=github-funding-comment"));
+        assert!(handoff.contains("externalReference=github-funding-comment%3A"));
+        assert!(plan.check.text.contains("Stripe Checkout funding handoff"));
+        assert!(plan
+            .check
+            .text
+            .contains("verified Stripe webhook reconciliation"));
     }
 
     #[test]
@@ -1244,6 +1350,7 @@ extract-data-to-schema
             comment_body: "/agent-bounty fund nope USDC via BaseUsdcEscrow".to_string(),
             contributor_login: None,
             comment_id: None,
+            funding_api_base_url: None,
             existing_idempotency_keys: vec![],
         });
 
@@ -1262,6 +1369,7 @@ extract-data-to-schema
             comment_body: "/agent-bounty fund 5 USDC via Simulated".to_string(),
             contributor_login: None,
             comment_id: None,
+            funding_api_base_url: None,
             existing_idempotency_keys: vec![],
         });
 
@@ -1281,6 +1389,7 @@ extract-data-to-schema
             comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
             contributor_login: None,
             comment_id: Some("123".to_string()),
+            funding_api_base_url: None,
             existing_idempotency_keys: vec![existing_key.to_string()],
         });
 
@@ -1298,6 +1407,7 @@ extract-data-to-schema
             comment_body: "/agent-bounty fund 5 USDC via BaseUsdcEscrow".to_string(),
             contributor_login: None,
             comment_id: None,
+            funding_api_base_url: None,
             existing_idempotency_keys: vec![],
         });
 
@@ -1315,6 +1425,7 @@ extract-data-to-schema
             comment_body: "/agent-bounty fund 5 USD via BaseUsdcEscrow".to_string(),
             contributor_login: None,
             comment_id: None,
+            funding_api_base_url: None,
             existing_idempotency_keys: vec![],
         });
 

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -193,6 +193,7 @@ struct PlanGitHubFundingCommentArgs {
     comment_body: String,
     contributor_login: Option<String>,
     comment_id: Option<String>,
+    funding_api_base_url: Option<String>,
     #[serde(default)]
     existing_idempotency_keys: Vec<String>,
 }
@@ -933,6 +934,7 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                     "comment_body": string_property("GitHub issue comment body, for example `/agent-bounty fund 5 USDC via BaseUsdcEscrow`."),
                     "contributor_login": nullable_string_property("Optional GitHub login that authored the funding signal."),
                     "comment_id": nullable_string_property("Optional GitHub comment ID used to build an idempotency key."),
+                    "funding_api_base_url": nullable_string_property("Optional hosted API base URL to prefill the public StripeFiat funding page for Stripe funding comments."),
                     "existing_idempotency_keys": string_array_property("Previously processed funding-comment idempotency keys for duplicate detection.")
                 }),
                 &["repository", "issue_url", "title", "body", "comment_body"],
@@ -2262,6 +2264,7 @@ async fn plan_github_funding_comment(
         comment_body: args.comment_body,
         contributor_login: args.contributor_login,
         comment_id: args.comment_id,
+        funding_api_base_url: args.funding_api_base_url,
         existing_idempotency_keys: args.existing_idempotency_keys,
     }))
 }
@@ -3159,6 +3162,10 @@ mod tests {
         assert_eq!(
             plan_github_funding.input_schema["properties"]["existing_idempotency_keys"]["type"],
             "array"
+        );
+        assert_eq!(
+            plan_github_funding.input_schema["properties"]["funding_api_base_url"]["type"][0],
+            "string"
         );
 
         let plan_github_claim = descriptors

--- a/docs/github-dogfooding.md
+++ b/docs/github-dogfooding.md
@@ -45,12 +45,18 @@ The safe operator path is:
 3. Supporters comment with `/agent-bounty fund <amount> <currency> via <rail>`.
 4. An operator runs the deterministic funding-comment planner and checks the
    idempotency key and `requires_operator_reconciliation` flag.
-5. For `BaseUsdcEscrow`, reconcile the indexed `EscrowCreated` event. For
+5. For `StripeFiatLedger` comments, the planner can include a public funding
+   handoff URL to `https://nspg13.github.io/agent-bounties/funding.html` with
+   the stable issue-derived bounty id, amount, rail, source, and idempotency
+   key prefilled. Set repository variable `AGENT_BOUNTIES_API_BASE_URL` to also
+   prefill the hosted API base URL. This link is only a Checkout UI handoff; it
+   does not create ledger credit.
+6. For `BaseUsdcEscrow`, reconcile the indexed `EscrowCreated` event. For
    `StripeFiatLedger`, reconcile the paid Checkout webhook, then reserve that
    verified balance through `add_bounty_funding`.
-6. Link the platform bounty URL back to the issue.
-7. The bounty becomes claimable only after funding is reconciled.
-8. Accepted work gets a proof comment; code review alone still does not approve
+7. Link the platform bounty URL back to the issue.
+8. The bounty becomes claimable only after funding is reconciled.
+9. Accepted work gets a proof comment; code review alone still does not approve
    payout or settlement.
 
 This keeps GitHub useful for discovery and pooling demand while preserving the
@@ -182,7 +188,11 @@ exists:
   creates or updates a planner comment marked with
   `<!-- agent-bounties-funding-comment -->`. The comment includes the funding
   comment id and idempotency key so operators can reconcile actual Stripe/Base
-  funding without granting settlement authority to GitHub comments.
+  funding without granting settlement authority to GitHub comments. If
+  repository variable `AGENT_BOUNTIES_API_BASE_URL` is set, valid
+  `StripeFiatLedger` comments also include a prefilled public Stripe Checkout
+  funding-page handoff; verified Stripe webhooks remain the only fiat funding
+  credit authority.
 - `.github/workflows/paid-bounty-claim-comments.yml` handles issue comments
   beginning with `/agent-bounty claim` or `/agent-bounty attempt` on
   bounty-labeled issues. It runs `scripts/github-claim-comment.sh`, executes

--- a/scripts/github_funding_comment.py
+++ b/scripts/github_funding_comment.py
@@ -206,6 +206,10 @@ def run_github_funding_plan(
     for key in idempotency_keys:
         command.extend(["--existing-idempotency-key", key])
 
+    funding_api_base_url = str(env.get("AGENT_BOUNTIES_API_BASE_URL") or "").strip()
+    if funding_api_base_url:
+        command.extend(["--funding-api-base-url", funding_api_base_url])
+
     result = subprocess.run(
         command,
         cwd=workspace,
@@ -359,6 +363,9 @@ def run_self_test() -> int:
     issue_body = (repo_root / "examples" / "github-paid-bounty-issue.md").read_text(
         encoding="utf-8"
     )
+    issue_body = issue_body.replace("10 USDC", "10 USD").replace(
+        "BaseUsdcEscrow", "StripeFiatLedger"
+    )
     event = {
         "repository": {"full_name": "agent-bounties/agent-bounties"},
         "issue": {
@@ -371,7 +378,7 @@ def run_self_test() -> int:
         "comment": {
             "id": 12345,
             "html_url": "https://github.com/agent-bounties/agent-bounties/issues/1#issuecomment-12345",
-            "body": "/agent-bounty fund 5 USDC via BaseUsdcEscrow",
+            "body": "/agent-bounty fund 5 USD via StripeFiatLedger",
             "user": {"login": "example-agent"},
         },
     }
@@ -401,6 +408,7 @@ def run_self_test() -> int:
             "GITHUB_WORKSPACE": str(repo_root),
             "RUNNER_TEMP": str(tmp_dir),
             "AGENT_BOUNTIES_FUNDING_COMMENTS_FILE": str(existing_path),
+            "AGENT_BOUNTIES_API_BASE_URL": "https://api.agentbounties.example",
             "DRY_RUN": "1",
         }
     )
@@ -416,6 +424,9 @@ def run_self_test() -> int:
         "Agent bounty funding signal: Success",
         "requires operator reconciliation",
         "Idempotency key: github-funding-comment:agent-bounties/agent-bounties:https://github.com/agent-bounties/agent-bounties/issues/1:comment:12345",
+        "Stripe Checkout funding handoff",
+        "apiBaseUrl=https%3A%2F%2Fapi.agentbounties.example",
+        "rail=StripeFiat",
         "Distribution feedback requested",
     ]
     missing = [needle for needle in required if needle not in output]


### PR DESCRIPTION
## Summary
- add optional `funding_api_base_url` to GitHub funding-comment planning across API, MCP, CLI, and workflow wiring
- include a public Stripe Checkout funding-page handoff URL for valid `StripeFiatLedger` funding comments
- document that the handoff is a UI default only; verified Stripe webhook reconciliation remains the fiat funding authority

## Contributor queue
- Checked open PRs before edits: #24 remains open with `CHANGES_REQUESTED` and no newer contributor commits after review.
- Latest external discovery comment on #55 has already been answered with safe contribution guidance and distribution questions.
- Public maintainer notice for this change was posted on #88 before edits: https://github.com/NSPG13/agent-bounties/issues/88#issuecomment-4919902456

## Payment / PayPal boundary
- This builds on the existing Stripe Checkout payment-method configuration path for card, wallet, and PayPal-capable Checkout.
- It does not add a direct PayPal ledger, direct PayPal API integration, or PayPal payout rail.
- Funding comments, links, Checkout URLs, and redirects are not settlement evidence.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p github-app funding_comment_plan`
- `cargo test -p api github_funding_comment_plan`
- `cargo test -p mcp-server tool_descriptors_publish_machine_readable_input_schemas`
- `python scripts\github_funding_comment.py --self-test`
- `cargo run -p cli -- docs-contract-check`
- `scripts/check.ps1` full gate via child PowerShell capture