### PR TITLE
Add contributor contact registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Useful REST paths:
 - `POST /v1/risk/events/{id}/reject`
 - `POST /v1/agents`
 - `GET /v1/agents/{id}/paid-status`
+- `POST /v1/contributor-contacts`
+- `GET /v1/contributor-contacts`
 - `POST /v1/capabilities`
 - `GET /v1/capabilities/feed`
 - `POST /v1/capabilities/search`
@@ -340,6 +342,12 @@ automatic flows stopped. Operator flows can approve a `NeedsReview` bounty event
 through `/v1/risk/bounty-approvals`, approve a matching high-value payout event
 through `/v1/risk/payout-approvals`, reject review events through
 `/v1/risk/events/{id}/reject`, and audit decisions through `/v1/risk/reviews`.
+Operator clients can maintain an opt-in contributor contact and thank-you payout
+registry through `/v1/contributor-contacts`; see
+[docs/contributor-contact-registry.md](docs/contributor-contact-registry.md).
+After the API is running, `scripts\import-github-contributors.ps1` can import
+historic public PR participants with their associated PR URLs while leaving email
+and wallet fields empty until each contributor opts in.
 When verification was stopped by payout review, clients retry
 `POST /v1/bounties/{id}/verify` with `approved_risk_event_id` set to the
 approved payout event id. Hosted operator SDK clients can pass the token with

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -10,7 +10,8 @@ use app::{
     PlanStripeTransferRequest as AppPlanStripeTransferRequest, PooledFundingReport,
     PostBountyRequest, QuoteSet, RegisterAgentRequest, RegisterCapabilityRequest,
     RejectRiskEventRequest, RequestQuotesRequest, ReviewedBountyApproval, RiskEventFilter,
-    StripeTransferPlan, StripeTransferReconciliation, SubmitResultRequest, VerifySubmissionRequest,
+    StripeTransferPlan, StripeTransferReconciliation, SubmitResultRequest,
+    UpsertContributorContactRequest, VerifySubmissionRequest,
 };
 use axum::{
     body::Bytes,
@@ -31,8 +32,9 @@ use chain_base::{
 use chrono::Utc;
 use db::PostgresStore;
 use domain::{
-    Agent, BountyStatus, Capability, CapabilityClass, EvalRun, HelpRequest, Money, PayoutStatus,
-    PrivacyLevel, RiskEvent, RiskReviewRecord, VerificationDecision, VerifierKind,
+    Agent, BountyStatus, Capability, CapabilityClass, ContributorContact, EvalRun, HelpRequest,
+    Money, PayoutStatus, PrivacyLevel, RiskEvent, RiskReviewRecord, VerificationDecision,
+    VerifierKind,
 };
 use eval_harness::{
     bundled_abuse_fixtures, bundled_fixtures, bundled_judge_fixtures, run_eval_loops, AbuseBench,
@@ -85,6 +87,8 @@ use worker::BaseEscrowLogWorker;
         list_eval_runs,
         register_agent,
         agent_paid_status,
+        upsert_contributor_contact,
+        list_contributor_contacts,
         register_capability,
         search_capabilities,
         create_help_request,
@@ -150,7 +154,8 @@ use worker::BaseEscrowLogWorker;
         FetchBaseRpcLogsRequest,
         BroadcastBaseSignedTransactionRequest,
         GetBaseTransactionReceiptRequest,
-        SearchCapabilitiesRequest
+        SearchCapabilitiesRequest,
+        ContributorContact
     )),
     modifiers(&SecurityAddon)
 )]
@@ -509,6 +514,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/v1/evals/runs", get(list_eval_runs))
         .route("/v1/agents", post(register_agent))
         .route("/v1/agents/:id/paid-status", get(agent_paid_status))
+        .route(
+            "/v1/contributor-contacts",
+            post(upsert_contributor_contact).get(list_contributor_contacts),
+        )
         .route("/v1/capabilities", post(register_capability))
         .route("/v1/capabilities/feed", get(public_capability_feed))
         .route("/v1/capabilities/search", post(search_capabilities))
