### PR TITLE
fix(hosted): rehydrate bounty status from Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,7 @@ jobs:
         run: test -n "$AGENT_BOUNTIES_TEST_DATABASE_URL"
 
       - name: Run Postgres sync regressions
-        run: cargo test -p api github_issue_api_sync_postgres -- --ignored --nocapture
+        run: |
+          cargo test -p api github_issue_api_sync_postgres -- --ignored --nocapture
+          cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
+          cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -4733,10 +4733,12 @@ mod tests {
                 external_reference: Some("base-tx-before-indexer".to_string()),
                 stripe_success_url: None,
                 stripe_cancel_url: None,
-                base_escrow_contract: None,
-                base_payer: None,
-                base_token: None,
-                base_network: None,
+                base_escrow_contract: Some(
+                    "0x1111111111111111111111111111111111111111".to_string(),
+                ),
+                base_payer: Some("0x2222222222222222222222222222222222222222".to_string()),
+                base_token: Some("0x3333333333333333333333333333333333333333".to_string()),
+                base_network: Some("base-mainnet".to_string()),
             }),
         )
         .await

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -30,7 +30,7 @@ use chain_base::{
     EthSendRawTransactionRequest, RpcLogSubmission, RpcTransactionReceipt,
 };
 use chrono::Utc;
