### PR TITLE
feat: add consent-aware audience attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ Useful REST paths:
 - `GET /v1/agents/{id}/paid-status`
 - `POST /v1/contributor-contacts`
 - `GET /v1/contributor-contacts`
+- `POST|GET /v1/audience/members`
+- `POST|GET /v1/audience/interactions`
+- `POST|GET /v1/audience/discovery-responses`
+- `POST|GET /v1/audience/outreach-attempts`
+- `GET /v1/audience/report`
 - `POST /v1/capabilities`
 - `GET /v1/capabilities/feed`
 - `POST /v1/capabilities/search`

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1,17 +1,19 @@
 use app::{
-    build_base_indexer_status_report, build_live_money_readiness_report, hash_artifact,
-    stripe_secret_key_mode_from_secret, AddFundingContributionRequest, ApproveRiskBountyRequest,
-    ApproveRiskPayoutRequest, BaseEscrowReconciliation, BaseIndexerHeartbeatStatus,
-    BaseIndexerScanCursor, BaseIndexerStatusConfig, BaseIndexerStatusReport,
-    BaseReleaseQueueRequest, BountyNetwork, BountyStatusResponse, ClaimBountyRequest,
-    CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest, FundingIntentReport,
-    LiveMoneyReadinessConfig, LiveMoneyReadinessReport, OpenPooledBountyRequest,
-    PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
-    PlanStripeTransferRequest as AppPlanStripeTransferRequest, PooledFundingReport,
-    PostBountyRequest, QuoteSet, RegisterAgentRequest, RegisterCapabilityRequest,
-    RejectRiskEventRequest, RequestQuotesRequest, ReviewedBountyApproval, RiskEventFilter,
-    StripeTransferPlan, StripeTransferReconciliation, SubmitResultRequest,
-    UpsertContributorContactRequest, VerifySubmissionRequest,
+    build_audience_report, build_base_indexer_status_report, build_live_money_readiness_report,
+    hash_artifact, stripe_secret_key_mode_from_secret, AddFundingContributionRequest,
+    ApproveRiskBountyRequest, ApproveRiskPayoutRequest, BaseEscrowReconciliation,
+    BaseIndexerHeartbeatStatus, BaseIndexerScanCursor, BaseIndexerStatusConfig,
+    BaseIndexerStatusReport, BaseReleaseQueueRequest, BountyNetwork, BountyStatusResponse,
+    ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
+    FundingIntentReport, LiveMoneyReadinessConfig, LiveMoneyReadinessReport,
+    OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest,
+    PlanBaseReleaseRequest, PlanStripeTransferRequest as AppPlanStripeTransferRequest,
+    PooledFundingReport, PostBountyRequest, QuoteSet, RecordAudienceInteractionRequest,
+    RecordDiscoveryResponseRequest, RecordOutreachAttemptRequest, RegisterAgentRequest,
+    RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
+    ReviewedBountyApproval, RiskEventFilter, StripeTransferPlan, StripeTransferReconciliation,
+    SubmitResultRequest, UpsertAudienceMemberRequest, UpsertContributorContactRequest,
+    VerifySubmissionRequest,
 };
 use axum::{
     body::Bytes,
@@ -30,10 +32,11 @@ use chain_base::{
     EthSendRawTransactionRequest, RpcLogSubmission, RpcTransactionReceipt,
 };
 use chrono::Utc;
-use db::{BountyStatusScope, GitHubIssueSyncBountyUpsert, PostgresStore};
+use db::{BountyStatusScope, DbError, GitHubIssueSyncBountyUpsert, PostgresStore};
 use domain::{
-    Agent, BountyStatus, Capability, CapabilityClass, ContributorContact, EvalRun, HelpRequest,
-    Money, PaymentRail, PayoutStatus, PrivacyLevel, RiskEvent, RiskReviewRecord,
+    Agent, AudienceInteraction, AudienceMember, AudienceReport, BountyStatus, Capability,
+    CapabilityClass, ContributorContact, DiscoveryResponse, EvalRun, HelpRequest, Money,
+    OutreachAttempt, PaymentRail, PayoutStatus, PrivacyLevel, RiskEvent, RiskReviewRecord,
     VerificationDecision, VerifierKind,
 };
 use eval_harness::{
@@ -90,6 +93,15 @@ use worker::BaseEscrowLogWorker;
         agent_paid_status,
         upsert_contributor_contact,
         list_contributor_contacts,
+        upsert_audience_member,
+        list_audience_members,
+        record_audience_interaction,
+        list_audience_interactions,
+        record_discovery_response,
+        list_discovery_responses,
+        record_outreach_attempt,
+        list_outreach_attempts,
+        audience_report,
         register_capability,
         search_capabilities,
         create_help_request,
@@ -159,7 +171,12 @@ use worker::BaseEscrowLogWorker;
         BroadcastBaseSignedTransactionRequest,
         GetBaseTransactionReceiptRequest,
         SearchCapabilitiesRequest,
-        ContributorContact
+        ContributorContact,
+        AudienceMember,
+        AudienceInteraction,
+        DiscoveryResponse,
+        OutreachAttempt,
+        AudienceReport
     )),
     modifiers(&SecurityAddon)
 )]
@@ -534,6 +551,23 @@ async fn main() -> anyhow::Result<()> {
             "/v1/contributor-contacts",
             post(upsert_contributor_contact).get(list_contributor_contacts),
         )
+        .route(
+            "/v1/audience/members",
+            post(upsert_audience_member).get(list_audience_members),
+        )
+        .route(
+            "/v1/audience/interactions",
+            post(record_audience_interaction).get(list_audience_interactions),
+        )
+        .route(
+            "/v1/audience/discovery-responses",
+            post(record_discovery_response).get(list_discovery_responses),
+        )
+        .route(
+            "/v1/audience/outreach-attempts",
+            post(record_outreach_attempt).get(list_outreach_attempts),
+        )
+        .route("/v1/audience/report", get(audience_report))
         .route("/v1/capabilities", post(register_capability))
         .route("/v1/capabilities/feed", get(public_capability_feed))
         .route("/v1/capabilities/search", post(search_capabilities))
