### PR TITLE
feat: add wallet-native Base funding flow

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -4535,11 +4535,7 @@ mod tests {
             222,
             0,
         );
-        created_log.tx_hash = format!(
-            "0x{}{}",
-            Uuid::new_v4().simple(),
-            Uuid::new_v4().simple()
-        );
+        created_log.tx_hash = format!("0x{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
         let created_tx_hash = created_log.tx_hash.clone();
         let mut other_log = raw_created_log(
             other_onchain_escrow_id,
@@ -4551,11 +4547,7 @@ mod tests {
             223,
             0,
         );
-        other_log.tx_hash = format!(
-            "0x{}{}",
-            Uuid::new_v4().simple(),
-            Uuid::new_v4().simple()
-        );
+        other_log.tx_hash = format!("0x{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
 
         let report = worker::process_base_evm_logs_and_persist(
             &indexer_store,

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -2752,15 +2752,22 @@ async fn bounty_status(
         let network = state.network.lock().expect("state poisoned");
         network.status(id).map_err(|_| StatusCode::NOT_FOUND)?
     };
-    status.base_escrow_events = state
-        .base_log_worker
-        .lock()
-        .expect("state poisoned")
-        .indexed_events()
-        .iter()
-        .filter(|event| event.bounty_id == id)
-        .cloned()
-        .collect();
+    status.base_escrow_events = if let Some(store) = &state.store {
+        store
+            .list_base_escrow_events_for_bounty(id)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    } else {
+        state
+            .base_log_worker
+            .lock()
+            .expect("state poisoned")
+            .indexed_events()
+            .iter()
+            .filter(|event| event.bounty_id == id)
+            .cloned()
+            .collect()
+    };
     Ok(Json(status))
 }
 
@@ -4470,6 +4477,110 @@ mod tests {
         assert_eq!(stale_status.bounty.title, edited.title);
     }
 
+    #[tokio::test]
+    #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
+    async fn bounty_status_reads_base_events_from_postgres_after_cross_process_indexing() {
+        let database_url = postgres_test_database_url();
+        let api_store = PostgresStore::connect(&database_url).await.unwrap();
+        api_store.migrate().await.unwrap();
+
+        let mut api_network = BountyNetwork::default();
+        let bounty = api_network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Expose separately indexed Base evidence".to_string(),
+                template_slug: "fix-ci-failure".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+        let other_bounty = api_network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Filter unrelated Base evidence".to_string(),
+                template_slug: "fix-ci-failure".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+        api_store.upsert_bounty(&bounty).await.unwrap();
+        api_store.upsert_bounty(&other_bounty).await.unwrap();
+        let api_state =
+            test_state_with_operator_token_and_store(api_network, "secret-token", api_store);
+
+        let initial_status = bounty_status(State(api_state.clone()), Path(bounty.id))
+            .await
+            .unwrap()
+            .0;
+        assert!(initial_status.base_escrow_events.is_empty());
+
+        let indexer_store = PostgresStore::connect(&database_url).await.unwrap();
+        let mut indexer_network = hydrate_network(&indexer_store).await.unwrap();
+        let mut indexer_worker = worker::hydrate_base_log_worker(&indexer_store)
+            .await
+            .unwrap();
+        let terms_hash = format!("0x{}", bounty.terms_hash.clone().unwrap());
+        let other_terms_hash = format!("0x{}", other_bounty.terms_hash.clone().unwrap());
+        let onchain_escrow_id = bounty.id.as_u128() % 1_000_000_000_000 + 10_000;
+        let other_onchain_escrow_id = onchain_escrow_id + 1;
+        let mut created_log = raw_created_log(
+            onchain_escrow_id,
+            bounty.id,
+            "0x2222222222222222222222222222222222222222",
+            "0x3333333333333333333333333333333333333333",
+            bounty.amount.clone(),
+            &terms_hash,
+            222,
+            0,
+        );
+        created_log.tx_hash = format!(
+            "0x{}{}",
+            Uuid::new_v4().simple(),
+            Uuid::new_v4().simple()
+        );
+        let created_tx_hash = created_log.tx_hash.clone();
+        let mut other_log = raw_created_log(
+            other_onchain_escrow_id,
+            other_bounty.id,
+            "0x2222222222222222222222222222222222222222",
+            "0x3333333333333333333333333333333333333333",
+            other_bounty.amount,
+            &other_terms_hash,
+            223,
+            0,
+        );
+        other_log.tx_hash = format!(
+            "0x{}{}",
+            Uuid::new_v4().simple(),
+            Uuid::new_v4().simple()
+        );
+
+        let report = worker::process_base_evm_logs_and_persist(
+            &indexer_store,
+            &mut indexer_worker,
+            &mut indexer_network,
+            vec![created_log, other_log],
+        )
+        .await
+        .unwrap();
+        assert_eq!(report.applied_events.len(), 2);
+
+        let status = bounty_status(State(api_state), Path(bounty.id))
+            .await
+            .unwrap()
+            .0;
+
+        assert_eq!(status.base_escrow_events.len(), 1);
+        assert_eq!(status.base_escrow_events[0].bounty_id, bounty.id);
+        assert_eq!(
+            status.base_escrow_events[0].onchain_escrow_id,
+            onchain_escrow_id
+        );
+        assert_eq!(status.base_escrow_events[0].tx_hash, created_tx_hash);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
     async fn github_issue_api_sync_postgres_serializes_concurrent_initial_sync() {
@@ -5757,6 +5868,62 @@ mod tests {
             status.settlements[0].payout_intents[0].status,
             PayoutStatus::Paid
         );
+    }
+
+    #[tokio::test]
+    async fn bounty_status_uses_local_base_worker_events_without_store() {
+        let mut network = BountyNetwork::default();
+        let bounty = network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Expose local Base escrow evidence".to_string(),
+                template_slug: "fix-ci-failure".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+        let other_bounty = network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Keep other Base escrow evidence out".to_string(),
+                template_slug: "fix-ci-failure".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+        let state = test_state(network);
+        let event = chain_base::simulated_created_event(
+            bounty.id,
+            21,
+            "0x3333333333333333333333333333333333333333",
+            bounty.amount.clone(),
+            bounty.terms_hash.clone().unwrap(),
+        );
+        let other_event = chain_base::simulated_created_event(
+            other_bounty.id,
+            22,
+            "0x3333333333333333333333333333333333333333",
+            other_bounty.amount,
+            other_bounty.terms_hash.unwrap(),
+        );
+
+        {
+            let mut worker = state.base_log_worker.lock().expect("state poisoned");
+            worker.ingest_indexed_event(event.clone()).unwrap();
+            worker.ingest_indexed_event(other_event).unwrap();
+        }
+
+        let status = bounty_status(State(state), Path(bounty.id))
+            .await
+            .unwrap()
+            .0;
+
+        assert_eq!(status.base_escrow_events.len(), 1);
+        assert_eq!(status.base_escrow_events[0].id, event.id);
+        assert_eq!(status.base_escrow_events[0].bounty_id, bounty.id);
+        assert_eq!(status.base_escrow_events[0].onchain_escrow_id, 21);
     }
 
     #[tokio::test]

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -2748,11 +2748,20 @@ async fn bounty_status(
     State(state): State<SharedState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<BountyStatusResponse>, StatusCode> {
-    let network = state.network.lock().expect("state poisoned");
-    network
-        .status(id)
-        .map(Json)
-        .map_err(|_| StatusCode::NOT_FOUND)
+    let mut status = {
+        let network = state.network.lock().expect("state poisoned");
+        network.status(id).map_err(|_| StatusCode::NOT_FOUND)?
+    };
+    status.base_escrow_events = state
+        .base_log_worker
+        .lock()
+        .expect("state poisoned")
+        .indexed_events()
+        .iter()
+        .filter(|event| event.bounty_id == id)
+        .cloned()
+        .collect();
+    Ok(Json(status))
 }
 
 async fn public_proof_page(

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -962,6 +962,8 @@ pub struct BountyStatusResponse {
     pub funding_intents: Vec<FundingIntent>,
     pub funding_contributions: Vec<FundingContribution>,
     pub escrows: Vec<Escrow>,
+    #[serde(default)]
+    pub base_escrow_events: Vec<BaseEscrowEvent>,
     pub claims: Vec<Claim>,
     pub submissions: Vec<Submission>,
     pub verifier_results: Vec<VerifierResult>,
@@ -2651,6 +2653,7 @@ impl BountyNetwork {
             funding_intents,
             funding_contributions,
             escrows,
+            base_escrow_events: Vec::new(),
             claims,
             submissions,
             verifier_results,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -854,37 +854,26 @@ impl PostgresStore {
         .fetch_all(&self.pool)
         .await?;
 
-        rows.into_iter()
-            .map(|row| {
-                let amount = match (
-                    row.try_get::<Option<i64>, _>("amount")?,
-                    row.try_get::<Option<String>, _>("currency")?,
-                ) {
-                    (Some(amount), Some(currency)) => Some(Money::new(amount, currency)?),
-                    _ => None,
-                };
-                Ok(BaseEscrowEvent {
-                    id: row.try_get("id")?,
-                    log_key: row.try_get("log_key")?,
-                    tx_hash: row.try_get("tx_hash")?,
-                    block_number: u64_from_i64(row.try_get("block_number")?)?,
-                    onchain_escrow_id: row
-                        .try_get::<String, _>("onchain_escrow_id")?
-                        .parse()
-                        .map_err(|_| DbError::InvalidEnum("onchain_escrow_id".to_string()))?,
-                    bounty_id: row.try_get("bounty_id")?,
-                    kind: parse_base_escrow_event_kind(row.try_get::<String, _>("kind")?)?,
-                    status: parse_escrow_status(row.try_get::<String, _>("status")?)?,
-                    token: row.try_get("token")?,
-                    amount,
-                    terms_hash: row.try_get("terms_hash")?,
-                    proof_hash: row.try_get("proof_hash")?,
-                    reason_hash: row.try_get("reason_hash")?,
-                    dispute_hash: row.try_get("dispute_hash")?,
-                    occurred_at: row.try_get("occurred_at")?,
-                })
-            })
-            .collect()
+        rows.into_iter().map(base_escrow_event_from_row).collect()
+    }
+
+    pub async fn list_base_escrow_events_for_bounty(
+        &self,
+        bounty_id: Id,
+    ) -> DbResult<Vec<BaseEscrowEvent>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, log_key, tx_hash, block_number, onchain_escrow_id, bounty_id, kind, status, token, amount, currency, terms_hash, proof_hash, reason_hash, dispute_hash, occurred_at
+            FROM base_escrow_events
+            WHERE bounty_id = $1
+            ORDER BY block_number, COALESCE(log_index, 0), occurred_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(base_escrow_event_from_row).collect()
     }
 
     pub async fn get_base_log_cursor(
@@ -1734,6 +1723,36 @@ fn parse_base_escrow_event_kind(value: String) -> DbResult<BaseEscrowEventKind> 
         "Paused" => Ok(BaseEscrowEventKind::Paused),
         _ => Err(DbError::InvalidEnum(value)),
     }
+}
+
+fn base_escrow_event_from_row(row: PgRow) -> DbResult<BaseEscrowEvent> {
+    let amount = match (
+        row.try_get::<Option<i64>, _>("amount")?,
+        row.try_get::<Option<String>, _>("currency")?,
+    ) {
+        (Some(amount), Some(currency)) => Some(Money::new(amount, currency)?),
+        _ => None,
+    };
+    Ok(BaseEscrowEvent {
+        id: row.try_get("id")?,
+        log_key: row.try_get("log_key")?,
+        tx_hash: row.try_get("tx_hash")?,
+        block_number: u64_from_i64(row.try_get("block_number")?)?,
+        onchain_escrow_id: row
+            .try_get::<String, _>("onchain_escrow_id")?
+            .parse()
+            .map_err(|_| DbError::InvalidEnum("onchain_escrow_id".to_string()))?,
+        bounty_id: row.try_get("bounty_id")?,
+        kind: parse_base_escrow_event_kind(row.try_get::<String, _>("kind")?)?,
+        status: parse_escrow_status(row.try_get::<String, _>("status")?)?,
+        token: row.try_get("token")?,
+        amount,
+        terms_hash: row.try_get("terms_hash")?,
+        proof_hash: row.try_get("proof_hash")?,
+        reason_hash: row.try_get("reason_hash")?,
+        dispute_hash: row.try_get("dispute_hash")?,
+        occurred_at: row.try_get("occurred_at")?,
+    })
 }
 
 fn parse_risk_surface(value: String) -> DbResult<RiskSurface> {

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -253,6 +253,26 @@ you control. Hosted transaction broadcast is disabled unless
 `ENABLE_BASE_TX_BROADCAST=true`; transaction hashes and planner output are not
 settlement.
 
+For low-value Base mainnet funding, the public funding page also exposes a
+wallet-native path:
+
+```text
+https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl=<api>&bountyId=<bounty-id>&rail=BaseUsdc
+```
+
+Use the `Connect wallet` action with an injected EIP-1193 wallet. The page
+requires Base mainnet (`0x2105`, chain `8453`), then requests the hosted
+`/v1/base/funding-plan` with the verified Base mainnet escrow and native USDC
+deployment constants. Before any `eth_sendTransaction`, the page rejects plans
+whose chain, payer, escrow target, token, bounty id, amount, or terms hash do
+not match the connected wallet, hosted bounty, and
+`deployments/base-mainnet.json`. The wallet flow still requires two separate
+confirmations: USDC `approve` first, escrow `createEscrow` second.
+
+Do not describe a wallet popup, submitted transaction hash, or successful wallet
+return value as funded. Funding is reconciled only after hosted read-only status
+shows matching indexed `EscrowCreated` evidence.
+
 After the escrow contract emits `EscrowCreated`, reconcile the indexed event.
 Tool: `reconcile_base_escrow_event`.
 

--- a/docs/hosted-base-usdc-beta-runbook.md
+++ b/docs/hosted-base-usdc-beta-runbook.md
@@ -138,6 +138,28 @@ broadcast through the wallet or a trusted operator workstation.
 The posted bounty supplies the amount, payee, and terms hash; they are not part
 of the funding-plan request payload.
 
+For the low-value Base mainnet path, funders can use the public funding page's
+wallet-native flow instead of copying calldata into a developer tool:
+
+```text
+https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl=<api>&bountyId=<bounty-id>&rail=BaseUsdc
+```
+
+The page uses an injected EIP-1193 wallet and requires an explicit `Connect
+wallet` action before requesting Base mainnet (`0x2105`, chain `8453`). It does
+not request or store private keys, seed phrases, signatures, or wallet history.
+It uses the verified Base mainnet escrow and native USDC constants from
+`deployments/base-mainnet.json`; contract and token query parameters are not
+trusted for wallet funding. Before the two `eth_sendTransaction` prompts, it
+rejects any hosted funding plan whose chain, payer, escrow target, token, bounty
+id, amount, or terms hash does not match the connected wallet and hosted bounty.
+
+The two confirmations remain separate: USDC `approve` first, escrow
+`createEscrow` second. If a prompt is rejected or a transaction is reported
+reverted, do not start an automatic retry loop. A wallet transaction hash is
+still not funding; the public page can show funding reconciled only after hosted
+read-only status reports matching indexed `EscrowCreated` evidence.
+
 ## 4. Make the Bounty Claimable
 
 After funding transactions are mined, fetch and reconcile escrow logs from the

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -170,6 +170,11 @@ def main() -> int:
         "Prefer PayPal",
         "PayPal is selected inside Stripe Checkout",
         "Plan Base USDC escrow",
+        "Fund with Base wallet",
+        "Connect wallet",
+        "EIP-1193",
+        "0x2105",
+        "two wallet confirmations",
         "/v1/base/funding-plan",
         "createEscrow",
         "EscrowCreated",
@@ -370,6 +375,20 @@ def main() -> int:
         or "EscrowCreated" not in base_funding_handoff.get("settlement_authority", "")
     ):
         fail("static discovery manifest must advertise Base funding plan handoff")
+    wallet_native_base = discovery.get("wallet_native_base_funding", {})
+    if (
+        wallet_native_base.get("provider_standard") != "EIP-1193"
+        or wallet_native_base.get("chain_id_hex") != "0x2105"
+        or wallet_native_base.get("escrow_contract")
+        != "0x150C6dFbCe7803cc7f634f59b0624e87349CEAce"
+        or wallet_native_base.get("native_usdc")
+        != "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+        or "terms hash" not in wallet_native_base.get("required_plan_checks", [])
+        or "createEscrow" not in wallet_native_base.get("wallet_confirmations", [])
+        or "transaction hashes are not funding"
+        not in wallet_native_base.get("settlement_authority", "")
+    ):
+        fail("static discovery manifest must advertise wallet-native Base funding safeguards")
 
     print("site check ok")
     return 0

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -59,6 +59,7 @@ Invoke-Checked { cargo run -p cli -- github-proof-comment-plan --bounty-id 00000
 Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbounties.local --mcp-base-url https://agentbounties.local/mcp }
 Invoke-Checked { cargo run -p cli -- discovery-report --input-fixture crates\cli\fixtures\discovery_answers.json --json-out target\tmp\discovery-report.json --markdown-out target\tmp\discovery-report.md }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\check-site.py }
+Invoke-Checked { node scripts\test-base-wallet-flow.js }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m pip install -r scripts\requirements-attest.txt }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_base_deployment_attest.py -v }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\check-render-blueprint.py }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -109,6 +109,7 @@ cargo run -p cli -- discovery-report \
   --json-out target/tmp/discovery-report.json \
   --markdown-out target/tmp/discovery-report.md
 "${python_cmd[@]}" scripts/check-site.py
+node scripts/test-base-wallet-flow.js
 "${python_cmd[@]}" -m pip install -r scripts/requirements-attest.txt
 "${python_cmd[@]}" scripts/test_base_deployment_attest.py -v
 "${python_cmd[@]}" scripts/check-render-blueprint.py

--- a/scripts/test-base-wallet-flow.js
+++ b/scripts/test-base-wallet-flow.js
@@ -1,0 +1,240 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const repoRoot = path.resolve(__dirname, "..");
+const source = fs.readFileSync(path.join(repoRoot, "site", "main.js"), "utf8");
+
+const context = {
+  console,
+  document: {
+    getElementById() {
+      return null;
+    },
+  },
+  URLSearchParams,
+};
+context.window = context;
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "site/main.js" });
+
+const wallet = context.window.AgentBountiesBaseWallet;
+const config = wallet.baseMainnetWalletConfig;
+const bountyId = "31f83d55-f388-4cc8-b384-651403b71163";
+const payer = "0x0a8a657ba581f7a7c7dcd59ef637b7fbc6249850";
+const termsHash = "886ef7e42d7f2968ae5b44a9f963a95b4726d8d7244a6fbe35af6f2cffbbc7af";
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function bounty(overrides = {}) {
+  return {
+    id: bountyId,
+    amount: { amount: 1_000_000, currency: "usdc" },
+    funding_mode: "BaseUsdcEscrow",
+    funding_targets: [],
+    status: "Unfunded",
+    terms_hash: termsHash,
+    ...overrides,
+  };
+}
+
+function validPlan(overrides = {}) {
+  const plan = {
+    network: {
+      name: "Base",
+      chain_id: config.chainId,
+      native_usdc_token_address: config.nativeUsdc,
+    },
+    bounty: bounty(),
+    create: {
+      bounty_id: bountyId,
+      payer,
+      token: config.nativeUsdc,
+      amount: { amount: 1_000_000, currency: "usdc" },
+      terms_hash: termsHash,
+    },
+    funding: {
+      approve: {
+        from: payer,
+        to: config.nativeUsdc,
+        value_wei: 0,
+        data: "0xapprove",
+        function: "approve(address,uint256)",
+      },
+      create_escrow: {
+        from: payer,
+        to: config.escrowContract,
+        value_wei: 0,
+        data: "0xcreate",
+        function: "createEscrow(bytes32,address,uint256,bytes32)",
+      },
+    },
+  };
+  return Object.assign(plan, overrides);
+}
+
+function statusReport({ reconciled = false } = {}) {
+  return {
+    bounty: bounty({ status: reconciled ? "Claimable" : "Unfunded" }),
+    funding_summary: {
+      applied: { amount: reconciled ? 1_000_000 : 0, currency: "usdc" },
+      remaining: { amount: reconciled ? 0 : 1_000_000, currency: "usdc" },
+      claimable: reconciled,
+      partitions: [
+        {
+          rail: "BaseUsdc",
+          confirmed: { amount: reconciled ? 1_000_000 : 0, currency: "usdc" },
+          remaining: { amount: reconciled ? 0 : 1_000_000, currency: "usdc" },
+          escrow_count: reconciled ? 1 : 0,
+          claimable: reconciled,
+        },
+      ],
+    },
+    escrows: reconciled ? [{ id: "escrow-1" }] : [],
+  };
+}
+
+function mockProvider(handlers) {
+  const calls = [];
+  return {
+    calls,
+    async request(request) {
+      calls.push(request);
+      const handler = handlers[request.method];
+      if (Array.isArray(handler)) {
+        const next = handler.shift();
+        return typeof next === "function" ? next(request.params) : next;
+      }
+      if (typeof handler === "function") {
+        return handler(request.params);
+      }
+      return handler;
+    },
+  };
+}
+
+function mockFetch(responses) {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    const response = responses.shift();
+    if (!response) {
+      throw new Error(`unexpected fetch ${url}`);
+    }
+    if (response.ok === false) {
+      return { ok: false, status: response.status || 500, json: async () => response.body || {} };
+    }
+    return { ok: true, status: 200, json: async () => response };
+  };
+  fetchImpl.calls = calls;
+  return fetchImpl;
+}
+
+async function assertRejects(promise, pattern) {
+  let rejected = false;
+  try {
+    await promise;
+  } catch (error) {
+    rejected = true;
+    assert(pattern.test(error.message), `${error.message} did not match ${pattern}`);
+  }
+  assert(rejected, "expected promise to reject");
+}
+
+(async () => {
+  await assertRejects(wallet.connectBaseWallet(null), /No injected EVM wallet/);
+
+  await assertRejects(
+    wallet.connectBaseWallet(mockProvider({
+      eth_requestAccounts: () => [payer],
+      eth_chainId: ["0x1"],
+      wallet_switchEthereumChain: () => {
+        throw new Error("User rejected network switch");
+      },
+    })),
+    /User rejected network switch/,
+  );
+
+  await assertRejects(
+    wallet.connectBaseWallet(mockProvider({
+      eth_requestAccounts: () => {
+        throw new Error("User rejected account request");
+      },
+    })),
+    /User rejected account request/,
+  );
+
+  const mismatch = validPlan();
+  mismatch.network.chain_id = 1;
+  mismatch.create.token = "0x9999999999999999999999999999999999999999";
+  mismatch.funding.approve.to = mismatch.create.token;
+  mismatch.create.payer = "0x1111111111111111111111111111111111111111";
+  const issues = wallet.baseWalletPlanValidationIssues(mismatch, {
+    bountyId,
+    connectedAddress: payer,
+    hostedBounty: bounty(),
+  });
+  assert(issues.some((issue) => issue.includes("Base mainnet chain 8453")));
+  assert(issues.some((issue) => issue.includes("connected wallet")));
+  assert(issues.some((issue) => issue.includes("native USDC")));
+
+  const pendingProvider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_sendTransaction: ["0xapprove", "0xescrow"],
+    eth_getTransactionReceipt: { status: "0x1" },
+  });
+  const pendingResult = await wallet.fundBaseWalletBounty({
+    apiBaseUrl: "https://api.example.com",
+    bountyId,
+    connectedAddress: payer,
+    fetchImpl: mockFetch([statusReport(), validPlan(), statusReport()]),
+    provider: pendingProvider,
+  });
+  assert.strictEqual(pendingResult.heading, "waiting for confirmations");
+  assert.strictEqual(
+    pendingProvider.calls.filter((call) => call.method === "eth_sendTransaction").length,
+    2,
+  );
+  assert(pendingResult.lines.includes("Wallet transactions or transaction hashes are not funding evidence"));
+
+  const revertedResult = await wallet.fundBaseWalletBounty({
+    apiBaseUrl: "https://api.example.com",
+    bountyId,
+    connectedAddress: payer,
+    fetchImpl: mockFetch([statusReport(), validPlan()]),
+    provider: mockProvider({
+      eth_chainId: "0x2105",
+      eth_sendTransaction: ["0xapprove", "0xescrow"],
+      eth_getTransactionReceipt: { status: "0x0" },
+    }),
+  });
+  assert.strictEqual(revertedResult.heading, "needs operator review");
+  assert(revertedResult.lines.includes("reverted"));
+
+  const reconciledResult = await wallet.fundBaseWalletBounty({
+    apiBaseUrl: "https://api.example.com",
+    bountyId,
+    connectedAddress: payer,
+    fetchImpl: mockFetch([statusReport(), validPlan(), statusReport({ reconciled: true })]),
+    provider: mockProvider({
+      eth_chainId: "0x2105",
+      eth_sendTransaction: ["0xapprove", "0xescrow"],
+      eth_getTransactionReceipt: { status: "0x1" },
+    }),
+  });
+  assert.strictEqual(reconciledResult.heading, "funding reconciled");
+  assert(reconciledResult.lines.includes("State: funding reconciled"));
+  assert(reconciledResult.lines.includes("indexed EscrowCreated evidence"));
+
+  const genericClaimableWithoutBaseEscrow = wallet.baseWalletStatusLines({
+    bounty: bounty({ status: "Claimable" }),
+    funding_summary: { claimable: true, applied: { amount: 1, currency: "usd" }, remaining: { amount: 0, currency: "usd" } },
+    escrows: [],
+  });
+  assert(genericClaimableWithoutBaseEscrow.includes("State: waiting for confirmations"));
+
+  console.log("base wallet flow tests passed");
+})();

