### PR TITLE
feat: bounty inventory guard (5 live open bounties) (#116)

### DIFF
--- a/.github/workflows/bounty-inventory-guard.yml
+++ b/.github/workflows/bounty-inventory-guard.yml
@@ -1,0 +1,52 @@
+name: Bounty inventory guard
+
+on:
+  schedule:
+    - cron: "0 */12 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/bounty_inventory_guard.py"
+      - "scripts/test_bounty_inventory_guard.py"
+      - "scripts/fixtures/bounty_inventory_*.json"
+      - ".github/workflows/bounty-inventory-guard.yml"
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run inventory guard unit tests
+        run: python scripts/test_bounty_inventory_guard.py -v
+
+  live-report:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Count open bounty issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          BOUNTY_INVENTORY_THRESHOLD: "5"
+        run: |
+          python scripts/bounty_inventory_guard.py \
+            --json-out bounty-inventory-report.json \
+            --md-out bounty-inventory-report.md
+      - name: Upload report artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bounty-inventory-report
+          path: |
+            bounty-inventory-report.json
+            bounty-inventory-report.md

--- a/docs/agent-contribution-starter.md
+++ b/docs/agent-contribution-starter.md
@@ -62,6 +62,31 @@ blocked task is `route_blocked_goal`. Public bounties that need funding are at
 at `/public/bounties`, `GET /v1/bounties/feed`, and MCP
 `list_claimable_bounties`.
 
+## Bounty inventory guard (distribution)
+
+Maintainers and agents can check whether the repository has enough **open public
+issues labeled `bounty`** for organic solver traffic:
+
+```powershell
+python scripts/bounty_inventory_guard.py
+python scripts/bounty_inventory_guard.py --threshold 5 --fail-below
+python scripts/test_bounty_inventory_guard.py -v
+```
+
+On Unix-like shells:
+
+```bash
+python scripts/bounty_inventory_guard.py
+python scripts/bounty_inventory_guard.py --threshold 5 --fail-below
+python scripts/test_bounty_inventory_guard.py -v
+```
+
+The guard prints Markdown and JSON. It **does not** mark any issue as funded,
+claimable, accepted, payable, or paid. Threshold defaults to `5` and can be set
+with `--threshold` or `BOUNTY_INVENTORY_THRESHOLD`. A scheduled workflow
+`.github/workflows/bounty-inventory-guard.yml` runs unit tests on PRs and a live
+report on a schedule / manual dispatch.
+
 ## Picking Work
 
 Good first agent work usually has:

--- a/scripts/bounty_inventory_guard.py
+++ b/scripts/bounty_inventory_guard.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Count open public GitHub issues labeled `bounty` and report inventory health.
+
+Does not claim any issue is funded, claimable, accepted, payable, or paid.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+NON_ACTIONABLE_LABELS = frozenset(
+    {
+        "duplicate",
+        "invalid",
+        "wontfix",
+        "won't fix",
+        "not-actionable",
+        "not actionable",
+        "spam",
+        "closed",
+    }
+)
+
+
+@dataclass
+class InventoryReport:
+    repository: str
+    threshold: int
+    open_bounty_count: int
+    missing_count: int
+    below_threshold: bool
+    issue_urls: list[str]
+    excluded_count: int
+    suggested_next_action: str
+    disclaimer: str
+
+    def to_markdown(self) -> str:
+        status = "BELOW THRESHOLD" if self.below_threshold else "OK"
+        lines = [
+            f"# Bounty inventory guard — {status}",
+            "",
+            f"- Repository: `{self.repository}`",
+            f"- Open actionable `bounty` issues: **{self.open_bounty_count}**",
+            f"- Threshold: **{self.threshold}**",
+            f"- Missing to threshold: **{self.missing_count}**",
+            f"- Excluded (non-actionable labels): **{self.excluded_count}**",
+            "",
+            "## Issue URLs",
+        ]
+        if self.issue_urls:
+            lines.extend(f"- {url}" for url in self.issue_urls)
+        else:
+            lines.append("- _(none)_")
+        lines.extend(
+            [
+                "",
+                "## Suggested next action",
+                "",
+                self.suggested_next_action,
+                "",
+                "## Disclaimer",
+                "",
+                self.disclaimer,
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", "NSPG13/agent-bounties"),
+        help="owner/repo (default: GITHUB_REPOSITORY or NSPG13/agent-bounties)",
+    )
+    p.add_argument(
+        "--threshold",
+        type=int,
+        default=int(os.environ.get("BOUNTY_INVENTORY_THRESHOLD", "5")),
+        help="Minimum open actionable bounty issues (default 5)",
+    )
+    p.add_argument(
+        "--fixture",
+        type=Path,
+        default=None,
+        help="Optional JSON file of issue objects (offline / tests)",
+    )
+    p.add_argument(
+        "--json-out",
+        type=Path,
+        default=None,
+        help="Write JSON report to this path",
+    )
+    p.add_argument(
+        "--md-out",
+        type=Path,
+        default=None,
+        help="Write Markdown report to this path",
+    )
+    p.add_argument(
+        "--fail-below",
+        action="store_true",
+        help="Exit with code 2 when count is below threshold",
+    )
+    return p.parse_args(argv)
+
+
+def label_names(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels") or []
+    names: set[str] = set()
+    for lab in labels:
+        if isinstance(lab, str):
+            names.add(lab.lower())
+        elif isinstance(lab, dict) and lab.get("name"):
+            names.add(str(lab["name"]).lower())
+    return names
+
+
+def is_actionable_bounty(issue: dict[str, Any]) -> bool:
+    if issue.get("state") and str(issue["state"]).lower() != "open":
+        return False
+    if issue.get("pull_request") is not None:
+        return False
+    names = label_names(issue)
+    if "bounty" not in names:
+        return False
+    if names & NON_ACTIONABLE_LABELS:
+        return False
+    return True
+
+
+def issue_url(issue: dict[str, Any], repository: str) -> str:
+    if issue.get("html_url"):
+        return str(issue["html_url"])
+    number = issue.get("number")
+    return f"https://github.com/{repository}/issues/{number}"
+
+
+def fetch_open_issues(repository: str, token: str | None) -> list[dict[str, Any]]:
+    """Paginate GitHub REST issues with label bounty, state open."""
+    owner, _, repo = repository.partition("/")
+    if not owner or not repo:
+        raise SystemExit(f"invalid repository: {repository!r}")
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "agent-bounties-inventory-guard",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    issues: list[dict[str, Any]] = []
+    page = 1
+    while page <= 20:
+        qs = urllib.parse.urlencode(
+            {
+                "state": "open",
+                "labels": "bounty",
+                "per_page": "100",
+                "page": str(page),
+            }
+        )
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues?{qs}"
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                batch = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise SystemExit(f"GitHub API error {exc.code}: {body[:500]}") from exc
+        if not isinstance(batch, list) or not batch:
+            break
+        issues.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return issues
+
+
+def build_report(
+    repository: str,
+    threshold: int,
+    issues: list[dict[str, Any]],
+) -> InventoryReport:
+    actionable: list[dict[str, Any]] = []
+    excluded = 0
+    for issue in issues:
+        if is_actionable_bounty(issue):
+            actionable.append(issue)
+        else:
+            # Only count exclusions among items that had bounty-ish intent
+            if "bounty" in label_names(issue) or issue.get("state") == "open":
+                excluded += 1
+
+    urls = [issue_url(i, repository) for i in actionable]
+    count = len(actionable)
+    missing = max(0, threshold - count)
+    below = count < threshold
+    if below:
+        action = (
+            f"Open or fund at least {missing} more public actionable bounty issue(s) "
+            f"(label `bounty`, keep open, avoid non-actionable labels) so organic "
+            f"solvers have inventory. This report does not mark any issue as funded."
+        )
+    else:
+        action = (
+            "Inventory is at or above threshold. Keep monitoring; this report does "
+            "not imply any listed issue is funded or claimable."
+        )
+    disclaimer = (
+        "Counts open GitHub issues labeled `bounty` only. This report does not "
+        "imply any bounty is funded, claimable, accepted, payable, or paid unless "
+        "verified platform payment evidence exists separately."
+    )
+    return InventoryReport(
+        repository=repository,
+        threshold=threshold,
+        open_bounty_count=count,
+        missing_count=missing,
+        below_threshold=below,
+        issue_urls=urls,
+        excluded_count=excluded,
+        suggested_next_action=action,
+        disclaimer=disclaimer,
+    )
+
+
+def load_fixture(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, dict) and "issues" in data:
+        data = data["issues"]
+    if not isinstance(data, list):
+        raise SystemExit("fixture must be a JSON list of issues or {issues: [...]}")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.threshold < 0:
+        raise SystemExit("threshold must be >= 0")
+
+    if args.fixture:
+        issues = load_fixture(args.fixture)
+    else:
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        issues = fetch_open_issues(args.repository, token)
+
+    report = build_report(args.repository, args.threshold, issues)
+    payload = asdict(report)
+    md = report.to_markdown()
+
+    print(md)
+    print("--- JSON ---")
+    print(json.dumps(payload, indent=2))
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    if args.md_out:
+        args.md_out.parent.mkdir(parents=True, exist_ok=True)
+        args.md_out.write_text(md, encoding="utf-8")
+
+    if args.fail_below and report.below_threshold:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fixtures/bounty_inventory_above.json
+++ b/scripts/fixtures/bounty_inventory_above.json
@@ -1,0 +1,10 @@
+{
+  "issues": [
+    {"number": 1, "state": "open", "html_url": "https://github.com/example/repo/issues/1", "labels": [{"name": "bounty"}]},
+    {"number": 2, "state": "open", "html_url": "https://github.com/example/repo/issues/2", "labels": [{"name": "bounty"}, {"name": "ai-agent-welcome"}]},
+    {"number": 3, "state": "open", "html_url": "https://github.com/example/repo/issues/3", "labels": [{"name": "bounty"}]},
+    {"number": 4, "state": "open", "html_url": "https://github.com/example/repo/issues/4", "labels": [{"name": "bounty"}]},
+    {"number": 5, "state": "open", "html_url": "https://github.com/example/repo/issues/5", "labels": [{"name": "bounty"}]},
+    {"number": 6, "state": "open", "html_url": "https://github.com/example/repo/issues/6", "labels": [{"name": "bounty"}]}
+  ]
+}

--- a/scripts/fixtures/bounty_inventory_below.json
+++ b/scripts/fixtures/bounty_inventory_below.json
@@ -1,0 +1,6 @@
+{
+  "issues": [
+    {"number": 1, "state": "open", "html_url": "https://github.com/example/repo/issues/1", "labels": [{"name": "bounty"}]},
+    {"number": 2, "state": "open", "html_url": "https://github.com/example/repo/issues/2", "labels": [{"name": "bounty"}]}
+  ]
+}

--- a/scripts/fixtures/bounty_inventory_noisy.json
+++ b/scripts/fixtures/bounty_inventory_noisy.json
@@ -1,0 +1,13 @@
+{
+  "issues": [
+    {"number": 1, "state": "open", "html_url": "https://github.com/example/repo/issues/1", "labels": [{"name": "bounty"}]},
+    {"number": 2, "state": "open", "html_url": "https://github.com/example/repo/issues/2", "labels": [{"name": "bounty"}, {"name": "duplicate"}]},
+    {"number": 3, "state": "closed", "html_url": "https://github.com/example/repo/issues/3", "labels": [{"name": "bounty"}]},
+    {"number": 4, "state": "open", "html_url": "https://github.com/example/repo/issues/4", "labels": [{"name": "enhancement"}]},
+    {"number": 5, "state": "open", "html_url": "https://github.com/example/repo/pull/5", "labels": [{"name": "bounty"}], "pull_request": {}},
+    {"number": 6, "state": "open", "html_url": "https://github.com/example/repo/issues/6", "labels": [{"name": "bounty"}, {"name": "invalid"}]},
+    {"number": 7, "state": "open", "html_url": "https://github.com/example/repo/issues/7", "labels": [{"name": "bounty"}]},
+    {"number": 8, "state": "open", "html_url": "https://github.com/example/repo/issues/8", "labels": [{"name": "bounty"}]},
+    {"number": 9, "state": "open", "html_url": "https://github.com/example/repo/issues/9", "labels": [{"name": "bounty"}]}
+  ]
+}

--- a/scripts/test_bounty_inventory_guard.py
+++ b/scripts/test_bounty_inventory_guard.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Tests for bounty_inventory_guard.py (no network)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = Path(__file__).resolve().parent / "bounty_inventory_guard.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def run_guard(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class BountyInventoryGuardTests(unittest.TestCase):
+    def test_above_threshold(self) -> None:
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "5",
+            "--repository",
+            "example/repo",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+        self.assertIn("OK", proc.stdout)
+        # JSON section
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        self.assertEqual(payload["open_bounty_count"], 6)
+        self.assertFalse(payload["below_threshold"])
+        self.assertEqual(payload["missing_count"], 0)
+        self.assertIn("does not imply", payload["disclaimer"].lower())
+
+    def test_below_threshold_fail_below(self) -> None:
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_below.json"),
+            "--threshold",
+            "5",
+            "--fail-below",
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr + proc.stdout)
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        self.assertEqual(payload["open_bounty_count"], 2)
+        self.assertTrue(payload["below_threshold"])
+        self.assertEqual(payload["missing_count"], 3)
+
+    def test_noisy_excludes_non_actionable(self) -> None:
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_noisy.json"),
+            "--threshold",
+            "5",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        # 1,7,8,9 actionable = 4; 2 duplicate, 3 closed, 4 no bounty, 5 PR, 6 invalid
+        self.assertEqual(payload["open_bounty_count"], 4)
+        self.assertTrue(payload["below_threshold"])
+        self.assertEqual(payload["missing_count"], 1)
+        self.assertEqual(len(payload["issue_urls"]), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements #116 — automated guard for open public GitHub issues labeled `bounty`.

## Changes
- `scripts/bounty_inventory_guard.py` — counts open actionable `bounty` issues; threshold default 5 (`--threshold` / `BOUNTY_INVENTORY_THRESHOLD`)
- JSON + Markdown output with URLs, missing count, suggested action
- Explicit disclaimer: does **not** imply funded/claimable/accepted/payable/paid
- Fixtures + `scripts/test_bounty_inventory_guard.py`
- Workflow `.github/workflows/bounty-inventory-guard.yml`
- Docs: `docs/agent-contribution-starter.md`

## Test plan
```bash
python scripts/test_bounty_inventory_guard.py -v
python scripts/bounty_inventory_guard.py --fixture scripts/fixtures/bounty_inventory_noisy.json --threshold 5
```

## Payment (if this bounty settles)
Preferred: **USDC on Base**
`0xfd3600efdfcd6f02c515f93237e2caaff293769f`