@@ -1189,6 +1223,282 @@ async fn list_contributor_contacts(
     require_operator(&state, &headers)?;
     let network = state.network.lock().expect("state poisoned");
     Ok(Json(network.list_contributor_contacts()))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/audience/members",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = AudienceMember),
+        (status = 400, description = "Invalid public identity record"),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn upsert_audience_member(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(request): Json<UpsertAudienceMemberRequest>,
+) -> Result<Json<AudienceMember>, StatusCode> {
+    require_operator(&state, &headers)?;
+    let member = {
+        let mut network = state.network.lock().expect("state poisoned");
+        network
+            .upsert_audience_member(request)
+            .map_err(|_| StatusCode::BAD_REQUEST)?
+    };
+    if let Some(store) = &state.store {
+        store
+            .upsert_audience_member(&member)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(Json(member))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/audience/members",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = Vec<AudienceMember>),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn list_audience_members(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<AudienceMember>>, StatusCode> {
+    require_operator(&state, &headers)?;
+    if let Some(store) = &state.store {
+        return store
+            .list_audience_members()
+            .await
+            .map(Json)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+    }
+    let network = state.network.lock().expect("state poisoned");
+    Ok(Json(network.list_audience_members()))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/audience/interactions",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = AudienceInteraction),
+        (status = 400, description = "Invalid or unknown audience interaction"),
+        (status = 409, description = "Provider event ID conflicts with an immutable stored event"),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn record_audience_interaction(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(request): Json<RecordAudienceInteractionRequest>,
+) -> Result<Json<AudienceInteraction>, StatusCode> {
+    require_operator(&state, &headers)?;
+    let (interaction, member) = {
+        let mut network = state.network.lock().expect("state poisoned");
+        let interaction = network
+            .record_audience_interaction(request)
+            .map_err(|_| StatusCode::BAD_REQUEST)?;
+        let member = network
+            .audience_members
+            .get(&interaction.audience_member_id)
+            .cloned()
+            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+        (interaction, member)
+    };
+    if let Some(store) = &state.store {
+        store
+            .upsert_audience_interaction_with_member(&member, &interaction)
+            .await
+            .map_err(|error| match error {
+                DbError::AudienceConflict(_) => StatusCode::CONFLICT,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            })?;
+    }
+    Ok(Json(interaction))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/audience/interactions",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = Vec<AudienceInteraction>),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn list_audience_interactions(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<AudienceInteraction>>, StatusCode> {
+    require_operator(&state, &headers)?;
+    if let Some(store) = &state.store {
+        return store
+            .list_audience_interactions()
+            .await
+            .map(Json)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+    }
+    let network = state.network.lock().expect("state poisoned");
+    Ok(Json(network.list_audience_interactions()))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/audience/discovery-responses",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = DiscoveryResponse),
+        (status = 400, description = "Response lacks a public source or private-storage consent"),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn record_discovery_response(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(request): Json<RecordDiscoveryResponseRequest>,
+) -> Result<Json<DiscoveryResponse>, StatusCode> {
+    require_operator(&state, &headers)?;
+    let response = {
+        let mut network = state.network.lock().expect("state poisoned");
+        network
+            .record_discovery_response(request)
+            .map_err(|_| StatusCode::BAD_REQUEST)?
+    };
+    if let Some(store) = &state.store {
+        store
+            .upsert_discovery_response(&response)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(Json(response))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/audience/discovery-responses",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = Vec<DiscoveryResponse>),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn list_discovery_responses(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<DiscoveryResponse>>, StatusCode> {
+    require_operator(&state, &headers)?;
+    if let Some(store) = &state.store {
+        return store
+            .list_discovery_responses()
+            .await
+            .map(Json)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+    }
+    let network = state.network.lock().expect("state poisoned");
+    Ok(Json(network.list_discovery_responses()))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/audience/outreach-attempts",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = OutreachAttempt),
+        (status = 400, description = "Private outreach lacks explicit consent or public outreach lacks a URL"),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn record_outreach_attempt(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+    Json(request): Json<RecordOutreachAttemptRequest>,
+) -> Result<Json<OutreachAttempt>, StatusCode> {
+    require_operator(&state, &headers)?;
+    let attempt = {
+        let mut network = state.network.lock().expect("state poisoned");
+        network
+            .record_outreach_attempt(request)
+            .map_err(|_| StatusCode::BAD_REQUEST)?
+    };
+    if let Some(store) = &state.store {
+        store
+            .upsert_outreach_attempt(&attempt)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(Json(attempt))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/audience/outreach-attempts",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = Vec<OutreachAttempt>),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn list_outreach_attempts(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<OutreachAttempt>>, StatusCode> {
+    require_operator(&state, &headers)?;
+    if let Some(store) = &state.store {
+        return store
+            .list_outreach_attempts()
+            .await
+            .map(Json)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
+    }
+    let network = state.network.lock().expect("state poisoned");
+    Ok(Json(network.list_outreach_attempts()))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/audience/report",
+    security(("operator_api_token" = []), ("operator_bearer" = [])),
+    responses(
+        (status = 200, body = AudienceReport),
+        (status = 401, description = "Operator token required when OPERATOR_API_TOKEN is configured")
+    )
+)]
+async fn audience_report(
+    State(state): State<SharedState>,
+    headers: HeaderMap,
+) -> Result<Json<AudienceReport>, StatusCode> {
+    require_operator(&state, &headers)?;
+    if let Some(store) = &state.store {
+        let members = store
+            .list_audience_members()
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let interactions = store
+            .list_audience_interactions()
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let responses = store
+            .list_discovery_responses()
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let attempts = store
+            .list_outreach_attempts()
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        return Ok(Json(build_audience_report(
+            &members,
+            &interactions,
+            &responses,
+            &attempts,
+        )));
+    }
+    let network = state.network.lock().expect("state poisoned");
+    Ok(Json(network.audience_report()))
 }
 
 #[utoipa::path(post, path = "/v1/capabilities")]
@@ -3410,6 +3720,30 @@ async fn hydrate_network(store: &PostgresStore) -> anyhow::Result<BountyNetwork>
             .into_iter()
             .map(|contact| (contact.id, contact))
             .collect(),
+        audience_members: store
+            .list_audience_members()
+            .await?
+            .into_iter()
+            .map(|member| (member.id, member))
+            .collect(),
+        audience_interactions: store
+            .list_audience_interactions()
+            .await?
+            .into_iter()
+            .map(|interaction| (interaction.id, interaction))
+            .collect(),
+        discovery_responses: store
+            .list_discovery_responses()
+            .await?
+            .into_iter()
+            .map(|response| (response.id, response))
+            .collect(),
+        outreach_attempts: store
+            .list_outreach_attempts()
+            .await?
+            .into_iter()
+            .map(|attempt| (attempt.id, attempt))
+            .collect(),
         capabilities: store
             .list_capabilities()
             .await?
@@ -4558,6 +4892,152 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
+    async fn audience_audit_persists_idempotently_across_processes() {
+        let database_url = postgres_test_database_url();
+        let first_store = PostgresStore::connect(&database_url).await.unwrap();
+        first_store.migrate().await.unwrap();
+        let first_state = test_state_with_operator_token_and_store(
+            BountyNetwork::default(),
+            "secret-token",
+            first_store,
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert(OPERATOR_TOKEN_HEADER, "secret-token".parse().unwrap());
+        let unique = Uuid::new_v4();
+
+        let member = upsert_audience_member(
+            State(first_state.clone()),
+            headers.clone(),
+            Json(UpsertAudienceMemberRequest {
+                provider: domain::AudienceProvider::Github,
+                external_id: format!("github-user-{unique}"),
+                handle: format!("audience-{unique}"),
+                public_profile_url: Some(format!("https://github.com/audience-{unique}")),
+                roles: vec![],
+                observed_at: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        let stale_store = PostgresStore::connect(&database_url).await.unwrap();
+        let stale_network = hydrate_network(&stale_store).await.unwrap();
+        let stale_state =
+            test_state_with_operator_token_and_store(stale_network, "secret-token", stale_store);
+        let event_id = format!("pull-request:{unique}");
+        let interaction = record_audience_interaction(
+            State(first_state),
+            headers.clone(),
+            Json(RecordAudienceInteractionRequest {
+                audience_member_id: member.id,
+                provider_event_id: event_id.clone(),
+                kind: domain::AudienceInteractionKind::PullRequestOpened,
+                public_url: Some(format!(
+                    "https://github.com/NSPG13/agent-bounties/pull/{unique}"
+                )),
+                occurred_at: None,
+                referrer_url: None,
+                campaign: Some("postgres-audience-test".to_string()),
+                source_interaction_id: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        let star = record_audience_interaction(
+            State(stale_state.clone()),
+            headers.clone(),
+            Json(RecordAudienceInteractionRequest {
+                audience_member_id: member.id,
+                provider_event_id: format!("star:{unique}"),
+                kind: domain::AudienceInteractionKind::RepoStarred,
+                public_url: Some("https://github.com/NSPG13/agent-bounties/stargazers".to_string()),
+                occurred_at: None,
+                referrer_url: None,
+                campaign: Some("postgres-audience-test".to_string()),
+                source_interaction_id: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        assert_ne!(star.id, interaction.id);
+        let conflicting_replay = record_audience_interaction(
+            State(stale_state),
+            headers.clone(),
+            Json(RecordAudienceInteractionRequest {
+                audience_member_id: member.id,
+                provider_event_id: event_id.clone(),
+                kind: domain::AudienceInteractionKind::FundingSignaled,
+                public_url: interaction.public_url.clone(),
+                occurred_at: Some(interaction.occurred_at),
+                referrer_url: None,
+                campaign: Some("postgres-audience-test".to_string()),
+                source_interaction_id: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(conflicting_replay, StatusCode::CONFLICT);
+
+        let second_store = PostgresStore::connect(&database_url).await.unwrap();
+        let second_network = hydrate_network(&second_store).await.unwrap();
+        let second_state =
+            test_state_with_operator_token_and_store(second_network, "secret-token", second_store);
+        let replay = record_audience_interaction(
+            State(second_state.clone()),
+            headers.clone(),
+            Json(RecordAudienceInteractionRequest {
+                audience_member_id: member.id,
+                provider_event_id: event_id,
+                kind: domain::AudienceInteractionKind::PullRequestOpened,
+                public_url: interaction.public_url.clone(),
+                occurred_at: Some(interaction.occurred_at),
+                referrer_url: None,
+                campaign: Some("postgres-audience-test".to_string()),
+                source_interaction_id: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+        assert_eq!(replay.id, interaction.id);
+
+        let persisted = list_audience_interactions(State(second_state.clone()), headers.clone())
+            .await
+            .unwrap()
+            .0
+            .into_iter()
+            .filter(|candidate| candidate.audience_member_id == member.id)
+            .collect::<Vec<_>>();
+        assert_eq!(persisted.len(), 2);
+        let persisted_member = list_audience_members(State(second_state.clone()), headers.clone())
+            .await
+            .unwrap()
+            .0
+            .into_iter()
+            .find(|candidate| candidate.id == member.id)
+            .unwrap();
+        assert!(persisted_member
+            .roles
+            .contains(&domain::AudienceRole::Contributor));
+        assert!(persisted_member
+            .roles
+            .contains(&domain::AudienceRole::Promoter));
+        assert_eq!(
+            persisted_member.lifecycle_stage,
+            domain::AudienceLifecycleStage::Retained
+        );
+        let report = audience_report(State(second_state), headers)
+            .await
+            .unwrap()
+            .0;
+        assert!(report.total_members >= 1);
+        assert!(report.total_interactions >= 1);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
     async fn github_issue_api_sync_postgres_rejects_stale_cross_process_activity() {
         let database_url = postgres_test_database_url();
         let store = PostgresStore::connect(&database_url).await.unwrap();
@@ -5318,6 +5798,11 @@ mod tests {
         assert!(paths.contains_key("/v1/risk/events/{id}/reject"));
         assert!(paths.contains_key("/v1/agents/{id}/paid-status"));
         assert!(paths.contains_key("/v1/contributor-contacts"));
+        assert!(paths.contains_key("/v1/audience/members"));
+        assert!(paths.contains_key("/v1/audience/interactions"));
+        assert!(paths.contains_key("/v1/audience/discovery-responses"));
+        assert!(paths.contains_key("/v1/audience/outreach-attempts"));
+        assert!(paths.contains_key("/v1/audience/report"));
         assert!(paths.contains_key("/v1/capabilities/search"));
         assert!(paths.contains_key("/v1/base/indexer-status"));
         assert!(paths.contains_key("/v1/base/escrow-events"));
@@ -5468,6 +5953,93 @@ mod tests {
             .0;
         assert_eq!(contacts.len(), 1);
         assert_eq!(contacts[0].associated_prs, vec!["#24".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn audience_audit_is_operator_gated_and_reports_public_attribution() {
+        let state = test_state_with_operator_token(BountyNetwork::default(), "secret-token");
+        let request = UpsertAudienceMemberRequest {
+            provider: domain::AudienceProvider::Github,
+            external_id: "U_123".to_string(),
+            handle: "nexicturbo".to_string(),
+            public_profile_url: Some("https://github.com/nexicturbo".to_string()),
+            roles: vec![],
+            observed_at: None,
+        };
+        let denied = upsert_audience_member(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(request.clone()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(denied, StatusCode::UNAUTHORIZED);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(OPERATOR_TOKEN_HEADER, "secret-token".parse().unwrap());
+        let member = upsert_audience_member(State(state.clone()), headers.clone(), Json(request))
+            .await
+            .unwrap()
+            .0;
+        let _ = record_audience_interaction(
+            State(state.clone()),
+            headers.clone(),
+            Json(RecordAudienceInteractionRequest {
+                audience_member_id: member.id,
+                provider_event_id: "pull-request:138".to_string(),
+                kind: domain::AudienceInteractionKind::PullRequestOpened,
+                public_url: Some("https://github.com/NSPG13/agent-bounties/pull/138".to_string()),
+                occurred_at: None,
+                referrer_url: None,
+                campaign: Some("github-bounty-label".to_string()),
+                source_interaction_id: None,
+            }),
+        )
+        .await
+        .unwrap();
+        let _ = record_outreach_attempt(
+            State(state.clone()),
+            headers.clone(),
+            Json(RecordOutreachAttemptRequest {
+                audience_member_id: member.id,
+                provider_event_id: "issue-comment:feedback:138".to_string(),
+                channel: domain::OutreachChannel::GithubPublic,
+                public_url: Some(
+                    "https://github.com/NSPG13/agent-bounties/pull/138#issuecomment-1".to_string(),
+                ),
+                prompt_version: "distribution-v1".to_string(),
+                status: domain::OutreachStatus::Responded,
+                sent_at: None,
+            }),
+        )
+        .await
+        .unwrap();
+        let _ = record_discovery_response(
+            State(state.clone()),
+            headers.clone(),
+            Json(RecordDiscoveryResponseRequest {
+                audience_member_id: member.id,
+                interaction_id: None,
+                provider_response_id: "pr-body:138".to_string(),
+                public_source_url: Some(
+                    "https://github.com/NSPG13/agent-bounties/pull/138".to_string(),
+                ),
+                found_via: "GitHub issue list".to_string(),
+                motivation: "clear payout-integrity scope".to_string(),
+                improvement_suggestion: "show durable payment evidence".to_string(),
+                agent_or_tool: Some("coding agent".to_string()),
+                private_storage_consent: false,
+                captured_at: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let report = audience_report(State(state), headers).await.unwrap().0;
+        assert_eq!(report.total_members, 1);
+        assert_eq!(report.total_interactions, 1);
+        assert_eq!(report.members_asked_for_discovery_feedback, 1);
+        assert_eq!(report.members_with_discovery_responses, 1);
     }
 
     #[tokio::test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -6,12 +6,15 @@ use chain_base::{
 };
 use chrono::{DateTime, Utc};
 use domain::{
-    Agent, Bounty, BountyStatus, Capability, CapabilityClass, Claim, ContributorContact, Escrow,
+    Agent, AudienceInteraction, AudienceInteractionKind, AudienceLifecycleStage, AudienceMember,
+    AudienceMetric, AudienceProvider, AudienceReport, AudienceRole, Bounty, BountyStatus,
+    Capability, CapabilityClass, Claim, ContributorContact, DiscoveryResponse, Escrow,
     EscrowStatus, FundingContribution, FundingContributionStatus, FundingIntent,
-    FundingIntentStatus, FundingMode, FundingPartitionTarget, HelpRequest, Id, Money, PaymentEvent,
-    PaymentEventStatus, PaymentRail, PayoutIntent, PayoutStatus, PrivacyLevel, ProofRecord, Quote,
-    ReputationEvent, RiskAction, RiskEvent, RiskReviewOutcome, RiskReviewRecord, RiskSurface,
-    Settlement, Submission, TemplateSignal, VerificationDecision, VerifierKind, VerifierResult,
+    FundingIntentStatus, FundingMode, FundingPartitionTarget, HelpRequest, Id, Money,
+    OutreachAttempt, OutreachChannel, OutreachStatus, PaymentEvent, PaymentEventStatus,
+    PaymentRail, PayoutIntent, PayoutStatus, PrivacyLevel, ProofRecord, Quote, ReputationEvent,
+    RiskAction, RiskEvent, RiskReviewOutcome, RiskReviewRecord, RiskSurface, Settlement,
+    Submission, TemplateSignal, VerificationDecision, VerifierKind, VerifierResult,
 };
 use ledger::{credit, debit, AccountCode, Ledger, LedgerEntry};
 use payments_stripe::{
@@ -26,7 +29,7 @@ use risk::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use thiserror::Error;
 use uuid::Uuid;
 use verifier_sdk::{verify_with_builtin, VerificationInput};
@@ -75,6 +78,10 @@ pub enum AppError {
     InvalidStripePayout(String),
     #[error("invalid contributor contact: {0}")]
     InvalidContributorContact(String),
+    #[error("audience member not found")]
+    AudienceMemberNotFound,
+    #[error("invalid audience record: {0}")]
+    InvalidAudienceRecord(String),
     #[error(transparent)]
     Domain(#[from] domain::DomainError),
     #[error(transparent)]
@@ -687,6 +694,112 @@ fn dedup_nonempty(values: impl IntoIterator<Item = String>) -> Vec<String> {
     normalized
 }
 
+fn required_audience_string(value: String, field: &str) -> AppResult<String> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        return Err(AppError::InvalidAudienceRecord(format!(
+            "{field} is required"
+        )));
+    }
+    Ok(value)
+}
+
+fn normalized_public_url(value: Option<String>, field: &str) -> AppResult<Option<String>> {
+    let Some(value) = normalized_optional_string(value) else {
+        return Ok(None);
+    };
+    if !(value.starts_with("https://") || value.starts_with("http://")) {
+        return Err(AppError::InvalidAudienceRecord(format!(
+            "{field} must be an http(s) URL"
+        )));
+    }
+    Ok(Some(value))
+}
+
+fn deterministic_audience_id(record_kind: &str, key: &str) -> Id {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_URL,
+        format!("agent-bounties:{record_kind}:{key}").as_bytes(),
+    )
+}
+
+fn dedup_audience_roles(values: impl IntoIterator<Item = AudienceRole>) -> Vec<AudienceRole> {
+    let mut roles = Vec::new();
+    for role in values {
+        if !roles.contains(&role) {
+            roles.push(role);
+        }
+    }
+    if roles.is_empty() {
+        roles.push(AudienceRole::Observer);
+    }
+    roles
+}
+
+fn role_for_interaction(kind: AudienceInteractionKind) -> AudienceRole {
+    match kind {
+        AudienceInteractionKind::IssueOpened
+        | AudienceInteractionKind::PullRequestOpened
+        | AudienceInteractionKind::IssueCommented
+        | AudienceInteractionKind::PullRequestReviewed => AudienceRole::Contributor,
+        AudienceInteractionKind::BountyPosted => AudienceRole::BountyPoster,
+        AudienceInteractionKind::FundingSignaled => AudienceRole::ProspectiveFunder,
+        AudienceInteractionKind::BountyFunded => AudienceRole::Funder,
+        AudienceInteractionKind::ClaimSignaled => AudienceRole::ProspectiveSolver,
+        AudienceInteractionKind::BountyClaimed => AudienceRole::Claimer,
+        AudienceInteractionKind::SubmissionMade | AudienceInteractionKind::SubmissionAccepted => {
+            AudienceRole::Solver
+        }
+        AudienceInteractionKind::VerificationSubmitted => AudienceRole::Verifier,
+        AudienceInteractionKind::PayoutReceived => AudienceRole::Recipient,
+        AudienceInteractionKind::RepoStarred
+        | AudienceInteractionKind::BountyUpvoted
+        | AudienceInteractionKind::ProofShared
+        | AudienceInteractionKind::ReferralCreated => AudienceRole::Promoter,
+    }
+}
+
+fn lifecycle_for_roles(roles: &[AudienceRole]) -> AudienceLifecycleStage {
+    if roles.iter().any(|role| {
+        matches!(
+            role,
+            AudienceRole::BountyPoster
+                | AudienceRole::Funder
+                | AudienceRole::Solver
+                | AudienceRole::Verifier
+                | AudienceRole::Recipient
+        )
+    }) {
+        AudienceLifecycleStage::Converted
+    } else if roles.iter().any(|role| *role != AudienceRole::Observer) {
+        AudienceLifecycleStage::Engaged
+    } else {
+        AudienceLifecycleStage::Observed
+    }
+}
+
+fn interaction_kind_key(kind: AudienceInteractionKind) -> &'static str {
+    match kind {
+        AudienceInteractionKind::IssueOpened => "issue_opened",
+        AudienceInteractionKind::PullRequestOpened => "pull_request_opened",
+        AudienceInteractionKind::IssueCommented => "issue_commented",
+        AudienceInteractionKind::PullRequestReviewed => "pull_request_reviewed",
+        AudienceInteractionKind::BountyPosted => "bounty_posted",
+        AudienceInteractionKind::FundingSignaled => "funding_signaled",
+        AudienceInteractionKind::BountyFunded => "bounty_funded",
+        AudienceInteractionKind::ClaimSignaled => "claim_signaled",
+        AudienceInteractionKind::BountyClaimed => "bounty_claimed",
+        AudienceInteractionKind::SubmissionMade => "submission_made",
+        AudienceInteractionKind::SubmissionAccepted => "submission_accepted",
+        AudienceInteractionKind::VerificationSubmitted => "verification_submitted",
+        AudienceInteractionKind::PayoutReceived => "payout_received",
+        AudienceInteractionKind::RepoStarred => "repo_starred",
+        AudienceInteractionKind::BountyUpvoted => "bounty_upvoted",
+        AudienceInteractionKind::ProofShared => "proof_shared",
+        AudienceInteractionKind::ReferralCreated => "referral_created",
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegisterAgentRequest {
     pub handle: String,
@@ -709,6 +822,55 @@ pub struct UpsertContributorContactRequest {
     #[serde(default)]
     pub source: Option<String>,
     pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpsertAudienceMemberRequest {
+    pub provider: AudienceProvider,
+    pub external_id: String,
+    pub handle: String,
+    pub public_profile_url: Option<String>,
+    #[serde(default)]
+    pub roles: Vec<AudienceRole>,
+    pub observed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordAudienceInteractionRequest {
+    pub audience_member_id: Id,
+    pub provider_event_id: String,
+    pub kind: AudienceInteractionKind,
+    pub public_url: Option<String>,
+    pub occurred_at: Option<DateTime<Utc>>,
+    pub referrer_url: Option<String>,
+    pub campaign: Option<String>,
+    pub source_interaction_id: Option<Id>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordDiscoveryResponseRequest {
+    pub audience_member_id: Id,
+    pub interaction_id: Option<Id>,
+    pub provider_response_id: String,
+    pub public_source_url: Option<String>,
+    pub found_via: String,
+    pub motivation: String,
+    pub improvement_suggestion: String,
+    pub agent_or_tool: Option<String>,
+    #[serde(default)]
+    pub private_storage_consent: bool,
+    pub captured_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordOutreachAttemptRequest {
+    pub audience_member_id: Id,
+    pub provider_event_id: String,
+    pub channel: OutreachChannel,
+    pub public_url: Option<String>,
+    pub prompt_version: String,
+    pub status: OutreachStatus,
+    pub sent_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1131,6 +1293,10 @@ pub struct StripeFundingReconciliation {
 pub struct BountyNetwork {
     pub agents: HashMap<Id, Agent>,
     pub contributor_contacts: HashMap<Id, ContributorContact>,
+    pub audience_members: HashMap<Id, AudienceMember>,
+    pub audience_interactions: HashMap<Id, AudienceInteraction>,
+    pub discovery_responses: HashMap<Id, DiscoveryResponse>,
+    pub outreach_attempts: HashMap<Id, OutreachAttempt>,
     pub capabilities: HashMap<Id, Capability>,
     pub help_requests: HashMap<Id, HelpRequest>,
     pub quotes: HashMap<Id, Quote>,
@@ -1157,6 +1323,10 @@ impl Default for BountyNetwork {
         Self {
             agents: HashMap::new(),
             contributor_contacts: HashMap::new(),
+            audience_members: HashMap::new(),
+            audience_interactions: HashMap::new(),
+            discovery_responses: HashMap::new(),
+            outreach_attempts: HashMap::new(),
             capabilities: HashMap::new(),
             help_requests: HashMap::new(),
             quotes: HashMap::new(),
@@ -1177,6 +1347,100 @@ impl Default for BountyNetwork {
             ledger: Ledger::new(),
             risk_policy: RiskPolicy::default(),
         }
+    }
+}
+
+pub fn build_audience_report(
+    members: &[AudienceMember],
+    interactions: &[AudienceInteraction],
+    discovery_responses: &[DiscoveryResponse],
+    outreach_attempts: &[OutreachAttempt],
+) -> AudienceReport {
+    let asked_member_ids: HashSet<_> = outreach_attempts
+        .iter()
+        .map(|attempt| attempt.audience_member_id)
+        .collect();
+    let answered_member_ids: HashSet<_> = discovery_responses
+        .iter()
+        .map(|response| response.audience_member_id)
+        .collect();
+    let mut interaction_counts_by_member = HashMap::<Id, u64>::new();
+    let mut posters = HashSet::new();
+    let mut funders = HashSet::new();
+    let mut solvers = HashSet::new();
+    let mut paid = HashSet::new();
+    let mut interactions_by_kind = BTreeMap::<String, u64>::new();
+    let mut repo_stars = 0_u64;
+    let mut shares = 0_u64;
+
+    for interaction in interactions {
+        *interaction_counts_by_member
+            .entry(interaction.audience_member_id)
+            .or_default() += 1;
+        *interactions_by_kind
+            .entry(interaction_kind_key(interaction.kind).to_string())
+            .or_default() += 1;
+        match interaction.kind {
+            AudienceInteractionKind::BountyPosted => {
+                posters.insert(interaction.audience_member_id);
+            }
+            AudienceInteractionKind::BountyFunded => {
+                funders.insert(interaction.audience_member_id);
+            }
+            AudienceInteractionKind::SubmissionMade
+            | AudienceInteractionKind::SubmissionAccepted => {
+                solvers.insert(interaction.audience_member_id);
+            }
+            AudienceInteractionKind::PayoutReceived => {
+                paid.insert(interaction.audience_member_id);
+            }
+            AudienceInteractionKind::RepoStarred => repo_stars += 1,
+            AudienceInteractionKind::ProofShared | AudienceInteractionKind::ReferralCreated => {
+                shares += 1;
+            }
+            _ => {}
+        }
+    }
+
+    let mut not_asked_or_answered_handles = members
+        .iter()
+        .filter(|member| {
+            !asked_member_ids.contains(&member.id) && !answered_member_ids.contains(&member.id)
+        })
+        .map(|member| member.handle.clone())
+        .collect::<Vec<_>>();
+    let mut asked_without_response_handles = members
+        .iter()
+        .filter(|member| {
+            asked_member_ids.contains(&member.id) && !answered_member_ids.contains(&member.id)
+        })
+        .map(|member| member.handle.clone())
+        .collect::<Vec<_>>();
+    not_asked_or_answered_handles.sort_by_key(|handle| handle.to_lowercase());
+    asked_without_response_handles.sort_by_key(|handle| handle.to_lowercase());
+
+    AudienceReport {
+        total_members: members.len() as u64,
+        total_interactions: interactions.len() as u64,
+        members_asked_for_discovery_feedback: asked_member_ids.len() as u64,
+        members_with_discovery_responses: answered_member_ids.len() as u64,
+        repeat_participants: interaction_counts_by_member
+            .values()
+            .filter(|count| **count >= 2)
+            .count() as u64,
+        external_bounty_posters: posters.len() as u64,
+        external_funders: funders.len() as u64,
+        external_solvers: solvers.len() as u64,
+        paid_participants: paid.len() as u64,
+        repo_stars_attributed: repo_stars,
+        shares_attributed: shares,
+        not_asked_or_answered_handles,
+        asked_without_response_handles,
+        interactions_by_kind: interactions_by_kind
+            .into_iter()
+            .map(|(key, count)| AudienceMetric { key, count })
+            .collect(),
+        generated_at: Utc::now(),
     }
 }
 
@@ -1278,6 +1542,307 @@ impl BountyNetwork {
                 .then_with(|| left.github_login.cmp(&right.github_login))
         });
         contacts
+    }
+
+    pub fn upsert_audience_member(
+        &mut self,
+        request: UpsertAudienceMemberRequest,
+    ) -> AppResult<AudienceMember> {
+        let external_id = required_audience_string(request.external_id, "external_id")?;
+        let handle = required_audience_string(request.handle, "handle")?;
+        let public_profile_url =
+            normalized_public_url(request.public_profile_url, "public_profile_url")?;
+        let observed_at = request.observed_at.unwrap_or_else(Utc::now);
+        let external_id_key = external_id.to_lowercase();
+        let existing_id = self.audience_members.iter().find_map(|(id, member)| {
+            (member.provider == request.provider
+                && member.external_id.to_lowercase() == external_id_key)
+                .then_some(*id)
+        });
+
+        let member = if let Some(existing_id) = existing_id {
+            let mut member = self
+                .audience_members
+                .get(&existing_id)
+                .cloned()
+                .ok_or(AppError::AudienceMemberNotFound)?;
+            let mut roles = member.roles.clone();
+            roles.extend(request.roles);
+            member.external_id = external_id;
+            member.handle = handle;
+            if public_profile_url.is_some() {
+                member.public_profile_url = public_profile_url;
+            }
+            member.roles = dedup_audience_roles(roles);
+            member.lifecycle_stage = member
+                .lifecycle_stage
+                .max(lifecycle_for_roles(&member.roles));
+            member.first_seen_at = member.first_seen_at.min(observed_at);
+            member.last_seen_at = member.last_seen_at.max(observed_at);
+            member
+        } else {
+            let roles = dedup_audience_roles(request.roles);
+            let provider_key = format!("{:?}", request.provider).to_lowercase();
+            AudienceMember {
+                id: deterministic_audience_id(
+                    "member",
+                    &format!("{provider_key}:{external_id_key}"),
+                ),
+                provider: request.provider,
+                external_id,
+                handle,
+                public_profile_url,
+                lifecycle_stage: lifecycle_for_roles(&roles),
+                roles,
+                first_seen_at: observed_at,
+                last_seen_at: observed_at,
+            }
+        };
+        self.audience_members.insert(member.id, member.clone());
+        Ok(member)
+    }
+
+    pub fn list_audience_members(&self) -> Vec<AudienceMember> {
+        let mut members: Vec<_> = self.audience_members.values().cloned().collect();
+        members.sort_by(|left, right| {
+            left.first_seen_at
+                .cmp(&right.first_seen_at)
+                .then_with(|| left.handle.cmp(&right.handle))
+        });
+        members
+    }
+
+    pub fn record_audience_interaction(
+        &mut self,
+        request: RecordAudienceInteractionRequest,
+    ) -> AppResult<AudienceInteraction> {
+        if !self
+            .audience_members
+            .contains_key(&request.audience_member_id)
+        {
+            return Err(AppError::AudienceMemberNotFound);
+        }
+        let provider_event_id =
+            required_audience_string(request.provider_event_id, "provider_event_id")?;
+        if let Some(existing) = self.audience_interactions.values().find(|interaction| {
+            interaction.audience_member_id == request.audience_member_id
+                && interaction.provider_event_id == provider_event_id
+        }) {
+            return Ok(existing.clone());
+        }
+        if let Some(source_interaction_id) = request.source_interaction_id {
+            if !self
+                .audience_interactions
+                .contains_key(&source_interaction_id)
+            {
+                return Err(AppError::InvalidAudienceRecord(
+                    "source_interaction_id was not found".to_string(),
+                ));
+            }
+        }
+
+        let public_url = normalized_public_url(request.public_url, "public_url")?;
+        let referrer_url = normalized_public_url(request.referrer_url, "referrer_url")?;
+        let occurred_at = request.occurred_at.unwrap_or_else(Utc::now);
+        let interaction = AudienceInteraction {
+            id: deterministic_audience_id(
+                "interaction",
+                &format!("{}:{provider_event_id}", request.audience_member_id),
+            ),
+            audience_member_id: request.audience_member_id,
+            provider_event_id,
+            kind: request.kind,
+            public_url,
+            occurred_at,
+            referrer_url,
+            campaign: normalized_optional_string(request.campaign),
+            source_interaction_id: request.source_interaction_id,
+        };
+        self.audience_interactions
+            .insert(interaction.id, interaction.clone());
+
+        let interaction_count = self
+            .audience_interactions
+            .values()
+            .filter(|candidate| candidate.audience_member_id == request.audience_member_id)
+            .count();
+        if let Some(member) = self.audience_members.get_mut(&request.audience_member_id) {
+            let mut roles = member.roles.clone();
+            roles.push(role_for_interaction(request.kind));
+            member.roles = dedup_audience_roles(roles);
+            member.last_seen_at = member.last_seen_at.max(occurred_at);
+            member.lifecycle_stage = if interaction_count >= 2 {
+                AudienceLifecycleStage::Retained
+            } else {
+                member
+                    .lifecycle_stage
+                    .max(lifecycle_for_roles(&member.roles))
+            };
+        }
+        Ok(interaction)
+    }
+
+    pub fn list_audience_interactions(&self) -> Vec<AudienceInteraction> {
+        let mut interactions: Vec<_> = self.audience_interactions.values().cloned().collect();
+        interactions.sort_by(|left, right| {
+            left.occurred_at
+                .cmp(&right.occurred_at)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        interactions
+    }
+
+    pub fn record_discovery_response(
+        &mut self,
+        request: RecordDiscoveryResponseRequest,
+    ) -> AppResult<DiscoveryResponse> {
+        if !self
+            .audience_members
+            .contains_key(&request.audience_member_id)
+        {
+            return Err(AppError::AudienceMemberNotFound);
+        }
+        if let Some(interaction_id) = request.interaction_id {
+            let interaction = self
+                .audience_interactions
+                .get(&interaction_id)
+                .ok_or_else(|| {
+                    AppError::InvalidAudienceRecord("interaction_id was not found".to_string())
+                })?;
+            if interaction.audience_member_id != request.audience_member_id {
+                return Err(AppError::InvalidAudienceRecord(
+                    "interaction_id belongs to another audience member".to_string(),
+                ));
+            }
+        }
+        let provider_response_id =
+            required_audience_string(request.provider_response_id, "provider_response_id")?;
+        if let Some(existing) = self.discovery_responses.values().find(|response| {
+            response.audience_member_id == request.audience_member_id
+                && response.provider_response_id == provider_response_id
+        }) {
+            return Ok(existing.clone());
+        }
+        let public_source_url =
+            normalized_public_url(request.public_source_url, "public_source_url")?;
+        if public_source_url.is_none() && !request.private_storage_consent {
+            return Err(AppError::InvalidAudienceRecord(
+                "a discovery response requires a public source URL or private_storage_consent=true"
+                    .to_string(),
+            ));
+        }
+
+        let response = DiscoveryResponse {
+            id: deterministic_audience_id(
+                "discovery-response",
+                &format!("{}:{provider_response_id}", request.audience_member_id),
+            ),
+            audience_member_id: request.audience_member_id,
+            interaction_id: request.interaction_id,
+            provider_response_id,
+            public_source_url,
+            found_via: required_audience_string(request.found_via, "found_via")?,
+            motivation: required_audience_string(request.motivation, "motivation")?,
+            improvement_suggestion: required_audience_string(
+                request.improvement_suggestion,
+                "improvement_suggestion",
+            )?,
+            agent_or_tool: normalized_optional_string(request.agent_or_tool),
+            private_storage_consent: request.private_storage_consent,
+            captured_at: request.captured_at.unwrap_or_else(Utc::now),
+        };
+        self.discovery_responses
+            .insert(response.id, response.clone());
+        Ok(response)
+    }
+
+    pub fn list_discovery_responses(&self) -> Vec<DiscoveryResponse> {
+        let mut responses: Vec<_> = self.discovery_responses.values().cloned().collect();
+        responses.sort_by(|left, right| {
+            left.captured_at
+                .cmp(&right.captured_at)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        responses
+    }
+
+    pub fn record_outreach_attempt(
+        &mut self,
+        request: RecordOutreachAttemptRequest,
+    ) -> AppResult<OutreachAttempt> {
+        let member = self
+            .audience_members
+            .get(&request.audience_member_id)
+            .ok_or(AppError::AudienceMemberNotFound)?;
+        let provider_event_id =
+            required_audience_string(request.provider_event_id, "provider_event_id")?;
+        if let Some(existing) = self.outreach_attempts.values().find(|attempt| {
+            attempt.audience_member_id == request.audience_member_id
+                && attempt.provider_event_id == provider_event_id
+        }) {
+            return Ok(existing.clone());
+        }
+
+        let public_url = normalized_public_url(request.public_url, "public_url")?;
+        let consent_contact_id = if request.channel == OutreachChannel::EmailPrivate {
+            let contact = self
+                .contributor_contacts
+                .values()
+                .find(|contact| {
+                    contact.github_login.eq_ignore_ascii_case(&member.handle)
+                        && contact.contact_consent
+                        && contact.outreach_allowed
+                })
+                .ok_or_else(|| {
+                    AppError::InvalidAudienceRecord(
+                        "private outreach requires an opted-in contributor contact".to_string(),
+                    )
+                })?;
+            Some(contact.id)
+        } else {
+            if public_url.is_none() {
+                return Err(AppError::InvalidAudienceRecord(
+                    "public outreach requires public_url".to_string(),
+                ));
+            }
+            None
+        };
+
+        let attempt = OutreachAttempt {
+            id: deterministic_audience_id(
+                "outreach",
+                &format!("{}:{provider_event_id}", request.audience_member_id),
+            ),
+            audience_member_id: request.audience_member_id,
+            provider_event_id,
+            channel: request.channel,
+            public_url,
+            prompt_version: required_audience_string(request.prompt_version, "prompt_version")?,
+            status: request.status,
+            consent_contact_id,
+            sent_at: request.sent_at.unwrap_or_else(Utc::now),
+        };
+        self.outreach_attempts.insert(attempt.id, attempt.clone());
+        Ok(attempt)
+    }
+
+    pub fn list_outreach_attempts(&self) -> Vec<OutreachAttempt> {
+        let mut attempts: Vec<_> = self.outreach_attempts.values().cloned().collect();
+        attempts.sort_by(|left, right| {
+            left.sent_at
+                .cmp(&right.sent_at)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        attempts
+    }
+
+    pub fn audience_report(&self) -> AudienceReport {
+        build_audience_report(
+            &self.list_audience_members(),
+            &self.list_audience_interactions(),
+            &self.list_discovery_responses(),
+            &self.list_outreach_attempts(),
+        )
     }
 
     pub fn register_capability(
@@ -4680,6 +5245,176 @@ mod tests {
         );
         assert!(second.wallet_consent);
         assert_eq!(network.list_contributor_contacts().len(), 1);
+    }
+
+    #[test]
+    fn audience_registry_is_idempotent_and_reports_conversion_gaps() {
+        let mut network = BountyNetwork::default();
+        let member = network
+            .upsert_audience_member(UpsertAudienceMemberRequest {
+                provider: AudienceProvider::Github,
+                external_id: "U_123".to_string(),
+                handle: "nexicturbo".to_string(),
+                public_profile_url: Some("https://github.com/nexicturbo".to_string()),
+                roles: vec![],
+                observed_at: None,
+            })
+            .unwrap();
+        let same_member = network
+            .upsert_audience_member(UpsertAudienceMemberRequest {
+                provider: AudienceProvider::Github,
+                external_id: "u_123".to_string(),
+                handle: "NexicTurbo".to_string(),
+                public_profile_url: None,
+                roles: vec![AudienceRole::Contributor],
+                observed_at: None,
+            })
+            .unwrap();
+        assert_eq!(member.id, same_member.id);
+
+        let interaction_request = RecordAudienceInteractionRequest {
+            audience_member_id: member.id,
+            provider_event_id: "pull-request:128".to_string(),
+            kind: AudienceInteractionKind::PullRequestOpened,
+            public_url: Some("https://github.com/NSPG13/agent-bounties/pull/128".to_string()),
+            occurred_at: None,
+            referrer_url: None,
+            campaign: Some("github-bounty-label".to_string()),
+            source_interaction_id: None,
+        };
+        let first = network
+            .record_audience_interaction(interaction_request.clone())
+            .unwrap();
+        let duplicate = network
+            .record_audience_interaction(interaction_request)
+            .unwrap();
+        assert_eq!(first.id, duplicate.id);
+        assert_eq!(network.list_audience_interactions().len(), 1);
+
+        network
+            .record_audience_interaction(RecordAudienceInteractionRequest {
+                audience_member_id: member.id,
+                provider_event_id: "payout:escrow:1".to_string(),
+                kind: AudienceInteractionKind::PayoutReceived,
+                public_url: Some("https://basescan.org/tx/0xabc".to_string()),
+                occurred_at: None,
+                referrer_url: None,
+                campaign: None,
+                source_interaction_id: Some(first.id),
+            })
+            .unwrap();
+        network
+            .record_outreach_attempt(RecordOutreachAttemptRequest {
+                audience_member_id: member.id,
+                provider_event_id: "issue-comment:feedback:128".to_string(),
+                channel: OutreachChannel::GithubPublic,
+                public_url: Some(
+                    "https://github.com/NSPG13/agent-bounties/issues/127#issuecomment-1"
+                        .to_string(),
+                ),
+                prompt_version: "distribution-v1".to_string(),
+                status: OutreachStatus::Responded,
+                sent_at: None,
+            })
+            .unwrap();
+        network
+            .record_discovery_response(RecordDiscoveryResponseRequest {
+                audience_member_id: member.id,
+                interaction_id: Some(first.id),
+                provider_response_id: "issue-comment:answer:128".to_string(),
+                public_source_url: Some(
+                    "https://github.com/NSPG13/agent-bounties/pull/138".to_string(),
+                ),
+                found_via: "GitHub bounty issue search".to_string(),
+                motivation: "Small scope and deterministic checks".to_string(),
+                improvement_suggestion: "Show exact settlement status".to_string(),
+                agent_or_tool: Some("autonomous coding agent".to_string()),
+                private_storage_consent: false,
+                captured_at: None,
+            })
+            .unwrap();
+
+        let report = network.audience_report();
+        assert_eq!(report.total_members, 1);
+        assert_eq!(report.total_interactions, 2);
+        assert_eq!(report.repeat_participants, 1);
+        assert_eq!(report.paid_participants, 1);
+        assert_eq!(report.members_asked_for_discovery_feedback, 1);
+        assert_eq!(report.members_with_discovery_responses, 1);
+        assert!(report.not_asked_or_answered_handles.is_empty());
+        assert!(report.asked_without_response_handles.is_empty());
+        assert_eq!(
+            network.audience_members[&member.id].lifecycle_stage,
+            AudienceLifecycleStage::Retained
+        );
+    }
+
+    #[test]
+    fn private_audience_data_and_outreach_require_explicit_consent() {
+        let mut network = BountyNetwork::default();
+        let member = network
+            .upsert_audience_member(UpsertAudienceMemberRequest {
+                provider: AudienceProvider::Github,
+                external_id: "U_456".to_string(),
+                handle: "private-user".to_string(),
+                public_profile_url: Some("https://github.com/private-user".to_string()),
+                roles: vec![],
+                observed_at: None,
+            })
+            .unwrap();
+
+        let response_error = network
+            .record_discovery_response(RecordDiscoveryResponseRequest {
+                audience_member_id: member.id,
+                interaction_id: None,
+                provider_response_id: "private-form:1".to_string(),
+                public_source_url: None,
+                found_via: "private referral".to_string(),
+                motivation: "payment trust".to_string(),
+                improvement_suggestion: "simpler funding".to_string(),
+                agent_or_tool: None,
+                private_storage_consent: false,
+                captured_at: None,
+            })
+            .unwrap_err();
+        assert!(matches!(
+            response_error,
+            AppError::InvalidAudienceRecord(message)
+                if message.contains("private_storage_consent")
+        ));
+
+        let outreach_request = RecordOutreachAttemptRequest {
+            audience_member_id: member.id,
+            provider_event_id: "email:distribution-v1".to_string(),
+            channel: OutreachChannel::EmailPrivate,
+            public_url: None,
+            prompt_version: "distribution-v1".to_string(),
+            status: OutreachStatus::Pending,
+            sent_at: None,
+        };
+        let outreach_error = network
+            .record_outreach_attempt(outreach_request.clone())
+            .unwrap_err();
+        assert!(matches!(
+            outreach_error,
+            AppError::InvalidAudienceRecord(message) if message.contains("opted-in")
+        ));
+
+        let contact = network
+            .upsert_contributor_contact(UpsertContributorContactRequest {
+                github_login: "private-user".to_string(),
+                email: Some("private@example.com".to_string()),
+                payout_wallet: None,
+                associated_prs: vec![],
+                contact_consent: true,
+                wallet_consent: false,
+                outreach_allowed: true,
+                source: Some("private-opt-in".to_string()),
+                notes: None,
+            })
+            .unwrap();
+        let attempt = network.record_outreach_attempt(outreach_request).unwrap();
+        assert_eq!(attempt.consent_contact_id, Some(contact.id));
     }
 
     #[test]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,12 +1,14 @@
 use chain_base::{BaseEscrowEvent, BaseEscrowEventKind};
 use chrono::{DateTime, Utc};
 use domain::{
-    Agent, AgentStatus, Bounty, BountyStatus, Capability, CapabilityClass, Claim,
-    ContributorContact, Escrow, EscrowStatus, EvalRun, FundingContribution,
+    Agent, AgentStatus, AudienceInteraction, AudienceInteractionKind, AudienceLifecycleStage,
+    AudienceMember, AudienceProvider, Bounty, BountyStatus, Capability, CapabilityClass, Claim,
+    ContributorContact, DiscoveryResponse, Escrow, EscrowStatus, EvalRun, FundingContribution,
     FundingContributionStatus, FundingIntent, FundingIntentStatus, FundingMode, HelpRequest, Id,
-    Money, PaymentEvent, PaymentEventStatus, PaymentRail, PrivacyLevel, ProofRecord, Quote,
-    ReputationEvent, RiskAction, RiskEvent, RiskReviewOutcome, RiskReviewRecord, RiskSurface,
-    Settlement, Submission, TemplateSignal, VerificationDecision, VerifierKind, VerifierResult,
+    Money, OutreachAttempt, OutreachChannel, OutreachStatus, PaymentEvent, PaymentEventStatus,
+    PaymentRail, PrivacyLevel, ProofRecord, Quote, ReputationEvent, RiskAction, RiskEvent,
+    RiskReviewOutcome, RiskReviewRecord, RiskSurface, Settlement, Submission, TemplateSignal,
+    VerificationDecision, VerifierKind, VerifierResult,
 };
 use ledger::{LedgerEntry, Posting};
 use sqlx::{postgres::PgRow, PgPool, Row};
@@ -36,6 +38,36 @@ const UPSERT_PAYMENT_EVENT_SQL: &str = r#"
                 ELSE EXCLUDED.received_at
               END
             "#;
+const UPSERT_AUDIENCE_MEMBER_SQL: &str = r#"
+            INSERT INTO audience_members
+              (id, provider, external_id, external_id_normalized, handle, public_profile_url, roles, lifecycle_stage, first_seen_at, last_seen_at)
+            VALUES ($1, $2, $3, lower($3), $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (provider, external_id_normalized) DO UPDATE SET
+              external_id = EXCLUDED.external_id,
+              handle = EXCLUDED.handle,
+              public_profile_url = COALESCE(EXCLUDED.public_profile_url, audience_members.public_profile_url),
+              roles = (
+                SELECT COALESCE(jsonb_agg(role ORDER BY role::text), '[]'::jsonb)
+                FROM (
+                  SELECT DISTINCT role
+                  FROM jsonb_array_elements(audience_members.roles || EXCLUDED.roles) AS merged(role)
+                ) AS unique_roles
+              ),
+              lifecycle_stage = CASE
+                WHEN audience_members.lifecycle_stage = 'Retained' OR EXCLUDED.lifecycle_stage = 'Retained' THEN 'Retained'
+                WHEN audience_members.lifecycle_stage = 'Converted' OR EXCLUDED.lifecycle_stage = 'Converted' THEN 'Converted'
+                WHEN audience_members.lifecycle_stage = 'Engaged' OR EXCLUDED.lifecycle_stage = 'Engaged' THEN 'Engaged'
+                ELSE 'Observed'
+              END,
+              first_seen_at = LEAST(audience_members.first_seen_at, EXCLUDED.first_seen_at),
+              last_seen_at = GREATEST(audience_members.last_seen_at, EXCLUDED.last_seen_at)
+            "#;
+const INSERT_AUDIENCE_INTERACTION_SQL: &str = r#"
+            INSERT INTO audience_interactions
+              (id, audience_member_id, provider_event_id, kind, public_url, occurred_at, referrer_url, campaign, source_interaction_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (audience_member_id, provider_event_id) DO NOTHING
+            "#;
 
 #[derive(Debug, Error)]
 pub enum DbError {
@@ -49,6 +81,8 @@ pub enum DbError {
     InvalidEnum(String),
     #[error("integer value cannot fit target type: {0}")]
     IntegerOverflow(String),
+    #[error("conflicting audience event replay: {0}")]
+    AudienceConflict(String),
 }
 
 pub type DbResult<T> = Result<T, DbError>;
@@ -307,6 +341,286 @@ impl PostgresStore {
                     notes: row.try_get("notes")?,
                     created_at: row.try_get("created_at")?,
                     updated_at: row.try_get("updated_at")?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn upsert_audience_member(&self, member: &AudienceMember) -> DbResult<()> {
+        sqlx::query(UPSERT_AUDIENCE_MEMBER_SQL)
+            .bind(member.id)
+            .bind(format!("{:?}", member.provider))
+            .bind(&member.external_id)
+            .bind(&member.handle)
+            .bind(&member.public_profile_url)
+            .bind(serde_json::to_value(&member.roles)?)
+            .bind(format!("{:?}", member.lifecycle_stage))
+            .bind(member.first_seen_at)
+            .bind(member.last_seen_at)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn list_audience_members(&self) -> DbResult<Vec<AudienceMember>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, provider, external_id, handle, public_profile_url, roles, lifecycle_stage, first_seen_at, last_seen_at
+            FROM audience_members
+            ORDER BY first_seen_at, handle
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(AudienceMember {
+                    id: row.try_get("id")?,
+                    provider: parse_audience_provider(row.try_get::<String, _>("provider")?)?,
+                    external_id: row.try_get("external_id")?,
+                    handle: row.try_get("handle")?,
+                    public_profile_url: row.try_get("public_profile_url")?,
+                    roles: serde_json::from_value(row.try_get("roles")?)?,
+                    lifecycle_stage: parse_audience_lifecycle_stage(
+                        row.try_get::<String, _>("lifecycle_stage")?,
+                    )?,
+                    first_seen_at: row.try_get("first_seen_at")?,
+                    last_seen_at: row.try_get("last_seen_at")?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn upsert_audience_interaction(
+        &self,
+        interaction: &AudienceInteraction,
+    ) -> DbResult<()> {
+        sqlx::query(INSERT_AUDIENCE_INTERACTION_SQL)
+            .bind(interaction.id)
+            .bind(interaction.audience_member_id)
+            .bind(&interaction.provider_event_id)
+            .bind(format!("{:?}", interaction.kind))
+            .bind(&interaction.public_url)
+            .bind(interaction.occurred_at)
+            .bind(&interaction.referrer_url)
+            .bind(&interaction.campaign)
+            .bind(interaction.source_interaction_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn upsert_audience_interaction_with_member(
+        &self,
+        member: &AudienceMember,
+        interaction: &AudienceInteraction,
+    ) -> DbResult<()> {
+        let mut transaction = self.pool.begin().await?;
+        sqlx::query(UPSERT_AUDIENCE_MEMBER_SQL)
+            .bind(member.id)
+            .bind(format!("{:?}", member.provider))
+            .bind(&member.external_id)
+            .bind(&member.handle)
+            .bind(&member.public_profile_url)
+            .bind(serde_json::to_value(&member.roles)?)
+            .bind(format!("{:?}", member.lifecycle_stage))
+            .bind(member.first_seen_at)
+            .bind(member.last_seen_at)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(INSERT_AUDIENCE_INTERACTION_SQL)
+            .bind(interaction.id)
+            .bind(interaction.audience_member_id)
+            .bind(&interaction.provider_event_id)
+            .bind(format!("{:?}", interaction.kind))
+            .bind(&interaction.public_url)
+            .bind(interaction.occurred_at)
+            .bind(&interaction.referrer_url)
+            .bind(&interaction.campaign)
+            .bind(interaction.source_interaction_id)
+            .execute(&mut *transaction)
+            .await?;
+
+        let persisted = sqlx::query(
+            r#"
+            SELECT id, kind, public_url, referrer_url, campaign, source_interaction_id
+            FROM audience_interactions
+            WHERE audience_member_id = $1 AND provider_event_id = $2
+            "#,
+        )
+        .bind(interaction.audience_member_id)
+        .bind(&interaction.provider_event_id)
+        .fetch_one(&mut *transaction)
+        .await?;
+        let persisted_id: Id = persisted.try_get("id")?;
+        let persisted_kind: String = persisted.try_get("kind")?;
+        let persisted_public_url: Option<String> = persisted.try_get("public_url")?;
+        let persisted_referrer_url: Option<String> = persisted.try_get("referrer_url")?;
+        let persisted_campaign: Option<String> = persisted.try_get("campaign")?;
+        let persisted_source_interaction_id: Option<Id> =
+            persisted.try_get("source_interaction_id")?;
+        if persisted_id != interaction.id
+            || persisted_kind != format!("{:?}", interaction.kind)
+            || persisted_public_url != interaction.public_url
+            || persisted_referrer_url != interaction.referrer_url
+            || persisted_campaign != interaction.campaign
+            || persisted_source_interaction_id != interaction.source_interaction_id
+        {
+            return Err(DbError::AudienceConflict(format!(
+                "member={} provider_event_id={}",
+                interaction.audience_member_id, interaction.provider_event_id
+            )));
+        }
+
+        sqlx::query(
+            r#"
+            UPDATE audience_members
+            SET lifecycle_stage = 'Retained'
+            WHERE id = $1
+              AND (SELECT COUNT(*) FROM audience_interactions WHERE audience_member_id = $1) >= 2
+            "#,
+        )
+        .bind(member.id)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    pub async fn list_audience_interactions(&self) -> DbResult<Vec<AudienceInteraction>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, audience_member_id, provider_event_id, kind, public_url, occurred_at, referrer_url, campaign, source_interaction_id
+            FROM audience_interactions
+            ORDER BY occurred_at, id
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(AudienceInteraction {
+                    id: row.try_get("id")?,
+                    audience_member_id: row.try_get("audience_member_id")?,
+                    provider_event_id: row.try_get("provider_event_id")?,
+                    kind: parse_audience_interaction_kind(row.try_get::<String, _>("kind")?)?,
+                    public_url: row.try_get("public_url")?,
+                    occurred_at: row.try_get("occurred_at")?,
+                    referrer_url: row.try_get("referrer_url")?,
+                    campaign: row.try_get("campaign")?,
+                    source_interaction_id: row.try_get("source_interaction_id")?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn upsert_discovery_response(&self, response: &DiscoveryResponse) -> DbResult<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO discovery_responses
+              (id, audience_member_id, interaction_id, provider_response_id, public_source_url, found_via, motivation, improvement_suggestion, agent_or_tool, private_storage_consent, captured_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            ON CONFLICT (audience_member_id, provider_response_id) DO NOTHING
+            "#,
+        )
+        .bind(response.id)
+        .bind(response.audience_member_id)
+        .bind(response.interaction_id)
+        .bind(&response.provider_response_id)
+        .bind(&response.public_source_url)
+        .bind(&response.found_via)
+        .bind(&response.motivation)
+        .bind(&response.improvement_suggestion)
+        .bind(&response.agent_or_tool)
+        .bind(response.private_storage_consent)
+        .bind(response.captured_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn list_discovery_responses(&self) -> DbResult<Vec<DiscoveryResponse>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, audience_member_id, interaction_id, provider_response_id, public_source_url, found_via, motivation, improvement_suggestion, agent_or_tool, private_storage_consent, captured_at
+            FROM discovery_responses
+            ORDER BY captured_at, id
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(DiscoveryResponse {
+                    id: row.try_get("id")?,
+                    audience_member_id: row.try_get("audience_member_id")?,
+                    interaction_id: row.try_get("interaction_id")?,
+                    provider_response_id: row.try_get("provider_response_id")?,
+                    public_source_url: row.try_get("public_source_url")?,
+                    found_via: row.try_get("found_via")?,
+                    motivation: row.try_get("motivation")?,
+                    improvement_suggestion: row.try_get("improvement_suggestion")?,
+                    agent_or_tool: row.try_get("agent_or_tool")?,
+                    private_storage_consent: row.try_get("private_storage_consent")?,
+                    captured_at: row.try_get("captured_at")?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn upsert_outreach_attempt(&self, attempt: &OutreachAttempt) -> DbResult<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO outreach_attempts
+              (id, audience_member_id, provider_event_id, channel, public_url, prompt_version, status, consent_contact_id, sent_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (audience_member_id, provider_event_id) DO UPDATE SET
+              status = CASE
+                WHEN outreach_attempts.status IN ('Responded', 'Declined', 'Unreachable') THEN outreach_attempts.status
+                ELSE EXCLUDED.status
+              END
+            "#,
+        )
+        .bind(attempt.id)
+        .bind(attempt.audience_member_id)
+        .bind(&attempt.provider_event_id)
+        .bind(format!("{:?}", attempt.channel))
+        .bind(&attempt.public_url)
+        .bind(&attempt.prompt_version)
+        .bind(format!("{:?}", attempt.status))
+        .bind(attempt.consent_contact_id)
+        .bind(attempt.sent_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn list_outreach_attempts(&self) -> DbResult<Vec<OutreachAttempt>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, audience_member_id, provider_event_id, channel, public_url, prompt_version, status, consent_contact_id, sent_at
+            FROM outreach_attempts
+            ORDER BY sent_at, id
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(OutreachAttempt {
+                    id: row.try_get("id")?,
+                    audience_member_id: row.try_get("audience_member_id")?,
+                    provider_event_id: row.try_get("provider_event_id")?,
+                    channel: parse_outreach_channel(row.try_get::<String, _>("channel")?)?,
+                    public_url: row.try_get("public_url")?,
+                    prompt_version: row.try_get("prompt_version")?,
+                    status: parse_outreach_status(row.try_get::<String, _>("status")?)?,
+                    consent_contact_id: row.try_get("consent_contact_id")?,
+                    sent_at: row.try_get("sent_at")?,
                 })
             })
             .collect()
@@ -2009,6 +2323,70 @@ fn parse_agent_status(value: String) -> DbResult<AgentStatus> {
     }
 }
 
+fn parse_audience_provider(value: String) -> DbResult<AudienceProvider> {
+    match value.as_str() {
+        "Github" => Ok(AudienceProvider::Github),
+        "HostedApi" => Ok(AudienceProvider::HostedApi),
+        "Mcp" => Ok(AudienceProvider::Mcp),
+        "BaseWallet" => Ok(AudienceProvider::BaseWallet),
+        "Stripe" => Ok(AudienceProvider::Stripe),
+        "Other" => Ok(AudienceProvider::Other),
+        _ => Err(DbError::InvalidEnum(value)),
+    }
+}
+
+fn parse_audience_lifecycle_stage(value: String) -> DbResult<AudienceLifecycleStage> {
+    match value.as_str() {
+        "Observed" => Ok(AudienceLifecycleStage::Observed),
+        "Engaged" => Ok(AudienceLifecycleStage::Engaged),
+        "Converted" => Ok(AudienceLifecycleStage::Converted),
+        "Retained" => Ok(AudienceLifecycleStage::Retained),
+        _ => Err(DbError::InvalidEnum(value)),
+    }
+}
+
+fn parse_audience_interaction_kind(value: String) -> DbResult<AudienceInteractionKind> {
+    match value.as_str() {
+        "IssueOpened" => Ok(AudienceInteractionKind::IssueOpened),
+        "PullRequestOpened" => Ok(AudienceInteractionKind::PullRequestOpened),
+        "IssueCommented" => Ok(AudienceInteractionKind::IssueCommented),
+        "PullRequestReviewed" => Ok(AudienceInteractionKind::PullRequestReviewed),
+        "BountyPosted" => Ok(AudienceInteractionKind::BountyPosted),
+        "FundingSignaled" => Ok(AudienceInteractionKind::FundingSignaled),
+        "BountyFunded" => Ok(AudienceInteractionKind::BountyFunded),
+        "ClaimSignaled" => Ok(AudienceInteractionKind::ClaimSignaled),
+        "BountyClaimed" => Ok(AudienceInteractionKind::BountyClaimed),
+        "SubmissionMade" => Ok(AudienceInteractionKind::SubmissionMade),
+        "SubmissionAccepted" => Ok(AudienceInteractionKind::SubmissionAccepted),
+        "VerificationSubmitted" => Ok(AudienceInteractionKind::VerificationSubmitted),
+        "PayoutReceived" => Ok(AudienceInteractionKind::PayoutReceived),
+        "RepoStarred" => Ok(AudienceInteractionKind::RepoStarred),
+        "BountyUpvoted" => Ok(AudienceInteractionKind::BountyUpvoted),
+        "ProofShared" => Ok(AudienceInteractionKind::ProofShared),
+        "ReferralCreated" => Ok(AudienceInteractionKind::ReferralCreated),
+        _ => Err(DbError::InvalidEnum(value)),
+    }
+}
+
+fn parse_outreach_channel(value: String) -> DbResult<OutreachChannel> {
+    match value.as_str() {
+        "GithubPublic" => Ok(OutreachChannel::GithubPublic),
+        "OtherPublic" => Ok(OutreachChannel::OtherPublic),
+        "EmailPrivate" => Ok(OutreachChannel::EmailPrivate),
+        _ => Err(DbError::InvalidEnum(value)),
+    }
+}
+
+fn parse_outreach_status(value: String) -> DbResult<OutreachStatus> {
+    match value.as_str() {
+        "Pending" => Ok(OutreachStatus::Pending),
+        "Responded" => Ok(OutreachStatus::Responded),
+        "Declined" => Ok(OutreachStatus::Declined),
+        "Unreachable" => Ok(OutreachStatus::Unreachable),
+        _ => Err(DbError::InvalidEnum(value)),
+    }
+}
+
 fn persisted_nonnegative_money(amount: i64, currency: String) -> DbResult<Money> {
     if amount == 0 {
         Ok(Money::zero(currency))
@@ -2277,6 +2655,10 @@ mod tests {
         for table in [
             "agents",
             "contributor_contacts",
+            "audience_members",
+            "audience_interactions",
+            "discovery_responses",
+            "outreach_attempts",
             "capabilities",
             "help_requests",
             "quotes",
@@ -2311,6 +2693,10 @@ mod tests {
         assert!(CORE_MIGRATION.contains("stripe_cancel_url TEXT"));
         assert!(CORE_MIGRATION.contains("github_login_normalized TEXT"));
         assert!(CORE_MIGRATION.contains("outreach_allowed BOOLEAN"));
+        assert!(CORE_MIGRATION.contains("private_storage_consent BOOLEAN"));
+        assert!(CORE_MIGRATION.contains("consent_contact_id UUID"));
+        assert!(CORE_MIGRATION.contains("REFERENCES audience_members(id) ON DELETE CASCADE"));
+        assert!(CORE_MIGRATION.contains("idx_audience_interactions_kind_occurred"));
         assert!(CORE_MIGRATION.contains("fund-contribution:"));
         assert!(CORE_MIGRATION.contains("CHECK (platform_fee >= 0)"));
         assert!(CORE_MIGRATION.contains("DROP CONSTRAINT IF EXISTS settlements_platform_fee_check"));

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -149,6 +149,160 @@ impl ContributorContact {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AudienceProvider {
+    Github,
+    HostedApi,
+    Mcp,
+    BaseWallet,
+    Stripe,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AudienceRole {
+    Observer,
+    Contributor,
+    BountyPoster,
+    ProspectiveFunder,
+    Funder,
+    ProspectiveSolver,
+    Claimer,
+    Solver,
+    Verifier,
+    Recipient,
+    Promoter,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AudienceLifecycleStage {
+    Observed,
+    Engaged,
+    Converted,
+    Retained,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AudienceMember {
+    pub id: Id,
+    pub provider: AudienceProvider,
+    pub external_id: String,
+    pub handle: String,
+    pub public_profile_url: Option<String>,
+    pub roles: Vec<AudienceRole>,
+    pub lifecycle_stage: AudienceLifecycleStage,
+    pub first_seen_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AudienceInteractionKind {
+    IssueOpened,
+    PullRequestOpened,
+    IssueCommented,
+    PullRequestReviewed,
+    BountyPosted,
+    FundingSignaled,
+    BountyFunded,
+    ClaimSignaled,
+    BountyClaimed,
+    SubmissionMade,
+    SubmissionAccepted,
+    VerificationSubmitted,
+    PayoutReceived,
+    RepoStarred,
+    BountyUpvoted,
+    ProofShared,
+    ReferralCreated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AudienceInteraction {
+    pub id: Id,
+    pub audience_member_id: Id,
+    pub provider_event_id: String,
+    pub kind: AudienceInteractionKind,
+    pub public_url: Option<String>,
+    pub occurred_at: DateTime<Utc>,
+    pub referrer_url: Option<String>,
+    pub campaign: Option<String>,
+    pub source_interaction_id: Option<Id>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DiscoveryResponse {
+    pub id: Id,
+    pub audience_member_id: Id,
+    pub interaction_id: Option<Id>,
+    pub provider_response_id: String,
+    pub public_source_url: Option<String>,
+    pub found_via: String,
+    pub motivation: String,
+    pub improvement_suggestion: String,
+    pub agent_or_tool: Option<String>,
+    pub private_storage_consent: bool,
+    pub captured_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OutreachChannel {
+    GithubPublic,
+    OtherPublic,
+    EmailPrivate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OutreachStatus {
+    Pending,
+    Responded,
+    Declined,
+    Unreachable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct OutreachAttempt {
+    pub id: Id,
+    pub audience_member_id: Id,
+    pub provider_event_id: String,
+    pub channel: OutreachChannel,
+    pub public_url: Option<String>,
+    pub prompt_version: String,
+    pub status: OutreachStatus,
+    pub consent_contact_id: Option<Id>,
+    pub sent_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AudienceMetric {
+    pub key: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AudienceReport {
+    pub total_members: u64,
+    pub total_interactions: u64,
+    pub members_asked_for_discovery_feedback: u64,
+    pub members_with_discovery_responses: u64,
+    pub repeat_participants: u64,
+    pub external_bounty_posters: u64,
+    pub external_funders: u64,
+    pub external_solvers: u64,
+    pub paid_participants: u64,
+    pub repo_stars_attributed: u64,
+    pub shares_attributed: u64,
+    pub not_asked_or_answered_handles: Vec<String>,
+    pub asked_without_response_handles: Vec<String>,
+    pub interactions_by_kind: Vec<AudienceMetric>,
+    pub generated_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Capability {
     pub id: Id,

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -4618,6 +4618,30 @@ async fn hydrate_network(store: &PostgresStore) -> anyhow::Result<BountyNetwork>
             .into_iter()
             .map(|contact| (contact.id, contact))
             .collect(),
+        audience_members: store
+            .list_audience_members()
+            .await?
+            .into_iter()
+            .map(|member| (member.id, member))
+            .collect(),
+        audience_interactions: store
+            .list_audience_interactions()
+            .await?
+            .into_iter()
+            .map(|interaction| (interaction.id, interaction))
+            .collect(),
+        discovery_responses: store
+            .list_discovery_responses()
+            .await?
+            .into_iter()
+            .map(|response| (response.id, response))
+            .collect(),
+        outreach_attempts: store
+            .list_outreach_attempts()
+            .await?
+            .into_iter()
+            .map(|attempt| (attempt.id, attempt))
+            .collect(),
         capabilities: store
             .list_capabilities()
             .await?

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -559,6 +559,30 @@ pub async fn hydrate_bounty_network(store: &PostgresStore) -> anyhow::Result<Bou
             .into_iter()
             .map(|contact| (contact.id, contact))
             .collect(),
+        audience_members: store
+            .list_audience_members()
+            .await?
+            .into_iter()
+            .map(|member| (member.id, member))
+            .collect(),
+        audience_interactions: store
+            .list_audience_interactions()
+            .await?
+            .into_iter()
+            .map(|interaction| (interaction.id, interaction))
+            .collect(),
+        discovery_responses: store
+            .list_discovery_responses()
+            .await?
+            .into_iter()
+            .map(|response| (response.id, response))
+            .collect(),
+        outreach_attempts: store
+            .list_outreach_attempts()
+            .await?
+            .into_iter()
+            .map(|attempt| (attempt.id, attempt))
+            .collect(),
         capabilities: store
             .list_capabilities()
             .await?

--- a/docs/audience-attribution.md
+++ b/docs/audience-attribution.md
@@ -1,0 +1,92 @@
+# Audience Attribution And Outreach Audit
+
+The audience registry answers four operational questions without turning public
+participation into a private-data collection exercise:
+
+1. Who has interacted with the network?
+2. Which public actions did they take, and did they return?
+3. Who was asked how they found the project, and who answered?
+4. Which sources produced real bounty posts, reconciled funding, solving,
+   payouts, stars, upvotes, or shares?
+
+The registry is operator-only. It complements, but does not replace,
+`contributor_contacts`:
+
+- `audience_members` stores a public provider identity, public profile URL,
+  roles, and first/last-seen timestamps.
+- `audience_interactions` stores idempotent public events and attribution links.
+- `discovery_responses` stores structured answers only when they have a public
+  source URL or explicit private-storage consent.
+- `outreach_attempts` stores one prompt event per participant. Private email
+  outreach is rejected unless the contributor contact has both contact consent
+  and outreach permission.
+- `contributor_contacts` remains the only place for opt-in email and payout
+  wallet data.
+
+Do not scrape or infer email addresses, wallets, private messages, or account
+ownership. Do not copy raw GitHub comment bodies into the registry.
+
+Keep only the fields needed for attribution and outreach coverage. On a
+verified deletion request, an operator can delete the corresponding
+`audience_members` row; interactions, discovery responses, and outreach rows
+are removed by foreign-key cascade. There is intentionally no unauthenticated
+public deletion endpoint.
+
+## GitHub Audit
+
+Generate a read-only live audit:
+
+```powershell
+python scripts\github_audience_audit.py `
+  --repository NSPG13/agent-bounties `
+  --output target\github-audience-audit.json
+```
+
+The command indexes public issue, PR, comment, review, bounty reaction, and
+stargazer evidence. A `/agent-bounty fund` comment is recorded as
+`funding_signaled`, never `bounty_funded`; only reconciled payment evidence may
+create the latter. The same rule applies to claim signals versus accepted
+claims.
+
+Natural-language answers are listed under `discovery_answer_candidates` with a
+public source URL. They are not auto-interpreted. A maintainer must read the
+source, summarize the answer faithfully, and use
+`POST /v1/audience/discovery-responses`. A reviewed JSON array can also be
+passed with `--curated-responses path/to/responses.json`; the importer accepts
+only public source URLs and never turns that file into private-contact consent.
+
+After reviewing the dry-run output, sync public identity, interaction, and
+outreach records to a running API:
+
+```powershell
+$env:OPERATOR_API_TOKEN = "<operator-token>"
+python scripts\github_audience_audit.py `
+  --repository NSPG13/agent-bounties `
+  --output target\github-audience-audit.json `
+  --sync `
+  --api-base-url https://api.example.com `
+  --curated-responses scripts\fixtures\github_discovery_responses.curated.json
+```
+
+The import is idempotent by provider identity and provider event ID. Replaying
+the same audit does not inflate participants, interactions, stars, or outreach
+counts.
+
+## Operator API
+
+- `POST|GET /v1/audience/members`
+- `POST|GET /v1/audience/interactions`
+- `POST|GET /v1/audience/discovery-responses`
+- `POST|GET /v1/audience/outreach-attempts`
+- `GET /v1/audience/report`
+
+The report exposes not-asked-or-answered handles, asked-without-response
+handles, repeat participation, and attributed conversion counts. It is an operational report,
+not payment evidence and not a basis for accepting work.
+
+## GitHub Stars
+
+An AI agent can star a repository only while acting as an authenticated GitHub
+user with write access to that user's starring permission. The action must be
+explicitly authorized by the human or account owner. Never auto-star, trade
+payment for a star, or treat a star as proof of work, funding, or settlement.

--- a/docs/contributor-contact-registry.md
+++ b/docs/contributor-contact-registry.md
@@ -8,6 +8,11 @@ The registry is operator-only. Do not expose it as a public signup form until
 the deployment has a real consent screen, retention policy, export path, and
 deletion path.
 
+Public identities and public interaction history belong in the separate
+audience attribution registry described in `docs/audience-attribution.md`.
+Do not put every GitHub participant into this contact table: this table is for
+explicitly consented private contact or payout details.
+
 ## Public Outreach Rules
 
 - Public GitHub comments may ask contributors to share a Base-compatible wallet
@@ -45,7 +50,8 @@ case-insensitive GitHub login. `GET /v1/contributor-contacts` lists stored
 records. Both routes require `OPERATOR_API_TOKEN` when hosted operator auth is
 configured.
 
-Import historic public PR participants from GitHub after the API is running:
+Import historic public participation into the separate audience registry after
+the API is running:
 
 ```powershell
 $env:OPERATOR_API_TOKEN = "<operator-token>"
@@ -54,10 +60,9 @@ $env:OPERATOR_API_TOKEN = "<operator-token>"
   -ApiBaseUrl "https://api.example.com"
 ```
 
-The import stores GitHub login and associated PR URLs only. `email` and
-`payout_wallet` remain `null` until the contributor opts in. If a record already
-exists, the import reads it first and preserves existing consent, email, wallet,
-source, and notes fields while merging PR URLs.
+The compatibility wrapper runs the public GitHub audience audit. It does not
+create contributor contact records or infer email/wallet data. Create or update
+a contributor contact only after an explicit private-contact or payout opt-in.
 
 Example wallet-only opt-in:
 

--- a/docs/distribution-learning.md
+++ b/docs/distribution-learning.md
@@ -139,3 +139,9 @@ Use the report to decide which labels, public proof pages, funding language,
 MCP discovery affordances, bounty listings, and agent workflows deserve more
 distribution effort. Do not use it to approve PRs, accept bounty work, or settle
 funds.
+
+For the live public GitHub audit and consent-aware operator persistence, use
+`scripts/github_audience_audit.py` and `GET /v1/audience/report` as documented in
+`docs/audience-attribution.md`. The audit treats funding and claim comments as
+signals, not completed financial or work events, and leaves natural-language
+answer interpretation to a maintainer.

--- a/migrations/0001_core.sql
+++ b/migrations/0001_core.sql
@@ -53,6 +53,85 @@ ALTER TABLE contributor_contacts
 CREATE UNIQUE INDEX IF NOT EXISTS idx_contributor_contacts_github_login_normalized
   ON contributor_contacts (github_login_normalized);
 
+CREATE TABLE IF NOT EXISTS audience_members (
+  id UUID PRIMARY KEY,
+  provider TEXT NOT NULL,
+  external_id TEXT NOT NULL,
+  external_id_normalized TEXT NOT NULL,
+  handle TEXT NOT NULL,
+  public_profile_url TEXT,
+  roles JSONB NOT NULL DEFAULT '[]'::jsonb,
+  lifecycle_stage TEXT NOT NULL,
+  first_seen_at TIMESTAMPTZ NOT NULL,
+  last_seen_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (provider, external_id_normalized),
+  CHECK (length(trim(external_id)) > 0),
+  CHECK (length(trim(handle)) > 0),
+  CHECK (last_seen_at >= first_seen_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audience_members_last_seen_at
+  ON audience_members (last_seen_at DESC);
+
+CREATE TABLE IF NOT EXISTS audience_interactions (
+  id UUID PRIMARY KEY,
+  audience_member_id UUID NOT NULL REFERENCES audience_members(id) ON DELETE CASCADE,
+  provider_event_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  public_url TEXT,
+  occurred_at TIMESTAMPTZ NOT NULL,
+  referrer_url TEXT,
+  campaign TEXT,
+  source_interaction_id UUID REFERENCES audience_interactions(id) ON DELETE SET NULL,
+  UNIQUE (audience_member_id, provider_event_id),
+  CHECK (length(trim(provider_event_id)) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audience_interactions_member_occurred
+  ON audience_interactions (audience_member_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_audience_interactions_kind_occurred
+  ON audience_interactions (kind, occurred_at DESC);
+
+CREATE TABLE IF NOT EXISTS discovery_responses (
+  id UUID PRIMARY KEY,
+  audience_member_id UUID NOT NULL REFERENCES audience_members(id) ON DELETE CASCADE,
+  interaction_id UUID REFERENCES audience_interactions(id) ON DELETE SET NULL,
+  provider_response_id TEXT NOT NULL,
+  public_source_url TEXT,
+  found_via TEXT NOT NULL,
+  motivation TEXT NOT NULL,
+  improvement_suggestion TEXT NOT NULL,
+  agent_or_tool TEXT,
+  private_storage_consent BOOLEAN NOT NULL DEFAULT false,
+  captured_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (audience_member_id, provider_response_id),
+  CHECK (length(trim(provider_response_id)) > 0),
+  CHECK (length(trim(found_via)) > 0),
+  CHECK (length(trim(motivation)) > 0),
+  CHECK (length(trim(improvement_suggestion)) > 0),
+  CHECK (public_source_url IS NOT NULL OR private_storage_consent)
+);
+
+CREATE TABLE IF NOT EXISTS outreach_attempts (
+  id UUID PRIMARY KEY,
+  audience_member_id UUID NOT NULL REFERENCES audience_members(id) ON DELETE CASCADE,
+  provider_event_id TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  public_url TEXT,
+  prompt_version TEXT NOT NULL,
+  status TEXT NOT NULL,
+  consent_contact_id UUID REFERENCES contributor_contacts(id) ON DELETE CASCADE,
+  sent_at TIMESTAMPTZ NOT NULL,
+  UNIQUE (audience_member_id, provider_event_id),
+  CHECK (length(trim(provider_event_id)) > 0),
+  CHECK (length(trim(prompt_version)) > 0),
+  CHECK (channel != 'EmailPrivate' OR consent_contact_id IS NOT NULL),
+  CHECK (channel = 'EmailPrivate' OR public_url IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_outreach_attempts_member_sent
+  ON outreach_attempts (audience_member_id, sent_at);
+
 CREATE TABLE IF NOT EXISTS capabilities (
   id UUID PRIMARY KEY,
   agent_id UUID NOT NULL REFERENCES agents(id),

--- a/scripts/check-postgres.ps1
+++ b/scripts/check-postgres.ps1
@@ -46,6 +46,9 @@ try {
     $env:AGENT_BOUNTIES_TEST_DATABASE_URL = $databaseUrl
     try {
         Invoke-Checked {
+            cargo test -p api tests::audience_audit_persists_idempotently_across_processes -- --ignored --exact --nocapture
+        }
+        Invoke-Checked {
             cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
         }
         Invoke-Checked {

--- a/scripts/check-postgres.sh
+++ b/scripts/check-postgres.sh
@@ -34,6 +34,7 @@ database_url="${DATABASE_URL:-postgres://agent_bounties:agent_bounties@localhost
 
 cargo build -p api -p mcp-server
 export AGENT_BOUNTIES_TEST_DATABASE_URL="$database_url"
+cargo test -p api tests::audience_audit_persists_idempotently_across_processes -- --ignored --exact --nocapture
 cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture
 cargo test -p mcp-server tests::mcp_bounty_status_reads_scoped_postgres_after_cross_process_funding -- --ignored --exact --nocapture
 cargo run -p cli -- service-smoke-spawn \

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -57,6 +57,7 @@ Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_claim_commen
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_proof_comment.py --self-test }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_sync_hosted_bounty_inventory.py -v }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_diagnose_hosted_api.py -v }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_github_audience_audit.py -v }
 Invoke-Checked { cargo run -p cli -- github-proof-comment-plan --bounty-id 00000000-0000-0000-0000-000000000001 --proof-url https://agentbounties.local/public/proofs/example --verifier-summary "GitHub CI passed" }
 Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbounties.local --mcp-base-url https://agentbounties.local/mcp }
 Invoke-Checked { cargo run -p cli -- discovery-report --input-fixture crates\cli\fixtures\discovery_answers.json --json-out target\tmp\discovery-report.json --markdown-out target\tmp\discovery-report.md }
@@ -73,7 +74,7 @@ Invoke-Checked { cargo run -p cli -- funding-rehearsal-demo }
 Invoke-Checked { cargo run -p cli -- real-funding-readiness --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x036CbD53842c5426634e7929541eC2318f3dCF7e }
 Invoke-Checked { & (Join-Path $repoRoot "scripts\real-funding-rehearsal.ps1") }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py crates\sdk-python\examples\cofund_claim.py }
-Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\diagnose_hosted_api.py scripts\test_diagnose_hosted_api.py scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py scripts\sync_hosted_bounty_inventory.py scripts\test_sync_hosted_bounty_inventory.py scripts\validate_real_funding_rehearsal.py }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\diagnose_hosted_api.py scripts\test_diagnose_hosted_api.py scripts\github_audience_audit.py scripts\test_github_audience_audit.py scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py scripts\sync_hosted_bounty_inventory.py scripts\test_sync_hosted_bounty_inventory.py scripts\validate_real_funding_rehearsal.py }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\check-site.py scripts\check-render-blueprint.py scripts\stage_review_contract_root.py scripts\test_stage_review_contract_root.py scripts\base_deployment_attest.py scripts\test_base_deployment_attest.py scripts\build_base_attest_fixtures.py }
 Pop-Location
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -99,6 +99,7 @@ cargo run -p cli -- github-claim-comment-plan \
 "${python_cmd[@]}" scripts/github_proof_comment.py --self-test
 "${python_cmd[@]}" scripts/test_sync_hosted_bounty_inventory.py -v
 "${python_cmd[@]}" scripts/test_diagnose_hosted_api.py -v
+"${python_cmd[@]}" scripts/test_github_audience_audit.py -v
 cargo run -p cli -- github-proof-comment-plan \
   --bounty-id 00000000-0000-0000-0000-000000000001 \
   --proof-url https://agentbounties.local/public/proofs/example \
@@ -138,6 +139,8 @@ bash scripts/real-funding-rehearsal.sh
   scripts/test_sync_hosted_bounty_inventory.py \
   scripts/diagnose_hosted_api.py \
   scripts/test_diagnose_hosted_api.py \
+  scripts/github_audience_audit.py \
+  scripts/test_github_audience_audit.py \
   scripts/check-site.py \
   scripts/check-render-blueprint.py \
   scripts/stage_review_contract_root.py \

--- a/scripts/fixtures/github_audience_audit.json
+++ b/scripts/fixtures/github_audience_audit.json
@@ -1,0 +1,129 @@
+{
+  "repository": "NSPG13/agent-bounties",
+  "issues": [
+    {
+      "id": 101,
+      "number": 10,
+      "html_url": "https://github.com/NSPG13/agent-bounties/pull/10",
+      "created_at": "2026-07-01T10:00:00Z",
+      "body": "## How I found this\nGitHub bounty label search made the scope visible.",
+      "labels": [],
+      "pull_request": {},
+      "user": {
+        "id": 2,
+        "login": "alice-agent",
+        "type": "User",
+        "html_url": "https://github.com/alice-agent"
+      }
+    },
+    {
+      "id": 102,
+      "number": 11,
+      "html_url": "https://github.com/NSPG13/agent-bounties/issues/11",
+      "created_at": "2026-07-02T10:00:00Z",
+      "body": "A deterministic documentation bounty.",
+      "labels": [{"name": "bounty"}],
+      "user": {
+        "id": 3,
+        "login": "bob-human",
+        "type": "User",
+        "html_url": "https://github.com/bob-human"
+      }
+    }
+  ],
+  "pulls": [],
+  "issue_comments": [
+    {
+      "id": 201,
+      "html_url": "https://github.com/NSPG13/agent-bounties/issues/11#issuecomment-201",
+      "issue_url": "https://api.github.com/repos/NSPG13/agent-bounties/issues/11",
+      "created_at": "2026-07-02T11:00:00Z",
+      "body": "@bob-human How did you find Agent Bounties? What made this bounty or project worth participating in?",
+      "user": {
+        "id": 1,
+        "login": "NSPG13",
+        "type": "User",
+        "html_url": "https://github.com/NSPG13"
+      }
+    },
+    {
+      "id": 202,
+      "html_url": "https://github.com/NSPG13/agent-bounties/issues/11#issuecomment-202",
+      "issue_url": "https://api.github.com/repos/NSPG13/agent-bounties/issues/11",
+      "created_at": "2026-07-02T12:00:00Z",
+      "body": "Discovery feedback: I found Agent Bounties through GitHub search.",
+      "user": {
+        "id": 3,
+        "login": "bob-human",
+        "type": "User",
+        "html_url": "https://github.com/bob-human"
+      }
+    },
+    {
+      "id": 203,
+      "html_url": "https://github.com/NSPG13/agent-bounties/issues/11#issuecomment-203",
+      "issue_url": "https://api.github.com/repos/NSPG13/agent-bounties/issues/11",
+      "created_at": "2026-07-02T13:00:00Z",
+      "body": "/agent-bounty fund 100 usdc",
+      "user": {
+        "id": 3,
+        "login": "bob-human",
+        "type": "User",
+        "html_url": "https://github.com/bob-human"
+      }
+    },
+    {
+      "id": 204,
+      "html_url": "https://github.com/NSPG13/agent-bounties/issues/11#issuecomment-204",
+      "issue_url": "https://api.github.com/repos/NSPG13/agent-bounties/issues/11",
+      "created_at": "2026-07-02T14:00:00Z",
+      "body": "/claim",
+      "user": {
+        "id": 4,
+        "login": "claim-bot[bot]",
+        "type": "Bot",
+        "html_url": "https://github.com/apps/claim-bot"
+      }
+    }
+  ],
+  "review_comments": [],
+  "reviews": [
+    {
+      "id": 301,
+      "pull_number": 10,
+      "submitted_at": "2026-07-03T10:00:00Z",
+      "body": "Looks deterministic.",
+      "user": {
+        "id": 2,
+        "login": "alice-agent",
+        "type": "User",
+        "html_url": "https://github.com/alice-agent"
+      }
+    }
+  ],
+  "reactions": [
+    {
+      "id": 401,
+      "issue_number": 11,
+      "content": "+1",
+      "created_at": "2026-07-04T10:00:00Z",
+      "user": {
+        "id": 2,
+        "login": "alice-agent",
+        "type": "User",
+        "html_url": "https://github.com/alice-agent"
+      }
+    }
+  ],
+  "stargazers": [
+    {
+      "starred_at": "2026-07-05T10:00:00Z",
+      "user": {
+        "id": 3,
+        "login": "bob-human",
+        "type": "User",
+        "html_url": "https://github.com/bob-human"
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/github_discovery_responses.curated.json
+++ b/scripts/fixtures/github_discovery_responses.curated.json
@@ -1,0 +1,65 @@
+[
+  {
+    "handle": "AI-hotpot",
+    "provider_response_id": "github:issue-body:4836542845",
+    "public_source_url": "https://github.com/NSPG13/agent-bounties/pull/40",
+    "found_via": "GitHub issue search for open issues with AI-agent-welcome and bounty labels.",
+    "motivation": "Concrete acceptance criteria, a small public-web scope, and deterministic review and tests.",
+    "improvement_suggestion": "Not provided in this response.",
+    "agent_or_tool": "Not provided in this response."
+  },
+  {
+    "handle": "Andre-Silva-Peixoto",
+    "provider_response_id": "github:issue-body:4850766084",
+    "public_source_url": "https://github.com/NSPG13/agent-bounties/pull/129",
+    "found_via": "GitHub search for label:bounty and ai-agent-welcome, filtered to unfunded issues without an active PR lane.",
+    "motivation": "Clear deterministic scope, offline fixtures, and a real on-chain escrow path.",
+    "improvement_suggestion": "Fund bounties in escrow before agents invest implementation time and show a clearer active-lane signal.",
+    "agent_or_tool": "Cursor agent with Python and the GitHub CLI."
+  },
+  {
+    "handle": "hyperxiaoerxz-hash",
+    "provider_response_id": "github:issue-comment:4915897383",
+    "public_source_url": "https://github.com/NSPG13/agent-bounties/issues/55#issuecomment-4915897383",
+    "found_via": "GitHub searches for USDC, bounty, ai-agent-welcome, and agent/payment terms, filtered through a local short-cycle task tracker.",
+    "motivation": "Narrow scope, explicit Base USDC and hosted-beta wording, deterministic acceptance, active review, and an unambiguous payment-trust boundary.",
+    "improvement_suggestion": "Show funded, claimable, and paid as separate states and provide one canonical post-merge settlement flow with proof or escrow links.",
+    "agent_or_tool": "AI-agent workflow using GitHub search, competition filtering, a local work tracker, and schema/payload checks."
+  },
+  {
+    "handle": "joebkarwalo",
+    "provider_response_id": "github:issue-body:4838309139",
+    "public_source_url": "https://github.com/NSPG13/agent-bounties/pull/63",
+    "found_via": "Review of the open bounty backlog for public documentation and web-public gaps.",
+    "motivation": "The task clarified the public/private funding-data boundary and unblocked safer funding-pool UI work.",
+    "improvement_suggestion": "Not provided in this response.",
+    "agent_or_tool": "Not provided in this response."
+  },
+  {
+    "handle": "nexicturbo",
+    "provider_response_id": "github:issue-body:4851721792",
+    "public_source_url": "https://github.com/NSPG13/agent-bounties/pull/138",
+    "found_via": "The public Agent Bounties issue list while looking for small payout-integrity tasks with clear verification surfaces.",
+    "motivation": "The task bound an observed escrow release log to exact release calldata, making payment evidence more trustworthy and testable.",
+    "improvement_suggestion": "Not provided in this response.",
+    "agent_or_tool": "Not provided in this response."
+  },
+  {
+    "handle": "Syzygys",
+    "provider_response_id": "github:issue-comment:4913388821",
+    "public_source_url": "https://github.com/NSPG13/agent-bounties/pull/27#issuecomment-4913388821",
+    "found_via": "A GitHub bounty-discovery workflow searching open bounty-labelled issues and filtering for agent-friendly, low-friction work.",
+    "motivation": "Agent-friendly labels, clear acceptance criteria, a small deterministic implementation surface, local checks, and explicit non-settlement invariants.",
+    "improvement_suggestion": "Not provided in this response.",
+    "agent_or_tool": "An autonomous coding-agent discovery workflow using GitHub labels, scope filtering, repository inspection, focused Rust changes, and local validation."
+  },
+  {
+    "handle": "Thedoddo",
+    "provider_response_id": "github:issue-body:4851895074",
+    "public_source_url": "https://github.com/NSPG13/agent-bounties/pull/139",
+    "found_via": "GitHub label search for bounty.",
+    "motivation": "A focused, testable change with clear acceptance criteria.",
+    "improvement_suggestion": "Not provided in this response.",
+    "agent_or_tool": "Not provided in this response."
+  }
+]

--- a/scripts/github_audience_audit.py
+++ b/scripts/github_audience_audit.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Audit public GitHub participation and optionally sync it to the operator API.
+
+The audit deliberately excludes email addresses, wallets, and raw comment text.
+Natural-language discovery answers are emitted as curation candidates rather
+than being interpreted or stored automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+DISCOVERY_QUESTION_MARKERS = (
+    "how did you find agent bounties",
+    "how exactly did you discover",
+    "exactly how did you discover",
+    "please answer the discovery questions",
+    "what made this bounty or project worth participating",
+)
+DISCOVERY_ANSWER_MARKERS = (
+    "## how i found",
+    "how i found this",
+    "discovery feedback",
+    "i found this through",
+    "found agent bounties",
+)
+MENTION_RE = re.compile(r"(?<![A-Za-z0-9-])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def flatten_pages(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError("GitHub response must be a JSON array")
+    if value and all(isinstance(page, list) for page in value):
+        return [item for page in value for item in page if isinstance(item, dict)]
+    return [item for item in value if isinstance(item, dict)]
+
+
+def gh_api(repository: str, suffix: str, *, accept: str | None = None) -> list[dict[str, Any]]:
+    command = [
+        "gh",
+        "api",
+        "--paginate",
+        "--slurp",
+        f"repos/{repository}/{suffix.lstrip('/')}",
+    ]
+    if accept:
+        command.extend(["-H", f"Accept: {accept}"])
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    return flatten_pages(json.loads(completed.stdout))
+
+
+def collect_snapshot(repository: str) -> dict[str, Any]:
+    issues = gh_api(repository, "issues?state=all&per_page=100")
+    pulls = gh_api(repository, "pulls?state=all&per_page=100")
+    issue_comments = gh_api(repository, "issues/comments?per_page=100")
+    review_comments = gh_api(repository, "pulls/comments?per_page=100")
+    reviews: list[dict[str, Any]] = []
+    for pull in pulls:
+        number = pull.get("number")
+        if isinstance(number, int):
+            for review in gh_api(repository, f"pulls/{number}/reviews?per_page=100"):
+                review["pull_number"] = number
+                reviews.append(review)
+
+    bounty_issues = [
+        issue
+        for issue in issues
+        if "pull_request" not in issue
+        and "bounty" in {str(label.get("name", "")).lower() for label in issue.get("labels", [])}
+    ]
+    reactions: list[dict[str, Any]] = []
+    for issue in bounty_issues:
+        number = issue.get("number")
+        if isinstance(number, int):
+            for reaction in gh_api(
+                repository,
+                f"issues/{number}/reactions?per_page=100",
+                accept="application/vnd.github+json",
+            ):
+                reaction["issue_number"] = number
+                reactions.append(reaction)
+
+    stargazers = gh_api(
+        repository,
+        "stargazers?per_page=100",
+        accept="application/vnd.github.star+json",
+    )
+    return {
+        "repository": repository,
+        "fetched_at": utc_now(),
+        "issues": issues,
+        "pulls": pulls,
+        "issue_comments": issue_comments,
+        "review_comments": review_comments,
+        "reviews": reviews,
+        "reactions": reactions,
+        "stargazers": stargazers,
+    }
+
+
+def is_external_user(user: Any, owner_login: str, include_owner: bool) -> bool:
+    if not isinstance(user, dict):
+        return False
+    login = str(user.get("login", "")).strip()
+    if not login or login.lower().endswith("[bot]") or user.get("type") == "Bot":
+        return False
+    return include_owner or login.lower() != owner_login.lower()
+
+
+def participant_from_user(user: dict[str, Any]) -> dict[str, Any]:
+    login = str(user["login"])
+    external_id = str(user.get("id") or user.get("node_id") or login.lower())
+    return {
+        "provider": "github",
+        "external_id": external_id,
+        "handle": login,
+        "public_profile_url": user.get("html_url") or f"https://github.com/{login}",
+    }
+
+
+def matched_marker(body: str, markers: tuple[str, ...]) -> str | None:
+    lowered = body.lower()
+    return next((marker for marker in markers if marker in lowered), None)
+
+
+def issue_number_from_api_url(url: str) -> int | None:
+    try:
+        return int(url.rstrip("/").rsplit("/", 1)[-1])
+    except (TypeError, ValueError):
+        return None
+
+
+def build_audit(
+    snapshot: dict[str, Any], owner_login: str, *, include_owner: bool = False
+) -> dict[str, Any]:
+    participants: dict[str, dict[str, Any]] = {}
+    interactions: dict[tuple[str, str], dict[str, Any]] = {}
+    answer_candidates: dict[tuple[str, str], dict[str, Any]] = {}
+    outreach: dict[tuple[str, str], dict[str, Any]] = {}
+    issues_by_number = {
+        issue["number"]: issue
+        for issue in snapshot.get("issues", [])
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+
+    def register(user: Any) -> str | None:
+        if not is_external_user(user, owner_login, include_owner):
+            return None
+        participant = participant_from_user(user)
+        key = participant["handle"].lower()
+        participants[key] = participant
+        return key
+
+    def add_interaction(
+        user: Any,
+        provider_event_id: str,
+        kind: str,
+        public_url: str | None,
+        occurred_at: str | None,
+    ) -> None:
+        login_key = register(user)
+        if login_key is None:
+            return
+        interactions[(login_key, provider_event_id)] = {
+            "handle": participants[login_key]["handle"],
+            "provider_event_id": provider_event_id,
+            "kind": kind,
+            "public_url": public_url,
+            "occurred_at": occurred_at,
+            "referrer_url": None,
+            "campaign": "github-public-activity",
+            "source_interaction_id": None,
+        }
+
+    def consider_answer(
+        user: Any, body: Any, provider_response_id: str, public_url: str | None
+    ) -> None:
+        if not isinstance(body, str):
+            return
+        marker = matched_marker(body, DISCOVERY_ANSWER_MARKERS)
+        if marker is None:
+            return
+        login_key = register(user)
+        if login_key is None or not public_url:
+            return
+        answer_candidates[(login_key, provider_response_id)] = {
+            "handle": participants[login_key]["handle"],
+            "provider_response_id": provider_response_id,
+            "public_source_url": public_url,
+            "matched_marker": marker,
+            "curation_required": True,
+        }
+
+    for issue in snapshot.get("issues", []):
+        if not isinstance(issue, dict):
+            continue
+        is_pull = "pull_request" in issue
+        issue_id = issue.get("id") or issue.get("number")
+        kind = "pull_request_opened" if is_pull else "issue_opened"
+        add_interaction(
+            issue.get("user"),
+            f"github:issue:{issue_id}:{kind}",
+            kind,
+            issue.get("html_url"),
+            issue.get("created_at"),
+        )
+        labels = {str(label.get("name", "")).lower() for label in issue.get("labels", [])}
+        if not is_pull and "bounty" in labels:
+            add_interaction(
+                issue.get("user"),
+                f"github:issue:{issue_id}:bounty_posted",
+                "bounty_posted",
+                issue.get("html_url"),
+                issue.get("created_at"),
+            )
+        consider_answer(
+            issue.get("user"),
+            issue.get("body"),
+            f"github:issue-body:{issue_id}",
+            issue.get("html_url"),
+        )
+
+    last_external_commenter_by_issue: dict[int, str] = {}
+    issue_comments = sorted(
+        (comment for comment in snapshot.get("issue_comments", []) if isinstance(comment, dict)),
+        key=lambda comment: (comment.get("created_at") or "", str(comment.get("id") or "")),
+    )
+    for comment in issue_comments:
+        comment_id = comment.get("id")
+        body = str(comment.get("body") or "")
+        user = comment.get("user")
+        issue_number = issue_number_from_api_url(str(comment.get("issue_url", "")))
+        commenter_key = register(user)
+        add_interaction(
+            user,
+            f"github:issue-comment:{comment_id}",
+            "issue_commented",
+            comment.get("html_url"),
+            comment.get("created_at"),
+        )
+        command = body.strip().lower()
+        if command.startswith("/agent-bounty fund"):
+            add_interaction(
+                user,
+                f"github:issue-comment:{comment_id}:funding-signal",
+                "funding_signaled",
+                comment.get("html_url"),
+                comment.get("created_at"),
+            )
+        if command.startswith("/claim") or command.startswith("/agent-bounty claim"):
+            add_interaction(
+                user,
+                f"github:issue-comment:{comment_id}:claim-signal",
+                "claim_signaled",
+                comment.get("html_url"),
+                comment.get("created_at"),
+            )
+        consider_answer(
+            user,
+            body,
+            f"github:issue-comment:{comment_id}",
+            comment.get("html_url"),
+        )
+
+        author_login = str((user or {}).get("login", ""))
+        is_discovery_question = author_login.lower() == owner_login.lower() and matched_marker(
+            body, DISCOVERY_QUESTION_MARKERS
+        )
+        if is_discovery_question:
+            mentions = {mention.lower() for mention in MENTION_RE.findall(body)}
+            target_keys = [key for key in mentions if key in participants]
+            if not target_keys:
+                issue = issues_by_number.get(issue_number)
+                target_key = register((issue or {}).get("user"))
+                if target_key is None and issue_number is not None:
+                    target_key = last_external_commenter_by_issue.get(issue_number)
+                target_keys = [target_key] if target_key else []
+            for target_key in target_keys:
+                outreach[(target_key, str(comment_id))] = {
+                    "handle": participants[target_key]["handle"],
+                    "provider_event_id": f"github:discovery-prompt:{comment_id}:{target_key}",
+                    "channel": "github_public",
+                    "public_url": comment.get("html_url"),
+                    "prompt_version": "distribution-v1",
+                    "status": "pending",
+                    "sent_at": comment.get("created_at"),
+                }
+        if commenter_key is not None and issue_number is not None:
+            last_external_commenter_by_issue[issue_number] = commenter_key
+
+    for review_comment in snapshot.get("review_comments", []):
+        if not isinstance(review_comment, dict):
+            continue
+        comment_id = review_comment.get("id")
+        add_interaction(
+            review_comment.get("user"),
+            f"github:review-comment:{comment_id}",
+            "pull_request_reviewed",
+            review_comment.get("html_url"),
+            review_comment.get("created_at"),
+        )
+        consider_answer(
+            review_comment.get("user"),
+            review_comment.get("body"),
+            f"github:review-comment:{comment_id}",
+            review_comment.get("html_url"),
+        )
+
+    for review in snapshot.get("reviews", []):
+        if not isinstance(review, dict):
+            continue
+        review_id = review.get("id")
+        pull_number = review.get("pull_number")
+        public_url = (
+            f"https://github.com/{snapshot.get('repository')}/pull/{pull_number}"
+            if pull_number
+            else None
+        )
+        add_interaction(
+            review.get("user"),
+            f"github:review:{review_id}",
+            "pull_request_reviewed",
+            public_url,
+            review.get("submitted_at"),
+        )
+        consider_answer(
+            review.get("user"),
+            review.get("body"),
+            f"github:review:{review_id}",
+            public_url,
+        )
+
+    for reaction in snapshot.get("reactions", []):
+        if not isinstance(reaction, dict) or reaction.get("content") != "+1":
+            continue
+        issue = issues_by_number.get(reaction.get("issue_number"))
+        add_interaction(
+            reaction.get("user"),
+            f"github:reaction:{reaction.get('id')}",
+            "bounty_upvoted",
+            (issue or {}).get("html_url"),
+            reaction.get("created_at"),
+        )
+
+    for stargazer in snapshot.get("stargazers", []):
+        if not isinstance(stargazer, dict):
+            continue
+        user = stargazer.get("user") if isinstance(stargazer.get("user"), dict) else stargazer
+        login = str((user or {}).get("login", "")).lower()
+        add_interaction(
+            user,
+            f"github:star:{login}",
+            "repo_starred",
+            f"https://github.com/{snapshot.get('repository')}/stargazers",
+            stargazer.get("starred_at"),
+        )
+
+    answered_keys = {key for key, _ in answer_candidates}
+    asked_keys = {key for key, _ in outreach}
+    for attempt in outreach.values():
+        if attempt["handle"].lower() in answered_keys:
+            attempt["status"] = "responded"
+    participant_keys = set(participants)
+    not_asked_or_answered = participant_keys - asked_keys - answered_keys
+    asked_without_answer = asked_keys - answered_keys
+
+    first_seen_by_handle: dict[str, str] = {}
+    for interaction in interactions.values():
+        occurred_at = interaction.get("occurred_at")
+        handle_key = interaction["handle"].lower()
+        if occurred_at and (
+            handle_key not in first_seen_by_handle
+            or occurred_at < first_seen_by_handle[handle_key]
+        ):
+            first_seen_by_handle[handle_key] = occurred_at
+    for key, participant in participants.items():
+        participant["observed_at"] = first_seen_by_handle.get(key)
+        participant["roles"] = []
+
+    return {
+        "repository": snapshot.get("repository"),
+        "generated_at": utc_now(),
+        "privacy_boundary": {
+            "public_identity_and_event_urls_only": True,
+            "email_scraped": False,
+            "wallet_inferred": False,
+            "raw_comment_text_stored": False,
+            "discovery_answers_require_human_curation": True,
+        },
+        "participants": sorted(participants.values(), key=lambda item: item["handle"].lower()),
+        "interactions": sorted(
+            interactions.values(),
+            key=lambda item: (item.get("occurred_at") or "", item["provider_event_id"]),
+        ),
+        "outreach_attempts": sorted(
+            outreach.values(), key=lambda item: (item["handle"].lower(), item["provider_event_id"])
+        ),
+        "discovery_answer_candidates": sorted(
+            answer_candidates.values(),
+            key=lambda item: (item["handle"].lower(), item["provider_response_id"]),
+        ),
+        "coverage": {
+            "participant_count": len(participants),
+            "asked_count": len(asked_keys),
+            "answer_candidate_count": len(answered_keys),
+            "not_asked_or_answered_handles": sorted(
+                participants[key]["handle"] for key in not_asked_or_answered
+            ),
+            "asked_without_answer_handles": sorted(
+                participants[key]["handle"] for key in asked_without_answer
+            ),
+        },
+    }
+
+
+def http_post_json(base_url: str, path: str, payload: dict[str, Any], token: str | None) -> Any:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["x-operator-token"] = token
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{path} returned HTTP {error.code}: {detail}") from error
+
+
+def sync_audit(
+    audit: dict[str, Any],
+    api_base_url: str,
+    token: str | None,
+    *,
+    curated_responses: list[dict[str, Any]] | None = None,
+    post_json: Callable[[str, str, dict[str, Any], str | None], Any] = http_post_json,
+) -> dict[str, int]:
+    member_ids: dict[str, str] = {}
+    for participant in audit["participants"]:
+        stored = post_json(api_base_url, "/v1/audience/members", participant, token)
+        member_ids[participant["handle"].lower()] = stored["id"]
+
+    for interaction in audit["interactions"]:
+        payload = dict(interaction)
+        handle = payload.pop("handle").lower()
+        payload["audience_member_id"] = member_ids[handle]
+        post_json(api_base_url, "/v1/audience/interactions", payload, token)
+
+    for attempt in audit["outreach_attempts"]:
+        payload = dict(attempt)
+        handle = payload.pop("handle").lower()
+        payload["audience_member_id"] = member_ids[handle]
+        post_json(api_base_url, "/v1/audience/outreach-attempts", payload, token)
+
+    responses_synced = 0
+    for response in curated_responses or []:
+        payload = dict(response)
+        handle = str(payload.pop("handle", "")).lower()
+        if handle not in member_ids:
+            raise ValueError(f"curated discovery response references unknown handle: {handle}")
+        public_source_url = str(payload.get("public_source_url") or "")
+        if not public_source_url.startswith(("https://", "http://")):
+            raise ValueError("curated discovery responses must use a public source URL")
+        payload["audience_member_id"] = member_ids[handle]
+        payload["private_storage_consent"] = False
+        post_json(api_base_url, "/v1/audience/discovery-responses", payload, token)
+        responses_synced += 1
+
+    return {
+        "members_synced": len(audit["participants"]),
+        "interactions_synced": len(audit["interactions"]),
+        "outreach_attempts_synced": len(audit["outreach_attempts"]),
+        "discovery_responses_synced": responses_synced,
+        "discovery_candidates_requiring_curation": len(audit["discovery_answer_candidates"]),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", default="NSPG13/agent-bounties")
+    parser.add_argument("--owner-login", default="NSPG13")
+    parser.add_argument("--fixture", type=Path)
+    parser.add_argument("--snapshot-output", type=Path)
+    parser.add_argument("--output", type=Path, default=Path("target/github-audience-audit.json"))
+    parser.add_argument("--include-owner", action="store_true")
+    parser.add_argument("--curated-responses", type=Path)
+    parser.add_argument("--sync", action="store_true")
+    parser.add_argument("--api-base-url", default="http://127.0.0.1:8080")
+    parser.add_argument("--operator-token-env", default="OPERATOR_API_TOKEN")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.fixture:
+        snapshot = json.loads(args.fixture.read_text(encoding="utf-8"))
+    else:
+        snapshot = collect_snapshot(args.repository)
+    snapshot.setdefault("repository", args.repository)
+    if args.snapshot_output:
+        args.snapshot_output.parent.mkdir(parents=True, exist_ok=True)
+        args.snapshot_output.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
+    audit = build_audit(snapshot, args.owner_login, include_owner=args.include_owner)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(audit, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(audit["coverage"], indent=2))
+    print(f"audit_output={args.output}")
+
+    if args.sync:
+        token = os.environ.get(args.operator_token_env)
+        curated_responses = None
+        if args.curated_responses:
+            curated_responses = json.loads(args.curated_responses.read_text(encoding="utf-8"))
+            if not isinstance(curated_responses, list):
+                raise ValueError("--curated-responses must contain a JSON array")
+        result = sync_audit(
+            audit,
+            args.api_base_url,
+            token,
+            curated_responses=curated_responses,
+        )
+        print(json.dumps(result, indent=2))
+        if result["discovery_candidates_requiring_curation"]:
+            print(
+                "Discovery answer candidates were not auto-stored; curate their public source URLs "
+                "through POST /v1/audience/discovery-responses.",
+                file=sys.stderr,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/import-github-contributors.ps1
+++ b/scripts/import-github-contributors.ps1
@@ -7,106 +7,42 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-
-if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
-    throw "GitHub CLI 'gh' is required."
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$python = Get-Command python -ErrorAction SilentlyContinue
+if (-not $python) {
+    $python = Get-Command py -ErrorAction SilentlyContinue
+}
+if (-not $python) {
+    throw "Python is required."
 }
 
-$prsJson = gh pr list `
-    --repo $Repository `
-    --state all `
-    --limit $Limit `
-    --json number,url,author
-
-$prs = $prsJson | ConvertFrom-Json
-$contributors = @{}
-
-foreach ($pr in $prs) {
-    if ($null -eq $pr.author -or [string]::IsNullOrWhiteSpace($pr.author.login)) {
-        continue
-    }
-    if ($pr.author.is_bot) {
-        continue
-    }
-    if (-not $IncludeOwner -and $pr.author.login -eq "NSPG13") {
-        continue
-    }
-
-    $login = $pr.author.login
-    if (-not $contributors.ContainsKey($login)) {
-        $contributors[$login] = [System.Collections.Generic.List[string]]::new()
-    }
-    $contributors[$login].Add($pr.url)
+Write-Warning "This compatibility wrapper now imports public GitHub participation into the consent-aware audience registry. It does not add inferred contacts, email addresses, or wallets."
+if ($Limit -ne 200) {
+    Write-Warning "-Limit is retained for compatibility but ignored; the idempotent audit paginates all public repository activity."
 }
 
-$headers = @{}
-if (-not [string]::IsNullOrWhiteSpace($OperatorToken)) {
-    $headers["x-operator-token"] = $OperatorToken
+$output = Join-Path $repoRoot "target\github-audience-audit.json"
+$arguments = @(
+    (Join-Path $PSScriptRoot "github_audience_audit.py"),
+    "--repository", $Repository,
+    "--output", $output,
+    "--sync",
+    "--api-base-url", $ApiBaseUrl
+)
+if ($IncludeOwner) {
+    $arguments += "--include-owner"
 }
 
-$existingByLogin = @{}
+$previousToken = $env:OPERATOR_API_TOKEN
 try {
-    $existingContacts = Invoke-RestMethod `
-        -Method Get `
-        -Uri "$ApiBaseUrl/v1/contributor-contacts" `
-        -Headers $headers
-    foreach ($contact in $existingContacts) {
-        $existingByLogin[$contact.github_login.ToLowerInvariant()] = $contact
+    if (-not [string]::IsNullOrWhiteSpace($OperatorToken)) {
+        $env:OPERATOR_API_TOKEN = $OperatorToken
     }
-} catch {
-    Write-Warning "Could not read existing contributor contacts; import will use public PR history only. $($_.Exception.Message)"
+    & $python.Source @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "GitHub audience audit exited with code $LASTEXITCODE"
+    }
 }
-
-foreach ($login in ($contributors.Keys | Sort-Object)) {
-    $associatedPrs = $contributors[$login] | Sort-Object -Unique
-    $existing = $existingByLogin[$login.ToLowerInvariant()]
-    $existingPrs = @()
-    if ($null -ne $existing -and $null -ne $existing.associated_prs) {
-        $existingPrs = @($existing.associated_prs)
-    }
-    $mergedPrs = @($associatedPrs + $existingPrs) | Sort-Object -Unique
-    $email = $null
-    $payoutWallet = $null
-    $contactConsent = $false
-    $walletConsent = $false
-    $outreachAllowed = $false
-    $source = "github-pr-history"
-    $notes = "Imported from public GitHub PR history. Email and wallet unknown until contributor opt-in."
-
-    if ($null -ne $existing) {
-        $email = $existing.email
-        $payoutWallet = $existing.payout_wallet
-        $contactConsent = [bool]$existing.contact_consent
-        $walletConsent = [bool]$existing.wallet_consent
-        $outreachAllowed = [bool]$existing.outreach_allowed
-        if (-not [string]::IsNullOrWhiteSpace($existing.source)) {
-            $source = $existing.source
-        }
-        if (-not [string]::IsNullOrWhiteSpace($existing.notes)) {
-            $notes = $existing.notes
-        }
-    }
-
-    $body = @{
-        github_login = $login
-        email = $email
-        payout_wallet = $payoutWallet
-        associated_prs = @($mergedPrs)
-        contact_consent = $contactConsent
-        wallet_consent = $walletConsent
-        outreach_allowed = $outreachAllowed
-        source = $source
-        notes = $notes
-    } | ConvertTo-Json -Depth 5
-
-    Invoke-RestMethod `
-        -Method Post `
-        -Uri "$ApiBaseUrl/v1/contributor-contacts" `
-        -Headers $headers `
-        -ContentType "application/json" `
-        -Body $body | Out-Null
-
-    Write-Output "Imported $login with $($mergedPrs.Count) PR(s)."
+finally {
+    $env:OPERATOR_API_TOKEN = $previousToken
 }
-
-Write-Output "Imported $($contributors.Count) contributor contact record(s)."

--- a/scripts/test_github_audience_audit.py
+++ b/scripts/test_github_audience_audit.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "github_audience_audit", SCRIPT_DIR / "github_audience_audit.py"
+)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class GitHubAudienceAuditTests(unittest.TestCase):
+    def setUp(self) -> None:
+        fixture = SCRIPT_DIR / "fixtures" / "github_audience_audit.json"
+        self.snapshot = json.loads(fixture.read_text(encoding="utf-8"))
+        self.audit = MODULE.build_audit(self.snapshot, "NSPG13")
+
+    def test_public_activity_is_deduplicated_and_bots_are_excluded(self) -> None:
+        handles = [participant["handle"] for participant in self.audit["participants"]]
+        self.assertEqual(handles, ["alice-agent", "bob-human"])
+        self.assertNotIn("NSPG13", handles)
+        self.assertNotIn("claim-bot[bot]", handles)
+
+        kinds = [interaction["kind"] for interaction in self.audit["interactions"]]
+        self.assertIn("bounty_posted", kinds)
+        self.assertIn("funding_signaled", kinds)
+        self.assertIn("repo_starred", kinds)
+        self.assertIn("bounty_upvoted", kinds)
+        self.assertNotIn("bounty_funded", kinds)
+
+    def test_volunteered_and_requested_answers_close_coverage_without_inference(self) -> None:
+        coverage = self.audit["coverage"]
+        self.assertEqual(coverage["participant_count"], 2)
+        self.assertEqual(coverage["asked_count"], 1)
+        self.assertEqual(coverage["answer_candidate_count"], 2)
+        self.assertEqual(coverage["not_asked_or_answered_handles"], [])
+        self.assertEqual(coverage["asked_without_answer_handles"], [])
+        self.assertTrue(
+            all(
+                candidate["curation_required"]
+                for candidate in self.audit["discovery_answer_candidates"]
+            )
+        )
+        self.assertTrue(self.audit["privacy_boundary"]["raw_comment_text_stored"] is False)
+
+    def test_sync_writes_members_events_and_outreach_but_not_unstructured_answers(self) -> None:
+        calls: list[tuple[str, dict]] = []
+
+        def fake_post(base_url: str, path: str, payload: dict, token: str | None) -> dict:
+            self.assertEqual(base_url, "https://api.example")
+            self.assertEqual(token, "operator-token")
+            calls.append((path, payload))
+            if path == "/v1/audience/members":
+                return {"id": f"member:{payload['handle'].lower()}"}
+            return {"id": "stored"}
+
+        result = MODULE.sync_audit(
+            self.audit,
+            "https://api.example",
+            "operator-token",
+            post_json=fake_post,
+        )
+
+        self.assertEqual(result["members_synced"], 2)
+        self.assertEqual(
+            result["discovery_candidates_requiring_curation"],
+            len(self.audit["discovery_answer_candidates"]),
+        )
+        paths = [path for path, _ in calls]
+        self.assertEqual(paths.count("/v1/audience/members"), 2)
+        self.assertEqual(
+            paths.count("/v1/audience/interactions"), len(self.audit["interactions"])
+        )
+        self.assertEqual(
+            paths.count("/v1/audience/outreach-attempts"),
+            len(self.audit["outreach_attempts"]),
+        )
+        self.assertNotIn("/v1/audience/discovery-responses", paths)
+
+    def test_maintainer_prompt_targets_latest_external_commenter_on_owner_issue(self) -> None:
+        snapshot = deepcopy(self.snapshot)
+        owner = {
+            "id": 1,
+            "login": "NSPG13",
+            "type": "User",
+            "html_url": "https://github.com/NSPG13",
+        }
+        charlie = {
+            "id": 5,
+            "login": "charlie-agent",
+            "type": "User",
+            "html_url": "https://github.com/charlie-agent",
+        }
+        snapshot["issues"].append(
+            {
+                "id": 103,
+                "number": 12,
+                "html_url": "https://github.com/NSPG13/agent-bounties/issues/12",
+                "created_at": "2026-07-06T10:00:00Z",
+                "body": "Maintainer-posted bounty.",
+                "labels": [{"name": "bounty"}],
+                "user": owner,
+            }
+        )
+        snapshot["issue_comments"].extend(
+            [
+                {
+                    "id": 205,
+                    "html_url": "https://github.com/NSPG13/agent-bounties/issues/12#issuecomment-205",
+                    "issue_url": "https://api.github.com/repos/NSPG13/agent-bounties/issues/12",
+                    "created_at": "2026-07-06T11:00:00Z",
+                    "body": "I can take this.",
+                    "user": charlie,
+                },
+                {
+                    "id": 206,
+                    "html_url": "https://github.com/NSPG13/agent-bounties/issues/12#issuecomment-206",
+                    "issue_url": "https://api.github.com/repos/NSPG13/agent-bounties/issues/12",
+                    "created_at": "2026-07-06T12:00:00Z",
+                    "body": "How did you find Agent Bounties? What made this bounty or project worth participating in?",
+                    "user": owner,
+                },
+            ]
+        )
+
+        audit = MODULE.build_audit(snapshot, "NSPG13")
+        attempts = [
+            attempt
+            for attempt in audit["outreach_attempts"]
+            if attempt["provider_event_id"].startswith("github:discovery-prompt:206")
+        ]
+        self.assertEqual([attempt["handle"] for attempt in attempts], ["charlie-agent"])
+
+    def test_explicit_curated_public_answer_can_be_synced(self) -> None:
+        calls: list[tuple[str, dict]] = []
+
+        def fake_post(base_url: str, path: str, payload: dict, token: str | None) -> dict:
+            calls.append((path, payload))
+            if path == "/v1/audience/members":
+                return {"id": f"member:{payload['handle'].lower()}"}
+            return {"id": "stored"}
+
+        result = MODULE.sync_audit(
+            self.audit,
+            "https://api.example",
+            None,
+            curated_responses=[
+                {
+                    "handle": "alice-agent",
+                    "provider_response_id": "github:issue-body:101",
+                    "public_source_url": "https://github.com/NSPG13/agent-bounties/pull/10",
+                    "found_via": "GitHub bounty label search",
+                    "motivation": "Clear scope",
+                    "improvement_suggestion": "Show exact payout state",
+                    "agent_or_tool": "coding agent",
+                }
+            ],
+            post_json=fake_post,
+        )
+
+        self.assertEqual(result["discovery_responses_synced"], 1)
+        response_calls = [
+            payload
+            for path, payload in calls
+            if path == "/v1/audience/discovery-responses"
+        ]
+        self.assertEqual(len(response_calls), 1)
+        self.assertEqual(response_calls[0]["audience_member_id"], "member:alice-agent")
+        self.assertFalse(response_calls[0]["private_storage_consent"])
+
+    def test_repository_curated_answers_reference_known_public_participants(self) -> None:
+        curated_path = (
+            SCRIPT_DIR / "fixtures" / "github_discovery_responses.curated.json"
+        )
+        curated = json.loads(curated_path.read_text(encoding="utf-8"))
+        self.assertEqual(len(curated), 7)
+        self.assertEqual(
+            len({response["provider_response_id"] for response in curated}), len(curated)
+        )
+        for response in curated:
+            self.assertTrue(response["handle"].strip())
+            self.assertTrue(response["public_source_url"].startswith("https://github.com/"))
+            self.assertTrue(response["found_via"].strip())
+            self.assertTrue(response["motivation"].strip())
+            self.assertTrue(response["improvement_suggestion"].strip())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the missing operational audience database without conflating public participation with private contact consent.

- adds durable `audience_members`, `audience_interactions`, `discovery_responses`, and `outreach_attempts`
- keeps email and payout wallets exclusively in the existing explicit-consent contact registry
- adds operator-gated API CRUD/list surfaces and an aggregate funnel report
- makes member plus event persistence transactional across API processes
- rejects conflicting replay of the same provider event ID
- derives retained participation from durable event count and merges roles monotonically
- adds deletion cascades for verified removal requests
- adds a full public GitHub audit/import loop with no raw comment, email, or wallet scraping
- distinguishes funding/claim signals from reconciled funding and accepted claims
- adds seven human-curated public discovery summaries; unstructured candidates are never auto-interpreted
- converts the old contributor import into a compatibility wrapper for the audience registry

Refs #147.

## Current evidence

The live read-only audit found 21 external public participants. Before the final outreach:
- 14 had been directly asked for distribution feedback
- 7 had clear public answer evidence
- 4 had neither an ask nor an answer

One non-repeated public request was then sent to those four. Every current participant is now either represented by public answer evidence or has been asked. This is outreach coverage, not response completion.

The same audit found:
- 49 claim signals
- 0 external bounty posts
- 0 reconciled external funding events
- 0 attributed repository stars
- 0 payouts

## Payment truth

This PR does not release escrow, mark a funding comment as money, accept bounty work, authorize payout, deploy Render, or mutate the Base contract. `funding_signaled` and `claim_signaled` are separate event types from real funding and accepted claims.

## Privacy boundary

- public provider identity and public event URLs only
- no scraped/inferred email
- no inferred wallet ownership
- no raw GitHub comment bodies persisted
- private discovery storage requires explicit consent
- private outreach requires an opted-in contributor contact
- stars remain voluntary authenticated-user actions

## Verification

- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1`
- `powershell -ExecutionPolicy Bypass -File scripts/check-postgres.ps1`
- `cargo test -p app -p db -p api -p worker -p mcp-server`
- `python scripts/test_github_audience_audit.py -v`
- `cargo run -p cli -- docs-contract-check`
- `python scripts/check-site.py`
- `python scripts/check-render-blueprint.py`
- `git diff --check`

The full gate and Postgres cross-process gate pass.