### PR TITLE
fix(base): attest release calldata before payout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,5 @@ jobs:
           cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
           cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture
           cargo test -p db tests::base_log_pipeline_rolls_back_paid_state_when_cursor_commit_fails -- --ignored --exact --nocapture
+          cargo test -p worker tests::base_indexer_poll_applies_release_with_mock_rpc -- --ignored --exact --nocapture
+          cargo test -p worker tests::base_indexer_poll_quarantines_release_failures_with_mock_rpc -- --ignored --exact --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,4 @@ jobs:
           cargo test -p api github_issue_api_sync_postgres -- --ignored --nocapture
           cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
           cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture
+          cargo test -p db tests::base_log_pipeline_rolls_back_paid_state_when_cursor_commit_fails -- --ignored --exact --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror 1.0.69",
+ "tokio",
  "uuid",
 ]
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Useful REST paths:
 - `POST /v1/base/log-query`
 - `POST /v1/base/funding-plan`
 - `POST /v1/base/release-queue`
+- `GET /v1/base/release-attestations/{bounty_id}`
 - `POST /v1/base/release-plan`
 - `POST /v1/base/refund-plan`
 - `POST /v1/base/dispute-plan`

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -3,11 +3,11 @@ use app::{
     hash_artifact, stripe_secret_key_mode_from_secret, AddFundingContributionRequest,
     ApproveRiskBountyRequest, ApproveRiskPayoutRequest, BaseEscrowReconciliation,
     BaseIndexerHeartbeatStatus, BaseIndexerScanCursor, BaseIndexerStatusConfig,
-    BaseIndexerStatusReport, BaseReleaseQueueRequest, BaseReleaseTransactionEvidence,
-    BountyNetwork, BountyStatusResponse, ClaimBountyRequest, CreateFundingIntentRequest,
-    CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport, LiveMoneyReadinessConfig,
-    LiveMoneyReadinessReport, OpenPooledBountyRequest, PlanBaseDisputeRequest,
-    PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
+    BaseIndexerStatusReport, BaseReleaseAttestationStatus, BaseReleaseQueueRequest,
+    BaseReleaseTransactionEvidence, BountyNetwork, BountyStatusResponse, ClaimBountyRequest,
+    CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport,
+    LiveMoneyReadinessConfig, LiveMoneyReadinessReport, OpenPooledBountyRequest,
+    PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
     PlanStripeTransferRequest as AppPlanStripeTransferRequest, PooledFundingReport,
     PostBountyRequest, QuoteSet, RecordAudienceInteractionRequest, RecordDiscoveryResponseRequest,
     RecordOutreachAttemptRequest, RegisterAgentRequest, RegisterCapabilityRequest,
@@ -35,7 +35,8 @@ use chain_base::{
 };
 use chrono::Utc;
 use db::{
-    BaseLogPersistenceBatch, BountyStatusScope, DbError, GitHubIssueSyncBountyUpsert, PostgresStore,
+    BaseLogPersistenceBatch, BaseReleaseAttestationRecord, BountyStatusScope, DbError,
+    GitHubIssueSyncBountyUpsert, PostgresStore,
 };
 use domain::{
     Agent, AudienceInteraction, AudienceMember, AudienceReport, BountyStatus, Capability,
@@ -68,7 +69,7 @@ use std::sync::{Arc, Mutex};
 use tower_http::cors::CorsLayer;
 use utoipa::openapi::security::{ApiKey, ApiKeyValue, Http, HttpAuthScheme, SecurityScheme};
 use utoipa::openapi::Components;
-use utoipa::{Modify, OpenApi, ToSchema};
+use utoipa::{IntoParams, Modify, OpenApi, ToSchema};
 use uuid::Uuid;
 use worker::BaseEscrowLogWorker;
 
@@ -124,6 +125,7 @@ use worker::BaseEscrowLogWorker;
         get_base_transaction_receipt,
         plan_base_funding,
         list_base_release_queue,
+        list_base_release_attestation_audit,
         plan_stripe_checkout_top_up,
         plan_stripe_connect_account,
         plan_stripe_connect_transfer,
@@ -180,6 +182,9 @@ use worker::BaseEscrowLogWorker;
         AudienceInteraction,
         DiscoveryResponse,
         OutreachAttempt,
+        BaseReleaseAttestationAuditReport,
+        BaseReleaseAttestationAuditRecord,
+        BaseReleaseAttestationRecipientAuditRecord,
         AudienceReport
     )),
     modifiers(&SecurityAddon)