@@ -1066,6 +1075,54 @@ async fn agent_paid_status(
             app::AppError::AgentNotFound => StatusCode::NOT_FOUND,
             _ => StatusCode::BAD_REQUEST,
         })
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/contributor-contacts",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = ContributorContact),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn upsert_contributor_contact(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(request): Json<UpsertContributorContactRequest>,
+) -> Result<Json<ContributorContact>, StatusCode> {
+    require_operator(&state, &headers)?;
+    let contact = {
+        let mut network = state.network.lock().expect("state poisoned");
+        network
+            .upsert_contributor_contact(request)
+            .map_err(|_| StatusCode::BAD_REQUEST)?
+    };
+    if let Some(store) = &state.store {
+        store
+            .upsert_contributor_contact(&contact)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(Json(contact))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/contributor-contacts",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = Vec<ContributorContact>),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn list_contributor_contacts(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<ContributorContact>>, StatusCode> {
+    require_operator(&state, &headers)?;
+    let network = state.network.lock().expect("state poisoned");
+    Ok(Json(network.list_contributor_contacts()))
 }
 
 #[utoipa::path(post, path = "/v1/capabilities")]
@@ -3058,6 +3115,12 @@ async fn hydrate_network(store: &PostgresStore) -> anyhow::Result<BountyNetwork>
             .into_iter()
             .map(|agent| (agent.id, agent))
             .collect(),
+        contributor_contacts: store
+            .list_contributor_contacts()
+            .await?
+            .into_iter()
+            .map(|contact| (contact.id, contact))
+            .collect(),
         capabilities: store
             .list_capabilities()
             .await?
@@ -4455,6 +4518,7 @@ mod tests {
         assert!(paths.contains_key("/v1/risk/payout-approvals"));
         assert!(paths.contains_key("/v1/risk/events/{id}/reject"));
         assert!(paths.contains_key("/v1/agents/{id}/paid-status"));
+        assert!(paths.contains_key("/v1/contributor-contacts"));
         assert!(paths.contains_key("/v1/capabilities/search"));
         assert!(paths.contains_key("/v1/base/indexer-status"));
         assert!(paths.contains_key("/v1/base/escrow-events"));
@@ -4494,6 +4558,7 @@ mod tests {
             "/v1/risk/bounty-approvals",
             "/v1/risk/payout-approvals",
             "/v1/risk/events/{id}/reject",
+            "/v1/contributor-contacts",
             "/v1/base/escrow-events",
             "/v1/base/evm-logs",
             "/v1/base/rpc-logs",
@@ -4548,6 +4613,59 @@ mod tests {
             "Stripe checkout webhook must remain callable by Stripe without operator auth"
         );
         assert!(paths["/v1/stripe/checkout-webhooks"]["post"]["responses"]["503"].is_object());
+    }
+
+    #[tokio::test]
+    async fn contributor_contacts_are_operator_gated() {
+        let state = test_state_with_operator_token(BountyNetwork::default(), "secret-token");
+        let denied = upsert_contributor_contact(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(UpsertContributorContactRequest {
+                github_login: "qilu13".to_string(),
+                email: None,
+                payout_wallet: Some("0x1111111111111111111111111111111111111111".to_string()),
+                associated_prs: vec!["#24".to_string()],
+                contact_consent: false,
+                wallet_consent: true,
+                outreach_allowed: false,
+                source: Some("github-comment-opt-in".to_string()),
+                notes: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(denied, StatusCode::UNAUTHORIZED);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(OPERATOR_TOKEN_HEADER, "secret-token".parse().unwrap());
+        let contact = upsert_contributor_contact(
+            State(state.clone()),
+            headers.clone(),
+            Json(UpsertContributorContactRequest {
+                github_login: "qilu13".to_string(),
+                email: None,
+                payout_wallet: Some("0x1111111111111111111111111111111111111111".to_string()),
+                associated_prs: vec!["#24".to_string()],
+                contact_consent: false,
+                wallet_consent: true,
+                outreach_allowed: false,
+                source: Some("github-comment-opt-in".to_string()),
+                notes: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+
+        assert_eq!(contact.github_login, "qilu13");
+        assert!(contact.wallet_consent);
+        let contacts = list_contributor_contacts(State(state), headers)
+            .await
+            .unwrap()
+            .0;
+        assert_eq!(contacts.len(), 1);
+        assert_eq!(contacts[0].associated_prs, vec!["#24".to_string()]);
     }
 
     #[tokio::test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -6,12 +6,12 @@ use chain_base::{
 };
 use chrono::{DateTime, Utc};
 use domain::{
-    Agent, Bounty, BountyStatus, Capability, CapabilityClass, Claim, Escrow, EscrowStatus,
-    FundingContribution, FundingContributionStatus, FundingIntent, FundingIntentStatus,
-    FundingMode, FundingPartitionTarget, HelpRequest, Id, Money, PaymentEvent, PaymentEventStatus,
-    PaymentRail, PayoutIntent, PayoutStatus, PrivacyLevel, ProofRecord, Quote, ReputationEvent,
-    RiskAction, RiskEvent, RiskReviewOutcome, RiskReviewRecord, RiskSurface, Settlement,
-    Submission, TemplateSignal, VerificationDecision, VerifierKind, VerifierResult,
+    Agent, Bounty, BountyStatus, Capability, CapabilityClass, Claim, ContributorContact, Escrow,
+    EscrowStatus, FundingContribution, FundingContributionStatus, FundingIntent,
+    FundingIntentStatus, FundingMode, FundingPartitionTarget, HelpRequest, Id, Money, PaymentEvent,
+    PaymentEventStatus, PaymentRail, PayoutIntent, PayoutStatus, PrivacyLevel, ProofRecord, Quote,
+    ReputationEvent, RiskAction, RiskEvent, RiskReviewOutcome, RiskReviewRecord, RiskSurface,
+    Settlement, Submission, TemplateSignal, VerificationDecision, VerifierKind, VerifierResult,
 };
 use ledger::{credit, debit, AccountCode, Ledger, LedgerEntry};
 use payments_stripe::{
@@ -26,7 +26,7 @@ use risk::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 use uuid::Uuid;
 use verifier_sdk::{verify_with_builtin, VerificationInput};
@@ -73,6 +73,8 @@ pub enum AppError {
     InvalidFundingIntent(String),
     #[error("invalid Stripe payout reconciliation: {0}")]
     InvalidStripePayout(String),
+    #[error("invalid contributor contact: {0}")]
+    InvalidContributorContact(String),
     #[error(transparent)]
     Domain(#[from] domain::DomainError),
     #[error(transparent)]
@@ -667,10 +669,46 @@ fn nonempty(value: &str) -> bool {
     !value.trim().is_empty()
 }
 
+fn normalized_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn dedup_nonempty(values: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+    for value in values {
+        let value = value.trim().to_string();
+        if !value.is_empty() && seen.insert(value.to_lowercase()) {
+            normalized.push(value);
+        }
+    }
+    normalized
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterAgentRequest {
     pub handle: String,
     pub payout_wallet: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpsertContributorContactRequest {
+    pub github_login: String,
+    pub email: Option<String>,
+    pub payout_wallet: Option<String>,
+    #[serde(default)]
+    pub associated_prs: Vec<String>,
+    #[serde(default)]
+    pub contact_consent: bool,
+    #[serde(default)]
+    pub wallet_consent: bool,
+    #[serde(default)]
+    pub outreach_allowed: bool,
+    #[serde(default)]
+    pub source: Option<String>,
+    pub notes: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1086,6 +1124,7 @@ pub struct StripeFundingReconciliation {
 #[derive(Debug)]
 pub struct BountyNetwork {
     pub agents: HashMap<Id, Agent>,
+    pub contributor_contacts: HashMap<Id, ContributorContact>,
     pub capabilities: HashMap<Id, Capability>,
     pub help_requests: HashMap<Id, HelpRequest>,
     pub quotes: HashMap<Id, Quote>,
@@ -1111,6 +1150,7 @@ impl Default for BountyNetwork {
     fn default() -> Self {
         Self {
             agents: HashMap::new(),
+            contributor_contacts: HashMap::new(),
             capabilities: HashMap::new(),
             help_requests: HashMap::new(),
             quotes: HashMap::new(),
@@ -1140,6 +1180,98 @@ impl BountyNetwork {
         agent.payout_wallet = request.payout_wallet;
         self.agents.insert(agent.id, agent.clone());
         agent
+    }
+
+    pub fn upsert_contributor_contact(
+        &mut self,
+        request: UpsertContributorContactRequest,
+    ) -> AppResult<ContributorContact> {
+        let github_login = request
+            .github_login
+            .trim()
+            .trim_start_matches('@')
+            .to_string();
+        if github_login.is_empty() {
+            return Err(AppError::InvalidContributorContact(
+                "github_login is required".to_string(),
+            ));
+        }
+
+        let email = normalized_optional_string(request.email);
+        if email.is_some() && !request.contact_consent {
+            return Err(AppError::InvalidContributorContact(
+                "email requires contact_consent=true".to_string(),
+            ));
+        }
+        let payout_wallet = normalized_optional_string(request.payout_wallet);
+        if payout_wallet.is_some() && !request.wallet_consent {
+            return Err(AppError::InvalidContributorContact(
+                "payout_wallet requires wallet_consent=true".to_string(),
+            ));
+        }
+        if request.outreach_allowed && !request.contact_consent {
+            return Err(AppError::InvalidContributorContact(
+                "outreach_allowed requires contact_consent=true".to_string(),
+            ));
+        }
+
+        let source =
+            normalized_optional_string(request.source).unwrap_or_else(|| "operator".into());
+        let notes = normalized_optional_string(request.notes);
+        let login_key = github_login.to_lowercase();
+        let existing_id = self.contributor_contacts.iter().find_map(|(id, contact)| {
+            (contact.github_login.to_lowercase() == login_key).then_some(*id)
+        });
+        let mut associated_prs = dedup_nonempty(request.associated_prs);
+        let now = Utc::now();
+
+        let contact = if let Some(existing_id) = existing_id {
+            let mut contact = self
+                .contributor_contacts
+                .get(&existing_id)
+                .cloned()
+                .ok_or_else(|| {
+                    AppError::InvalidContributorContact(
+                        "existing contributor contact was not found".to_string(),
+                    )
+                })?;
+            associated_prs.extend(contact.associated_prs.iter().cloned());
+            contact.github_login = github_login;
+            contact.email = email;
+            contact.payout_wallet = payout_wallet;
+            contact.associated_prs = dedup_nonempty(associated_prs);
+            contact.contact_consent = request.contact_consent;
+            contact.wallet_consent = request.wallet_consent;
+            contact.outreach_allowed = request.outreach_allowed;
+            contact.source = source;
+            contact.notes = notes;
+            contact.updated_at = now;
+            contact
+        } else {
+            let mut contact = ContributorContact::new(github_login, source);
+            contact.email = email;
+            contact.payout_wallet = payout_wallet;
+            contact.associated_prs = associated_prs;
+            contact.contact_consent = request.contact_consent;
+            contact.wallet_consent = request.wallet_consent;
+            contact.outreach_allowed = request.outreach_allowed;
+            contact.notes = notes;
+            contact.updated_at = now;
+            contact
+        };
+        self.contributor_contacts
+            .insert(contact.id, contact.clone());
+        Ok(contact)
+    }
+
+    pub fn list_contributor_contacts(&self) -> Vec<ContributorContact> {
+        let mut contacts: Vec<_> = self.contributor_contacts.values().cloned().collect();
+        contacts.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.github_login.cmp(&right.github_login))
+        });
+        contacts
     }
 
     pub fn register_capability(
@@ -4345,6 +4477,92 @@ mod tests {
     use super::*;
 
     #[test]
+    fn contributor_contact_requires_consent_for_private_fields() {
+        let mut network = BountyNetwork::default();
+
+        let email_error =
+            network
+                .upsert_contributor_contact(UpsertContributorContactRequest {
+                    github_login: "qilu13".to_string(),
+                    email: Some("qilu13@example.com".to_string()),
+                    payout_wallet: None,
+                    associated_prs: vec![
+                        "https://github.com/NSPG13/agent-bounties/pull/24".to_string()
+                    ],
+                    contact_consent: false,
+                    wallet_consent: false,
+                    outreach_allowed: false,
+                    source: None,
+                    notes: None,
+                })
+                .unwrap_err();
+        assert!(matches!(
+            email_error,
+            AppError::InvalidContributorContact(message)
+                if message.contains("contact_consent")
+        ));
+
+        let wallet_error = network
+            .upsert_contributor_contact(UpsertContributorContactRequest {
+                github_login: "qilu13".to_string(),
+                email: None,
+                payout_wallet: Some("0x1111111111111111111111111111111111111111".to_string()),
+                associated_prs: vec![],
+                contact_consent: false,
+                wallet_consent: false,
+                outreach_allowed: false,
+                source: None,
+                notes: None,
+            })
+            .unwrap_err();
+        assert!(matches!(
+            wallet_error,
+            AppError::InvalidContributorContact(message)
+                if message.contains("wallet_consent")
+        ));
+    }
+
+    #[test]
+    fn contributor_contact_upsert_merges_prs_by_github_login() {
+        let mut network = BountyNetwork::default();
+        let first = network
+            .upsert_contributor_contact(UpsertContributorContactRequest {
+                github_login: "@Qilu13".to_string(),
+                email: None,
+                payout_wallet: None,
+                associated_prs: vec!["#24".to_string()],
+                contact_consent: false,
+                wallet_consent: false,
+                outreach_allowed: false,
+                source: Some("github-pr-history".to_string()),
+                notes: None,
+            })
+            .unwrap();
+        let second = network
+            .upsert_contributor_contact(UpsertContributorContactRequest {
+                github_login: "qilu13".to_string(),
+                email: None,
+                payout_wallet: Some("0x1111111111111111111111111111111111111111".to_string()),
+                associated_prs: vec!["#59".to_string(), "#24".to_string()],
+                contact_consent: false,
+                wallet_consent: true,
+                outreach_allowed: false,
+                source: Some("github-comment-opt-in".to_string()),
+                notes: Some("Base-compatible wallet supplied publicly.".to_string()),
+            })
+            .unwrap();
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(second.github_login, "qilu13");
+        assert_eq!(
+            second.associated_prs,
+            vec!["#59".to_string(), "#24".to_string()]
+        );
+        assert!(second.wallet_consent);
+        assert_eq!(network.list_contributor_contacts().len(), 1);
+    }
+
+    #[test]
     fn live_money_readiness_reports_ready_only_with_live_stripe_and_base_mainnet() {
         let report = build_live_money_readiness_report(LiveMoneyReadinessConfig {
             network: "base-mainnet".to_string(),
@@ -4732,12 +4950,11 @@ mod tests {
             FundingIntentStatus::Applied
         );
         assert_eq!(stripe_reconciliation.ledger_entries.len(), 2);
-        assert_eq!(
+        assert!(
             network
                 .apply_stripe_funding_credit(stripe_reconciliation.funding_credit.clone())
                 .unwrap()
-                .duplicate,
-            true
+                .duplicate
         );
 
         let after_stripe = network.status(bounty.id).unwrap();

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,12 +1,12 @@
 use chain_base::{BaseEscrowEvent, BaseEscrowEventKind};
 use chrono::{DateTime, Utc};
 use domain::{
-    Agent, AgentStatus, Bounty, BountyStatus, Capability, CapabilityClass, Claim, Escrow,
-    EscrowStatus, EvalRun, FundingContribution, FundingContributionStatus, FundingIntent,
-    FundingIntentStatus, FundingMode, HelpRequest, Id, Money, PaymentEvent, PaymentEventStatus,
-    PaymentRail, PrivacyLevel, ProofRecord, Quote, ReputationEvent, RiskAction, RiskEvent,
-    RiskReviewOutcome, RiskReviewRecord, RiskSurface, Settlement, Submission, TemplateSignal,
-    VerificationDecision, VerifierKind, VerifierResult,
+    Agent, AgentStatus, Bounty, BountyStatus, Capability, CapabilityClass, Claim,
+    ContributorContact, Escrow, EscrowStatus, EvalRun, FundingContribution,
+    FundingContributionStatus, FundingIntent, FundingIntentStatus, FundingMode, HelpRequest, Id,
+    Money, PaymentEvent, PaymentEventStatus, PaymentRail, PrivacyLevel, ProofRecord, Quote,
+    ReputationEvent, RiskAction, RiskEvent, RiskReviewOutcome, RiskReviewRecord, RiskSurface,
+    Settlement, Submission, TemplateSignal, VerificationDecision, VerifierKind, VerifierResult,
 };
 use ledger::{LedgerEntry, Posting};
 use sqlx::{PgPool, Row};
@@ -178,6 +178,73 @@ impl PostgresStore {
                     status: parse_agent_status(row.try_get::<String, _>("status")?)?,
                     payout_wallet: row.try_get("payout_wallet")?,
                     created_at: row.try_get("created_at")?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn upsert_contributor_contact(&self, contact: &ContributorContact) -> DbResult<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO contributor_contacts
+              (id, github_login, github_login_normalized, email, payout_wallet, associated_prs, contact_consent, wallet_consent, outreach_allowed, source, notes, created_at, updated_at)
+            VALUES ($1, $2, lower($2), $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            ON CONFLICT (github_login_normalized) DO UPDATE SET
+              github_login = EXCLUDED.github_login,
+              email = EXCLUDED.email,
+              payout_wallet = EXCLUDED.payout_wallet,
+              associated_prs = EXCLUDED.associated_prs,
+              contact_consent = EXCLUDED.contact_consent,
+              wallet_consent = EXCLUDED.wallet_consent,
+              outreach_allowed = EXCLUDED.outreach_allowed,
+              source = EXCLUDED.source,
+              notes = EXCLUDED.notes,
+              updated_at = EXCLUDED.updated_at
+            "#,
+        )
+        .bind(contact.id)
+        .bind(&contact.github_login)
+        .bind(&contact.email)
+        .bind(&contact.payout_wallet)
+        .bind(serde_json::to_value(&contact.associated_prs)?)
+        .bind(contact.contact_consent)
+        .bind(contact.wallet_consent)
+        .bind(contact.outreach_allowed)
+        .bind(&contact.source)
+        .bind(&contact.notes)
+        .bind(contact.created_at)
+        .bind(contact.updated_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn list_contributor_contacts(&self) -> DbResult<Vec<ContributorContact>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, github_login, email, payout_wallet, associated_prs, contact_consent, wallet_consent, outreach_allowed, source, notes, created_at, updated_at
+            FROM contributor_contacts
+            ORDER BY created_at, github_login
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(ContributorContact {
+                    id: row.try_get("id")?,
+                    github_login: row.try_get("github_login")?,
+                    email: row.try_get("email")?,
+                    payout_wallet: row.try_get("payout_wallet")?,
+                    associated_prs: serde_json::from_value(row.try_get("associated_prs")?)?,
+                    contact_consent: row.try_get("contact_consent")?,
+                    wallet_consent: row.try_get("wallet_consent")?,
+                    outreach_allowed: row.try_get("outreach_allowed")?,
+                    source: row.try_get("source")?,
+                    notes: row.try_get("notes")?,
+                    created_at: row.try_get("created_at")?,
+                    updated_at: row.try_get("updated_at")?,
                 })
             })
             .collect()
@@ -1683,6 +1750,7 @@ mod tests {
     fn migration_contains_durable_market_tables() {
         for table in [
             "agents",
+            "contributor_contacts",
             "capabilities",
             "help_requests",
             "quotes",
@@ -1715,6 +1783,8 @@ mod tests {
         assert!(CORE_MIGRATION.contains("settlement_id UUID"));
         assert!(CORE_MIGRATION.contains("stripe_success_url TEXT"));
         assert!(CORE_MIGRATION.contains("stripe_cancel_url TEXT"));
+        assert!(CORE_MIGRATION.contains("github_login_normalized TEXT"));
+        assert!(CORE_MIGRATION.contains("outreach_allowed BOOLEAN"));
         assert!(CORE_MIGRATION.contains("fund-contribution:"));
     }
 

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -107,6 +107,42 @@ impl Agent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ContributorContact {
+    pub id: Id,
+    pub github_login: String,
+    pub email: Option<String>,
+    pub payout_wallet: Option<String>,
+    pub associated_prs: Vec<String>,
+    pub contact_consent: bool,
+    pub wallet_consent: bool,
+    pub outreach_allowed: bool,
+    pub source: String,
+    pub notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl ContributorContact {
+    pub fn new(github_login: impl Into<String>, source: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            github_login: github_login.into(),
+            email: None,
+            payout_wallet: None,
+            associated_prs: Vec::new(),
+            contact_consent: false,
+            wallet_consent: false,
+            outreach_allowed: false,
+            source: source.into(),
+            notes: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Capability {
     pub id: Id,
     pub agent_id: Id,

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -3039,6 +3039,7 @@ async fn record_eval_run(state: &SharedState, run: EvalRun) -> Result<(), String
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
 
@@ -4242,6 +4243,12 @@ async fn hydrate_network(store: &PostgresStore) -> anyhow::Result<BountyNetwork>
             .await?
             .into_iter()
             .map(|agent| (agent.id, agent))
+            .collect(),
+        contributor_contacts: store
+            .list_contributor_contacts()
+            .await?
+            .into_iter()
+            .map(|contact| (contact.id, contact))
             .collect(),
         capabilities: store
             .list_capabilities()

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -553,6 +553,12 @@ pub async fn hydrate_bounty_network(store: &PostgresStore) -> anyhow::Result<Bou
             .into_iter()
             .map(|agent| (agent.id, agent))
             .collect(),
+        contributor_contacts: store
+            .list_contributor_contacts()
+            .await?
+            .into_iter()
+            .map(|contact| (contact.id, contact))
+            .collect(),
         capabilities: store
             .list_capabilities()
             .await?

--- a/docs/contributor-contact-registry.md
+++ b/docs/contributor-contact-registry.md
@@ -1,0 +1,117 @@
+# Contributor Contact And Thank-You Registry
+
+Use the contributor contact registry when maintainers need to track historic
+contributors, thank-you USDC distributions, payout-wallet opt-ins, and private
+outreach consent.
+
+The registry is operator-only. Do not expose it as a public signup form until
+the deployment has a real consent screen, retention policy, export path, and
+deletion path.
+
+## Public Outreach Rules
+
+- Public GitHub comments may ask contributors to share a Base-compatible wallet
+  address if they want to opt in to a thank-you USDC distribution.
+- Public GitHub comments must not ask contributors to post email addresses.
+- Email can be stored only when the contributor provides it through a private or
+  authenticated channel and explicitly consents to outreach.
+- Wallet addresses can be stored only when the contributor explicitly opts in to
+  receiving payout or thank-you funds at that address.
+- A thank-you distribution is not bounty acceptance, merge approval, escrow
+  release, or settlement evidence.
+- Payment state changes still require deterministic verifier output, operator
+  decision, and reconciled Stripe/Base evidence.
+
+## Suggested Public Comment
+
+```text
+Thank you for participating in Agent Bounties. We are preparing a small
+thank-you USDC distribution today for historic external contributors.
+
+If you want to opt in and have not already shared one, please reply with a
+Base-compatible wallet address. Do not post an email address publicly. If you
+want private email/contact updates, a maintainer can arrange a private opt-in
+path.
+
+This thank-you is separate from bounty acceptance, PR merge approval, payout
+approval, or escrow settlement. Any actual transfer will be recorded only after
+on-chain evidence is available.
+```
+
+## API
+
+`POST /v1/contributor-contacts` creates or updates a contributor record by
+case-insensitive GitHub login. `GET /v1/contributor-contacts` lists stored
+records. Both routes require `OPERATOR_API_TOKEN` when hosted operator auth is
+configured.
+
+Import historic public PR participants from GitHub after the API is running:
+
+```powershell
+$env:OPERATOR_API_TOKEN = "<operator-token>"
+.\scripts\import-github-contributors.ps1 `
+  -Repository "NSPG13/agent-bounties" `
+  -ApiBaseUrl "https://api.example.com"
+```
+
+The import stores GitHub login and associated PR URLs only. `email` and
+`payout_wallet` remain `null` until the contributor opts in. If a record already
+exists, the import reads it first and preserves existing consent, email, wallet,
+source, and notes fields while merging PR URLs.
+
+Example wallet-only opt-in:
+
+```powershell
+$body = @{
+  github_login = "qilu13"
+  email = $null
+  payout_wallet = "0x1111111111111111111111111111111111111111"
+  associated_prs = @("#24", "#43", "#59")
+  contact_consent = $false
+  wallet_consent = $true
+  outreach_allowed = $false
+  source = "github-comment-opt-in"
+  notes = "Contributor supplied a Base-compatible wallet in a public PR or issue comment."
+} | ConvertTo-Json
+
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "http://127.0.0.1:8080/v1/contributor-contacts" `
+  -Headers @{ "x-operator-token" = $env:OPERATOR_API_TOKEN } `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+Example private outreach opt-in:
+
+```json
+{
+  "github_login": "example-contributor",
+  "email": "contributor@example.com",
+  "payout_wallet": null,
+  "associated_prs": ["#123"],
+  "contact_consent": true,
+  "wallet_consent": false,
+  "outreach_allowed": true,
+  "source": "private-opt-in",
+  "notes": "Contributor gave email privately and opted into project updates."
+}
+```
+
+## Stored Fields
+
+- `github_login`: public GitHub username.
+- `email`: optional private email, stored only with `contact_consent=true`.
+- `payout_wallet`: optional Base-compatible payout wallet, stored only with
+  `wallet_consent=true`.
+- `associated_prs`: PR numbers or URLs tied to the contributor's work.
+- `contact_consent`: whether private contact data may be stored.
+- `wallet_consent`: whether the wallet may be used for payout or thank-you
+  distribution planning.
+- `outreach_allowed`: whether project outreach is allowed; requires
+  `contact_consent=true`.
+- `source`: where the opt-in came from.
+- `notes`: maintainer-only context. Do not put secrets or raw payment data here.
+
+Unknown emails should be stored as `null`. Do not scrape or infer emails from
+Git commits, profiles, or third-party enrichment services for outreach.

--- a/migrations/0001_core.sql
+++ b/migrations/0001_core.sql
@@ -6,6 +6,53 @@ CREATE TABLE IF NOT EXISTS agents (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS contributor_contacts (
+  id UUID PRIMARY KEY,
+  github_login TEXT NOT NULL,
+  github_login_normalized TEXT NOT NULL UNIQUE,
+  email TEXT,
+  payout_wallet TEXT,
+  associated_prs JSONB NOT NULL DEFAULT '[]'::jsonb,
+  contact_consent BOOLEAN NOT NULL DEFAULT false,
+  wallet_consent BOOLEAN NOT NULL DEFAULT false,
+  outreach_allowed BOOLEAN NOT NULL DEFAULT false,
+  source TEXT NOT NULL,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS github_login_normalized TEXT;
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS email TEXT;
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS payout_wallet TEXT;
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS associated_prs JSONB NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS contact_consent BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS wallet_consent BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS outreach_allowed BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'operator';
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS notes TEXT;
+ALTER TABLE contributor_contacts
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+UPDATE contributor_contacts
+SET github_login_normalized = lower(github_login)
+WHERE github_login_normalized IS NULL;
+
+ALTER TABLE contributor_contacts
+  ALTER COLUMN github_login_normalized SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contributor_contacts_github_login_normalized
+  ON contributor_contacts (github_login_normalized);
+
 CREATE TABLE IF NOT EXISTS capabilities (
   id UUID PRIMARY KEY,
   agent_id UUID NOT NULL REFERENCES agents(id),

--- a/scripts/import-github-contributors.ps1
+++ b/scripts/import-github-contributors.ps1
@@ -1,0 +1,112 @@
+param(
+    [string]$Repository = "NSPG13/agent-bounties",
+    [string]$ApiBaseUrl = "http://127.0.0.1:8080",
+    [string]$OperatorToken = $env:OPERATOR_API_TOKEN,
+    [int]$Limit = 200,
+    [switch]$IncludeOwner
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI 'gh' is required."
+}
+
+$prsJson = gh pr list `
+    --repo $Repository `
+    --state all `
+    --limit $Limit `
+    --json number,url,author
+
+$prs = $prsJson | ConvertFrom-Json
+$contributors = @{}
+
+foreach ($pr in $prs) {
+    if ($null -eq $pr.author -or [string]::IsNullOrWhiteSpace($pr.author.login)) {
+        continue
+    }
+    if ($pr.author.is_bot) {
+        continue
+    }
+    if (-not $IncludeOwner -and $pr.author.login -eq "NSPG13") {
+        continue
+    }
+
+    $login = $pr.author.login
+    if (-not $contributors.ContainsKey($login)) {
+        $contributors[$login] = [System.Collections.Generic.List[string]]::new()
+    }
+    $contributors[$login].Add($pr.url)
+}
+
+$headers = @{}
+if (-not [string]::IsNullOrWhiteSpace($OperatorToken)) {
+    $headers["x-operator-token"] = $OperatorToken
+}
+
+$existingByLogin = @{}
+try {
+    $existingContacts = Invoke-RestMethod `
+        -Method Get `
+        -Uri "$ApiBaseUrl/v1/contributor-contacts" `
+        -Headers $headers
+    foreach ($contact in $existingContacts) {
+        $existingByLogin[$contact.github_login.ToLowerInvariant()] = $contact
+    }
+} catch {
+    Write-Warning "Could not read existing contributor contacts; import will use public PR history only. $($_.Exception.Message)"
+}
+
+foreach ($login in ($contributors.Keys | Sort-Object)) {
+    $associatedPrs = $contributors[$login] | Sort-Object -Unique
+    $existing = $existingByLogin[$login.ToLowerInvariant()]
+    $existingPrs = @()
+    if ($null -ne $existing -and $null -ne $existing.associated_prs) {
+        $existingPrs = @($existing.associated_prs)
+    }
+    $mergedPrs = @($associatedPrs + $existingPrs) | Sort-Object -Unique
+    $email = $null
+    $payoutWallet = $null
+    $contactConsent = $false
+    $walletConsent = $false
+    $outreachAllowed = $false
+    $source = "github-pr-history"
+    $notes = "Imported from public GitHub PR history. Email and wallet unknown until contributor opt-in."
+
+    if ($null -ne $existing) {
+        $email = $existing.email
+        $payoutWallet = $existing.payout_wallet
+        $contactConsent = [bool]$existing.contact_consent
+        $walletConsent = [bool]$existing.wallet_consent
+        $outreachAllowed = [bool]$existing.outreach_allowed
+        if (-not [string]::IsNullOrWhiteSpace($existing.source)) {
+            $source = $existing.source
+        }
+        if (-not [string]::IsNullOrWhiteSpace($existing.notes)) {
+            $notes = $existing.notes
+        }
+    }
+
+    $body = @{
+        github_login = $login
+        email = $email
+        payout_wallet = $payoutWallet
+        associated_prs = @($mergedPrs)
+        contact_consent = $contactConsent
+        wallet_consent = $walletConsent
+        outreach_allowed = $outreachAllowed
+        source = $source
+        notes = $notes
+    } | ConvertTo-Json -Depth 5
+
+    Invoke-RestMethod `
+        -Method Post `
+        -Uri "$ApiBaseUrl/v1/contributor-contacts" `
+        -Headers $headers `
+        -ContentType "application/json" `
+        -Body $body | Out-Null
+
+    Write-Output "Imported $login with $($mergedPrs.Count) PR(s)."
+}
+
+Write-Output "Imported $($contributors.Count) contributor contact record(s)."

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -24,7 +24,8 @@
       <h1>Privacy policy</h1>
       <p>Agent Bounties is designed around public, digital bounty work. Do not place secrets, private customer data, payment card numbers, or confidential materials in public bounty descriptions, proof records, issues, or comments.</p>
       <h2>Data handled by the project</h2>
-      <p>The software can store agent handles, public wallet addresses, GitHub identifiers, bounty terms, claims, submissions, proof records, verifier results, funding intents, payout intents, ledger entries, and payment metadata needed for reconciliation.</p>
+      <p>The software can store agent handles, public wallet addresses, GitHub identifiers, optional contributor contact details provided with consent, bounty terms, claims, submissions, proof records, verifier results, funding intents, payout intents, ledger entries, and payment metadata needed for reconciliation.</p>
+      <p>Do not post email addresses in public GitHub issues, pull requests, bounty comments, or proof records. Contributor emails should be collected only through a private or authenticated opt-in path.</p>
       <h2>Payment data</h2>
       <p>Card, wallet, and PayPal-capable payment details are entered on Stripe-hosted Checkout. Agent Bounties receives Stripe event metadata and identifiers required to reconcile funding, but it does not collect raw payment credentials.</p>
       <h2>Public records</h2>


### PR DESCRIPTION
## Summary
- adds an operator-only contributor contact registry for GitHub login, optional consented email, optional consented payout wallet, associated PRs, and outreach flags
- persists the registry in Postgres and hydrates it in API, MCP, and worker services
- documents public wallet opt-in rules, private email handling, and a historic PR contributor import script
- notifies historic external contributors in maintainer notice #110

## Maintainer notice and open PR impact
- Public notice: #110
- Open PR queue checked before changes: #24 by @qilu13 was open and already waiting on contributor changes; this change should not invalidate its SDK example scope.
- Collaboration branch impact: none required for this change.

## Verification
- cargo fmt --all
- cargo test -p app
- cargo test -p db
- cargo test -p api
- cargo build -p mcp-server -p worker
- cargo run -p cli -- docs-contract-check
- cargo clippy -p app -p db -p api -p mcp-server -p worker --all-targets -- -D warnings
- git diff --check
- PowerShell script parse check for scripts/import-github-contributors.ps1