--- a/scripts/test-base-wallet-flow.js
+++ b/scripts/test-base-wallet-flow.js
@@ -27,6 +27,8 @@ const payer = "0x0a8a657ba581f7a7c7dcd59ef637b7fbc6249850";
 const otherAddress = "0x1111111111111111111111111111111111111111";
 const termsHash = "0x886ef7e42d7f2968ae5b44a9f963a95b4726d8d7244a6fbe35af6f2cffbbc7af";
 const amountMinor = 1_000_000;
+const escrowTxHash = `0x${"ab".repeat(32)}`;
+const otherEscrowTxHash = `0x${"cd".repeat(32)}`;
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -58,6 +60,74 @@ function encodeApprove(spender, amount) {
 
 function encodeCreateEscrow(id, token, amount, hash) {
   return `0x64a20554${uuidBytes32(id)}${wordAddress(token)}${wordUint(amount)}${word(hash)}`;
+}
+
+function evidenceFixture(overrides = {}) {
+  return {
+    amount: String(amountMinor),
+    bountyId: `0x${uuidBytes32(bountyId)}`,
+    logIndex: "0x0",
+    onchainEscrowId: "7",
+    payer,
+    termsHash,
+    token: config.nativeUsdc.toLowerCase(),
+    txHash: escrowTxHash,
+    ...overrides,
+  };
+}
+
+function escrowCreatedLog(evidence = evidenceFixture()) {
+  return {
+    address: config.escrowContract,
+    topics: [
+      config.escrowCreatedTopic,
+      `0x${wordUint(evidence.onchainEscrowId)}`,
+      evidence.bountyId,
+      `0x${wordAddress(evidence.payer)}`,
+    ],
+    data: `0x${wordAddress(evidence.token)}${wordUint(evidence.amount)}${word(evidence.termsHash)}`,
+    transactionHash: evidence.txHash,
+    blockNumber: "0x10",
+    logIndex: evidence.logIndex || "0x0",
+  };
+}
+
+function escrowReceipt(evidence = evidenceFixture()) {
+  return {
+    status: "0x1",
+    transactionHash: evidence.txHash,
+    logs: [escrowCreatedLog(evidence)],
+  };
+}
+
+function hostedEscrow(evidence = evidenceFixture(), overrides = {}) {
+  return {
+    id: `escrow-${evidence.onchainEscrowId}`,
+    bounty_id: bountyId,
+    rail: "BaseUsdc",
+    token: config.nativeUsdc,
+    amount: { amount: amountMinor, currency: "usdc" },
+    status: "Funded",
+    external_reference: `base:${evidence.onchainEscrowId}`,
+    ...overrides,
+  };
+}
+
+function hostedEscrowEvent(evidence = evidenceFixture(), overrides = {}) {
+  return {
+    id: `event-${evidence.onchainEscrowId}`,
+    log_key: `${evidence.txHash}:${evidence.logIndex || "0x0"}`,
+    tx_hash: evidence.txHash,
+    block_number: 16,
+    onchain_escrow_id: Number(evidence.onchainEscrowId),
+    bounty_id: bountyId,
+    kind: "Created",
+    status: "Funded",
+    token: config.nativeUsdc,
+    amount: { amount: amountMinor, currency: "usdc" },
+    terms_hash: termsHash,
+    ...overrides,
+  };
 }
 
 function bounty(overrides = {}) {
@@ -107,24 +177,40 @@ function validPlan() {
   };
 }
 
-function statusReport({ reconciled = false } = {}) {
+function statusReport({ reconciled = false, evidence = evidenceFixture(), otherEscrow = false } = {}) {
+  const activeEvidence = reconciled ? evidence : null;
+  const raceEvidence = otherEscrow ? evidenceFixture({
+    onchainEscrowId: "8",
+    payer: otherAddress,
+    txHash: otherEscrowTxHash,
+  }) : null;
+  const escrows = [
+    ...(activeEvidence ? [hostedEscrow(activeEvidence)] : []),
+    ...(raceEvidence ? [hostedEscrow(raceEvidence)] : []),
+  ];
+  const baseEscrowEvents = [
+    ...(activeEvidence ? [hostedEscrowEvent(activeEvidence)] : []),
+    ...(raceEvidence ? [hostedEscrowEvent(raceEvidence)] : []),
+  ];
+  const claimable = escrows.length > 0;
   return {
-    bounty: bounty({ status: reconciled ? "Claimable" : "Unfunded" }),
+    bounty: bounty({ status: claimable ? "Claimable" : "Unfunded" }),
     funding_summary: {
-      applied: { amount: reconciled ? amountMinor : 0, currency: "usdc" },
-      remaining: { amount: reconciled ? 0 : amountMinor, currency: "usdc" },
-      claimable: reconciled,
+      applied: { amount: claimable ? amountMinor : 0, currency: "usdc" },
+      remaining: { amount: claimable ? 0 : amountMinor, currency: "usdc" },
+      claimable,
       partitions: [
         {
           rail: "BaseUsdc",
-          confirmed: { amount: reconciled ? amountMinor : 0, currency: "usdc" },
-          remaining: { amount: reconciled ? 0 : amountMinor, currency: "usdc" },
-          escrow_count: reconciled ? 1 : 0,
-          claimable: reconciled,
+          confirmed: { amount: claimable ? amountMinor : 0, currency: "usdc" },
+          remaining: { amount: claimable ? 0 : amountMinor, currency: "usdc" },
+          escrow_count: escrows.length,
+          claimable,
         },
       ],
     },
-    escrows: reconciled ? [{ id: "escrow-1" }] : [],
+    escrows,
+    base_escrow_events: baseEscrowEvents,
   };
 }
 
@@ -425,7 +511,7 @@ async function assertBadPlanDoesNotSend(label, mutatePlan, pattern) {
     provider: mockProvider({
       eth_chainId: "0x2105",
       eth_accounts: () => [payer],
-      eth_sendTransaction: ["0xescrowhash"],
+      eth_sendTransaction: [escrowTxHash],
       eth_getTransactionReceipt: { status: "0x0" },
     }),
     review,
@@ -435,6 +521,7 @@ async function assertBadPlanDoesNotSend(label, mutatePlan, pattern) {
   assert(escrowRevert.lines.includes("reverted"));
 
   const pendingFetch = mockFetch([statusReport(), statusReport()]);
+  const expectedEvidence = evidenceFixture({ txHash: escrowTxHash });
   const pending = await wallet.sendBaseWalletEscrow({
     fetchImpl: pendingFetch,
     pollAttempts: 2,
@@ -442,8 +529,8 @@ async function assertBadPlanDoesNotSend(label, mutatePlan, pattern) {
     provider: mockProvider({
       eth_chainId: "0x2105",
       eth_accounts: () => [payer],
-      eth_sendTransaction: ["0xescrowhash"],
-      eth_getTransactionReceipt: { status: "0x1" },
+      eth_sendTransaction: [escrowTxHash],
+      eth_getTransactionReceipt: escrowReceipt(expectedEvidence),
     }),
     review,
     shareUrl: "https://example.com/share",
@@ -452,7 +539,49 @@ async function assertBadPlanDoesNotSend(label, mutatePlan, pattern) {
   assert.strictEqual(pendingFetch.calls.length, 2);
   assert(!pending.lines.includes("Share link"));
 
-  const reconciledFetch = mockFetch([statusReport(), statusReport(), statusReport({ reconciled: true })]);
+  const raceFetch = mockFetch([statusReport({ otherEscrow: true })]);
+  const race = await wallet.sendBaseWalletEscrow({
+    fetchImpl: raceFetch,
+    pollAttempts: 1,
+    pollDelayMs: 0,
+    provider: mockProvider({
+      eth_chainId: "0x2105",
+      eth_accounts: () => [payer],
+      eth_sendTransaction: [escrowTxHash],
+      eth_getTransactionReceipt: escrowReceipt(expectedEvidence),
+    }),
+    review,
+    shareUrl: "https://example.com/share",
+  });
+  assert.strictEqual(race.heading, "waiting for confirmations");
+  assert(race.lines.includes("Whole bounty claimable: yes"));
+  assert(!race.lines.includes("Share link"));
+
+  const pendingRaceFetch = mockFetch([statusReport({ otherEscrow: true })]);
+  await assertRejects(
+    wallet.sendBaseWalletEscrow({
+      fetchImpl: pendingRaceFetch,
+      pollDelayMs: 0,
+      provider: mockProvider({
+        eth_chainId: "0x2105",
+        eth_accounts: () => [payer],
+        eth_sendTransaction: [escrowTxHash],
+        eth_getTransactionReceipt: [null, null],
+      }),
+      receiptAttempts: 2,
+      receiptDelayMs: 0,
+      review,
+      shareUrl: "https://example.com/share",
+    }),
+    /did not produce a successful receipt/,
+  );
+  assert.strictEqual(pendingRaceFetch.calls.length, 0);
+
+  const reconciledFetch = mockFetch([
+    statusReport(),
+    statusReport(),
+    statusReport({ reconciled: true, evidence: expectedEvidence }),
+  ]);
   const reconciled = await wallet.sendBaseWalletEscrow({
     fetchImpl: reconciledFetch,
     pollAttempts: 3,
@@ -460,14 +589,15 @@ async function assertBadPlanDoesNotSend(label, mutatePlan, pattern) {
     provider: mockProvider({
       eth_chainId: "0x2105",
       eth_accounts: () => [payer],
-      eth_sendTransaction: ["0xescrowhash"],
-      eth_getTransactionReceipt: { status: "0x1" },
+      eth_sendTransaction: [escrowTxHash],
+      eth_getTransactionReceipt: escrowReceipt(expectedEvidence),
     }),
     review,
     shareUrl: "https://example.com/share",
   });
   assert.strictEqual(reconciled.heading, "funding reconciled");
   assert.strictEqual(reconciledFetch.calls.length, 3);
+  assert.strictEqual(reconciled.escrowEvidence.txHash, escrowTxHash);
   assert(reconciled.lines.includes("Share link: https://example.com/share"));
   assert(reconciled.lines.includes("Default CTA: Post your own bounty."));
 

--- a/scripts/test-base-wallet-flow.js
+++ b/scripts/test-base-wallet-flow.js
@@ -13,6 +13,7 @@ const context = {
       return null;
     },
   },
+  setTimeout,
   URLSearchParams,
 };
 context.window = context;
@@ -23,16 +24,47 @@ const wallet = context.window.AgentBountiesBaseWallet;
 const config = wallet.baseMainnetWalletConfig;
 const bountyId = "31f83d55-f388-4cc8-b384-651403b71163";
 const payer = "0x0a8a657ba581f7a7c7dcd59ef637b7fbc6249850";
-const termsHash = "886ef7e42d7f2968ae5b44a9f963a95b4726d8d7244a6fbe35af6f2cffbbc7af";
+const otherAddress = "0x1111111111111111111111111111111111111111";
+const termsHash = "0x886ef7e42d7f2968ae5b44a9f963a95b4726d8d7244a6fbe35af6f2cffbbc7af";
+const amountMinor = 1_000_000;
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+function hex(value) {
+  return String(value || "").replace(/^0x/i, "").toLowerCase();
+}
+
+function word(value) {
+  return hex(value).padStart(64, "0");
+}
+
+function wordAddress(address) {
+  return word(hex(address));
+}
+
+function wordUint(value) {
+  return BigInt(value).toString(16).padStart(64, "0");
+}
+
+function uuidBytes32(value) {
+  return hex(String(value).replace(/-/g, "")).padStart(64, "0");
+}
+
+function encodeApprove(spender, amount) {
+  return `0x095ea7b3${wordAddress(spender)}${wordUint(amount)}`;
+}
+
+function encodeCreateEscrow(id, token, amount, hash) {
+  return `0x64a20554${uuidBytes32(id)}${wordAddress(token)}${wordUint(amount)}${word(hash)}`;
+}
+
 function bounty(overrides = {}) {
   return {
     id: bountyId,
-    amount: { amount: 1_000_000, currency: "usdc" },
+    title: "Wallet funding test bounty",
+    amount: { amount: amountMinor, currency: "usdc" },
     funding_mode: "BaseUsdcEscrow",
     funding_targets: [],
     status: "Unfunded",
@@ -41,8 +73,8 @@ function bounty(overrides = {}) {
   };
 }
 
-function validPlan(overrides = {}) {
-  const plan = {
+function validPlan() {
+  return {
     network: {
       name: "Base",
       chain_id: config.chainId,
@@ -53,7 +85,7 @@ function validPlan(overrides = {}) {
       bounty_id: bountyId,
       payer,
       token: config.nativeUsdc,
-      amount: { amount: 1_000_000, currency: "usdc" },
+      amount: { amount: amountMinor, currency: "usdc" },
       terms_hash: termsHash,
     },
     funding: {
@@ -61,33 +93,32 @@ function validPlan(overrides = {}) {
         from: payer,
         to: config.nativeUsdc,
         value_wei: 0,
-        data: "0xapprove",
+        data: encodeApprove(config.escrowContract, amountMinor),
         function: "approve(address,uint256)",
       },
       create_escrow: {
         from: payer,
         to: config.escrowContract,
         value_wei: 0,
-        data: "0xcreate",
+        data: encodeCreateEscrow(bountyId, config.nativeUsdc, amountMinor, termsHash),
         function: "createEscrow(bytes32,address,uint256,bytes32)",
       },
     },
   };
-  return Object.assign(plan, overrides);
 }
 
 function statusReport({ reconciled = false } = {}) {
   return {
     bounty: bounty({ status: reconciled ? "Claimable" : "Unfunded" }),
     funding_summary: {
-      applied: { amount: reconciled ? 1_000_000 : 0, currency: "usdc" },
-      remaining: { amount: reconciled ? 0 : 1_000_000, currency: "usdc" },
+      applied: { amount: reconciled ? amountMinor : 0, currency: "usdc" },
+      remaining: { amount: reconciled ? 0 : amountMinor, currency: "usdc" },
       claimable: reconciled,
       partitions: [
         {
           rail: "BaseUsdc",
-          confirmed: { amount: reconciled ? 1_000_000 : 0, currency: "usdc" },
-          remaining: { amount: reconciled ? 0 : 1_000_000, currency: "usdc" },
+          confirmed: { amount: reconciled ? amountMinor : 0, currency: "usdc" },
+          remaining: { amount: reconciled ? 0 : amountMinor, currency: "usdc" },
           escrow_count: reconciled ? 1 : 0,
           claimable: reconciled,
         },
@@ -105,13 +136,17 @@ function mockProvider(handlers) {
       calls.push(request);
       const handler = handlers[request.method];
       if (Array.isArray(handler)) {
+        assert(handler.length > 0, `unexpected provider call ${request.method}`);
         const next = handler.shift();
         return typeof next === "function" ? next(request.params) : next;
       }
       if (typeof handler === "function") {
         return handler(request.params);
       }
-      return handler;
+      if (handler !== undefined) {
+        return handler;
+      }
+      throw new Error(`unexpected provider call ${request.method}`);
     },
   };
 }
@@ -120,14 +155,12 @@ function mockFetch(responses) {
   const calls = [];
   const fetchImpl = async (url, options) => {
     calls.push({ url, options });
+    assert(responses.length > 0, `unexpected fetch ${url}`);
     const response = responses.shift();
-    if (!response) {
-      throw new Error(`unexpected fetch ${url}`);
-    }
     if (response.ok === false) {
       return { ok: false, status: response.status || 500, json: async () => response.body || {} };
     }
-    return { ok: true, status: 200, json: async () => response };
+    return { ok: true, status: 200, json: async () => clone(response) };
   };
   fetchImpl.calls = calls;
   return fetchImpl;
@@ -144,7 +177,53 @@ async function assertRejects(promise, pattern) {
   assert(rejected, "expected promise to reject");
 }
 
+function sendCount(provider) {
+  return provider.calls.filter((call) => call.method === "eth_sendTransaction").length;
+}
+
+async function reviewValidPlan(provider = mockProvider({
+  eth_chainId: "0x2105",
+  eth_accounts: () => [payer],
+})) {
+  return wallet.prepareBaseWalletFundingPlan({
+    apiBaseUrl: "https://api.example.com",
+    bountyId,
+    connectedAddress: payer,
+    fetchImpl: mockFetch([statusReport(), validPlan()]),
+    provider,
+  });
+}
+
+async function assertBadPlanDoesNotSend(label, mutatePlan, pattern) {
+  const plan = validPlan();
+  mutatePlan(plan);
+  const provider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_accounts: () => [payer],
+    eth_sendTransaction: () => {
+      throw new Error(`unexpected send for ${label}`);
+    },
+  });
+  await assertRejects(
+    wallet.prepareBaseWalletFundingPlan({
+      apiBaseUrl: "https://api.example.com",
+      bountyId,
+      connectedAddress: payer,
+      fetchImpl: mockFetch([statusReport(), plan]),
+      provider,
+    }),
+    pattern,
+  );
+  assert.strictEqual(sendCount(provider), 0, `${label} sent a transaction`);
+}
+
 (async () => {
+  assert(wallet, "wallet helper export missing");
+  assert.strictEqual(
+    wallet.decodeBaseWalletPlanCalldata(validPlan()).approve.spender,
+    config.escrowContract.toLowerCase(),
+  );
+
   await assertRejects(wallet.connectBaseWallet(null), /No injected EVM wallet/);
 
   await assertRejects(
@@ -167,74 +246,259 @@ async function assertRejects(promise, pattern) {
     /User rejected account request/,
   );
 
-  const mismatch = validPlan();
-  mismatch.network.chain_id = 1;
-  mismatch.create.token = "0x9999999999999999999999999999999999999999";
-  mismatch.funding.approve.to = mismatch.create.token;
-  mismatch.create.payer = "0x1111111111111111111111111111111111111111";
-  const issues = wallet.baseWalletPlanValidationIssues(mismatch, {
-    bountyId,
-    connectedAddress: payer,
-    hostedBounty: bounty(),
-  });
-  assert(issues.some((issue) => issue.includes("Base mainnet chain 8453")));
-  assert(issues.some((issue) => issue.includes("connected wallet")));
-  assert(issues.some((issue) => issue.includes("native USDC")));
+  const review = await reviewValidPlan();
+  assert.strictEqual(review.heading, "ready for human wallet review");
+  assert(review.lines.includes("Approval spender decoded from calldata"));
+  assert(review.lines.includes("Create escrow calldata"));
 
-  const pendingProvider = mockProvider({
-    eth_chainId: "0x2105",
-    eth_sendTransaction: ["0xapprove", "0xescrow"],
-    eth_getTransactionReceipt: { status: "0x1" },
-  });
-  const pendingResult = await wallet.fundBaseWalletBounty({
-    apiBaseUrl: "https://api.example.com",
-    bountyId,
-    connectedAddress: payer,
-    fetchImpl: mockFetch([statusReport(), validPlan(), statusReport()]),
-    provider: pendingProvider,
-  });
-  assert.strictEqual(pendingResult.heading, "waiting for confirmations");
-  assert.strictEqual(
-    pendingProvider.calls.filter((call) => call.method === "eth_sendTransaction").length,
-    2,
+  await assertBadPlanDoesNotSend(
+    "approval spender word mismatch",
+    (plan) => {
+      plan.funding.approve.data = encodeApprove(otherAddress, amountMinor);
+    },
+    /approval calldata spender/,
   );
-  assert(pendingResult.lines.includes("Wallet transactions or transaction hashes are not funding evidence"));
+  await assertBadPlanDoesNotSend(
+    "approval amount word mismatch",
+    (plan) => {
+      plan.funding.approve.data = encodeApprove(config.escrowContract, amountMinor + 1);
+    },
+    /calldata amount/,
+  );
+  await assertBadPlanDoesNotSend(
+    "createEscrow bounty id word mismatch",
+    (plan) => {
+      plan.funding.create_escrow.data = encodeCreateEscrow(
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        config.nativeUsdc,
+        amountMinor,
+        termsHash,
+      );
+    },
+    /calldata bounty id/,
+  );
+  await assertBadPlanDoesNotSend(
+    "createEscrow token word mismatch",
+    (plan) => {
+      plan.funding.create_escrow.data = encodeCreateEscrow(bountyId, otherAddress, amountMinor, termsHash);
+    },
+    /calldata token/,
+  );
+  await assertBadPlanDoesNotSend(
+    "createEscrow amount word mismatch",
+    (plan) => {
+      plan.funding.create_escrow.data = encodeCreateEscrow(bountyId, config.nativeUsdc, amountMinor + 1, termsHash);
+    },
+    /calldata amount/,
+  );
+  await assertBadPlanDoesNotSend(
+    "createEscrow terms hash word mismatch",
+    (plan) => {
+      plan.funding.create_escrow.data = encodeCreateEscrow(
+        bountyId,
+        config.nativeUsdc,
+        amountMinor,
+        `0x${"2".repeat(64)}`,
+      );
+    },
+    /calldata terms hash/,
+  );
+  await assertBadPlanDoesNotSend(
+    "escrow target mismatch",
+    (plan) => {
+      plan.funding.create_escrow.to = otherAddress;
+    },
+    /escrow target/,
+  );
+  await assertBadPlanDoesNotSend(
+    "nonzero ETH value",
+    (plan) => {
+      plan.funding.approve.value_wei = 1;
+    },
+    /zero ETH value/,
+  );
+  await assertBadPlanDoesNotSend(
+    "missing terms hash",
+    (plan) => {
+      plan.create.terms_hash = "";
+    },
+    /terms hash/,
+  );
 
-  const revertedResult = await wallet.fundBaseWalletBounty({
-    apiBaseUrl: "https://api.example.com",
-    bountyId,
-    connectedAddress: payer,
-    fetchImpl: mockFetch([statusReport(), validPlan()]),
+  const approvalProvider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_accounts: () => [payer],
+    eth_sendTransaction: ["0xapprovehash"],
+    eth_getTransactionReceipt: [{ status: "0x1" }],
+  });
+  const approval = await wallet.sendBaseWalletApproval({
+    provider: approvalProvider,
+    review,
+    receiptDelayMs: 0,
+  });
+  assert.strictEqual(approval.heading, "approval confirmed");
+  assert.strictEqual(sendCount(approvalProvider), 1);
+
+  const changedChainProvider = mockProvider({
+    eth_chainId: "0x1",
+    eth_accounts: () => [payer],
+  });
+  await assertRejects(
+    wallet.sendBaseWalletApproval({ provider: changedChainProvider, review, receiptDelayMs: 0 }),
+    /Base mainnet/,
+  );
+  assert.strictEqual(sendCount(changedChainProvider), 0);
+
+  const changedAccountProvider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_accounts: () => [otherAddress],
+  });
+  await assertRejects(
+    wallet.sendBaseWalletApproval({ provider: changedAccountProvider, review, receiptDelayMs: 0 }),
+    /account changed/,
+  );
+  assert.strictEqual(sendCount(changedAccountProvider), 0);
+
+  const approvalRejectProvider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_accounts: () => [payer],
+    eth_sendTransaction: () => {
+      throw new Error("User rejected approval");
+    },
+  });
+  await assertRejects(
+    wallet.sendBaseWalletApproval({ provider: approvalRejectProvider, review, receiptDelayMs: 0 }),
+    /User rejected approval/,
+  );
+  assert.strictEqual(sendCount(approvalRejectProvider), 1);
+
+  const approvalRevertProvider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_accounts: () => [payer],
+    eth_sendTransaction: ["0xapprovehash"],
+    eth_getTransactionReceipt: [{ status: "0x0" }],
+  });
+  await assertRejects(
+    wallet.sendBaseWalletApproval({ provider: approvalRevertProvider, review, receiptDelayMs: 0 }),
+    /reverted/,
+  );
+  assert.strictEqual(sendCount(approvalRevertProvider), 1);
+
+  const betweenSendProvider = mockProvider({
+    eth_chainId: ["0x2105", "0x1"],
+    eth_accounts: [[payer], [payer]],
+    eth_sendTransaction: ["0xapprovehash"],
+    eth_getTransactionReceipt: [{ status: "0x1" }],
+  });
+  await wallet.sendBaseWalletApproval({ provider: betweenSendProvider, review, receiptDelayMs: 0 });
+  await assertRejects(
+    wallet.sendBaseWalletEscrow({
+      fetchImpl: mockFetch([]),
+      provider: betweenSendProvider,
+      review,
+      pollDelayMs: 0,
+    }),
+    /Base mainnet/,
+  );
+  assert.strictEqual(sendCount(betweenSendProvider), 1);
+
+  const escrowRejectProvider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_accounts: () => [payer],
+    eth_sendTransaction: () => {
+      throw new Error("User rejected escrow");
+    },
+  });
+  await assertRejects(
+    wallet.sendBaseWalletEscrow({
+      fetchImpl: mockFetch([]),
+      provider: escrowRejectProvider,
+      review,
+      pollDelayMs: 0,
+    }),
+    /User rejected escrow/,
+  );
+  assert.strictEqual(sendCount(escrowRejectProvider), 1);
+
+  const escrowRevert = await wallet.sendBaseWalletEscrow({
+    fetchImpl: mockFetch([]),
     provider: mockProvider({
       eth_chainId: "0x2105",
-      eth_sendTransaction: ["0xapprove", "0xescrow"],
+      eth_accounts: () => [payer],
+      eth_sendTransaction: ["0xescrowhash"],
       eth_getTransactionReceipt: { status: "0x0" },
     }),
+    review,
+    pollDelayMs: 0,
   });
-  assert.strictEqual(revertedResult.heading, "needs operator review");
-  assert(revertedResult.lines.includes("reverted"));
+  assert.strictEqual(escrowRevert.heading, "needs operator review");
+  assert(escrowRevert.lines.includes("reverted"));
 
-  const reconciledResult = await wallet.fundBaseWalletBounty({
-    apiBaseUrl: "https://api.example.com",
-    bountyId,
-    connectedAddress: payer,
-    fetchImpl: mockFetch([statusReport(), validPlan(), statusReport({ reconciled: true })]),
+  const pendingFetch = mockFetch([statusReport(), statusReport()]);
+  const pending = await wallet.sendBaseWalletEscrow({
+    fetchImpl: pendingFetch,
+    pollAttempts: 2,
+    pollDelayMs: 0,
     provider: mockProvider({
       eth_chainId: "0x2105",
-      eth_sendTransaction: ["0xapprove", "0xescrow"],
+      eth_accounts: () => [payer],
+      eth_sendTransaction: ["0xescrowhash"],
       eth_getTransactionReceipt: { status: "0x1" },
     }),
+    review,
+    shareUrl: "https://example.com/share",
   });
-  assert.strictEqual(reconciledResult.heading, "funding reconciled");
-  assert(reconciledResult.lines.includes("State: funding reconciled"));
-  assert(reconciledResult.lines.includes("indexed EscrowCreated evidence"));
+  assert.strictEqual(pending.heading, "waiting for confirmations");
+  assert.strictEqual(pendingFetch.calls.length, 2);
+  assert(!pending.lines.includes("Share link"));
+
+  const reconciledFetch = mockFetch([statusReport(), statusReport(), statusReport({ reconciled: true })]);
+  const reconciled = await wallet.sendBaseWalletEscrow({
+    fetchImpl: reconciledFetch,
+    pollAttempts: 3,
+    pollDelayMs: 0,
+    provider: mockProvider({
+      eth_chainId: "0x2105",
+      eth_accounts: () => [payer],
+      eth_sendTransaction: ["0xescrowhash"],
+      eth_getTransactionReceipt: { status: "0x1" },
+    }),
+    review,
+    shareUrl: "https://example.com/share",
+  });
+  assert.strictEqual(reconciled.heading, "funding reconciled");
+  assert.strictEqual(reconciledFetch.calls.length, 3);
+  assert(reconciled.lines.includes("Share link: https://example.com/share"));
+  assert(reconciled.lines.includes("Default CTA: Post your own bounty."));
 
   const genericClaimableWithoutBaseEscrow = wallet.baseWalletStatusLines({
     bounty: bounty({ status: "Claimable" }),
-    funding_summary: { claimable: true, applied: { amount: 1, currency: "usd" }, remaining: { amount: 0, currency: "usd" } },
+    funding_summary: {
+      claimable: true,
+      applied: { amount: 1, currency: "usd" },
+      remaining: { amount: 0, currency: "usd" },
+    },
     escrows: [],
-  });
+  }, { shareUrl: "https://example.com/share" });
   assert(genericClaimableWithoutBaseEscrow.includes("State: waiting for confirmations"));
+  assert(!genericClaimableWithoutBaseEscrow.includes("Share link"));
+
+  const busyState = { busy: false };
+  let releaseBusy;
+  const firstAction = wallet.runExclusiveWalletAction(
+    busyState,
+    () => new Promise((resolve) => {
+      releaseBusy = resolve;
+    }),
+  );
+  await Promise.resolve();
+  await assertRejects(
+    wallet.runExclusiveWalletAction(busyState, async () => "second"),
+    /already in progress/,
+  );
+  releaseBusy("first");
+  assert.strictEqual(await firstAction, "first");
+  assert.strictEqual(busyState.busy, false);
 
   console.log("base wallet flow tests passed");
 })();

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -254,6 +254,31 @@
     "supported_rail": "BaseUsdc",
     "settlement_authority": "transaction plans are not funding; Base funding requires indexed EscrowCreated log reconciliation"
   },
+  "wallet_native_base_funding": {
+    "page": "https://nspg13.github.io/agent-bounties/funding.html",
+    "action": "connect_wallet_then_fund",
+    "provider_standard": "EIP-1193",
+    "network": "base-mainnet",
+    "chain_id": 8453,
+    "chain_id_hex": "0x2105",
+    "escrow_contract": "0x150C6dFbCe7803cc7f634f59b0624e87349CEAce",
+    "native_usdc": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "required_plan_checks": [
+      "connected payer",
+      "Base mainnet chain id",
+      "verified escrow contract",
+      "native USDC token",
+      "bounty id",
+      "amount",
+      "terms hash"
+    ],
+    "wallet_confirmations": [
+      "USDC approve",
+      "createEscrow"
+    ],
+    "query_param_policy": "apiBaseUrl and bountyId may prefill the page; contract and token query parameters are ignored for wallet funding.",
+    "settlement_authority": "wallet prompts and transaction hashes are not funding; only hosted status with indexed EscrowCreated evidence can show Base wallet funding reconciled"
+  },
   "base_mainnet_escrow": {
     "network": "base-mainnet",
     "chain_id": 8453,

--- a/site/funding.html
+++ b/site/funding.html
@@ -119,6 +119,31 @@
       <section class="band muted compact">
         <div class="section-grid">
           <div>
+            <h2>Fund with Base wallet</h2>
+            <p class="fine">Use an injected EIP-1193 wallet on Base mainnet for native USDC escrow funding. This page uses the verified Base mainnet escrow and native USDC addresses from the deployment manifest, requests two wallet confirmations, and shows funding as reconciled only after hosted status reports indexed <code>EscrowCreated</code> evidence.</p>
+          </div>
+          <form id="base-wallet-form" class="funding-form">
+            <label>
+              Hosted API base URL
+              <input name="walletApiBaseUrl" type="url" placeholder="https://api.example.com" required>
+            </label>
+            <label>
+              Bounty ID
+              <input name="walletBountyId" placeholder="00000000-0000-0000-0000-000000000001" required>
+            </label>
+            <p class="fine form-note">Base mainnet only: chain <code>8453</code>, escrow <code>0x150C6dFbCe7803cc7f634f59b0624e87349CEAce</code>, native USDC <code>0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913</code>. Contract and token query parameters are ignored for wallet funding.</p>
+            <div class="actions">
+              <button id="base-wallet-connect" class="button secondary" type="button">Connect wallet</button>
+              <button class="button primary" type="submit">Fund with Base wallet</button>
+            </div>
+            <output id="base-wallet-output" class="output readiness-output" aria-live="polite">Connect a Base mainnet wallet before planning or signing. No private key, seed phrase, or raw wallet history is requested.</output>
+          </form>
+        </div>
+      </section>
+
+      <section class="band muted compact">
+        <div class="section-grid">
+          <div>
             <h2>Plan Base USDC escrow</h2>
             <p class="fine">This creates unsigned transaction intents only. Review the `approve` and `createEscrow` calldata in your wallet or operator workstation, then reconcile the indexed <code>EscrowCreated</code> log after broadcast. Transaction planning does not fund a bounty.</p>
           </div>

--- a/site/funding.html
+++ b/site/funding.html
@@ -120,7 +120,7 @@
         <div class="section-grid">
           <div>
             <h2>Fund with Base wallet</h2>
-            <p class="fine">Use an injected EIP-1193 wallet on Base mainnet for native USDC escrow funding. This page uses the verified Base mainnet escrow and native USDC addresses from the deployment manifest, requests two wallet confirmations, and shows funding as reconciled only after hosted status reports indexed <code>EscrowCreated</code> evidence.</p>
+            <p class="fine">Use an injected EIP-1193 wallet on Base mainnet for native USDC escrow funding. This page uses the verified Base mainnet escrow and native USDC addresses from the deployment manifest, shows a decoded transaction review before the two wallet confirmations, requires a successful approval receipt before escrow signing, and shows funding as reconciled only after hosted status reports indexed <code>EscrowCreated</code> evidence.</p>
           </div>
           <form id="base-wallet-form" class="funding-form">
             <label>
@@ -134,7 +134,10 @@
             <p class="fine form-note">Base mainnet only: chain <code>8453</code>, escrow <code>0x150C6dFbCe7803cc7f634f59b0624e87349CEAce</code>, native USDC <code>0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913</code>. Contract and token query parameters are ignored for wallet funding.</p>
             <div class="actions">
               <button id="base-wallet-connect" class="button secondary" type="button">Connect wallet</button>
-              <button class="button primary" type="submit">Fund with Base wallet</button>
+              <button class="button primary" type="submit">Review Base funding plan</button>
+              <button id="base-wallet-approve" class="button secondary" type="button" disabled>Sign USDC approval</button>
+              <button id="base-wallet-escrow" class="button secondary" type="button" disabled>Sign escrow</button>
+              <button id="base-wallet-refresh" class="button secondary" type="button" disabled>Refresh status</button>
             </div>
             <output id="base-wallet-output" class="output readiness-output" aria-live="polite">Connect a Base mainnet wallet before planning or signing. No private key, seed phrase, or raw wallet history is requested.</output>
           </form>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -32,6 +32,12 @@ Start here:
   matched Stripe funding intent.
 - Base USDC funding plan handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&network=base-sepolia&escrowContract={escrow}&payer={payer}&token={usdc}&rail=BaseUsdc&source={source}
+- Wallet-native Base mainnet funding:
+  https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&rail=BaseUsdc&source={source}
+  Use the Connect wallet action with an EIP-1193 wallet. The page requires
+  Base mainnet chain 8453, verified native USDC and escrow deployment
+  constants, two separate wallet confirmations for approve and createEscrow,
+  and read-only hosted status polling before it can show funding reconciled.
 - Hosted API health preflight: enter an API base URL on the funding page and run
   the read-only check_health action for /health. The expected body is ok.
 - Hosted readiness preflight: after health passes, run the read-only
@@ -180,6 +186,10 @@ Payment invariants:
   state.
 - Stripe funding is credited only after a verified checkout.session.completed webhook.
 - Base USDC funding and payouts require indexed escrow logs.
+- Wallet-native Base funding uses an injected EIP-1193 wallet and ignores
+  contract/token query parameters. Before eth_sendTransaction, the hosted plan
+  must match Base mainnet chain 8453, the connected payer, verified native USDC,
+  the verified escrow contract, bounty id, amount, and terms hash.
 - Verified Base mainnet pilot escrow:
   `0x150C6dFbCe7803cc7f634f59b0624e87349CEAce` on chain `8453`, deployed at
   block `48422806`, using native USDC
@@ -189,6 +199,8 @@ Payment invariants:
   1 USDC; a deployment or transaction hash is not settlement evidence.
 - Base funding plans are unsigned transaction intents only; they do not sign,
   broadcast, fund, or settle anything.
+- Base wallet transaction hashes remain pending evidence until the hosted status
+  shows matching indexed EscrowCreated reconciliation.
 - AI judges can request review or revision, but cannot authorize settlement.
 
 Distribution feedback request:

--- a/site/main.js
+++ b/site/main.js
@@ -150,8 +150,23 @@
   const readinessOutput = document.getElementById("readiness-output");
   const baseForm = document.getElementById("base-plan-form");
   const baseOutput = document.getElementById("base-plan-output");
+  const baseWalletForm = document.getElementById("base-wallet-form");
+  const baseWalletConnect = document.getElementById("base-wallet-connect");
+  const baseWalletOutput = document.getElementById("base-wallet-output");
   const checkoutStatusOutput = document.getElementById("checkout-status-output");
   const checkoutStatusRefresh = document.getElementById("checkout-status-refresh");
+
+  const baseMainnetWalletConfig = {
+    network: "base-mainnet",
+    chainId: 8453,
+    chainIdHex: "0x2105",
+    escrowContract: "0x150C6dFbCe7803cc7f634f59b0624e87349CEAce",
+    nativeUsdc: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  };
+
+  function normalizedText(value) {
+    return String(value || "").trim();
+  }
 
   function firstCheckoutStatusParam(searchParams, names) {
     for (const name of names) {
@@ -187,6 +202,299 @@
     }
     const fractional = String(absolute % base).padStart(exponent, "0");
     return `${sign}${whole}.${fractional} ${currency.toUpperCase()}`;
+  }
+
+  function normalizeAddress(value) {
+    const normalized = normalizedText(value).toLowerCase();
+    return /^0x[0-9a-f]{40}$/.test(normalized) ? normalized : "";
+  }
+
+  function sameAddress(left, right) {
+    const leftAddress = normalizeAddress(left);
+    return leftAddress !== "" && leftAddress === normalizeAddress(right);
+  }
+
+  function normalizeChainId(value) {
+    if (typeof value === "number") {
+      return value;
+    }
+    const text = normalizedText(value).toLowerCase();
+    if (text.startsWith("0x")) {
+      return Number.parseInt(text, 16);
+    }
+    return Number.parseInt(text, 10);
+  }
+
+  function sameMoney(left, right) {
+    return left
+      && right
+      && left.amount === right.amount
+      && normalizedText(left.currency).toLowerCase() === normalizedText(right.currency).toLowerCase();
+  }
+
+  function baseFundingTargetAmount(bounty) {
+    const targets = Array.isArray(bounty && bounty.funding_targets)
+      ? bounty.funding_targets
+      : [];
+    const baseTarget = targets.find((target) => target && target.rail === "BaseUsdc");
+    return baseTarget && baseTarget.amount ? baseTarget.amount : bounty && bounty.amount;
+  }
+
+  function quantityHex(value) {
+    if (typeof value === "string" && value.startsWith("0x")) {
+      return value;
+    }
+    const numeric = typeof value === "bigint" ? value : BigInt(value || 0);
+    return `0x${numeric.toString(16)}`;
+  }
+
+  function evmTransactionRequest(intent, fallbackFrom) {
+    return {
+      from: intent.from || fallbackFrom,
+      to: intent.to,
+      value: quantityHex(intent.value_wei || 0),
+      data: intent.data,
+    };
+  }
+
+  function baseWalletPlanValidationIssues(plan, context) {
+    const issues = [];
+    const connectedAddress = context && context.connectedAddress;
+    const expectedBountyId = context && context.bountyId;
+    const hostedBounty = context && context.hostedBounty;
+    const bounty = plan && plan.bounty ? plan.bounty : {};
+    const create = plan && plan.create ? plan.create : {};
+    const funding = plan && plan.funding ? plan.funding : {};
+    const network = plan && plan.network ? plan.network : funding.network || {};
+    const approve = funding.approve || {};
+    const createEscrow = funding.create_escrow || {};
+    const configured = baseMainnetWalletConfig;
+
+    if (normalizeChainId(network.chain_id) !== configured.chainId) {
+      issues.push("funding plan is not for Base mainnet chain 8453");
+    }
+    if (expectedBountyId && bounty.id !== expectedBountyId) {
+      issues.push("funding plan bounty id does not match the displayed bounty");
+    }
+    if (expectedBountyId && create.bounty_id !== expectedBountyId) {
+      issues.push("funding plan createEscrow bounty id does not match the displayed bounty");
+    }
+    if (!sameAddress(connectedAddress, create.payer)) {
+      issues.push("funding plan payer does not match the connected wallet");
+    }
+    if (!sameAddress(connectedAddress, approve.from) || !sameAddress(connectedAddress, createEscrow.from)) {
+      issues.push("transaction sender does not match the connected wallet");
+    }
+    if (!sameAddress(create.token, configured.nativeUsdc) || !sameAddress(approve.to, configured.nativeUsdc)) {
+      issues.push("funding plan token is not native USDC on Base mainnet");
+    }
+    if (!sameAddress(createEscrow.to, configured.escrowContract)) {
+      issues.push("funding plan escrow target does not match the verified Base mainnet deployment");
+    }
+    if (!normalizedText(approve.data) || !normalizedText(createEscrow.data)) {
+      issues.push("funding plan is missing approval or escrow calldata");
+    }
+    if (approve.function !== "approve(address,uint256)") {
+      issues.push("approval transaction is not USDC approve(address,uint256)");
+    }
+    if (createEscrow.function !== "createEscrow(bytes32,address,uint256,bytes32)") {
+      issues.push("escrow transaction is not createEscrow(bytes32,address,uint256,bytes32)");
+    }
+    if (bounty.terms_hash && create.terms_hash && bounty.terms_hash !== create.terms_hash) {
+      issues.push("funding plan terms hash does not match the bounty terms hash");
+    }
+    if (hostedBounty) {
+      if (hostedBounty.id && hostedBounty.id !== bounty.id) {
+        issues.push("funding plan bounty id does not match hosted status readback");
+      }
+      if (hostedBounty.terms_hash && create.terms_hash && hostedBounty.terms_hash !== create.terms_hash) {
+        issues.push("funding plan terms hash does not match hosted status readback");
+      }
+      if (!sameMoney(baseFundingTargetAmount(hostedBounty), create.amount)) {
+        issues.push("funding plan amount does not match hosted Base funding target");
+      }
+    }
+    if (!sameMoney(baseFundingTargetAmount(bounty), create.amount)) {
+      issues.push("funding plan amount does not match the bounty Base funding target");
+    }
+
+    return issues;
+  }
+
+  function validateBaseWalletPlan(plan, context) {
+    const issues = baseWalletPlanValidationIssues(plan, context);
+    if (issues.length > 0) {
+      throw new Error(`Base wallet funding plan rejected: ${issues.join("; ")}`);
+    }
+    return plan;
+  }
+
+  function baseWalletFundingStatusModel(report) {
+    const summary = report && report.funding_summary ? report.funding_summary : {};
+    const partitions = Array.isArray(summary.partitions) ? summary.partitions : [];
+    const basePartition = partitions.find((partition) => partition && partition.rail === "BaseUsdc");
+    const escrows = Array.isArray(report && report.escrows) ? report.escrows : [];
+    const escrowCount = basePartition && typeof basePartition.escrow_count === "number"
+      ? basePartition.escrow_count
+      : escrows.length;
+    const baseClaimable = basePartition ? basePartition.claimable === true : summary.claimable === true && escrowCount > 0;
+    const reconciled = baseClaimable && escrowCount > 0;
+    return {
+      basePartition,
+      bounty: report && report.bounty ? report.bounty : {},
+      escrowCount,
+      heading: reconciled ? "funding reconciled" : "waiting for confirmations",
+      reconciled,
+      summary,
+    };
+  }
+
+  function baseWalletStatusLines(report) {
+    const state = baseWalletFundingStatusModel(report);
+    const applied = state.basePartition && state.basePartition.confirmed
+      ? state.basePartition.confirmed
+      : state.summary.applied;
+    const remaining = state.basePartition && state.basePartition.remaining
+      ? state.basePartition.remaining
+      : state.summary.remaining;
+    const lines = [
+      `State: ${state.heading}`,
+      `Bounty status: ${state.bounty.status || "unknown"}`,
+      `Base applied funding: ${displayMoney(applied)}`,
+      `Base remaining funding: ${displayMoney(remaining)}`,
+      `Indexed Base escrows: ${state.escrowCount}`,
+      `Bounty claimable from Base evidence: ${state.reconciled ? "yes" : "no"}`,
+    ];
+    if (state.reconciled) {
+      lines.push("Base funding is reconciled only because hosted status reports matching indexed EscrowCreated evidence.");
+      lines.push("Default CTA: Post your own bounty.");
+    } else {
+      lines.push("Wallet transactions or transaction hashes are not funding evidence. Keep polling hosted status until indexed EscrowCreated evidence is reconciled.");
+    }
+    return lines.join("\n");
+  }
+
+  async function providerRequest(provider, method, params) {
+    if (!provider || typeof provider.request !== "function") {
+      throw new Error("No injected EVM wallet provider found.");
+    }
+    return provider.request({ method, params: params || [] });
+  }
+
+  async function connectBaseWallet(provider) {
+    const accounts = await providerRequest(provider, "eth_requestAccounts");
+    const address = Array.isArray(accounts) && accounts.length > 0 ? normalizeAddress(accounts[0]) : "";
+    if (!address) {
+      throw new Error("Wallet did not return a usable account address.");
+    }
+    let chainId = normalizedText(await providerRequest(provider, "eth_chainId")).toLowerCase();
+    if (chainId !== baseMainnetWalletConfig.chainIdHex) {
+      await providerRequest(provider, "wallet_switchEthereumChain", [{ chainId: baseMainnetWalletConfig.chainIdHex }]);
+      chainId = normalizedText(await providerRequest(provider, "eth_chainId")).toLowerCase();
+    }
+    if (chainId !== baseMainnetWalletConfig.chainIdHex) {
+      throw new Error("Wallet is not connected to Base mainnet.");
+    }
+    return { address, chainId };
+  }
+
+  async function readHostedBountyStatus(fetchImpl, apiBaseUrl, bountyId) {
+    const response = await fetchImpl(`${apiBaseUrl}/v1/bounties/${bountyId}`, {
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) {
+      throw new Error(`Hosted bounty status failed with ${response.status}`);
+    }
+    return response.json();
+  }
+
+  async function requestBaseFundingPlan(fetchImpl, apiBaseUrl, request) {
+    const response = await fetchImpl(`${apiBaseUrl}/v1/base/funding-plan`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      throw new Error(`Base funding plan failed with ${response.status}`);
+    }
+    return response.json();
+  }
+
+  async function fundBaseWalletBounty(options) {
+    const fetchImpl = options.fetchImpl || window.fetch.bind(window);
+    const provider = options.provider;
+    const apiBaseUrl = normalizedText(options.apiBaseUrl).replace(/\/+$/, "");
+    const bountyId = normalizedText(options.bountyId);
+    const connectedAddress = normalizeAddress(options.connectedAddress);
+    const onState = typeof options.onState === "function" ? options.onState : () => {};
+
+    if (!apiBaseUrl || !bountyId || !connectedAddress) {
+      throw new Error("Hosted API URL, bounty id, and connected wallet are required.");
+    }
+
+    const chainId = normalizedText(await providerRequest(provider, "eth_chainId")).toLowerCase();
+    if (chainId !== baseMainnetWalletConfig.chainIdHex) {
+      throw new Error("Wallet must stay on Base mainnet before funding.");
+    }
+
+    onState("Reading hosted bounty status...");
+    const statusBefore = await readHostedBountyStatus(fetchImpl, apiBaseUrl, bountyId);
+    onState("Requesting Base mainnet funding plan...");
+    const plan = await requestBaseFundingPlan(fetchImpl, apiBaseUrl, {
+      bounty_id: bountyId,
+      escrow_contract: baseMainnetWalletConfig.escrowContract,
+      payer: connectedAddress,
+      token: baseMainnetWalletConfig.nativeUsdc,
+      network: baseMainnetWalletConfig.network,
+    });
+    validateBaseWalletPlan(plan, {
+      bountyId,
+      connectedAddress,
+      hostedBounty: statusBefore.bounty,
+    });
+
+    onState("Request wallet confirmation 1 of 2: USDC approval.");
+    const approveHash = await providerRequest(provider, "eth_sendTransaction", [
+      evmTransactionRequest(plan.funding.approve, connectedAddress),
+    ]);
+    onState("Approval submitted. Request wallet confirmation 2 of 2: create escrow.");
+    const escrowHash = await providerRequest(provider, "eth_sendTransaction", [
+      evmTransactionRequest(plan.funding.create_escrow, connectedAddress),
+    ]);
+
+    let receipt = null;
+    try {
+      receipt = await providerRequest(provider, "eth_getTransactionReceipt", [escrowHash]);
+    } catch (_error) {
+      receipt = null;
+    }
+    if (receipt && receipt.status === "0x0") {
+      return {
+        approveHash,
+        escrowHash,
+        heading: "needs operator review",
+        lines: [
+          "State: needs operator review",
+          `Approval transaction: ${approveHash}`,
+          `Escrow transaction: ${escrowHash}`,
+          "The wallet/provider reports the escrow transaction reverted. No retry was attempted.",
+        ].join("\n"),
+      };
+    }
+
+    onState("Escrow submitted. Reading hosted status for indexed EscrowCreated evidence...");
+    const statusAfter = await readHostedBountyStatus(fetchImpl, apiBaseUrl, bountyId);
+    return {
+      approveHash,
+      escrowHash,
+      heading: baseWalletFundingStatusModel(statusAfter).heading,
+      lines: [
+        `Approval transaction: ${approveHash}`,
+        `Escrow transaction: ${escrowHash}`,
+        "",
+        baseWalletStatusLines(statusAfter),
+      ].join("\n"),
+    };
   }
 
   function stripeFundingIntents(report) {
@@ -328,6 +636,18 @@
     refreshCheckoutStatus();
   }
 
+  window.AgentBountiesBaseWallet = {
+    baseMainnetWalletConfig,
+    baseWalletFundingStatusModel,
+    baseWalletPlanValidationIssues,
+    baseWalletStatusLines,
+    connectBaseWallet,
+    evmTransactionRequest,
+    fundBaseWalletBounty,
+    normalizeAddress,
+    validateBaseWalletPlan,
+  };
+
   if (!form || !output) return;
 
   function randomUuid() {
@@ -431,6 +751,10 @@
     setNamedInputValue(baseForm, "baseEscrowContract", prefillValues.escrowContract);
     setNamedInputValue(baseForm, "basePayer", prefillValues.payer);
     setNamedInputValue(baseForm, "baseToken", prefillValues.token);
+  }
+  if (baseWalletForm) {
+    setNamedInputValue(baseWalletForm, "walletApiBaseUrl", prefillValues.apiBaseUrl);
+    setNamedInputValue(baseWalletForm, "walletBountyId", prefillValues.bountyId);
   }
   if (prefillOutput) {
     if (prefilledFields.length > 0) {
@@ -561,6 +885,54 @@
         baseOutput.textContent = `${JSON.stringify(summary, null, 2)}\n\nSign and broadcast these transactions from the payer wallet outside this site. This plan is not funding; the bounty is funded only after an indexed EscrowCreated log is reconciled.`;
       } catch (error) {
         baseOutput.textContent = `${error.message}\n\nNo transaction was signed or broadcast. Confirm the hosted API URL, bounty id, escrow contract, payer wallet, token, network, and that the bounty is Base USDC funding-ready.`;
+      }
+    });
+  }
+
+  let baseWalletConnection = null;
+  if (baseWalletForm && baseWalletOutput) {
+    if (baseWalletConnect) {
+      baseWalletConnect.addEventListener("click", async () => {
+        baseWalletOutput.textContent = "Requesting wallet account and Base mainnet network...";
+        try {
+          baseWalletConnection = await connectBaseWallet(window.ethereum);
+          baseWalletOutput.textContent = [
+            "State: wallet connected",
+            `Connected address: ${baseWalletConnection.address}`,
+            "Network: Base mainnet (8453)",
+            "No transaction has been planned, signed, or broadcast.",
+          ].join("\n");
+        } catch (error) {
+          baseWalletConnection = null;
+          baseWalletOutput.textContent = `${error.message}\n\nNo transaction was signed. Connect a wallet that supports EIP-1193 and Base mainnet.`;
+        }
+      });
+    }
+
+    baseWalletForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const data = new FormData(baseWalletForm);
+      const apiBaseUrl = String(data.get("walletApiBaseUrl") || "").replace(/\/+$/, "");
+      const bountyId = String(data.get("walletBountyId") || "").trim();
+      if (!baseWalletConnection) {
+        baseWalletOutput.textContent = "Connect a Base mainnet wallet before funding. No transaction was signed.";
+        return;
+      }
+
+      try {
+        const result = await fundBaseWalletBounty({
+          apiBaseUrl,
+          bountyId,
+          connectedAddress: baseWalletConnection.address,
+          fetchImpl: window.fetch.bind(window),
+          provider: window.ethereum,
+          onState(message) {
+            baseWalletOutput.textContent = message;
+          },
+        });
+        baseWalletOutput.textContent = result.lines;
+      } catch (error) {
+        baseWalletOutput.textContent = `${error.message}\n\nNo retry loop was started. If a wallet prompt was rejected or a transaction reverted, inspect the wallet and hosted bounty status before trying again. Transaction hashes are not reconciled funding.`;
       }
     });
   }

--- a/site/main.js
+++ b/site/main.js
@@ -152,6 +152,9 @@
   const baseOutput = document.getElementById("base-plan-output");
   const baseWalletForm = document.getElementById("base-wallet-form");
   const baseWalletConnect = document.getElementById("base-wallet-connect");
+  const baseWalletApprove = document.getElementById("base-wallet-approve");
+  const baseWalletEscrow = document.getElementById("base-wallet-escrow");
+  const baseWalletRefresh = document.getElementById("base-wallet-refresh");
   const baseWalletOutput = document.getElementById("base-wallet-output");
   const checkoutStatusOutput = document.getElementById("checkout-status-output");
   const checkoutStatusRefresh = document.getElementById("checkout-status-refresh");
@@ -232,6 +235,70 @@
       && normalizedText(left.currency).toLowerCase() === normalizedText(right.currency).toLowerCase();
   }
 
+  function normalizedQuantityToBigInt(value) {
+    if (typeof value === "bigint") {
+      return value;
+    }
+    if (typeof value === "number") {
+      return Number.isSafeInteger(value) ? BigInt(value) : null;
+    }
+    const text = normalizedText(value).toLowerCase();
+    if (/^0x[0-9a-f]+$/.test(text)) {
+      return BigInt(text);
+    }
+    if (/^[0-9]+$/.test(text)) {
+      return BigInt(text);
+    }
+    return null;
+  }
+
+  function moneyAmountBigInt(money) {
+    return money ? normalizedQuantityToBigInt(money.amount) : null;
+  }
+
+  function sameBigInt(left, right) {
+    return typeof left === "bigint" && typeof right === "bigint" && left === right;
+  }
+
+  function isZeroQuantity(value) {
+    const numeric = normalizedQuantityToBigInt(value);
+    return numeric !== null && numeric === 0n;
+  }
+
+  function stripHexPrefix(value) {
+    return normalizedText(value).replace(/^0x/i, "").toLowerCase();
+  }
+
+  function normalizeHexData(value) {
+    const hex = stripHexPrefix(value);
+    return hex.length % 2 === 0 && /^[0-9a-f]*$/.test(hex) ? `0x${hex}` : "";
+  }
+
+  function normalizeBytes32(value) {
+    const hex = stripHexPrefix(value);
+    return /^[0-9a-f]{64}$/.test(hex) ? `0x${hex}` : "";
+  }
+
+  function uuidToBytes32(value) {
+    const uuidHex = normalizedText(value).toLowerCase().replace(/-/g, "");
+    return /^[0-9a-f]{32}$/.test(uuidHex) ? `0x${uuidHex.padStart(64, "0")}` : "";
+  }
+
+  function calldataWord(data, index) {
+    const hex = stripHexPrefix(data);
+    const start = 8 + index * 64;
+    return `0x${hex.slice(start, start + 64)}`;
+  }
+
+  function calldataWordAddress(word) {
+    const hex = stripHexPrefix(word);
+    return /^[0-9a-f]{64}$/.test(hex) ? normalizeAddress(`0x${hex.slice(24)}`) : "";
+  }
+
+  function calldataWordBigInt(word) {
+    return normalizedQuantityToBigInt(word);
+  }
+
   function baseFundingTargetAmount(bounty) {
     const targets = Array.isArray(bounty && bounty.funding_targets)
       ? bounty.funding_targets
@@ -257,6 +324,62 @@
     };
   }
 
+  function decodeApproveCalldata(data) {
+    const normalized = normalizeHexData(data);
+    const issues = [];
+    const expectedLength = 2 + 8 + 64 * 2;
+    if (!normalized) {
+      issues.push("approval calldata is not valid hex");
+      return { issues };
+    }
+    if (normalized.length !== expectedLength) {
+      issues.push("approval calldata length is not approve(address,uint256)");
+    }
+    if (!normalized.startsWith("0x095ea7b3")) {
+      issues.push("approval calldata selector is not approve(address,uint256)");
+    }
+    return {
+      amount: calldataWordBigInt(calldataWord(normalized, 1)),
+      data: normalized,
+      issues,
+      selector: normalized.slice(0, 10),
+      spender: calldataWordAddress(calldataWord(normalized, 0)),
+    };
+  }
+
+  function decodeCreateEscrowCalldata(data) {
+    const normalized = normalizeHexData(data);
+    const issues = [];
+    const expectedLength = 2 + 8 + 64 * 4;
+    if (!normalized) {
+      issues.push("createEscrow calldata is not valid hex");
+      return { issues };
+    }
+    if (normalized.length !== expectedLength) {
+      issues.push("createEscrow calldata length is not createEscrow(bytes32,address,uint256,bytes32)");
+    }
+    if (!normalized.startsWith("0x64a20554")) {
+      issues.push("createEscrow calldata selector is not createEscrow(bytes32,address,uint256,bytes32)");
+    }
+    return {
+      amount: calldataWordBigInt(calldataWord(normalized, 2)),
+      bountyId: normalizeBytes32(calldataWord(normalized, 0)),
+      data: normalized,
+      issues,
+      selector: normalized.slice(0, 10),
+      termsHash: normalizeBytes32(calldataWord(normalized, 3)),
+      token: calldataWordAddress(calldataWord(normalized, 1)),
+    };
+  }
+
+  function decodeBaseWalletPlanCalldata(plan) {
+    const funding = plan && plan.funding ? plan.funding : {};
+    return {
+      approve: decodeApproveCalldata(funding.approve && funding.approve.data),
+      createEscrow: decodeCreateEscrowCalldata(funding.create_escrow && funding.create_escrow.data),
+    };
+  }
+
   function baseWalletPlanValidationIssues(plan, context) {
     const issues = [];
     const connectedAddress = context && context.connectedAddress;
@@ -269,6 +392,21 @@
     const approve = funding.approve || {};
     const createEscrow = funding.create_escrow || {};
     const configured = baseMainnetWalletConfig;
+    const decoded = decodeBaseWalletPlanCalldata(plan);
+    const expectedBountyBytes32 = uuidToBytes32(expectedBountyId || bounty.id || create.bounty_id);
+    const createAmount = moneyAmountBigInt(create.amount);
+    const bountyTargetAmount = moneyAmountBigInt(baseFundingTargetAmount(bounty));
+    const hostedTargetAmount = hostedBounty ? moneyAmountBigInt(baseFundingTargetAmount(hostedBounty)) : null;
+    const createTermsHash = normalizeBytes32(create.terms_hash);
+    const bountyTermsHash = normalizeBytes32(bounty.terms_hash);
+    const hostedTermsHash = hostedBounty && hostedBounty.terms_hash ? normalizeBytes32(hostedBounty.terms_hash) : "";
+
+    for (const issue of decoded.approve.issues) {
+      issues.push(issue);
+    }
+    for (const issue of decoded.createEscrow.issues) {
+      issues.push(issue);
+    }
 
     if (normalizeChainId(network.chain_id) !== configured.chainId) {
       issues.push("funding plan is not for Base mainnet chain 8453");
@@ -291,8 +429,35 @@
     if (!sameAddress(createEscrow.to, configured.escrowContract)) {
       issues.push("funding plan escrow target does not match the verified Base mainnet deployment");
     }
-    if (!normalizedText(approve.data) || !normalizedText(createEscrow.data)) {
-      issues.push("funding plan is missing approval or escrow calldata");
+    if (!sameAddress(decoded.approve.spender, configured.escrowContract)) {
+      issues.push("approval calldata spender does not match the verified Base mainnet escrow");
+    }
+    if (!sameAddress(decoded.createEscrow.token, configured.nativeUsdc)) {
+      issues.push("createEscrow calldata token is not native USDC on Base mainnet");
+    }
+    if (!expectedBountyBytes32 || decoded.createEscrow.bountyId !== expectedBountyBytes32) {
+      issues.push("createEscrow calldata bounty id does not match the displayed bounty");
+    }
+    if (!sameBigInt(decoded.approve.amount, createAmount) || !sameBigInt(decoded.createEscrow.amount, createAmount)) {
+      issues.push("calldata amount does not match the displayed Base funding amount");
+    }
+    if (!sameBigInt(createAmount, bountyTargetAmount)) {
+      issues.push("funding plan amount does not match the bounty Base funding target");
+    }
+    if (hostedBounty && !sameBigInt(createAmount, hostedTargetAmount)) {
+      issues.push("funding plan amount does not match hosted Base funding target");
+    }
+    if (!createTermsHash || !bountyTermsHash || createTermsHash !== bountyTermsHash) {
+      issues.push("funding plan terms hash does not match the bounty terms hash");
+    }
+    if (hostedBounty && hostedTermsHash && createTermsHash !== hostedTermsHash) {
+      issues.push("funding plan terms hash does not match hosted status readback");
+    }
+    if (decoded.createEscrow.termsHash !== createTermsHash) {
+      issues.push("createEscrow calldata terms hash does not match the displayed terms hash");
+    }
+    if (!isZeroQuantity(approve.value_wei) || !isZeroQuantity(createEscrow.value_wei)) {
+      issues.push("Base wallet funding transactions must carry exactly zero ETH value");
     }
     if (approve.function !== "approve(address,uint256)") {
       issues.push("approval transaction is not USDC approve(address,uint256)");
@@ -300,15 +465,9 @@
     if (createEscrow.function !== "createEscrow(bytes32,address,uint256,bytes32)") {
       issues.push("escrow transaction is not createEscrow(bytes32,address,uint256,bytes32)");
     }
-    if (bounty.terms_hash && create.terms_hash && bounty.terms_hash !== create.terms_hash) {
-      issues.push("funding plan terms hash does not match the bounty terms hash");
-    }
     if (hostedBounty) {
       if (hostedBounty.id && hostedBounty.id !== bounty.id) {
         issues.push("funding plan bounty id does not match hosted status readback");
-      }
-      if (hostedBounty.terms_hash && create.terms_hash && hostedBounty.terms_hash !== create.terms_hash) {
-        issues.push("funding plan terms hash does not match hosted status readback");
       }
       if (!sameMoney(baseFundingTargetAmount(hostedBounty), create.amount)) {
         issues.push("funding plan amount does not match hosted Base funding target");
@@ -349,7 +508,8 @@
     };
   }
 
-  function baseWalletStatusLines(report) {
+  function baseWalletStatusLines(report, options) {
+    const outputOptions = options || {};
     const state = baseWalletFundingStatusModel(report);
     const applied = state.basePartition && state.basePartition.confirmed
       ? state.basePartition.confirmed
@@ -364,9 +524,13 @@
       `Base remaining funding: ${displayMoney(remaining)}`,
       `Indexed Base escrows: ${state.escrowCount}`,
       `Bounty claimable from Base evidence: ${state.reconciled ? "yes" : "no"}`,
+      `Whole bounty claimable: ${state.summary.claimable === true ? "yes" : "no"}`,
     ];
     if (state.reconciled) {
       lines.push("Base funding is reconciled only because hosted status reports matching indexed EscrowCreated evidence.");
+      if (outputOptions.shareUrl) {
+        lines.push(`Share link: ${outputOptions.shareUrl}`);
+      }
       lines.push("Default CTA: Post your own bounty.");
     } else {
       lines.push("Wallet transactions or transaction hashes are not funding evidence. Keep polling hosted status until indexed EscrowCreated evidence is reconciled.");
@@ -398,6 +562,19 @@
     return { address, chainId };
   }
 
+  async function assertBaseWalletStillConnected(provider, expectedAddress) {
+    const chainId = normalizedText(await providerRequest(provider, "eth_chainId")).toLowerCase();
+    if (chainId !== baseMainnetWalletConfig.chainIdHex) {
+      throw new Error("Wallet must stay on Base mainnet before signing.");
+    }
+    const accounts = await providerRequest(provider, "eth_accounts");
+    const address = Array.isArray(accounts) && accounts.length > 0 ? normalizeAddress(accounts[0]) : "";
+    if (!sameAddress(address, expectedAddress)) {
+      throw new Error("Connected wallet account changed before signing.");
+    }
+    return { address, chainId };
+  }
+
   async function readHostedBountyStatus(fetchImpl, apiBaseUrl, bountyId) {
     const response = await fetchImpl(`${apiBaseUrl}/v1/bounties/${bountyId}`, {
       headers: { accept: "application/json" },
@@ -420,7 +597,38 @@
     return response.json();
   }
 
-  async function fundBaseWalletBounty(options) {
+  function baseWalletReviewLines(review) {
+    const plan = review.plan;
+    const bounty = plan.bounty || {};
+    const create = plan.create || {};
+    const funding = plan.funding || {};
+    const approve = funding.approve || {};
+    const createEscrow = funding.create_escrow || {};
+    const decoded = review.decoded;
+    const bountyTitle = bounty.title ? `${bounty.title} (${bounty.id})` : bounty.id || review.bountyId;
+    return [
+      "State: ready for human wallet review",
+      `Bounty: ${bountyTitle}`,
+      `Bounty id: ${review.bountyId}`,
+      `Amount: ${displayMoney(create.amount)}`,
+      `Terms hash: ${normalizeBytes32(create.terms_hash)}`,
+      `Token: ${baseMainnetWalletConfig.nativeUsdc}`,
+      `Approval target: ${approve.to}`,
+      `Approval spender decoded from calldata: ${decoded.approve.spender}`,
+      `Escrow target: ${createEscrow.to}`,
+      `CreateEscrow token decoded from calldata: ${decoded.createEscrow.token}`,
+      `CreateEscrow bounty id decoded from calldata: ${decoded.createEscrow.bountyId}`,
+      `CreateEscrow terms hash decoded from calldata: ${decoded.createEscrow.termsHash}`,
+      "Approval ETH value: 0",
+      "Escrow ETH value: 0",
+      `Approval calldata: ${approve.data}`,
+      `Create escrow calldata: ${createEscrow.data}`,
+      "",
+      "Review these exact decoded values before signing. Sign USDC approval first; the escrow transaction stays disabled until the approval receipt succeeds.",
+    ].join("\n");
+  }
+
+  async function prepareBaseWalletFundingPlan(options) {
     const fetchImpl = options.fetchImpl || window.fetch.bind(window);
     const provider = options.provider;
     const apiBaseUrl = normalizedText(options.apiBaseUrl).replace(/\/+$/, "");
@@ -432,10 +640,7 @@
       throw new Error("Hosted API URL, bounty id, and connected wallet are required.");
     }
 
-    const chainId = normalizedText(await providerRequest(provider, "eth_chainId")).toLowerCase();
-    if (chainId !== baseMainnetWalletConfig.chainIdHex) {
-      throw new Error("Wallet must stay on Base mainnet before funding.");
-    }
+    await assertBaseWalletStillConnected(provider, connectedAddress);
 
     onState("Reading hosted bounty status...");
     const statusBefore = await readHostedBountyStatus(fetchImpl, apiBaseUrl, bountyId);
@@ -452,49 +657,168 @@
       connectedAddress,
       hostedBounty: statusBefore.bounty,
     });
+    const review = {
+      apiBaseUrl,
+      bountyId,
+      connectedAddress,
+      decoded: decodeBaseWalletPlanCalldata(plan),
+      plan,
+      statusBefore,
+    };
+    return {
+      ...review,
+      heading: "ready for human wallet review",
+      lines: baseWalletReviewLines(review),
+    };
+  }
 
-    onState("Request wallet confirmation 1 of 2: USDC approval.");
-    const approveHash = await providerRequest(provider, "eth_sendTransaction", [
-      evmTransactionRequest(plan.funding.approve, connectedAddress),
-    ]);
-    onState("Approval submitted. Request wallet confirmation 2 of 2: create escrow.");
-    const escrowHash = await providerRequest(provider, "eth_sendTransaction", [
-      evmTransactionRequest(plan.funding.create_escrow, connectedAddress),
-    ]);
+  function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
 
-    let receipt = null;
-    try {
-      receipt = await providerRequest(provider, "eth_getTransactionReceipt", [escrowHash]);
-    } catch (_error) {
-      receipt = null;
+  async function waitForTransactionSuccess(provider, txHash, options) {
+    const receiptOptions = options || {};
+    const attempts = receiptOptions.attempts || 8;
+    const delayMs = typeof receiptOptions.delayMs === "number" ? receiptOptions.delayMs : 2000;
+    const sleepImpl = receiptOptions.sleepImpl || sleep;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      const receipt = await providerRequest(provider, "eth_getTransactionReceipt", [txHash]);
+      if (receipt && receipt.status === "0x1") {
+        return receipt;
+      }
+      if (receipt && receipt.status === "0x0") {
+        throw new Error("Wallet transaction reverted before required receipt confirmation.");
+      }
+      if (attempt + 1 < attempts && delayMs > 0) {
+        await sleepImpl(delayMs);
+      }
     }
+    throw new Error("Wallet transaction did not produce a successful receipt within the bounded polling window.");
+  }
+
+  async function readTransactionReceiptOnce(provider, txHash) {
+    try {
+      return await providerRequest(provider, "eth_getTransactionReceipt", [txHash]);
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  async function sendBaseWalletApproval(options) {
+    const provider = options.provider;
+    const review = options.review;
+    const onState = typeof options.onState === "function" ? options.onState : () => {};
+    const connectedAddress = normalizeAddress(options.connectedAddress || review.connectedAddress);
+    await assertBaseWalletStillConnected(provider, connectedAddress);
+    onState("Request wallet confirmation: USDC approval.");
+    const approveHash = await providerRequest(provider, "eth_sendTransaction", [
+      evmTransactionRequest(review.plan.funding.approve, connectedAddress),
+    ]);
+    onState("Approval submitted. Waiting for a successful approval receipt before escrow can be signed...");
+    await waitForTransactionSuccess(provider, approveHash, {
+      attempts: options.receiptAttempts,
+      delayMs: options.receiptDelayMs,
+      sleepImpl: options.sleepImpl,
+    });
+    return {
+      approveHash,
+      heading: "approval confirmed",
+      lines: [
+        "State: approval confirmed",
+        `Approval transaction: ${approveHash}`,
+        "A successful approval receipt was read. Review once more, then sign the escrow transaction.",
+      ].join("\n"),
+    };
+  }
+
+  async function pollBaseWalletReconciliation(options) {
+    const fetchImpl = options.fetchImpl || window.fetch.bind(window);
+    const apiBaseUrl = normalizedText(options.apiBaseUrl).replace(/\/+$/, "");
+    const bountyId = normalizedText(options.bountyId);
+    const onState = typeof options.onState === "function" ? options.onState : () => {};
+    const attempts = options.attempts || 6;
+    const delayMs = typeof options.delayMs === "number" ? options.delayMs : 2000;
+    const sleepImpl = options.sleepImpl || sleep;
+    let latestReport = null;
+
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      onState(`Reading hosted status for indexed EscrowCreated evidence (${attempt + 1}/${attempts})...`);
+      latestReport = await readHostedBountyStatus(fetchImpl, apiBaseUrl, bountyId);
+      const model = baseWalletFundingStatusModel(latestReport);
+      if (model.reconciled) {
+        return {
+          heading: model.heading,
+          lines: baseWalletStatusLines(latestReport, { shareUrl: options.shareUrl }),
+          report: latestReport,
+        };
+      }
+      if (attempt + 1 < attempts && delayMs > 0) {
+        await sleepImpl(delayMs);
+      }
+    }
+
+    return {
+      heading: "waiting for confirmations",
+      lines: baseWalletStatusLines(latestReport, { shareUrl: options.shareUrl }),
+      report: latestReport,
+    };
+  }
+
+  async function sendBaseWalletEscrow(options) {
+    const provider = options.provider;
+    const review = options.review;
+    const onState = typeof options.onState === "function" ? options.onState : () => {};
+    const connectedAddress = normalizeAddress(options.connectedAddress || review.connectedAddress);
+    await assertBaseWalletStillConnected(provider, connectedAddress);
+    onState("Request wallet confirmation: create escrow.");
+    const escrowHash = await providerRequest(provider, "eth_sendTransaction", [
+      evmTransactionRequest(review.plan.funding.create_escrow, connectedAddress),
+    ]);
+    const receipt = await readTransactionReceiptOnce(provider, escrowHash);
     if (receipt && receipt.status === "0x0") {
       return {
-        approveHash,
         escrowHash,
         heading: "needs operator review",
         lines: [
           "State: needs operator review",
-          `Approval transaction: ${approveHash}`,
           `Escrow transaction: ${escrowHash}`,
           "The wallet/provider reports the escrow transaction reverted. No retry was attempted.",
         ].join("\n"),
       };
     }
 
-    onState("Escrow submitted. Reading hosted status for indexed EscrowCreated evidence...");
-    const statusAfter = await readHostedBountyStatus(fetchImpl, apiBaseUrl, bountyId);
+    const reconciliation = await pollBaseWalletReconciliation({
+      apiBaseUrl: review.apiBaseUrl,
+      bountyId: review.bountyId,
+      attempts: options.pollAttempts,
+      delayMs: options.pollDelayMs,
+      fetchImpl: options.fetchImpl,
+      onState,
+      shareUrl: options.shareUrl,
+      sleepImpl: options.sleepImpl,
+    });
     return {
-      approveHash,
       escrowHash,
-      heading: baseWalletFundingStatusModel(statusAfter).heading,
+      heading: reconciliation.heading,
       lines: [
-        `Approval transaction: ${approveHash}`,
         `Escrow transaction: ${escrowHash}`,
         "",
-        baseWalletStatusLines(statusAfter),
+        reconciliation.lines,
       ].join("\n"),
+      report: reconciliation.report,
     };
+  }
+
+  async function runExclusiveWalletAction(state, task) {
+    if (state.busy) {
+      throw new Error("A Base wallet action is already in progress.");
+    }
+    state.busy = true;
+    try {
+      return await task();
+    } finally {
+      state.busy = false;
+    }
   }
 
   function stripeFundingIntents(report) {
@@ -640,11 +964,17 @@
     baseMainnetWalletConfig,
     baseWalletFundingStatusModel,
     baseWalletPlanValidationIssues,
+    baseWalletReviewLines,
     baseWalletStatusLines,
     connectBaseWallet,
+    decodeBaseWalletPlanCalldata,
     evmTransactionRequest,
-    fundBaseWalletBounty,
     normalizeAddress,
+    pollBaseWalletReconciliation,
+    prepareBaseWalletFundingPlan,
+    runExclusiveWalletAction,
+    sendBaseWalletApproval,
+    sendBaseWalletEscrow,
     validateBaseWalletPlan,
   };
 
@@ -890,37 +1220,87 @@
   }
 
   let baseWalletConnection = null;
+  let baseWalletReview = null;
+  let baseWalletApprovalHash = "";
+  const baseWalletActionState = { busy: false };
+
+  function setElementDisabled(element, disabled) {
+    if (element) {
+      element.disabled = disabled;
+    }
+  }
+
+  function baseWalletShareUrl(apiBaseUrl, bountyId) {
+    try {
+      const url = new URL(window.location.href);
+      url.search = new URLSearchParams({
+        apiBaseUrl,
+        bountyId,
+        rail: "BaseUsdc",
+        source: "base-wallet",
+      }).toString();
+      return url.toString();
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function updateBaseWalletButtons() {
+    const busy = baseWalletActionState.busy;
+    const hasReview = Boolean(baseWalletReview);
+    const hasApproval = Boolean(baseWalletApprovalHash);
+    setElementDisabled(baseWalletConnect, busy);
+    setElementDisabled(baseWalletForm && baseWalletForm.querySelector("button[type='submit']"), busy || !baseWalletConnection);
+    setElementDisabled(baseWalletApprove, busy || !hasReview || hasApproval);
+    setElementDisabled(baseWalletEscrow, busy || !hasReview || !hasApproval);
+    setElementDisabled(baseWalletRefresh, busy || !hasReview);
+  }
+
+  function resetBaseWalletSigningState() {
+    baseWalletReview = null;
+    baseWalletApprovalHash = "";
+    updateBaseWalletButtons();
+  }
+
+  async function runBaseWalletUiAction(task) {
+    try {
+      await runExclusiveWalletAction(baseWalletActionState, task);
+    } catch (error) {
+      baseWalletOutput.textContent = `${error.message}\n\nNo automatic retry was started. Inspect the wallet and hosted bounty status before trying again. Transaction hashes are not reconciled funding.`;
+    } finally {
+      updateBaseWalletButtons();
+    }
+  }
+
   if (baseWalletForm && baseWalletOutput) {
+    updateBaseWalletButtons();
     if (baseWalletConnect) {
       baseWalletConnect.addEventListener("click", async () => {
-        baseWalletOutput.textContent = "Requesting wallet account and Base mainnet network...";
-        try {
+        await runBaseWalletUiAction(async () => {
+          baseWalletOutput.textContent = "Requesting wallet account and Base mainnet network...";
           baseWalletConnection = await connectBaseWallet(window.ethereum);
+          resetBaseWalletSigningState();
           baseWalletOutput.textContent = [
             "State: wallet connected",
             `Connected address: ${baseWalletConnection.address}`,
             "Network: Base mainnet (8453)",
             "No transaction has been planned, signed, or broadcast.",
           ].join("\n");
-        } catch (error) {
-          baseWalletConnection = null;
-          baseWalletOutput.textContent = `${error.message}\n\nNo transaction was signed. Connect a wallet that supports EIP-1193 and Base mainnet.`;
-        }
+        });
       });
     }
 
     baseWalletForm.addEventListener("submit", async (event) => {
       event.preventDefault();
-      const data = new FormData(baseWalletForm);
-      const apiBaseUrl = String(data.get("walletApiBaseUrl") || "").replace(/\/+$/, "");
-      const bountyId = String(data.get("walletBountyId") || "").trim();
-      if (!baseWalletConnection) {
-        baseWalletOutput.textContent = "Connect a Base mainnet wallet before funding. No transaction was signed.";
-        return;
-      }
+      await runBaseWalletUiAction(async () => {
+        const data = new FormData(baseWalletForm);
+        const apiBaseUrl = String(data.get("walletApiBaseUrl") || "").replace(/\/+$/, "");
+        const bountyId = String(data.get("walletBountyId") || "").trim();
+        if (!baseWalletConnection) {
+          throw new Error("Connect a Base mainnet wallet before planning. No transaction was signed.");
+        }
 
-      try {
-        const result = await fundBaseWalletBounty({
+        baseWalletReview = await prepareBaseWalletFundingPlan({
           apiBaseUrl,
           bountyId,
           connectedAddress: baseWalletConnection.address,
@@ -930,11 +1310,78 @@
             baseWalletOutput.textContent = message;
           },
         });
-        baseWalletOutput.textContent = result.lines;
-      } catch (error) {
-        baseWalletOutput.textContent = `${error.message}\n\nNo retry loop was started. If a wallet prompt was rejected or a transaction reverted, inspect the wallet and hosted bounty status before trying again. Transaction hashes are not reconciled funding.`;
-      }
+        baseWalletApprovalHash = "";
+        baseWalletOutput.textContent = baseWalletReview.lines;
+      });
     });
+
+    if (baseWalletApprove) {
+      baseWalletApprove.addEventListener("click", async () => {
+        await runBaseWalletUiAction(async () => {
+          if (!baseWalletReview) {
+            throw new Error("Review a Base wallet funding plan before signing approval.");
+          }
+          const result = await sendBaseWalletApproval({
+            connectedAddress: baseWalletConnection && baseWalletConnection.address,
+            provider: window.ethereum,
+            review: baseWalletReview,
+            onState(message) {
+              baseWalletOutput.textContent = message;
+            },
+          });
+          baseWalletApprovalHash = result.approveHash;
+          baseWalletOutput.textContent = result.lines;
+        });
+      });
+    }
+
+    if (baseWalletEscrow) {
+      baseWalletEscrow.addEventListener("click", async () => {
+        await runBaseWalletUiAction(async () => {
+          if (!baseWalletReview || !baseWalletApprovalHash) {
+            throw new Error("A successful approval receipt is required before escrow signing.");
+          }
+          const result = await sendBaseWalletEscrow({
+            connectedAddress: baseWalletConnection && baseWalletConnection.address,
+            fetchImpl: window.fetch.bind(window),
+            pollAttempts: 6,
+            pollDelayMs: 2000,
+            provider: window.ethereum,
+            review: baseWalletReview,
+            shareUrl: baseWalletShareUrl(baseWalletReview.apiBaseUrl, baseWalletReview.bountyId),
+            onState(message) {
+              baseWalletOutput.textContent = message;
+            },
+          });
+          baseWalletOutput.textContent = [
+            `Approval transaction: ${baseWalletApprovalHash}`,
+            result.lines,
+          ].join("\n");
+        });
+      });
+    }
+
+    if (baseWalletRefresh) {
+      baseWalletRefresh.addEventListener("click", async () => {
+        await runBaseWalletUiAction(async () => {
+          if (!baseWalletReview) {
+            throw new Error("Review a Base wallet funding plan before refreshing status.");
+          }
+          const result = await pollBaseWalletReconciliation({
+            apiBaseUrl: baseWalletReview.apiBaseUrl,
+            bountyId: baseWalletReview.bountyId,
+            attempts: 1,
+            delayMs: 0,
+            fetchImpl: window.fetch.bind(window),
+            shareUrl: baseWalletShareUrl(baseWalletReview.apiBaseUrl, baseWalletReview.bountyId),
+            onState(message) {
+              baseWalletOutput.textContent = message;
+            },
+          });
+          baseWalletOutput.textContent = result.lines;
+        });
+      });
+    }
   }
 
   form.addEventListener("submit", async (event) => {

--- a/site/main.js
+++ b/site/main.js
@@ -164,6 +164,7 @@
     chainId: 8453,
     chainIdHex: "0x2105",
     escrowContract: "0x150C6dFbCe7803cc7f634f59b0624e87349CEAce",
+    escrowCreatedTopic: "0xb67bc2da9ebef7d93355d3f5b6c7cc857b34cc7a4b8b2850ff3dcb90ea563ac2",
     nativeUsdc: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   };
 
@@ -297,6 +298,12 @@
 
   function calldataWordBigInt(word) {
     return normalizedQuantityToBigInt(word);
+  }
+
+  function abiDataWord(data, index) {
+    const hex = stripHexPrefix(data);
+    const start = index * 64;
+    return `0x${hex.slice(start, start + 64)}`;
   }
 
   function baseFundingTargetAmount(bounty) {
@@ -488,7 +495,149 @@
     return plan;
   }
 
-  function baseWalletFundingStatusModel(report) {
+  function decodeEscrowCreatedLog(log, receiptTxHash) {
+    const topics = Array.isArray(log && log.topics) ? log.topics.map(normalizeBytes32) : [];
+    const data = normalizeHexData(log && log.data);
+    const txHash = normalizeBytes32(
+      (log && (log.transactionHash || log.transaction_hash || log.txHash || log.tx_hash)) || receiptTxHash,
+    );
+    if (!sameAddress(log && log.address, baseMainnetWalletConfig.escrowContract)) {
+      return null;
+    }
+    if (topics.length !== 4 || topics[0] !== baseMainnetWalletConfig.escrowCreatedTopic) {
+      return null;
+    }
+    if (!data || data.length !== 2 + 64 * 3 || !txHash) {
+      throw new Error("EscrowCreated log from the verified contract is malformed.");
+    }
+    const onchainEscrowId = normalizedQuantityToBigInt(topics[1]);
+    const bountyId = normalizeBytes32(topics[2]);
+    const payer = calldataWordAddress(topics[3]);
+    const token = calldataWordAddress(abiDataWord(data, 0));
+    const amount = normalizedQuantityToBigInt(abiDataWord(data, 1));
+    const termsHash = normalizeBytes32(abiDataWord(data, 2));
+    if (onchainEscrowId === null || !bountyId || !payer || !token || amount === null || !termsHash) {
+      throw new Error("EscrowCreated log from the verified contract could not be decoded.");
+    }
+    return {
+      amount: amount.toString(),
+      bountyId,
+      logIndex: normalizedText(log && (log.logIndex || log.log_index)),
+      onchainEscrowId: onchainEscrowId.toString(),
+      payer,
+      termsHash,
+      token,
+      txHash,
+    };
+  }
+
+  function decodeEscrowCreatedReceipt(receipt, expected) {
+    if (!receipt || normalizeChainId(receipt.status) !== 1) {
+      throw new Error("Escrow transaction receipt was not successful.");
+    }
+    const submittedHash = normalizeBytes32(expected && expected.txHash);
+    const receiptHash = normalizeBytes32(receipt.transactionHash || receipt.transaction_hash || receipt.txHash || receipt.tx_hash);
+    if (submittedHash && receiptHash && submittedHash !== receiptHash) {
+      throw new Error("Escrow transaction receipt hash does not match the submitted transaction.");
+    }
+    const expectedBountyId = uuidToBytes32(expected && expected.bountyId);
+    const expectedAmount = moneyAmountBigInt(expected && expected.amount);
+    const expectedTermsHash = normalizeBytes32(expected && expected.termsHash);
+    const logs = Array.isArray(receipt.logs) ? receipt.logs : [];
+    const mismatches = [];
+    for (const log of logs) {
+      const evidence = decodeEscrowCreatedLog(log, receiptHash || submittedHash);
+      if (!evidence) {
+        continue;
+      }
+      const issues = [];
+      if (!expectedBountyId || evidence.bountyId !== expectedBountyId) {
+        issues.push("bounty id");
+      }
+      if (!sameAddress(evidence.payer, expected && expected.payer)) {
+        issues.push("payer");
+      }
+      if (!sameAddress(evidence.token, expected && expected.token)) {
+        issues.push("token");
+      }
+      if (!sameBigInt(normalizedQuantityToBigInt(evidence.amount), expectedAmount)) {
+        issues.push("amount");
+      }
+      if (!expectedTermsHash || evidence.termsHash !== expectedTermsHash) {
+        issues.push("terms hash");
+      }
+      if (issues.length === 0) {
+        return evidence;
+      }
+      mismatches.push(issues.join(", "));
+    }
+    const detail = mismatches.length > 0 ? ` Mismatched fields: ${mismatches.join("; ")}.` : "";
+    throw new Error(`Escrow receipt did not contain matching EscrowCreated evidence from the verified escrow contract.${detail}`);
+  }
+
+  function eventOnchainEscrowId(event) {
+    return normalizedQuantityToBigInt(
+      event && (
+        event.onchain_escrow_id
+        || event.onchainEscrowId
+        || event.onchain_id
+        || event.onchainId
+      ),
+    );
+  }
+
+  function escrowOnchainEscrowId(escrow) {
+    const direct = eventOnchainEscrowId(escrow);
+    if (direct !== null) {
+      return direct;
+    }
+    const reference = normalizedText(
+      escrow && (escrow.external_reference || escrow.externalReference || escrow.reference),
+    ).toLowerCase();
+    const match = /^base:([0-9]+)$/.exec(reference);
+    return match ? BigInt(match[1]) : null;
+  }
+
+  function hostedEventMatchesEvidence(event, evidence) {
+    const eventAmount = moneyAmountBigInt(event && event.amount);
+    return normalizedText(event && event.kind).toLowerCase() === "created"
+      && normalizeBytes32(event && (event.tx_hash || event.txHash || event.transaction_hash || event.transactionHash)) === evidence.txHash
+      && sameBigInt(eventOnchainEscrowId(event), normalizedQuantityToBigInt(evidence.onchainEscrowId))
+      && uuidToBytes32(event && (event.bounty_id || event.bountyId)) === evidence.bountyId
+      && sameAddress(event && event.token, evidence.token)
+      && sameBigInt(eventAmount, normalizedQuantityToBigInt(evidence.amount))
+      && normalizeBytes32(event && (event.terms_hash || event.termsHash)) === evidence.termsHash;
+  }
+
+  function hostedEscrowMatchesEvidence(escrow, evidence) {
+    const status = normalizedText(escrow && escrow.status).toLowerCase();
+    const eventId = normalizedQuantityToBigInt(evidence.onchainEscrowId);
+    const escrowId = escrowOnchainEscrowId(escrow);
+    return ["funded", "released", "disputed"].includes(status)
+      && sameBigInt(escrowId, eventId)
+      && uuidToBytes32(escrow && (escrow.bounty_id || escrow.bountyId)) === evidence.bountyId
+      && sameAddress(escrow && escrow.token, evidence.token)
+      && sameBigInt(moneyAmountBigInt(escrow && escrow.amount), normalizedQuantityToBigInt(evidence.amount));
+  }
+
+  function matchingHostedBaseEscrow(report, evidence) {
+    if (!report || !evidence) {
+      return null;
+    }
+    const events = Array.isArray(report.base_escrow_events)
+      ? report.base_escrow_events
+      : Array.isArray(report.baseEscrowEvents)
+        ? report.baseEscrowEvents
+        : [];
+    const escrows = Array.isArray(report.escrows) ? report.escrows : [];
+    const event = events.find((candidate) => hostedEventMatchesEvidence(candidate, evidence));
+    const escrow = escrows.find((candidate) => hostedEscrowMatchesEvidence(candidate, evidence));
+    return event && escrow ? { event, escrow } : null;
+  }
+
+  function baseWalletFundingStatusModel(report, options) {
+    const expectedEvidence = options && options.expectedEvidence;
+    const matchedEvidence = matchingHostedBaseEscrow(report, expectedEvidence);
     const summary = report && report.funding_summary ? report.funding_summary : {};
     const partitions = Array.isArray(summary.partitions) ? summary.partitions : [];
     const basePartition = partitions.find((partition) => partition && partition.rail === "BaseUsdc");
@@ -496,13 +645,13 @@
     const escrowCount = basePartition && typeof basePartition.escrow_count === "number"
       ? basePartition.escrow_count
       : escrows.length;
-    const baseClaimable = basePartition ? basePartition.claimable === true : summary.claimable === true && escrowCount > 0;
-    const reconciled = baseClaimable && escrowCount > 0;
+    const reconciled = Boolean(matchedEvidence);
     return {
       basePartition,
       bounty: report && report.bounty ? report.bounty : {},
       escrowCount,
       heading: reconciled ? "funding reconciled" : "waiting for confirmations",
+      matchedEvidence,
       reconciled,
       summary,
     };
@@ -510,7 +659,7 @@
 
   function baseWalletStatusLines(report, options) {
     const outputOptions = options || {};
-    const state = baseWalletFundingStatusModel(report);
+    const state = baseWalletFundingStatusModel(report, outputOptions);
     const applied = state.basePartition && state.basePartition.confirmed
       ? state.basePartition.confirmed
       : state.summary.applied;
@@ -523,11 +672,13 @@
       `Base applied funding: ${displayMoney(applied)}`,
       `Base remaining funding: ${displayMoney(remaining)}`,
       `Indexed Base escrows: ${state.escrowCount}`,
-      `Bounty claimable from Base evidence: ${state.reconciled ? "yes" : "no"}`,
+      `Bounty claimable from this Base evidence: ${state.reconciled ? "yes" : "no"}`,
       `Whole bounty claimable: ${state.summary.claimable === true ? "yes" : "no"}`,
     ];
     if (state.reconciled) {
-      lines.push("Base funding is reconciled only because hosted status reports matching indexed EscrowCreated evidence.");
+      lines.push(`Matched escrow transaction: ${outputOptions.expectedEvidence.txHash}`);
+      lines.push(`Matched on-chain escrow id: ${outputOptions.expectedEvidence.onchainEscrowId}`);
+      lines.push("Base funding is reconciled only because hosted status reports the same indexed EscrowCreated transaction provenance.");
       if (outputOptions.shareUrl) {
         lines.push(`Share link: ${outputOptions.shareUrl}`);
       }
@@ -696,14 +847,6 @@
     throw new Error("Wallet transaction did not produce a successful receipt within the bounded polling window.");
   }
 
-  async function readTransactionReceiptOnce(provider, txHash) {
-    try {
-      return await providerRequest(provider, "eth_getTransactionReceipt", [txHash]);
-    } catch (_error) {
-      return null;
-    }
-  }
-
   async function sendBaseWalletApproval(options) {
     const provider = options.provider;
     const review = options.review;
@@ -744,11 +887,16 @@
     for (let attempt = 0; attempt < attempts; attempt += 1) {
       onState(`Reading hosted status for indexed EscrowCreated evidence (${attempt + 1}/${attempts})...`);
       latestReport = await readHostedBountyStatus(fetchImpl, apiBaseUrl, bountyId);
-      const model = baseWalletFundingStatusModel(latestReport);
+      const model = baseWalletFundingStatusModel(latestReport, {
+        expectedEvidence: options.expectedEvidence,
+      });
       if (model.reconciled) {
         return {
           heading: model.heading,
-          lines: baseWalletStatusLines(latestReport, { shareUrl: options.shareUrl }),
+          lines: baseWalletStatusLines(latestReport, {
+            expectedEvidence: options.expectedEvidence,
+            shareUrl: options.shareUrl,
+          }),
           report: latestReport,
         };
       }
@@ -759,7 +907,10 @@
 
     return {
       heading: "waiting for confirmations",
-      lines: baseWalletStatusLines(latestReport, { shareUrl: options.shareUrl }),
+      lines: baseWalletStatusLines(latestReport, {
+        expectedEvidence: options.expectedEvidence,
+        shareUrl: options.shareUrl,
+      }),
       report: latestReport,
     };
   }
@@ -774,24 +925,58 @@
     const escrowHash = await providerRequest(provider, "eth_sendTransaction", [
       evmTransactionRequest(review.plan.funding.create_escrow, connectedAddress),
     ]);
-    const receipt = await readTransactionReceiptOnce(provider, escrowHash);
-    if (receipt && receipt.status === "0x0") {
+    onState("Escrow submitted. Waiting for a successful escrow receipt...");
+    let receipt;
+    try {
+      receipt = await waitForTransactionSuccess(provider, escrowHash, {
+        attempts: options.receiptAttempts,
+        delayMs: options.receiptDelayMs,
+        sleepImpl: options.sleepImpl,
+      });
+    } catch (error) {
+      if (error instanceof Error && /reverted/.test(error.message)) {
+        return {
+          escrowHash,
+          heading: "needs operator review",
+          lines: [
+            "State: needs operator review",
+            `Escrow transaction: ${escrowHash}`,
+            "The wallet/provider reports the escrow transaction reverted. No retry was attempted.",
+          ].join("\n"),
+        };
+      }
+      throw error;
+    }
+    let escrowEvidence;
+    try {
+      escrowEvidence = decodeEscrowCreatedReceipt(receipt, {
+        amount: review.plan.create && review.plan.create.amount,
+        bountyId: review.bountyId,
+        payer: connectedAddress,
+        termsHash: review.plan.create && review.plan.create.terms_hash,
+        token: baseMainnetWalletConfig.nativeUsdc,
+        txHash: escrowHash,
+      });
+    } catch (error) {
       return {
         escrowHash,
         heading: "needs operator review",
         lines: [
           "State: needs operator review",
           `Escrow transaction: ${escrowHash}`,
-          "The wallet/provider reports the escrow transaction reverted. No retry was attempted.",
+          error instanceof Error ? error.message : String(error),
+          "The submitted transaction is not treated as funding. No retry was attempted.",
         ].join("\n"),
       };
     }
+    onState("EscrowCreated log matched the submitted transaction. Polling hosted indexed evidence...");
 
     const reconciliation = await pollBaseWalletReconciliation({
       apiBaseUrl: review.apiBaseUrl,
       bountyId: review.bountyId,
       attempts: options.pollAttempts,
       delayMs: options.pollDelayMs,
+      expectedEvidence: escrowEvidence,
       fetchImpl: options.fetchImpl,
       onState,
       shareUrl: options.shareUrl,
@@ -802,9 +987,12 @@
       heading: reconciliation.heading,
       lines: [
         `Escrow transaction: ${escrowHash}`,
+        `EscrowCreated transaction evidence: ${escrowEvidence.txHash}`,
+        `EscrowCreated on-chain escrow id: ${escrowEvidence.onchainEscrowId}`,
         "",
         reconciliation.lines,
       ].join("\n"),
+      escrowEvidence,
       report: reconciliation.report,
     };
   }
@@ -967,8 +1155,10 @@
     baseWalletReviewLines,
     baseWalletStatusLines,
     connectBaseWallet,
+    decodeEscrowCreatedReceipt,
     decodeBaseWalletPlanCalldata,
     evmTransactionRequest,
+    matchingHostedBaseEscrow,
     normalizeAddress,
     pollBaseWalletReconciliation,
     prepareBaseWalletFundingPlan,
@@ -1222,6 +1412,7 @@
   let baseWalletConnection = null;
   let baseWalletReview = null;
   let baseWalletApprovalHash = "";
+  let baseWalletEscrowEvidence = null;
   const baseWalletActionState = { busy: false };
 
   function setElementDisabled(element, disabled) {
@@ -1259,6 +1450,7 @@
   function resetBaseWalletSigningState() {
     baseWalletReview = null;
     baseWalletApprovalHash = "";
+    baseWalletEscrowEvidence = null;
     updateBaseWalletButtons();
   }
 
@@ -1311,6 +1503,7 @@
           },
         });
         baseWalletApprovalHash = "";
+        baseWalletEscrowEvidence = null;
         baseWalletOutput.textContent = baseWalletReview.lines;
       });
     });
@@ -1330,6 +1523,7 @@
             },
           });
           baseWalletApprovalHash = result.approveHash;
+          baseWalletEscrowEvidence = null;
           baseWalletOutput.textContent = result.lines;
         });
       });
@@ -1348,11 +1542,14 @@
             pollDelayMs: 2000,
             provider: window.ethereum,
             review: baseWalletReview,
+            receiptAttempts: 8,
+            receiptDelayMs: 2000,
             shareUrl: baseWalletShareUrl(baseWalletReview.apiBaseUrl, baseWalletReview.bountyId),
             onState(message) {
               baseWalletOutput.textContent = message;
             },
           });
