### PR TITLE
feat: show Checkout reconciliation status

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -84,7 +84,9 @@ To deploy from the Dashboard after the PR is merged:
    `https://nspg13.github.io/agent-bounties/success.html?apiBaseUrl=<api>&bountyId=<bounty-id>&externalReference=<external-reference>`.
    The page may show `waiting for webhook`, `funding reconciled`, or `needs
    operator review` from `GET /v1/bounties/{id}`, but the Checkout redirect
-   itself is not funding evidence.
+   itself is not funding evidence. It should show `funding reconciled` only
+   when the matched Stripe funding intent is `Applied`; generic bounty
+   claimability is displayed separately.
 
 The checked-in Base worker starts at block `48422806` for escrow
 `0x150C6dFbCe7803cc7f634f59b0624e87349CEAce`. It is read-only with respect to

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -80,6 +80,11 @@ To deploy from the Dashboard after the PR is merged:
    `AGENT_BOUNTIES_API_BASE_URL` so GitHub funding-comment handoffs can prefill
    the public Stripe Checkout funding page. A dead or unverified API URL should
    not be advertised to funders.
+10. Verify a post-Checkout return URL in the browser:
+   `https://nspg13.github.io/agent-bounties/success.html?apiBaseUrl=<api>&bountyId=<bounty-id>&externalReference=<external-reference>`.
+   The page may show `waiting for webhook`, `funding reconciled`, or `needs
+   operator review` from `GET /v1/bounties/{id}`, but the Checkout redirect
+   itself is not funding evidence.
 
 The checked-in Base worker starts at block `48422806` for escrow
 `0x150C6dFbCe7803cc7f634f59b0624e87349CEAce`. It is read-only with respect to

--- a/docs/live-money-activation.md
+++ b/docs/live-money-activation.md
@@ -219,8 +219,10 @@ https://nspg13.github.io/agent-bounties/success.html?apiBaseUrl=$PUBLIC_BASE_URL
 The page reads `GET /v1/bounties/{id}` and shows `Checkout returned`, `waiting
 for webhook`, `funding reconciled`, or `needs operator review`. It must never
 present the redirect itself as funding evidence. `funding reconciled` is shown
-only when the hosted status reports an applied funding intent, reconciled
-`checkout.session.completed` webhook evidence, or a claimable bounty state.
+only when the matching Stripe funding intent reports `Applied` webhook evidence
+for the supplied funding intent id or external reference. Generic bounty
+claimability can come from another rail or contribution and must be shown
+separately, not attributed to the Checkout return.
 
 ## Payout Flow
 

--- a/docs/live-money-activation.md
+++ b/docs/live-money-activation.md
@@ -209,6 +209,19 @@ PayPal-capable path explicit on the static funding page. The parameter is a UI
 hint only; Stripe Checkout decides whether PayPal is available for the account,
 customer location, browser, currency, and configured payment-method set.
 
+After Checkout returns, route funders to the static status page with the hosted
+API URL, bounty id, and external reference:
+
+```text
+https://nspg13.github.io/agent-bounties/success.html?apiBaseUrl=$PUBLIC_BASE_URL&bountyId=<bounty-id>&externalReference=<external-reference>
+```
+
+The page reads `GET /v1/bounties/{id}` and shows `Checkout returned`, `waiting
+for webhook`, `funding reconciled`, or `needs operator review`. It must never
+present the redirect itself as funding evidence. `funding reconciled` is shown
+only when the hosted status reports an applied funding intent, reconciled
+`checkout.session.completed` webhook evidence, or a claimable bounty state.
+
 ## Payout Flow
 
 1. Solver submits an artifact.

--- a/schemas/discovery-manifest.v1.json
+++ b/schemas/discovery-manifest.v1.json
@@ -196,6 +196,7 @@
     },
     "real_money_rehearsal": { "$ref": "#/$defs/real_money_rehearsal" },
     "funding_handoff": { "$ref": "#/$defs/funding_handoff" },
+    "checkout_return_status": { "$ref": "#/$defs/checkout_return_status" },
     "distribution_feedback": { "$ref": "#/$defs/distribution_feedback" },
     "risk_policy": {
       "type": "object",
@@ -418,6 +419,42 @@
         "supported_rail": {
           "type": "string",
           "const": "StripeFiat"
+        },
+        "settlement_authority": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "checkout_return_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "page",
+        "purpose",
+        "endpoint_template",
+        "query_params",
+        "states",
+        "settlement_authority"
+      ],
+      "properties": {
+        "page": { "$ref": "#/$defs/uri" },
+        "purpose": { "type": "string", "minLength": 1 },
+        "endpoint_template": { "$ref": "#/$defs/uri-template" },
+        "query_params": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "contains": { "const": "bountyId" }
+        },
+        "states": {
+          "type": "array",
+          "minItems": 3,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "non_secret_fields": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
         },
         "settlement_authority": {
           "type": "string",

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -201,12 +201,26 @@ def main() -> int:
         "Hosted API status is unavailable",
         "Funding intent id",
         "Default CTA: Post your own bounty.",
+        "Bounty claimable:",
         "apiBaseUrl",
         "externalReference",
     ]
     for phrase in required_checkout_status_js:
         if phrase not in main_js:
             fail(f"main.js missing Checkout status coverage: {phrase}")
