### PR TITLE
Add public Base funding planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,11 @@ Hosted public bounty and funding pages can link to the same form with
 parameters so human funders do not need to copy IDs by hand. Those query
 parameters are UI defaults only; they do not credit funding or make a bounty
 claimable.
+The same funding page can plan Base USDC escrow funding by calling the hosted
+`/v1/base/funding-plan` endpoint after `/health` passes. It returns unsigned
+`approve` and `createEscrow` transaction intents only; a wallet must sign and
+broadcast them externally, and the bounty is funded only after an indexed
+`EscrowCreated` log is reconciled.
 Checkout may show debit card, credit card, wallet, or PayPal where the hosted
 Stripe account and Dashboard configuration support those methods.
 The funding page also includes a read-only hosted health and readiness check for

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -114,6 +114,10 @@ def main() -> int:
         "bountyId",
         "amountMinor",
         "funding_source",
+        "Plan Base USDC escrow",
+        "/v1/base/funding-plan",
+        "createEscrow",
+        "EscrowCreated",
     ]
     for phrase in required_funding_phrases:
         if phrase not in funding and phrase not in main_js:
@@ -151,6 +155,15 @@ def main() -> int:
         or "amountMinor" not in funding_handoff.get("query_params", [])
     ):
         fail("static discovery manifest must advertise public funding handoff query params")
+    base_funding_handoff = discovery.get("base_funding_handoff", {})
+    if (
+        base_funding_handoff.get("endpoint_template") != "{api_base_url}/v1/base/funding-plan"
+        or base_funding_handoff.get("supported_rail") != "BaseUsdc"
+        or "escrowContract" not in base_funding_handoff.get("query_params", [])
+        or "payer" not in base_funding_handoff.get("query_params", [])
+        or "EscrowCreated" not in base_funding_handoff.get("settlement_authority", "")
+    ):
+        fail("static discovery manifest must advertise Base funding plan handoff")
 
     print("site check ok")
     return 0

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -23,6 +23,23 @@
     "supported_rail": "StripeFiat",
     "settlement_authority": "query parameters are UI defaults only; funding still requires verified Stripe webhook reconciliation"
   },
