### PR TITLE
feat: add DB freshness evidence to health endpoint

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -679,9 +679,42 @@ fn service_bind_addr(configured: Option<&str>, port: Option<&str>, default_addr:
         .unwrap_or_else(|| default_addr.to_string())
 }
 
-#[utoipa::path(get, path = "/health", responses((status = 200, body = String)))]
-async fn health() -> &'static str {
-    "ok"
+#[derive(serde::Serialize)]
+struct HealthResponse {
+    status: String,
+    db: Option<DbHealth>,
+}
+
+#[derive(serde::Serialize)]
+struct DbHealth {
+    connected: bool,
+    last_bounty_created_at: Option<String>,
+    bounty_count: Option<i64>,
+}
+
+#[utoipa::path(get, path = "/health", responses((status = 200, body = HealthResponse)))]
+async fn health(State(state): State<SharedState>) -> Json<HealthResponse> {
+    let db_health = if let Some(ref store) = state.store {
+        match store.health_check().await {
+            Ok((connected, last_at, count)) => Some(DbHealth {
+                connected,
+                last_bounty_created_at: last_at,
+                bounty_count: count,
+            }),
+            Err(_) => Some(DbHealth {
+                connected: false,
+                last_bounty_created_at: None,
+                bounty_count: None,
+            }),
+        }
+    } else {
+        None
+    };
+
+    Json(HealthResponse {
+        status: "ok".to_string(),
+        db: db_health,
+    })
 }
 
 #[utoipa::path(get, path = "/llms.txt", responses((status = 200, body = String)))]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -187,6 +187,28 @@ impl PostgresStore {
         }
     }
 
+    pub async fn health_check(&self) -> DbResult<(bool, Option<String>, Option<i64>)> {
+        let row = sqlx::query(
+            r#"
+            SELECT 
+                COUNT(*) as bounty_count,
+                MAX(created_at) as last_bounty_created_at
+            FROM bounties
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        let bounty_count: i64 = row.get("bounty_count");
+        let last_bounty_created_at: Option<chrono::NaiveDateTime> = row.get("last_bounty_created_at");
+
+        Ok((
+            true,
+            last_bounty_created_at.map(|dt| dt.to_string()),
+            Some(bounty_count),
+        ))
+    }
+
     pub async fn upsert_agent(&self, agent: &Agent) -> DbResult<()> {
         sqlx::query(
             r#"


### PR DESCRIPTION
Fixes #130

Adds database connectivity and freshness information to the /health endpoint to help operators detect lag between process memory and Postgres state.

Changes:
- Modified health endpoint to query Postgres for freshness info
- Added db.health_check() method to PostgresStore  
- Health response now includes: db.connected, db.last_bounty_created_at, db.bounty_count

This addresses acceptance criteria #7: expose freshness/version evidence in health output.

Discovery feedback: Found via GitHub label search for 'bounty'. Worth attempting because it's a focused, testable change with clear acceptance criteria.

Signed-off-by: Ghost <ghost@agent-bounties.local>