+    required_checkout_classifier_tests = [
+        "checkoutStatusLines",
+        "AwaitingEvidence",
+        "different-checkout",
+        "checkout status classifier tests passed",
+        "1.000000 USDC",
+        "5.00 USD",
+        "Hosted API status is unavailable",
+    ]
+    checkout_test = (repo_root / "scripts" / "test-checkout-status.js").read_text(encoding="utf-8")
+    for phrase in required_checkout_classifier_tests:
+        if phrase not in checkout_test:
+            fail(f"test-checkout-status.js missing classifier test coverage: {phrase}")
 
     if "sk_live" in index + funding + main_js:
         fail("site must not include secret-looking Stripe live keys")
@@ -229,6 +243,14 @@ def main() -> int:
         fail("llms.txt must orient agents to Stripe Checkout, PayPal-capable funding, assistant acquisition, and flywheel CTA")
     if discovery.get("open_source") is not True:
         fail("static discovery manifest must advertise open_source=true")
+    checkout_status = discovery.get("checkout_return_status", {})
+    if (
+        "matched Stripe funding intent in Applied state"
+        not in checkout_status.get("settlement_authority", "")
+        or "Generic bounty claimability"
+        not in checkout_status.get("settlement_authority", "")
+    ):
+        fail("static discovery manifest must keep Checkout reconciliation tied to the matched Applied Stripe intent")
     assistant_acquisition = discovery.get("assistant_acquisition", {})
     if (
         "I want to make money with AI"

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -88,6 +88,7 @@ def main() -> int:
     earn = (site_dir / "earn.html").read_text(encoding="utf-8")
     post = (site_dir / "post.html").read_text(encoding="utf-8")
     funding = (site_dir / "funding.html").read_text(encoding="utf-8")
+    success = (site_dir / "success.html").read_text(encoding="utf-8")
     main_js = (site_dir / "main.js").read_text(encoding="utf-8")
     llms = (site_dir / "llms.txt").read_text(encoding="utf-8")
     discovery = json.loads((site_dir / ".well-known/agent-bounties.json").read_text())
@@ -178,6 +179,34 @@ def main() -> int:
     for phrase in required_funding_phrases:
         if phrase not in funding and phrase not in main_js:
             fail(f"funding page missing required phrase: {phrase}")
+
+    required_success_phrases = [
+        "Checkout submitted",
+        "Funding status",
+        "checkout-status-output",
+        "Refresh status",
+        "Stripe accepted the Checkout session",
+        "signed Stripe webhook",
+        "Post your own bounty",
+    ]
+    for phrase in required_success_phrases:
+        if phrase not in success:
+            fail(f"success.html missing required phrase: {phrase}")
+    required_checkout_status_js = [
+        "/v1/bounties/",
+        "waiting for webhook",
+        "funding reconciled",
+        "needs operator review",
+        "checkout.session.completed webhook is reconciled",
+        "Hosted API status is unavailable",
+        "Funding intent id",
+        "Default CTA: Post your own bounty.",
+        "apiBaseUrl",
+        "externalReference",
+    ]
+    for phrase in required_checkout_status_js:
+        if phrase not in main_js:
+            fail(f"main.js missing Checkout status coverage: {phrase}")
 
     if "sk_live" in index + funding + main_js:
         fail("site must not include secret-looking Stripe live keys")
@@ -288,6 +317,19 @@ def main() -> int:
         or "paymentPreference" not in funding_handoff.get("query_params", [])
     ):
         fail("static discovery manifest must advertise public funding handoff query params")
