### PR TITLE
fix: validate PR docs against staged contract sources

### DIFF
--- a/docs/contributor-first-maintenance.md
+++ b/docs/contributor-first-maintenance.md
@@ -41,6 +41,12 @@ include it in the public notice with a concrete repair path. Useful but
 not-main-ready work should still be eligible for a collaboration branch when the
 security rules allow it.
 
+The external review scripts run the trusted maintainer-built docs checker. They
+stage only bounded, regular UTF-8 API and MCP source files from the fetched PR
+worktree into a clean temporary contract root. This lets the checker recognize
+new routes and tools without compiling or executing contributor code. Missing,
+symlinked, out-of-root, binary, or oversized contract sources fail intake.
+
 ## Public Maintainer Notice
 
 Publish the notice before code edits. Use

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -60,6 +60,7 @@ Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbo
 Invoke-Checked { cargo run -p cli -- discovery-report --input-fixture crates\cli\fixtures\discovery_answers.json --json-out target\tmp\discovery-report.json --markdown-out target\tmp\discovery-report.md }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\check-site.py }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\check-render-blueprint.py }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_stage_review_contract_root.py -v }
 Invoke-Checked { cargo run -p cli -- docs-contract-check }
 Invoke-Checked { cargo run -p cli -- demo }
 Invoke-Checked { cargo run -p cli -- pooled-funding-demo }
@@ -68,7 +69,7 @@ Invoke-Checked { cargo run -p cli -- real-funding-readiness --network base-sepol
 Invoke-Checked { & (Join-Path $repoRoot "scripts\real-funding-rehearsal.ps1") }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py crates\sdk-python\examples\cofund_claim.py }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py scripts\validate_real_funding_rehearsal.py }
-Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\check-site.py scripts\check-render-blueprint.py }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\check-site.py scripts\check-render-blueprint.py scripts\stage_review_contract_root.py scripts\test_stage_review_contract_root.py }
 Pop-Location
 
 Push-Location (Join-Path $repoRoot "crates\sdk-typescript")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -110,6 +110,7 @@ cargo run -p cli -- discovery-report \
   --markdown-out target/tmp/discovery-report.md
 "${python_cmd[@]}" scripts/check-site.py
 "${python_cmd[@]}" scripts/check-render-blueprint.py
+"${python_cmd[@]}" scripts/test_stage_review_contract_root.py -v
 cargo run -p cli -- docs-contract-check
 cargo run -p cli -- demo
 cargo run -p cli -- pooled-funding-demo
@@ -130,6 +131,8 @@ bash scripts/real-funding-rehearsal.sh
   scripts/github_proof_comment.py \
   scripts/check-site.py \
   scripts/check-render-blueprint.py \
+  scripts/stage_review_contract_root.py \
+  scripts/test_stage_review_contract_root.py \
   scripts/validate_real_funding_rehearsal.py
 
 cd "$repo_root/crates/sdk-typescript"

--- a/scripts/review-external-pr.ps1
+++ b/scripts/review-external-pr.ps1
@@ -15,6 +15,15 @@ if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction Sile
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $targetRoot = Join-Path $repoRoot "target\pr-review"
 New-Item -ItemType Directory -Force -Path $targetRoot | Out-Null
