### PR TITLE
Add hosted production smoke workflow

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,114 @@
+name: Production Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_base_url:
+        description: "Deployed API base URL, for example https://agent-bounties-api.onrender.com"
+        required: false
+        type: string
+      mcp_base_url:
+        description: "Deployed MCP base URL, for example https://agent-bounties-mcp.onrender.com"
+        required: false
+        type: string
+      require_eval_history:
+        description: "Require persisted eval-run history on the deployed API"
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    - cron: "43 10 * * *"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/production-smoke.yml"
+      - "README.md"
+      - "docs/deployment.md"
+      - "docs/production-smoke.md"
+      - "scripts/check-production-smoke.*"
+      - "crates/api/**"
+      - "crates/cli/**"
+      - "crates/mcp-server/**"
+      - "crates/web-public/**"
+  pull_request:
+    paths:
+      - ".github/workflows/production-smoke.yml"
+      - "README.md"
+      - "docs/deployment.md"
+      - "docs/production-smoke.md"
+      - "scripts/check-production-smoke.*"
+      - "crates/api/**"
+      - "crates/cli/**"
+      - "crates/mcp-server/**"
+      - "crates/web-public/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  production-smoke:
+    runs-on: ubuntu-latest
+    env:
+      PRODUCTION_API_BASE_URL: ${{ inputs.api_base_url || vars.PRODUCTION_API_BASE_URL }}
+      PRODUCTION_MCP_BASE_URL: ${{ inputs.mcp_base_url || vars.PRODUCTION_MCP_BASE_URL }}
+      REQUIRE_EVAL_HISTORY_INPUT: ${{ inputs.require_eval_history || 'false' }}
+      REQUIRE_EVAL_HISTORY_VAR: ${{ vars.PRODUCTION_SMOKE_REQUIRE_EVAL_HISTORY || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve production smoke configuration
+        id: config
+        shell: bash
+        run: |
+          if [[ -z "${PRODUCTION_API_BASE_URL}" || -z "${PRODUCTION_MCP_BASE_URL}" ]]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Production Smoke"
+              echo
+              echo "Skipped because PRODUCTION_API_BASE_URL and PRODUCTION_MCP_BASE_URL are not both configured."
+              echo
+              echo "Set repository variables for scheduled/push smoke, or pass workflow_dispatch inputs for a one-off hosted deploy check."
+              echo "Do not set AGENT_BOUNTIES_API_BASE_URL for GitHub funding-comment handoffs until this smoke passes for the same API URL."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          require_eval_history="false"
+          if [[ "${REQUIRE_EVAL_HISTORY_INPUT,,}" == "true" || "${REQUIRE_EVAL_HISTORY_VAR,,}" == "true" ]]; then
+            require_eval_history="true"
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "require_eval_history=${require_eval_history}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Production Smoke"
+            echo
+            echo "- API: ${PRODUCTION_API_BASE_URL}"
+            echo "- MCP: ${PRODUCTION_MCP_BASE_URL}"
+            echo "- Require eval history: ${require_eval_history}"
+            echo
+            echo "This workflow is read-only. It does not create funding intents, Checkout Sessions, Base transactions, ledger credits, or payout state."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.config.outputs.enabled == 'true'
+
+      - uses: Swatinem/rust-cache@v2
+        if: steps.config.outputs.enabled == 'true'
+
+      - name: Run read-only hosted production smoke
+        if: steps.config.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          args=(
+            --api-base-url "${PRODUCTION_API_BASE_URL}"
+            --mcp-base-url "${PRODUCTION_MCP_BASE_URL}"
+          )
+          if [[ "${{ steps.config.outputs.require_eval_history }}" == "true" ]]; then
+            args+=(--require-eval-history)
+          fi
+          bash scripts/check-production-smoke.sh "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -471,6 +471,12 @@ The funding page also includes a read-only hosted readiness check for
 `/v1/readiness/live-money?network=base-mainnet` so funders can see non-secret
 Stripe live, signed-webhook, Base mainnet, and PayPal-capable
 method-configuration signals before creating a funding intent.
+For hosted deployments, run the read-only `Production Smoke` GitHub Actions
+workflow or `scripts/check-production-smoke.*` against the API/MCP URLs before
+advertising a hosted API in funding links. Only set repository variable
+`AGENT_BOUNTIES_API_BASE_URL` after production smoke passes for that same API
+URL; otherwise GitHub funding comments should leave the API field for funders or
+operators to fill manually.
 
 Agents and operators should check them before posting or funding bounties that
 expect live Stripe fiat or Base mainnet USDC movement. The live-money readiness
@@ -558,6 +564,10 @@ default contributor gate remains fast and does not require Docker.
 The separate `Real Funding Rehearsal` workflow publishes the validated
 `funding-rehearsal-demo.json` and `real-funding-readiness.json` artifacts on
 manual runs, scheduled runs, and payment-path changes.
+The separate `Production Smoke` workflow is read-only against configured hosted
+API/MCP URLs. It skips when `PRODUCTION_API_BASE_URL` and
+`PRODUCTION_MCP_BASE_URL` are absent, and fails if configured hosted discovery,
+readiness, public pages, or payment-boundary contracts regress.
 The separate `Containers` workflow runs `scripts/check-production-compose.sh`
 when production packaging files change or when manually dispatched. That gate
 validates and builds the optional Base indexer worker service before starting

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,6 +69,13 @@ To deploy from the Dashboard after the PR is merged:
 6. Update `PUBLIC_BASE_URL` and `MCP_BASE_URL` if Render assigned different
    hostnames or you attached custom domains.
 7. Run the read-only production smoke against the deployed URLs.
+8. After production smoke passes, set repository variables
+   `PRODUCTION_API_BASE_URL` and `PRODUCTION_MCP_BASE_URL` so the scheduled
+   `Production Smoke` workflow can keep checking the hosted API/MCP surfaces.
+9. Only after the same API URL passes production smoke, set
+   `AGENT_BOUNTIES_API_BASE_URL` so GitHub funding-comment handoffs can prefill
+   the public Stripe Checkout funding page. A dead or unverified API URL should
+   not be advertised to funders.
 
 The Blueprint uses low paid service/database plans because the Base indexer is a
 background worker and real-money webhooks should not depend on sleeping
@@ -198,6 +205,13 @@ bash scripts/check-production-smoke.sh --api-base-url https://api.example.com --
 
 Use `-RequireEvalHistory` or `--require-eval-history` after the environment has
 run and persisted at least one eval suite.
+
+The same gate is available as the `Production Smoke` GitHub Actions workflow.
+Use manual dispatch for one-off URL checks, or set repository variables
+`PRODUCTION_API_BASE_URL` and `PRODUCTION_MCP_BASE_URL` for scheduled/push
+checks. The workflow skips when URLs are absent and fails when configured hosted
+endpoints are unhealthy. Treat a passing run as the prerequisite for configuring
+`AGENT_BOUNTIES_API_BASE_URL` in the GitHub repository.
 
 ## Payment Controls
 

--- a/docs/production-smoke.md
+++ b/docs/production-smoke.md
@@ -25,6 +25,21 @@ The scripts also read `PRODUCTION_API_BASE_URL` and `PRODUCTION_MCP_BASE_URL`.
 Use `-RequireEvalHistory` or `--require-eval-history` after a deployment has
 run at least one eval suite and persisted the run history.
 
+GitHub Actions also exposes a `Production Smoke` workflow. It runs on schedule,
+on relevant pushes, and by manual dispatch. For scheduled and push runs, set
+repository variables:
+
+- `PRODUCTION_API_BASE_URL`
+- `PRODUCTION_MCP_BASE_URL`
+- optional `PRODUCTION_SMOKE_REQUIRE_EVAL_HISTORY=true`
+
+If either production URL is missing, the workflow skips and writes a summary
+instead of failing contributor PRs. If both URLs are configured, it runs the
+same read-only hosted gate and fails on unhealthy discovery, readiness, or
+public page contracts. Do not set `AGENT_BOUNTIES_API_BASE_URL` for GitHub
+funding-comment handoffs until this production smoke passes for the same API
+URL.
+
 The gate checks:
 
 - API and MCP health endpoints.


### PR DESCRIPTION
## Summary
- add a read-only `Production Smoke` GitHub Actions workflow for hosted API/MCP verification
- skip safely when `PRODUCTION_API_BASE_URL` / `PRODUCTION_MCP_BASE_URL` are not configured
- document that `AGENT_BOUNTIES_API_BASE_URL` should only be set after production smoke passes for the same API URL

## Contributor queue
- Checked open PRs before edits: #24 remains open with `CHANGES_REQUESTED` and no newer contributor commits/comments requiring maintainer action first.
- Recent external comments on #55 remain answered with safe contribution guidance and distribution questions.
- Public maintainer notice for this change was posted before edits: #96.

## Deployment finding
- Static site is live: https://nspg13.github.io/agent-bounties/funding.html
- Current documented Render API URL is not production-ready: `GET https://agent-bounties-api.onrender.com/health` returns HTTP 404.
- Repository variable `AGENT_BOUNTIES_API_BASE_URL` is still unset, which is correct until the hosted API passes production smoke.

## Payment boundary
- This workflow is read-only.
- It does not create funding intents, Checkout Sessions, Base transactions, ledger credits, escrow events, or payout state.
- It protects the Stripe funding handoff by preventing dead/unverified API URLs from being advertised as self-serve funding endpoints.

## Verification
- `git diff --check`
- `python scripts\check-render-blueprint.py`
- `cargo run -p cli -- docs-contract-check`
- `bash -n scripts/check-production-smoke.sh`
- `bash scripts/check-production-smoke.sh --api-base-url https://agent-bounties-api.onrender.com --mcp-base-url https://agent-bounties-mcp.onrender.com` failed as expected with HTTP 404 on `/health`
- `scripts/check.ps1` full gate via child PowerShell capture