+    checkout_return_status = discovery.get("checkout_return_status", {})
+    if (
+        checkout_return_status.get("page")
+        != "https://nspg13.github.io/agent-bounties/success.html"
+        or checkout_return_status.get("endpoint_template")
+        != "{api_base_url}/v1/bounties/{bounty_id}"
+        or "waiting for webhook" not in checkout_return_status.get("states", [])
+        or "funding reconciled" not in checkout_return_status.get("states", [])
+        or "needs operator review" not in checkout_return_status.get("states", [])
+        or "Checkout redirect success is not funding"
+        not in checkout_return_status.get("settlement_authority", "")
+    ):
+        fail("static discovery manifest must advertise Checkout return status safeguards")
     paypal_checkout_handoff = discovery.get("paypal_checkout_handoff", {})
     if (
         paypal_checkout_handoff.get("supported_rail") != "StripeFiat"

--- a/scripts/test-checkout-status.js
+++ b/scripts/test-checkout-status.js
@@ -1,0 +1,126 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const repoRoot = path.resolve(__dirname, "..");
+const source = fs.readFileSync(path.join(repoRoot, "site", "main.js"), "utf8");
+
+const context = {
+  console,
+  document: {
+    getElementById() {
+      return null;
+    },
+  },
+  URLSearchParams,
+};
+context.window = context;
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "site/main.js" });
+
+const checkout = context.window.AgentBountiesCheckoutStatus;
+
+function report(overrides = {}) {
+  return {
+    bounty: { id: "bounty-1", status: "Claimable" },
+    funding_summary: {
+      applied: { amount: 0, currency: "usd" },
+      remaining: { amount: 500, currency: "usd" },
+      claimable: false,
+      ...overrides.funding_summary,
+    },
+    funding_intents: overrides.funding_intents || [],
+  };
+}
+
+assert.strictEqual(checkout.displayMoney({ amount: 500, currency: "usd" }), "5.00 USD");
+assert.strictEqual(checkout.displayMoney({ amount: 1000000, currency: "usdc" }), "1.000000 USDC");
+
+const awaitingWithUnrelatedClaimability = checkout.checkoutStatusLines(
+  report({
+    funding_summary: {
+      applied: { amount: 1000000, currency: "usdc" },
+      remaining: { amount: 0, currency: "usdc" },
+      claimable: true,
+    },
+    funding_intents: [
+      {
+        id: "stripe-intent-1",
+        rail: "StripeFiat",
+        status: "AwaitingEvidence",
+        external_reference: "checkout-target",
+      },
+    ],
+  }),
+  { bountyId: "bounty-1", externalReference: "checkout-target" },
+);
+assert(awaitingWithUnrelatedClaimability.includes("State: waiting for webhook"));
+assert(!awaitingWithUnrelatedClaimability.includes("State: funding reconciled"));
+assert(awaitingWithUnrelatedClaimability.includes("Bounty claimable: yes"));
+assert(awaitingWithUnrelatedClaimability.includes("matching Checkout funding intent to show Applied webhook evidence"));
+
+const mismatchedIdentifier = checkout.checkoutStatusLines(
+  report({
+    funding_summary: {
+      applied: { amount: 500, currency: "usd" },
+      remaining: { amount: 0, currency: "usd" },
+      claimable: true,
+    },
+    funding_intents: [
+      {
+        id: "stripe-intent-2",
+        rail: "StripeFiat",
+        status: "Applied",
+        external_reference: "different-checkout",
+      },
+    ],
+  }),
+  { bountyId: "bounty-1", externalReference: "checkout-target" },
+);
+assert(mismatchedIdentifier.includes("State: waiting for webhook"));
+assert(mismatchedIdentifier.includes("Funding intent: not identified for external reference checkout-target"));
+assert(!mismatchedIdentifier.includes("Funding intent id: stripe-intent-2"));
+assert(!mismatchedIdentifier.includes("different-checkout"));
+
+const appliedMatch = checkout.checkoutStatusLines(
+  report({
+    funding_summary: {
+      applied: { amount: 500, currency: "usd" },
+      remaining: { amount: 0, currency: "usd" },
+      claimable: true,
+    },
+    funding_intents: [
+      {
+        id: "stripe-intent-3",
+        rail: "StripeFiat",
+        status: "Applied",
+        external_reference: "checkout-target",
+      },
+    ],
+  }),
+  { bountyId: "bounty-1", externalReference: "checkout-target" },
+);
+assert(appliedMatch.includes("State: funding reconciled"));
+assert(appliedMatch.includes("Funding intent id: stripe-intent-3"));
+
+const rejectedMatch = checkout.checkoutStatusLines(
+  report({
+    funding_intents: [
+      {
+        id: "stripe-intent-4",
+        rail: "StripeFiat",
+        status: "Rejected",
+        external_reference: "checkout-target",
+      },
+    ],
+  }),
+  { bountyId: "bounty-1", externalReference: "checkout-target" },
+);
+assert(rejectedMatch.includes("State: needs operator review"));
+
+const unavailable = checkout.checkoutUnavailableStatusLines("Hosted bounty status returned 503");
+assert(unavailable.includes("State: needs operator review"));
+assert(unavailable.includes("Hosted API status is unavailable"));
+
+console.log("checkout status classifier tests passed");

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -181,6 +181,35 @@
     "supported_rail": "StripeFiat",
     "settlement_authority": "query parameters are UI defaults only; funding still requires verified Stripe webhook reconciliation"
   },
