### PR TITLE
Add funding page API health preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,10 +467,11 @@ parameters are UI defaults only; they do not credit funding or make a bounty
 claimable.
 Checkout may show debit card, credit card, wallet, or PayPal where the hosted
 Stripe account and Dashboard configuration support those methods.
-The funding page also includes a read-only hosted readiness check for
-`/v1/readiness/live-money?network=base-mainnet` so funders can see non-secret
-Stripe live, signed-webhook, Base mainnet, and PayPal-capable
-method-configuration signals before creating a funding intent.
+The funding page also includes a read-only hosted health and readiness check for
+`/health` and `/v1/readiness/live-money?network=base-mainnet` so funders can
+confirm the API URL is alive before inspecting non-secret Stripe live,
+signed-webhook, Base mainnet, and PayPal-capable method-configuration signals
+before creating a funding intent.
 For hosted deployments, run the read-only `Production Smoke` GitHub Actions
 workflow or `scripts/check-production-smoke.*` against the API/MCP URLs before
 advertising a hosted API in funding links. Only set repository variable

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -105,6 +105,8 @@ def main() -> int:
         "No payment credentials were collected here",
         "STRIPE_PAYMENT_METHOD_CONFIGURATION",
         "Check readiness",
+        "/health",
+        "Hosted API health",
         "/v1/readiness/live-money?network=base-mainnet",
         "stripe_payment_method_configuration_configured",
         "Prefilled funding request",
@@ -126,9 +128,17 @@ def main() -> int:
     questions = discovery.get("distribution_feedback", {}).get("questions", [])
     if len(questions) < 4:
         fail("static discovery manifest must include distribution feedback questions")
+    hosted_health = discovery.get("hosted_health", {})
+    if (
+        hosted_health.get("funding_page_action") != "check_health"
+        or hosted_health.get("endpoint_template") != "{api_base_url}/health"
+        or hosted_health.get("expected_body") != "ok"
+    ):
+        fail("static discovery manifest must advertise hosted health preflight")
     hosted_readiness = discovery.get("hosted_readiness", {})
     if (
         hosted_readiness.get("funding_page_action") != "check_readiness"
+        or hosted_readiness.get("health_preflight") != "{api_base_url}/health"
         or "stripe_payment_method_configuration_configured"
         not in hosted_readiness.get("non_secret_fields", [])
     ):

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -24,9 +24,16 @@
     "settlement_authority": "query parameters are UI defaults only; funding still requires verified Stripe webhook reconciliation"
   },
   "llms_txt": "https://nspg13.github.io/agent-bounties/llms.txt",