-use db::{GitHubIssueSyncBountyUpsert, PostgresStore};
+use db::{BountyStatusScope, GitHubIssueSyncBountyUpsert, PostgresStore};
 use domain::{
     Agent, BountyStatus, Capability, CapabilityClass, ContributorContact, EvalRun, HelpRequest,
     Money, PaymentRail, PayoutStatus, PrivacyLevel, RiskEvent, RiskReviewRecord,
@@ -2790,27 +2790,105 @@ async fn bounty_status(
     State(state): State<SharedState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<BountyStatusResponse>, StatusCode> {
+    bounty_status_snapshot(&state, id).await.map(Json)
+}
+
+async fn bounty_status_snapshot(
+    state: &SharedState,
+    id: Uuid,
+) -> Result<BountyStatusResponse, StatusCode> {
+    if let Some(store) = &state.store {
+        let scope = store
+            .load_bounty_status_scope(id)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .ok_or(StatusCode::NOT_FOUND)?;
+        return bounty_status_from_scope(scope);
+    }
+
     let mut status = {
         let network = state.network.lock().expect("state poisoned");
         network.status(id).map_err(|_| StatusCode::NOT_FOUND)?
     };
-    status.base_escrow_events = if let Some(store) = &state.store {
-        store
-            .list_base_escrow_events_for_bounty(id)
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    } else {
-        state
-            .base_log_worker
-            .lock()
-            .expect("state poisoned")
-            .indexed_events()
-            .iter()
-            .filter(|event| event.bounty_id == id)
-            .cloned()
-            .collect()
+    status.base_escrow_events = state
+        .base_log_worker
+        .lock()
+        .expect("state poisoned")
+        .indexed_events()
+        .iter()
+        .filter(|event| event.bounty_id == id)
+        .cloned()
+        .collect();
+    Ok(status)
+}
+
+fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResponse, StatusCode> {
+    let bounty_id = scope.bounty.id;
+    let base_escrow_events = scope.base_escrow_events;
+    let network = BountyNetwork {
+        bounties: [(scope.bounty.id, scope.bounty)].into_iter().collect(),
+        funding_intents: scope
+            .funding_intents
+            .into_iter()
+            .map(|intent| (intent.id, intent))
+            .collect(),
+        funding_contributions: scope
+            .funding_contributions
+            .into_iter()
+            .map(|contribution| (contribution.id, contribution))
+            .collect(),
+        escrows: scope
+            .escrows
+            .into_iter()
+            .map(|escrow| (escrow.id, escrow))
+            .collect(),
+        claims: scope
+            .claims
+            .into_iter()
+            .map(|claim| (claim.id, claim))
+            .collect(),
+        submissions: scope
+            .submissions
+            .into_iter()
+            .map(|submission| (submission.id, submission))
+            .collect(),
+        verifier_results: scope
+            .verifier_results
+            .into_iter()
+            .map(|result| (result.id, result))
+            .collect(),
+        proofs: scope
+            .proofs
+            .into_iter()
+            .map(|proof| (proof.id, proof))
+            .collect(),
+        settlements: scope
+            .settlements
+            .into_iter()
+            .map(|settlement| (settlement.id, settlement))
+            .collect(),
+        reputation_events: scope
+            .reputation_events
+            .into_iter()
+            .map(|event| (event.id, event))
+            .collect(),
+        template_signals: scope
+            .template_signals
+            .into_iter()
+            .map(|signal| (signal.id, signal))
+            .collect(),
+        risk_events: scope
+            .risk_events
+            .into_iter()
+            .map(|event| (event.id, event))
+            .collect(),
+        ..BountyNetwork::default()
     };
-    Ok(Json(status))
+    let mut status = network
+        .status(bounty_id)
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+    status.base_escrow_events = base_escrow_events;
+    Ok(status)
 }
 
 async fn public_proof_page(
@@ -4639,7 +4717,33 @@ mod tests {
             .await
             .unwrap()
             .0;
+        assert_eq!(initial_status.bounty.status, BountyStatus::Unfunded);
+        assert!(!initial_status.funding_summary.claimable);
         assert!(initial_status.base_escrow_events.is_empty());
+        let funding_intent = create_funding_intent(
+            State(api_state.clone()),
+            Path(bounty.id),
+            Json(CreateFundingIntentRequest {
+                bounty_id: bounty.id,
+                contributor_agent_id: None,
+                source_organization_id: None,
+                amount_minor: bounty.amount.amount,
+                currency: bounty.amount.currency.clone(),
+                rail: PaymentRail::BaseUsdc,
+                external_reference: Some("base-tx-before-indexer".to_string()),
+                stripe_success_url: None,
+                stripe_cancel_url: None,
+                base_escrow_contract: None,
+                base_payer: None,
+                base_token: None,
+                base_network: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0
+        .intent;
+        assert_eq!(funding_intent.status, FundingIntentStatus::AwaitingEvidence);
 
         let indexer_store = PostgresStore::connect(&database_url).await.unwrap();
         let mut indexer_network = hydrate_network(&indexer_store).await.unwrap();
@@ -4689,6 +4793,16 @@ mod tests {
             .unwrap()
             .0;
 
+        assert_eq!(status.bounty.status, BountyStatus::Claimable);
+        assert!(status.funding_summary.claimable);
+        assert_eq!(status.funding_intents.len(), 1);
+        assert_eq!(status.funding_intents[0].id, funding_intent.id);
+        assert_eq!(
+            status.funding_intents[0].status,
+            FundingIntentStatus::Applied
+        );
+        assert_eq!(status.escrows.len(), 1);
+        assert_eq!(status.escrows[0].status, domain::EscrowStatus::Funded);
         assert_eq!(status.base_escrow_events.len(), 1);
         assert_eq!(status.base_escrow_events[0].bounty_id, bounty.id);
         assert_eq!(

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -125,6 +125,23 @@ pub struct BaseIndexerHeartbeat {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone)]
+pub struct BountyStatusScope {
+    pub bounty: Bounty,
+    pub funding_intents: Vec<FundingIntent>,
+    pub funding_contributions: Vec<FundingContribution>,
+    pub escrows: Vec<Escrow>,
+    pub base_escrow_events: Vec<BaseEscrowEvent>,
+    pub claims: Vec<Claim>,
+    pub submissions: Vec<Submission>,
+    pub verifier_results: Vec<VerifierResult>,
+    pub proofs: Vec<ProofRecord>,
+    pub settlements: Vec<Settlement>,
+    pub reputation_events: Vec<ReputationEvent>,
+    pub template_signals: Vec<TemplateSignal>,
+    pub risk_events: Vec<RiskEvent>,
+}
+
 #[derive(Debug, Default)]
 pub struct InMemoryStore {
     pub agents: HashMap<Id, Agent>,
@@ -593,6 +610,375 @@ impl PostgresStore {
         .await?;
 
         rows.into_iter().map(|row| bounty_from_row(&row)).collect()
+    }
+
+    pub async fn load_bounty_status_scope(
+        &self,
+        bounty_id: Id,
+    ) -> DbResult<Option<BountyStatusScope>> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+            .execute(&mut *tx)
+            .await?;
+
+        let bounty = sqlx::query(
+            r#"
+            SELECT id, help_request_id, title, template_slug, amount, currency, funding_targets, funding_mode, privacy, status, terms_hash, created_at
+            FROM bounties
+            WHERE id = $1
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(|row| bounty_from_row(&row))
+        .transpose()?;
+
+        let Some(bounty) = bounty else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+
+        let funding_intents = sqlx::query(
+            r#"
+            SELECT id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, external_reference, stripe_success_url, stripe_cancel_url, created_at
+            FROM funding_intents
+            WHERE bounty_id = $1
+            ORDER BY created_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(FundingIntent {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                contributor_agent_id: row.try_get("contributor_agent_id")?,
+                source_organization_id: row.try_get("source_organization_id")?,
+                rail: parse_payment_rail(row.try_get::<String, _>("rail")?)?,
+                amount: Money::new(
+                    row.try_get::<i64, _>("amount")?,
+                    row.try_get::<String, _>("currency")?,
+                )?,
+                status: parse_funding_intent_status(row.try_get::<String, _>("status")?)?,
+                external_reference: row.try_get("external_reference")?,
+                stripe_success_url: row.try_get("stripe_success_url")?,
+                stripe_cancel_url: row.try_get("stripe_cancel_url")?,
+                created_at: row.try_get("created_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let funding_contributions = sqlx::query(
+            r#"
+            SELECT id, bounty_id, contributor_agent_id, source_organization_id, rail, amount, currency, status, funding_ledger_entry_id, refund_ledger_entry_id, settlement_id, external_reference, created_at
+            FROM funding_contributions
+            WHERE bounty_id = $1
+            ORDER BY created_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(FundingContribution {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                contributor_agent_id: row.try_get("contributor_agent_id")?,
+                source_organization_id: row.try_get("source_organization_id")?,
+                rail: parse_payment_rail(row.try_get::<String, _>("rail")?)?,
+                amount: Money::new(
+                    row.try_get::<i64, _>("amount")?,
+                    row.try_get::<String, _>("currency")?,
+                )?,
+                status: parse_funding_contribution_status(row.try_get::<String, _>("status")?)?,
+                funding_ledger_entry_id: row.try_get("funding_ledger_entry_id")?,
+                refund_ledger_entry_id: row.try_get("refund_ledger_entry_id")?,
+                settlement_id: row.try_get("settlement_id")?,
+                external_reference: row.try_get("external_reference")?,
+                created_at: row.try_get("created_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let escrows = sqlx::query(
+            r#"
+            SELECT id, bounty_id, rail, token, amount, currency, status, external_reference
+            FROM escrows
+            WHERE bounty_id = $1
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(Escrow {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                rail: parse_payment_rail(row.try_get::<String, _>("rail")?)?,
+                token: row.try_get("token")?,
+                amount: Money::new(
+                    row.try_get::<i64, _>("amount")?,
+                    row.try_get::<String, _>("currency")?,
+                )?,
+                status: parse_escrow_status(row.try_get::<String, _>("status")?)?,
+                external_reference: row.try_get("external_reference")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let base_escrow_events = sqlx::query(
+            r#"
+            SELECT id, log_key, tx_hash, block_number, onchain_escrow_id, bounty_id, kind, status, token, amount, currency, terms_hash, proof_hash, reason_hash, dispute_hash, occurred_at
+            FROM base_escrow_events
+            WHERE bounty_id = $1
+            ORDER BY block_number, COALESCE(log_index, 0), occurred_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(base_escrow_event_from_row)
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let claims = sqlx::query(
+            r#"
+            SELECT id, bounty_id, solver_agent_id, claimed_at
+            FROM claims
+            WHERE bounty_id = $1
+            ORDER BY claimed_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(Claim {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                solver_agent_id: row.try_get("solver_agent_id")?,
+                claimed_at: row.try_get("claimed_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let submissions = sqlx::query(
+            r#"
+            SELECT id, bounty_id, solver_agent_id, artifact_digest, artifact_uri, submitted_at
+            FROM submissions
+            WHERE bounty_id = $1
+            ORDER BY submitted_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(Submission {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                solver_agent_id: row.try_get("solver_agent_id")?,
+                artifact_digest: row.try_get("artifact_digest")?,
+                artifact_uri: row.try_get("artifact_uri")?,
+                submitted_at: row.try_get("submitted_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let verifier_results = sqlx::query(
+            r#"
+            SELECT id, bounty_id, submission_id, verifier_agent_id, kind, decision, summary, confidence, signed_payload_hash, created_at
+            FROM verifier_results
+            WHERE bounty_id = $1
+            ORDER BY created_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(VerifierResult {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                submission_id: row.try_get("submission_id")?,
+                verifier_agent_id: row.try_get("verifier_agent_id")?,
+                kind: parse_verifier_kind(row.try_get::<String, _>("kind")?)?,
+                decision: parse_verification_decision(row.try_get::<String, _>("decision")?)?,
+                summary: row.try_get("summary")?,
+                confidence: row.try_get("confidence")?,
+                signed_payload_hash: row.try_get("signed_payload_hash")?,
+                created_at: row.try_get("created_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let proofs = sqlx::query(
+            r#"
+            SELECT id, bounty_id, submission_id, verifier_result_id, proof_hash, public_summary, privacy, created_at
+            FROM proof_records
+            WHERE bounty_id = $1
+            ORDER BY created_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(ProofRecord {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                submission_id: row.try_get("submission_id")?,
+                verifier_result_id: row.try_get("verifier_result_id")?,
+                proof_hash: row.try_get("proof_hash")?,
+                public_summary: row.try_get("public_summary")?,
+                privacy: parse_privacy(row.try_get::<String, _>("privacy")?)?,
+                created_at: row.try_get("created_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let settlements = sqlx::query(
+            r#"
+            SELECT id, bounty_id, proof_record_id, rail, payout_intents, platform_fee, currency, created_at
+            FROM settlements
+            WHERE bounty_id = $1
+            ORDER BY created_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            let platform_fee_amount = row.try_get::<i64, _>("platform_fee")?;
+            let currency = row.try_get::<String, _>("currency")?;
+            let platform_fee = persisted_nonnegative_money(platform_fee_amount, currency)?;
+            Ok(Settlement {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                proof_record_id: row.try_get("proof_record_id")?,
+                rail: parse_payment_rail(row.try_get::<String, _>("rail")?)?,
+                payout_intents: serde_json::from_value(row.try_get("payout_intents")?)?,
+                platform_fee,
+                created_at: row.try_get("created_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let reputation_events = sqlx::query(
+            r#"
+            SELECT id, agent_id, bounty_id, capability_class, template_slug, delta, reason, created_at
+            FROM reputation_events
+            WHERE bounty_id = $1
+            ORDER BY created_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(ReputationEvent {
+                id: row.try_get("id")?,
+                agent_id: row.try_get("agent_id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                capability_class: parse_capability_class(
+                    row.try_get::<String, _>("capability_class")?,
+                )?,
+                template_slug: row.try_get("template_slug")?,
+                delta: row.try_get("delta")?,
+                reason: row.try_get("reason")?,
+                created_at: row.try_get("created_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let template_signals = sqlx::query(
+            r#"
+            SELECT id, bounty_id, proof_record_id, template_slug, capability_class, verifier_kind, amount, currency, success, created_at
+            FROM template_signals
+            WHERE bounty_id = $1
+            ORDER BY created_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            Ok(TemplateSignal {
+                id: row.try_get("id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                proof_record_id: row.try_get("proof_record_id")?,
+                template_slug: row.try_get("template_slug")?,
+                capability_class: parse_capability_class(
+                    row.try_get::<String, _>("capability_class")?,
+                )?,
+                verifier_kind: parse_verifier_kind(row.try_get::<String, _>("verifier_kind")?)?,
+                amount: Money::new(
+                    row.try_get::<i64, _>("amount")?,
+                    row.try_get::<String, _>("currency")?,
+                )?,
+                success: row.try_get("success")?,
+                created_at: row.try_get("created_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        let risk_events = sqlx::query(
+            r#"
+            SELECT id, subject_id, agent_id, bounty_id, surface, action, score, reasons, created_at
+            FROM risk_events
+            WHERE bounty_id = $1
+            ORDER BY created_at
+            "#,
+        )
+        .bind(bounty_id)
+        .fetch_all(&mut *tx)
+        .await?
+        .into_iter()
+        .map(|row| {
+            let score: i32 = row.try_get("score")?;
+            Ok(RiskEvent {
+                id: row.try_get("id")?,
+                subject_id: row.try_get("subject_id")?,
+                agent_id: row.try_get("agent_id")?,
+                bounty_id: row.try_get("bounty_id")?,
+                surface: parse_risk_surface(row.try_get::<String, _>("surface")?)?,
+                action: parse_risk_action(row.try_get::<String, _>("action")?)?,
+                score: u16::try_from(score)
+                    .map_err(|_| DbError::IntegerOverflow("risk_event.score".to_string()))?,
+                reasons: serde_json::from_value(row.try_get("reasons")?)?,
+                created_at: row.try_get("created_at")?,
+            })
+        })
+        .collect::<DbResult<Vec<_>>>()?;
+
+        tx.commit().await?;
+        Ok(Some(BountyStatusScope {
+            bounty,
+            funding_intents,
+            funding_contributions,
+            escrows,
+            base_escrow_events,
+            claims,
+            submissions,
+            verifier_results,
+            proofs,
+            settlements,
+            reputation_events,
+            template_signals,
+            risk_events,
+        }))
     }
 
     pub async fn upsert_funding_contribution(

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -4353,10 +4353,12 @@ mod tests {
                 external_reference: Some("mcp-base-tx-before-indexer".to_string()),
                 stripe_success_url: None,
                 stripe_cancel_url: None,
-                base_escrow_contract: None,
-                base_payer: None,
-                base_token: None,
-                base_network: None,
+                base_escrow_contract: Some(
+                    "0x1111111111111111111111111111111111111111".to_string(),
+                ),
+                base_payer: Some("0x2222222222222222222222222222222222222222".to_string()),
+                base_token: Some("0x3333333333333333333333333333333333333333".to_string()),
+                base_network: Some("base-mainnet".to_string()),
             }),
         )
         .await

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -2,9 +2,9 @@ use app::{
     build_base_indexer_status_report, build_live_money_readiness_report,
     stripe_secret_key_mode_from_secret, AddFundingContributionRequest, ApproveRiskBountyRequest,
     ApproveRiskPayoutRequest, BaseIndexerHeartbeatStatus, BaseIndexerScanCursor,
-    BaseIndexerStatusConfig, BaseReleaseQueueRequest, BountyNetwork, ClaimBountyRequest,
-    CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport,
-    LiveMoneyReadinessConfig, OpenPooledBountyRequest, PlanBaseDisputeRequest,
+    BaseIndexerStatusConfig, BaseReleaseQueueRequest, BountyNetwork, BountyStatusResponse,
+    ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
+    FundingIntentReport, LiveMoneyReadinessConfig, OpenPooledBountyRequest, PlanBaseDisputeRequest,
     PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
     PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest, RegisterAgentRequest,
     RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
@@ -25,7 +25,7 @@ use chain_base::{
     BaseRpcUrlConfig, EvmLog, RpcLogSubmission,
 };
 use chrono::Utc;
-use db::PostgresStore;
+use db::{BountyStatusScope, PostgresStore};
 use domain::{
     Agent, BountyStatus, CapabilityClass, EvalRun, HelpRequest, Money, PaymentRail, PayoutStatus,
     PrivacyLevel, RiskReviewRecord,
@@ -1907,20 +1907,118 @@ async fn get_bounty_status(
     State(state): State<SharedState>,
     Json(args): Json<BountyIdArgs>,
 ) -> Json<serde_json::Value> {
-    let network = state.network.lock().expect("state poisoned");
-    match network.status(args.bounty_id) {
+    match bounty_status_snapshot(&state, args.bounty_id).await {
         Ok(status) => mcp_json(status),
         Err(error) => mcp_error(error),
     }
+}
+
+async fn bounty_status_snapshot(
+    state: &SharedState,
+    bounty_id: Uuid,
+) -> Result<BountyStatusResponse, String> {
+    if let Some(store) = &state.store {
+        let scope = store
+            .load_bounty_status_scope(bounty_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "bounty not found".to_string())?;
+        return bounty_status_from_scope(scope);
+    }
+
+    let mut status = {
+        let network = state.network.lock().expect("state poisoned");
+        network
+            .status(bounty_id)
+            .map_err(|error| error.to_string())?
+    };
+    status.base_escrow_events = state
+        .base_log_worker
+        .lock()
+        .expect("state poisoned")
+        .indexed_events()
+        .iter()
+        .filter(|event| event.bounty_id == bounty_id)
+        .cloned()
+        .collect();
+    Ok(status)
+}
+
+fn bounty_status_from_scope(scope: BountyStatusScope) -> Result<BountyStatusResponse, String> {
+    let bounty_id = scope.bounty.id;
+    let base_escrow_events = scope.base_escrow_events;
+    let network = BountyNetwork {
+        bounties: [(scope.bounty.id, scope.bounty)].into_iter().collect(),
+        funding_intents: scope
+            .funding_intents
+            .into_iter()
+            .map(|intent| (intent.id, intent))
+            .collect(),
+        funding_contributions: scope
+            .funding_contributions
+            .into_iter()
+            .map(|contribution| (contribution.id, contribution))
+            .collect(),
+        escrows: scope
+            .escrows
+            .into_iter()
+            .map(|escrow| (escrow.id, escrow))
+            .collect(),
+        claims: scope
+            .claims
+            .into_iter()
+            .map(|claim| (claim.id, claim))
+            .collect(),
+        submissions: scope
+            .submissions
+            .into_iter()
+            .map(|submission| (submission.id, submission))
+            .collect(),
+        verifier_results: scope
+            .verifier_results
+            .into_iter()
+            .map(|result| (result.id, result))
+            .collect(),
+        proofs: scope
+            .proofs
+            .into_iter()
+            .map(|proof| (proof.id, proof))
+            .collect(),
+        settlements: scope
+            .settlements
+            .into_iter()
+            .map(|settlement| (settlement.id, settlement))
+            .collect(),
+        reputation_events: scope
+            .reputation_events
+            .into_iter()
+            .map(|event| (event.id, event))
+            .collect(),
+        template_signals: scope
+            .template_signals
+            .into_iter()
+            .map(|signal| (signal.id, signal))
+            .collect(),
+        risk_events: scope
+            .risk_events
+            .into_iter()
+            .map(|event| (event.id, event))
+            .collect(),
+        ..BountyNetwork::default()
+    };
+    let mut status = network
+        .status(bounty_id)
+        .map_err(|error| error.to_string())?;
+    status.base_escrow_events = base_escrow_events;
+    Ok(status)
 }
 
 async fn get_paid_status(
     State(state): State<SharedState>,
     Json(args): Json<PaidStatusArgs>,
 ) -> Json<serde_json::Value> {
-    let network = state.network.lock().expect("state poisoned");
     match (args.bounty_id, args.agent_id) {
-        (Some(bounty_id), None) => match network.status(bounty_id) {
+        (Some(bounty_id), None) => match bounty_status_snapshot(&state, bounty_id).await {
             Ok(status) => {
                 let api = public_base_url_from_env();
                 let proof_url = status.proofs.first().map(|proof| {
@@ -1954,45 +2052,49 @@ async fn get_paid_status(
             }
             Err(error) => mcp_error(error),
         },
-        (None, Some(agent_id)) => match network.agent_payout_status(agent_id) {
-            Ok(status) => {
-                let paid = status.payouts.iter().find(|payout| {
-                    payout.status == PayoutStatus::Paid && payout.rail != PaymentRail::Simulated
-                });
-                let evidence_payout = paid.or_else(|| status.payouts.first());
-                let trigger = if paid.is_some() {
-                    Some(web_public::PostValueTrigger::ReconciledPayout)
-                } else if evidence_payout.is_some() || !status.reputation_events.is_empty() {
-                    Some(web_public::PostValueTrigger::VerifiedCompletion)
-                } else {
-                    None
-                };
-                let api = public_base_url_from_env();
-                let share_url = evidence_payout
-                    .map(|payout| {
-                        format!(
-                            "{}/public/proofs/{}",
-                            api.trim_end_matches('/'),
-                            payout.proof_record_id
-                        )
-                    })
-                    .unwrap_or_else(|| {
-                        format!("{}/public/agents/{agent_id}", api.trim_end_matches('/'))
+        (None, Some(agent_id)) => {
+            let network = state.network.lock().expect("state poisoned");
+            match network.agent_payout_status(agent_id) {
+                Ok(status) => {
+                    let paid = status.payouts.iter().find(|payout| {
+                        payout.status == PayoutStatus::Paid && payout.rail != PaymentRail::Simulated
                     });
-                let post_value_loop = trigger
-                    .map(|trigger| web_public::post_value_loop(Some(trigger), Some(&share_url)));
-                mcp_json(serde_json::json!({
-                    "scope": "agent",
-                    "agent_id": agent_id,
-                    "agent": status.agent,
-                    "payouts": status.payouts,
-                    "totals": status.totals,
-                    "reputation_events": status.reputation_events,
-                    "post_value_loop": post_value_loop
-                }))
+                    let evidence_payout = paid.or_else(|| status.payouts.first());
+                    let trigger = if paid.is_some() {
+                        Some(web_public::PostValueTrigger::ReconciledPayout)
+                    } else if evidence_payout.is_some() || !status.reputation_events.is_empty() {
+                        Some(web_public::PostValueTrigger::VerifiedCompletion)
+                    } else {
+                        None
+                    };
+                    let api = public_base_url_from_env();
+                    let share_url = evidence_payout
+                        .map(|payout| {
+                            format!(
+                                "{}/public/proofs/{}",
+                                api.trim_end_matches('/'),
+                                payout.proof_record_id
+                            )
+                        })
+                        .unwrap_or_else(|| {
+                            format!("{}/public/agents/{agent_id}", api.trim_end_matches('/'))
+                        });
+                    let post_value_loop = trigger.map(|trigger| {
+                        web_public::post_value_loop(Some(trigger), Some(&share_url))
+                    });
+                    mcp_json(serde_json::json!({
+                        "scope": "agent",
+                        "agent_id": agent_id,
+                        "agent": status.agent,
+                        "payouts": status.payouts,
+                        "totals": status.totals,
+                        "reputation_events": status.reputation_events,
+                        "post_value_loop": post_value_loop
+                    }))
+                }
+                Err(error) => mcp_error(error),
             }
-            Err(error) => mcp_error(error),
-        },
+        }
         (None, None) => mcp_error("get_paid_status requires bounty_id or agent_id"),
         (Some(_), Some(_)) => {
             mcp_error("get_paid_status accepts either bounty_id or agent_id, not both")
@@ -4190,6 +4292,162 @@ mod tests {
         assert!(body.get("payment_method_types").is_none());
     }
 
+    #[tokio::test]
+    #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
+    async fn mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding() {
+        let database_url = postgres_test_database_url();
+        let reader_store = PostgresStore::connect(&database_url).await.unwrap();
+        reader_store.migrate().await.unwrap();
+
+        let mut reader_network = BountyNetwork::default();
+        let bounty = reader_network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Expose MCP scoped Base evidence".to_string(),
+                template_slug: "fix-ci-failure".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: domain::FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+        let other_bounty = reader_network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Filter unrelated MCP Base evidence".to_string(),
+                template_slug: "fix-ci-failure".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: domain::FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+            })
+            .unwrap();
+        reader_store.upsert_bounty(&bounty).await.unwrap();
+        reader_store.upsert_bounty(&other_bounty).await.unwrap();
+        let reader_state =
+            test_state_with_operator_token_and_store(reader_network, "secret-token", reader_store);
+
+        let initial_status = get_bounty_status(
+            State(reader_state.clone()),
+            Json(BountyIdArgs {
+                bounty_id: bounty.id,
+            }),
+        )
+        .await
+        .0;
+        let initial_json = &initial_status["content"][0]["json"];
+        assert_eq!(initial_json["bounty"]["status"], "Unfunded");
+        assert_eq!(initial_json["funding_summary"]["claimable"], false);
+        assert_eq!(
+            initial_json["base_escrow_events"].as_array().unwrap().len(),
+            0
+        );
+
+        let funding_intent = create_funding_intent(
+            State(reader_state.clone()),
+            Json(CreateFundingIntentRequest {
+                bounty_id: bounty.id,
+                contributor_agent_id: None,
+                source_organization_id: None,
+                amount_minor: bounty.amount.amount,
+                currency: bounty.amount.currency.clone(),
+                rail: PaymentRail::BaseUsdc,
+                external_reference: Some("mcp-base-tx-before-indexer".to_string()),
+                stripe_success_url: None,
+                stripe_cancel_url: None,
+                base_escrow_contract: None,
+                base_payer: None,
+                base_token: None,
+                base_network: None,
+            }),
+        )
+        .await
+        .0;
+        let funding_json = &funding_intent["content"][0]["json"]["intent"];
+        assert_eq!(funding_json["status"], "AwaitingEvidence");
+
+        let indexer_store = PostgresStore::connect(&database_url).await.unwrap();
+        let indexer_network = hydrate_network(&indexer_store).await.unwrap();
+        let indexer_state = test_state_with_operator_token_and_store(
+            indexer_network,
+            "secret-token",
+            indexer_store,
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert(OPERATOR_TOKEN_HEADER, "secret-token".parse().unwrap());
+        let onchain_escrow_id = bounty.id.as_u128() % 1_000_000_000_000 + 20_000;
+        let event = chain_base::simulated_created_event(
+            bounty.id,
+            onchain_escrow_id,
+            "0x3333333333333333333333333333333333333333",
+            bounty.amount.clone(),
+            bounty.terms_hash.clone().unwrap(),
+        );
+        let event_tx_hash = event.tx_hash.clone();
+        let other_event = chain_base::simulated_created_event(
+            other_bounty.id,
+            onchain_escrow_id + 1,
+            "0x3333333333333333333333333333333333333333",
+            other_bounty.amount.clone(),
+            other_bounty.terms_hash.clone().unwrap(),
+        );
+        let reconciled =
+            reconcile_base_escrow_event(State(indexer_state.clone()), headers.clone(), Json(event))
+                .await
+                .0;
+        assert!(reconciled.get("error").is_none(), "{reconciled}");
+        let other_reconciled =
+            reconcile_base_escrow_event(State(indexer_state), headers, Json(other_event)).await;
+        assert!(
+            other_reconciled.0.get("error").is_none(),
+            "{}",
+            other_reconciled.0
+        );
+
+        let status = get_bounty_status(
+            State(reader_state.clone()),
+            Json(BountyIdArgs {
+                bounty_id: bounty.id,
+            }),
+        )
+        .await
+        .0;
+        let status_json = &status["content"][0]["json"];
+        assert_eq!(status_json["bounty"]["status"], "Claimable");
+        assert_eq!(status_json["funding_summary"]["claimable"], true);
+        assert_eq!(status_json["funding_intents"].as_array().unwrap().len(), 1);
+        assert_eq!(status_json["funding_intents"][0]["status"], "Applied");
+        assert_eq!(status_json["escrows"].as_array().unwrap().len(), 1);
+        assert_eq!(status_json["escrows"][0]["status"], "Funded");
+        assert_eq!(
+            status_json["base_escrow_events"].as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(
+            status_json["base_escrow_events"][0]["bounty_id"]
+                .as_str()
+                .unwrap(),
+            bounty.id.to_string().as_str()
+        );
+        assert_eq!(
+            status_json["base_escrow_events"][0]["tx_hash"]
+                .as_str()
+                .unwrap(),
+            event_tx_hash.as_str()
+        );
+
+        let paid_status = get_paid_status(
+            State(reader_state),
+            Json(PaidStatusArgs {
+                bounty_id: Some(bounty.id),
+                agent_id: None,
+            }),
+        )
+        .await
+        .0;
+        let paid_json = &paid_status["content"][0]["json"];
+        assert_eq!(paid_json["bounty_status"], "Claimable");
+        assert_eq!(paid_json["post_value_loop"]["trigger"], "funded_bounty");
+    }
+
     fn test_state() -> SharedState {
         test_state_with_network(BountyNetwork::default())
     }
@@ -4242,6 +4500,32 @@ mod tests {
             operator_api_token: Some(token.to_string()),
             store: None,
         })
+    }
+
+    fn test_state_with_operator_token_and_store(
+        network: BountyNetwork,
+        token: &str,
+        store: PostgresStore,
+    ) -> SharedState {
+        Arc::new(AppState {
+            network: Mutex::new(network),
+            base_log_worker: Mutex::new(BaseEscrowLogWorker::default()),
+            eval_runs: Mutex::new(Vec::new()),
+            base_rpc_urls: BaseRpcUrlConfig::default(),
+            base_broadcast_enabled: false,
+            stripe_secret_key: None,
+            stripe_live_execution_enabled: false,
+            stripe_api_base_url: STRIPE_API_BASE_URL.to_string(),
+            stripe_payment_method_configuration: None,
+            operator_api_token: Some(token.to_string()),
+            store: Some(store),
+        })
+    }
+
+    fn postgres_test_database_url() -> String {
+        std::env::var("AGENT_BOUNTIES_TEST_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .expect("set AGENT_BOUNTIES_TEST_DATABASE_URL or DATABASE_URL")
     }
 
     fn valid_github_issue_body() -> String {

--- a/scripts/check-postgres.ps1
+++ b/scripts/check-postgres.ps1
@@ -42,6 +42,19 @@ try {
     }
 
     Invoke-Checked { cargo build -p api -p mcp-server }
+    $previousTestDatabaseUrl = $env:AGENT_BOUNTIES_TEST_DATABASE_URL
+    $env:AGENT_BOUNTIES_TEST_DATABASE_URL = $databaseUrl
+    try {
+        Invoke-Checked {
+            cargo test -p api bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact
+        }
+        Invoke-Checked {
+            cargo test -p mcp-server mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact
+        }
+    }
+    finally {
+        $env:AGENT_BOUNTIES_TEST_DATABASE_URL = $previousTestDatabaseUrl
+    }
     Invoke-Checked {
         cargo run -p cli -- service-smoke-spawn `
             --api-base-url http://127.0.0.1:18180 `

--- a/scripts/check-postgres.ps1
+++ b/scripts/check-postgres.ps1
@@ -46,10 +46,10 @@ try {
     $env:AGENT_BOUNTIES_TEST_DATABASE_URL = $databaseUrl
     try {
         Invoke-Checked {
-            cargo test -p api bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact
+            cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
         }
         Invoke-Checked {
-            cargo test -p mcp-server mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact
+            cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture
         }
     }
     finally {

--- a/scripts/check-postgres.sh
+++ b/scripts/check-postgres.sh
@@ -34,8 +34,8 @@ database_url="${DATABASE_URL:-postgres://agent_bounties:agent_bounties@localhost
 
 cargo build -p api -p mcp-server
 export AGENT_BOUNTIES_TEST_DATABASE_URL="$database_url"
-cargo test -p api bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact
-cargo test -p mcp-server mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact
+cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
+cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture
 cargo run -p cli -- service-smoke-spawn \
   --api-base-url http://127.0.0.1:18180 \
   --mcp-base-url http://127.0.0.1:18190 \

--- a/scripts/check-postgres.sh
+++ b/scripts/check-postgres.sh
@@ -33,6 +33,9 @@ fi
 database_url="${DATABASE_URL:-postgres://agent_bounties:agent_bounties@localhost:5432/agent_bounties}"
 
 cargo build -p api -p mcp-server
+export AGENT_BOUNTIES_TEST_DATABASE_URL="$database_url"
+cargo test -p api bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact
+cargo test -p mcp-server mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact
 cargo run -p cli -- service-smoke-spawn \
   --api-base-url http://127.0.0.1:18180 \
   --mcp-base-url http://127.0.0.1:18190 \


### PR DESCRIPTION
Refs #130.

## Summary
- make API `GET /v1/bounties/{id}` rehydrate the bounty status snapshot from Postgres when a store is configured, instead of trusting the API process-local `BountyNetwork`
- make MCP `get_bounty_status` and bounty-scoped `get_paid_status` use the same DB-authoritative status snapshot
- preserve the existing local in-memory path when no Postgres store is configured
- keep #121's operator-gated GitHub sync and atomic upsert behavior untouched

## First failing harness
The existing ignored Postgres cross-process test now proves more than event visibility:
- an API process starts with stale `Unfunded` state
- a Base funding intent is created and persisted
- an independent indexer process hydrates from Postgres and persists matching `EscrowCreated` evidence
- the same API state must then report `Claimable`, claimable funding summary, the matching funding intent in `Applied`, the funded escrow, and only the relevant persisted Base event

Before this patch, the handler appended persisted Base events to a stale in-memory bounty status, so the API could still advertise `Unfunded` / not claimable after the worker had persisted funding evidence.

## Validation
- `git diff --check`
- `python scripts/check-site.py` -> `site check ok`
- `python -m json.tool site/.well-known/agent-bounties.json`

Not run locally: `cargo`/Rust tests, because `cargo` is not installed on this Windows PATH. GitHub Actions should provide the Rust compile/test signal.

## Discovery feedback
I found #130 while monitoring the accepted #127 Base payout path. It is worth attempting because stale hosted state blocks trustworthy claim/proof/release evidence for the first Base payout loop, and a DB-authoritative read path is the smallest useful slice that moves payout visibility forward without replacing the merged #121 write path.