+  "checkout_return_status": {
+    "page": "https://nspg13.github.io/agent-bounties/success.html",
+    "purpose": "After Stripe Checkout redirects back, read hosted bounty status and show whether the funding intent is waiting for webhook reconciliation, reconciled, or needs operator review.",
+    "endpoint_template": "{api_base_url}/v1/bounties/{bounty_id}",
+    "query_params": [
+      "apiBaseUrl",
+      "bountyId",
+      "fundingIntentId",
+      "externalReference",
+      "source",
+      "paymentPreference"
+    ],
+    "states": [
+      "Checkout returned",
+      "waiting for webhook",
+      "funding reconciled",
+      "needs operator review"
+    ],
+    "non_secret_fields": [
+      "bounty.status",
+      "funding_summary.applied",
+      "funding_summary.remaining",
+      "funding_summary.claimable",
+      "funding_intents.id",
+      "funding_intents.status",
+      "funding_intents.external_reference"
+    ],
+    "settlement_authority": "Checkout redirect success is not funding; only a hosted status response showing an applied funding intent, reconciled webhook evidence, or claimable bounty can show funding as reconciled."
+  },
   "paypal_checkout_handoff": {
     "page": "https://nspg13.github.io/agent-bounties/funding.html",
     "purpose": "Route human funders to Stripe-hosted Checkout with PayPal preferred where Stripe supports and enables it.",

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -208,7 +208,7 @@
       "funding_intents.status",
       "funding_intents.external_reference"
     ],