+  "hosted_health": {
+    "endpoint_template": "{api_base_url}/health",
+    "funding_page_action": "check_health",
+    "expected_body": "ok",
+    "settlement_authority": "informational only; health checks do not create funding, payout, or settlement state"
+  },
   "hosted_readiness": {
     "endpoint_template": "{api_base_url}/v1/readiness/live-money?network=base-mainnet",
     "funding_page_action": "check_readiness",
+    "health_preflight": "{api_base_url}/health",
     "settlement_authority": "informational only; funding still requires verified webhook or indexed chain evidence",
     "non_secret_fields": [
       "stripe_secret_key_mode",

--- a/site/funding.html
+++ b/site/funding.html
@@ -40,7 +40,7 @@
             <div class="readiness-panel" aria-labelledby="readiness-title">
               <div>
                 <h3 id="readiness-title">Hosted readiness</h3>
-                <p class="fine">Check live-money readiness before creating a funding intent. This only reads <code>/v1/readiness/live-money?network=base-mainnet</code>; it does not create a Checkout Session or move funds.</p>
+                <p class="fine">Check hosted API health and live-money readiness before creating a funding intent. This only reads <code>/health</code> and <code>/v1/readiness/live-money?network=base-mainnet</code>; it does not create a Checkout Session or move funds.</p>
               </div>
               <button id="readiness-button" class="button secondary" type="button">Check readiness</button>
               <output id="readiness-output" class="output readiness-output" aria-live="polite">Enter a hosted API URL, then check readiness.</output>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -10,8 +10,10 @@ Start here:
 - Funding guide: https://nspg13.github.io/agent-bounties/funding.html
 - Prefilled Stripe funding handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&amountMinor={amount_minor}&currency=usd&rail=StripeFiat&source={source}
-- Hosted readiness preflight: enter an API base URL on the funding page and run
-  the read-only check_readiness action for
+- Hosted API health preflight: enter an API base URL on the funding page and run
+  the read-only check_health action for /health. The expected body is ok.
+- Hosted readiness preflight: after health passes, run the read-only
+  check_readiness action for
   /v1/readiness/live-money?network=base-mainnet
 
 Payment invariants:
@@ -20,6 +22,9 @@ Payment invariants:
 - Stripe Checkout funding can show card, wallet, or PayPal-capable payment methods where the hosted Stripe account supports them.
 - Funding page query parameters are UI defaults only; they do not create funding
   or settlement.
+- Hosted health and readiness checks are informational only; they do not create
+  funding intents, Checkout Sessions, transactions, ledger credits, or payout
+  state.
 - Stripe funding is credited only after a verified checkout.session.completed webhook.
 - Base USDC funding and payouts require indexed escrow logs.
 - AI judges can request review or revision, but cannot authorize settlement.

--- a/site/main.js
+++ b/site/main.js
@@ -157,6 +157,19 @@
     return value ? "ready" : "needs setup";
   }
 
+  async function checkHostedHealth(apiBaseUrl) {
+    const response = await fetch(`${apiBaseUrl}/health`, {
+      headers: { accept: "text/plain" },
+    });
+    if (!response.ok) {
+      throw new Error(`Hosted API health check failed with ${response.status}`);
+    }
+    const body = (await response.text()).trim();
+    if (body !== "ok") {
+      throw new Error("Hosted API health check did not return ok");
+    }
+  }
+
   function formatReadiness(report) {
     const checks = Array.isArray(report.checks) ? report.checks : [];
     const methodConfig = report.stripe_payment_method_configuration_configured === true;
@@ -169,6 +182,7 @@
       );
 
     return [
+      "Hosted API health: ok",
       `Network: ${report.network || "unknown"} (${report.network_chain_id || "unknown"})`,
       `Live-money gate: ${configuredLabel(report.live_money_ready === true)}`,
       `Stripe live execution: ${configuredLabel(report.stripe_live_mode_ready === true)}`,
@@ -195,8 +209,10 @@
         return;
       }
 
-      readinessOutput.textContent = "Checking hosted live-money readiness...";
+      readinessOutput.textContent = "Checking hosted API health...";
       try {
+        await checkHostedHealth(apiBaseUrl);
+        readinessOutput.textContent = "Hosted API health is ok. Checking live-money readiness...";
         const response = await fetch(`${apiBaseUrl}/v1/readiness/live-money?network=base-mainnet`, {
           headers: { accept: "application/json" },
         });
@@ -205,7 +221,7 @@
         }
         readinessOutput.textContent = formatReadiness(await response.json());
       } catch (error) {
-        readinessOutput.textContent = `${error.message}\n\nNo funding intent or Checkout Session was created. Confirm the hosted API URL, CORS settings, and live-money readiness endpoint.`;
+        readinessOutput.textContent = `${error.message}\n\nNo funding intent or Checkout Session was created. Confirm the hosted API URL, CORS settings, /health endpoint, and live-money readiness endpoint.`;
       }
     });
   }


### PR DESCRIPTION
## Summary
- add a `/health` preflight before the public funding page requests live-money readiness
- advertise the hosted health preflight in the static discovery manifest and `/llms.txt`
- update the site contract check and README so the public funding UX reflects the same API-health boundary as production smoke

## Contributor queue
- Checked open PRs before edits: #24 remains open with `CHANGES_REQUESTED` and no newer contributor commits/comments requiring maintainer action first.
- Recent external comments on #55 remain answered with safe contribution guidance and distribution questions.
- Public maintainer notice for this change was posted before edits: #98.

## Payment boundary
- This is read-only browser-side preflight.
- It does not create funding intents, Checkout Sessions, Base transactions, ledger credits, escrow events, or payout state.
- A passing health/readiness check is still not settlement evidence; Stripe funding still requires verified webhook reconciliation.

## Verification
- `python scripts\check-site.py`
- `node --check site\main.js`
- `python -m json.tool site\.well-known\agent-bounties.json`
- `cargo run -p cli -- docs-contract-check`
- `git diff --check`
- `scripts/check.ps1` full gate via child PowerShell capture