+  "base_funding_handoff": {
+    "page": "https://nspg13.github.io/agent-bounties/funding.html",
+    "purpose": "Plan unsigned Base USDC approve and createEscrow transactions for a hosted Base-funded bounty.",
+    "endpoint_template": "{api_base_url}/v1/base/funding-plan",
+    "query_params": [
+      "apiBaseUrl",
+      "bountyId",
+      "network",
+      "escrowContract",
+      "payer",
+      "token",
+      "rail",
+      "source"
+    ],
+    "supported_rail": "BaseUsdc",
+    "settlement_authority": "transaction plans are not funding; Base funding requires indexed EscrowCreated log reconciliation"
+  },
   "llms_txt": "https://nspg13.github.io/agent-bounties/llms.txt",
   "hosted_health": {
     "endpoint_template": "{api_base_url}/health",

--- a/site/funding.html
+++ b/site/funding.html
@@ -101,6 +101,43 @@
           </div>
         </div>
       </section>
+
+      <section class="band muted compact">
+        <div class="section-grid">
+          <div>
+            <h2>Plan Base USDC escrow</h2>
+            <p class="fine">This creates unsigned transaction intents only. Review the `approve` and `createEscrow` calldata in your wallet or operator workstation, then reconcile the indexed <code>EscrowCreated</code> log after broadcast. Transaction planning does not fund a bounty.</p>
+          </div>
+          <form id="base-plan-form" class="funding-form">
+            <label>
+              Hosted API base URL
+              <input name="baseApiBaseUrl" type="url" placeholder="https://api.example.com" required>
+            </label>
+            <label>
+              Bounty ID
+              <input name="baseBountyId" placeholder="00000000-0000-0000-0000-000000000001" required>
+            </label>
+            <label>
+              Base network
+              <input name="baseNetwork" value="base-sepolia" required>
+            </label>
+            <label>
+              Escrow contract
+              <input name="baseEscrowContract" placeholder="0x1111111111111111111111111111111111111111" required>
+            </label>
+            <label>
+              Payer wallet
+              <input name="basePayer" placeholder="0x2222222222222222222222222222222222222222" required>
+            </label>
+            <label>
+              USDC token
+              <input name="baseToken" value="0x036CbD53842c5426634e7929541eC2318f3dCF7e" required>
+            </label>
+            <button class="button secondary" type="submit">Plan Base funding</button>
+            <output id="base-plan-output" class="output readiness-output" aria-live="polite">Generate an unsigned Base USDC funding plan for a posted Base bounty.</output>
+          </form>
+        </div>
+      </section>
     </main>
 
     <footer>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -10,6 +10,8 @@ Start here:
 - Funding guide: https://nspg13.github.io/agent-bounties/funding.html
 - Prefilled Stripe funding handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&amountMinor={amount_minor}&currency=usd&rail=StripeFiat&source={source}
+- Base USDC funding plan handoff:
+  https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&network=base-sepolia&escrowContract={escrow}&payer={payer}&token={usdc}&rail=BaseUsdc&source={source}
 - Hosted API health preflight: enter an API base URL on the funding page and run
   the read-only check_health action for /health. The expected body is ok.
 - Hosted readiness preflight: after health passes, run the read-only
@@ -27,6 +29,8 @@ Payment invariants:
   state.
 - Stripe funding is credited only after a verified checkout.session.completed webhook.
 - Base USDC funding and payouts require indexed escrow logs.
+- Base funding plans are unsigned transaction intents only; they do not sign,
+  broadcast, fund, or settle anything.
 - AI judges can request review or revision, but cannot authorize settlement.
 
 Distribution feedback request:

--- a/site/main.js
+++ b/site/main.js
@@ -73,6 +73,8 @@
   const prefillOutput = document.getElementById("prefill-output");
   const readinessButton = document.getElementById("readiness-button");
   const readinessOutput = document.getElementById("readiness-output");
+  const baseForm = document.getElementById("base-plan-form");
+  const baseOutput = document.getElementById("base-plan-output");
   if (!form || !output) return;
 
   function randomUuid() {
@@ -106,6 +108,15 @@
     return false;
   }
 
+  function setNamedInputValue(targetForm, name, value) {
+    const field = targetForm && targetForm.elements.namedItem(name);
+    if (field instanceof HTMLInputElement && value) {
+      field.value = value;
+      return true;
+    }
+    return false;
+  }
+
   const organizationField = form.elements.namedItem("organizationId");
   if (organizationField instanceof HTMLInputElement) {
     const storageKey = "agent-bounties-public-funder-id";
@@ -129,6 +140,10 @@
     externalReference: firstQueryParam(query, ["externalReference", "external_reference"]),
     source: firstQueryParam(query, ["source", "funding_source"]),
     rail: firstQueryParam(query, ["rail"]),
+    network: firstQueryParam(query, ["network", "baseNetwork", "base_network"]),
+    escrowContract: firstQueryParam(query, ["escrowContract", "escrow_contract", "baseEscrowContract", "base_escrow_contract"]),
+    payer: firstQueryParam(query, ["payer", "basePayer", "base_payer"]),
+    token: firstQueryParam(query, ["token", "baseToken", "base_token"]),
   };
 
   const prefilledFields = [
@@ -142,6 +157,14 @@
   const fundingSource = prefillValues.source || "funding-page";
   form.dataset.fundingSource = fundingSource;
   form.dataset.fundingRail = prefillValues.rail || "StripeFiat";
+  if (baseForm) {
+    setNamedInputValue(baseForm, "baseApiBaseUrl", prefillValues.apiBaseUrl);
+    setNamedInputValue(baseForm, "baseBountyId", prefillValues.bountyId);
+    setNamedInputValue(baseForm, "baseNetwork", prefillValues.network);
+    setNamedInputValue(baseForm, "baseEscrowContract", prefillValues.escrowContract);
+    setNamedInputValue(baseForm, "basePayer", prefillValues.payer);
+    setNamedInputValue(baseForm, "baseToken", prefillValues.token);
+  }
   if (prefillOutput) {
     if (prefilledFields.length > 0) {
       const railNotice = prefillValues.rail && prefillValues.rail !== "StripeFiat"
@@ -222,6 +245,51 @@
         readinessOutput.textContent = formatReadiness(await response.json());
       } catch (error) {
         readinessOutput.textContent = `${error.message}\n\nNo funding intent or Checkout Session was created. Confirm the hosted API URL, CORS settings, /health endpoint, and live-money readiness endpoint.`;
+      }
+    });
+  }
+
+  if (baseForm && baseOutput) {
+    baseForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const data = new FormData(baseForm);
+      const apiBaseUrl = String(data.get("baseApiBaseUrl") || "").replace(/\/+$/, "");
+      const bountyId = String(data.get("baseBountyId") || "").trim();
+      const network = String(data.get("baseNetwork") || "base-sepolia").trim();
+      const escrowContract = String(data.get("baseEscrowContract") || "").trim();
+      const payer = String(data.get("basePayer") || "").trim();
+      const token = String(data.get("baseToken") || "").trim();
+
+      baseOutput.textContent = "Checking hosted API health...";
+      try {
+        await checkHostedHealth(apiBaseUrl);
+        baseOutput.textContent = "Hosted API health is ok. Planning unsigned Base funding transactions...";
+        const response = await fetch(`${apiBaseUrl}/v1/base/funding-plan`, {
+          method: "POST",
+          headers: { "content-type": "application/json", accept: "application/json" },
+          body: JSON.stringify({
+            bounty_id: bountyId,
+            escrow_contract: escrowContract,
+            payer,
+            token,
+            network,
+          }),
+        });
+        if (!response.ok) {
+          throw new Error(`Base funding plan failed with ${response.status}`);
+        }
+        const plan = await response.json();
+        const summary = {
+          network: plan.network && plan.network.name,
+          chain_id: plan.network && plan.network.chain_id,
+          bounty_id: plan.bounty && plan.bounty.id,
+          amount: plan.create && plan.create.amount,
+          approve: plan.funding && plan.funding.approve,
+          create_escrow: plan.funding && plan.funding.create_escrow,
+        };
+        baseOutput.textContent = `${JSON.stringify(summary, null, 2)}\n\nSign and broadcast these transactions from the payer wallet outside this site. This plan is not funding; the bounty is funded only after an indexed EscrowCreated log is reconciled.`;
+      } catch (error) {
+        baseOutput.textContent = `${error.message}\n\nNo transaction was signed or broadcast. Confirm the hosted API URL, bounty id, escrow contract, payer wallet, token, network, and that the bounty is Base USDC funding-ready.`;
       }
     });
   }


### PR DESCRIPTION
## Summary
- add a public Base USDC planning panel to the static funding page
- advertise the Base funding handoff in `/.well-known/agent-bounties.json` and `/llms.txt`
- extend the static site check so the handoff and settlement boundary cannot drift silently

## Payment boundary
This is read-only planning. It calls `/v1/base/funding-plan` after `/health` passes and displays unsigned `approve` and `createEscrow` transaction intents. It does not sign, broadcast, fund, credit, settle, or mark any bounty funded. Base funding remains effective only after an indexed `EscrowCreated` log is reconciled.

## Contributor queue
Checked before edits. PR #24 remains open with `CHANGES_REQUESTED` and no new contributor commits. I posted a fresh status/repair-path comment there, and posted closure/redirect comments on closed bounty issues #2-#5 where contributors had left `/claim` or `/attempt` comments.

## Notice
Public maintainer notice: #100.

## Checks
- `scripts/preflight.ps1 -Mode core`
- `python scripts\check-site.py`
- `node --check site\main.js`
- `python -m json.tool site\.well-known\agent-bounties.json | Out-Null`
- `cargo run -p cli -- docs-contract-check`
- `git diff --check`
- `scripts\check.ps1`