-    "settlement_authority": "Checkout redirect success is not funding; only a hosted status response showing an applied funding intent, reconciled webhook evidence, or claimable bounty can show funding as reconciled."
+    "settlement_authority": "Checkout redirect success is not funding; only a hosted status response showing the matched Stripe funding intent in Applied state can show this Checkout as reconciled. Generic bounty claimability must be displayed separately because it can come from another rail or contribution."
   },
   "paypal_checkout_handoff": {
     "page": "https://nspg13.github.io/agent-bounties/funding.html",

--- a/site/funding.html
+++ b/site/funding.html
@@ -94,6 +94,7 @@
             <li>The site asks the hosted API to create a Stripe fiat funding intent for the bounty.</li>
             <li>The hosted API creates a Stripe Checkout Session for that exact funding intent.</li>
             <li>You choose an eligible payment method on Stripe Checkout, not on this website. Use PayPal there if it appears.</li>
+            <li>Checkout returns to the status page, which reads the hosted bounty record and may show <code>waiting for webhook</code>, <code>funding reconciled</code>, or <code>needs operator review</code>.</li>
             <li>Stripe sends <code>checkout.session.completed</code> to the hosted webhook endpoint.</li>
             <li>The platform verifies the signature, checks bounty metadata, credits the ledger, and reserves funding into the bounty.</li>
           </ol>

--- a/site/funding.html
+++ b/site/funding.html
@@ -94,7 +94,7 @@
             <li>The site asks the hosted API to create a Stripe fiat funding intent for the bounty.</li>
             <li>The hosted API creates a Stripe Checkout Session for that exact funding intent.</li>
             <li>You choose an eligible payment method on Stripe Checkout, not on this website. Use PayPal there if it appears.</li>
-            <li>Checkout returns to the status page, which reads the hosted bounty record and may show <code>waiting for webhook</code>, <code>funding reconciled</code>, or <code>needs operator review</code>.</li>
+            <li>Checkout returns to the status page, which reads the hosted bounty record and may show <code>waiting for webhook</code>, <code>funding reconciled</code>, or <code>needs operator review</code> for the matched Stripe funding intent.</li>
             <li>Stripe sends <code>checkout.session.completed</code> to the hosted webhook endpoint.</li>
             <li>The platform verifies the signature, checks bounty metadata, credits the ledger, and reserves funding into the bounty.</li>
           </ol>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -25,6 +25,10 @@ Start here:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&amountMinor={amount_minor}&currency=usd&rail=StripeFiat&source={source}
 - PayPal-capable human funding handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&amountMinor={amount_minor}&currency=usd&rail=StripeFiat&paymentPreference=paypal&source={source}
+- Post-Checkout funding status:
+  https://nspg13.github.io/agent-bounties/success.html?apiBaseUrl={api}&bountyId={bounty_id}&externalReference={external_reference}
+  This page reads {api}/v1/bounties/{bounty_id} and can show Checkout returned,
+  waiting for webhook, funding reconciled, or needs operator review.
 - Base USDC funding plan handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&network=base-sepolia&escrowContract={escrow}&payer={payer}&token={usdc}&rail=BaseUsdc&source={source}
 - Hosted API health preflight: enter an API base URL on the funding page and run
@@ -166,6 +170,10 @@ Payment invariants:
 - PayPal preference links are UI hints only; PayPal availability is decided inside Stripe Checkout by Stripe account eligibility, Dashboard setup, currency, location, browser, and payment-method configuration.
 - Funding page query parameters are UI defaults only; they do not create funding
   or settlement.
+- A Checkout return/success page is not funding evidence. It may show funding
+  reconciled only after the hosted API reports an applied funding intent,
+  reconciled checkout.session.completed webhook evidence, or a claimable bounty
+  state.
 - Hosted health and readiness checks are informational only; they do not create
   funding intents, Checkout Sessions, transactions, ledger credits, or payout
   state.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -28,7 +28,8 @@ Start here:
 - Post-Checkout funding status:
   https://nspg13.github.io/agent-bounties/success.html?apiBaseUrl={api}&bountyId={bounty_id}&externalReference={external_reference}
   This page reads {api}/v1/bounties/{bounty_id} and can show Checkout returned,
-  waiting for webhook, funding reconciled, or needs operator review.
+  waiting for webhook, funding reconciled, or needs operator review for the
+  matched Stripe funding intent.
 - Base USDC funding plan handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&network=base-sepolia&escrowContract={escrow}&payer={payer}&token={usdc}&rail=BaseUsdc&source={source}
 - Hosted API health preflight: enter an API base URL on the funding page and run
@@ -171,9 +172,9 @@ Payment invariants:
 - Funding page query parameters are UI defaults only; they do not create funding
   or settlement.
 - A Checkout return/success page is not funding evidence. It may show funding
-  reconciled only after the hosted API reports an applied funding intent,
-  reconciled checkout.session.completed webhook evidence, or a claimable bounty
-  state.
+  reconciled only after the matched Stripe funding intent reports Applied
+  checkout.session.completed webhook evidence. Generic bounty claimability can
+  come from another rail or contribution and must be displayed separately.
 - Hosted health and readiness checks are informational only; they do not create
   funding intents, Checkout Sessions, transactions, ledger credits, or payout
   state.

--- a/site/main.js
+++ b/site/main.js
@@ -167,7 +167,26 @@
     if (!money || typeof money.amount !== "number") {
       return "unknown";
     }
-    return `${money.amount} ${money.currency || "minor units"}`;
+    const currency = String(money.currency || "").trim().toLowerCase();
+    const exponent = {
+      usd: 2,
+      eur: 2,
+      gbp: 2,
+      usdc: 6,
+    }[currency];
+    if (typeof exponent !== "number") {
+      return `${money.amount} minor units${currency ? ` ${currency.toUpperCase()}` : ""}`;
+    }
+    const minor = Math.trunc(money.amount);
+    const sign = minor < 0 ? "-" : "";
+    const absolute = Math.abs(minor);
+    const base = 10 ** exponent;
+    const whole = Math.trunc(absolute / base);
+    if (exponent === 0) {
+      return `${sign}${whole} ${currency.toUpperCase()}`;
+    }
+    const fractional = String(absolute % base).padStart(exponent, "0");
+    return `${sign}${whole}.${fractional} ${currency.toUpperCase()}`;
   }
 
   function stripeFundingIntents(report) {
@@ -179,17 +198,15 @@
   function matchingStripeFundingIntent(report, lookup) {
     const intents = stripeFundingIntents(report);
     if (lookup.fundingIntentId) {
-      const match = intents.find((intent) => intent.id === lookup.fundingIntentId);
-      if (match) return match;
+      return intents.find((intent) => intent.id === lookup.fundingIntentId) || null;
     }
     if (lookup.externalReference) {
-      const match = intents.find((intent) => intent.external_reference === lookup.externalReference);
-      if (match) return match;
+      return intents.find((intent) => intent.external_reference === lookup.externalReference) || null;
     }
     return intents.length === 1 ? intents[0] : null;
   }
 
-  function checkoutStatusLines(report, lookup) {
+  function checkoutStatusModel(report, lookup) {
     const bounty = report.bounty || {};
     const summary = report.funding_summary || {};
     const intent = matchingStripeFundingIntent(report, lookup);
@@ -198,18 +215,36 @@
     const appliedMinor = summary.applied && typeof summary.applied.amount === "number"
       ? summary.applied.amount
       : 0;
-    const heading = status === "Applied" || claimable
+    const heading = status === "Applied"
       ? "funding reconciled"
       : status === "Rejected"
         ? "needs operator review"
         : "waiting for webhook";
+    return {
+      appliedMinor,
+      bounty,
+      claimable,
+      heading,
+      intent,
+      status,
+      summary,
+    };
+  }
+
+  function checkoutStatusLines(report, lookup) {
+    const state = checkoutStatusModel(report, lookup);
+    const bounty = state.bounty;
+    const summary = state.summary;
+    const intent = state.intent;
+    const status = state.status;
+    const claimable = state.claimable;
     const lines = [
-      `State: ${heading}`,
+      `State: ${state.heading}`,
       `Bounty status: ${bounty.status || "unknown"}`,
       `Bounty id: ${lookup.bountyId || bounty.id || "unknown"}`,
       `Applied funding: ${displayMoney(summary.applied)}`,
       `Remaining funding: ${displayMoney(summary.remaining)}`,
-      `Claimable: ${claimable ? "yes" : "no"}`,
+      `Bounty claimable: ${claimable ? "yes" : "no"}`,
     ];
 
     if (intent) {
@@ -220,13 +255,13 @@
       lines.push(`Funding intent: not identified${lookup.externalReference ? ` for external reference ${lookup.externalReference}` : ""}`);
     }
 
-    if (status === "Applied" || claimable) {
-      lines.push("Funding is reconciled only because the hosted API reports applied webhook evidence or a claimable bounty state.");
+    if (status === "Applied") {
+      lines.push("Funding is reconciled only because the matching Stripe funding intent reports applied checkout.session.completed webhook evidence.");
       lines.push("Default CTA: Post your own bounty.");
     } else if (status === "Rejected") {
       lines.push("The hosted API rejected this funding intent. Contact the operator with the funding intent id if available.");
-    } else if (appliedMinor > 0) {
-      lines.push("Some funding is applied, but this return page still waits for the matching Checkout funding intent or full claimable state.");
+    } else if (state.appliedMinor > 0 || claimable) {
+      lines.push("Some bounty funding or claimability exists, but this return page still waits for the matching Checkout funding intent to show Applied webhook evidence.");
     } else {
       lines.push("Checkout returned, but funding is still pending until the signed checkout.session.completed webhook is reconciled.");
       lines.push("Refresh this page after a few seconds. If it stays pending, the hosted operator should check webhook delivery.");
@@ -234,6 +269,23 @@
 
     return lines.join("\n");
   }
+
+  function checkoutUnavailableStatusLines(message) {
+    return [
+      "State: needs operator review",
+      message,
+      "Hosted API status is unavailable, so this page cannot show funding as reconciled.",
+      "Refresh later or ask the operator to inspect webhook delivery for the funding intent.",
+    ].join("\n");
+  }
+
+  window.AgentBountiesCheckoutStatus = {
+    checkoutStatusLines,
+    checkoutStatusModel,
+    checkoutUnavailableStatusLines,
+    displayMoney,
+    matchingStripeFundingIntent,
+  };
 
   async function refreshCheckoutStatus() {
     if (!checkoutStatusOutput) return;
@@ -265,12 +317,7 @@
       checkoutStatusOutput.textContent = checkoutStatusLines(await response.json(), lookup);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      checkoutStatusOutput.textContent = [
-        "State: needs operator review",
-        message,
-        "Hosted API status is unavailable, so this page cannot show funding as reconciled.",
-        "Refresh later or ask the operator to inspect webhook delivery for the funding intent.",
-      ].join("\n");
+      checkoutStatusOutput.textContent = checkoutUnavailableStatusLines(message);
     }
   }
 

--- a/site/main.js
+++ b/site/main.js
@@ -150,6 +150,137 @@
   const readinessOutput = document.getElementById("readiness-output");
   const baseForm = document.getElementById("base-plan-form");
   const baseOutput = document.getElementById("base-plan-output");
+  const checkoutStatusOutput = document.getElementById("checkout-status-output");
+  const checkoutStatusRefresh = document.getElementById("checkout-status-refresh");
+
+  function firstCheckoutStatusParam(searchParams, names) {
+    for (const name of names) {
+      const value = searchParams.get(name);
+      if (value && value.trim()) {
+        return value.trim();
+      }
+    }
+    return "";
+  }
+
+  function displayMoney(money) {
+    if (!money || typeof money.amount !== "number") {
+      return "unknown";
+    }
+    return `${money.amount} ${money.currency || "minor units"}`;
+  }
+
+  function stripeFundingIntents(report) {
+    return Array.isArray(report.funding_intents)
+      ? report.funding_intents.filter((intent) => intent && intent.rail === "StripeFiat")
+      : [];
+  }
+
+  function matchingStripeFundingIntent(report, lookup) {
+    const intents = stripeFundingIntents(report);
+    if (lookup.fundingIntentId) {
+      const match = intents.find((intent) => intent.id === lookup.fundingIntentId);
+      if (match) return match;
+    }
+    if (lookup.externalReference) {
+      const match = intents.find((intent) => intent.external_reference === lookup.externalReference);
+      if (match) return match;
+    }
+    return intents.length === 1 ? intents[0] : null;
+  }
+
+  function checkoutStatusLines(report, lookup) {
+    const bounty = report.bounty || {};
+    const summary = report.funding_summary || {};
+    const intent = matchingStripeFundingIntent(report, lookup);
+    const status = intent && intent.status;
+    const claimable = summary.claimable === true;
+    const appliedMinor = summary.applied && typeof summary.applied.amount === "number"
+      ? summary.applied.amount
+      : 0;
+    const heading = status === "Applied" || claimable
+      ? "funding reconciled"
+      : status === "Rejected"
+        ? "needs operator review"
+        : "waiting for webhook";
+    const lines = [
+      `State: ${heading}`,
+      `Bounty status: ${bounty.status || "unknown"}`,
+      `Bounty id: ${lookup.bountyId || bounty.id || "unknown"}`,
+      `Applied funding: ${displayMoney(summary.applied)}`,
+      `Remaining funding: ${displayMoney(summary.remaining)}`,
+      `Claimable: ${claimable ? "yes" : "no"}`,
+    ];
+
+    if (intent) {
+      lines.push(`Funding intent id: ${intent.id}`);
+      lines.push(`Funding intent status: ${status || "unknown"}`);
+      lines.push(`External reference: ${intent.external_reference || "not set"}`);
+    } else {
+      lines.push(`Funding intent: not identified${lookup.externalReference ? ` for external reference ${lookup.externalReference}` : ""}`);
+    }
+
+    if (status === "Applied" || claimable) {
+      lines.push("Funding is reconciled only because the hosted API reports applied webhook evidence or a claimable bounty state.");
+      lines.push("Default CTA: Post your own bounty.");
+    } else if (status === "Rejected") {
+      lines.push("The hosted API rejected this funding intent. Contact the operator with the funding intent id if available.");
+    } else if (appliedMinor > 0) {
+      lines.push("Some funding is applied, but this return page still waits for the matching Checkout funding intent or full claimable state.");
+    } else {
+      lines.push("Checkout returned, but funding is still pending until the signed checkout.session.completed webhook is reconciled.");
+      lines.push("Refresh this page after a few seconds. If it stays pending, the hosted operator should check webhook delivery.");
+    }
+
+    return lines.join("\n");
+  }
+
+  async function refreshCheckoutStatus() {
+    if (!checkoutStatusOutput) return;
+    const params = new URLSearchParams(window.location.search);
+    const lookup = {
+      apiBaseUrl: firstCheckoutStatusParam(params, ["apiBaseUrl", "api_base_url", "api"]),
+      bountyId: firstCheckoutStatusParam(params, ["bountyId", "bounty_id"]),
+      fundingIntentId: firstCheckoutStatusParam(params, ["fundingIntentId", "funding_intent_id"]),
+      externalReference: firstCheckoutStatusParam(params, ["externalReference", "external_reference"]),
+    };
+    if (!lookup.apiBaseUrl || !lookup.bountyId) {
+      checkoutStatusOutput.textContent = [
+        "State: Checkout returned",
+        "Missing hosted API or bounty id in the return link, so this page cannot verify funding.",
+        "A Checkout redirect is not funding evidence. Open the funding page or hosted bounty status to check reconciliation.",
+      ].join("\n");
+      return;
+    }
+
+    const apiBaseUrl = lookup.apiBaseUrl.replace(/\/+$/, "");
+    checkoutStatusOutput.textContent = "Checkout returned. Reading hosted bounty status...";
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/bounties/${lookup.bountyId}`, {
+        headers: { accept: "application/json" },
+      });
+      if (!response.ok) {
+        throw new Error(`Hosted bounty status returned ${response.status}`);
+      }
+      checkoutStatusOutput.textContent = checkoutStatusLines(await response.json(), lookup);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      checkoutStatusOutput.textContent = [
+        "State: needs operator review",
+        message,
+        "Hosted API status is unavailable, so this page cannot show funding as reconciled.",
+        "Refresh later or ask the operator to inspect webhook delivery for the funding intent.",
+      ].join("\n");
+    }
+  }
+
+  if (checkoutStatusOutput) {
+    if (checkoutStatusRefresh) {
+      checkoutStatusRefresh.addEventListener("click", refreshCheckoutStatus);
+    }
+    refreshCheckoutStatus();
+  }
+
   if (!form || !output) return;
 
   function randomUuid() {
@@ -403,7 +534,14 @@
       String(data.get("externalReference") || "").trim() ||
       `${source}-${paymentPreference === "paypal" ? "paypal-" : ""}checkout-${Date.now()}`;
     const pageBase = `${window.location.origin}${window.location.pathname.replace(/funding\.html$/, "")}`;
-    const returnQuery = `?bountyId=${encodeURIComponent(bountyId)}&source=${encodeURIComponent(source)}&paymentPreference=${encodeURIComponent(paymentPreference)}`;
+    const returnParams = new URLSearchParams({
+      apiBaseUrl,
+      bountyId,
+      source,
+      paymentPreference,
+      externalReference,
+    });
+    const returnQuery = `?${returnParams.toString()}`;
 
     try {
       if (paymentPreference === "paypal") {

--- a/site/success.html
+++ b/site/success.html
@@ -12,7 +12,19 @@
       <p class="eyebrow">Checkout</p>
       <h1>Checkout submitted</h1>
       <p>Stripe accepted the Checkout session. The bounty is not funded until the hosted API verifies the signed Stripe webhook and reconciles it to the funding intent.</p>
-      <p><a class="button primary" href="funding.html">Back to funding</a></p>
+      <section class="readiness-panel" id="checkout-status-panel" aria-labelledby="checkout-status-title">
+        <div>
+          <h2 id="checkout-status-title">Funding status</h2>
+          <p class="fine">This status reads the hosted bounty record after Checkout return. A redirect is not payment evidence; only the reconciled funding intent or bounty status can show funding.</p>
+        </div>
+        <button id="checkout-status-refresh" class="button secondary" type="button">Refresh status</button>
+        <output id="checkout-status-output" class="output readiness-output" aria-live="polite">Checkout returned. Waiting for status details.</output>
+      </section>
+      <p class="actions">
+        <a class="button primary" href="funding.html">Back to funding</a>
+        <a class="button secondary" href="post.html">Post your own bounty</a>
+      </p>
     </main>
+    <script src="main.js"></script>
   </body>
 </html>

--- a/site/success.html
+++ b/site/success.html
@@ -15,7 +15,7 @@
       <section class="readiness-panel" id="checkout-status-panel" aria-labelledby="checkout-status-title">
         <div>
           <h2 id="checkout-status-title">Funding status</h2>
-          <p class="fine">This status reads the hosted bounty record after Checkout return. A redirect is not payment evidence; only the reconciled funding intent or bounty status can show funding.</p>
+          <p class="fine">This status reads the hosted bounty record after Checkout return. A redirect is not payment evidence; only the matched Stripe funding intent in Applied state can show this Checkout as reconciled. Bounty claimability is displayed separately.</p>
         </div>
         <button id="checkout-status-refresh" class="button secondary" type="button">Refresh status</button>
         <output id="checkout-status-output" class="output readiness-output" aria-live="polite">Checkout returned. Waiting for status details.</output>


### PR DESCRIPTION
Refs #114

## Summary
- Adds a post-Checkout status panel on success.html that reads GET /v1/bounties/{id} and distinguishes Checkout returned, waiting for webhook, funding reconciled, and needs operator review.
- Carries apiBaseUrl, bountyId, paymentPreference, source, and externalReference into the Stripe return URL so the status page can find the relevant funding intent without exposing Stripe customer/session payloads.
- Updates the static discovery manifest, /llms.txt, deployment docs, and site checks so assistants preserve the rule that a Checkout redirect is not funding evidence.

## Proof
- python scripts\\check-site.py -> site check ok
- node --check site\\main.js
- python -m json.tool site\\.well-known\\agent-bounties.json
- python -m json.tool schemas\\discovery-manifest.v1.json
- git diff --check

## Not run
- cargo run -p cli -- docs-contract-check, because cargo is not installed on this Windows PATH.

## Discovery feedback
I found #114 from the current public Agent Bounties issue list while following up on active GitHub/Gmail bounty lanes. It was worth attempting because the scope is narrow, user-facing, and directly reinforces the key settlement boundary: Stripe Checkout return success is not funding; only verified webhook reconciliation can produce a funded state.

Payment note: this PR, issue amount, or status text is not bounty acceptance or payout authorization. Payment should only be assumed after maintainer acceptance and verified settlement/payment evidence.