@@ -228,6 +233,49 @@ struct AppState {
 
 type SharedState = Arc<AppState>;
 const OPERATOR_TOKEN_HEADER: &str = "x-operator-token";
+const BASE_RELEASE_ATTESTATION_STATUS_LIMIT: usize = 25;
+const BASE_RELEASE_ATTESTATION_AUDIT_DEFAULT_LIMIT: usize = 25;
+const BASE_RELEASE_ATTESTATION_AUDIT_MAX_LIMIT: usize = 100;
+
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+struct BaseReleaseAttestationAuditQuery {
+    /// Optional maximum number of attestation records to return. Values are capped at 100.
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct BaseReleaseAttestationAuditReport {
+    bounty_id: Uuid,
+    limit: usize,
+    returned: usize,
+    truncated: bool,
+    redacted_fields: Vec<String>,
+    evidence_boundary: String,
+    records: Vec<BaseReleaseAttestationAuditRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct BaseReleaseAttestationAuditRecord {
+    network: String,
+    tx_hash: String,
+    log_key: String,
+    bounty_id: Uuid,
+    onchain_escrow_id: String,
+    calldata_hash: Option<String>,
+    proof_hash: Option<String>,
+    recipients: Vec<BaseReleaseAttestationRecipientAuditRecord>,
+    escrow_contract: String,
+    verdict: String,
+    reason: String,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct BaseReleaseAttestationRecipientAuditRecord {
+    address: String,
+    amount_minor: Option<String>,
+    currency: Option<String>,
+}
 
 fn non_empty_secret(secret: String) -> Option<String> {
     let trimmed = secret.trim();
@@ -613,6 +661,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/v1/base/log-query", post(plan_base_log_query))
         .route("/v1/base/funding-plan", post(plan_base_funding))
         .route("/v1/base/release-queue", post(list_base_release_queue))
+        .route(
+            "/v1/base/release-attestations/:bounty_id",
+            get(list_base_release_attestation_audit),
+        )
         .route("/v1/base/release-plan", post(plan_base_release))
         .route("/v1/base/refund-plan", post(plan_base_refund))
         .route("/v1/base/dispute-plan", post(plan_base_dispute))
@@ -3210,10 +3262,10 @@ fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResp
     let base_escrow_events = scope.base_escrow_events;
     let base_release_attestations = scope
         .base_release_attestations
-        .into_iter()
-        .map(serde_json::to_value)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .iter()
+        .take(BASE_RELEASE_ATTESTATION_STATUS_LIMIT)
+        .map(base_release_attestation_status_from_record)
+        .collect();
     let network = BountyNetwork {
         bounties: [(scope.bounty.id, scope.bounty)].into_iter().collect(),
         funding_intents: scope
@@ -3279,6 +3331,168 @@ fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResp
     status.base_escrow_events = base_escrow_events;
     status.base_release_attestations = base_release_attestations;
     Ok(status)
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/base/release-attestations/{bounty_id}",
+    params(
+        ("bounty_id" = Uuid, Path, description = "Hosted bounty UUID."),
+        BaseReleaseAttestationAuditQuery
+    ),
+    responses(
+        (status = 200, description = "Bounded redacted Base release attestation audit records.", body = BaseReleaseAttestationAuditReport),
+        (status = 401, description = "Operator authorization required."),
+        (status = 503, description = "Persistent store unavailable.")
+    ),
+    security(
+        ("operator_api_token" = []),
+        ("operator_bearer" = [])
+    )
+)]
+async fn list_base_release_attestation_audit(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Path(bounty_id): Path<Uuid>,
+    Query(query): Query<BaseReleaseAttestationAuditQuery>,
+) -> Result<Json<BaseReleaseAttestationAuditReport>, StatusCode> {
+    require_operator(&state, &headers)?;
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let limit = bounded_base_release_attestation_audit_limit(query.limit);
+    let mut records = store
+        .list_base_release_attestations_for_bounty_limited(bounty_id, limit + 1)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let truncated = records.len() > limit;
+    records.truncate(limit);
+    Ok(Json(base_release_attestation_audit_report(
+        bounty_id, limit, truncated, records,
+    )))
+}
+
+fn base_release_attestation_status_from_record(
+    record: &BaseReleaseAttestationRecord,
+) -> BaseReleaseAttestationStatus {
+    BaseReleaseAttestationStatus {
+        network: record.network.clone(),
+        tx_hash: record.tx_hash.clone(),
+        log_key: record.log_key.clone(),
+        bounty_id: record.bounty_id,
+        onchain_escrow_id: record.onchain_escrow_id.clone(),
+        calldata_hash: record.calldata_hash.clone(),
+        proof_hash: record.proof_hash.clone(),
+        recipient_count: record
+            .recipients
+            .as_array()
+            .map(|recipients| recipients.len())
+            .unwrap_or(0),
+        verdict: record.verdict.clone(),
+        created_at: record.created_at,
+    }
+}
+
+fn bounded_base_release_attestation_audit_limit(limit: Option<usize>) -> usize {
+    limit
+        .unwrap_or(BASE_RELEASE_ATTESTATION_AUDIT_DEFAULT_LIMIT)
+        .clamp(1, BASE_RELEASE_ATTESTATION_AUDIT_MAX_LIMIT)
+}
+
+fn base_release_attestation_audit_report(
+    bounty_id: Uuid,
+    limit: usize,
+    truncated: bool,
+    records: Vec<BaseReleaseAttestationRecord>,
+) -> BaseReleaseAttestationAuditReport {
+    let records = records
+        .into_iter()
+        .take(limit)
+        .map(base_release_attestation_audit_record)
+        .collect::<Vec<_>>();
+    BaseReleaseAttestationAuditReport {
+        bounty_id,
+        limit,
+        returned: records.len(),
+        truncated,
+        redacted_fields: vec![
+            "settlement_signer".to_string(),
+            "platform_fee_wallet".to_string(),
+        ],
+        evidence_boundary:
+            "Operator audit view; raw provider URLs, signer config, and fee-wallet config are not returned."
+                .to_string(),
+        records,
+    }
+}
+
+fn base_release_attestation_audit_record(
+    record: BaseReleaseAttestationRecord,
+) -> BaseReleaseAttestationAuditRecord {
+    BaseReleaseAttestationAuditRecord {
+        network: record.network,
+        tx_hash: record.tx_hash,
+        log_key: record.log_key,
+        bounty_id: record.bounty_id,
+        onchain_escrow_id: record.onchain_escrow_id,
+        calldata_hash: record.calldata_hash,
+        proof_hash: record.proof_hash,
+        recipients: base_release_attestation_recipients(&record.recipients),
+        escrow_contract: record.escrow_contract,
+        verdict: record.verdict,
+        reason: record.reason,
+        created_at: record.created_at.to_rfc3339(),
+    }
+}
+
+fn base_release_attestation_recipients(
+    recipients: &serde_json::Value,
+) -> Vec<BaseReleaseAttestationRecipientAuditRecord> {
+    recipients
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let address = item.get("address")?.as_str()?.to_string();
+                    Some(BaseReleaseAttestationRecipientAuditRecord {
+                        address,
+                        amount_minor: base_release_attestation_amount_minor(item.get("amount")),
+                        currency: base_release_attestation_currency(item.get("amount")),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn base_release_attestation_amount_minor(amount: Option<&serde_json::Value>) -> Option<String> {
+    let value = amount?;
+    if let Some(amount) = value.as_str() {
+        return Some(amount.to_string());
+    }
+    if let Some(amount) = value.as_i64() {
+        return Some(amount.to_string());
+    }
+    if let Some(amount) = value.as_u64() {
+        return Some(amount.to_string());
+    }
+    let nested = value.get("amount")?;
+    if let Some(amount) = nested.as_str() {
+        return Some(amount.to_string());
+    }
+    if let Some(amount) = nested.as_i64() {
+        return Some(amount.to_string());
+    }
+    nested.as_u64().map(|amount| amount.to_string())
+}
+
+fn base_release_attestation_currency(amount: Option<&serde_json::Value>) -> Option<String> {
+    amount?
+        .get("currency")
+        .and_then(|currency| currency.as_str())
+        .map(|currency| currency.to_string())
 }
 
 async fn public_proof_page(
@@ -5898,6 +6112,7 @@ mod tests {
         assert!(paths.contains_key("/v1/base/fetch-rpc-logs"));
         assert!(paths.contains_key("/v1/base/broadcast-signed-transaction"));
         assert!(paths.contains_key("/v1/base/transaction-receipt"));
+        assert!(paths.contains_key("/v1/base/release-attestations/{bounty_id}"));
         assert!(paths.contains_key("/v1/base/refund-plan"));
         assert!(paths.contains_key("/v1/base/dispute-plan"));
         assert!(paths.contains_key("/v1/stripe/live/checkout-top-ups"));
@@ -5968,6 +6183,21 @@ mod tests {
             .any(|requirement| requirement.get("operator_api_token").is_some()));
         assert!(paths["/v1/base/transaction-receipt"]["post"]["responses"]["401"].is_object());
 
+        let release_attestation_security = paths["/v1/base/release-attestations/{bounty_id}"]
+            ["get"]["security"]
+            .as_array()
+            .unwrap();
+        assert!(release_attestation_security
+            .iter()
+            .any(|requirement| requirement.get("operator_api_token").is_some()));
+        assert!(release_attestation_security
+            .iter()
+            .any(|requirement| requirement.get("operator_bearer").is_some()));
+        assert!(
+            paths["/v1/base/release-attestations/{bounty_id}"]["get"]["responses"]["401"]
+                .is_object()
+        );
+
         assert!(
             paths["/v1/stripe/live/funding-intents/{id}/checkout-session"]["post"]
                 .get("security")
@@ -5986,6 +6216,50 @@ mod tests {
             "Stripe checkout webhook must remain callable by Stripe without operator auth"
         );
         assert!(paths["/v1/stripe/checkout-webhooks"]["post"]["responses"]["503"].is_object());
+    }
+
+    #[test]
+    fn base_release_attestation_status_redacts_sensitive_fields() {
+        let record = test_base_release_attestation_record(0);
+
+        let status = base_release_attestation_status_from_record(&record);
+        let serialized = serde_json::to_string(&status).unwrap();
+
+        assert_eq!(status.recipient_count, 2);
+        assert!(serialized.contains("passed"));
+        assert!(!serialized.contains("settlement_signer"));
+        assert!(!serialized.contains("platform_fee_wallet"));
+        assert!(!serialized.contains("0x5555555555555555555555555555555555555555"));
+        assert!(!serialized.contains("0x7777777777777777777777777777777777777777"));
+    }
+
+    #[test]
+    fn base_release_attestation_audit_report_caps_and_types_recipients() {
+        let bounty_id = Uuid::new_v4();
+        let first = test_base_release_attestation_record(0);
+        let second = test_base_release_attestation_record(1);
+
+        let report = base_release_attestation_audit_report(bounty_id, 1, true, vec![first, second]);
+        let serialized = serde_json::to_string(&report).unwrap();
+
+        assert_eq!(report.bounty_id, bounty_id);
+        assert_eq!(report.limit, 1);
+        assert_eq!(report.returned, 1);
+        assert!(report.truncated);
+        assert!(report
+            .redacted_fields
+            .contains(&"settlement_signer".to_string()));
+        assert_eq!(report.records[0].recipients.len(), 2);
+        assert_eq!(
+            report.records[0].recipients[0].amount_minor.as_deref(),
+            Some("1000000")
+        );
+        assert_eq!(
+            report.records[0].recipients[0].currency.as_deref(),
+            Some("usdc")
+        );
+        assert!(!serialized.contains("0x5555555555555555555555555555555555555555"));
+        assert!(!serialized.contains("0x7777777777777777777777777777777777777777"));
     }
 
     #[tokio::test]
@@ -7521,6 +7795,42 @@ mod tests {
             service_bind_addr(None, None, "127.0.0.1:8080"),
             "127.0.0.1:8080"
         );
+    }
+
+    fn test_base_release_attestation_record(index: usize) -> BaseReleaseAttestationRecord {
+        BaseReleaseAttestationRecord {
+            id: Uuid::new_v4(),
+            network: "base-mainnet".to_string(),
+            tx_hash: format!("0x{index:064x}"),
+            log_key: format!("0x{index:064x}:7"),
+            bounty_id: Uuid::new_v4(),
+            onchain_escrow_id: "7".to_string(),
+            calldata_hash: Some(
+                "0x1111111111111111111111111111111111111111111111111111111111111111".to_string(),
+            ),
+            proof_hash: Some(
+                "0x2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+            ),
+            recipients: serde_json::json!([
+                {
+                    "address": "0x3333333333333333333333333333333333333333",
+                    "amount": {
+                        "amount": 1000000,
+                        "currency": "usdc"
+                    }
+                },
+                {
+                    "address": "0x4444444444444444444444444444444444444444",
+                    "amount": "250000"
+                }
+            ]),
+            escrow_contract: "0x150C6dFbCe7803cc7f634f59b0624e87349CEAce".to_string(),
+            settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+            platform_fee_wallet: Some("0x7777777777777777777777777777777777777777".to_string()),
+            verdict: "passed".to_string(),
+            reason: "release calldata matches pending Base settlement plan".to_string(),
+            created_at: Utc::now(),
+        }
     }
 
     async fn payable_base_bounty() -> (BountyNetwork, Bounty, ProofRecord) {

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -434,9 +434,6 @@ struct GetBaseTransactionReceiptRequest {
     request_id: Option<u64>,
     network: Option<String>,
     reconcile_logs: Option<bool>,
-    escrow_contract: Option<String>,
-    settlement_signer: Option<String>,
-    platform_fee_wallet: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2225,9 +2222,22 @@ async fn get_base_transaction_receipt(
     let mut transaction_request = None;
     let mut transaction = None;
     let reconciliation = if request.reconcile_logs.unwrap_or(false) {
+        let escrow_contract =
+            base_escrow_contract_for_chain(network.chain_id).ok_or(StatusCode::BAD_REQUEST)?;
+        let settlement_signer =
+            env::var("BASE_SETTLEMENT_SIGNER").map_err(|_| StatusCode::BAD_REQUEST)?;
+        let platform_fee_wallet = env::var("BASE_PLATFORM_FEE_WALLET").ok();
         let logs = receipt
             .logs_to_evm_logs()
             .map_err(|error| base_rpc_fetch_status(&error))?;
+        let logs = logs
+            .into_iter()
+            .filter(|log| {
+                chain_base::normalize_evm_address(&log.address)
+                    .map(|address| address == escrow_contract)
+                    .unwrap_or(false)
+            })
+            .collect::<Vec<_>>();
         let release_attestations = if logs_contain_release(&logs) {
             let tx_request = eth_get_transaction_by_hash_request(&tx_hash, request_id + 1)
                 .map_err(|error| base_rpc_fetch_status(&error))?;
@@ -2235,25 +2245,26 @@ async fn get_base_transaction_receipt(
                 .await
                 .map_err(|error| base_rpc_fetch_status(&error))?;
             let tx = tx_response.result.ok_or(StatusCode::BAD_REQUEST)?;
-            let escrow_contract = request
-                .escrow_contract
-                .clone()
-                .or_else(|| base_escrow_contract_for_chain(network.chain_id))
-                .ok_or(StatusCode::BAD_REQUEST)?;
-            let settlement_signer = request
-                .settlement_signer
-                .clone()
-                .or_else(|| env::var("BASE_SETTLEMENT_SIGNER").ok())
-                .ok_or(StatusCode::BAD_REQUEST)?;
-            let platform_fee_wallet = request
-                .platform_fee_wallet
-                .clone()
-                .or_else(|| env::var("BASE_PLATFORM_FEE_WALLET").ok())
+            let receipt_tx_hash = receipt
+                .normalized_tx_hash()
+                .map_err(|error| base_rpc_fetch_status(&error))?;
+            if receipt_tx_hash != tx_hash {
+                return Err(StatusCode::BAD_REQUEST);
+            }
+            let transaction_tx_hash = tx
+                .normalized_hash()
+                .map_err(|error| base_rpc_fetch_status(&error))?;
+            if transaction_tx_hash != tx_hash {
+                return Err(StatusCode::BAD_REQUEST);
+            }
+            let chain_id = tx
+                .chain_id()
+                .map_err(|error| base_rpc_fetch_status(&error))?
                 .ok_or(StatusCode::BAD_REQUEST)?;
             let to = tx.to.clone().ok_or(StatusCode::BAD_REQUEST)?;
             let evidence = BaseReleaseTransactionEvidence {
                 tx_hash: tx.hash.clone(),
-                chain_id: network.chain_id,
+                chain_id,
                 expected_chain_id: network.chain_id,
                 from: tx.from.clone(),
                 settlement_signer,
@@ -2409,6 +2420,12 @@ async fn process_base_evm_logs_with_release_attestations(
         for settlement in &settlements {
             store
                 .upsert_settlement(settlement)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        }
+        for attestation in &report.release_attestations {
+            store
+                .upsert_base_release_attestation(attestation)
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         }
@@ -6963,6 +6980,7 @@ mod tests {
                     "from": "0x5555555555555555555555555555555555555555",
                     "to": "0x1111111111111111111111111111111111111111",
                     "input": release_plan.transaction.data,
+                    "chainId": "0x14a34",
                     "blockNumber": "0xb",
                     "transactionIndex": "0x0"
                 }
@@ -6979,6 +6997,18 @@ mod tests {
         let _ = reconcile_base_escrow_event(State(state.clone()), HeaderMap::new(), Json(created))
             .await
             .unwrap();
+        std::env::set_var(
+            "BASE_SETTLEMENT_SIGNER",
+            "0x5555555555555555555555555555555555555555",
+        );
+        std::env::set_var(
+            "BASE_SEPOLIA_ESCROW_CONTRACT",
+            "0x1111111111111111111111111111111111111111",
+        );
+        std::env::set_var(
+            "BASE_PLATFORM_FEE_WALLET",
+            "0x4444444444444444444444444444444444444444",
+        );
 
         let report = get_base_transaction_receipt(
             State(state.clone()),
@@ -6988,9 +7018,6 @@ mod tests {
                 request_id: Some(14),
                 network: Some("base-sepolia".to_string()),
                 reconcile_logs: Some(true),
-                escrow_contract: Some("0x1111111111111111111111111111111111111111".to_string()),
-                settlement_signer: Some("0x5555555555555555555555555555555555555555".to_string()),
-                platform_fee_wallet: Some("0x4444444444444444444444444444444444444444".to_string()),
             }),
         )
         .await

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -4,17 +4,16 @@ use app::{
     ApproveRiskBountyRequest, ApproveRiskPayoutRequest, BaseEscrowReconciliation,
     BaseIndexerHeartbeatStatus, BaseIndexerScanCursor, BaseIndexerStatusConfig,
     BaseIndexerStatusReport, BaseReleaseQueueRequest, BaseReleaseTransactionEvidence,
-    BountyNetwork, BountyStatusResponse,
-    ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
-    FundingIntentReport, LiveMoneyReadinessConfig, LiveMoneyReadinessReport,
-    OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest,
-    PlanBaseReleaseRequest, PlanStripeTransferRequest as AppPlanStripeTransferRequest,
-    PooledFundingReport, PostBountyRequest, QuoteSet, RecordAudienceInteractionRequest,
-    RecordDiscoveryResponseRequest, RecordOutreachAttemptRequest, RegisterAgentRequest,
-    RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
-    ReviewedBountyApproval, RiskEventFilter, StripeTransferPlan, StripeTransferReconciliation,
-    SubmitResultRequest, UpsertAudienceMemberRequest, UpsertContributorContactRequest,
-    VerifySubmissionRequest,
+    BountyNetwork, BountyStatusResponse, ClaimBountyRequest, CreateFundingIntentRequest,
+    CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport, LiveMoneyReadinessConfig,
+    LiveMoneyReadinessReport, OpenPooledBountyRequest, PlanBaseDisputeRequest,
+    PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
+    PlanStripeTransferRequest as AppPlanStripeTransferRequest, PooledFundingReport,
+    PostBountyRequest, QuoteSet, RecordAudienceInteractionRequest, RecordDiscoveryResponseRequest,
+    RecordOutreachAttemptRequest, RegisterAgentRequest, RegisterCapabilityRequest,
+    RejectRiskEventRequest, RequestQuotesRequest, ReviewedBountyApproval, RiskEventFilter,
+    StripeTransferPlan, StripeTransferReconciliation, SubmitResultRequest,
+    UpsertAudienceMemberRequest, UpsertContributorContactRequest, VerifySubmissionRequest,
 };
 use axum::{
     body::Bytes,
@@ -2399,9 +2398,9 @@ async fn process_base_evm_logs_with_release_attestations(
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         }
-        for event in &indexed_events {
+        for attestation in &report.release_attestations {
             store
-                .upsert_base_escrow_event(event)
+                .upsert_base_release_attestation(attestation)
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         }
@@ -2423,9 +2422,9 @@ async fn process_base_evm_logs_with_release_attestations(
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         }
-        for attestation in &report.release_attestations {
+        for event in &indexed_events {
             store
-                .upsert_base_release_attestation(attestation)
+                .upsert_base_escrow_event(event)
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         }
@@ -3231,6 +3230,12 @@ async fn bounty_status_snapshot(
 fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResponse, StatusCode> {
     let bounty_id = scope.bounty.id;
     let base_escrow_events = scope.base_escrow_events;
+    let base_release_attestations = scope
+        .base_release_attestations
+        .into_iter()
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let network = BountyNetwork {
         bounties: [(scope.bounty.id, scope.bounty)].into_iter().collect(),
         funding_intents: scope
@@ -3294,6 +3299,7 @@ fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResp
         .status(bounty_id)
         .map_err(|_| StatusCode::NOT_FOUND)?;
     status.base_escrow_events = base_escrow_events;
+    status.base_release_attestations = base_release_attestations;
     Ok(status)
 }
 

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -34,7 +34,9 @@ use chain_base::{
     RpcTransaction, RpcTransactionReceipt,
 };
 use chrono::Utc;
-use db::{BountyStatusScope, DbError, GitHubIssueSyncBountyUpsert, PostgresStore};
+use db::{
+    BaseLogPersistenceBatch, BountyStatusScope, DbError, GitHubIssueSyncBountyUpsert, PostgresStore,
+};
 use domain::{
     Agent, AudienceInteraction, AudienceMember, AudienceReport, BountyStatus, Capability,
     CapabilityClass, ContributorContact, DiscoveryResponse, EvalRun, HelpRequest, Money,
@@ -2392,43 +2394,19 @@ async fn process_base_evm_logs_with_release_attestations(
     };
 
     if let Some(store) = &state.store {
-        for bounty in &bounties {
-            store
-                .upsert_bounty(bounty)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        }
-        for attestation in &report.release_attestations {
-            store
-                .upsert_base_release_attestation(attestation)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        }
-        for intent in &funding_intents {
-            store
-                .upsert_funding_intent(intent)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        }
-        for escrow in &escrows {
-            store
-                .upsert_escrow(escrow)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        }
-        for settlement in &settlements {
-            store
-                .upsert_settlement(settlement)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        }
-        for event in &indexed_events {
-            store
-                .upsert_base_escrow_event(event)
-                .await
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        }
-        persist_ledger_entries(store, &report.ledger_entries).await?;
+        store
+            .persist_base_log_pipeline(BaseLogPersistenceBatch {
+                bounties: &bounties,
+                release_attestations: &report.release_attestations,
+                funding_intents: &funding_intents,
+                escrows: &escrows,
+                settlements: &settlements,
+                ledger_entries: &report.ledger_entries,
+                base_escrow_events: &indexed_events,
+                cursor: None,
+            })
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     }
 
     Ok(report)

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -3,7 +3,8 @@ use app::{
     hash_artifact, stripe_secret_key_mode_from_secret, AddFundingContributionRequest,
     ApproveRiskBountyRequest, ApproveRiskPayoutRequest, BaseEscrowReconciliation,
     BaseIndexerHeartbeatStatus, BaseIndexerScanCursor, BaseIndexerStatusConfig,
-    BaseIndexerStatusReport, BaseReleaseQueueRequest, BountyNetwork, BountyStatusResponse,
+    BaseIndexerStatusReport, BaseReleaseQueueRequest, BaseReleaseTransactionEvidence,
+    BountyNetwork, BountyStatusResponse,
     ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
     FundingIntentReport, LiveMoneyReadinessConfig, LiveMoneyReadinessReport,
     OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest,
@@ -25,11 +26,13 @@ use axum::{
 };
 use bounty_router::{BountyRouter, RouteDecision};
 use chain_base::{
-    base_network_descriptor, broadcast_signed_transaction, eth_get_transaction_receipt_request,
-    eth_send_raw_transaction_request, fetch_base_escrow_logs, fetch_transaction_receipt,
+    base_network_descriptor, broadcast_signed_transaction, eth_get_transaction_by_hash_request,
+    eth_get_transaction_receipt_request, eth_send_raw_transaction_request, evm_event_topic,
+    fetch_base_escrow_logs, fetch_transaction_by_hash, fetch_transaction_receipt,
     rpc_logs_to_evm_logs, BaseEscrowEvent, BaseEscrowLogQuery, BaseNetworkDescriptor,
-    BaseRpcUrlConfig, ChainBaseError, EthGetLogsRequest, EthGetTransactionReceiptRequest,
-    EthSendRawTransactionRequest, RpcLogSubmission, RpcTransactionReceipt,
+    BaseRpcUrlConfig, ChainBaseError, EthGetLogsRequest, EthGetTransactionByHashRequest,
+    EthGetTransactionReceiptRequest, EthSendRawTransactionRequest, RpcLogSubmission,
+    RpcTransaction, RpcTransactionReceipt,
 };
 use chrono::Utc;
 use db::{BountyStatusScope, DbError, GitHubIssueSyncBountyUpsert, PostgresStore};
@@ -58,7 +61,7 @@ use payments_stripe::{
 };
 use risk::{RiskPolicy, RiskPolicyDescriptor};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::sync::{Arc, Mutex};
 use tower_http::cors::CorsLayer;
@@ -431,6 +434,9 @@ struct GetBaseTransactionReceiptRequest {
     request_id: Option<u64>,
     network: Option<String>,
     reconcile_logs: Option<bool>,
+    escrow_contract: Option<String>,
+    settlement_signer: Option<String>,
+    platform_fee_wallet: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -453,11 +459,13 @@ struct BaseSignedTransactionBroadcastReport {
 struct BaseTransactionReceiptReport {
     network: BaseNetworkDescriptor,
     request: EthGetTransactionReceiptRequest,
+    transaction_request: Option<EthGetTransactionByHashRequest>,
     receipt_found: bool,
     tx_hash: String,
     block_number: Option<u64>,
     succeeded: Option<bool>,
     log_count: usize,
+    transaction: Option<RpcTransaction>,
     receipt: Option<RpcTransactionReceipt>,
     reconciliation: Option<worker::BaseLogPipelineReport>,
 }
@@ -2195,11 +2203,13 @@ async fn get_base_transaction_receipt(
         return Ok(Json(BaseTransactionReceiptReport {
             network,
             request: rpc_request,
+            transaction_request: None,
             receipt_found: false,
             tx_hash,
             block_number: None,
             succeeded: None,
             log_count: 0,
+            transaction: None,
             receipt: None,
             reconciliation: None,
         }));
@@ -2212,11 +2222,57 @@ async fn get_base_transaction_receipt(
         .succeeded()
         .map_err(|error| base_rpc_fetch_status(&error))?;
     let log_count = receipt.logs.len();
+    let mut transaction_request = None;
+    let mut transaction = None;
     let reconciliation = if request.reconcile_logs.unwrap_or(false) {
         let logs = receipt
             .logs_to_evm_logs()
             .map_err(|error| base_rpc_fetch_status(&error))?;
-        Some(process_base_evm_logs(&state, logs).await?)
+        let release_attestations = if logs_contain_release(&logs) {
+            let tx_request = eth_get_transaction_by_hash_request(&tx_hash, request_id + 1)
+                .map_err(|error| base_rpc_fetch_status(&error))?;
+            let tx_response = fetch_transaction_by_hash(&rpc_url, &tx_hash, request_id + 1)
+                .await
+                .map_err(|error| base_rpc_fetch_status(&error))?;
+            let tx = tx_response.result.ok_or(StatusCode::BAD_REQUEST)?;
+            let escrow_contract = request
+                .escrow_contract
+                .clone()
+                .or_else(|| base_escrow_contract_for_chain(network.chain_id))
+                .ok_or(StatusCode::BAD_REQUEST)?;
+            let settlement_signer = request
+                .settlement_signer
+                .clone()
+                .or_else(|| env::var("BASE_SETTLEMENT_SIGNER").ok())
+                .ok_or(StatusCode::BAD_REQUEST)?;
+            let platform_fee_wallet = request
+                .platform_fee_wallet
+                .clone()
+                .or_else(|| env::var("BASE_PLATFORM_FEE_WALLET").ok())
+                .ok_or(StatusCode::BAD_REQUEST)?;
+            let to = tx.to.clone().ok_or(StatusCode::BAD_REQUEST)?;
+            let evidence = BaseReleaseTransactionEvidence {
+                tx_hash: tx.hash.clone(),
+                chain_id: network.chain_id,
+                expected_chain_id: network.chain_id,
+                from: tx.from.clone(),
+                settlement_signer,
+                to,
+                escrow_contract,
+                input: tx.input.clone(),
+                receipt_succeeded: succeeded.unwrap_or(false),
+                platform_fee_wallet,
+            };
+            transaction_request = Some(tx_request);
+            transaction = Some(tx);
+            HashMap::from([(tx_hash.to_ascii_lowercase(), evidence)])
+        } else {
+            HashMap::new()
+        };
+        Some(
+            process_base_evm_logs_with_release_attestations(&state, logs, &release_attestations)
+                .await?,
+        )
     } else {
         None
     };
@@ -2224,14 +2280,25 @@ async fn get_base_transaction_receipt(
     Ok(Json(BaseTransactionReceiptReport {
         network,
         request: rpc_request,
+        transaction_request,
         receipt_found: true,
         tx_hash,
         block_number,
         succeeded,
         log_count,
+        transaction,
         receipt: Some(receipt),
         reconciliation,
     }))
+}
+
+fn logs_contain_release(logs: &[chain_base::EvmLog]) -> bool {
+    let released_topic = evm_event_topic("EscrowReleased(uint256,bytes32)");
+    logs.iter().any(|log| {
+        log.topics
+            .first()
+            .is_some_and(|topic| topic.eq_ignore_ascii_case(&released_topic))
+    })
 }
 
 fn base_rpc_fetch_status(error: &ChainBaseError) -> StatusCode {
@@ -2239,6 +2306,9 @@ fn base_rpc_fetch_status(error: &ChainBaseError) -> StatusCode {
         ChainBaseError::UnknownNetwork(_)
         | ChainBaseError::InvalidAddress(_)
         | ChainBaseError::InvalidBlockRange { .. }
+        | ChainBaseError::InvalidReleaseCalldata(_)
+        | ChainBaseError::ReleaseCalldataMismatch(_)
+        | ChainBaseError::DuplicateReleaseRecipient(_)
         | ChainBaseError::InvalidSignedTransaction(_)
         | ChainBaseError::InvalidTransactionHash(_) => StatusCode::BAD_REQUEST,
         ChainBaseError::MissingRpcUrl { .. } => StatusCode::SERVICE_UNAVAILABLE,
@@ -2250,10 +2320,19 @@ async fn process_base_evm_logs(
     state: &SharedState,
     logs: Vec<chain_base::EvmLog>,
 ) -> Result<worker::BaseLogPipelineReport, StatusCode> {
+    process_base_evm_logs_with_release_attestations(state, logs, &HashMap::new()).await
+}
+
+async fn process_base_evm_logs_with_release_attestations(
+    state: &SharedState,
+    logs: Vec<chain_base::EvmLog>,
+    release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
+) -> Result<worker::BaseLogPipelineReport, StatusCode> {
     let (report, indexed_events, bounties, funding_intents, escrows, settlements) = {
         let mut network = state.network.lock().expect("state poisoned");
         let mut worker = state.base_log_worker.lock().expect("state poisoned");
-        let report = worker.process_logs(logs, &mut network);
+        let report =
+            worker.process_logs_with_release_attestations(logs, &mut network, release_attestations);
         let applied_event_ids = report
             .applied_events
             .iter()
@@ -4088,7 +4167,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn raw_base_evm_log_endpoint_marks_bounty_paid() {
+    async fn raw_base_evm_log_endpoint_requires_release_attestation() {
         let (network, bounty, proof) = payable_base_bounty().await;
         let state = test_state(network);
         let logs = raw_created_and_released_logs(&bounty, &proof);
@@ -4098,15 +4177,18 @@ mod tests {
             .unwrap()
             .0;
 
-        assert!(report.failures.is_empty());
-        assert_eq!(report.applied_events.len(), 2);
-        assert_eq!(report.ledger_entries.len(), 1);
+        assert_eq!(report.failures.len(), 1);
+        assert!(report.failures[0]
+            .reason
+            .contains("requires matching release transaction calldata attestation"));
+        assert_eq!(report.applied_events.len(), 1);
+        assert!(report.ledger_entries.is_empty());
         let network = state.network.lock().expect("state poisoned");
         let status = network.status(bounty.id).unwrap();
-        assert_eq!(status.bounty.status, BountyStatus::Paid);
+        assert_eq!(status.bounty.status, BountyStatus::Payable);
         assert_eq!(
             status.settlements[0].payout_intents[0].status,
-            PayoutStatus::Paid
+            PayoutStatus::Pending
         );
     }
 
@@ -4150,11 +4232,14 @@ mod tests {
         .unwrap()
         .0;
 
-        assert!(report.failures.is_empty());
-        assert_eq!(report.applied_events.len(), 1);
+        assert_eq!(report.failures.len(), 1);
+        assert!(report.failures[0]
+            .reason
+            .contains("requires matching release transaction calldata attestation"));
+        assert!(report.applied_events.is_empty());
         let network = state.network.lock().expect("state poisoned");
         let status = network.status(bounty.id).unwrap();
-        assert_eq!(status.bounty.status, BountyStatus::Paid);
+        assert_eq!(status.bounty.status, BountyStatus::Payable);
     }
 
     #[tokio::test]
@@ -6640,7 +6725,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn base_rpc_log_endpoint_normalizes_provider_logs_and_marks_bounty_paid() {
+    async fn base_rpc_log_endpoint_normalizes_provider_logs_and_requires_release_attestation() {
         let (network, bounty, proof) = payable_base_bounty().await;
         let state = test_state(network);
         let logs = raw_created_and_released_logs(&bounty, &proof)
@@ -6663,15 +6748,19 @@ mod tests {
         .unwrap()
         .0;
 
-        assert_eq!(report.applied_events.len(), 2);
+        assert_eq!(report.applied_events.len(), 1);
+        assert_eq!(report.failures.len(), 1);
+        assert!(report.failures[0]
+            .reason
+            .contains("requires matching release transaction calldata attestation"));
         let status = bounty_status(State(state), Path(bounty.id))
             .await
             .unwrap()
             .0;
-        assert_eq!(status.bounty.status, BountyStatus::Paid);
+        assert_eq!(status.bounty.status, BountyStatus::Payable);
         assert_eq!(
             status.settlements[0].payout_intents[0].status,
-            PayoutStatus::Paid
+            PayoutStatus::Pending
         );
     }
 
@@ -6732,7 +6821,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn base_fetch_rpc_logs_endpoint_fetches_provider_logs_and_marks_bounty_paid() {
+    async fn base_fetch_rpc_logs_endpoint_fetches_provider_logs_and_requires_release_attestation() {
         let (network, bounty, proof) = payable_base_bounty().await;
         let logs = raw_created_and_released_logs(&bounty, &proof)
             .into_iter()
@@ -6764,15 +6853,19 @@ mod tests {
         assert_eq!(report.request.method, "eth_getLogs");
         assert_eq!(report.request.params[0].from_block, "0xa");
         assert_eq!(report.fetched_logs, 2);
-        assert_eq!(report.reconciliation.applied_events.len(), 2);
+        assert_eq!(report.reconciliation.applied_events.len(), 1);
+        assert_eq!(report.reconciliation.failures.len(), 1);
+        assert!(report.reconciliation.failures[0]
+            .reason
+            .contains("requires matching release transaction calldata attestation"));
         let status = bounty_status(State(state), Path(bounty.id))
             .await
             .unwrap()
             .0;
-        assert_eq!(status.bounty.status, BountyStatus::Paid);
+        assert_eq!(status.bounty.status, BountyStatus::Payable);
         assert_eq!(
             status.settlements[0].payout_intents[0].status,
-            PayoutStatus::Paid
+            PayoutStatus::Pending
         );
     }
 
@@ -6843,16 +6936,38 @@ mod tests {
         let (network, bounty, proof) = payable_base_bounty().await;
         let release_log = raw_released_log(7, &format!("0x{}", proof.proof_hash), 11, 0);
         let receipt_tx_hash = release_log.tx_hash.clone();
-        let rpc_url = spawn_rpc_response(serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 14,
-            "result": {
-                "transactionHash": receipt_tx_hash.clone(),
-                "blockNumber": "0xb",
-                "status": "0x1",
-                "logs": [rpc_log_from_evm_log(release_log)]
-            }
-        }));
+        let release_plan = network
+            .plan_base_release(PlanBaseReleaseRequest {
+                bounty_id: bounty.id,
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+                network: Some("base-sepolia".to_string()),
+            })
+            .unwrap();
+        let rpc_url = spawn_rpc_responses(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 14,
+                "result": {
+                    "transactionHash": receipt_tx_hash.clone(),
+                    "blockNumber": "0xb",
+                    "status": "0x1",
+                    "logs": [rpc_log_from_evm_log(release_log)]
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 15,
+                "result": {
+                    "hash": receipt_tx_hash.clone(),
+                    "from": "0x5555555555555555555555555555555555555555",
+                    "to": "0x1111111111111111111111111111111111111111",
+                    "input": release_plan.transaction.data,
+                    "blockNumber": "0xb",
+                    "transactionIndex": "0x0"
+                }
+            }),
+        ]);
         let state = test_state_with_base_rpc(network, rpc_url);
         let created = chain_base::simulated_created_event(
             bounty.id,
@@ -6873,6 +6988,9 @@ mod tests {
                 request_id: Some(14),
                 network: Some("base-sepolia".to_string()),
                 reconcile_logs: Some(true),
+                escrow_contract: Some("0x1111111111111111111111111111111111111111".to_string()),
+                settlement_signer: Some("0x5555555555555555555555555555555555555555".to_string()),
+                platform_fee_wallet: Some("0x4444444444444444444444444444444444444444".to_string()),
             }),
         )
         .await
@@ -7351,19 +7469,25 @@ mod tests {
     }
 
     fn spawn_rpc_response(response: serde_json::Value) -> String {
+        spawn_rpc_responses(vec![response])
+    }
+
+    fn spawn_rpc_responses(responses: Vec<serde_json::Value>) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut buffer = [0u8; 8192];
-            let _ = stream.read(&mut buffer).unwrap();
-            let body = response.to_string();
-            let response = format!(
-                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                body.len(),
-                body
-            );
-            stream.write_all(response.as_bytes()).unwrap();
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buffer = [0u8; 8192];
+                let _ = stream.read(&mut buffer).unwrap();
+                let body = response.to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+            }
         });
         format!("http://{address}")
     }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1153,6 +1153,8 @@ pub struct BountyStatusResponse {
     pub escrows: Vec<Escrow>,
     #[serde(default)]
     pub base_escrow_events: Vec<BaseEscrowEvent>,
+    #[serde(default)]
+    pub base_release_attestations: Vec<Value>,
     pub claims: Vec<Claim>,
     pub submissions: Vec<Submission>,
     pub verifier_results: Vec<VerifierResult>,
@@ -2740,13 +2742,6 @@ impl BountyNetwork {
         event: BaseEscrowEvent,
         evidence: BaseReleaseTransactionEvidence,
     ) -> AppResult<BaseEscrowReconciliation> {
-        if event.kind == BaseEscrowEventKind::Released
-            && self
-                .ledger
-                .has_external_event(&format!("base-release:{}", event.log_key))
-        {
-            return self.apply_base_escrow_event_inner(event, None);
-        }
         let attestation = self.attest_base_release_event(&event, &evidence)?;
         self.apply_base_escrow_event_inner(event, Some(attestation))
     }
@@ -2960,7 +2955,7 @@ impl BountyNetwork {
             ));
         }
 
-        let expected_call = self.pending_base_release_call_for_attestation(
+        let expected_call = self.base_release_call_for_attestation(
             event.bounty_id,
             event.onchain_escrow_id,
             evidence.platform_fee_wallet.clone(),
@@ -2992,7 +2987,7 @@ impl BountyNetwork {
         })
     }
 
-    fn pending_base_release_call_for_attestation(
+    fn base_release_call_for_attestation(
         &self,
         bounty_id: Id,
         onchain_escrow_id: u128,
@@ -3004,15 +2999,14 @@ impl BountyNetwork {
             .find(|settlement| {
                 settlement.bounty_id == bounty_id
                     && settlement.rail == PaymentRail::BaseUsdc
-                    && settlement
-                        .payout_intents
-                        .iter()
-                        .any(|intent| intent.status == PayoutStatus::Pending)
+                    && settlement.payout_intents.iter().any(|intent| {
+                        matches!(intent.status, PayoutStatus::Pending | PayoutStatus::Paid)
+                    })
             })
             .cloned()
             .ok_or_else(|| {
                 AppError::InvalidBaseEscrowEvent(
-                    "released event has no pending Base settlement".to_string(),
+                    "released event has no Base settlement to attest".to_string(),
                 )
             })?;
         let proof = self
@@ -3027,7 +3021,7 @@ impl BountyNetwork {
             .payout_intents
             .iter()
             .filter(|intent| intent.rail == PaymentRail::BaseUsdc)
-            .filter(|intent| intent.status == PayoutStatus::Pending)
+            .filter(|intent| matches!(intent.status, PayoutStatus::Pending | PayoutStatus::Paid))
             .map(|intent| {
                 let agent = self.agents.get(&intent.recipient_agent_id).ok_or_else(|| {
                     AppError::InvalidBaseEscrowEvent(format!(
@@ -3442,6 +3436,7 @@ impl BountyNetwork {
             funding_contributions,
             escrows,
             base_escrow_events: Vec::new(),
+            base_release_attestations: Vec::new(),
             claims,
             submissions,
             verifier_results,
@@ -6403,6 +6398,17 @@ mod tests {
         assert_eq!(paid_agent_payouts.totals[0].pending_minor, 0);
         assert_eq!(paid_agent_payouts.totals[0].paid_minor, 1_000_000);
         assert_eq!(paid_status.template_signals.len(), 1);
+        assert_eq!(network.ledger.entries().len(), 2);
+
+        let mut mismatched_replay_evidence = release_evidence.clone();
+        mismatched_replay_evidence.input = "0xdeadbeef".to_string();
+        let mismatched_replay = network
+            .apply_attested_base_release_event(released.clone(), mismatched_replay_evidence)
+            .unwrap_err();
+        assert!(matches!(
+            mismatched_replay,
+            AppError::InvalidBaseEscrowEvent(_)
+        ));
         assert_eq!(network.ledger.entries().len(), 2);
 
         let replay = network

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1094,7 +1094,7 @@ pub struct BaseReleaseTransactionEvidence {
     pub escrow_contract: String,
     pub input: String,
     pub receipt_succeeded: bool,
-    pub platform_fee_wallet: String,
+    pub platform_fee_wallet: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2996,7 +2996,7 @@ impl BountyNetwork {
         &self,
         bounty_id: Id,
         onchain_escrow_id: u128,
-        platform_fee_wallet: String,
+        platform_fee_wallet: Option<String>,
     ) -> AppResult<BaseEscrowReleaseCall> {
         let settlement = self
             .settlements
@@ -3048,6 +3048,12 @@ impl BountyNetwork {
             })
             .collect::<AppResult<Vec<_>>>()?;
         if settlement.platform_fee.amount > 0 {
+            let platform_fee_wallet = platform_fee_wallet.ok_or_else(|| {
+                AppError::InvalidBaseEscrowEvent(
+                    "platform fee wallet is required for fee-bearing Base release attestation"
+                        .to_string(),
+                )
+            })?;
             recipients.push(EscrowRecipient {
                 address: platform_fee_wallet,
                 amount: settlement.platform_fee.clone(),
@@ -6377,7 +6383,7 @@ mod tests {
             escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
             input: release_plan.transaction.data.clone(),
             receipt_succeeded: true,
-            platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+            platform_fee_wallet: Some("0x4444444444444444444444444444444444444444".to_string()),
         };
         let reconciliation = network
             .apply_attested_base_release_event(released.clone(), release_evidence.clone())
@@ -7077,7 +7083,9 @@ mod tests {
                     escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
                     input: release_plan.transaction.data.clone(),
                     receipt_succeeded: true,
-                    platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+                    platform_fee_wallet: Some(
+                        "0x4444444444444444444444444444444444444444".to_string(),
+                    ),
                 },
             )
             .unwrap_err();
@@ -7103,7 +7111,9 @@ mod tests {
                     escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
                     input: release_plan.transaction.data.clone(),
                     receipt_succeeded: true,
-                    platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+                    platform_fee_wallet: Some(
+                        "0x4444444444444444444444444444444444444444".to_string(),
+                    ),
                 },
             )
             .unwrap();
@@ -7636,7 +7646,9 @@ mod tests {
                     escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
                     input: release_plan.transaction.data.clone(),
                     receipt_succeeded: true,
-                    platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
+                    platform_fee_wallet: Some(
+                        "0x5555555555555555555555555555555555555555".to_string(),
+                    ),
                 },
             )
             .unwrap();

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1145,6 +1145,20 @@ pub struct BaseReleaseQueueItem {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseReleaseAttestationStatus {
+    pub network: String,
+    pub tx_hash: String,
+    pub log_key: String,
+    pub bounty_id: Id,
+    pub onchain_escrow_id: String,
+    pub calldata_hash: Option<String>,
+    pub proof_hash: Option<String>,
+    pub recipient_count: usize,
+    pub verdict: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BountyStatusResponse {
     pub bounty: Bounty,
     pub funding_summary: PooledFundingSummary,
@@ -1154,7 +1168,7 @@ pub struct BountyStatusResponse {
     #[serde(default)]
     pub base_escrow_events: Vec<BaseEscrowEvent>,
     #[serde(default)]
-    pub base_release_attestations: Vec<Value>,
+    pub base_release_attestations: Vec<BaseReleaseAttestationStatus>,
     pub claims: Vec<Claim>,
     pub submissions: Vec<Submission>,
     pub verifier_results: Vec<VerifierResult>,

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -2836,8 +2836,7 @@ impl BountyNetwork {
             }
             BaseEscrowEventKind::Released => {
                 let release_event_id = format!("base-release:{}", event.log_key);
-                let already_released = self.ledger.has_external_event(&release_event_id);
-                if release_attestation.is_none() && !already_released {
+                if release_attestation.is_none() {
                     return Err(AppError::InvalidBaseEscrowEvent(
                         "released event requires matching release transaction calldata attestation"
                             .to_string(),

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,6 +1,7 @@
 use bounty_router::{template_for_class, BountyRouter};
 use chain_base::{
-    base_network_descriptor, BaseEscrowCreate, BaseEscrowEvent, BaseEscrowEventKind,
+    attest_base_release_calldata, base_network_descriptor, normalize_evm_address,
+    normalize_evm_hash, BaseEscrowCreate, BaseEscrowEvent, BaseEscrowEventKind,
     BaseEscrowFundingPlan, BaseEscrowRelease, BaseEscrowReleaseCall, BaseEscrowTxPlanner,
     BaseNetworkDescriptor, ChainBaseError, EscrowRecipient, EvmTransactionIntent,
 };
@@ -1083,6 +1084,32 @@ pub struct BaseReleasePlan {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseReleaseTransactionEvidence {
+    pub tx_hash: String,
+    pub chain_id: u64,
+    pub expected_chain_id: u64,
+    pub from: String,
+    pub settlement_signer: String,
+    pub to: String,
+    pub escrow_contract: String,
+    pub input: String,
+    pub receipt_succeeded: bool,
+    pub platform_fee_wallet: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseReleaseAttestation {
+    pub tx_hash: String,
+    pub calldata_hash: String,
+    pub chain_id: u64,
+    pub onchain_escrow_id: u128,
+    pub proof_hash: String,
+    pub recipients: Vec<EscrowRecipient>,
+    pub passed: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BaseRefundPlan {
     pub network: BaseNetworkDescriptor,
     pub bounty: Bounty,
@@ -1216,6 +1243,8 @@ pub struct BaseEscrowReconciliation {
     pub funding_intents: Vec<FundingIntent>,
     pub settlements: Vec<Settlement>,
     pub ledger_entries: Vec<LedgerEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release_attestation: Option<BaseReleaseAttestation>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2703,6 +2732,30 @@ impl BountyNetwork {
         &mut self,
         event: BaseEscrowEvent,
     ) -> AppResult<BaseEscrowReconciliation> {
+        self.apply_base_escrow_event_inner(event, None)
+    }
+
+    pub fn apply_attested_base_release_event(
+        &mut self,
+        event: BaseEscrowEvent,
+        evidence: BaseReleaseTransactionEvidence,
+    ) -> AppResult<BaseEscrowReconciliation> {
+        if event.kind == BaseEscrowEventKind::Released
+            && self
+                .ledger
+                .has_external_event(&format!("base-release:{}", event.log_key))
+        {
+            return self.apply_base_escrow_event_inner(event, None);
+        }
+        let attestation = self.attest_base_release_event(&event, &evidence)?;
+        self.apply_base_escrow_event_inner(event, Some(attestation))
+    }
+
+    fn apply_base_escrow_event_inner(
+        &mut self,
+        event: BaseEscrowEvent,
+        release_attestation: Option<BaseReleaseAttestation>,
+    ) -> AppResult<BaseEscrowReconciliation> {
         if event.onchain_escrow_id == 0 {
             return Err(AppError::InvalidBaseEscrowEvent(
                 "onchain escrow id must be non-zero".to_string(),
@@ -2787,16 +2840,22 @@ impl BountyNetwork {
                 self.mark_bounty_claimable_if_fully_funded(event.bounty_id)?;
             }
             BaseEscrowEventKind::Released => {
+                let release_event_id = format!("base-release:{}", event.log_key);
+                let already_released = self.ledger.has_external_event(&release_event_id);
+                if release_attestation.is_none() && !already_released {
+                    return Err(AppError::InvalidBaseEscrowEvent(
+                        "released event requires matching release transaction calldata attestation"
+                            .to_string(),
+                    ));
+                }
                 let proof_hash = event.proof_hash.clone().ok_or_else(|| {
                     AppError::InvalidBaseEscrowEvent(
                         "released event must include proof hash".to_string(),
                     )
                 })?;
-                if let Some(entry) = self.mark_base_release_paid(
-                    event.bounty_id,
-                    &proof_hash,
-                    format!("base-release:{}", event.log_key),
-                )? {
+                if let Some(entry) =
+                    self.mark_base_release_paid(event.bounty_id, &proof_hash, release_event_id)?
+                {
                     ledger_entries.push(entry);
                 }
                 self.update_base_escrow_status(escrow_id, EscrowStatus::Released)?;
@@ -2848,6 +2907,164 @@ impl BountyNetwork {
             funding_intents,
             settlements,
             ledger_entries,
+            release_attestation,
+        })
+    }
+
+    fn attest_base_release_event(
+        &self,
+        event: &BaseEscrowEvent,
+        evidence: &BaseReleaseTransactionEvidence,
+    ) -> AppResult<BaseReleaseAttestation> {
+        if event.kind != BaseEscrowEventKind::Released {
+            return Err(AppError::InvalidBaseEscrowEvent(
+                "release attestation can only be applied to released events".to_string(),
+            ));
+        }
+        if !evidence.receipt_succeeded {
+            return Err(AppError::InvalidBaseEscrowEvent(
+                "release transaction receipt did not succeed".to_string(),
+            ));
+        }
+        if evidence.chain_id != evidence.expected_chain_id {
+            return Err(AppError::InvalidBaseEscrowEvent(format!(
+                "release transaction chain {} does not match expected chain {}",
+                evidence.chain_id, evidence.expected_chain_id
+            )));
+        }
+        let event_tx_hash = normalize_evm_hash(&event.tx_hash)
+            .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?;
+        let evidence_tx_hash = normalize_evm_hash(&evidence.tx_hash)
+            .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?;
+        if event_tx_hash != evidence_tx_hash {
+            return Err(AppError::InvalidBaseEscrowEvent(
+                "release log transaction hash does not match transaction evidence".to_string(),
+            ));
+        }
+        let tx_to = normalize_evm_address(&evidence.to)
+            .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?;
+        let expected_to = normalize_evm_address(&evidence.escrow_contract)
+            .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?;
+        if tx_to != expected_to {
+            return Err(AppError::InvalidBaseEscrowEvent(
+                "release transaction target is not the configured escrow contract".to_string(),
+            ));
+        }
+        let tx_from = normalize_evm_address(&evidence.from)
+            .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?;
+        let expected_from = normalize_evm_address(&evidence.settlement_signer)
+            .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?;
+        if tx_from != expected_from {
+            return Err(AppError::InvalidBaseEscrowEvent(
+                "release transaction signer is not the configured settlement signer".to_string(),
+            ));
+        }
+
+        let expected_call = self.pending_base_release_call_for_attestation(
+            event.bounty_id,
+            event.onchain_escrow_id,
+            evidence.platform_fee_wallet.clone(),
+        )?;
+        let proof_hash = event.proof_hash.clone().ok_or_else(|| {
+            AppError::InvalidBaseEscrowEvent("released event must include proof hash".to_string())
+        })?;
+        if normalize_evm_hash(&proof_hash)
+            .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?
+            != normalize_evm_hash(&expected_call.proof_hash)
+                .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?
+        {
+            return Err(AppError::InvalidBaseEscrowEvent(
+                "released event proof hash does not match accepted proof".to_string(),
+            ));
+        }
+
+        let calldata = attest_base_release_calldata(&evidence.input, &expected_call)
+            .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?;
+        Ok(BaseReleaseAttestation {
+            tx_hash: evidence_tx_hash,
+            calldata_hash: calldata.calldata_hash,
+            chain_id: evidence.chain_id,
+            onchain_escrow_id: calldata.onchain_escrow_id,
+            proof_hash: calldata.proof_hash,
+            recipients: calldata.recipients,
+            passed: true,
+            reason: "release calldata matches pending Base settlement plan".to_string(),
+        })
+    }
+
+    fn pending_base_release_call_for_attestation(
+        &self,
+        bounty_id: Id,
+        onchain_escrow_id: u128,
+        platform_fee_wallet: String,
+    ) -> AppResult<BaseEscrowReleaseCall> {
+        let settlement = self
+            .settlements
+            .values()
+            .find(|settlement| {
+                settlement.bounty_id == bounty_id
+                    && settlement.rail == PaymentRail::BaseUsdc
+                    && settlement
+                        .payout_intents
+                        .iter()
+                        .any(|intent| intent.status == PayoutStatus::Pending)
+            })
+            .cloned()
+            .ok_or_else(|| {
+                AppError::InvalidBaseEscrowEvent(
+                    "released event has no pending Base settlement".to_string(),
+                )
+            })?;
+        let proof = self
+            .proofs
+            .get(&settlement.proof_record_id)
+            .ok_or_else(|| {
+                AppError::InvalidBaseEscrowEvent(
+                    "released event has no matching proof record".to_string(),
+                )
+            })?;
+        let mut recipients = settlement
+            .payout_intents
+            .iter()
+            .filter(|intent| intent.rail == PaymentRail::BaseUsdc)
+            .filter(|intent| intent.status == PayoutStatus::Pending)
+            .map(|intent| {
+                let agent = self.agents.get(&intent.recipient_agent_id).ok_or_else(|| {
+                    AppError::InvalidBaseEscrowEvent(format!(
+                        "recipient agent {} is missing",
+                        intent.recipient_agent_id
+                    ))
+                })?;
+                let address = agent.payout_wallet.clone().ok_or_else(|| {
+                    AppError::InvalidBaseEscrowEvent(format!(
+                        "recipient agent {} has no payout wallet",
+                        agent.id
+                    ))
+                })?;
+                Ok(EscrowRecipient {
+                    address,
+                    amount: intent.amount.clone(),
+                })
+            })
+            .collect::<AppResult<Vec<_>>>()?;
+        if settlement.platform_fee.amount > 0 {
+            recipients.push(EscrowRecipient {
+                address: platform_fee_wallet,
+                amount: settlement.platform_fee.clone(),
+            });
+        }
+        BaseEscrowRelease {
+            escrow_id: base_escrow_uuid(bounty_id, onchain_escrow_id),
+            recipients: recipients.clone(),
+            proof_hash: proof.proof_hash.clone(),
+        }
+        .validate_split(&settlement_total_amount(&settlement)?)
+        .map_err(|error| AppError::InvalidBaseEscrowEvent(error.to_string()))?;
+
+        Ok(BaseEscrowReleaseCall {
+            onchain_escrow_id,
+            recipients,
+            proof_hash: proof.proof_hash.clone(),
         })
     }
 
@@ -6142,8 +6359,31 @@ mod tests {
         );
         assert!(release_plan.transaction.data.starts_with("0xbfc95334"));
         let released = chain_base::simulated_released_event(bounty.id, 1, proof.proof_hash);
-        let reconciliation = network.apply_base_escrow_event(released.clone()).unwrap();
+        let untrusted_release = network
+            .apply_base_escrow_event(released.clone())
+            .unwrap_err();
+        assert!(matches!(
+            untrusted_release,
+            AppError::InvalidBaseEscrowEvent(message)
+                if message.contains("requires matching release transaction calldata attestation")
+        ));
+        let release_evidence = BaseReleaseTransactionEvidence {
+            tx_hash: released.tx_hash.clone(),
+            chain_id: release_plan.network.chain_id,
+            expected_chain_id: release_plan.network.chain_id,
+            from: "0x5555555555555555555555555555555555555555".to_string(),
+            settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+            to: release_plan.transaction.to.clone(),
+            escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+            input: release_plan.transaction.data.clone(),
+            receipt_succeeded: true,
+            platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+        };
+        let reconciliation = network
+            .apply_attested_base_release_event(released.clone(), release_evidence.clone())
+            .unwrap();
         assert_eq!(reconciliation.ledger_entries.len(), 1);
+        assert!(reconciliation.release_attestation.is_some());
 
         let paid_status = network.status(bounty.id).unwrap();
         assert_eq!(paid_status.bounty.status, BountyStatus::Paid);
@@ -6159,7 +6399,9 @@ mod tests {
         assert_eq!(paid_status.template_signals.len(), 1);
         assert_eq!(network.ledger.entries().len(), 2);
 
-        let replay = network.apply_base_escrow_event(released).unwrap();
+        let replay = network
+            .apply_attested_base_release_event(released, release_evidence)
+            .unwrap();
         assert!(replay.ledger_entries.is_empty());
         assert_eq!(network.ledger.entries().len(), 2);
     }
@@ -6811,13 +7053,33 @@ mod tests {
             })
             .await
             .unwrap();
+        let release_plan = network
+            .plan_base_release(PlanBaseReleaseRequest {
+                bounty_id: bounty.id,
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+                network: Some("base-mainnet".to_string()),
+            })
+            .unwrap();
 
+        let wrong_proof_release =
+            chain_base::simulated_released_event(bounty.id, 9, format!("0x{}", "00".repeat(32)));
         let err = network
-            .apply_base_escrow_event(chain_base::simulated_released_event(
-                bounty.id,
-                9,
-                format!("0x{}", "00".repeat(32)),
-            ))
+            .apply_attested_base_release_event(
+                wrong_proof_release.clone(),
+                BaseReleaseTransactionEvidence {
+                    tx_hash: wrong_proof_release.tx_hash.clone(),
+                    chain_id: release_plan.network.chain_id,
+                    expected_chain_id: release_plan.network.chain_id,
+                    from: "0x5555555555555555555555555555555555555555".to_string(),
+                    settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+                    to: release_plan.transaction.to.clone(),
+                    escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                    input: release_plan.transaction.data.clone(),
+                    receipt_succeeded: true,
+                    platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+                },
+            )
             .unwrap_err();
         assert!(matches!(err, AppError::InvalidBaseEscrowEvent(_)));
         let status = network.status(bounty.id).unwrap();
@@ -6827,12 +7089,23 @@ mod tests {
             PayoutStatus::Pending
         );
 
+        let released = chain_base::simulated_released_event(bounty.id, 9, proof.proof_hash);
         network
-            .apply_base_escrow_event(chain_base::simulated_released_event(
-                bounty.id,
-                9,
-                proof.proof_hash,
-            ))
+            .apply_attested_base_release_event(
+                released.clone(),
+                BaseReleaseTransactionEvidence {
+                    tx_hash: released.tx_hash.clone(),
+                    chain_id: release_plan.network.chain_id,
+                    expected_chain_id: release_plan.network.chain_id,
+                    from: "0x5555555555555555555555555555555555555555".to_string(),
+                    settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+                    to: release_plan.transaction.to.clone(),
+                    escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                    input: release_plan.transaction.data.clone(),
+                    receipt_succeeded: true,
+                    platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+                },
+            )
             .unwrap();
         let status = network.status(bounty.id).unwrap();
         assert_eq!(status.bounty.status, BountyStatus::Paid);
@@ -7348,12 +7621,24 @@ mod tests {
             })
             .unwrap();
         assert_eq!(release_plan.release_call.recipients.len(), 1);
+        let released =
+            chain_base::simulated_released_event(bounty.id, 42, proof.proof_hash.clone());
         network
-            .apply_base_escrow_event(chain_base::simulated_released_event(
-                bounty.id,
-                42,
-                proof.proof_hash.clone(),
-            ))
+            .apply_attested_base_release_event(
+                released.clone(),
+                BaseReleaseTransactionEvidence {
+                    tx_hash: released.tx_hash.clone(),
+                    chain_id: release_plan.network.chain_id,
+                    expected_chain_id: release_plan.network.chain_id,
+                    from: "0x5555555555555555555555555555555555555555".to_string(),
+                    settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+                    to: release_plan.transaction.to.clone(),
+                    escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                    input: release_plan.transaction.data.clone(),
+                    receipt_succeeded: true,
+                    platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
+                },
+            )
             .unwrap();
         let after_base = network.status(bounty.id).unwrap();
         assert_eq!(after_base.bounty.status, BountyStatus::Payable);

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -16,6 +16,12 @@ pub enum ChainBaseError {
     DuplicateLog,
     #[error("invalid escrow release split")]
     InvalidReleaseSplit,
+    #[error("invalid escrow release calldata: {0}")]
+    InvalidReleaseCalldata(String),
+    #[error("escrow release calldata does not match plan: {0}")]
+    ReleaseCalldataMismatch(String),
+    #[error("duplicate escrow release recipient: {0}")]
+    DuplicateReleaseRecipient(String),
     #[error("invalid EVM address: {0}")]
     InvalidAddress(String),
     #[error("invalid bytes32 hex value: {0}")]
@@ -67,7 +73,7 @@ pub struct BaseEscrowCreate {
     pub terms_hash: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EscrowRecipient {
     pub address: String,
     pub amount: Money,
@@ -85,6 +91,21 @@ pub struct BaseEscrowReleaseCall {
     pub onchain_escrow_id: u128,
     pub recipients: Vec<EscrowRecipient>,
     pub proof_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecodedBaseEscrowReleaseCall {
+    pub onchain_escrow_id: u128,
+    pub recipients: Vec<EscrowRecipient>,
+    pub proof_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BaseReleaseCalldataAttestation {
+    pub calldata_hash: String,
+    pub onchain_escrow_id: u128,
+    pub proof_hash: String,
+    pub recipients: Vec<EscrowRecipient>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -273,6 +294,130 @@ impl BaseEscrowRelease {
     }
 }
 
+pub fn decode_base_release_calldata(
+    data: &str,
+    currency: impl Into<String>,
+) -> Result<DecodedBaseEscrowReleaseCall, ChainBaseError> {
+    let currency = currency.into();
+    let bytes = calldata_bytes(data)?;
+    let expected_selector = selector("release(uint256,address[],uint256[],bytes32)");
+    if bytes.len() < 4 || bytes[..4] != expected_selector {
+        return Err(ChainBaseError::InvalidReleaseCalldata(
+            "wrong release selector".to_string(),
+        ));
+    }
+    let args = &bytes[4..];
+    if args.len() < 32 * 4 {
+        return Err(ChainBaseError::InvalidReleaseCalldata(
+            "missing release static arguments".to_string(),
+        ));
+    }
+
+    let onchain_escrow_id = word_to_u128(read_calldata_word(args, 0)?)?;
+    let recipients_offset = calldata_offset(read_calldata_word(args, 1)?)?;
+    let amounts_offset = calldata_offset(read_calldata_word(args, 2)?)?;
+    let proof_hash = word_hex(read_calldata_word(args, 3)?);
+    let recipient_words = read_dynamic_words(args, recipients_offset)?;
+    let amount_words = read_dynamic_words(args, amounts_offset)?;
+    if recipient_words.len() != amount_words.len() {
+        return Err(ChainBaseError::InvalidReleaseCalldata(
+            "recipient and amount array lengths differ".to_string(),
+        ));
+    }
+
+    let mut seen = HashSet::new();
+    let mut recipients = Vec::with_capacity(recipient_words.len());
+    for (recipient_word, amount_word) in recipient_words.into_iter().zip(amount_words) {
+        let address = normalize_address(address_from_word(recipient_word))?;
+        if !seen.insert(address.clone()) {
+            return Err(ChainBaseError::DuplicateReleaseRecipient(address));
+        }
+        let amount = word_to_u128(amount_word)?;
+        let amount = i64::try_from(amount).map_err(|_| ChainBaseError::InvalidAmount)?;
+        recipients.push(EscrowRecipient {
+            address,
+            amount: Money::new(amount, currency.clone())
+                .map_err(|_| ChainBaseError::InvalidAmount)?,
+        });
+    }
+    validate_release_recipients(&recipients)?;
+
+    Ok(DecodedBaseEscrowReleaseCall {
+        onchain_escrow_id,
+        recipients,
+        proof_hash,
+    })
+}
+
+pub fn attest_base_release_calldata(
+    data: &str,
+    expected: &BaseEscrowReleaseCall,
+) -> Result<BaseReleaseCalldataAttestation, ChainBaseError> {
+    validate_release_recipients(&expected.recipients)?;
+    let currency = expected.recipients[0].amount.currency.clone();
+    let decoded = decode_base_release_calldata(data, currency)?;
+    if decoded.onchain_escrow_id != expected.onchain_escrow_id {
+        return Err(ChainBaseError::ReleaseCalldataMismatch(
+            "escrow id differs".to_string(),
+        ));
+    }
+    if normalize_hash(&decoded.proof_hash)? != normalize_hash(&expected.proof_hash)? {
+        return Err(ChainBaseError::ReleaseCalldataMismatch(
+            "proof hash differs".to_string(),
+        ));
+    }
+    if decoded.recipients.len() != expected.recipients.len() {
+        return Err(ChainBaseError::ReleaseCalldataMismatch(
+            "recipient count differs".to_string(),
+        ));
+    }
+
+    let mut expected_seen = HashSet::new();
+    for (index, (actual, expected)) in decoded
+        .recipients
+        .iter()
+        .zip(expected.recipients.iter())
+        .enumerate()
+    {
+        let expected_address = normalize_address(&expected.address)?;
+        if !expected_seen.insert(expected_address.clone()) {
+            return Err(ChainBaseError::DuplicateReleaseRecipient(expected_address));
+        }
+        if actual.address != expected_address {
+            return Err(ChainBaseError::ReleaseCalldataMismatch(format!(
+                "recipient {index} address differs"
+            )));
+        }
+        if actual.amount != expected.amount {
+            return Err(ChainBaseError::ReleaseCalldataMismatch(format!(
+                "recipient {index} amount differs"
+            )));
+        }
+    }
+
+    Ok(BaseReleaseCalldataAttestation {
+        calldata_hash: calldata_keccak256(data)?,
+        onchain_escrow_id: decoded.onchain_escrow_id,
+        proof_hash: decoded.proof_hash,
+        recipients: decoded.recipients,
+    })
+}
+
+pub fn normalize_evm_address(address: impl AsRef<str>) -> Result<String, ChainBaseError> {
+    normalize_address(address)
+}
+
+pub fn normalize_evm_hash(hash: &str) -> Result<String, ChainBaseError> {
+    normalize_hash(hash)
+}
+
+pub fn calldata_keccak256(data: &str) -> Result<String, ChainBaseError> {
+    let bytes = calldata_bytes(data)?;
+    let mut hasher = Keccak256::new();
+    hasher.update(&bytes);
+    Ok(format!("0x{}", hex::encode(hasher.finalize())))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BaseEscrowEventKind {
     Created,
@@ -368,10 +513,25 @@ pub struct EthGetTransactionReceiptRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EthGetTransactionByHashRequest {
+    pub jsonrpc: String,
+    pub id: u64,
+    pub method: String,
+    pub params: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EthGetTransactionReceiptResponse {
     pub jsonrpc: String,
     pub id: u64,
     pub result: Option<RpcTransactionReceipt>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EthGetTransactionByHashResponse {
+    pub jsonrpc: String,
+    pub id: u64,
+    pub result: Option<RpcTransaction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -440,6 +600,16 @@ pub struct EthGetTransactionReceiptEnvelope {
     pub id: u64,
     #[serde(default)]
     pub result: Option<RpcTransactionReceipt>,
+    #[serde(default)]
+    pub error: Option<EthJsonRpcError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EthGetTransactionByHashEnvelope {
+    pub jsonrpc: String,
+    pub id: u64,
+    #[serde(default)]
+    pub result: Option<RpcTransaction>,
     #[serde(default)]
     pub error: Option<EthJsonRpcError>,
 }
@@ -531,6 +701,24 @@ impl TryFrom<EthGetTransactionReceiptEnvelope> for EthGetTransactionReceiptRespo
     }
 }
 
+impl TryFrom<EthGetTransactionByHashEnvelope> for EthGetTransactionByHashResponse {
+    type Error = ChainBaseError;
+
+    fn try_from(envelope: EthGetTransactionByHashEnvelope) -> Result<Self, Self::Error> {
+        if let Some(error) = envelope.error {
+            return Err(ChainBaseError::RpcProviderError {
+                code: error.code,
+                message: error.message,
+            });
+        }
+        Ok(Self {
+            jsonrpc: envelope.jsonrpc,
+            id: envelope.id,
+            result: envelope.result,
+        })
+    }
+}
+
 impl TryFrom<EthBlockNumberEnvelope> for EthBlockNumberResponse {
     type Error = ChainBaseError;
 
@@ -575,6 +763,18 @@ pub struct RpcTransactionReceipt {
     pub status: Option<String>,
     #[serde(default)]
     pub logs: Vec<RpcEvmLog>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RpcTransaction {
+    pub hash: String,
+    pub from: String,
+    pub to: Option<String>,
+    pub input: String,
+    #[serde(rename = "blockNumber")]
+    pub block_number: Option<String>,
+    #[serde(rename = "transactionIndex")]
+    pub transaction_index: Option<String>,
 }
 
 pub fn base_network_descriptor(network: &str) -> Result<BaseNetworkDescriptor, ChainBaseError> {
@@ -643,6 +843,14 @@ pub fn parse_eth_get_transaction_receipt_response(
     envelope.try_into()
 }
 
+pub fn parse_eth_get_transaction_by_hash_response(
+    value: Value,
+) -> Result<EthGetTransactionByHashResponse, ChainBaseError> {
+    let envelope: EthGetTransactionByHashEnvelope = serde_json::from_value(value)
+        .map_err(|error| ChainBaseError::InvalidRpcResponse(error.to_string()))?;
+    envelope.try_into()
+}
+
 pub fn parse_eth_block_number_response(
     value: Value,
 ) -> Result<EthBlockNumberResponse, ChainBaseError> {
@@ -671,6 +879,19 @@ pub fn eth_get_transaction_receipt_request(
         jsonrpc: "2.0".to_string(),
         id: request_id,
         method: "eth_getTransactionReceipt".to_string(),
+        params: vec![normalize_hash(tx_hash)
+            .map_err(|_| ChainBaseError::InvalidTransactionHash(tx_hash.to_string()))?],
+    })
+}
+
+pub fn eth_get_transaction_by_hash_request(
+    tx_hash: &str,
+    request_id: u64,
+) -> Result<EthGetTransactionByHashRequest, ChainBaseError> {
+    Ok(EthGetTransactionByHashRequest {
+        jsonrpc: "2.0".to_string(),
+        id: request_id,
+        method: "eth_getTransactionByHash".to_string(),
         params: vec![normalize_hash(tx_hash)
             .map_err(|_| ChainBaseError::InvalidTransactionHash(tx_hash.to_string()))?],
     })
@@ -839,6 +1060,35 @@ where
     )
 }
 
+pub async fn fetch_transaction_by_hash(
+    rpc_url: &str,
+    tx_hash: &str,
+    request_id: u64,
+) -> Result<EthGetTransactionByHashResponse, ChainBaseError> {
+    fetch_transaction_by_hash_with_transport(
+        rpc_url,
+        tx_hash,
+        request_id,
+        &ReqwestJsonRpcTransport::default(),
+    )
+    .await
+}
+
+pub async fn fetch_transaction_by_hash_with_transport<T>(
+    rpc_url: &str,
+    tx_hash: &str,
+    request_id: u64,
+    transport: &T,
+) -> Result<EthGetTransactionByHashResponse, ChainBaseError>
+where
+    T: JsonRpcTransport + ?Sized,
+{
+    let request = eth_get_transaction_by_hash_request(tx_hash, request_id)?;
+    parse_eth_get_transaction_by_hash_response(
+        transport.post_json_value(rpc_url, &json!(request)).await?,
+    )
+}
+
 fn non_empty_env(key: &str) -> Option<String> {
     env::var(key)
         .ok()
@@ -932,6 +1182,21 @@ impl RpcTransactionReceipt {
 
     pub fn logs_to_evm_logs(&self) -> Result<Vec<EvmLog>, ChainBaseError> {
         rpc_logs_to_evm_logs(self.logs.clone())
+    }
+}
+
+impl RpcTransaction {
+    pub fn normalized_hash(&self) -> Result<String, ChainBaseError> {
+        normalize_hash(&self.hash)
+            .map_err(|_| ChainBaseError::InvalidTransactionHash(self.hash.clone()))
+    }
+
+    pub fn normalized_from(&self) -> Result<String, ChainBaseError> {
+        normalize_address(&self.from)
+    }
+
+    pub fn normalized_to(&self) -> Result<Option<String>, ChainBaseError> {
+        self.to.as_deref().map(normalize_address).transpose()
     }
 }
 
@@ -1162,7 +1427,7 @@ pub fn simulated_created_event(
     BaseEscrowEvent {
         id: Uuid::new_v4(),
         log_key: format!("base:{onchain_escrow_id}:created"),
-        tx_hash: format!("0x{}", Uuid::new_v4().simple()),
+        tx_hash: simulated_tx_hash(),
         block_number: 1,
         onchain_escrow_id,
         bounty_id,
@@ -1186,7 +1451,7 @@ pub fn simulated_released_event(
     BaseEscrowEvent {
         id: Uuid::new_v4(),
         log_key: format!("base:{onchain_escrow_id}:released"),
-        tx_hash: format!("0x{}", Uuid::new_v4().simple()),
+        tx_hash: simulated_tx_hash(),
         block_number: 2,
         onchain_escrow_id,
         bounty_id,
@@ -1210,7 +1475,7 @@ pub fn simulated_refunded_event(
     BaseEscrowEvent {
         id: Uuid::new_v4(),
         log_key: format!("base:{onchain_escrow_id}:refunded"),
-        tx_hash: format!("0x{}", Uuid::new_v4().simple()),
+        tx_hash: simulated_tx_hash(),
         block_number: 2,
         onchain_escrow_id,
         bounty_id,
@@ -1234,7 +1499,7 @@ pub fn simulated_disputed_event(
     BaseEscrowEvent {
         id: Uuid::new_v4(),
         log_key: format!("base:{onchain_escrow_id}:disputed"),
-        tx_hash: format!("0x{}", Uuid::new_v4().simple()),
+        tx_hash: simulated_tx_hash(),
         block_number: 2,
         onchain_escrow_id,
         bounty_id,
@@ -1252,6 +1517,11 @@ pub fn simulated_disputed_event(
 
 pub fn base_usdc_rail() -> PaymentRail {
     PaymentRail::BaseUsdc
+}
+
+fn simulated_tx_hash() -> String {
+    let id = Uuid::new_v4().simple().to_string();
+    format!("0x{id}{id}")
 }
 
 pub fn evm_event_topic(signature: &str) -> String {
@@ -1384,6 +1654,81 @@ fn decode_words(
             let start = index * 64;
             parse_bytes32(&trimmed[start..start + 64])
                 .map_err(|_| ChainBaseError::InvalidLogData(event_name.to_string()))
+        })
+        .collect()
+}
+
+fn calldata_bytes(data: &str) -> Result<Vec<u8>, ChainBaseError> {
+    let normalized = normalize_data(data).map_err(|_| {
+        ChainBaseError::InvalidReleaseCalldata("calldata must be 0x-prefixed hex".to_string())
+    })?;
+    hex::decode(&normalized[2..]).map_err(|_| {
+        ChainBaseError::InvalidReleaseCalldata("calldata hex could not be decoded".to_string())
+    })
+}
+
+fn read_calldata_word(args: &[u8], word_index: usize) -> Result<[u8; 32], ChainBaseError> {
+    let start = word_index
+        .checked_mul(32)
+        .ok_or_else(|| ChainBaseError::InvalidReleaseCalldata("word index overflow".to_string()))?;
+    let end = start
+        .checked_add(32)
+        .ok_or_else(|| ChainBaseError::InvalidReleaseCalldata("word index overflow".to_string()))?;
+    let slice = args.get(start..end).ok_or_else(|| {
+        ChainBaseError::InvalidReleaseCalldata("calldata word out of bounds".to_string())
+    })?;
+    slice.try_into().map_err(|_| {
+        ChainBaseError::InvalidReleaseCalldata("calldata word has invalid length".to_string())
+    })
+}
+
+fn calldata_offset(word: [u8; 32]) -> Result<usize, ChainBaseError> {
+    let offset = word_to_u128(word).map_err(|_| {
+        ChainBaseError::InvalidReleaseCalldata("dynamic offset is too large".to_string())
+    })?;
+    let offset = usize::try_from(offset).map_err(|_| {
+        ChainBaseError::InvalidReleaseCalldata("dynamic offset is too large".to_string())
+    })?;
+    if offset % 32 != 0 || offset < 32 * 4 {
+        return Err(ChainBaseError::InvalidReleaseCalldata(
+            "dynamic offset is not a valid ABI word offset".to_string(),
+        ));
+    }
+    Ok(offset)
+}
+
+fn read_dynamic_words(args: &[u8], offset: usize) -> Result<Vec<[u8; 32]>, ChainBaseError> {
+    let length_end = offset.checked_add(32).ok_or_else(|| {
+        ChainBaseError::InvalidReleaseCalldata("dynamic array offset overflow".to_string())
+    })?;
+    let length_word = args.get(offset..length_end).ok_or_else(|| {
+        ChainBaseError::InvalidReleaseCalldata("dynamic array length missing".to_string())
+    })?;
+    let length = word_to_u128(length_word.try_into().map_err(|_| {
+        ChainBaseError::InvalidReleaseCalldata("dynamic array length invalid".to_string())
+    })?)
+    .map_err(|_| ChainBaseError::InvalidReleaseCalldata("array length too large".to_string()))?;
+    let length = usize::try_from(length).map_err(|_| {
+        ChainBaseError::InvalidReleaseCalldata("array length too large".to_string())
+    })?;
+    let byte_len = length.checked_mul(32).ok_or_else(|| {
+        ChainBaseError::InvalidReleaseCalldata("dynamic array byte length overflow".to_string())
+    })?;
+    let start = length_end;
+    let end = start.checked_add(byte_len).ok_or_else(|| {
+        ChainBaseError::InvalidReleaseCalldata("dynamic array byte length overflow".to_string())
+    })?;
+    let values = args.get(start..end).ok_or_else(|| {
+        ChainBaseError::InvalidReleaseCalldata("dynamic array extends past calldata".to_string())
+    })?;
+    values
+        .chunks_exact(32)
+        .map(|chunk| {
+            chunk.try_into().map_err(|_| {
+                ChainBaseError::InvalidReleaseCalldata(
+                    "dynamic array word has invalid length".to_string(),
+                )
+            })
         })
         .collect()
 }
@@ -1687,6 +2032,60 @@ mod tests {
         assert!(tx
             .data
             .contains("00000000000000000000000000000000000000000000000000000000000000e0"));
+
+        let decoded = decode_base_release_calldata(&tx.data, "usdc").unwrap();
+        assert_eq!(decoded.onchain_escrow_id, 7);
+        assert_eq!(decoded.proof_hash, release.proof_hash);
+        assert_eq!(decoded.recipients.len(), 2);
+        assert_eq!(decoded.recipients[0].address, release.recipients[0].address);
+        assert_eq!(decoded.recipients[0].amount, release.recipients[0].amount);
+
+        let attestation = attest_base_release_calldata(&tx.data, &release).unwrap();
+        assert_eq!(attestation.onchain_escrow_id, 7);
+        assert_eq!(attestation.recipients, decoded.recipients);
+        assert!(attestation.calldata_hash.starts_with("0x"));
+    }
+
+    #[test]
+    fn release_calldata_attestation_rejects_wrong_recipient_amount_and_duplicates() {
+        let planner =
+            BaseEscrowTxPlanner::new("0x1111111111111111111111111111111111111111").unwrap();
+        let release = BaseEscrowReleaseCall {
+            onchain_escrow_id: 7,
+            proof_hash: format!("0x{}", "cd".repeat(32)),
+            recipients: vec![
+                EscrowRecipient {
+                    address: "0x2222222222222222222222222222222222222222".to_string(),
+                    amount: Money::new(900, "usdc").unwrap(),
+                },
+                EscrowRecipient {
+                    address: "0x3333333333333333333333333333333333333333".to_string(),
+                    amount: Money::new(100, "usdc").unwrap(),
+                },
+            ],
+        };
+        let tx = planner.release(&release).unwrap();
+
+        let mut wrong_amount = release.clone();
+        wrong_amount.recipients[0].amount = Money::new(899, "usdc").unwrap();
+        assert!(matches!(
+            attest_base_release_calldata(&tx.data, &wrong_amount),
+            Err(ChainBaseError::ReleaseCalldataMismatch(_))
+        ));
+
+        let mut duplicate = release.clone();
+        duplicate.recipients[1].address = duplicate.recipients[0].address.clone();
+        let duplicate_tx = planner.release(&duplicate).unwrap();
+        assert!(matches!(
+            decode_base_release_calldata(&duplicate_tx.data, "usdc"),
+            Err(ChainBaseError::DuplicateReleaseRecipient(_))
+        ));
+
+        let wrong_selector = format!("0xdeadbeef{}", &tx.data[10..]);
+        assert!(matches!(
+            decode_base_release_calldata(&wrong_selector, "usdc"),
+            Err(ChainBaseError::InvalidReleaseCalldata(_))
+        ));
     }
 
     #[test]

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -771,6 +771,8 @@ pub struct RpcTransaction {
     pub from: String,
     pub to: Option<String>,
     pub input: String,
+    #[serde(rename = "chainId")]
+    pub chain_id: Option<String>,
     #[serde(rename = "blockNumber")]
     pub block_number: Option<String>,
     #[serde(rename = "transactionIndex")]
@@ -1197,6 +1199,10 @@ impl RpcTransaction {
 
     pub fn normalized_to(&self) -> Result<Option<String>, ChainBaseError> {
         self.to.as_deref().map(normalize_address).transpose()
+    }
+
+    pub fn chain_id(&self) -> Result<Option<u64>, ChainBaseError> {
+        self.chain_id.as_deref().map(parse_rpc_quantity).transpose()
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,12 +1,12 @@
 use anyhow::{anyhow, bail, Context, Result};
 use app::{
     build_live_money_readiness_report, hash_artifact, stripe_secret_key_mode_from_secret,
-    AddFundingContributionRequest, BaseReleaseQueueRequest, BountyNetwork, ClaimBountyRequest,
-    CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
-    FundingIntentNextAction, FundingPartitionTargetRequest, LiveMoneyReadinessConfig,
-    OpenPooledBountyRequest, PlanBaseReleaseRequest, PlanStripeTransferRequest, PostBountyRequest,
-    RegisterAgentRequest, RegisterCapabilityRequest, RequestQuotesRequest, SubmitResultRequest,
-    VerifySubmissionRequest,
+    AddFundingContributionRequest, BaseReleaseQueueRequest, BaseReleaseTransactionEvidence,
+    BountyNetwork, ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest,
+    FundQuoteRequest, FundingIntentNextAction, FundingPartitionTargetRequest,
+    LiveMoneyReadinessConfig, OpenPooledBountyRequest, PlanBaseReleaseRequest,
+    PlanStripeTransferRequest, PostBountyRequest, RegisterAgentRequest, RegisterCapabilityRequest,
+    RequestQuotesRequest, SubmitResultRequest, VerifySubmissionRequest,
 };
 use chain_base::{
     base_network_descriptor, broadcast_signed_transaction, eth_get_transaction_receipt_request,
@@ -734,7 +734,7 @@ async fn demo() -> Result<()> {
     });
     let solver = network.register_agent(RegisterAgentRequest {
         handle: "solver-agent".to_string(),
-        payout_wallet: Some("0xsolver".to_string()),
+        payout_wallet: Some("0x2222222222222222222222222222222222222222".to_string()),
     });
     network.register_capability(RegisterCapabilityRequest {
         agent_id: solver.id,
@@ -802,9 +802,29 @@ async fn demo() -> Result<()> {
             approved_risk_event_id: None,
         })
         .await?;
+    let release_plan = network.plan_base_release(PlanBaseReleaseRequest {
+        bounty_id: bounty.id,
+        escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+        platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
+        network: Some("base-sepolia".to_string()),
+    })?;
     let released = simulated_released_event(bounty.id, 1, proof.proof_hash.clone());
     indexer.ingest(released.clone())?;
-    network.apply_base_escrow_event(released)?;
+    network.apply_attested_base_release_event(
+        released.clone(),
+        BaseReleaseTransactionEvidence {
+            tx_hash: released.tx_hash.clone(),
+            chain_id: release_plan.network.chain_id,
+            expected_chain_id: release_plan.network.chain_id,
+            from: "0x5555555555555555555555555555555555555555".to_string(),
+            settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+            to: release_plan.transaction.to.clone(),
+            escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+            input: release_plan.transaction.data.clone(),
+            receipt_succeeded: true,
+            platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
+        },
+    )?;
     let status = network.status(bounty.id)?;
 
     println!("demo_status={:?}", status.bounty.status);
@@ -1022,15 +1042,26 @@ async fn funding_rehearsal_demo() -> Result<()> {
         .await?;
     let base_release_plan = network.plan_base_release(PlanBaseReleaseRequest {
         bounty_id: bounty.id,
-        escrow_contract,
+        escrow_contract: escrow_contract.clone(),
         platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
         network: Some("base-sepolia".to_string()),
     })?;
-    let base_released = network.apply_base_escrow_event(simulated_released_event(
-        bounty.id,
-        77,
-        proof.proof_hash.clone(),
-    ))?;
+    let released = simulated_released_event(bounty.id, 77, proof.proof_hash.clone());
+    let base_released = network.apply_attested_base_release_event(
+        released.clone(),
+        BaseReleaseTransactionEvidence {
+            tx_hash: released.tx_hash.clone(),
+            chain_id: base_release_plan.network.chain_id,
+            expected_chain_id: base_release_plan.network.chain_id,
+            from: "0x5555555555555555555555555555555555555555".to_string(),
+            settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+            to: base_release_plan.transaction.to.clone(),
+            escrow_contract,
+            input: base_release_plan.transaction.data.clone(),
+            receipt_succeeded: true,
+            platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
+        },
+    )?;
     let stripe_connect_eligibility =
         network.apply_stripe_connect_snapshot(ConnectAccountSnapshot {
             agent_id: solver.id,
@@ -6095,7 +6126,15 @@ fn request_contracts() -> BTreeMap<String, RequestContract> {
         &mut contracts,
         "/v1/base/transaction-receipt",
         &["tx_hash"],
-        &["tx_hash", "request_id", "network", "reconcile_logs"],
+        &[
+            "tx_hash",
+            "request_id",
+            "network",
+            "reconcile_logs",
+            "escrow_contract",
+            "settlement_signer",
+            "platform_fee_wallet",
+        ],
         &["request_id"],
     );
     contracts

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -822,7 +822,7 @@ async fn demo() -> Result<()> {
             escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
             input: release_plan.transaction.data.clone(),
             receipt_succeeded: true,
-            platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
+            platform_fee_wallet: Some("0x5555555555555555555555555555555555555555".to_string()),
         },
     )?;
     let status = network.status(bounty.id)?;
@@ -1059,7 +1059,7 @@ async fn funding_rehearsal_demo() -> Result<()> {
             escrow_contract,
             input: base_release_plan.transaction.data.clone(),
             receipt_succeeded: true,
-            platform_fee_wallet: "0x5555555555555555555555555555555555555555".to_string(),
+            platform_fee_wallet: Some("0x5555555555555555555555555555555555555555".to_string()),
         },
     )?;
     let stripe_connect_eligibility =
@@ -6126,15 +6126,7 @@ fn request_contracts() -> BTreeMap<String, RequestContract> {
         &mut contracts,
         "/v1/base/transaction-receipt",
         &["tx_hash"],
-        &[
-            "tx_hash",
-            "request_id",
-            "network",
-            "reconcile_logs",
-            "escrow_contract",
-            "settlement_signer",
-            "platform_fee_wallet",
-        ],
+        &["tx_hash", "request_id", "network", "reconcile_logs"],
         &["request_id"],
     );
     contracts

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -16,3 +16,6 @@ serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -176,6 +176,25 @@ pub struct BountyStatusScope {
     pub risk_events: Vec<RiskEvent>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BaseReleaseAttestationRecord {
+    pub id: Id,
+    pub network: String,
+    pub tx_hash: String,
+    pub log_key: String,
+    pub bounty_id: Id,
+    pub onchain_escrow_id: String,
+    pub calldata_hash: Option<String>,
+    pub proof_hash: Option<String>,
+    pub recipients: serde_json::Value,
+    pub escrow_contract: String,
+    pub settlement_signer: String,
+    pub platform_fee_wallet: Option<String>,
+    pub verdict: String,
+    pub reason: String,
+    pub created_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Default)]
 pub struct InMemoryStore {
     pub agents: HashMap<Id, Agent>,
@@ -1576,6 +1595,70 @@ impl PostgresStore {
         rows.into_iter().map(base_escrow_event_from_row).collect()
     }
 
+    pub async fn upsert_base_release_attestation(
+        &self,
+        record: &BaseReleaseAttestationRecord,
+    ) -> DbResult<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO base_release_attestations
+              (id, network, tx_hash, log_key, bounty_id, onchain_escrow_id, calldata_hash, proof_hash, recipients, escrow_contract, settlement_signer, platform_fee_wallet, verdict, reason, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            ON CONFLICT (network, tx_hash, log_key) DO UPDATE SET
+              bounty_id = EXCLUDED.bounty_id,
+              onchain_escrow_id = EXCLUDED.onchain_escrow_id,
+              calldata_hash = EXCLUDED.calldata_hash,
+              proof_hash = EXCLUDED.proof_hash,
+              recipients = EXCLUDED.recipients,
+              escrow_contract = EXCLUDED.escrow_contract,
+              settlement_signer = EXCLUDED.settlement_signer,
+              platform_fee_wallet = EXCLUDED.platform_fee_wallet,
+              verdict = EXCLUDED.verdict,
+              reason = EXCLUDED.reason,
+              created_at = EXCLUDED.created_at
+            "#,
+        )
+        .bind(record.id)
+        .bind(&record.network)
+        .bind(&record.tx_hash)
+        .bind(&record.log_key)
+        .bind(record.bounty_id)
+        .bind(&record.onchain_escrow_id)
+        .bind(&record.calldata_hash)
+        .bind(&record.proof_hash)
+        .bind(&record.recipients)
+        .bind(&record.escrow_contract)
+        .bind(&record.settlement_signer)
+        .bind(&record.platform_fee_wallet)
+        .bind(&record.verdict)
+        .bind(&record.reason)
+        .bind(record.created_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn list_base_release_attestations_for_bounty(
+        &self,
+        bounty_id: Id,
+    ) -> DbResult<Vec<BaseReleaseAttestationRecord>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, network, tx_hash, log_key, bounty_id, onchain_escrow_id, calldata_hash, proof_hash, recipients, escrow_contract, settlement_signer, platform_fee_wallet, verdict, reason, created_at
+            FROM base_release_attestations
+            WHERE bounty_id = $1
+            ORDER BY created_at, tx_hash, log_key
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(base_release_attestation_from_row)
+            .collect()
+    }
+
     pub async fn get_base_log_cursor(
         &self,
         network: &str,
@@ -2527,6 +2610,26 @@ fn base_escrow_event_from_row(row: PgRow) -> DbResult<BaseEscrowEvent> {
     })
 }
 
+fn base_release_attestation_from_row(row: PgRow) -> DbResult<BaseReleaseAttestationRecord> {
+    Ok(BaseReleaseAttestationRecord {
+        id: row.try_get("id")?,
+        network: row.try_get("network")?,
+        tx_hash: row.try_get("tx_hash")?,
+        log_key: row.try_get("log_key")?,
+        bounty_id: row.try_get("bounty_id")?,
+        onchain_escrow_id: row.try_get("onchain_escrow_id")?,
+        calldata_hash: row.try_get("calldata_hash")?,
+        proof_hash: row.try_get("proof_hash")?,
+        recipients: row.try_get("recipients")?,
+        escrow_contract: row.try_get("escrow_contract")?,
+        settlement_signer: row.try_get("settlement_signer")?,
+        platform_fee_wallet: row.try_get("platform_fee_wallet")?,
+        verdict: row.try_get("verdict")?,
+        reason: row.try_get("reason")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
 fn parse_risk_surface(value: String) -> DbResult<RiskSurface> {
     match value.as_str() {
         "HelpRequest" => Ok(RiskSurface::HelpRequest),
@@ -2667,6 +2770,7 @@ mod tests {
             "funding_contributions",
             "escrows",
             "base_escrow_events",
+            "base_release_attestations",
             "claims",
             "submissions",
             "verifier_results",

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 
 pub const CORE_MIGRATION: &str = include_str!("../../../migrations/0001_core.sql");
 const MIGRATION_ADVISORY_LOCK_ID: i64 = 4_270_265_017;
+const BASE_RELEASE_ATTESTATION_STATUS_LIMIT: i64 = 25;
 const UPSERT_PAYMENT_EVENT_SQL: &str = r#"
             INSERT INTO payment_events (id, rail, external_id, status, payload_hash, received_at)
             VALUES ($1, $2, $3, $4, $5, $6)
@@ -1107,10 +1108,12 @@ impl PostgresStore {
             SELECT id, network, tx_hash, log_key, bounty_id, onchain_escrow_id, calldata_hash, proof_hash, recipients, escrow_contract, settlement_signer, platform_fee_wallet, verdict, reason, created_at
             FROM base_release_attestations
             WHERE bounty_id = $1
-            ORDER BY created_at, tx_hash, log_key
+            ORDER BY created_at DESC, tx_hash DESC, log_key DESC
+            LIMIT $2
             "#,
         )
         .bind(bounty_id)
+        .bind(BASE_RELEASE_ATTESTATION_STATUS_LIMIT)
         .fetch_all(&mut *tx)
         .await?
         .into_iter()
@@ -1696,6 +1699,30 @@ impl PostgresStore {
             "#,
         )
         .bind(bounty_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(base_release_attestation_from_row)
+            .collect()
+    }
+
+    pub async fn list_base_release_attestations_for_bounty_limited(
+        &self,
+        bounty_id: Id,
+        limit: usize,
+    ) -> DbResult<Vec<BaseReleaseAttestationRecord>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, network, tx_hash, log_key, bounty_id, onchain_escrow_id, calldata_hash, proof_hash, recipients, escrow_contract, settlement_signer, platform_fee_wallet, verdict, reason, created_at
+            FROM base_release_attestations
+            WHERE bounty_id = $1
+            ORDER BY created_at DESC, tx_hash DESC, log_key DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(bounty_id)
+        .bind(limit as i64)
         .fetch_all(&self.pool)
         .await?;
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -198,6 +198,26 @@ pub struct BaseReleaseAttestationRecord {
     pub created_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct BaseLogPersistenceCursor<'a> {
+    pub network: &'a str,
+    pub escrow_contract: &'a str,
+    pub last_scanned_block: u64,
+    pub last_log_key: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BaseLogPersistenceBatch<'a> {
+    pub bounties: &'a [Bounty],
+    pub release_attestations: &'a [BaseReleaseAttestationRecord],
+    pub funding_intents: &'a [FundingIntent],
+    pub escrows: &'a [Escrow],
+    pub settlements: &'a [Settlement],
+    pub ledger_entries: &'a [LedgerEntry],
+    pub base_escrow_events: &'a [BaseEscrowEvent],
+    pub cursor: Option<BaseLogPersistenceCursor<'a>>,
+}
+
 #[derive(Debug, Default)]
 pub struct InMemoryStore {
     pub agents: HashMap<Id, Agent>,
@@ -1740,6 +1760,268 @@ impl PostgresStore {
         Ok(())
     }
 
+    pub async fn persist_base_log_pipeline(
+        &self,
+        batch: BaseLogPersistenceBatch<'_>,
+    ) -> DbResult<()> {
+        let mut tx = self.pool.begin().await?;
+
+        for bounty in batch.bounties {
+            sqlx::query(
+                r#"
+                INSERT INTO bounties
+                  (id, help_request_id, title, template_slug, amount, currency, funding_targets, funding_mode, privacy, status, terms_hash, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                ON CONFLICT (id) DO UPDATE SET
+                  help_request_id = EXCLUDED.help_request_id,
+                  title = EXCLUDED.title,
+                  template_slug = EXCLUDED.template_slug,
+                  amount = EXCLUDED.amount,
+                  currency = EXCLUDED.currency,
+                  funding_targets = EXCLUDED.funding_targets,
+                  funding_mode = EXCLUDED.funding_mode,
+                  privacy = EXCLUDED.privacy,
+                  status = EXCLUDED.status,
+                  terms_hash = EXCLUDED.terms_hash
+                "#,
+            )
+            .bind(bounty.id)
+            .bind(bounty.help_request_id)
+            .bind(&bounty.title)
+            .bind(&bounty.template_slug)
+            .bind(bounty.amount.amount)
+            .bind(&bounty.amount.currency)
+            .bind(serde_json::to_value(&bounty.funding_targets)?)
+            .bind(format!("{:?}", bounty.funding_mode))
+            .bind(format!("{:?}", bounty.privacy))
+            .bind(format!("{:?}", bounty.status))
+            .bind(&bounty.terms_hash)
+            .bind(bounty.created_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        for record in batch.release_attestations {
+            let result = sqlx::query(
+                r#"
+                INSERT INTO base_release_attestations
+                  (id, network, tx_hash, log_key, bounty_id, onchain_escrow_id, calldata_hash, proof_hash, recipients, escrow_contract, settlement_signer, platform_fee_wallet, verdict, reason, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+                ON CONFLICT (network, tx_hash, log_key) DO UPDATE SET
+                  id = base_release_attestations.id
+                WHERE base_release_attestations.bounty_id = EXCLUDED.bounty_id
+                  AND base_release_attestations.onchain_escrow_id = EXCLUDED.onchain_escrow_id
+                  AND base_release_attestations.calldata_hash IS NOT DISTINCT FROM EXCLUDED.calldata_hash
+                  AND base_release_attestations.proof_hash IS NOT DISTINCT FROM EXCLUDED.proof_hash
+                  AND base_release_attestations.recipients = EXCLUDED.recipients
+                  AND base_release_attestations.escrow_contract = EXCLUDED.escrow_contract
+                  AND base_release_attestations.settlement_signer = EXCLUDED.settlement_signer
+                  AND base_release_attestations.platform_fee_wallet IS NOT DISTINCT FROM EXCLUDED.platform_fee_wallet
+                  AND base_release_attestations.verdict = EXCLUDED.verdict
+                  AND base_release_attestations.reason = EXCLUDED.reason
+                "#,
+            )
+            .bind(record.id)
+            .bind(&record.network)
+            .bind(&record.tx_hash)
+            .bind(&record.log_key)
+            .bind(record.bounty_id)
+            .bind(&record.onchain_escrow_id)
+            .bind(&record.calldata_hash)
+            .bind(&record.proof_hash)
+            .bind(&record.recipients)
+            .bind(&record.escrow_contract)
+            .bind(&record.settlement_signer)
+            .bind(&record.platform_fee_wallet)
+            .bind(&record.verdict)
+            .bind(&record.reason)
+            .bind(record.created_at)
+            .execute(&mut *tx)
+            .await?;
+            if result.rows_affected() == 0 {
+                return Err(DbError::ImmutableAttestationConflict(format!(
+                    "{} {} {}",
+                    record.network, record.tx_hash, record.log_key
+                )));
+            }
+        }
+
+        for intent in batch.funding_intents {
+            sqlx::query(
+                r#"
+                INSERT INTO funding_intents
+                  (id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, external_reference, stripe_success_url, stripe_cancel_url, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                ON CONFLICT (id) DO UPDATE SET
+                  contributor_agent_id = EXCLUDED.contributor_agent_id,
+                  source_organization_id = EXCLUDED.source_organization_id,
+                  rail = EXCLUDED.rail,
+                  amount = EXCLUDED.amount,
+                  currency = EXCLUDED.currency,
+                  status = EXCLUDED.status,
+                  external_reference = EXCLUDED.external_reference,
+                  stripe_success_url = EXCLUDED.stripe_success_url,
+                  stripe_cancel_url = EXCLUDED.stripe_cancel_url
+                "#,
+            )
+            .bind(intent.id)
+            .bind(intent.bounty_id)
+            .bind(intent.contributor_agent_id)
+            .bind(intent.source_organization_id)
+            .bind(format!("{:?}", intent.rail))
+            .bind(intent.amount.amount)
+            .bind(&intent.amount.currency)
+            .bind(format!("{:?}", intent.status))
+            .bind(&intent.external_reference)
+            .bind(&intent.stripe_success_url)
+            .bind(&intent.stripe_cancel_url)
+            .bind(intent.created_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        for escrow in batch.escrows {
+            sqlx::query(
+                r#"
+                INSERT INTO escrows
+                  (id, bounty_id, rail, token, amount, currency, status, external_reference)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                ON CONFLICT (id) DO UPDATE SET
+                  bounty_id = EXCLUDED.bounty_id,
+                  rail = EXCLUDED.rail,
+                  token = EXCLUDED.token,
+                  amount = EXCLUDED.amount,
+                  currency = EXCLUDED.currency,
+                  status = EXCLUDED.status,
+                  external_reference = EXCLUDED.external_reference
+                "#,
+            )
+            .bind(escrow.id)
+            .bind(escrow.bounty_id)
+            .bind(format!("{:?}", escrow.rail))
+            .bind(&escrow.token)
+            .bind(escrow.amount.amount)
+            .bind(&escrow.amount.currency)
+            .bind(format!("{:?}", escrow.status))
+            .bind(&escrow.external_reference)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        for settlement in batch.settlements {
+            sqlx::query(
+                r#"
+                INSERT INTO settlements
+                  (id, bounty_id, proof_record_id, rail, payout_intents, platform_fee, currency, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                ON CONFLICT (id) DO UPDATE SET
+                  rail = EXCLUDED.rail,
+                  payout_intents = EXCLUDED.payout_intents,
+                  platform_fee = EXCLUDED.platform_fee,
+                  currency = EXCLUDED.currency
+                "#,
+            )
+            .bind(settlement.id)
+            .bind(settlement.bounty_id)
+            .bind(settlement.proof_record_id)
+            .bind(format!("{:?}", settlement.rail))
+            .bind(serde_json::to_value(&settlement.payout_intents)?)
+            .bind(settlement.platform_fee.amount)
+            .bind(&settlement.platform_fee.currency)
+            .bind(settlement.created_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        for entry in batch.ledger_entries {
+            sqlx::query(
+                r#"
+                INSERT INTO ledger_entries (id, external_event_id, memo, postings, created_at)
+                VALUES ($1, $2, $3, $4, $5)
+                ON CONFLICT (external_event_id) DO NOTHING
+                "#,
+            )
+            .bind(entry.id)
+            .bind(&entry.external_event_id)
+            .bind(&entry.memo)
+            .bind(serde_json::to_value(&entry.postings)?)
+            .bind(entry.created_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        for event in batch.base_escrow_events {
+            let log_index = log_index_from_key(&event.log_key)
+                .map(i64_from_u64)
+                .transpose()?;
+            sqlx::query(
+                r#"
+                INSERT INTO base_escrow_events
+                  (id, log_key, tx_hash, block_number, log_index, onchain_escrow_id, bounty_id, kind, status, token, amount, currency, terms_hash, proof_hash, reason_hash, dispute_hash, occurred_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+                ON CONFLICT (log_key) DO UPDATE SET
+                  tx_hash = EXCLUDED.tx_hash,
+                  block_number = EXCLUDED.block_number,
+                  log_index = EXCLUDED.log_index,
+                  onchain_escrow_id = EXCLUDED.onchain_escrow_id,
+                  bounty_id = EXCLUDED.bounty_id,
+                  kind = EXCLUDED.kind,
+                  status = EXCLUDED.status,
+                  token = EXCLUDED.token,
+                  amount = EXCLUDED.amount,
+                  currency = EXCLUDED.currency,
+                  terms_hash = EXCLUDED.terms_hash,
+                  proof_hash = EXCLUDED.proof_hash,
+                  reason_hash = EXCLUDED.reason_hash,
+                  dispute_hash = EXCLUDED.dispute_hash,
+                  occurred_at = EXCLUDED.occurred_at
+                "#,
+            )
+            .bind(event.id)
+            .bind(&event.log_key)
+            .bind(&event.tx_hash)
+            .bind(i64_from_u64(event.block_number)?)
+            .bind(log_index)
+            .bind(event.onchain_escrow_id.to_string())
+            .bind(event.bounty_id)
+            .bind(format!("{:?}", event.kind))
+            .bind(format!("{:?}", event.status))
+            .bind(&event.token)
+            .bind(event.amount.as_ref().map(|amount| amount.amount))
+            .bind(event.amount.as_ref().map(|amount| amount.currency.clone()))
+            .bind(&event.terms_hash)
+            .bind(&event.proof_hash)
+            .bind(&event.reason_hash)
+            .bind(&event.dispute_hash)
+            .bind(event.occurred_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        if let Some(cursor) = batch.cursor {
+            sqlx::query(
+                r#"
+                INSERT INTO base_log_cursors
+                  (network, escrow_contract, last_scanned_block, last_log_key, updated_at)
+                VALUES ($1, $2, $3, $4, now())
+                ON CONFLICT (network, escrow_contract) DO UPDATE SET
+                  last_scanned_block = GREATEST(base_log_cursors.last_scanned_block, EXCLUDED.last_scanned_block),
+                  last_log_key = COALESCE(EXCLUDED.last_log_key, base_log_cursors.last_log_key),
+                  updated_at = now()
+                "#,
+            )
+            .bind(cursor.network)
+            .bind(normalize_key_address(cursor.escrow_contract))
+            .bind(i64_from_u64(cursor.last_scanned_block)?)
+            .bind(cursor.last_log_key)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
     pub async fn get_base_indexer_heartbeat(
         &self,
         network: &str,
@@ -2757,7 +3039,8 @@ fn bounty_from_row(row: &PgRow) -> DbResult<Bounty> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use domain::{FundingMode, Money};
+    use domain::{FundingIntentStatus, FundingMode, Money, PaymentRail};
+    use ledger::{credit, debit};
 
     #[test]
     fn store_tracks_agents_and_bounties() {
@@ -2873,5 +3156,173 @@ mod tests {
         assert!(UPDATE_GITHUB_ISSUE_SYNC_BOUNTY_SQL.contains("WHERE id = $1"));
         assert!(UPDATE_GITHUB_ISSUE_SYNC_BOUNTY_SQL.contains("RETURNING id"));
         assert!(!UPDATE_GITHUB_ISSUE_SYNC_BOUNTY_SQL.contains("created_at ="));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn base_log_pipeline_rolls_back_paid_state_when_cursor_commit_fails() {
+        let database_url = std::env::var("AGENT_BOUNTIES_TEST_DATABASE_URL")
+            .expect("AGENT_BOUNTIES_TEST_DATABASE_URL must be set for ignored Postgres tests");
+        let store = PostgresStore::connect(&database_url).await.unwrap();
+        store.migrate().await.unwrap();
+
+        let now = Utc::now();
+        let amount = Money::new(1_000_000, "usdc").unwrap();
+        let mut bounty = Bounty::new(
+            "Atomic Base release persistence",
+            "fix-ci-failure",
+            amount.clone(),
+            FundingMode::BaseUsdcEscrow,
+            PrivacyLevel::Public,
+        );
+        bounty.status = BountyStatus::Payable;
+        store.upsert_bounty(&bounty).await.unwrap();
+
+        let mut paid_bounty = bounty.clone();
+        paid_bounty.status = BountyStatus::Paid;
+        let tx_hash = format!("0x{}aaaaaaaa", bounty.id.simple());
+        let log_key = format!("{tx_hash}:7");
+        let escrow_contract = format!("0x{}00000000", bounty.id.simple());
+        let funding_intent = FundingIntent {
+            id: Id::new_v4(),
+            bounty_id: bounty.id,
+            contributor_agent_id: None,
+            source_organization_id: None,
+            rail: PaymentRail::BaseUsdc,
+            amount: amount.clone(),
+            status: FundingIntentStatus::Applied,
+            external_reference: Some(format!("atomic-release-test:{}", bounty.id)),
+            stripe_success_url: None,
+            stripe_cancel_url: None,
+            created_at: now,
+        };
+        let escrow = Escrow {
+            id: Id::new_v4(),
+            bounty_id: bounty.id,
+            rail: PaymentRail::BaseUsdc,
+            token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string(),
+            amount: amount.clone(),
+            status: EscrowStatus::Released,
+            external_reference: Some("base-escrow:7".to_string()),
+        };
+        let attestation = BaseReleaseAttestationRecord {
+            id: Id::new_v4(),
+            network: "base-mainnet".to_string(),
+            tx_hash: tx_hash.clone(),
+            log_key: log_key.clone(),
+            bounty_id: bounty.id,
+            onchain_escrow_id: "7".to_string(),
+            calldata_hash: Some(
+                "0x1111111111111111111111111111111111111111111111111111111111111111".to_string(),
+            ),
+            proof_hash: Some(
+                "0x2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+            ),
+            recipients: serde_json::json!([
+                {
+                    "address": "0x3333333333333333333333333333333333333333",
+                    "amount": "1000000"
+                }
+            ]),
+            escrow_contract: escrow_contract.clone(),
+            settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+            platform_fee_wallet: None,
+            verdict: "passed".to_string(),
+            reason: "release calldata matches pending Base settlement plan".to_string(),
+            created_at: now,
+        };
+        let ledger_entry = LedgerEntry::new(
+            "Base release paid",
+            Some(format!("base-release:{log_key}")),
+            vec![
+                debit("base_escrow", amount.clone()),
+                credit("solver_payable", amount.clone()),
+            ],
+        )
+        .unwrap();
+        let event = BaseEscrowEvent {
+            id: Id::new_v4(),
+            log_key: log_key.clone(),
+            tx_hash,
+            block_number: 48426133,
+            onchain_escrow_id: 7,
+            bounty_id: bounty.id,
+            kind: BaseEscrowEventKind::Released,
+            status: EscrowStatus::Released,
+            token: None,
+            amount: None,
+            terms_hash: None,
+            proof_hash: attestation.proof_hash.clone(),
+            reason_hash: None,
+            dispute_hash: None,
+            occurred_at: now,
+        };
+        let paid_bounties = [paid_bounty];
+        let release_attestations = [attestation];
+        let funding_intents = [funding_intent.clone()];
+        let escrows = [escrow.clone()];
+        let ledger_entries = [ledger_entry.clone()];
+        let base_escrow_events = [event];
+
+        let result = store
+            .persist_base_log_pipeline(BaseLogPersistenceBatch {
+                bounties: &paid_bounties,
+                release_attestations: &release_attestations,
+                funding_intents: &funding_intents,
+                escrows: &escrows,
+                settlements: &[],
+                ledger_entries: &ledger_entries,
+                base_escrow_events: &base_escrow_events,
+                cursor: Some(BaseLogPersistenceCursor {
+                    network: "base-mainnet",
+                    escrow_contract: &escrow_contract,
+                    last_scanned_block: u64::MAX,
+                    last_log_key: Some(&log_key),
+                }),
+            })
+            .await;
+        assert!(matches!(result, Err(DbError::IntegerOverflow(_))));
+
+        let stored_bounty = store
+            .list_bounties()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|stored| stored.id == bounty.id)
+            .unwrap();
+        assert_eq!(stored_bounty.status, BountyStatus::Payable);
+        assert!(store
+            .list_base_release_attestations_for_bounty(bounty.id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(store
+            .list_base_escrow_events_for_bounty(bounty.id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(!store
+            .list_funding_intents()
+            .await
+            .unwrap()
+            .iter()
+            .any(|stored| stored.id == funding_intent.id));
+        assert!(!store
+            .list_escrows()
+            .await
+            .unwrap()
+            .iter()
+            .any(|stored| stored.id == escrow.id));
+        assert!(!store
+            .list_ledger_entries()
+            .await
+            .unwrap()
+            .iter()
+            .any(|stored| stored.external_event_id == ledger_entry.external_event_id));
+        assert!(store
+            .get_base_log_cursor("base-mainnet", &escrow_contract)
+            .await
+            .unwrap()
+            .is_none());
     }
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -81,6 +81,8 @@ pub enum DbError {
     InvalidEnum(String),
     #[error("integer value cannot fit target type: {0}")]
     IntegerOverflow(String),
+    #[error("immutable attestation conflict: {0}")]
+    ImmutableAttestationConflict(String),
     #[error("conflicting audience event replay: {0}")]
     AudienceConflict(String),
 }
@@ -166,6 +168,7 @@ pub struct BountyStatusScope {
     pub funding_contributions: Vec<FundingContribution>,
     pub escrows: Vec<Escrow>,
     pub base_escrow_events: Vec<BaseEscrowEvent>,
+    pub base_release_attestations: Vec<BaseReleaseAttestationRecord>,
     pub claims: Vec<Claim>,
     pub submissions: Vec<Submission>,
     pub verifier_results: Vec<VerifierResult>,
@@ -1079,6 +1082,21 @@ impl PostgresStore {
         .map(base_escrow_event_from_row)
         .collect::<DbResult<Vec<_>>>()?;
 
+        let base_release_attestations = sqlx::query(
+            r#"
+            SELECT id, network, tx_hash, log_key, bounty_id, onchain_escrow_id, calldata_hash, proof_hash, recipients, escrow_contract, settlement_signer, platform_fee_wallet, verdict, reason, created_at
+            FROM base_release_attestations
+            WHERE bounty_id = $1
+            ORDER BY created_at, tx_hash, log_key
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(base_release_attestation_from_row)
+        .collect::<DbResult<Vec<_>>>()?;
+
         let claims = sqlx::query(
             r#"
             SELECT id, bounty_id, solver_agent_id, claimed_at
@@ -1303,6 +1321,7 @@ impl PostgresStore {
             funding_contributions,
             escrows,
             base_escrow_events,
+            base_release_attestations,
             claims,
             submissions,
             verifier_results,
@@ -1599,23 +1618,23 @@ impl PostgresStore {
         &self,
         record: &BaseReleaseAttestationRecord,
     ) -> DbResult<()> {
-        sqlx::query(
+        let result = sqlx::query(
             r#"
             INSERT INTO base_release_attestations
               (id, network, tx_hash, log_key, bounty_id, onchain_escrow_id, calldata_hash, proof_hash, recipients, escrow_contract, settlement_signer, platform_fee_wallet, verdict, reason, created_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
             ON CONFLICT (network, tx_hash, log_key) DO UPDATE SET
-              bounty_id = EXCLUDED.bounty_id,
-              onchain_escrow_id = EXCLUDED.onchain_escrow_id,
-              calldata_hash = EXCLUDED.calldata_hash,
-              proof_hash = EXCLUDED.proof_hash,
-              recipients = EXCLUDED.recipients,
-              escrow_contract = EXCLUDED.escrow_contract,
-              settlement_signer = EXCLUDED.settlement_signer,
-              platform_fee_wallet = EXCLUDED.platform_fee_wallet,
-              verdict = EXCLUDED.verdict,
-              reason = EXCLUDED.reason,
-              created_at = EXCLUDED.created_at
+              id = base_release_attestations.id
+            WHERE base_release_attestations.bounty_id = EXCLUDED.bounty_id
+              AND base_release_attestations.onchain_escrow_id = EXCLUDED.onchain_escrow_id
+              AND base_release_attestations.calldata_hash IS NOT DISTINCT FROM EXCLUDED.calldata_hash
+              AND base_release_attestations.proof_hash IS NOT DISTINCT FROM EXCLUDED.proof_hash
+              AND base_release_attestations.recipients = EXCLUDED.recipients
+              AND base_release_attestations.escrow_contract = EXCLUDED.escrow_contract
+              AND base_release_attestations.settlement_signer = EXCLUDED.settlement_signer
+              AND base_release_attestations.platform_fee_wallet IS NOT DISTINCT FROM EXCLUDED.platform_fee_wallet
+              AND base_release_attestations.verdict = EXCLUDED.verdict
+              AND base_release_attestations.reason = EXCLUDED.reason
             "#,
         )
         .bind(record.id)
@@ -1635,6 +1654,12 @@ impl PostgresStore {
         .bind(record.created_at)
         .execute(&self.pool)
         .await?;
+        if result.rows_affected() == 0 {
+            return Err(DbError::ImmutableAttestationConflict(format!(
+                "{} {} {}",
+                record.network, record.tx_hash, record.log_key
+            )));
+        }
         Ok(())
     }
 

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -23,8 +23,8 @@ use chain_base::{
     base_network_descriptor, broadcast_signed_transaction, eth_get_transaction_by_hash_request,
     eth_get_transaction_receipt_request, eth_send_raw_transaction_request, evm_event_topic,
     fetch_base_escrow_logs, fetch_transaction_by_hash, fetch_transaction_receipt,
-    rpc_logs_to_evm_logs, BaseEscrowEvent, BaseEscrowLogQuery, BaseNetworkDescriptor,
-    BaseRpcUrlConfig, EvmLog, RpcLogSubmission,
+    normalize_evm_address, rpc_logs_to_evm_logs, BaseEscrowEvent, BaseEscrowLogQuery,
+    BaseNetworkDescriptor, BaseRpcUrlConfig, EvmLog, RpcLogSubmission,
 };
 use chrono::Utc;
 use db::{BountyStatusScope, PostgresStore};
@@ -270,9 +270,6 @@ struct GetBaseTransactionReceiptArgs {
     request_id: Option<u64>,
     network: Option<String>,
     reconcile_logs: Option<bool>,
-    escrow_contract: Option<String>,
-    settlement_signer: Option<String>,
-    platform_fee_wallet: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1088,10 +1085,7 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                     "tx_hash": string_property("0x-prefixed transaction hash."),
                     "request_id": nullable_integer_property("Optional JSON-RPC request id."),
                     "network": nullable_enum_property(&["base-sepolia", "base-mainnet"], "Optional Base network; defaults to base-sepolia."),
-                    "reconcile_logs": nullable_boolean_property("When true, normalize receipt logs and run the Base escrow indexer."),
-                    "escrow_contract": nullable_string_property("Expected Base escrow contract for release calldata attestation; inferred for known deployments when omitted."),
-                    "settlement_signer": nullable_string_property("Expected settlement signer address. Required for EscrowReleased reconciliation unless BASE_SETTLEMENT_SIGNER is configured."),
-                    "platform_fee_wallet": nullable_string_property("Expected platform fee wallet used to rebuild the release plan. Required for EscrowReleased reconciliation unless BASE_PLATFORM_FEE_WALLET is configured.")
+                    "reconcile_logs": nullable_boolean_property("When true, normalize receipt logs and run the Base escrow indexer using configured release authorities.")
                 }),
                 &["tx_hash"],
             ),
@@ -2704,10 +2698,29 @@ async fn get_base_transaction_receipt(
     let mut transaction_request = None;
     let mut transaction = None;
     let reconciliation = if args.reconcile_logs.unwrap_or(false) {
+        let escrow_contract = match base_escrow_contract_for_chain(network.chain_id) {
+            Some(value) => value,
+            None => return mcp_error("configured Base escrow contract is unknown for network"),
+        };
+        let settlement_signer = match env::var("BASE_SETTLEMENT_SIGNER") {
+            Ok(value) => value,
+            Err(_) => {
+                return mcp_error("BASE_SETTLEMENT_SIGNER is required for release attestation")
+            }
+        };
+        let platform_fee_wallet = env::var("BASE_PLATFORM_FEE_WALLET").ok();
         let logs = match receipt.logs_to_evm_logs() {
             Ok(logs) => logs,
             Err(error) => return mcp_error(error),
         };
+        let logs = logs
+            .into_iter()
+            .filter(|log| {
+                normalize_evm_address(&log.address)
+                    .map(|address| address == escrow_contract)
+                    .unwrap_or(false)
+            })
+            .collect::<Vec<_>>();
         let release_attestations = if logs_contain_release(&logs) {
             let request = match eth_get_transaction_by_hash_request(&tx_hash, request_id + 1) {
                 Ok(request) => request,
@@ -2721,40 +2734,31 @@ async fn get_base_transaction_receipt(
             let Some(tx) = response.result else {
                 return mcp_error("release log reconciliation requires transaction input");
             };
+            let receipt_tx_hash = match receipt.normalized_tx_hash() {
+                Ok(value) => value,
+                Err(error) => return mcp_error(error),
+            };
+            if receipt_tx_hash != tx_hash {
+                return mcp_error("release receipt hash does not match requested transaction");
+            }
+            let transaction_tx_hash = match tx.normalized_hash() {
+                Ok(value) => value,
+                Err(error) => return mcp_error(error),
+            };
+            if transaction_tx_hash != tx_hash {
+                return mcp_error("release transaction hash does not match receipt");
+            }
+            let chain_id = match tx.chain_id() {
+                Ok(Some(value)) => value,
+                Ok(None) => return mcp_error("release transaction is missing chainId"),
+                Err(error) => return mcp_error(error),
+            };
             let Some(to) = tx.to.clone() else {
                 return mcp_error("release transaction is missing target contract");
             };
-            let escrow_contract = match args
-                .escrow_contract
-                .clone()
-                .or_else(|| base_escrow_contract_for_chain(network.chain_id))
-            {
-                Some(value) => value,
-                None => return mcp_error("escrow_contract is required to attest release calldata"),
-            };
-            let settlement_signer = match args
-                .settlement_signer
-                .clone()
-                .or_else(|| env::var("BASE_SETTLEMENT_SIGNER").ok())
-            {
-                Some(value) => value,
-                None => {
-                    return mcp_error("settlement_signer is required to attest release calldata")
-                }
-            };
-            let platform_fee_wallet = match args
-                .platform_fee_wallet
-                .clone()
-                .or_else(|| env::var("BASE_PLATFORM_FEE_WALLET").ok())
-            {
-                Some(value) => value,
-                None => {
-                    return mcp_error("platform_fee_wallet is required to attest release calldata")
-                }
-            };
             let evidence = BaseReleaseTransactionEvidence {
                 tx_hash: tx.hash.clone(),
-                chain_id: network.chain_id,
+                chain_id,
                 expected_chain_id: network.chain_id,
                 from: tx.from.clone(),
                 settlement_signer,
@@ -2890,6 +2894,11 @@ async fn process_base_evm_logs_with_release_attestations(
         }
         for settlement in &settlements {
             if let Err(error) = store.upsert_settlement(settlement).await {
+                return mcp_error(error);
+            }
+        }
+        for attestation in &report.release_attestations {
+            if let Err(error) = store.upsert_base_release_attestation(attestation).await {
                 return mcp_error(error);
             }
         }

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -2,12 +2,13 @@ use app::{
     build_base_indexer_status_report, build_live_money_readiness_report,
     stripe_secret_key_mode_from_secret, AddFundingContributionRequest, ApproveRiskBountyRequest,
     ApproveRiskPayoutRequest, BaseIndexerHeartbeatStatus, BaseIndexerScanCursor,
-    BaseIndexerStatusConfig, BaseReleaseQueueRequest, BaseReleaseTransactionEvidence,
-    BountyNetwork, BountyStatusResponse, ClaimBountyRequest, CreateFundingIntentRequest,
-    CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport, LiveMoneyReadinessConfig,
-    OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest,
-    PlanBaseReleaseRequest, PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest,
-    RegisterAgentRequest, RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
+    BaseIndexerStatusConfig, BaseReleaseAttestationStatus, BaseReleaseQueueRequest,
+    BaseReleaseTransactionEvidence, BountyNetwork, BountyStatusResponse, ClaimBountyRequest,
+    CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport,
+    LiveMoneyReadinessConfig, OpenPooledBountyRequest, PlanBaseDisputeRequest,
+    PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
+    PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest, RegisterAgentRequest,
+    RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
     ReviewedBountyApproval, RiskEventFilter, SubmitResultRequest, VerifySubmissionRequest,
 };
 use axum::{
@@ -26,7 +27,7 @@ use chain_base::{
     BaseNetworkDescriptor, BaseRpcUrlConfig, EvmLog, RpcLogSubmission,
 };
 use chrono::Utc;
-use db::{BaseLogPersistenceBatch, BountyStatusScope, PostgresStore};
+use db::{BaseLogPersistenceBatch, BaseReleaseAttestationRecord, BountyStatusScope, PostgresStore};
 use domain::{
     Agent, BountyStatus, CapabilityClass, EvalRun, HelpRequest, Money, PaymentRail, PayoutStatus,
     PrivacyLevel, RiskReviewRecord,
@@ -68,6 +69,49 @@ struct AppState {
 
 type SharedState = Arc<AppState>;
 const OPERATOR_TOKEN_HEADER: &str = "x-operator-token";
+const BASE_RELEASE_ATTESTATION_STATUS_LIMIT: usize = 25;
+const BASE_RELEASE_ATTESTATION_AUDIT_DEFAULT_LIMIT: usize = 25;
+const BASE_RELEASE_ATTESTATION_AUDIT_MAX_LIMIT: usize = 100;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BaseReleaseAttestationAuditArgs {
+    bounty_id: Uuid,
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BaseReleaseAttestationAuditReport {
+    bounty_id: Uuid,
+    limit: usize,
+    returned: usize,
+    truncated: bool,
+    redacted_fields: Vec<String>,
+    evidence_boundary: String,
+    records: Vec<BaseReleaseAttestationAuditRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BaseReleaseAttestationAuditRecord {
+    network: String,
+    tx_hash: String,
+    log_key: String,
+    bounty_id: Uuid,
+    onchain_escrow_id: String,
+    calldata_hash: Option<String>,
+    proof_hash: Option<String>,
+    recipients: Vec<BaseReleaseAttestationRecipientAuditRecord>,
+    escrow_contract: String,
+    verdict: String,
+    reason: String,
+    created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BaseReleaseAttestationRecipientAuditRecord {
+    address: String,
+    amount_minor: Option<String>,
+    currency: Option<String>,
+}
 
 fn non_empty_secret(secret: String) -> Option<String> {
     let trimmed = secret.trim();
@@ -439,6 +483,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/tools/list_base_release_queue",
             post(list_base_release_queue),
+        )
+        .route(
+            "/tools/list_base_release_attestations",
+            post(list_base_release_attestations),
         )
         .route("/tools/plan_base_release", post(plan_base_release))
         .route("/tools/plan_base_refund", post(plan_base_refund))
@@ -1178,6 +1226,18 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                 }),
                 &[],
             ),
+        ),
+        operator_tool(
+            "list_base_release_attestations",
+            "Read bounded redacted Base release attestation audit records for one bounty.",
+            object_tool_schema(
+                json!({
+                    "bounty_id": uuid_property("Hosted bounty UUID."),
+                    "limit": nullable_integer_property("Optional maximum number of attestation records to return, capped at 100.")
+                }),
+                &["bounty_id"],
+            ),
+            OPERATOR_TOKEN_REQUIRED_WHEN_CONFIGURED,
         ),
         tool(
             "run_bountybench",
@@ -1950,10 +2010,10 @@ fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResp
     let base_escrow_events = scope.base_escrow_events;
     let base_release_attestations = scope
         .base_release_attestations
-        .into_iter()
-        .map(serde_json::to_value)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| error.to_string())?;
+        .iter()
+        .take(BASE_RELEASE_ATTESTATION_STATUS_LIMIT)
+        .map(base_release_attestation_status_from_record)
+        .collect();
     let network = BountyNetwork {
         bounties: [(scope.bounty.id, scope.bounty)].into_iter().collect(),
         funding_intents: scope
@@ -2019,6 +2079,158 @@ fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResp
     status.base_escrow_events = base_escrow_events;
     status.base_release_attestations = base_release_attestations;
     Ok(status)
+}
+
+async fn list_base_release_attestations(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(args): Json<BaseReleaseAttestationAuditArgs>,
+) -> Json<serde_json::Value> {
+    if let Err(error) = require_operator(&state, &headers) {
+        return error;
+    }
+    let Some(store) = &state.store else {
+        return mcp_error("persistent store unavailable");
+    };
+    let limit = bounded_base_release_attestation_audit_limit(args.limit);
+    match store
+        .list_base_release_attestations_for_bounty_limited(args.bounty_id, limit + 1)
+        .await
+    {
+        Ok(mut records) => {
+            let truncated = records.len() > limit;
+            records.truncate(limit);
+            mcp_json(base_release_attestation_audit_report(
+                args.bounty_id,
+                limit,
+                truncated,
+                records,
+            ))
+        }
+        Err(error) => mcp_error(error),
+    }
+}
+
+fn base_release_attestation_status_from_record(
+    record: &BaseReleaseAttestationRecord,
+) -> BaseReleaseAttestationStatus {
+    BaseReleaseAttestationStatus {
+        network: record.network.clone(),
+        tx_hash: record.tx_hash.clone(),
+        log_key: record.log_key.clone(),
+        bounty_id: record.bounty_id,
+        onchain_escrow_id: record.onchain_escrow_id.clone(),
+        calldata_hash: record.calldata_hash.clone(),
+        proof_hash: record.proof_hash.clone(),
+        recipient_count: record
+            .recipients
+            .as_array()
+            .map(|recipients| recipients.len())
+            .unwrap_or(0),
+        verdict: record.verdict.clone(),
+        created_at: record.created_at,
+    }
+}
+
+fn bounded_base_release_attestation_audit_limit(limit: Option<usize>) -> usize {
+    limit
+        .unwrap_or(BASE_RELEASE_ATTESTATION_AUDIT_DEFAULT_LIMIT)
+        .clamp(1, BASE_RELEASE_ATTESTATION_AUDIT_MAX_LIMIT)
+}
+
+fn base_release_attestation_audit_report(
+    bounty_id: Uuid,
+    limit: usize,
+    truncated: bool,
+    records: Vec<BaseReleaseAttestationRecord>,
+) -> BaseReleaseAttestationAuditReport {
+    let records = records
+        .into_iter()
+        .take(limit)
+        .map(base_release_attestation_audit_record)
+        .collect::<Vec<_>>();
+    BaseReleaseAttestationAuditReport {
+        bounty_id,
+        limit,
+        returned: records.len(),
+        truncated,
+        redacted_fields: vec![
+            "settlement_signer".to_string(),
+            "platform_fee_wallet".to_string(),
+        ],
+        evidence_boundary:
+            "Operator audit view; raw provider URLs, signer config, and fee-wallet config are not returned."
+                .to_string(),
+        records,
+    }
+}
+
+fn base_release_attestation_audit_record(
+    record: BaseReleaseAttestationRecord,
+) -> BaseReleaseAttestationAuditRecord {
+    BaseReleaseAttestationAuditRecord {
+        network: record.network,
+        tx_hash: record.tx_hash,
+        log_key: record.log_key,
+        bounty_id: record.bounty_id,
+        onchain_escrow_id: record.onchain_escrow_id,
+        calldata_hash: record.calldata_hash,
+        proof_hash: record.proof_hash,
+        recipients: base_release_attestation_recipients(&record.recipients),
+        escrow_contract: record.escrow_contract,
+        verdict: record.verdict,
+        reason: record.reason,
+        created_at: record.created_at.to_rfc3339(),
+    }
+}
+
+fn base_release_attestation_recipients(
+    recipients: &Value,
+) -> Vec<BaseReleaseAttestationRecipientAuditRecord> {
+    recipients
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let address = item.get("address")?.as_str()?.to_string();
+                    Some(BaseReleaseAttestationRecipientAuditRecord {
+                        address,
+                        amount_minor: base_release_attestation_amount_minor(item.get("amount")),
+                        currency: base_release_attestation_currency(item.get("amount")),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn base_release_attestation_amount_minor(amount: Option<&Value>) -> Option<String> {
+    let value = amount?;
+    if let Some(amount) = value.as_str() {
+        return Some(amount.to_string());
+    }
+    if let Some(amount) = value.as_i64() {
+        return Some(amount.to_string());
+    }
+    if let Some(amount) = value.as_u64() {
+        return Some(amount.to_string());
+    }
+    let nested = value.get("amount")?;
+    if let Some(amount) = nested.as_str() {
+        return Some(amount.to_string());
+    }
+    if let Some(amount) = nested.as_i64() {
+        return Some(amount.to_string());
+    }
+    nested.as_u64().map(|amount| amount.to_string())
+}
+
+fn base_release_attestation_currency(amount: Option<&Value>) -> Option<String> {
+    amount?
+        .get("currency")
+        .and_then(|currency| currency.as_str())
+        .map(|currency| currency.to_string())
 }
 
 async fn get_paid_status(
@@ -3330,6 +3542,7 @@ mod tests {
             "fetch_base_rpc_logs",
             "broadcast_base_signed_transaction",
             "get_base_transaction_receipt",
+            "list_base_release_attestations",
             "approve_risk_bounty",
             "approve_risk_payout",
             "reject_risk_event",

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -26,7 +26,7 @@ use chain_base::{
     BaseNetworkDescriptor, BaseRpcUrlConfig, EvmLog, RpcLogSubmission,
 };
 use chrono::Utc;
-use db::{BountyStatusScope, PostgresStore};
+use db::{BaseLogPersistenceBatch, BountyStatusScope, PostgresStore};
 use domain::{
     Agent, BountyStatus, CapabilityClass, EvalRun, HelpRequest, Money, PaymentRail, PayoutStatus,
     PrivacyLevel, RiskReviewRecord,
@@ -2878,37 +2878,19 @@ async fn process_base_evm_logs_with_release_attestations(
         )
     };
     if let Some(store) = &state.store {
-        for bounty in &bounties {
-            if let Err(error) = store.upsert_bounty(bounty).await {
-                return mcp_error(error);
-            }
-        }
-        for attestation in &report.release_attestations {
-            if let Err(error) = store.upsert_base_release_attestation(attestation).await {
-                return mcp_error(error);
-            }
-        }
-        for intent in &funding_intents {
-            if let Err(error) = store.upsert_funding_intent(intent).await {
-                return mcp_error(error);
-            }
-        }
-        for escrow in &escrows {
-            if let Err(error) = store.upsert_escrow(escrow).await {
-                return mcp_error(error);
-            }
-        }
-        for settlement in &settlements {
-            if let Err(error) = store.upsert_settlement(settlement).await {
-                return mcp_error(error);
-            }
-        }
-        for event in &indexed_events {
-            if let Err(error) = store.upsert_base_escrow_event(event).await {
-                return mcp_error(error);
-            }
-        }
-        if let Err(error) = persist_ledger_entries(store, &report.ledger_entries).await {
+        if let Err(error) = store
+            .persist_base_log_pipeline(BaseLogPersistenceBatch {
+                bounties: &bounties,
+                release_attestations: &report.release_attestations,
+                funding_intents: &funding_intents,
+                escrows: &escrows,
+                settlements: &settlements,
+                ledger_entries: &report.ledger_entries,
+                base_escrow_events: &indexed_events,
+                cursor: None,
+            })
+            .await
+        {
             return mcp_error(error);
         }
     }

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -5,10 +5,9 @@ use app::{
     BaseIndexerStatusConfig, BaseReleaseQueueRequest, BaseReleaseTransactionEvidence,
     BountyNetwork, BountyStatusResponse, ClaimBountyRequest, CreateFundingIntentRequest,
     CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport, LiveMoneyReadinessConfig,
-    OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest,
-    PlanBaseRefundRequest, PlanBaseReleaseRequest,
-    PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest, RegisterAgentRequest,
-    RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
+    OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest,
+    PlanBaseReleaseRequest, PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest,
+    RegisterAgentRequest, RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
     ReviewedBountyApproval, RiskEventFilter, SubmitResultRequest, VerifySubmissionRequest,
 };
 use axum::{
@@ -1949,6 +1948,12 @@ async fn bounty_status_snapshot(
 fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResponse, String> {
     let bounty_id = scope.bounty.id;
     let base_escrow_events = scope.base_escrow_events;
+    let base_release_attestations = scope
+        .base_release_attestations
+        .into_iter()
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
     let network = BountyNetwork {
         bounties: [(scope.bounty.id, scope.bounty)].into_iter().collect(),
         funding_intents: scope
@@ -2012,6 +2017,7 @@ fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResp
         .status(bounty_id)
         .map_err(|error| error.to_string())?;
     status.base_escrow_events = base_escrow_events;
+    status.base_release_attestations = base_release_attestations;
     Ok(status)
 }
 
@@ -2877,8 +2883,8 @@ async fn process_base_evm_logs_with_release_attestations(
                 return mcp_error(error);
             }
         }
-        for event in &indexed_events {
-            if let Err(error) = store.upsert_base_escrow_event(event).await {
+        for attestation in &report.release_attestations {
+            if let Err(error) = store.upsert_base_release_attestation(attestation).await {
                 return mcp_error(error);
             }
         }
@@ -2897,8 +2903,8 @@ async fn process_base_evm_logs_with_release_attestations(
                 return mcp_error(error);
             }
         }
-        for attestation in &report.release_attestations {
-            if let Err(error) = store.upsert_base_release_attestation(attestation).await {
+        for event in &indexed_events {
+            if let Err(error) = store.upsert_base_escrow_event(event).await {
                 return mcp_error(error);
             }
         }

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -2,10 +2,11 @@ use app::{
     build_base_indexer_status_report, build_live_money_readiness_report,
     stripe_secret_key_mode_from_secret, AddFundingContributionRequest, ApproveRiskBountyRequest,
     ApproveRiskPayoutRequest, BaseIndexerHeartbeatStatus, BaseIndexerScanCursor,
-    BaseIndexerStatusConfig, BaseReleaseQueueRequest, BountyNetwork, BountyStatusResponse,
-    ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
-    FundingIntentReport, LiveMoneyReadinessConfig, OpenPooledBountyRequest, PlanBaseDisputeRequest,
-    PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
+    BaseIndexerStatusConfig, BaseReleaseQueueRequest, BaseReleaseTransactionEvidence,
+    BountyNetwork, BountyStatusResponse, ClaimBountyRequest, CreateFundingIntentRequest,
+    CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport, LiveMoneyReadinessConfig,
+    OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest,
+    PlanBaseRefundRequest, PlanBaseReleaseRequest,
     PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest, RegisterAgentRequest,
     RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
     ReviewedBountyApproval, RiskEventFilter, SubmitResultRequest, VerifySubmissionRequest,
@@ -19,8 +20,9 @@ use axum::{
 };
 use bounty_router::BountyRouter;
 use chain_base::{
-    base_network_descriptor, broadcast_signed_transaction, eth_get_transaction_receipt_request,
-    eth_send_raw_transaction_request, fetch_base_escrow_logs, fetch_transaction_receipt,
+    base_network_descriptor, broadcast_signed_transaction, eth_get_transaction_by_hash_request,
+    eth_get_transaction_receipt_request, eth_send_raw_transaction_request, evm_event_topic,
+    fetch_base_escrow_logs, fetch_transaction_by_hash, fetch_transaction_receipt,
     rpc_logs_to_evm_logs, BaseEscrowEvent, BaseEscrowLogQuery, BaseNetworkDescriptor,
     BaseRpcUrlConfig, EvmLog, RpcLogSubmission,
 };
@@ -43,7 +45,7 @@ use payments_stripe::{
 use risk::RiskPolicy;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::sync::{Arc, Mutex};
 use tower_http::cors::CorsLayer;
@@ -268,6 +270,9 @@ struct GetBaseTransactionReceiptArgs {
     request_id: Option<u64>,
     network: Option<String>,
     reconcile_logs: Option<bool>,
+    escrow_contract: Option<String>,
+    settlement_signer: Option<String>,
+    platform_fee_wallet: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1083,7 +1088,10 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                     "tx_hash": string_property("0x-prefixed transaction hash."),
                     "request_id": nullable_integer_property("Optional JSON-RPC request id."),
                     "network": nullable_enum_property(&["base-sepolia", "base-mainnet"], "Optional Base network; defaults to base-sepolia."),
-                    "reconcile_logs": nullable_boolean_property("When true, normalize receipt logs and run the Base escrow indexer.")
+                    "reconcile_logs": nullable_boolean_property("When true, normalize receipt logs and run the Base escrow indexer."),
+                    "escrow_contract": nullable_string_property("Expected Base escrow contract for release calldata attestation; inferred for known deployments when omitted."),
+                    "settlement_signer": nullable_string_property("Expected settlement signer address. Required for EscrowReleased reconciliation unless BASE_SETTLEMENT_SIGNER is configured."),
+                    "platform_fee_wallet": nullable_string_property("Expected platform fee wallet used to rebuild the release plan. Required for EscrowReleased reconciliation unless BASE_PLATFORM_FEE_WALLET is configured.")
                 }),
                 &["tx_hash"],
             ),
@@ -2678,6 +2686,8 @@ async fn get_base_transaction_receipt(
             "block_number": null,
             "succeeded": null,
             "log_count": 0,
+            "transaction_request": null,
+            "transaction": null,
             "receipt": null,
             "reconciliation": null
         }));
@@ -2691,12 +2701,79 @@ async fn get_base_transaction_receipt(
         Err(error) => return mcp_error(error),
     };
     let log_count = receipt.logs.len();
+    let mut transaction_request = None;
+    let mut transaction = None;
     let reconciliation = if args.reconcile_logs.unwrap_or(false) {
         let logs = match receipt.logs_to_evm_logs() {
             Ok(logs) => logs,
             Err(error) => return mcp_error(error),
         };
-        let reconciliation = process_base_evm_logs(&state, logs).await.0;
+        let release_attestations = if logs_contain_release(&logs) {
+            let request = match eth_get_transaction_by_hash_request(&tx_hash, request_id + 1) {
+                Ok(request) => request,
+                Err(error) => return mcp_error(error),
+            };
+            let response = match fetch_transaction_by_hash(&rpc_url, &tx_hash, request_id + 1).await
+            {
+                Ok(response) => response,
+                Err(error) => return mcp_error(error),
+            };
+            let Some(tx) = response.result else {
+                return mcp_error("release log reconciliation requires transaction input");
+            };
+            let Some(to) = tx.to.clone() else {
+                return mcp_error("release transaction is missing target contract");
+            };
+            let escrow_contract = match args
+                .escrow_contract
+                .clone()
+                .or_else(|| base_escrow_contract_for_chain(network.chain_id))
+            {
+                Some(value) => value,
+                None => return mcp_error("escrow_contract is required to attest release calldata"),
+            };
+            let settlement_signer = match args
+                .settlement_signer
+                .clone()
+                .or_else(|| env::var("BASE_SETTLEMENT_SIGNER").ok())
+            {
+                Some(value) => value,
+                None => {
+                    return mcp_error("settlement_signer is required to attest release calldata")
+                }
+            };
+            let platform_fee_wallet = match args
+                .platform_fee_wallet
+                .clone()
+                .or_else(|| env::var("BASE_PLATFORM_FEE_WALLET").ok())
+            {
+                Some(value) => value,
+                None => {
+                    return mcp_error("platform_fee_wallet is required to attest release calldata")
+                }
+            };
+            let evidence = BaseReleaseTransactionEvidence {
+                tx_hash: tx.hash.clone(),
+                chain_id: network.chain_id,
+                expected_chain_id: network.chain_id,
+                from: tx.from.clone(),
+                settlement_signer,
+                to,
+                escrow_contract,
+                input: tx.input.clone(),
+                receipt_succeeded: succeeded.unwrap_or(false),
+                platform_fee_wallet,
+            };
+            transaction_request = Some(request);
+            transaction = Some(tx);
+            HashMap::from([(tx_hash.to_ascii_lowercase(), evidence)])
+        } else {
+            HashMap::new()
+        };
+        let reconciliation =
+            process_base_evm_logs_with_release_attestations(&state, logs, &release_attestations)
+                .await
+                .0;
         if reconciliation.get("error").is_some() {
             return Json(reconciliation);
         }
@@ -2713,16 +2790,36 @@ async fn get_base_transaction_receipt(
         "block_number": block_number,
         "succeeded": succeeded,
         "log_count": log_count,
+        "transaction_request": transaction_request,
+        "transaction": transaction,
         "receipt": receipt,
         "reconciliation": reconciliation
     }))
 }
 
+fn logs_contain_release(logs: &[EvmLog]) -> bool {
+    let released_topic = evm_event_topic("EscrowReleased(uint256,bytes32)");
+    logs.iter().any(|log| {
+        log.topics
+            .first()
+            .is_some_and(|topic| topic.eq_ignore_ascii_case(&released_topic))
+    })
+}
+
 async fn process_base_evm_logs(state: &SharedState, logs: Vec<EvmLog>) -> Json<serde_json::Value> {
+    process_base_evm_logs_with_release_attestations(state, logs, &HashMap::new()).await
+}
+
+async fn process_base_evm_logs_with_release_attestations(
+    state: &SharedState,
+    logs: Vec<EvmLog>,
+    release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
+) -> Json<serde_json::Value> {
     let (report, indexed_events, bounties, funding_intents, escrows, settlements) = {
         let mut network = state.network.lock().expect("state poisoned");
         let mut worker = state.base_log_worker.lock().expect("state poisoned");
-        let report = worker.process_logs(logs, &mut network);
+        let report =
+            worker.process_logs_with_release_attestations(logs, &mut network, release_attestations);
         let applied_event_ids = report
             .applied_events
             .iter()

--- a/crates/sdk-python/agent_bounties/client.py
+++ b/crates/sdk-python/agent_bounties/client.py
@@ -599,6 +599,10 @@ class AgentBountiesClient:
             },
         )
 
+    def list_base_release_attestations(self, bounty_id: str, limit: int | None = None):
+        query = f"?limit={limit}" if limit is not None else ""
+        return self._request("GET", f"/v1/base/release-attestations/{bounty_id}{query}")
+
     def plan_stripe_checkout_top_up(
         self,
         organization_id: str,

--- a/crates/sdk-python/agent_bounties/client.py
+++ b/crates/sdk-python/agent_bounties/client.py
@@ -497,9 +497,6 @@ class AgentBountiesClient:
         request_id: int | None = None,
         network: str | None = None,
         reconcile_logs: bool | None = None,
-        escrow_contract: str | None = None,
-        settlement_signer: str | None = None,
-        platform_fee_wallet: str | None = None,
     ):
         return self._request(
             "POST",
@@ -509,9 +506,6 @@ class AgentBountiesClient:
                 "request_id": request_id,
                 "network": network,
                 "reconcile_logs": reconcile_logs,
-                "escrow_contract": escrow_contract,
-                "settlement_signer": settlement_signer,
-                "platform_fee_wallet": platform_fee_wallet,
             },
         )
 

--- a/crates/sdk-python/agent_bounties/client.py
+++ b/crates/sdk-python/agent_bounties/client.py
@@ -497,6 +497,9 @@ class AgentBountiesClient:
         request_id: int | None = None,
         network: str | None = None,
         reconcile_logs: bool | None = None,
+        escrow_contract: str | None = None,
+        settlement_signer: str | None = None,
+        platform_fee_wallet: str | None = None,
     ):
         return self._request(
             "POST",
@@ -506,6 +509,9 @@ class AgentBountiesClient:
                 "request_id": request_id,
                 "network": network,
                 "reconcile_logs": reconcile_logs,
+                "escrow_contract": escrow_contract,
+                "settlement_signer": settlement_signer,
+                "platform_fee_wallet": platform_fee_wallet,
             },
         )
 

--- a/crates/sdk-typescript/src/index.ts
+++ b/crates/sdk-typescript/src/index.ts
@@ -163,9 +163,6 @@ export interface GetBaseTransactionReceiptRequest {
   request_id?: number | null;
   network?: string | null;
   reconcile_logs?: boolean | null;
-  escrow_contract?: string | null;
-  settlement_signer?: string | null;
-  platform_fee_wallet?: string | null;
 }
 
 export type BaseEscrowEvent = Record<string, unknown>;
@@ -627,9 +624,6 @@ export class AgentBountiesClient {
         request_id: request.request_id ?? null,
         network: request.network ?? null,
         reconcile_logs: request.reconcile_logs ?? null,
-        escrow_contract: request.escrow_contract ?? null,
-        settlement_signer: request.settlement_signer ?? null,
-        platform_fee_wallet: request.platform_fee_wallet ?? null,
       }),
     });
   }

--- a/crates/sdk-typescript/src/index.ts
+++ b/crates/sdk-typescript/src/index.ts
@@ -163,6 +163,9 @@ export interface GetBaseTransactionReceiptRequest {
   request_id?: number | null;
   network?: string | null;
   reconcile_logs?: boolean | null;
+  escrow_contract?: string | null;
+  settlement_signer?: string | null;
+  platform_fee_wallet?: string | null;
 }
 
 export type BaseEscrowEvent = Record<string, unknown>;
@@ -624,6 +627,9 @@ export class AgentBountiesClient {
         request_id: request.request_id ?? null,
         network: request.network ?? null,
         reconcile_logs: request.reconcile_logs ?? null,
+        escrow_contract: request.escrow_contract ?? null,
+        settlement_signer: request.settlement_signer ?? null,
+        platform_fee_wallet: request.platform_fee_wallet ?? null,
       }),
     });
   }

--- a/crates/sdk-typescript/src/index.ts
+++ b/crates/sdk-typescript/src/index.ts
@@ -667,6 +667,15 @@ export class AgentBountiesClient {
     });
   }
 
+  async listBaseReleaseAttestations(bountyId: string, limit?: number): Promise<unknown> {
+    const params = new URLSearchParams();
+    if (limit !== undefined) {
+      params.set("limit", String(limit));
+    }
+    const query = params.toString();
+    return this.request(`/v1/base/release-attestations/${bountyId}${query ? `?${query}` : ""}`);
+  }
+
   async planStripeCheckoutTopUp(request: PlanStripeCheckoutTopUpRequest): Promise<unknown> {
     return this.request("/v1/stripe/checkout-top-ups", {
       method: "POST",

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -886,7 +886,7 @@ fn real_money_rehearsal_descriptor() -> RealMoneyRehearsalDescriptor {
         ],
         payout_evidence: vec![
             "Deterministic verifier acceptance creates proof records and settlement intents, but does not by itself move money.".to_string(),
-            "Base USDC payout becomes paid only after an indexed EscrowReleased log whose proof hash matches the accepted proof record.".to_string(),
+            "Base USDC payout becomes paid only after an indexed EscrowReleased log is bound to the successful release transaction calldata and that calldata matches the accepted proof, recipients, amounts, and escrow id.".to_string(),
             "Stripe fiat payout becomes paid only after transfer.created evidence matches payout intent, settlement, bounty, proof, and agent metadata.".to_string(),
         ],
         pooled_and_mixed_funding: true,
@@ -2593,7 +2593,7 @@ pub fn public_bounty_payment_lifecycle(
                 "All required payout evidence has reconciled and the bounty is terminally paid."
                     .to_string()
             } else {
-                "Payment is not final until Base EscrowReleased logs or Stripe transfer.created evidence reconcile against settlement metadata.".to_string()
+                "Payment is not final until Base EscrowReleased logs plus matching release calldata, or Stripe transfer.created evidence, reconcile against settlement metadata.".to_string()
             },
             next_action_url: Some(item.status_url.clone()),
         },

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -3,11 +3,11 @@ use app::{
     BaseEscrowReconciliation, BaseReleaseAttestation, BaseReleaseTransactionEvidence, BountyNetwork,
 };
 use chain_base::{
-    base_network_descriptor, calldata_keccak256, evm_event_topic, fetch_base_escrow_logs,
-    fetch_block_number, fetch_transaction_by_hash, fetch_transaction_receipt,
-    normalize_evm_address, normalize_evm_hash, rpc_logs_to_evm_logs, BaseEscrowEvent,
-    BaseEscrowEventKind, BaseEscrowLogDecoder, BaseEscrowLogQuery, BaseNetworkDescriptor,
-    ChainEventIndexer, EvmLog,
+    base_network_descriptor, calldata_keccak256, decode_base_release_calldata, evm_event_topic,
+    fetch_base_escrow_logs, fetch_block_number, fetch_transaction_by_hash,
+    fetch_transaction_receipt, normalize_evm_address, normalize_evm_hash, rpc_logs_to_evm_logs,
+    BaseEscrowEvent, BaseEscrowEventKind, BaseEscrowLogDecoder, BaseEscrowLogQuery,
+    BaseNetworkDescriptor, ChainEventIndexer, EvmLog,
 };
 use chrono::{DateTime, Utc};
 use db::{
@@ -72,6 +72,17 @@ pub struct BaseLogPipelineReport {
     pub ledger_entries: Vec<LedgerEntry>,
     pub release_attestations: Vec<BaseReleaseAttestationRecord>,
     pub failures: Vec<BaseLogFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseReleaseAttestationFailureEvidence {
+    pub tx_hash: String,
+    pub expected_chain_id: u64,
+    pub escrow_contract: String,
+    pub settlement_signer: String,
+    pub platform_fee_wallet: Option<String>,
+    pub input: Option<String>,
+    pub reason: String,
 }
 
 #[derive(Debug)]
@@ -152,6 +163,21 @@ impl BaseEscrowLogWorker {
         network: &mut BountyNetwork,
         release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
     ) -> BaseLogPipelineReport {
+        self.process_logs_with_release_evidence(
+            logs,
+            network,
+            release_attestations,
+            &HashMap::new(),
+        )
+    }
+
+    pub fn process_logs_with_release_evidence(
+        &mut self,
+        logs: impl IntoIterator<Item = EvmLog>,
+        network: &mut BountyNetwork,
+        release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
+        failed_release_attestations: &HashMap<String, BaseReleaseAttestationFailureEvidence>,
+    ) -> BaseLogPipelineReport {
         let mut logs = logs.into_iter().collect::<Vec<_>>();
         logs.sort_by_key(|log| (log.block_number, log.log_index));
 
@@ -184,6 +210,23 @@ impl BaseEscrowLogWorker {
                 self.advance_cursor(block_number, log_index, event.log_key.clone());
                 report.ending_cursor = self.cursor.clone();
                 continue;
+            }
+
+            if event.kind == BaseEscrowEventKind::Released {
+                if let Some(failure) =
+                    failed_release_attestations.get(&release_tx_key(&event.tx_hash))
+                {
+                    report
+                        .release_attestations
+                        .push(failed_release_attestation_record(&event, failure));
+                    report.failures.push(BaseLogFailure {
+                        block_number,
+                        log_index,
+                        log_key: event.log_key,
+                        reason: failure.reason.clone(),
+                    });
+                    break;
+                }
             }
 
             let reconciliation = match apply_event_with_optional_attestation(
@@ -328,6 +371,54 @@ fn release_attestation_record(
         reason: reason.to_string(),
         created_at: Utc::now(),
     }
+}
+
+fn failed_release_attestation_record(
+    event: &BaseEscrowEvent,
+    failure: &BaseReleaseAttestationFailureEvidence,
+) -> BaseReleaseAttestationRecord {
+    let decoded = failure
+        .input
+        .as_deref()
+        .and_then(|input| decode_base_release_calldata(input, "usdc").ok());
+    let recipients = decoded
+        .as_ref()
+        .map(|decoded| {
+            serde_json::to_value(&decoded.recipients).unwrap_or_else(|_| serde_json::json!([]))
+        })
+        .unwrap_or_else(|| serde_json::json!([]));
+    BaseReleaseAttestationRecord {
+        id: Id::new_v4(),
+        network: failure.expected_chain_id.to_string(),
+        tx_hash: normalize_evm_hash(&failure.tx_hash).unwrap_or_else(|_| failure.tx_hash.clone()),
+        log_key: event.log_key.clone(),
+        bounty_id: event.bounty_id,
+        onchain_escrow_id: event.onchain_escrow_id.to_string(),
+        calldata_hash: failure
+            .input
+            .as_deref()
+            .and_then(|input| calldata_keccak256(input).ok()),
+        proof_hash: decoded
+            .as_ref()
+            .map(|decoded| decoded.proof_hash.clone())
+            .or_else(|| event.proof_hash.clone()),
+        recipients,
+        escrow_contract: normalize_evm_address(&failure.escrow_contract)
+            .unwrap_or_else(|_| failure.escrow_contract.clone()),
+        settlement_signer: normalize_evm_address(&failure.settlement_signer)
+            .unwrap_or_else(|_| failure.settlement_signer.clone()),
+        platform_fee_wallet: failure
+            .platform_fee_wallet
+            .as_ref()
+            .map(|wallet| normalize_evm_address(wallet).unwrap_or_else(|_| wallet.clone())),
+        verdict: "failed".to_string(),
+        reason: failure.reason.clone(),
+        created_at: Utc::now(),
+    }
+}
+
+fn release_tx_key(tx_hash: &str) -> String {
+    normalize_evm_hash(tx_hash).unwrap_or_else(|_| tx_hash.to_ascii_lowercase())
 }
 
 fn cursor_from_events(events: &[BaseEscrowEvent]) -> BaseLogCursor {
@@ -639,15 +730,16 @@ pub async fn poll_base_indexer_once(
     let response = fetch_base_escrow_logs(&config.rpc_url, &query, config.request_id + 1).await?;
     let logs = rpc_logs_to_evm_logs(response.result)?;
     let fetched_logs = logs.len();
-    let release_attestations =
+    let release_attestation_fetch =
         fetch_release_transaction_evidence_for_logs(&config.rpc_url, &descriptor, config, &logs)
             .await?;
-    let reconciliation = process_base_evm_logs_and_persist_with_release_attestations(
+    let reconciliation = process_base_evm_logs_and_persist_with_release_evidence(
         store,
         &mut worker,
         &mut network,
         logs,
-        &release_attestations,
+        &release_attestation_fetch.attestations,
+        &release_attestation_fetch.failures,
         Some(BaseLogPersistenceCursor {
             network: &config.network,
             escrow_contract: &config.escrow_contract,
@@ -855,7 +947,33 @@ pub async fn process_base_evm_logs_and_persist_with_release_attestations(
     release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
     cursor_if_success: Option<BaseLogPersistenceCursor<'_>>,
 ) -> anyhow::Result<BaseLogPipelineReport> {
-    let report = worker.process_logs_with_release_attestations(logs, network, release_attestations);
+    process_base_evm_logs_and_persist_with_release_evidence(
+        store,
+        worker,
+        network,
+        logs,
+        release_attestations,
+        &HashMap::new(),
+        cursor_if_success,
+    )
+    .await
+}
+
+pub async fn process_base_evm_logs_and_persist_with_release_evidence(
+    store: &PostgresStore,
+    worker: &mut BaseEscrowLogWorker,
+    network: &mut BountyNetwork,
+    logs: Vec<EvmLog>,
+    release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
+    failed_release_attestations: &HashMap<String, BaseReleaseAttestationFailureEvidence>,
+    cursor_if_success: Option<BaseLogPersistenceCursor<'_>>,
+) -> anyhow::Result<BaseLogPipelineReport> {
+    let report = worker.process_logs_with_release_evidence(
+        logs,
+        network,
+        release_attestations,
+        failed_release_attestations,
+    );
     let applied_event_ids = report
         .applied_events
         .iter()
@@ -919,47 +1037,158 @@ pub async fn process_base_evm_logs_and_persist_with_release_attestations(
     Ok(report)
 }
 
+#[derive(Debug, Clone, Default)]
+struct ReleaseTransactionEvidenceFetchReport {
+    attestations: HashMap<String, BaseReleaseTransactionEvidence>,
+    failures: HashMap<String, BaseReleaseAttestationFailureEvidence>,
+}
+
 async fn fetch_release_transaction_evidence_for_logs(
     rpc_url: &str,
     descriptor: &BaseNetworkDescriptor,
     config: &BaseIndexerConfig,
     logs: &[EvmLog],
-) -> anyhow::Result<HashMap<String, BaseReleaseTransactionEvidence>> {
+) -> anyhow::Result<ReleaseTransactionEvidenceFetchReport> {
     let release_topic = evm_event_topic("EscrowReleased(uint256,bytes32)");
     let mut tx_hashes = Vec::new();
+    let mut report = ReleaseTransactionEvidenceFetchReport::default();
     for log in logs {
         if log.topics.first() != Some(&release_topic) {
             continue;
         }
-        let log_address = normalize_evm_address(&log.address)
-            .map_err(|error| anyhow!("invalid release log emitter address: {error}"))?;
+        let tx_key = release_tx_key(&log.tx_hash);
+        let log_address = match normalize_evm_address(&log.address) {
+            Ok(address) => address,
+            Err(error) => {
+                report.failures.insert(
+                    tx_key,
+                    failed_release_fetch(
+                        &log.tx_hash,
+                        descriptor,
+                        config,
+                        None,
+                        format!("invalid release log emitter address: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
         if log_address != config.escrow_contract {
-            return Err(anyhow!(
-                "release log emitted by {log_address}, expected configured escrow {}",
-                config.escrow_contract
-            ));
+            report.failures.insert(
+                tx_key,
+                failed_release_fetch(
+                    &log.tx_hash,
+                    descriptor,
+                    config,
+                    None,
+                    format!(
+                        "release log emitted by {log_address}, expected configured escrow {}",
+                        config.escrow_contract
+                    ),
+                ),
+            );
+            continue;
         }
-        let tx_hash = normalize_evm_hash(&log.tx_hash)
-            .map_err(|error| anyhow!("invalid release log transaction hash: {error}"))?;
+        let tx_hash = match normalize_evm_hash(&log.tx_hash) {
+            Ok(tx_hash) => tx_hash,
+            Err(error) => {
+                report.failures.insert(
+                    tx_key,
+                    failed_release_fetch(
+                        &log.tx_hash,
+                        descriptor,
+                        config,
+                        None,
+                        format!("invalid release log transaction hash: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
         if !tx_hashes.contains(&tx_hash) {
             tx_hashes.push(tx_hash);
         }
     }
 
-    let mut attestations = HashMap::new();
     for (index, tx_hash) in tx_hashes.into_iter().enumerate() {
         let request_id = config.request_id + 10 + (index as u64 * 2);
-        let receipt = fetch_transaction_receipt(rpc_url, &tx_hash, request_id)
-            .await?
-            .result
-            .ok_or_else(|| anyhow!("release transaction receipt not found for {tx_hash}"))?;
-        let receipt_tx_hash = receipt.normalized_tx_hash()?;
+        let receipt_response = match fetch_transaction_receipt(rpc_url, &tx_hash, request_id).await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        None,
+                        format!("release transaction receipt fetch failed for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
+        let Some(receipt) = receipt_response.result else {
+            report.failures.insert(
+                tx_hash.clone(),
+                failed_release_fetch(
+                    &tx_hash,
+                    descriptor,
+                    config,
+                    None,
+                    format!("release transaction receipt not found for {tx_hash}"),
+                ),
+            );
+            continue;
+        };
+        let receipt_tx_hash = match receipt.normalized_tx_hash() {
+            Ok(tx_hash) => tx_hash,
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        None,
+                        format!("invalid release receipt transaction hash for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
         if receipt_tx_hash != tx_hash {
-            return Err(anyhow!(
-                "release receipt hash {receipt_tx_hash} does not match requested transaction {tx_hash}"
-            ));
+            report.failures.insert(
+                tx_hash.clone(),
+                failed_release_fetch(
+                    &tx_hash,
+                    descriptor,
+                    config,
+                    None,
+                    format!(
+                        "release receipt hash {receipt_tx_hash} does not match requested transaction {tx_hash}"
+                    ),
+                ),
+            );
+            continue;
         }
-        let receipt_logs = receipt.logs_to_evm_logs()?;
+        let receipt_logs = match receipt.logs_to_evm_logs() {
+            Ok(logs) => logs,
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        None,
+                        format!("release receipt logs are invalid for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
         let receipt_has_configured_release = receipt_logs.iter().any(|log| {
             log.tx_hash == tx_hash
                 && log.topics.first() == Some(&release_topic)
@@ -968,47 +1197,206 @@ async fn fetch_release_transaction_evidence_for_logs(
                     .unwrap_or(false)
         });
         if !receipt_has_configured_release {
-            return Err(anyhow!(
+            let reason = format!(
                 "release receipt {tx_hash} has no EscrowReleased log emitted by configured escrow {}",
                 config.escrow_contract
-            ));
+            );
+            report.failures.insert(
+                tx_hash.clone(),
+                failed_release_fetch(&tx_hash, descriptor, config, None, reason),
+            );
+            continue;
         }
 
-        let transaction = fetch_transaction_by_hash(rpc_url, &tx_hash, request_id + 1)
-            .await?
-            .result
-            .ok_or_else(|| anyhow!("release transaction not found for {tx_hash}"))?;
-        let transaction_hash = transaction.normalized_hash()?;
+        let transaction_response =
+            match fetch_transaction_by_hash(rpc_url, &tx_hash, request_id + 1).await {
+                Ok(response) => response,
+                Err(error) => {
+                    report.failures.insert(
+                        tx_hash.clone(),
+                        failed_release_fetch(
+                            &tx_hash,
+                            descriptor,
+                            config,
+                            None,
+                            format!("release transaction fetch failed for {tx_hash}: {error}"),
+                        ),
+                    );
+                    continue;
+                }
+            };
+        let Some(transaction) = transaction_response.result else {
+            report.failures.insert(
+                tx_hash.clone(),
+                failed_release_fetch(
+                    &tx_hash,
+                    descriptor,
+                    config,
+                    None,
+                    format!("release transaction not found for {tx_hash}"),
+                ),
+            );
+            continue;
+        };
+        let input = Some(transaction.input.clone());
+        let transaction_hash = match transaction.normalized_hash() {
+            Ok(hash) => hash,
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        input,
+                        format!("invalid release transaction hash for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
         if transaction_hash != tx_hash {
-            return Err(anyhow!(
-                "release transaction hash {transaction_hash} does not match receipt {tx_hash}"
-            ));
+            report.failures.insert(
+                tx_hash.clone(),
+                failed_release_fetch(
+                    &tx_hash,
+                    descriptor,
+                    config,
+                    input,
+                    format!(
+                        "release transaction hash {transaction_hash} does not match receipt {tx_hash}"
+                    ),
+                ),
+            );
+            continue;
         }
-        let chain_id = transaction
-            .chain_id()?
-            .ok_or_else(|| anyhow!("release transaction {tx_hash} is missing chainId"))?;
-        let to = transaction
-            .normalized_to()?
-            .ok_or_else(|| anyhow!("release transaction {tx_hash} has no target contract"))?;
+        let chain_id = match transaction.chain_id() {
+            Ok(Some(chain_id)) => chain_id,
+            Ok(None) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        input,
+                        format!("release transaction {tx_hash} is missing chainId"),
+                    ),
+                );
+                continue;
+            }
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        input,
+                        format!("invalid release transaction chainId for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
+        let to = match transaction.normalized_to() {
+            Ok(Some(to)) => to,
+            Ok(None) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        input,
+                        format!("release transaction {tx_hash} has no target contract"),
+                    ),
+                );
+                continue;
+            }
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        input,
+                        format!("invalid release transaction target for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
+        let from = match transaction.normalized_from() {
+            Ok(from) => from,
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        input,
+                        format!("invalid release transaction sender for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
+        let receipt_succeeded = match receipt.succeeded() {
+            Ok(value) => value.unwrap_or(false),
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        input,
+                        format!("invalid release receipt status for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
 
-        attestations.insert(
+        report.attestations.insert(
             tx_hash.clone(),
             BaseReleaseTransactionEvidence {
                 tx_hash,
                 chain_id,
                 expected_chain_id: descriptor.chain_id,
-                from: transaction.normalized_from()?,
+                from,
                 settlement_signer: config.settlement_signer.clone(),
                 to,
                 escrow_contract: config.escrow_contract.clone(),
                 input: transaction.input.clone(),
-                receipt_succeeded: receipt.succeeded()?.unwrap_or(false),
+                receipt_succeeded,
                 platform_fee_wallet: config.platform_fee_wallet.clone(),
             },
         );
     }
 
-    Ok(attestations)
+    Ok(report)
+}
+
+fn failed_release_fetch(
+    tx_hash: &str,
+    descriptor: &BaseNetworkDescriptor,
+    config: &BaseIndexerConfig,
+    input: Option<String>,
+    reason: String,
+) -> BaseReleaseAttestationFailureEvidence {
+    BaseReleaseAttestationFailureEvidence {
+        tx_hash: tx_hash.to_string(),
+        expected_chain_id: descriptor.chain_id,
+        escrow_contract: config.escrow_contract.clone(),
+        settlement_signer: config.settlement_signer.clone(),
+        platform_fee_wallet: config.platform_fee_wallet.clone(),
+        input,
+        reason,
+    }
 }
 
 pub fn next_indexer_from_block(
@@ -1128,6 +1516,76 @@ mod tests {
         assert_eq!(status.bounty.status, BountyStatus::Paid);
         assert_eq!(status.escrows[0].status, EscrowStatus::Released);
         assert_eq!(network.ledger.entries().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn release_fetch_failure_persists_decoded_quarantine_record() {
+        let (mut network, bounty, proof) = payable_base_bounty().await;
+        let logs = raw_created_and_released_logs(&bounty, &proof);
+        let release_attestations = release_attestations_for(&network, &bounty, &logs[1]);
+        let planned = release_attestations
+            .get(&release_tx_key(&logs[1].tx_hash))
+            .expect("planned release evidence");
+        let failures = HashMap::from([(
+            release_tx_key(&logs[1].tx_hash),
+            BaseReleaseAttestationFailureEvidence {
+                tx_hash: logs[1].tx_hash.clone(),
+                expected_chain_id: planned.expected_chain_id,
+                escrow_contract: planned.escrow_contract.clone(),
+                settlement_signer: planned.settlement_signer.clone(),
+                platform_fee_wallet: planned.platform_fee_wallet.clone(),
+                input: Some(planned.input.clone()),
+                reason: "release transaction receipt not found for quarantine test".to_string(),
+            },
+        )]);
+        let mut worker = BaseEscrowLogWorker::default();
+
+        let report = worker.process_logs_with_release_evidence(
+            logs,
+            &mut network,
+            &HashMap::new(),
+            &failures,
+        );
+
+        assert_eq!(report.applied_events.len(), 1);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(
+            report.failures[0].reason,
+            "release transaction receipt not found for quarantine test"
+        );
+        assert_eq!(report.release_attestations.len(), 1);
+        let record = &report.release_attestations[0];
+        assert_eq!(record.verdict, "failed");
+        assert_eq!(
+            record.reason,
+            "release transaction receipt not found for quarantine test"
+        );
+        assert!(record.calldata_hash.is_some());
+        let expected_proof_hash = format!("0x{}", proof.proof_hash);
+        assert_eq!(
+            record.proof_hash.as_deref(),
+            Some(expected_proof_hash.as_str())
+        );
+        let recipients = record.recipients.as_array().expect("recipients array");
+        assert_eq!(recipients.len(), 1);
+        assert_eq!(
+            recipients[0]["address"],
+            serde_json::json!("0x2222222222222222222222222222222222222222")
+        );
+        assert_eq!(
+            recipients[0]["amount"]["amount"],
+            serde_json::json!(1_000_000)
+        );
+        assert_eq!(
+            recipients[0]["amount"]["currency"],
+            serde_json::json!("usdc")
+        );
+        let status = network.status(bounty.id).unwrap();
+        assert_eq!(status.bounty.status, BountyStatus::Payable);
+        assert_eq!(
+            status.settlements[0].payout_intents[0].status,
+            PayoutStatus::Pending
+        );
     }
 
     #[tokio::test]

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context};
-use app::{BaseEscrowReconciliation, BountyNetwork};
+use app::{BaseEscrowReconciliation, BaseReleaseTransactionEvidence, BountyNetwork};
 use chain_base::{
     base_network_descriptor, fetch_base_escrow_logs, fetch_block_number, rpc_logs_to_evm_logs,
     BaseEscrowEvent, BaseEscrowEventKind, BaseEscrowLogDecoder, BaseEscrowLogQuery,
@@ -10,7 +10,7 @@ use db::{BaseIndexerHeartbeat, PostgresStore};
 use domain::{Id, Submission, VerifierResult};
 use ledger::{Ledger, LedgerEntry};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use verifier_sdk::{VerificationInput, Verifier, VerifierResultType};
 
 pub struct VerificationJob<V: Verifier> {
@@ -135,6 +135,15 @@ impl BaseEscrowLogWorker {
         logs: impl IntoIterator<Item = EvmLog>,
         network: &mut BountyNetwork,
     ) -> BaseLogPipelineReport {
+        self.process_logs_with_release_attestations(logs, network, &HashMap::new())
+    }
+
+    pub fn process_logs_with_release_attestations(
+        &mut self,
+        logs: impl IntoIterator<Item = EvmLog>,
+        network: &mut BountyNetwork,
+        release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
+    ) -> BaseLogPipelineReport {
         let mut logs = logs.into_iter().collect::<Vec<_>>();
         logs.sort_by_key(|log| (log.block_number, log.log_index));
 
@@ -169,7 +178,11 @@ impl BaseEscrowLogWorker {
                 continue;
             }
 
-            let reconciliation = match network.apply_base_escrow_event(event.clone()) {
+            let reconciliation = match apply_event_with_optional_attestation(
+                network,
+                event.clone(),
+                release_attestations,
+            ) {
                 Ok(reconciliation) => reconciliation,
                 Err(error) => {
                     report.failures.push(BaseLogFailure {
@@ -208,6 +221,26 @@ impl BaseEscrowLogWorker {
         self.cursor.last_log_index = Some(log_index);
         self.cursor.last_log_key = Some(log_key);
     }
+}
+
+fn apply_event_with_optional_attestation(
+    network: &mut BountyNetwork,
+    event: BaseEscrowEvent,
+    release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
+) -> app::AppResult<BaseEscrowReconciliation> {
+    if event.kind == BaseEscrowEventKind::Released {
+        let evidence = release_attestations
+            .get(&event.tx_hash.to_ascii_lowercase())
+            .cloned()
+            .ok_or_else(|| {
+                app::AppError::InvalidBaseEscrowEvent(
+                    "released event requires matching release transaction calldata attestation"
+                        .to_string(),
+                )
+            })?;
+        return network.apply_attested_base_release_event(event, evidence);
+    }
+    network.apply_base_escrow_event(event)
 }
 
 fn applied_event(
@@ -828,8 +861,8 @@ fn nonempty(value: &str) -> bool {
 mod tests {
     use super::*;
     use app::{
-        hash_artifact, ClaimBountyRequest, PostBountyRequest, RegisterAgentRequest,
-        SubmitResultRequest, VerifySubmissionRequest,
+        hash_artifact, ClaimBountyRequest, PlanBaseReleaseRequest, PostBountyRequest,
+        RegisterAgentRequest, SubmitResultRequest, VerifySubmissionRequest,
     };
     use chain_base::{
         evm_address_word, evm_bytes32_word, evm_event_topic, evm_uint256_word, evm_words_data,
@@ -841,35 +874,47 @@ mod tests {
     use std::collections::HashMap;
 
     #[tokio::test]
-    async fn raw_base_logs_mark_payable_bounty_paid_once() {
+    async fn raw_base_logs_require_release_calldata_attestation() {
         let (mut network, bounty, proof) = payable_base_bounty().await;
         let logs = raw_created_and_released_logs(&bounty, &proof);
         let mut worker = BaseEscrowLogWorker::default();
 
         let report = worker.process_logs(logs.clone(), &mut network);
 
-        assert!(report.failures.is_empty());
+        assert_eq!(report.failures.len(), 1);
+        assert!(report.failures[0]
+            .reason
+            .contains("requires matching release transaction calldata attestation"));
         assert_eq!(report.decoded_events, 2);
-        assert_eq!(report.applied_events.len(), 2);
-        assert_eq!(report.ledger_entries.len(), 1);
-        assert_eq!(worker.indexed_events().len(), 2);
-        assert_eq!(worker.cursor().last_block_number, Some(11));
-        assert_eq!(worker.cursor().last_log_index, Some(0));
+        assert_eq!(report.applied_events.len(), 1);
+        assert!(report.ledger_entries.is_empty());
+        assert_eq!(worker.indexed_events().len(), 1);
+        assert_eq!(worker.cursor().last_block_number, Some(10));
 
+        let status = network.status(bounty.id).unwrap();
+        assert_eq!(status.bounty.status, BountyStatus::Payable);
+        assert_eq!(
+            status.settlements[0].payout_intents[0].status,
+            PayoutStatus::Pending
+        );
+        assert_eq!(network.ledger.entries().len(), 1);
+
+        let release_attestations = release_attestations_for(&network, &bounty, &logs[1]);
+        let mut attested_worker =
+            BaseEscrowLogWorker::from_indexed_events("usdc", worker.indexed_events().to_vec())
+                .unwrap();
+        let attested = attested_worker.process_logs_with_release_attestations(
+            vec![logs[1].clone()],
+            &mut network,
+            &release_attestations,
+        );
+        assert!(attested.failures.is_empty());
+        assert_eq!(attested.applied_events.len(), 1);
+        assert_eq!(attested.ledger_entries.len(), 1);
+        assert_eq!(attested_worker.indexed_events().len(), 2);
         let status = network.status(bounty.id).unwrap();
         assert_eq!(status.bounty.status, BountyStatus::Paid);
         assert_eq!(status.escrows[0].status, EscrowStatus::Released);
-        assert_eq!(
-            status.settlements[0].payout_intents[0].status,
-            PayoutStatus::Paid
-        );
-        assert_eq!(network.ledger.entries().len(), 2);
-
-        let replay = worker.process_logs(logs, &mut network);
-        assert!(replay.failures.is_empty());
-        assert_eq!(replay.applied_events.len(), 0);
-        assert_eq!(replay.skipped_duplicate_logs, 2);
-        assert!(replay.ledger_entries.is_empty());
         assert_eq!(network.ledger.entries().len(), 2);
     }
 
@@ -888,7 +933,12 @@ mod tests {
             BaseEscrowLogWorker::from_indexed_events("usdc", persisted_events).unwrap();
         assert_eq!(restarted_worker.cursor().last_block_number, Some(10));
 
-        let second_report = restarted_worker.process_logs(vec![logs[1].clone()], &mut network);
+        let release_attestations = release_attestations_for(&network, &bounty, &logs[1]);
+        let second_report = restarted_worker.process_logs_with_release_attestations(
+            vec![logs[1].clone()],
+            &mut network,
+            &release_attestations,
+        );
 
         assert!(second_report.failures.is_empty());
         assert_eq!(second_report.applied_events.len(), 1);
@@ -1066,7 +1116,7 @@ mod tests {
         let mut network = BountyNetwork::default();
         let solver = network.register_agent(RegisterAgentRequest {
             handle: "solver".to_string(),
-            payout_wallet: Some("0xsolver".to_string()),
+            payout_wallet: Some("0x2222222222222222222222222222222222222222".to_string()),
         });
         let bounty = network
             .post_funded_bounty(PostBountyRequest {
@@ -1133,6 +1183,36 @@ mod tests {
             ),
             raw_released_log(7, &proof_hash, 11, 0),
         ]
+    }
+
+    fn release_attestations_for(
+        network: &BountyNetwork,
+        bounty: &Bounty,
+        release_log: &EvmLog,
+    ) -> HashMap<String, BaseReleaseTransactionEvidence> {
+        let release_plan = network
+            .plan_base_release(PlanBaseReleaseRequest {
+                bounty_id: bounty.id,
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+                network: Some("base-mainnet".to_string()),
+            })
+            .unwrap();
+        HashMap::from([(
+            release_log.tx_hash.to_ascii_lowercase(),
+            BaseReleaseTransactionEvidence {
+                tx_hash: release_log.tx_hash.clone(),
+                chain_id: release_plan.network.chain_id,
+                expected_chain_id: release_plan.network.chain_id,
+                from: "0x5555555555555555555555555555555555555555".to_string(),
+                settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+                to: release_plan.transaction.to.clone(),
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                input: release_plan.transaction.data,
+                receipt_succeeded: true,
+                platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+            },
+        )])
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -4,10 +4,11 @@ use app::{
 };
 use chain_base::{
     base_network_descriptor, calldata_keccak256, decode_base_release_calldata, evm_event_topic,
-    fetch_base_escrow_logs, fetch_block_number, fetch_transaction_by_hash,
-    fetch_transaction_receipt, normalize_evm_address, normalize_evm_hash, rpc_logs_to_evm_logs,
-    BaseEscrowEvent, BaseEscrowEventKind, BaseEscrowLogDecoder, BaseEscrowLogQuery,
-    BaseNetworkDescriptor, ChainEventIndexer, EvmLog,
+    fetch_base_escrow_logs_with_transport, fetch_block_number_with_transport,
+    fetch_transaction_by_hash_with_transport, fetch_transaction_receipt_with_transport,
+    normalize_evm_address, normalize_evm_hash, rpc_logs_to_evm_logs, BaseEscrowEvent,
+    BaseEscrowEventKind, BaseEscrowLogDecoder, BaseEscrowLogQuery, BaseNetworkDescriptor,
+    ChainEventIndexer, EvmLog, JsonRpcTransport, ReqwestJsonRpcTransport,
 };
 use chrono::{DateTime, Utc};
 use db::{
@@ -340,9 +341,19 @@ fn release_attestation_record(
     verdict: &str,
     reason: &str,
 ) -> BaseReleaseAttestationRecord {
+    let decoded = if attestation.is_none() {
+        decode_base_release_calldata(&evidence.input, "usdc").ok()
+    } else {
+        None
+    };
     let recipients = attestation
         .map(|attestation| {
             serde_json::to_value(&attestation.recipients).unwrap_or_else(|_| serde_json::json!([]))
+        })
+        .or_else(|| {
+            decoded.as_ref().map(|decoded| {
+                serde_json::to_value(&decoded.recipients).unwrap_or_else(|_| serde_json::json!([]))
+            })
         })
         .unwrap_or_else(|| serde_json::json!([]));
     BaseReleaseAttestationRecord {
@@ -357,6 +368,7 @@ fn release_attestation_record(
             .or_else(|| calldata_keccak256(&evidence.input).ok()),
         proof_hash: attestation
             .map(|attestation| attestation.proof_hash.clone())
+            .or_else(|| decoded.as_ref().map(|decoded| decoded.proof_hash.clone()))
             .or_else(|| event.proof_hash.clone()),
         recipients,
         escrow_contract: normalize_evm_address(&evidence.escrow_contract)
@@ -679,8 +691,21 @@ pub async fn poll_base_indexer_once(
     store: &PostgresStore,
     config: &BaseIndexerConfig,
 ) -> anyhow::Result<BaseIndexerPollReport> {
+    let transport = ReqwestJsonRpcTransport::default();
+    poll_base_indexer_once_with_transport(store, config, &transport).await
+}
+
+async fn poll_base_indexer_once_with_transport<T>(
+    store: &PostgresStore,
+    config: &BaseIndexerConfig,
+    transport: &T,
+) -> anyhow::Result<BaseIndexerPollReport>
+where
+    T: JsonRpcTransport + ?Sized,
+{
     let descriptor = config.network_descriptor()?;
-    let latest_block = fetch_block_number(&config.rpc_url, config.request_id).await?;
+    let latest_block =
+        fetch_block_number_with_transport(&config.rpc_url, config.request_id, transport).await?;
     let confirmed_to_block = latest_block.checked_sub(config.confirmations);
     let scan_cursor = store
         .get_base_log_cursor(&config.network, &config.escrow_contract)
@@ -727,12 +752,23 @@ pub async fn poll_base_indexer_once(
 
     let to_block = bounded_to_block(from_block, confirmed_to_block, config.max_blocks_per_query);
     let query = BaseEscrowLogQuery::new(&config.escrow_contract, from_block, Some(to_block))?;
-    let response = fetch_base_escrow_logs(&config.rpc_url, &query, config.request_id + 1).await?;
+    let response = fetch_base_escrow_logs_with_transport(
+        &config.rpc_url,
+        &query,
+        config.request_id + 1,
+        transport,
+    )
+    .await?;
     let logs = rpc_logs_to_evm_logs(response.result)?;
     let fetched_logs = logs.len();
-    let release_attestation_fetch =
-        fetch_release_transaction_evidence_for_logs(&config.rpc_url, &descriptor, config, &logs)
-            .await?;
+    let release_attestation_fetch = fetch_release_transaction_evidence_for_logs_with_transport(
+        &config.rpc_url,
+        &descriptor,
+        config,
+        &logs,
+        transport,
+    )
+    .await?;
     let reconciliation = process_base_evm_logs_and_persist_with_release_evidence(
         store,
         &mut worker,
@@ -1043,12 +1079,16 @@ struct ReleaseTransactionEvidenceFetchReport {
     failures: HashMap<String, BaseReleaseAttestationFailureEvidence>,
 }
 
-async fn fetch_release_transaction_evidence_for_logs(
+async fn fetch_release_transaction_evidence_for_logs_with_transport<T>(
     rpc_url: &str,
     descriptor: &BaseNetworkDescriptor,
     config: &BaseIndexerConfig,
     logs: &[EvmLog],
-) -> anyhow::Result<ReleaseTransactionEvidenceFetchReport> {
+    transport: &T,
+) -> anyhow::Result<ReleaseTransactionEvidenceFetchReport>
+where
+    T: JsonRpcTransport + ?Sized,
+{
     let release_topic = evm_event_topic("EscrowReleased(uint256,bytes32)");
     let mut tx_hashes = Vec::new();
     let mut report = ReleaseTransactionEvidenceFetchReport::default();
@@ -1112,7 +1152,10 @@ async fn fetch_release_transaction_evidence_for_logs(
 
     for (index, tx_hash) in tx_hashes.into_iter().enumerate() {
         let request_id = config.request_id + 10 + (index as u64 * 2);
-        let receipt_response = match fetch_transaction_receipt(rpc_url, &tx_hash, request_id).await
+        let receipt_response = match fetch_transaction_receipt_with_transport(
+            rpc_url, &tx_hash, request_id, transport,
+        )
+        .await
         {
             Ok(response) => response,
             Err(error) => {
@@ -1208,23 +1251,29 @@ async fn fetch_release_transaction_evidence_for_logs(
             continue;
         }
 
-        let transaction_response =
-            match fetch_transaction_by_hash(rpc_url, &tx_hash, request_id + 1).await {
-                Ok(response) => response,
-                Err(error) => {
-                    report.failures.insert(
-                        tx_hash.clone(),
-                        failed_release_fetch(
-                            &tx_hash,
-                            descriptor,
-                            config,
-                            None,
-                            format!("release transaction fetch failed for {tx_hash}: {error}"),
-                        ),
-                    );
-                    continue;
-                }
-            };
+        let transaction_response = match fetch_transaction_by_hash_with_transport(
+            rpc_url,
+            &tx_hash,
+            request_id + 1,
+            transport,
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                report.failures.insert(
+                    tx_hash.clone(),
+                    failed_release_fetch(
+                        &tx_hash,
+                        descriptor,
+                        config,
+                        None,
+                        format!("release transaction fetch failed for {tx_hash}: {error}"),
+                    ),
+                );
+                continue;
+            }
+        };
         let Some(transaction) = transaction_response.result else {
             report.failures.insert(
                 tx_hash.clone(),
@@ -1466,12 +1515,17 @@ mod tests {
     };
     use chain_base::{
         evm_address_word, evm_bytes32_word, evm_event_topic, evm_uint256_word, evm_words_data,
+        ChainBaseError, RpcEvmLog,
     };
     use domain::{
         Bounty, BountyStatus, EscrowStatus, FundingMode, Money, PayoutStatus, PrivacyLevel,
         ProofRecord, VerifierKind,
     };
-    use std::collections::HashMap;
+    use serde_json::{json, Value};
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::{Arc, Mutex},
+    };
 
     #[tokio::test]
     async fn raw_base_logs_require_release_calldata_attestation() {
@@ -1489,7 +1543,10 @@ mod tests {
         assert_eq!(report.applied_events.len(), 1);
         assert!(report.ledger_entries.is_empty());
         assert_eq!(worker.indexed_events().len(), 1);
-        assert_eq!(worker.cursor().last_block_number, Some(10));
+        assert_eq!(
+            worker.cursor().last_block_number,
+            Some(logs[0].block_number)
+        );
 
         let status = network.status(bounty.id).unwrap();
         assert_eq!(status.bounty.status, BountyStatus::Payable);
@@ -1589,6 +1646,115 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
+    async fn base_indexer_poll_applies_release_with_mock_rpc() {
+        let store = postgres_store_for_worker_test().await;
+        let (network, bounty, proof) = payable_base_bounty().await;
+        let logs = raw_created_and_released_logs(&bounty, &proof);
+        let created_event = created_event_from_log(&logs[0]);
+        persist_payable_restart_fixture(&store, &network, &created_event, &logs[0].address).await;
+        let config = test_base_mainnet_indexer_config(&logs[1].address);
+        let release_plan = release_attestations_for(&network, &bounty, &logs[1]);
+        let planned = release_plan
+            .get(&release_tx_key(&logs[1].tx_hash))
+            .expect("planned release evidence");
+        let transport = MockJsonRpcTransport::new([
+            MockJsonRpcReply::value(rpc_response(
+                config.request_id,
+                latest_block_result(&logs[1], &config),
+            )),
+            MockJsonRpcReply::value(rpc_response(
+                config.request_id + 1,
+                json!([rpc_log_from_evm(&logs[1])]),
+            )),
+            MockJsonRpcReply::value(rpc_response(
+                config.request_id + 10,
+                release_receipt_result(&logs[1]),
+            )),
+            MockJsonRpcReply::value(rpc_response(
+                config.request_id + 11,
+                release_transaction_result(
+                    &logs[1],
+                    &config,
+                    &planned.input,
+                    8_453,
+                    &config.settlement_signer,
+                ),
+            )),
+        ]);
+
+        let report = poll_base_indexer_once_with_transport(&store, &config, &transport)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            transport.seen_methods(),
+            vec![
+                "eth_blockNumber",
+                "eth_getLogs",
+                "eth_getTransactionReceipt",
+                "eth_getTransactionByHash"
+            ]
+        );
+        assert_eq!(report.fetched_logs, 1);
+        assert_eq!(report.persisted_cursor_block, Some(logs[1].block_number));
+        let reconciliation = report.reconciliation.expect("reconciliation");
+        assert!(reconciliation.failures.is_empty());
+        assert_eq!(reconciliation.applied_events.len(), 1);
+        assert_eq!(reconciliation.ledger_entries.len(), 1);
+
+        let stored_bounty = stored_bounty(&store, bounty.id).await;
+        assert_eq!(stored_bounty.status, BountyStatus::Paid);
+        let records = store
+            .list_base_release_attestations_for_bounty(bounty.id)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].verdict, "passed");
+        assert_eq!(
+            records[0].reason,
+            "release calldata matches pending Base settlement plan"
+        );
+        let recipients = records[0].recipients.as_array().expect("recipients");
+        assert_eq!(recipients.len(), 1);
+        let events = store
+            .list_base_escrow_events_for_bounty(bounty.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == BaseEscrowEventKind::Released)
+                .count(),
+            1
+        );
+        let release_external_event = format!("base-release:{}", log_key_from_evm(&logs[1]));
+        let ledger_entries = store.list_ledger_entries().await.unwrap();
+        assert_eq!(
+            ledger_entries
+                .iter()
+                .filter(|entry| entry.external_event_id.as_deref()
+                    == Some(release_external_event.as_str()))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn base_indexer_poll_quarantines_release_failures_with_mock_rpc() {
+        for case in [
+            ReleasePollFailureCase::BadChain,
+            ReleasePollFailureCase::BadSigner,
+            ReleasePollFailureCase::WrongEmitter,
+            ReleasePollFailureCase::MissingTransaction,
+            ReleasePollFailureCase::RpcFailure,
+        ] {
+            assert_release_poll_failure_case(case).await;
+        }
+    }
+
+    #[tokio::test]
     async fn worker_can_resume_terminal_logs_after_created_event_restart() {
         let (mut network, bounty, proof) = payable_base_bounty().await;
         let logs = raw_created_and_released_logs(&bounty, &proof);
@@ -1601,7 +1767,10 @@ mod tests {
 
         let mut restarted_worker =
             BaseEscrowLogWorker::from_indexed_events("usdc", persisted_events).unwrap();
-        assert_eq!(restarted_worker.cursor().last_block_number, Some(10));
+        assert_eq!(
+            restarted_worker.cursor().last_block_number,
+            Some(logs[0].block_number)
+        );
 
         let release_attestations = release_attestations_for(&network, &bounty, &logs[1]);
         let second_report = restarted_worker.process_logs_with_release_attestations(
@@ -1621,7 +1790,13 @@ mod tests {
     fn terminal_log_without_create_does_not_advance_cursor() {
         let mut network = BountyNetwork::default();
         let mut worker = BaseEscrowLogWorker::default();
-        let release = raw_released_log(7, &format!("0x{}", "22".repeat(32)), 11, 0);
+        let release = raw_released_log(
+            "0x1111111111111111111111111111111111111111",
+            7,
+            &format!("0x{}", "22".repeat(32)),
+            11,
+            0,
+        );
 
         let report = worker.process_logs(vec![release], &mut network);
 
@@ -1726,6 +1901,379 @@ mod tests {
         }
     }
 
+    fn test_base_mainnet_indexer_config(escrow_contract: &str) -> BaseIndexerConfig {
+        BaseIndexerConfig {
+            network: "base-mainnet".to_string(),
+            rpc_url: "https://base-mainnet.example".to_string(),
+            escrow_contract: escrow_contract.to_string(),
+            settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+            platform_fee_wallet: Some("0x4444444444444444444444444444444444444444".to_string()),
+            start_block: Some(1),
+            poll_seconds: 15,
+            confirmations: 2,
+            max_blocks_per_query: 2_000,
+            request_id: 1,
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum ReleasePollFailureCase {
+        BadChain,
+        BadSigner,
+        WrongEmitter,
+        MissingTransaction,
+        RpcFailure,
+    }
+
+    impl ReleasePollFailureCase {
+        fn expected_reason(self) -> &'static str {
+            match self {
+                Self::BadChain => {
+                    "release transaction chain 8454 does not match expected chain 8453"
+                }
+                Self::BadSigner => {
+                    "release transaction signer is not the configured settlement signer"
+                }
+                Self::WrongEmitter => "release log emitted by",
+                Self::MissingTransaction => "release transaction not found",
+                Self::RpcFailure => "release transaction receipt fetch failed",
+            }
+        }
+
+        fn has_decodable_calldata(self) -> bool {
+            matches!(self, Self::BadChain | Self::BadSigner)
+        }
+    }
+
+    async fn assert_release_poll_failure_case(case: ReleasePollFailureCase) {
+        let store = postgres_store_for_worker_test().await;
+        let (network, bounty, proof) = payable_base_bounty().await;
+        let logs = raw_created_and_released_logs(&bounty, &proof);
+        let created_event = created_event_from_log(&logs[0]);
+        persist_payable_restart_fixture(&store, &network, &created_event, &logs[0].address).await;
+        let config = test_base_mainnet_indexer_config(&logs[1].address);
+        let release_plan = release_attestations_for(&network, &bounty, &logs[1]);
+        let planned = release_plan
+            .get(&release_tx_key(&logs[1].tx_hash))
+            .expect("planned release evidence");
+        let mut polled_release = logs[1].clone();
+        if matches!(case, ReleasePollFailureCase::WrongEmitter) {
+            polled_release.address = "0x9999999999999999999999999999999999999999".to_string();
+        }
+        let mut replies = vec![
+            MockJsonRpcReply::value(rpc_response(
+                config.request_id,
+                latest_block_result(&polled_release, &config),
+            )),
+            MockJsonRpcReply::value(rpc_response(
+                config.request_id + 1,
+                json!([rpc_log_from_evm(&polled_release)]),
+            )),
+        ];
+        match case {
+            ReleasePollFailureCase::WrongEmitter => {}
+            ReleasePollFailureCase::RpcFailure => {
+                replies.push(MockJsonRpcReply::error("receipt endpoint unavailable"));
+            }
+            ReleasePollFailureCase::MissingTransaction => {
+                replies.push(MockJsonRpcReply::value(rpc_response(
+                    config.request_id + 10,
+                    release_receipt_result(&polled_release),
+                )));
+                replies.push(MockJsonRpcReply::value(rpc_response(
+                    config.request_id + 11,
+                    Value::Null,
+                )));
+            }
+            ReleasePollFailureCase::BadChain => {
+                replies.push(MockJsonRpcReply::value(rpc_response(
+                    config.request_id + 10,
+                    release_receipt_result(&polled_release),
+                )));
+                replies.push(MockJsonRpcReply::value(rpc_response(
+                    config.request_id + 11,
+                    release_transaction_result(
+                        &polled_release,
+                        &config,
+                        &planned.input,
+                        8_454,
+                        &config.settlement_signer,
+                    ),
+                )));
+            }
+            ReleasePollFailureCase::BadSigner => {
+                replies.push(MockJsonRpcReply::value(rpc_response(
+                    config.request_id + 10,
+                    release_receipt_result(&polled_release),
+                )));
+                replies.push(MockJsonRpcReply::value(rpc_response(
+                    config.request_id + 11,
+                    release_transaction_result(
+                        &polled_release,
+                        &config,
+                        &planned.input,
+                        8_453,
+                        "0x6666666666666666666666666666666666666666",
+                    ),
+                )));
+            }
+        }
+        let transport = MockJsonRpcTransport::new(replies);
+
+        let report = poll_base_indexer_once_with_transport(&store, &config, &transport)
+            .await
+            .unwrap();
+
+        assert_eq!(report.fetched_logs, 1, "{case:?}");
+        assert_eq!(
+            report.persisted_cursor_block,
+            Some(logs[0].block_number),
+            "{case:?}"
+        );
+        let reconciliation = report.reconciliation.expect("reconciliation");
+        assert_eq!(reconciliation.applied_events.len(), 0, "{case:?}");
+        assert_eq!(reconciliation.failures.len(), 1, "{case:?}");
+        assert!(
+            reconciliation.failures[0]
+                .reason
+                .contains(case.expected_reason()),
+            "{case:?}: {}",
+            reconciliation.failures[0].reason
+        );
+        let stored_bounty = stored_bounty(&store, bounty.id).await;
+        assert_eq!(stored_bounty.status, BountyStatus::Payable, "{case:?}");
+        let records = store
+            .list_base_release_attestations_for_bounty(bounty.id)
+            .await
+            .unwrap();
+        assert_eq!(records.len(), 1, "{case:?}");
+        assert_eq!(records[0].verdict, "failed", "{case:?}");
+        assert!(
+            records[0].reason.contains(case.expected_reason()),
+            "{case:?}: {}",
+            records[0].reason
+        );
+        if case.has_decodable_calldata() {
+            assert!(records[0].calldata_hash.is_some(), "{case:?}");
+            let recipients = records[0].recipients.as_array().expect("recipients");
+            assert_eq!(recipients.len(), 1, "{case:?}");
+            assert_eq!(
+                recipients[0]["address"],
+                serde_json::json!("0x2222222222222222222222222222222222222222"),
+                "{case:?}"
+            );
+        }
+        let events = store
+            .list_base_escrow_events_for_bounty(bounty.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == BaseEscrowEventKind::Released)
+                .count(),
+            0,
+            "{case:?}"
+        );
+    }
+
+    async fn postgres_store_for_worker_test() -> PostgresStore {
+        let database_url = std::env::var("AGENT_BOUNTIES_TEST_DATABASE_URL")
+            .expect("AGENT_BOUNTIES_TEST_DATABASE_URL must be set for ignored Postgres tests");
+        let store = PostgresStore::connect(&database_url).await.unwrap();
+        store.migrate().await.unwrap();
+        store
+    }
+
+    async fn persist_payable_restart_fixture(
+        store: &PostgresStore,
+        network: &BountyNetwork,
+        created_event: &BaseEscrowEvent,
+        escrow_contract: &str,
+    ) {
+        for agent in network.agents.values() {
+            store.upsert_agent(agent).await.unwrap();
+        }
+        for bounty in network.bounties.values() {
+            store.upsert_bounty(bounty).await.unwrap();
+        }
+        for intent in network.funding_intents.values() {
+            store.upsert_funding_intent(intent).await.unwrap();
+        }
+        for escrow in network.escrows.values() {
+            store.upsert_escrow(escrow).await.unwrap();
+        }
+        for claim in network.claims.values() {
+            store.upsert_claim(claim).await.unwrap();
+        }
+        for submission in network.submissions.values() {
+            store.upsert_submission(submission).await.unwrap();
+        }
+        for result in network.verifier_results.values() {
+            store.upsert_verifier_result(result).await.unwrap();
+        }
+        for proof in network.proofs.values() {
+            store.upsert_proof_record(proof).await.unwrap();
+        }
+        for settlement in network.settlements.values() {
+            store.upsert_settlement(settlement).await.unwrap();
+        }
+        store.upsert_base_escrow_event(created_event).await.unwrap();
+        store
+            .upsert_base_log_cursor(
+                "base-mainnet",
+                escrow_contract,
+                created_event.block_number,
+                Some(&created_event.log_key),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn stored_bounty(store: &PostgresStore, bounty_id: Id) -> Bounty {
+        store
+            .list_bounties()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|bounty| bounty.id == bounty_id)
+            .expect("stored bounty")
+    }
+
+    fn created_event_from_log(log: &EvmLog) -> BaseEscrowEvent {
+        let mut decoder = BaseEscrowLogDecoder::default();
+        decoder.decode(log.clone()).unwrap()
+    }
+
+    fn rpc_log_from_evm(log: &EvmLog) -> RpcEvmLog {
+        RpcEvmLog {
+            address: log.address.clone(),
+            topics: log.topics.clone(),
+            data: log.data.clone(),
+            transaction_hash: log.tx_hash.clone(),
+            block_number: hex_quantity(log.block_number),
+            log_index: hex_quantity(log.log_index),
+        }
+    }
+
+    fn release_receipt_result(log: &EvmLog) -> Value {
+        json!({
+            "transactionHash": log.tx_hash.clone(),
+            "blockNumber": hex_quantity(log.block_number),
+            "status": "0x1",
+            "logs": [rpc_log_from_evm(log)]
+        })
+    }
+
+    fn release_transaction_result(
+        log: &EvmLog,
+        config: &BaseIndexerConfig,
+        input: &str,
+        chain_id: u64,
+        from: &str,
+    ) -> Value {
+        json!({
+            "hash": log.tx_hash.clone(),
+            "from": from,
+            "to": config.escrow_contract.clone(),
+            "input": input,
+            "chainId": hex_quantity(chain_id),
+            "blockNumber": hex_quantity(log.block_number),
+            "transactionIndex": "0x0"
+        })
+    }
+
+    fn latest_block_result(log: &EvmLog, config: &BaseIndexerConfig) -> Value {
+        json!(hex_quantity(log.block_number + config.confirmations))
+    }
+
+    fn rpc_response(id: u64, result: Value) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result
+        })
+    }
+
+    fn log_key_from_evm(log: &EvmLog) -> String {
+        format!("{}:{}", log.tx_hash.to_ascii_lowercase(), log.log_index)
+    }
+
+    fn hex_quantity(value: u64) -> String {
+        format!("0x{value:x}")
+    }
+
+    enum MockJsonRpcReply {
+        Value(Value),
+        Error(String),
+    }
+
+    impl MockJsonRpcReply {
+        fn value(value: Value) -> Self {
+            Self::Value(value)
+        }
+
+        fn error(message: impl Into<String>) -> Self {
+            Self::Error(message.into())
+        }
+    }
+
+    #[derive(Clone)]
+    struct MockJsonRpcTransport {
+        replies: Arc<Mutex<VecDeque<MockJsonRpcReply>>>,
+        methods: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl MockJsonRpcTransport {
+        fn new(replies: impl IntoIterator<Item = MockJsonRpcReply>) -> Self {
+            Self {
+                replies: Arc::new(Mutex::new(replies.into_iter().collect())),
+                methods: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn seen_methods(&self) -> Vec<&'static str> {
+            self.methods
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|method| match method.as_str() {
+                    "eth_blockNumber" => "eth_blockNumber",
+                    "eth_getLogs" => "eth_getLogs",
+                    "eth_getTransactionReceipt" => "eth_getTransactionReceipt",
+                    "eth_getTransactionByHash" => "eth_getTransactionByHash",
+                    _ => "unknown",
+                })
+                .collect()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl JsonRpcTransport for MockJsonRpcTransport {
+        async fn post_json_value(
+            &self,
+            _rpc_url: &str,
+            request: &Value,
+        ) -> Result<Value, ChainBaseError> {
+            let method = request
+                .get("method")
+                .and_then(Value::as_str)
+                .expect("JSON-RPC method")
+                .to_string();
+            self.methods.lock().unwrap().push(method);
+            let reply = self
+                .replies
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("mock JSON-RPC reply");
+            match reply {
+                MockJsonRpcReply::Value(value) => Ok(value),
+                MockJsonRpcReply::Error(message) => Err(ChainBaseError::RpcTransport(message)),
+            }
+        }
+    }
+
     #[test]
     fn base_indexer_heartbeat_marks_skipped_poll() {
         let config = test_base_indexer_config();
@@ -1794,10 +2342,6 @@ mod tests {
 
     async fn payable_base_bounty() -> (BountyNetwork, Bounty, ProofRecord) {
         let mut network = BountyNetwork::default();
-        let solver = network.register_agent(RegisterAgentRequest {
-            handle: "solver".to_string(),
-            payout_wallet: Some("0x2222222222222222222222222222222222222222".to_string()),
-        });
         let bounty = network
             .post_funded_bounty(PostBountyRequest {
                 title: "Extract data".to_string(),
@@ -1808,10 +2352,15 @@ mod tests {
                 privacy: PrivacyLevel::Public,
             })
             .unwrap();
+        let solver = network.register_agent(RegisterAgentRequest {
+            handle: format!("solver-{}", bounty.id),
+            payout_wallet: Some("0x2222222222222222222222222222222222222222".to_string()),
+        });
+        let onchain_escrow_id = test_onchain_escrow_id(bounty.id);
         network
             .apply_base_escrow_event(chain_base::simulated_created_event(
                 bounty.id,
-                7,
+                onchain_escrow_id,
                 "0x3333333333333333333333333333333333333333",
                 bounty.amount.clone(),
                 bounty.terms_hash.clone().unwrap(),
@@ -1850,19 +2399,32 @@ mod tests {
     fn raw_created_and_released_logs(bounty: &Bounty, proof: &ProofRecord) -> Vec<EvmLog> {
         let terms_hash = format!("0x{}", bounty.terms_hash.clone().unwrap());
         let proof_hash = format!("0x{}", proof.proof_hash);
-        vec![
+        let onchain_escrow_id = test_onchain_escrow_id(bounty.id);
+        let created_block = test_created_block_number(bounty.id);
+        let escrow_contract = test_escrow_contract(bounty.id);
+        let mut logs = vec![
             raw_created_log(
-                7,
+                &escrow_contract,
+                onchain_escrow_id,
                 bounty.id,
                 "0x2222222222222222222222222222222222222222",
                 "0x3333333333333333333333333333333333333333",
                 bounty.amount.clone(),
                 &terms_hash,
-                10,
+                created_block,
                 0,
             ),
-            raw_released_log(7, &proof_hash, 11, 0),
-        ]
+            raw_released_log(
+                &escrow_contract,
+                onchain_escrow_id,
+                &proof_hash,
+                created_block + 1,
+                0,
+            ),
+        ];
+        logs[0].tx_hash = format!("0x{}{}", bounty.id.simple(), "a".repeat(32));
+        logs[1].tx_hash = format!("0x{}{}", bounty.id.simple(), "b".repeat(32));
+        logs
     }
 
     fn release_attestations_for(
@@ -1870,10 +2432,11 @@ mod tests {
         bounty: &Bounty,
         release_log: &EvmLog,
     ) -> HashMap<String, BaseReleaseTransactionEvidence> {
+        let escrow_contract = release_log.address.clone();
         let release_plan = network
             .plan_base_release(PlanBaseReleaseRequest {
                 bounty_id: bounty.id,
-                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                escrow_contract: escrow_contract.clone(),
                 platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
                 network: Some("base-mainnet".to_string()),
             })
@@ -1887,7 +2450,7 @@ mod tests {
                 from: "0x5555555555555555555555555555555555555555".to_string(),
                 settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
                 to: release_plan.transaction.to.clone(),
-                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                escrow_contract,
                 input: release_plan.transaction.data,
                 receipt_succeeded: true,
                 platform_fee_wallet: Some("0x4444444444444444444444444444444444444444".to_string()),
@@ -1897,6 +2460,7 @@ mod tests {
 
     #[allow(clippy::too_many_arguments)]
     fn raw_created_log(
+        escrow_contract: &str,
         escrow_id: u128,
         bounty_id: Id,
         payer: &str,
@@ -1907,7 +2471,7 @@ mod tests {
         log_index: u64,
     ) -> EvmLog {
         EvmLog {
-            address: "0x1111111111111111111111111111111111111111".to_string(),
+            address: escrow_contract.to_string(),
             topics: vec![
                 evm_event_topic("EscrowCreated(uint256,bytes32,address,address,uint256,bytes32)"),
                 evm_uint256_word(escrow_id),
@@ -1929,13 +2493,14 @@ mod tests {
     }
 
     fn raw_released_log(
+        escrow_contract: &str,
         escrow_id: u128,
         proof_hash: &str,
         block_number: u64,
         log_index: u64,
     ) -> EvmLog {
         EvmLog {
-            address: "0x1111111111111111111111111111111111111111".to_string(),
+            address: escrow_contract.to_string(),
             topics: vec![
                 evm_event_topic("EscrowReleased(uint256,bytes32)"),
                 evm_uint256_word(escrow_id),
@@ -1951,5 +2516,21 @@ mod tests {
 
     fn bounty_bytes32(bounty_id: Id) -> String {
         format!("0x{}{}", "0".repeat(32), bounty_id.simple())
+    }
+
+    fn test_onchain_escrow_id(bounty_id: Id) -> u128 {
+        let simple = bounty_id.simple().to_string();
+        u128::from_str_radix(&simple[..16], 16).unwrap().max(1)
+    }
+
+    fn test_escrow_contract(bounty_id: Id) -> String {
+        let simple = bounty_id.simple().to_string();
+        format!("0x111111111111111111111111{}", &simple[..16])
+    }
+
+    fn test_created_block_number(bounty_id: Id) -> u64 {
+        let simple = bounty_id.simple().to_string();
+        let suffix = u64::from_str_radix(&simple[16..24], 16).unwrap();
+        50_000_000 + (suffix % 1_000_000)
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,12 +1,16 @@
 use anyhow::{anyhow, Context};
-use app::{BaseEscrowReconciliation, BaseReleaseTransactionEvidence, BountyNetwork};
+use app::{
+    BaseEscrowReconciliation, BaseReleaseAttestation, BaseReleaseTransactionEvidence, BountyNetwork,
+};
 use chain_base::{
-    base_network_descriptor, fetch_base_escrow_logs, fetch_block_number, rpc_logs_to_evm_logs,
-    BaseEscrowEvent, BaseEscrowEventKind, BaseEscrowLogDecoder, BaseEscrowLogQuery,
-    BaseNetworkDescriptor, ChainEventIndexer, EvmLog,
+    base_network_descriptor, calldata_keccak256, evm_event_topic, fetch_base_escrow_logs,
+    fetch_block_number, fetch_transaction_by_hash, fetch_transaction_receipt,
+    normalize_evm_address, normalize_evm_hash, rpc_logs_to_evm_logs, BaseEscrowEvent,
+    BaseEscrowEventKind, BaseEscrowLogDecoder, BaseEscrowLogQuery, BaseNetworkDescriptor,
+    ChainEventIndexer, EvmLog,
 };
 use chrono::{DateTime, Utc};
-use db::{BaseIndexerHeartbeat, PostgresStore};
+use db::{BaseIndexerHeartbeat, BaseReleaseAttestationRecord, PostgresStore};
 use domain::{Id, Submission, VerifierResult};
 use ledger::{Ledger, LedgerEntry};
 use serde::{Deserialize, Serialize};
@@ -63,6 +67,7 @@ pub struct BaseLogPipelineReport {
     pub applied_events: Vec<AppliedBaseEvent>,
     pub skipped_duplicate_logs: usize,
     pub ledger_entries: Vec<LedgerEntry>,
+    pub release_attestations: Vec<BaseReleaseAttestationRecord>,
     pub failures: Vec<BaseLogFailure>,
 }
 
@@ -185,6 +190,19 @@ impl BaseEscrowLogWorker {
             ) {
                 Ok(reconciliation) => reconciliation,
                 Err(error) => {
+                    if event.kind == BaseEscrowEventKind::Released {
+                        if let Some(evidence) =
+                            release_attestations.get(&event.tx_hash.to_ascii_lowercase())
+                        {
+                            report.release_attestations.push(release_attestation_record(
+                                &event,
+                                evidence,
+                                None,
+                                "failed",
+                                &error.to_string(),
+                            ));
+                        }
+                    }
                     report.failures.push(BaseLogFailure {
                         block_number,
                         log_index,
@@ -195,6 +213,19 @@ impl BaseEscrowLogWorker {
                 }
             };
             let ledger_entries = reconciliation.ledger_entries.clone();
+            if let Some(attestation) = reconciliation.release_attestation.as_ref() {
+                if let Some(evidence) =
+                    release_attestations.get(&event.tx_hash.to_ascii_lowercase())
+                {
+                    report.release_attestations.push(release_attestation_record(
+                        &event,
+                        evidence,
+                        Some(attestation),
+                        "passed",
+                        &attestation.reason,
+                    ));
+                }
+            }
             let applied = applied_event(&event, &reconciliation);
 
             if let Err(error) = self.indexer.ingest(event.clone()) {
@@ -256,6 +287,46 @@ fn applied_event(
     }
 }
 
+fn release_attestation_record(
+    event: &BaseEscrowEvent,
+    evidence: &BaseReleaseTransactionEvidence,
+    attestation: Option<&BaseReleaseAttestation>,
+    verdict: &str,
+    reason: &str,
+) -> BaseReleaseAttestationRecord {
+    let recipients = attestation
+        .map(|attestation| {
+            serde_json::to_value(&attestation.recipients).unwrap_or_else(|_| serde_json::json!([]))
+        })
+        .unwrap_or_else(|| serde_json::json!([]));
+    BaseReleaseAttestationRecord {
+        id: Id::new_v4(),
+        network: evidence.expected_chain_id.to_string(),
+        tx_hash: normalize_evm_hash(&evidence.tx_hash).unwrap_or_else(|_| evidence.tx_hash.clone()),
+        log_key: event.log_key.clone(),
+        bounty_id: event.bounty_id,
+        onchain_escrow_id: event.onchain_escrow_id.to_string(),
+        calldata_hash: attestation
+            .map(|attestation| attestation.calldata_hash.clone())
+            .or_else(|| calldata_keccak256(&evidence.input).ok()),
+        proof_hash: attestation
+            .map(|attestation| attestation.proof_hash.clone())
+            .or_else(|| event.proof_hash.clone()),
+        recipients,
+        escrow_contract: normalize_evm_address(&evidence.escrow_contract)
+            .unwrap_or_else(|_| evidence.escrow_contract.clone()),
+        settlement_signer: normalize_evm_address(&evidence.settlement_signer)
+            .unwrap_or_else(|_| evidence.settlement_signer.clone()),
+        platform_fee_wallet: evidence
+            .platform_fee_wallet
+            .as_ref()
+            .map(|wallet| normalize_evm_address(wallet).unwrap_or_else(|_| wallet.clone())),
+        verdict: verdict.to_string(),
+        reason: reason.to_string(),
+        created_at: Utc::now(),
+    }
+}
+
 fn cursor_from_events(events: &[BaseEscrowEvent]) -> BaseLogCursor {
     events
         .iter()
@@ -278,6 +349,8 @@ pub struct BaseIndexerConfig {
     pub network: String,
     pub rpc_url: String,
     pub escrow_contract: String,
+    pub settlement_signer: String,
+    pub platform_fee_wallet: Option<String>,
     pub start_block: Option<u64>,
     pub poll_seconds: u64,
     pub confirmations: u64,
@@ -343,15 +416,32 @@ impl BaseIndexerConfig {
             .map(|value| parse_u64_env("BASE_INDEXER_REQUEST_ID", &value))
             .transpose()?
             .unwrap_or(1);
+        let settlement_signer = lookup("BASE_SETTLEMENT_SIGNER")
+            .filter(|value| nonempty(value))
+            .ok_or_else(|| {
+                anyhow!("set BASE_SETTLEMENT_SIGNER before reconciling Base release logs")
+            })?;
+        let platform_fee_wallet =
+            lookup("BASE_PLATFORM_FEE_WALLET").filter(|value| nonempty(value));
 
         let escrow_contract =
             BaseEscrowLogQuery::new(escrow_contract, start_block.unwrap_or(0), None)?
                 .escrow_contract;
+        let settlement_signer = normalize_evm_address(&settlement_signer)
+            .map_err(|error| anyhow!("invalid BASE_SETTLEMENT_SIGNER: {error}"))?;
+        let platform_fee_wallet = platform_fee_wallet
+            .map(|wallet| {
+                normalize_evm_address(&wallet)
+                    .map_err(|error| anyhow!("invalid BASE_PLATFORM_FEE_WALLET: {error}"))
+            })
+            .transpose()?;
 
         Ok(Self {
             network,
             rpc_url,
             escrow_contract,
+            settlement_signer,
+            platform_fee_wallet,
             start_block,
             poll_seconds,
             confirmations,
@@ -546,8 +636,17 @@ pub async fn poll_base_indexer_once(
     let response = fetch_base_escrow_logs(&config.rpc_url, &query, config.request_id + 1).await?;
     let logs = rpc_logs_to_evm_logs(response.result)?;
     let fetched_logs = logs.len();
-    let reconciliation =
-        process_base_evm_logs_and_persist(store, &mut worker, &mut network, logs).await?;
+    let release_attestations =
+        fetch_release_transaction_evidence_for_logs(&config.rpc_url, &descriptor, config, &logs)
+            .await?;
+    let reconciliation = process_base_evm_logs_and_persist_with_release_attestations(
+        store,
+        &mut worker,
+        &mut network,
+        logs,
+        &release_attestations,
+    )
+    .await?;
     let persisted_cursor_block = if reconciliation.failures.is_empty() {
         let last_log_key = reconciliation.ending_cursor.last_log_key.as_deref();
         store
@@ -737,7 +836,24 @@ pub async fn process_base_evm_logs_and_persist(
     network: &mut BountyNetwork,
     logs: Vec<EvmLog>,
 ) -> anyhow::Result<BaseLogPipelineReport> {
-    let report = worker.process_logs(logs, network);
+    process_base_evm_logs_and_persist_with_release_attestations(
+        store,
+        worker,
+        network,
+        logs,
+        &HashMap::new(),
+    )
+    .await
+}
+
+pub async fn process_base_evm_logs_and_persist_with_release_attestations(
+    store: &PostgresStore,
+    worker: &mut BaseEscrowLogWorker,
+    network: &mut BountyNetwork,
+    logs: Vec<EvmLog>,
+    release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
+) -> anyhow::Result<BaseLogPipelineReport> {
+    let report = worker.process_logs_with_release_attestations(logs, network, release_attestations);
     let applied_event_ids = report
         .applied_events
         .iter()
@@ -792,11 +908,106 @@ pub async fn process_base_evm_logs_and_persist(
     for entry in &report.ledger_entries {
         store.insert_ledger_entry(entry).await?;
     }
+    for attestation in &report.release_attestations {
+        store.upsert_base_release_attestation(attestation).await?;
+    }
     for event in &indexed_events {
         store.upsert_base_escrow_event(event).await?;
     }
 
     Ok(report)
+}
+
+async fn fetch_release_transaction_evidence_for_logs(
+    rpc_url: &str,
+    descriptor: &BaseNetworkDescriptor,
+    config: &BaseIndexerConfig,
+    logs: &[EvmLog],
+) -> anyhow::Result<HashMap<String, BaseReleaseTransactionEvidence>> {
+    let release_topic = evm_event_topic("EscrowReleased(uint256,bytes32)");
+    let mut tx_hashes = Vec::new();
+    for log in logs {
+        if log.topics.first() != Some(&release_topic) {
+            continue;
+        }
+        let log_address = normalize_evm_address(&log.address)
+            .map_err(|error| anyhow!("invalid release log emitter address: {error}"))?;
+        if log_address != config.escrow_contract {
+            return Err(anyhow!(
+                "release log emitted by {log_address}, expected configured escrow {}",
+                config.escrow_contract
+            ));
+        }
+        let tx_hash = normalize_evm_hash(&log.tx_hash)
+            .map_err(|error| anyhow!("invalid release log transaction hash: {error}"))?;
+        if !tx_hashes.contains(&tx_hash) {
+            tx_hashes.push(tx_hash);
+        }
+    }
+
+    let mut attestations = HashMap::new();
+    for (index, tx_hash) in tx_hashes.into_iter().enumerate() {
+        let request_id = config.request_id + 10 + (index as u64 * 2);
+        let receipt = fetch_transaction_receipt(rpc_url, &tx_hash, request_id)
+            .await?
+            .result
+            .ok_or_else(|| anyhow!("release transaction receipt not found for {tx_hash}"))?;
+        let receipt_tx_hash = receipt.normalized_tx_hash()?;
+        if receipt_tx_hash != tx_hash {
+            return Err(anyhow!(
+                "release receipt hash {receipt_tx_hash} does not match requested transaction {tx_hash}"
+            ));
+        }
+        let receipt_logs = receipt.logs_to_evm_logs()?;
+        let receipt_has_configured_release = receipt_logs.iter().any(|log| {
+            log.tx_hash == tx_hash
+                && log.topics.first() == Some(&release_topic)
+                && normalize_evm_address(&log.address)
+                    .map(|address| address == config.escrow_contract)
+                    .unwrap_or(false)
+        });
+        if !receipt_has_configured_release {
+            return Err(anyhow!(
+                "release receipt {tx_hash} has no EscrowReleased log emitted by configured escrow {}",
+                config.escrow_contract
+            ));
+        }
+
+        let transaction = fetch_transaction_by_hash(rpc_url, &tx_hash, request_id + 1)
+            .await?
+            .result
+            .ok_or_else(|| anyhow!("release transaction not found for {tx_hash}"))?;
+        let transaction_hash = transaction.normalized_hash()?;
+        if transaction_hash != tx_hash {
+            return Err(anyhow!(
+                "release transaction hash {transaction_hash} does not match receipt {tx_hash}"
+            ));
+        }
+        let chain_id = transaction
+            .chain_id()?
+            .ok_or_else(|| anyhow!("release transaction {tx_hash} is missing chainId"))?;
+        let to = transaction
+            .normalized_to()?
+            .ok_or_else(|| anyhow!("release transaction {tx_hash} has no target contract"))?;
+
+        attestations.insert(
+            tx_hash.clone(),
+            BaseReleaseTransactionEvidence {
+                tx_hash,
+                chain_id,
+                expected_chain_id: descriptor.chain_id,
+                from: transaction.normalized_from()?,
+                settlement_signer: config.settlement_signer.clone(),
+                to,
+                escrow_contract: config.escrow_contract.clone(),
+                input: transaction.input.clone(),
+                receipt_succeeded: receipt.succeeded()?.unwrap_or(false),
+                platform_fee_wallet: config.platform_fee_wallet.clone(),
+            },
+        );
+    }
+
+    Ok(attestations)
 }
 
 pub fn next_indexer_from_block(
@@ -974,6 +1185,10 @@ mod tests {
                 "0x1111111111111111111111111111111111111111",
             ),
             ("BASE_INDEXER_START_BLOCK", "123"),
+            (
+                "BASE_SETTLEMENT_SIGNER",
+                "0x5555555555555555555555555555555555555555",
+            ),
         ]);
 
         let config =
@@ -1003,6 +1218,10 @@ mod tests {
                 "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD",
             ),
             ("BASE_INDEXER_START_BLOCK", "123"),
+            (
+                "BASE_SETTLEMENT_SIGNER",
+                "0x5555555555555555555555555555555555555555",
+            ),
         ]);
 
         let config =
@@ -1038,6 +1257,8 @@ mod tests {
             network: "base-sepolia".to_string(),
             rpc_url: "https://base-sepolia.example".to_string(),
             escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+            settlement_signer: "0x5555555555555555555555555555555555555555".to_string(),
+            platform_fee_wallet: Some("0x4444444444444444444444444444444444444444".to_string()),
             start_block: Some(1),
             poll_seconds: 15,
             confirmations: 2,
@@ -1210,7 +1431,7 @@ mod tests {
                 escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
                 input: release_plan.transaction.data,
                 receipt_succeeded: true,
-                platform_fee_wallet: "0x4444444444444444444444444444444444444444".to_string(),
+                platform_fee_wallet: Some("0x4444444444444444444444444444444444444444".to_string()),
             },
         )])
     }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -10,7 +10,10 @@ use chain_base::{
     ChainEventIndexer, EvmLog,
 };
 use chrono::{DateTime, Utc};
-use db::{BaseIndexerHeartbeat, BaseReleaseAttestationRecord, PostgresStore};
+use db::{
+    BaseIndexerHeartbeat, BaseLogPersistenceBatch, BaseLogPersistenceCursor,
+    BaseReleaseAttestationRecord, PostgresStore,
+};
 use domain::{Id, Submission, VerifierResult};
 use ledger::{Ledger, LedgerEntry};
 use serde::{Deserialize, Serialize};
@@ -645,18 +648,15 @@ pub async fn poll_base_indexer_once(
         &mut network,
         logs,
         &release_attestations,
+        Some(BaseLogPersistenceCursor {
+            network: &config.network,
+            escrow_contract: &config.escrow_contract,
+            last_scanned_block: to_block,
+            last_log_key: None,
+        }),
     )
     .await?;
     let persisted_cursor_block = if reconciliation.failures.is_empty() {
-        let last_log_key = reconciliation.ending_cursor.last_log_key.as_deref();
-        store
-            .upsert_base_log_cursor(
-                &config.network,
-                &config.escrow_contract,
-                to_block,
-                last_log_key,
-            )
-            .await?;
         Some(to_block)
     } else {
         scan_cursor.map(|cursor| cursor.last_scanned_block)
@@ -842,6 +842,7 @@ pub async fn process_base_evm_logs_and_persist(
         network,
         logs,
         &HashMap::new(),
+        None,
     )
     .await
 }
@@ -852,6 +853,7 @@ pub async fn process_base_evm_logs_and_persist_with_release_attestations(
     network: &mut BountyNetwork,
     logs: Vec<EvmLog>,
     release_attestations: &HashMap<String, BaseReleaseTransactionEvidence>,
+    cursor_if_success: Option<BaseLogPersistenceCursor<'_>>,
 ) -> anyhow::Result<BaseLogPipelineReport> {
     let report = worker.process_logs_with_release_attestations(logs, network, release_attestations);
     let applied_event_ids = report
@@ -893,27 +895,26 @@ pub async fn process_base_evm_logs_and_persist_with_release_attestations(
         .cloned()
         .collect::<Vec<_>>();
 
-    for bounty in &bounties {
-        store.upsert_bounty(bounty).await?;
-    }
-    for attestation in &report.release_attestations {
-        store.upsert_base_release_attestation(attestation).await?;
-    }
-    for intent in &funding_intents {
-        store.upsert_funding_intent(intent).await?;
-    }
-    for escrow in &escrows {
-        store.upsert_escrow(escrow).await?;
-    }
-    for settlement in &settlements {
-        store.upsert_settlement(settlement).await?;
-    }
-    for entry in &report.ledger_entries {
-        store.insert_ledger_entry(entry).await?;
-    }
-    for event in &indexed_events {
-        store.upsert_base_escrow_event(event).await?;
-    }
+    let cursor = if report.failures.is_empty() {
+        cursor_if_success.map(|cursor| BaseLogPersistenceCursor {
+            last_log_key: report.ending_cursor.last_log_key.as_deref(),
+            ..cursor
+        })
+    } else {
+        None
+    };
+    store
+        .persist_base_log_pipeline(BaseLogPersistenceBatch {
+            bounties: &bounties,
+            release_attestations: &report.release_attestations,
+            funding_intents: &funding_intents,
+            escrows: &escrows,
+            settlements: &settlements,
+            ledger_entries: &report.ledger_entries,
+            base_escrow_events: &indexed_events,
+            cursor,
+        })
+        .await?;
 
     Ok(report)
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -896,6 +896,9 @@ pub async fn process_base_evm_logs_and_persist_with_release_attestations(
     for bounty in &bounties {
         store.upsert_bounty(bounty).await?;
     }
+    for attestation in &report.release_attestations {
+        store.upsert_base_release_attestation(attestation).await?;
+    }
     for intent in &funding_intents {
         store.upsert_funding_intent(intent).await?;
     }
@@ -907,9 +910,6 @@ pub async fn process_base_evm_logs_and_persist_with_release_attestations(
     }
     for entry in &report.ledger_entries {
         store.insert_ledger_entry(entry).await?;
-    }
-    for attestation in &report.release_attestations {
-        store.upsert_base_release_attestation(attestation).await?;
     }
     for event in &indexed_events {
         store.upsert_base_escrow_event(event).await?;

--- a/docs/hosted-base-usdc-beta-runbook.md
+++ b/docs/hosted-base-usdc-beta-runbook.md
@@ -258,12 +258,19 @@ curl -sS "$PUBLIC_BASE_URL/v1/base/transaction-receipt" \
   --data '{
     "network": "base-sepolia",
     "tx_hash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-    "reconcile_logs": true
+    "reconcile_logs": true,
+    "escrow_contract": "0x1111111111111111111111111111111111111111",
+    "settlement_signer": "0x5555555555555555555555555555555555555555",
+    "platform_fee_wallet": "0x4444444444444444444444444444444444444444"
   }'
 ```
 
-The payout is complete only after the `EscrowReleased` event has been indexed
-and the platform state has moved to `Paid`.
+The payout is complete only after the `EscrowReleased` event is indexed, the
+receipt succeeded, the transaction signer/target match the configured release
+authority, and the `release(uint256,address[],uint256[],bytes32)` calldata
+matches the pending settlement recipients, amounts, escrow id, and proof hash.
+A transaction hash or `EscrowReleased` log alone is not recipient-level payout
+evidence.
 
 ## Rollback, Refund, and Dispute
 

--- a/docs/hosted-base-usdc-beta-runbook.md
+++ b/docs/hosted-base-usdc-beta-runbook.md
@@ -269,6 +269,12 @@ matches the pending settlement recipients, amounts, escrow id, and proof hash.
 A transaction hash or `EscrowReleased` log alone is not recipient-level payout
 evidence.
 
+Operator audit readback is available at
+`GET /v1/base/release-attestations/{bounty_id}?limit=25` and MCP
+`list_base_release_attestations`. The response is capped and redacts signer and
+fee-wallet configuration while preserving verdict, hashes, and typed recipient
+amounts for operator review.
+
 ## Rollback, Refund, and Dispute
 
 Use refund or dispute only after operator review records a reason.

--- a/docs/hosted-base-usdc-beta-runbook.md
+++ b/docs/hosted-base-usdc-beta-runbook.md
@@ -258,10 +258,7 @@ curl -sS "$PUBLIC_BASE_URL/v1/base/transaction-receipt" \
   --data '{
     "network": "base-sepolia",
     "tx_hash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-    "reconcile_logs": true,
-    "escrow_contract": "0x1111111111111111111111111111111111111111",
-    "settlement_signer": "0x5555555555555555555555555555555555555555",
-    "platform_fee_wallet": "0x4444444444444444444444444444444444444444"
+    "reconcile_logs": true
   }'
 ```
 

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -228,8 +228,12 @@ transaction hash only; it does not mark the bounty paid. Operators or agents
 then poll `POST /v1/base/transaction-receipt`, MCP
 `get_base_transaction_receipt`, or `cargo run -p cli -- base-transaction-receipt`.
 When the API/MCP receipt request uses `reconcile_logs=true`, the service
-normalizes receipt logs and runs the same Base escrow decoder/indexer. A bounty
-is marked `Paid` only if an indexed `EscrowReleased` log applies.
+normalizes receipt logs and runs the same Base escrow decoder/indexer. For
+`EscrowReleased`, the service also fetches the transaction by hash and requires
+the successful receipt, configured settlement signer, escrow contract, selector,
+escrow id, proof hash, recipient wallets, and per-recipient amounts to match the
+pending release plan. A transaction hash or `EscrowReleased` log alone is not
+recipient-level payout evidence and cannot mark the bounty `Paid`.
 
 Hosted operators should also set `OPERATOR_API_TOKEN`. When configured, API and
 MCP calls that reconcile normalized escrow events, submit settlement logs, fetch

--- a/docs/payment-model.md
+++ b/docs/payment-model.md
@@ -235,6 +235,12 @@ escrow id, proof hash, recipient wallets, and per-recipient amounts to match the
 pending release plan. A transaction hash or `EscrowReleased` log alone is not
 recipient-level payout evidence and cannot mark the bounty `Paid`.
 
+Operators can inspect bounded, redacted release-attestation audit records with
+`GET /v1/base/release-attestations/{bounty_id}?limit=25` or MCP
+`list_base_release_attestations`. Normal bounty status includes only capped
+attestation summaries; signer and fee-wallet configuration stay out of public
+status responses.
+
 Hosted operators should also set `OPERATOR_API_TOKEN`. When configured, API and
 MCP calls that reconcile normalized escrow events, submit settlement logs, fetch
 provider logs through server-side RPC URLs, broadcast signed transactions, or

--- a/migrations/0001_core.sql
+++ b/migrations/0001_core.sql
@@ -260,6 +260,28 @@ CREATE TABLE IF NOT EXISTS base_escrow_events (
   occurred_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS base_release_attestations (
+  id UUID PRIMARY KEY,
+  network TEXT NOT NULL,
+  tx_hash TEXT NOT NULL,
+  log_key TEXT NOT NULL,
+  bounty_id UUID NOT NULL REFERENCES bounties(id),
+  onchain_escrow_id TEXT NOT NULL,
+  calldata_hash TEXT,
+  proof_hash TEXT,
+  recipients JSONB NOT NULL DEFAULT '[]'::jsonb,
+  escrow_contract TEXT NOT NULL,
+  settlement_signer TEXT NOT NULL,
+  platform_fee_wallet TEXT,
+  verdict TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (network, tx_hash, log_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_base_release_attestations_bounty
+  ON base_release_attestations (bounty_id, created_at);
+
 CREATE TABLE IF NOT EXISTS base_log_cursors (
   network TEXT NOT NULL,
   escrow_contract TEXT NOT NULL,

--- a/scripts/check-postgres.ps1
+++ b/scripts/check-postgres.ps1
@@ -57,6 +57,12 @@ try {
         Invoke-Checked {
             cargo test -p db tests::base_log_pipeline_rolls_back_paid_state_when_cursor_commit_fails -- --ignored --exact --nocapture
         }
+        Invoke-Checked {
+            cargo test -p worker tests::base_indexer_poll_applies_release_with_mock_rpc -- --ignored --exact --nocapture
+        }
+        Invoke-Checked {
+            cargo test -p worker tests::base_indexer_poll_quarantines_release_failures_with_mock_rpc -- --ignored --exact --nocapture
+        }
     }
     finally {
         $env:AGENT_BOUNTIES_TEST_DATABASE_URL = $previousTestDatabaseUrl

--- a/scripts/check-postgres.ps1
+++ b/scripts/check-postgres.ps1
@@ -54,6 +54,9 @@ try {
         Invoke-Checked {
             cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture
         }
+        Invoke-Checked {
+            cargo test -p db tests::base_log_pipeline_rolls_back_paid_state_when_cursor_commit_fails -- --ignored --exact --nocapture
+        }
     }
     finally {
         $env:AGENT_BOUNTIES_TEST_DATABASE_URL = $previousTestDatabaseUrl

--- a/scripts/check-postgres.sh
+++ b/scripts/check-postgres.sh
@@ -38,6 +38,8 @@ cargo test -p api tests::audience_audit_persists_idempotently_across_processes -
 cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
 cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture
 cargo test -p db tests::base_log_pipeline_rolls_back_paid_state_when_cursor_commit_fails -- --ignored --exact --nocapture
+cargo test -p worker tests::base_indexer_poll_applies_release_with_mock_rpc -- --ignored --exact --nocapture
+cargo test -p worker tests::base_indexer_poll_quarantines_release_failures_with_mock_rpc -- --ignored --exact --nocapture
 cargo run -p cli -- service-smoke-spawn \
   --api-base-url http://127.0.0.1:18180 \
   --mcp-base-url http://127.0.0.1:18190 \

--- a/scripts/check-postgres.sh
+++ b/scripts/check-postgres.sh
@@ -37,6 +37,7 @@ export AGENT_BOUNTIES_TEST_DATABASE_URL="$database_url"
 cargo test -p api tests::audience_audit_persists_idempotently_across_processes -- --ignored --exact --nocapture
 cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
 cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture
+cargo test -p db tests::base_log_pipeline_rolls_back_paid_state_when_cursor_commit_fails -- --ignored --exact --nocapture
 cargo run -p cli -- service-smoke-spawn \
   --api-base-url http://127.0.0.1:18180 \
   --mcp-base-url http://127.0.0.1:18190 \


### PR DESCRIPTION
Refs #132.

## Summary
- require an attested Base release transaction before `EscrowReleased` can mark a payout as paid
- fetch and persist the matching `eth_getTransactionByHash` request/transaction for release-log reconciliation
- decode `release(uint256,address[],uint256[],bytes32)` calldata and compare escrow id, proof hash, recipients, amounts, target contract, signer, chain id, and receipt success
- surface the attestation through API/MCP responses, SDK request types, docs, and runbook copy

## How I found this
I found this through the public Agent Bounties issue list while looking for small, self-contained payout-integrity tasks with a clear verification surface. This issue looked worth attempting because the existing receipt path could see an `EscrowReleased` log, while the bounty asks for binding that log back to the exact release calldata that produced the payout.

## Validation
- `git diff --check`
- `node --check crates/sdk-typescript/src/index.ts`
- `python -m py_compile crates/sdk-python/agent_bounties/client.py`
- `python scripts/check-site.py`
- `python -c "import json; json.load(open(r'site\\.well-known\\agent-bounties.json', encoding='utf-8')); print('json ok')"`

I could not run `cargo fmt`/`cargo test` locally because `cargo` is not installed in this Windows Codex environment; I expect CI to provide the Rust compile/test signal.
