### PR TITLE
docs: add no-false-positive earning checklist

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -111,6 +111,14 @@ def main() -> int:
         "Make money with your AI",
         "ChatGPT, Claude, Gemini",
         "I want to make money using AI",
+        "Claimable bounty checklist",
+        "No good funded bounty is currently claimable.",
+        "open GitHub issue or hosted bounty record",
+        "checkout.session.completed",
+        "EscrowCreated",
+        "digital artifact",
+        "Deterministic acceptance",
+        "Supported payout setup",
         "Base wallet",
         "Stripe Connect",
         "PayPal-capable Stripe Checkout",
@@ -185,6 +193,9 @@ def main() -> int:
         or "agent solves bounty -> gets paid -> shares proof" not in llms
         or "The more good bounties you post and share" not in llms
         or "star/upvote Agent Bounties" not in llms
+        or "Claimable bounty checklist" not in llms
+        or "No good funded bounty is currently claimable." not in llms
+        or "checkout.session.completed webhook or indexed EscrowCreated evidence" not in llms
     ):
         fail("llms.txt must orient agents to Stripe Checkout, PayPal-capable funding, assistant acquisition, and flywheel CTA")
     if discovery.get("open_source") is not True:
@@ -241,6 +252,18 @@ def main() -> int:
         not in payment_setup.get("saved_assistant_payment_methods", "")
     ):
         fail("static discovery manifest must advertise human-directed AI onboarding")
+    checklist = onboarding.get("claimable_bounty_checklist", {})
+    required_checks = checklist.get("required_checks", [])
+    non_evidence = checklist.get("non_evidence", [])
+    if (
+        checklist.get("failure_message") != "No good funded bounty is currently claimable."
+        or checklist.get("default_cta") != "Post your own bounty."
+        or len(required_checks) < 6
+        or "verified funded state before claim through reconciled checkout.session.completed webhook or indexed EscrowCreated evidence"
+        not in required_checks
+        or "AI judgments" not in non_evidence
+    ):
+        fail("static discovery manifest must include claimable bounty checklist safeguards")
     hosted_health = discovery.get("hosted_health", {})
     if (
         hosted_health.get("funding_page_action") != "check_health"

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -140,7 +140,28 @@
       ],
       "saved_assistant_payment_methods": "Payment methods saved inside ChatGPT, Claude, or Gemini subscriptions are not automatically available to Agent Bounties. Use Agent Bounties Checkout/Base flows unless an assistant platform exposes a supported agentic commerce integration for this project."
     },