+$pythonCommand = Get-Command python -ErrorAction SilentlyContinue
+$pythonArgs = @()
+if (-not $pythonCommand) {
+    $pythonCommand = Get-Command py -ErrorAction SilentlyContinue
+    $pythonArgs = @("-3")
+}
+if (-not $pythonCommand) {
+    throw "python or py is required for external PR review"
+}
 
 function Invoke-Checked {
     param(
@@ -207,9 +216,24 @@ try {
     }
     Invoke-Checked { git worktree add --detach $worktreeFull $refName }
 
+    $contractRootPath = Join-Path $targetRoot "pr-$Pr-contract-root"
+    $contractRootFull = [System.IO.Path]::GetFullPath($contractRootPath)
+    if (-not $contractRootFull.StartsWith($targetRootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to use unsafe staged contract path: $contractRootFull"
+    }
+    if (Test-Path $contractRootFull) {
+        Remove-Item -LiteralPath $contractRootFull -Recurse -Force
+    }
+
     $docsCheckOk = $false
     $docsCheckOutput = ""
     try {
+        Invoke-Checked {
+            & $pythonCommand.Source @pythonArgs `
+                (Join-Path $repoRoot "scripts\stage_review_contract_root.py") `
+                --worktree $worktreeFull `
+                --output $contractRootFull
+        }
         $docsCheckStdout = Join-Path $targetRoot "pr-$Pr-docs-contract-check.stdout.log"
         $docsCheckStderr = Join-Path $targetRoot "pr-$Pr-docs-contract-check.stderr.log"
         foreach ($path in @($docsCheckStdout, $docsCheckStderr)) {
@@ -219,7 +243,7 @@ try {
         }
         $process = Start-Process `
             -FilePath "cargo" `
-            -ArgumentList @("run", "-p", "cli", "--", "docs-contract-check", "--root", $worktreeFull, "--contract-root", $repoRoot) `
+            -ArgumentList @("run", "-p", "cli", "--", "docs-contract-check", "--root", $worktreeFull, "--contract-root", $contractRootFull) `
             -RedirectStandardOutput $docsCheckStdout `
             -RedirectStandardError $docsCheckStderr `
             -Wait `
@@ -234,6 +258,9 @@ try {
         }
     } finally {
         Invoke-Checked { git worktree remove --force $worktreeFull }
+        if (Test-Path $contractRootFull) {
+            Remove-Item -LiteralPath $contractRootFull -Recurse -Force
+        }
     }
 
     $docsIssues = Get-DocsContractIssues $docsCheckOutput
@@ -326,7 +353,7 @@ try {
             $passedItems += "No risky paths were changed by the PR head reviewed here."
         }
         if ($docsCheckOk) {
-            $passedItems += "`docs-contract-check` passed against the trusted maintainer checkout."
+            $passedItems += "`docs-contract-check` passed with the trusted checker against bounded, staged PR route/tool sources."
         }
         if ($passedItems.Count -eq 0) {
             $passedItems += "The PR head was fetched and matched against GitHub before review; no merge-ready checks passed yet."

--- a/scripts/review-external-pr.sh
+++ b/scripts/review-external-pr.sh
@@ -55,6 +55,14 @@ for tool in gh git cargo; do
     exit 127
   fi
 done
+if command -v python3 >/dev/null 2>&1; then
+  python_cmd=(python3)
+elif command -v python >/dev/null 2>&1; then
+  python_cmd=(python)
+else
+  echo "python3 or python is required for external PR review" >&2
+  exit 127
+fi
 
 is_docs_path() {
   local path="$1"
@@ -187,7 +195,11 @@ git worktree add --detach "$worktree" "$ref_name" >/dev/null
 
 docs_contract_check="failed"
 docs_output="$tmp_root/docs-contract-check.log"
-if cargo run -p cli -- docs-contract-check --root "$worktree" --contract-root "$repo_root" >"$docs_output" 2>&1; then
+contract_root="$tmp_root/contract-root"
+"${python_cmd[@]}" "$repo_root/scripts/stage_review_contract_root.py" \
+  --worktree "$worktree" \
+  --output "$contract_root"
+if cargo run -p cli -- docs-contract-check --root "$worktree" --contract-root "$contract_root" >"$docs_output" 2>&1; then
   docs_contract_check="ok"
 fi
 cat "$docs_output"
@@ -259,7 +271,7 @@ if [[ "${#risky_files[@]}" -eq 0 ]]; then
   passed_items+=("No risky paths were changed by the PR head reviewed here.")
 fi
 if [[ "$docs_contract_check" == "ok" ]]; then
-  passed_items+=("docs-contract-check passed against the trusted maintainer checkout.")
+  passed_items+=("docs-contract-check passed with the trusted checker against bounded, staged PR route/tool sources.")
 fi
 if [[ "${#passed_items[@]}" -eq 0 ]]; then
   passed_items+=("The PR head was fetched and matched against GitHub before review; no merge-ready checks passed yet.")

--- a/scripts/stage_review_contract_root.py
+++ b/scripts/stage_review_contract_root.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Stage bounded API/MCP source files for trusted external-PR contract checks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+import sys
+from pathlib import Path
+
+
+REQUIRED_SOURCES = (
+    Path("crates/api/src/main.rs"),
+    Path("crates/mcp-server/src/main.rs"),
+)
+MAX_SOURCE_BYTES = 5 * 1024 * 1024
+
+
+class StageError(RuntimeError):
+    pass
+
+
+def require_within(path: Path, root: Path, label: str) -> None:
+    try:
+        path.relative_to(root)
+    except ValueError as error:
+        raise StageError(f"{label} escapes its trusted root: {path}") from error
+
+
+def stage_contract_root(
+    worktree: Path,
+    output: Path,
+    *,
+    max_source_bytes: int = MAX_SOURCE_BYTES,
+) -> list[dict[str, object]]:
+    if max_source_bytes <= 0:
+        raise StageError("max_source_bytes must be positive")
+
+    try:
+        worktree_root = worktree.resolve(strict=True)
+    except OSError as error:
+        raise StageError(f"external PR worktree does not exist: {worktree}") from error
+    if not worktree_root.is_dir():
+        raise StageError(f"external PR worktree is not a directory: {worktree_root}")
+
+    output_root = output.resolve(strict=False)
+    if output_root == worktree_root or worktree_root in output_root.parents:
+        raise StageError("staged contract root must be outside the external PR worktree")
+    if output.exists():
+        if output.is_symlink() or not output.is_dir():
+            raise StageError(f"staged contract root is not a regular directory: {output}")
+        if any(output.iterdir()):
+            raise StageError(f"staged contract root must be empty: {output}")
+    else:
+        output.mkdir(parents=True)
+    output_root = output.resolve(strict=True)
+
+    report: list[dict[str, object]] = []
+    for relative in REQUIRED_SOURCES:
+        source = worktree_root / relative
+        try:
+            source_stat = source.lstat()
+        except OSError as error:
+            raise StageError(f"required PR contract source is missing: {relative}") from error
+        if stat.S_ISLNK(source_stat.st_mode):
+            raise StageError(f"required PR contract source must not be a symlink: {relative}")
+        if not stat.S_ISREG(source_stat.st_mode):
+            raise StageError(f"required PR contract source must be a regular file: {relative}")
+
+        try:
+            resolved_source = source.resolve(strict=True)
+        except OSError as error:
+            raise StageError(f"unable to resolve PR contract source: {relative}") from error
+        require_within(resolved_source, worktree_root, str(relative))
+
+        data = source.read_bytes()
+        if len(data) > max_source_bytes:
+            raise StageError(
+                f"required PR contract source exceeds {max_source_bytes} bytes: {relative}"
+            )
+        if b"\x00" in data:
+            raise StageError(f"required PR contract source contains a NUL byte: {relative}")
+        try:
+            data.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise StageError(
+                f"required PR contract source is not valid UTF-8: {relative}"
+            ) from error
+
+        destination = output_root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        resolved_parent = destination.parent.resolve(strict=True)
+        require_within(resolved_parent, output_root, str(relative))
+        destination.write_bytes(data)
+        report.append(
+            {
+                "path": relative.as_posix(),
+                "bytes": len(data),
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }
+        )
+
+    return report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--worktree", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        sources = stage_contract_root(args.worktree, args.output)
+    except StageError as error:
+        print(f"external PR contract staging failed: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps({"staged_contract_root": str(args.output), "sources": sources}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_stage_review_contract_root.py
+++ b/scripts/test_stage_review_contract_root.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from stage_review_contract_root import REQUIRED_SOURCES, StageError, stage_contract_root
+
+
+class StageReviewContractRootTests(unittest.TestCase):
+    def make_worktree(self, root: Path) -> Path:
+        worktree = root / "worktree"
+        for index, relative in enumerate(REQUIRED_SOURCES):
+            source = worktree / relative
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text(f"// source {index}\n", encoding="utf-8")
+        return worktree
+
+    def test_stages_exact_regular_sources_with_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            worktree = self.make_worktree(root)
+            output = root / "staged"
+
+            report = stage_contract_root(worktree, output)
+
+            self.assertEqual([item["path"] for item in report], [p.as_posix() for p in REQUIRED_SOURCES])
+            self.assertTrue(all(len(str(item["sha256"])) == 64 for item in report))
+            for relative in REQUIRED_SOURCES:
+                self.assertEqual(
+                    (output / relative).read_bytes(),
+                    (worktree / relative).read_bytes(),
+                )
+
+    def test_rejects_missing_required_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            worktree = self.make_worktree(root)
+            (worktree / REQUIRED_SOURCES[0]).unlink()
+
+            with self.assertRaisesRegex(StageError, "missing"):
+                stage_contract_root(worktree, root / "staged")
+
+    def test_rejects_oversized_or_binary_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            worktree = self.make_worktree(root)
+            (worktree / REQUIRED_SOURCES[0]).write_bytes(b"12345")
+            with self.assertRaisesRegex(StageError, "exceeds"):
+                stage_contract_root(worktree, root / "oversized", max_source_bytes=4)
+
+            (worktree / REQUIRED_SOURCES[0]).write_bytes(b"source\x00data")
+            with self.assertRaisesRegex(StageError, "NUL"):
+                stage_contract_root(worktree, root / "binary")
+
+    def test_rejects_output_inside_untrusted_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            worktree = self.make_worktree(root)
+
+            with self.assertRaisesRegex(StageError, "outside"):
+                stage_contract_root(worktree, worktree / "staged")
+
+    def test_rejects_symlink_source_when_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            worktree = self.make_worktree(root)
+            source = worktree / REQUIRED_SOURCES[0]
+            target = root / "outside.rs"
+            target.write_text("// outside\n", encoding="utf-8")
+            source.unlink()
+            try:
+                source.symlink_to(target)
+            except OSError:
+                self.skipTest("symlink creation is unavailable")
+
+            with self.assertRaisesRegex(StageError, "symlink"):
+                stage_contract_root(worktree, root / "staged")
+
+    def test_review_scripts_pass_the_staged_contract_root(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        powershell = (repo_root / "scripts/review-external-pr.ps1").read_text(
+            encoding="utf-8"
+        )
+        shell = (repo_root / "scripts/review-external-pr.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("stage_review_contract_root.py", powershell)
+        self.assertIn('"--contract-root", $contractRootFull', powershell)
+        self.assertNotIn('"--contract-root", $repoRoot', powershell)
+        self.assertIn("stage_review_contract_root.py", shell)
+        self.assertIn('--contract-root "$contract_root"', shell)
+        self.assertNotIn('--contract-root "$repo_root"', shell)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- stage bounded API/MCP source files from fetched external PRs into a clean temporary contract root
- reject missing, symlinked, out-of-root, binary, invalid UTF-8, or oversized source inputs before the trusted checker reads them
- make Windows and Unix intake validate PR docs against the PR's actual route/tool contract without compiling or executing contributor code
- add deterministic staging and script-contract tests to the full gate

## Contributor-first notice

Notice: https://github.com/NSPG13/agent-bounties/issues/72#issuecomment-4930305599

Open PRs checked:
- #121 remains the active GitHub issue-sync lane. This change removes its false `unknown API route` warning only; the separate cross-process Postgres atomicity blocker remains.
- #118 remains changes-requested for its existing classifier/test blockers and does not overlap this change.

No contributor migration is required. Re-run `scripts/review-external-pr.ps1 -Pr <number>` or the shell equivalent to get the corrected contract result.

## Safety boundary

The maintainer-built CLI remains the only executed checker. PR source is treated as bounded inert data, copied only after path/type/size/encoding checks. This PR does not change bounty funding, review acceptance, payout, or settlement authority.

## Verification

- `scripts/check.ps1` full gate
- `python scripts/test_stage_review_contract_root.py -v`
- `scripts/review-external-pr.ps1 -Pr 121` reports `docs_contract_check=ok`, 79 API routes, 55 MCP tools, and manual-security-review for risky paths
- `bash -n scripts/review-external-pr.sh scripts/check.sh`