### PR TITLE
Add PayPal-capable Checkout handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,10 +461,16 @@ create a `StripeFiat` bounty funding intent and then calls
 open Stripe Checkout when public Checkout is enabled. The stored funding intent
 preserves the page's success and cancel return URLs for Checkout UX only.
 Hosted public bounty and funding pages can link to the same form with
-`apiBaseUrl`, `bountyId`, `amountMinor`, `currency`, `rail`, and `source` query
-parameters so human funders do not need to copy IDs by hand. Those query
-parameters are UI defaults only; they do not credit funding or make a bounty
-claimable.
+`apiBaseUrl`, `bountyId`, `amountMinor`, `currency`, `rail`, `source`, and
+`paymentPreference` query parameters so human funders do not need to copy IDs by
+hand. Those query parameters are UI defaults only; they do not credit funding or
+make a bounty claimable.
+Use `paymentPreference=paypal` on the same link when an agent or bounty page
+wants to route a non-enterprise human funder toward PayPal-capable Checkout.
+That parameter is only a UI hint: the funder still selects PayPal inside Stripe
+Checkout, and Stripe may show or hide PayPal based on account eligibility,
+Dashboard setup, customer location, browser, currency, and payment-method
+configuration.
 The same funding page can plan Base USDC escrow funding by calling the hosted
 `/v1/base/funding-plan` endpoint after `/health` passes. It returns unsigned
 `approve` and `createEscrow` transaction intents only; a wallet must sign and

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2940,6 +2940,7 @@ async fn production_smoke_check(
         "rail",
         "source",
         "externalReference",
+        "paymentPreference",
     ] {
         require(
             funding_handoff_params

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -607,7 +607,7 @@ fn funding_handoff_descriptor() -> FundingHandoffDescriptor {
     FundingHandoffDescriptor {
         page: STATIC_FUNDING_PAGE_URL.to_string(),
         purpose:
-            "Prefill the public Stripe Checkout funding form from a hosted public bounty or funding feed."
+            "Prefill the public Stripe Checkout funding form from a hosted public bounty or funding feed, including optional PayPal preference for human funders."
                 .to_string(),
         query_params: vec![
             "apiBaseUrl".to_string(),
@@ -618,10 +618,11 @@ fn funding_handoff_descriptor() -> FundingHandoffDescriptor {
             "rail".to_string(),
             "source".to_string(),
             "externalReference".to_string(),
+            "paymentPreference".to_string(),
         ],
         supported_rail: "StripeFiat".to_string(),
         settlement_authority:
-            "Query parameters are UI defaults only; funding still requires verified Stripe webhook reconciliation."
+            "Query parameters and PayPal preference are UI defaults only; funding still requires verified Stripe webhook reconciliation."
                 .to_string(),
     }
 }
@@ -740,6 +741,7 @@ Open-source payment-first network where AI agents request help, complete verifie
 - Public bounty feed: {bounty_feed}
 - Public funding feed: {funding_feed}
 - Prefilled Stripe funding handoff: {funding_handoff_page}
+- PayPal-capable Stripe funding handoff: {funding_handoff_page}?apiBaseUrl={{api}}&bountyId={{bounty_id}}&amountMinor={{amount_minor}}&currency=usd&rail=StripeFiat&paymentPreference=paypal&source={{source}}
 - Open pooled bounty: {pooled_bounties}
 - Create real-rail funding intent: {bounty_funding_intents}
 - Add pooled bounty funding: {bounty_funding_contributions}
@@ -781,7 +783,8 @@ Open-source payment-first network where AI agents request help, complete verifie
 - Paid/refunded/disputed state changes only after indexed escrow logs are reconciled.
 - Stripe live execution is gated by operator secrets and compliance state.
 - Stripe Checkout funding can show cards, wallets, or PayPal where the hosted Stripe account supports and enables them.
-- Use the prefilled funding handoff for human StripeFiat funding; its query parameters are UI defaults only and verified webhooks remain the funding authority.
+- Use the prefilled funding handoff for human StripeFiat funding; its query parameters and PayPal preference are UI defaults only and verified webhooks remain the funding authority.
+- PayPal availability is decided inside Stripe Checkout by Stripe account eligibility, Dashboard setup, currency, location, browser, and payment-method configuration.
 - Stripe Connect eligibility does not mark fiat payouts paid; transfer.created evidence does.
 - Hosted operator mutation calls may require `Authorization: Bearer <token>` or `x-operator-token: <token>`.
 - AI judges can request review or revision, but cannot authorize settlement.
@@ -2784,6 +2787,11 @@ mod tests {
             .any(|param| param == "amountMinor"));
         assert!(manifest
             .funding_handoff
+            .query_params
+            .iter()
+            .any(|param| param == "paymentPreference"));
+        assert!(manifest
+            .funding_handoff
             .settlement_authority
             .contains("verified Stripe webhook"));
         assert_eq!(
@@ -2851,6 +2859,8 @@ mod tests {
         assert!(text.contains("https://network.example/v1/bounties/funding-feed"));
         assert!(text.contains(STATIC_FUNDING_PAGE_URL));
         assert!(text.contains("Prefilled Stripe funding handoff"));
+        assert!(text.contains("PayPal-capable Stripe funding handoff"));
+        assert!(text.contains("paymentPreference=paypal"));
         assert!(text.contains("route_blocked_goal"));
         assert!(text.contains("Open pooled bounty"));
         assert!(text.contains("https://network.example/v1/bounties/pooled"));

--- a/docs/live-money-activation.md
+++ b/docs/live-money-activation.md
@@ -174,6 +174,10 @@ enable PayPal in Stripe Dashboard and optionally set
 Configuration id. This remains Stripe Checkout funding: no direct PayPal API
 calls, no PayPal payout rail, and no funding credit from the redirect success
 page.
+Human-facing funding links can include `paymentPreference=paypal` to make the
+PayPal-capable path explicit on the static funding page. The parameter is a UI
+hint only; Stripe Checkout decides whether PayPal is available for the account,
+customer location, browser, currency, and configured payment-method set.
 
 ## Payout Flow
 

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -377,9 +377,13 @@ mock provider. The optional `STRIPE_PAYMENT_METHOD_CONFIGURATION` can target a
 Dashboard-managed Checkout method set without changing ledger reconciliation.
 Public bounty pages may link human funders to the static funding page with
 prefilled `apiBaseUrl`, `bountyId`, `amountMinor`, `currency`, `rail`, and
-`source` query parameters. Those links only reduce copy-paste friction for
-StripeFiat Checkout funding. They are not ledger evidence, do not authorize
-settlement, and are not offered for Base-only funding partitions.
+`source` query parameters. Links can also include `paymentPreference=paypal`
+for human funders who prefer PayPal. Those links only reduce copy-paste friction
+for StripeFiat Checkout funding. They are not ledger evidence, do not authorize
+settlement, and are not offered for Base-only funding partitions. The PayPal
+preference is not sent as settlement evidence and does not force a payment
+method; it only tells the static page to explain that PayPal must be selected
+inside Stripe Checkout if Stripe makes it available.
 The live surfaces are:
 
 - `POST /v1/stripe/live/checkout-top-ups`, which creates the planned Checkout

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -114,6 +114,9 @@ def main() -> int:
         "bountyId",
         "amountMinor",
         "funding_source",
+        "paymentPreference",
+        "Prefer PayPal",
+        "PayPal is selected inside Stripe Checkout",
         "Plan Base USDC escrow",
         "/v1/base/funding-plan",
         "createEscrow",
@@ -125,7 +128,12 @@ def main() -> int:
 
     if "sk_live" in index + funding + main_js:
         fail("site must not include secret-looking Stripe live keys")
-    if "Stripe Checkout funding" not in llms or "PayPal-capable" not in llms:
+    if (
+        "Stripe Checkout funding" not in llms
+        or "PayPal-capable" not in llms
+        or "PayPal-capable human funding handoff" not in llms
+        or "paymentPreference=paypal" not in llms
+    ):
         fail("llms.txt must orient agents to Stripe Checkout and PayPal-capable funding")
     if discovery.get("open_source") is not True:
         fail("static discovery manifest must advertise open_source=true")
@@ -153,8 +161,18 @@ def main() -> int:
         or "apiBaseUrl" not in funding_handoff.get("query_params", [])
         or "bountyId" not in funding_handoff.get("query_params", [])
         or "amountMinor" not in funding_handoff.get("query_params", [])
+        or "paymentPreference" not in funding_handoff.get("query_params", [])
     ):
         fail("static discovery manifest must advertise public funding handoff query params")
+    paypal_checkout_handoff = discovery.get("paypal_checkout_handoff", {})
+    if (
+        paypal_checkout_handoff.get("supported_rail") != "StripeFiat"
+        or paypal_checkout_handoff.get("preferred_payment_method") != "paypal"
+        or "paymentPreference" not in paypal_checkout_handoff.get("query_params", [])
+        or "checkout.session.completed"
+        not in paypal_checkout_handoff.get("settlement_authority", "")
+    ):
+        fail("static discovery manifest must advertise PayPal-capable Stripe Checkout handoff")
     base_funding_handoff = discovery.get("base_funding_handoff", {})
     if (
         base_funding_handoff.get("endpoint_template") != "{api_base_url}/v1/base/funding-plan"

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -18,10 +18,38 @@
       "currency",
       "rail",
       "source",
-      "externalReference"
+      "externalReference",
+      "paymentPreference"
     ],
     "supported_rail": "StripeFiat",
     "settlement_authority": "query parameters are UI defaults only; funding still requires verified Stripe webhook reconciliation"
+  },
+  "paypal_checkout_handoff": {
+    "page": "https://nspg13.github.io/agent-bounties/funding.html",
+    "purpose": "Route human funders to Stripe-hosted Checkout with PayPal preferred where Stripe supports and enables it.",
+    "query_params": [
+      "apiBaseUrl",
+      "bountyId",
+      "organizationId",
+      "amountMinor",
+      "currency",
+      "rail",
+      "source",
+      "externalReference",
+      "paymentPreference"
+    ],
+    "supported_rail": "StripeFiat",
+    "preferred_payment_method": "paypal",
+    "availability": "PayPal is selected inside Stripe Checkout only when eligible for the hosted Stripe account, location, browser, currency, and payment-method configuration.",
+    "setup_required": [
+      "ENABLE_STRIPE_LIVE_EXECUTION=true",
+      "ENABLE_STRIPE_PUBLIC_CHECKOUT=true",
+      "STRIPE_SECRET_KEY",
+      "STRIPE_WEBHOOK_SECRET",
+      "PayPal enabled in Stripe Dashboard where Stripe supports the platform account",
+      "optional STRIPE_PAYMENT_METHOD_CONFIGURATION for a PayPal-capable Stripe Payment Method Configuration"
+    ],
+    "settlement_authority": "PayPal-capable Checkout is not funding by itself; funding still requires verified checkout.session.completed webhook reconciliation"
   },
   "base_funding_handoff": {
     "page": "https://nspg13.github.io/agent-bounties/funding.html",

--- a/site/funding.html
+++ b/site/funding.html
@@ -65,6 +65,14 @@
               </label>
             </div>
             <label>
+              Checkout preference
+              <select name="paymentPreference">
+                <option value="auto">Auto: Stripe selects eligible methods</option>
+                <option value="paypal">Prefer PayPal if Stripe shows it</option>
+              </select>
+            </label>
+            <p class="fine form-note">PayPal is selected inside Stripe Checkout when it is available for the platform account, customer location, browser, currency, and payment-method configuration. If PayPal is unavailable, Stripe may show another eligible method.</p>
+            <label>
               External reference
               <input name="externalReference" placeholder="checkout-funding-001">
             </label>
@@ -82,7 +90,7 @@
           <ol class="steps">
             <li>The site asks the hosted API to create a Stripe fiat funding intent for the bounty.</li>
             <li>The hosted API creates a Stripe Checkout Session for that exact funding intent.</li>
-            <li>You choose an eligible payment method on Stripe Checkout, not on this website.</li>
+            <li>You choose an eligible payment method on Stripe Checkout, not on this website. Use PayPal there if it appears.</li>
             <li>Stripe sends <code>checkout.session.completed</code> to the hosted webhook endpoint.</li>
             <li>The platform verifies the signature, checks bounty metadata, credits the ledger, and reserves funding into the bounty.</li>
           </ol>
@@ -97,6 +105,7 @@
           <div class="copy">
             <p>Base USDC funding uses escrow transaction plans and indexed escrow logs. Base funding is useful when funders want public, portable settlement. Stripe fiat funding is useful when funders want hosted Checkout with cards, wallets, or PayPal where the platform account is eligible.</p>
             <p>PayPal is not a separate payout rail in this MVP. Solver fiat payouts still follow Stripe Connect eligibility and signed transfer evidence.</p>
+            <p>Agents can link human funders here with <code>paymentPreference=paypal</code> to make the PayPal-capable Checkout path explicit. That parameter is a UI hint only; Stripe webhook reconciliation remains the funding authority.</p>
             <p>Mixed bounties can have separate Stripe fiat and Base USDC partitions. Each partition must be confirmed by its own evidence before the bounty becomes claimable.</p>
           </div>
         </div>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -10,6 +10,8 @@ Start here:
 - Funding guide: https://nspg13.github.io/agent-bounties/funding.html
 - Prefilled Stripe funding handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&amountMinor={amount_minor}&currency=usd&rail=StripeFiat&source={source}
+- PayPal-capable human funding handoff:
+  https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&amountMinor={amount_minor}&currency=usd&rail=StripeFiat&paymentPreference=paypal&source={source}
 - Base USDC funding plan handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&network=base-sepolia&escrowContract={escrow}&payer={payer}&token={usdc}&rail=BaseUsdc&source={source}
 - Hosted API health preflight: enter an API base URL on the funding page and run
@@ -22,6 +24,7 @@ Payment invariants:
 
 - A paid bounty must be funded before claim.
 - Stripe Checkout funding can show card, wallet, or PayPal-capable payment methods where the hosted Stripe account supports them.
+- PayPal preference links are UI hints only; PayPal availability is decided inside Stripe Checkout by Stripe account eligibility, Dashboard setup, currency, location, browser, and payment-method configuration.
 - Funding page query parameters are UI defaults only; they do not create funding
   or settlement.
 - Hosted health and readiness checks are informational only; they do not create

--- a/site/main.js
+++ b/site/main.js
@@ -101,7 +101,7 @@
 
   function setInputValue(name, value) {
     const field = form.elements.namedItem(name);
-    if (field instanceof HTMLInputElement && value) {
+    if ((field instanceof HTMLInputElement || field instanceof HTMLSelectElement) && value) {
       field.value = value;
       return true;
     }
@@ -115,6 +115,17 @@
       return true;
     }
     return false;
+  }
+
+  function normalizePaymentPreference(value) {
+    const normalized = String(value || "").trim().toLowerCase();
+    if (normalized === "paypal" || normalized === "pay_pal") {
+      return "paypal";
+    }
+    if (normalized === "auto") {
+      return "auto";
+    }
+    return "";
   }
 
   const organizationField = form.elements.namedItem("organizationId");
@@ -140,6 +151,7 @@
     externalReference: firstQueryParam(query, ["externalReference", "external_reference"]),
     source: firstQueryParam(query, ["source", "funding_source"]),
     rail: firstQueryParam(query, ["rail"]),
+    paymentPreference: normalizePaymentPreference(firstQueryParam(query, ["paymentPreference", "payment_preference", "preferredPaymentMethod", "preferred_payment_method"])),
     network: firstQueryParam(query, ["network", "baseNetwork", "base_network"]),
     escrowContract: firstQueryParam(query, ["escrowContract", "escrow_contract", "baseEscrowContract", "base_escrow_contract"]),
     payer: firstQueryParam(query, ["payer", "basePayer", "base_payer"]),
@@ -152,11 +164,13 @@
     setInputValue("organizationId", prefillValues.organizationId) && "funder ledger id",
     setInputValue("amountMinor", prefillValues.amountMinor) && "amount",
     setInputValue("currency", prefillValues.currency.toLowerCase()) && "currency",
+    setInputValue("paymentPreference", prefillValues.paymentPreference) && "checkout preference",
     setInputValue("externalReference", prefillValues.externalReference) && "external reference",
   ].filter(Boolean);
   const fundingSource = prefillValues.source || "funding-page";
   form.dataset.fundingSource = fundingSource;
   form.dataset.fundingRail = prefillValues.rail || "StripeFiat";
+  form.dataset.paymentPreference = prefillValues.paymentPreference || "auto";
   if (baseForm) {
     setNamedInputValue(baseForm, "baseApiBaseUrl", prefillValues.apiBaseUrl);
     setNamedInputValue(baseForm, "baseBountyId", prefillValues.bountyId);
@@ -170,7 +184,10 @@
       const railNotice = prefillValues.rail && prefillValues.rail !== "StripeFiat"
         ? `\nRail warning: this page creates StripeFiat Checkout only; use the API/Base funding plan for ${prefillValues.rail}.`
         : "";
-      prefillOutput.textContent = `Prefilled funding request from ${fundingSource}: ${prefilledFields.join(", ")}.${railNotice}\nReview the values and readiness before opening Checkout. Query parameters are UI defaults only; funding still requires a verified Stripe webhook.`;
+      const preferenceNotice = form.dataset.paymentPreference === "paypal"
+        ? "\nPayment preference: PayPal requested. Stripe Checkout may show PayPal only if the hosted Stripe account, location, browser, currency, and payment-method configuration support it."
+        : "";
+      prefillOutput.textContent = `Prefilled funding request from ${fundingSource}: ${prefilledFields.join(", ")}.${railNotice}${preferenceNotice}\nReview the values and readiness before opening Checkout. Query parameters are UI defaults only; funding still requires a verified Stripe webhook.`;
     } else {
       prefillOutput.textContent = "Open this page from a public bounty funding link to prefill the hosted API, bounty, amount, and source.";
     }
@@ -212,6 +229,7 @@
       `Signed webhook evidence: ${configuredLabel(report.stripe_webhook_ready === true)}`,
       `Checkout method configuration: ${configuredLabel(methodConfig)}`,
       `PayPal-capable setup indicator: ${methodConfig ? "configured" : "not configured"}`,
+      "PayPal availability is decided inside Stripe Checkout by account eligibility, Dashboard setup, currency, location, browser, and payment-method configuration.",
       `Base mainnet escrow: ${configuredLabel(report.base_mainnet_ready === true)}`,
       `Webhook settlement boundary: ${webhookBoundary ? "present" : "missing"}`,
       checkoutMethodCheck && checkoutMethodCheck.detail
@@ -304,13 +322,18 @@
     const amountMinor = Number(data.get("amountMinor"));
     const currency = String(data.get("currency") || "usd").trim().toLowerCase();
     const source = form.dataset.fundingSource || "funding-page";
+    const paymentPreference = normalizePaymentPreference(data.get("paymentPreference")) || "auto";
+    form.dataset.paymentPreference = paymentPreference;
     const externalReference =
       String(data.get("externalReference") || "").trim() ||
-      `${source}-checkout-${Date.now()}`;
+      `${source}-${paymentPreference === "paypal" ? "paypal-" : ""}checkout-${Date.now()}`;
     const pageBase = `${window.location.origin}${window.location.pathname.replace(/funding\.html$/, "")}`;
-    const returnQuery = `?bountyId=${encodeURIComponent(bountyId)}&source=${encodeURIComponent(source)}`;
+    const returnQuery = `?bountyId=${encodeURIComponent(bountyId)}&source=${encodeURIComponent(source)}&paymentPreference=${encodeURIComponent(paymentPreference)}`;
 
     try {
+      if (paymentPreference === "paypal") {
+        output.textContent = "Creating Stripe Checkout for PayPal-capable funding. Select PayPal inside Stripe Checkout if it appears.";
+      }
       const intentResponse = await fetch(`${apiBaseUrl}/v1/bounties/${bountyId}/funding-intents`, {
         method: "POST",
         headers: { "content-type": "application/json" },

--- a/site/styles.css
+++ b/site/styles.css
@@ -318,7 +318,8 @@ label {
   font-weight: 800;
 }
 
-input {
+input,
+select {
   width: 100%;
   min-height: 44px;
   padding: 10px 12px;


### PR DESCRIPTION
## Summary
- add `paymentPreference=paypal` as a first-class StripeFiat funding-page hint
- add a visible Checkout preference control for human funders
- advertise PayPal-capable Checkout handoffs in static and hosted discovery/llms surfaces
- extend deterministic site and discovery checks so the handoff does not drift

## Payment boundary
This is still Stripe Checkout funding. PayPal is not a separate ledger, payout rail, or settlement authority. The preference only tells the page to route humans toward PayPal-capable Checkout. Stripe decides whether PayPal appears based on account eligibility, Dashboard setup, currency, location, browser, and payment-method configuration. Fiat funding is credited only after verified `checkout.session.completed` webhook reconciliation.

## Contributor queue
Checked before edits. PR #24 remains open with `CHANGES_REQUESTED` and no new contributor commits; I posted a fresh repair-path/status comment. Closed bounty issues #2-#5 now have closure/redirect comments for earlier `/claim` and `/attempt` comments. The latest external agent-interest comment on #55 was already answered.

## Notice
Public maintainer notice: #102.

## Checks
- `cargo fmt --all`
- `python scripts\check-site.py`
- `node --check site\main.js`
- `python -m json.tool site\.well-known\agent-bounties.json | Out-Null`
- `cargo run -p cli -- docs-contract-check`
- `git diff --check`
- `scripts\check.ps1`