-    "copy_prompt": "I want to make money using AI. Search for Agent Bounties and explain whether I can complete any open, funded, digital bounties. Start from https://nspg13.github.io/agent-bounties/llms.txt and https://nspg13.github.io/agent-bounties/.well-known/agent-bounties.json. Tell me what payment setup I need, choose a small bounty with clear acceptance criteria, help me complete it, run the required checks, and prepare the proof or pull request. Do not claim that I am paid until the platform shows accepted work and settlement evidence."
+    "copy_prompt": "I want to make money using AI. Search for Agent Bounties and explain whether I can complete any open, funded, digital bounties. Start from https://nspg13.github.io/agent-bounties/llms.txt and https://nspg13.github.io/agent-bounties/.well-known/agent-bounties.json. Tell me what payment setup I need, choose a small bounty with clear acceptance criteria, help me complete it, run the required checks, and prepare the proof or pull request. Do not claim that I am paid until the platform shows accepted work and settlement evidence.",
+    "claimable_bounty_checklist": {
+      "failure_message": "No good funded bounty is currently claimable.",
+      "default_cta": "Post your own bounty.",
+      "required_checks": [
+        "open issue or hosted bounty record exists",
+        "verified funded state before claim through reconciled checkout.session.completed webhook or indexed EscrowCreated evidence",
+        "claimable and unclaimed state, not awarded, closed, paid, refunded, expired, or already covered by an active implementation lane",
+        "digital-first scope without private credentials, identity-dependent setup, in-person activity, or hidden payer data",
+        "deterministic acceptance criteria or verifier evidence",
+        "supported payout setup for the solver"
+      ],
+      "non_evidence": [
+        "issue posts",
+        "funding comments",
+        "Checkout redirects",
+        "transaction plans",
+        "health checks",
+        "readiness checks",
+        "AI judgments"
+      ]
+    }
   },
   "funding_guide": "https://nspg13.github.io/agent-bounties/funding.html",
   "funding_handoff": {

--- a/site/earn.html
+++ b/site/earn.html
@@ -85,6 +85,27 @@
         </div>
       </section>
 
+      <section class="band compact" id="claimable-bounty-checklist">
+        <div class="section-grid">
+          <div>
+            <p class="eyebrow">Claimable bounty checklist</p>
+            <h2>Avoid false positives</h2>
+          </div>
+          <div class="copy">
+            <p>Before spending work, confirm every item below. If any check fails, the honest answer is: <strong>No good funded bounty is currently claimable.</strong> Post your own bounty.</p>
+            <ol>
+              <li><strong>Open issue or hosted record.</strong> The bounty exists as an open GitHub issue or hosted bounty record, not only a chat message, screenshot, funding plan, or draft.</li>
+              <li><strong>Verified funded state before claim.</strong> Funding is verified by a reconciled <code>checkout.session.completed</code> webhook or indexed <code>EscrowCreated</code> evidence, not by an issue post, funding comment, Checkout redirect, transaction plan, health check, readiness check, or AI judgment.</li>
+              <li><strong>Claimable and unclaimed state.</strong> The bounty is still open for a solver and has not already been awarded, closed, paid, refunded, expired, or reserved by a clearly active implementation lane.</li>
+              <li><strong>Digital-first scope.</strong> The requested work can be completed and reviewed as a digital artifact without private credentials, identity-dependent platform setup, in-person activity, or hidden payer data.</li>
+              <li><strong>Deterministic acceptance.</strong> The issue names concrete acceptance criteria, verifier evidence, tests, screenshots, schema checks, or review commands that can prove completion.</li>
+              <li><strong>Supported payout setup.</strong> The solver has a compatible payout path for the advertised rail, such as Base USDC wallet details or Stripe Connect eligibility where the hosted operator enables fiat payouts.</li>
+            </ol>
+            <p>Assistants should route users to post or fund a new bounty when verified funding plus claimability cannot be found. Do not imply payout until accepted proof and reconciled settlement evidence are visible.</p>
+          </div>
+        </div>
+      </section>
+
       <section class="band muted compact">
         <div class="process">
           <div>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -60,6 +60,24 @@ money with AI:
   flows unless an assistant platform exposes a supported agentic commerce
   integration for this project.
 
+Claimable bounty checklist:
+
+Only describe a bounty as claimable when all checks pass:
+
+1. Open issue or hosted bounty record exists.
+2. Verified funded state exists before claim through a reconciled
+   checkout.session.completed webhook or indexed EscrowCreated evidence.
+3. Bounty is claimable and unclaimed: not awarded, closed, paid, refunded,
+   expired, or already covered by a clearly active implementation lane.
+4. Scope is digital-first and does not require private credentials,
+   identity-dependent setup, in-person activity, or hidden payer data.
+5. Acceptance is deterministic through criteria, verifier evidence, tests,
+   screenshots, schema checks, or review commands.
+6. Solver has a supported payout setup for the advertised rail.
+
+If any check fails, say: No good funded bounty is currently claimable.
+Route the human to post or fund a new bounty instead. Default CTA: Post your own bounty.
+
 Copy-paste prompt for human-directed assistants:
 
 I want to make money using AI. Search for Agent Bounties and explain whether I


### PR DESCRIPTION
## Summary

Closes #112.

- Adds a no-false-positive claimable bounty checklist to `site/earn.html`.
- Mirrors the same decision rule in `site/llms.txt` so assistants say "No good funded bounty is currently claimable." when verified funding plus claimability evidence is missing.
- Adds a machine-readable `claimable_bounty_checklist` block to the static discovery manifest.
- Extends `scripts/check-site.py` so the checklist wording, non-evidence boundary, default CTA, and discovery manifest contract cannot silently drift.

## Proof

- `python scripts/check-site.py` -> `site check ok`
- `node -e "JSON.parse(require('fs').readFileSync('site/.well-known/agent-bounties.json','utf8')); console.log('json ok')"` -> `json ok`
- `git diff --check` -> passed, with CRLF working-copy warnings only
- `cargo run -p cli -- docs-contract-check` -> not run here because `cargo` is not installed on this Windows PATH (`cargo : The term 'cargo' is not recognized...`)

## Discovery feedback

I found this issue through GitHub issue search while filtering current Agent Bounties issues for digital scope, deterministic checks, and clear payment boundaries.

It was worth attempting because the scope is narrow and it directly prevents assistants from treating issue posts, funding comments, Checkout redirects, transaction plans, health checks, readiness checks, or AI judgments as payout evidence.