+          baseWalletEscrowEvidence = result.escrowEvidence || null;
           baseWalletOutput.textContent = [
             `Approval transaction: ${baseWalletApprovalHash}`,
             result.lines,
@@ -1372,6 +1569,7 @@
             bountyId: baseWalletReview.bountyId,
             attempts: 1,
             delayMs: 0,
+            expectedEvidence: baseWalletEscrowEvidence,
             fetchImpl: window.fetch.bind(window),
             shareUrl: baseWalletShareUrl(baseWalletReview.apiBaseUrl, baseWalletReview.bountyId),
             onState(message) {


### PR DESCRIPTION
Closes #124.

## Summary

- adds a wallet-native Base mainnet funding panel to `funding.html`
- connects an injected EIP-1193 wallet, switches to Base mainnet, and keeps all wallet actions behind explicit user clicks
- requests the hosted Base funding plan with verified Base mainnet escrow/native USDC constants
- rejects mismatched chain, payer, escrow target, token, bounty id, amount, or terms hash before any `eth_sendTransaction`
- submits USDC `approve` and escrow `createEscrow` as separate wallet confirmations
- shows funding as reconciled only after hosted read-only bounty status reports indexed `EscrowCreated` evidence
- documents the wallet path in `/llms.txt`, the static discovery manifest, quickstart, and hosted Base runbook

## Safety boundaries

- no private key, seed phrase, signature, or raw wallet history is requested, stored, or logged
- hosted signed-transaction broadcast remains untouched
- contract/token query params are ignored for wallet funding; the wallet flow uses the checked-in Base mainnet deployment constants
- transaction hashes remain pending evidence until hosted status shows indexed `EscrowCreated` reconciliation
- rejected prompts and reverted escrow transactions do not trigger retry loops

## Verification

- `node scripts\test-base-wallet-flow.js` -> `base wallet flow tests passed`
- `node --check site\main.js`
- `node --check scripts\test-base-wallet-flow.js`
- `python scripts\check-site.py` -> `site check ok`
- `python -m json.tool site\.well-known\agent-bounties.json`
- `git diff --check`

Not run locally: cargo docs contract checks, because this Windows environment does not have `cargo` or `rustfmt` on PATH.

## Discovery feedback

Found through the public Agent Bounties issue list while monitoring accepted/pending Base payout work. It was worth attempting because the missing wallet-native flow is a payment-trust gap between a real Base wallet and reconciled funding, and the behavior is measurable with mocked EIP-1193 provider tests.
