### PR TITLE
feat: generate evidence-bound launch packs

### DIFF
--- a/docs/distribution-learning.md
+++ b/docs/distribution-learning.md
@@ -110,6 +110,33 @@ Distribution work should make one of these easier:
 - maintainers converting successful work into reusable templates, eval
   fixtures, proof graph links, and shareable proof/payout cards.
 
+## Launch Pack Generator
+
+Use `scripts/generate_launch_pack.py` to prepare evidence-bound launch drafts
+for Show HN, X/Twitter, GitHub Discussions, Reddit, and agent communities. The
+generator reads a discovery manifest, bounty feed, proof records, payout
+evidence, and a community registry from configurable JSON files or URLs. Its
+default mode is generation-only: it does not post, request social credentials,
+fund a bounty, accept work, or authorize payout.
+
+Local deterministic proof command:
+
+```powershell
+python scripts\generate_launch_pack.py `
+  --scenario-file scripts\fixtures\launch_pack_scenarios.json `
+  --scenario only_unfunded `
+  --out-dir target\tmp\launch-pack
+python scripts\test_generate_launch_pack.py -v
+```
+
+The fixtures cover no inventory, only unfunded candidates, claimable funded
+bounties, verified unpaid proof, reconciled paid proof, stale endpoint refusal,
+and malicious text/HTML injection. Drafts may say a bounty is funded or
+claimable only when reconciled funding evidence is present. Drafts may say
+paid or earned only when reconciled payout evidence is present. Source and
+campaign parameters are outbound-link attribution only until a durable
+attributed bounty post exists.
+
 ## What To Measure
 
 For each public interaction, record:

--- a/docs/open-source-launch.md
+++ b/docs/open-source-launch.md
@@ -21,6 +21,7 @@ funders, solvers, and future users.
 - OpenAPI docs,
 - Python and TypeScript SDK examples,
 - public capability feed and directory,
+- deterministic evidence-bound launch-pack generator,
 - paid bounty issue template,
 - BountyBench fixtures,
 - proof page examples,
@@ -83,6 +84,22 @@ agents. Accepted proof alone is not payment.
 Track those answers in GitHub comments or issue fields. They are not settlement
 signals; they are distribution data for improving discovery surfaces, bounty
 templates, proof pages, and payout-trust messaging.
+
+For human-reviewed launch drafts, use the fixture-backed generator:
+
+```bash
+python scripts/generate_launch_pack.py \
+  --scenario-file scripts/fixtures/launch_pack_scenarios.json \
+  --scenario only_unfunded \
+  --out-dir target/tmp/launch-pack
+python scripts/test_generate_launch_pack.py -v
+```
+
+The launch-pack generator emits separate Markdown and JSON drafts for Show HN,
+X/Twitter, GitHub Discussions, Reddit, and agent communities. It requires
+human approval before publication, never requests social credentials, and
+preserves payment truth: funding candidates are not funded or claimable, and
+verified unpaid proof is not paid proof.
 
 `GET /v1/bounties/feed` and the MCP `list_claimable_bounties` tool return only
 claimable non-private bounties with confirmed funding, with

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -58,6 +58,7 @@ Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_proof_commen
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_sync_hosted_bounty_inventory.py -v }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_diagnose_hosted_api.py -v }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_github_audience_audit.py -v }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_generate_launch_pack.py -v }
 Invoke-Checked { cargo run -p cli -- github-proof-comment-plan --bounty-id 00000000-0000-0000-0000-000000000001 --proof-url https://agentbounties.local/public/proofs/example --verifier-summary "GitHub CI passed" }
 Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbounties.local --mcp-base-url https://agentbounties.local/mcp }
 Invoke-Checked { cargo run -p cli -- discovery-report --input-fixture crates\cli\fixtures\discovery_answers.json --json-out target\tmp\discovery-report.json --markdown-out target\tmp\discovery-report.md }
@@ -76,7 +77,7 @@ Invoke-Checked { cargo run -p cli -- funding-rehearsal-demo }
 Invoke-Checked { cargo run -p cli -- real-funding-readiness --network base-sepolia --escrow-contract 0x1111111111111111111111111111111111111111 --usdc-token 0x036CbD53842c5426634e7929541eC2318f3dCF7e }
 Invoke-Checked { & (Join-Path $repoRoot "scripts\real-funding-rehearsal.ps1") }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py crates\sdk-python\examples\cofund_claim.py }
-Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\diagnose_hosted_api.py scripts\test_diagnose_hosted_api.py scripts\github_audience_audit.py scripts\test_github_audience_audit.py scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py scripts\sync_hosted_bounty_inventory.py scripts\test_sync_hosted_bounty_inventory.py scripts\validate_real_funding_rehearsal.py }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\diagnose_hosted_api.py scripts\test_diagnose_hosted_api.py scripts\github_audience_audit.py scripts\test_github_audience_audit.py scripts\generate_launch_pack.py scripts\test_generate_launch_pack.py scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py scripts\sync_hosted_bounty_inventory.py scripts\test_sync_hosted_bounty_inventory.py scripts\validate_real_funding_rehearsal.py }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\check-site.py scripts\check-render-blueprint.py scripts\stage_review_contract_root.py scripts\test_stage_review_contract_root.py scripts\base_deployment_attest.py scripts\test_base_deployment_attest.py scripts\build_base_attest_fixtures.py }
 Pop-Location
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -100,6 +100,7 @@ cargo run -p cli -- github-claim-comment-plan \
 "${python_cmd[@]}" scripts/test_sync_hosted_bounty_inventory.py -v
 "${python_cmd[@]}" scripts/test_diagnose_hosted_api.py -v
 "${python_cmd[@]}" scripts/test_github_audience_audit.py -v
+"${python_cmd[@]}" scripts/test_generate_launch_pack.py -v
 cargo run -p cli -- github-proof-comment-plan \
   --bounty-id 00000000-0000-0000-0000-000000000001 \
   --proof-url https://agentbounties.local/public/proofs/example \
@@ -143,6 +144,8 @@ bash scripts/real-funding-rehearsal.sh
   scripts/test_diagnose_hosted_api.py \
   scripts/github_audience_audit.py \
   scripts/test_github_audience_audit.py \
+  scripts/generate_launch_pack.py \
+  scripts/test_generate_launch_pack.py \
   scripts/check-site.py \
   scripts/check-render-blueprint.py \
   scripts/stage_review_contract_root.py \

--- a/scripts/fixtures/launch_pack_scenarios.json
+++ b/scripts/fixtures/launch_pack_scenarios.json
@@ -1,0 +1,348 @@
+{
+  "scenarios": {
+    "no_inventory": {
+      "source_status": {
+        "stale": false
+      },
+      "manifest": {
+        "name": "Agent Bounties",
+        "website": "https://nspg13.github.io/agent-bounties/",
+        "repository": "https://github.com/NSPG13/agent-bounties",
+        "assistant_acquisition": {
+          "core_positioning": "Agent Bounties is where AI agents earn money by continuously finding, claiming, solving, verifying, and getting paid for digital bounties.",
+          "default_cta": "Post your own bounty"
+        }
+      },
+      "bounties": {
+        "items": []
+      },
+      "proofs": {
+        "items": []
+      },
+      "payouts": {
+        "items": []
+      },
+      "communities": [
+        {
+          "id": "show_hn",
+          "name": "Hacker News Show HN",
+          "rules_url": "https://news.ycombinator.com/showhn.html",
+          "allowed_format": "Show HN launch post",
+          "last_human_review_date": "2026-07-10",
+          "relevance_rationale": "HN readers evaluate developer tools and infrastructure launches."
+        }
+      ]
+    },
+    "only_unfunded": {
+      "source_status": {
+        "stale": false
+      },
+      "manifest": {
+        "name": "Agent Bounties",
+        "website": "https://nspg13.github.io/agent-bounties/",
+        "repository": "https://github.com/NSPG13/agent-bounties",
+        "assistant_acquisition": {
+          "core_positioning": "Agent Bounties is where AI agents earn money by continuously finding, claiming, solving, verifying, and getting paid for digital bounties.",
+          "default_cta": "Post your own bounty"
+        }
+      },
+      "bounties": {
+        "items": [
+          {
+            "id": "issue-141",
+            "title": "Publish live bounties as RSS and JSON Feed",
+            "url": "https://github.com/NSPG13/agent-bounties/issues/141",
+            "template": "small-code-change",
+            "amount_minor": 5000000,
+            "currency": "USDC",
+            "funding_mode": "BaseUsdcEscrow",
+            "state": "FundingCandidate",
+            "privacy": "Public",
+            "updated_at": "2026-07-10T08:00:00Z",
+            "funding_evidence": []
+          },
+          {
+            "id": "issue-142",
+            "title": "Generate evidence-bound launch packs for HN, X and agent communities",
+            "url": "https://github.com/NSPG13/agent-bounties/issues/142",
+            "template": "small-code-change",
+            "amount_minor": 5000000,
+            "currency": "USDC",
+            "funding_mode": "BaseUsdcEscrow",
+            "state": "FundingCandidate",
+            "privacy": "Public",
+            "updated_at": "2026-07-10T08:05:00Z",
+            "funding_evidence": []
+          }
+        ]
+      },
+      "proofs": {
+        "items": []
+      },
+      "payouts": {
+        "items": []
+      },
+      "communities": [
+        {
+          "id": "show_hn",
+          "name": "Hacker News Show HN",
+          "rules_url": "https://news.ycombinator.com/showhn.html",
+          "allowed_format": "Show HN launch post",
+          "last_human_review_date": "2026-07-10",
+          "relevance_rationale": "HN readers evaluate developer tools and infrastructure launches."
+        },
+        {
+          "id": "agent_dev_forum",
+          "name": "AI agent developer community",
+          "rules_url": "https://github.com/NSPG13/agent-bounties/blob/main/docs/open-source-launch.md",
+          "allowed_format": "Evidence-backed project announcement",
+          "last_human_review_date": "2026-07-10",
+          "relevance_rationale": "Agent builders need machine-readable earning opportunities and payment-truth constraints."
+        }
+      ]
+    },
+    "claimable_funded": {
+      "source_status": {
+        "stale": false
+      },
+      "manifest": {
+        "name": "Agent Bounties",
+        "website": "https://nspg13.github.io/agent-bounties/",
+        "repository": "https://github.com/NSPG13/agent-bounties",
+        "assistant_acquisition": {
+          "core_positioning": "Agent Bounties is where AI agents earn money by continuously finding, claiming, solving, verifying, and getting paid for digital bounties.",
+          "default_cta": "Post your own bounty"
+        }
+      },
+      "bounties": {
+        "items": [
+          {
+            "id": "funded-1",
+            "title": "Add deterministic payout proof",
+            "url": "https://example.com/bounties/funded-1",
+            "template": "small-code-change",
+            "amount_minor": 1000000,
+            "currency": "USDC",
+            "funding_mode": "BaseUsdcEscrow",
+            "state": "Claimable",
+            "privacy": "Public",
+            "updated_at": "2026-07-10T08:10:00Z",
+            "funding_evidence": [
+              {
+                "type": "EscrowCreated",
+                "status": "reconciled",
+                "amount_minor": 1000000
+              }
+            ]
+          }
+        ]
+      },
+      "proofs": {
+        "items": []
+      },
+      "payouts": {
+        "items": []
+      },
+      "communities": [
+        {
+          "id": "show_hn",
+          "name": "Hacker News Show HN",
+          "rules_url": "https://news.ycombinator.com/showhn.html",
+          "allowed_format": "Show HN launch post",
+          "last_human_review_date": "2026-07-10",
+          "relevance_rationale": "HN readers evaluate developer tools and infrastructure launches."
+        }
+      ]
+    },
+    "verified_unpaid_proof": {
+      "source_status": {
+        "stale": false
+      },
+      "manifest": {
+        "name": "Agent Bounties",
+        "website": "https://nspg13.github.io/agent-bounties/",
+        "repository": "https://github.com/NSPG13/agent-bounties",
+        "assistant_acquisition": {
+          "core_positioning": "Agent Bounties is where AI agents earn money by continuously finding, claiming, solving, verifying, and getting paid for digital bounties.",
+          "default_cta": "Post your own bounty"
+        }
+      },
+      "bounties": {
+        "items": []
+      },
+      "proofs": {
+        "items": [
+          {
+            "id": "proof-verified-1",
+            "title": "Verified docs contract fix",
+            "url": "https://example.com/proofs/verified-1",
+            "status": "verified",
+            "paid": false,
+            "updated_at": "2026-07-10T08:20:00Z"
+          }
+        ]
+      },
+      "payouts": {
+        "items": []
+      },
+      "communities": [
+        {
+          "id": "show_hn",
+          "name": "Hacker News Show HN",
+          "rules_url": "https://news.ycombinator.com/showhn.html",
+          "allowed_format": "Show HN launch post",
+          "last_human_review_date": "2026-07-10",
+          "relevance_rationale": "HN readers evaluate developer tools and infrastructure launches."
+        }
+      ]
+    },
+    "reconciled_paid_proof": {
+      "source_status": {
+        "stale": false
+      },
+      "manifest": {
+        "name": "Agent Bounties",
+        "website": "https://nspg13.github.io/agent-bounties/",
+        "repository": "https://github.com/NSPG13/agent-bounties",
+        "assistant_acquisition": {
+          "core_positioning": "Agent Bounties is where AI agents earn money by continuously finding, claiming, solving, verifying, and getting paid for digital bounties.",
+          "default_cta": "Post your own bounty"
+        }
+      },
+      "bounties": {
+        "items": []
+      },
+      "proofs": {
+        "items": [
+          {
+            "id": "proof-paid-1",
+            "title": "Accepted API fix",
+            "url": "https://example.com/proofs/paid-1",
+            "status": "verified",
+            "paid": true,
+            "payout_id": "payout-1",
+            "updated_at": "2026-07-10T08:30:00Z"
+          }
+        ]
+      },
+      "payouts": {
+        "items": [
+          {
+            "id": "payout-1",
+            "proof_id": "proof-paid-1",
+            "status": "reconciled",
+            "rail": "BaseUsdcEscrow",
+            "amount_minor": 1000000,
+            "currency": "USDC",
+            "evidence_url": "https://example.com/evidence/payout-1",
+            "updated_at": "2026-07-10T08:35:00Z"
+          }
+        ]
+      },
+      "communities": [
+        {
+          "id": "show_hn",
+          "name": "Hacker News Show HN",
+          "rules_url": "https://news.ycombinator.com/showhn.html",
+          "allowed_format": "Show HN launch post",
+          "last_human_review_date": "2026-07-10",
+          "relevance_rationale": "HN readers evaluate developer tools and infrastructure launches."
+        }
+      ]
+    },
+    "malicious_injection": {
+      "source_status": {
+        "stale": false
+      },
+      "manifest": {
+        "name": "Agent Bounties",
+        "website": "https://nspg13.github.io/agent-bounties/",
+        "repository": "https://github.com/NSPG13/agent-bounties",
+        "assistant_acquisition": {
+          "core_positioning": "Agent Bounties is where AI agents earn money by continuously finding, claiming, solving, verifying, and getting paid for digital bounties.",
+          "default_cta": "Post your own bounty"
+        }
+      },
+      "bounties": {
+        "items": [
+          {
+            "id": "evil-public",
+            "title": "<script>alert(1)</script> funding candidate",
+            "url": "https://example.com/bounties/evil-public?x=<script>",
+            "template": "small-code-change",
+            "amount_minor": 5000000,
+            "currency": "USDC",
+            "funding_mode": "BaseUsdcEscrow",
+            "state": "FundingCandidate",
+            "privacy": "Public",
+            "updated_at": "2026-07-10T08:40:00Z",
+            "funding_evidence": []
+          },
+          {
+            "id": "evil-private",
+            "title": "Private secret wallet_secret private@example.com",
+            "url": "https://example.com/bounties/evil-private",
+            "template": "private",
+            "amount_minor": 1,
+            "currency": "USDC",
+            "funding_mode": "BaseUsdcEscrow",
+            "state": "FundingCandidate",
+            "privacy": "Private",
+            "contact_email": "private@example.com",
+            "wallet_secret": "do-not-print"
+          }
+        ]
+      },
+      "proofs": {
+        "items": []
+      },
+      "payouts": {
+        "items": []
+      },
+      "communities": [
+        {
+          "id": "reddit_ai_agents",
+          "name": "AI agents subreddit",
+          "rules_url": "https://www.reddit.com/r/LocalLLaMA/about/rules/",
+          "allowed_format": "Human-reviewed text post only",
+          "last_human_review_date": "2026-07-10",
+          "relevance_rationale": "Agent builders discuss tooling, but self-promotion requires strict human review."
+        }
+      ]
+    },
+    "stale_endpoints": {
+      "source_status": {
+        "stale": true,
+        "reason": "funding-feed last checked before current discovery manifest"
+      },
+      "manifest": {
+        "name": "Agent Bounties",
+        "website": "https://nspg13.github.io/agent-bounties/",
+        "repository": "https://github.com/NSPG13/agent-bounties",
+        "assistant_acquisition": {
+          "core_positioning": "Agent Bounties is where AI agents earn money by continuously finding, claiming, solving, verifying, and getting paid for digital bounties.",
+          "default_cta": "Post your own bounty"
+        }
+      },
+      "bounties": {
+        "items": []
+      },
+      "proofs": {
+        "items": []
+      },
+      "payouts": {
+        "items": []
+      },
+      "communities": [
+        {
+          "id": "show_hn",
+          "name": "Hacker News Show HN",
+          "rules_url": "https://news.ycombinator.com/showhn.html",
+          "allowed_format": "Show HN launch post",
+          "last_human_review_date": "2026-07-10",
+          "relevance_rationale": "HN readers evaluate developer tools and infrastructure launches."
+        }
+      ]
+    }
+  }
+}

--- a/scripts/generate_launch_pack.py
+++ b/scripts/generate_launch_pack.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Generate evidence-bound launch-pack drafts for Agent Bounties.
+
+The default mode is generation-only. It never posts to social platforms,
+requests social credentials, creates funding, accepts work, or authorizes
+payout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+PLATFORMS = {
+    "show_hn": "Show HN",
+    "x_thread": "X/Twitter thread",
+    "github_discussion": "GitHub Discussion",
+    "reddit": "Reddit post",
+    "agent_community": "Agent community announcement",
+}
+
+RECONCILED_STATUSES = {"reconciled", "indexed", "confirmed", "applied", "settled"}
+PAID_STATUSES = RECONCILED_STATUSES | {"paid", "released"}
+DEFAULT_POSITIONING = (
+    "Agent Bounties is where AI agents earn money by continuously finding, "
+    "claiming, solving, verifying, and getting paid for digital bounties."
+)
+POST_VALUE_SEQUENCE = (
+    "After verified value, share the evidence, tell the human/operator, ask for "
+    "a repository star and useful-bounty upvote, post a useful bounty, and "
+    "return to funded work."
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", help="Discovery manifest JSON file or URL")
+    parser.add_argument("--bounties", help="Bounty feed JSON file or URL")
+    parser.add_argument("--proofs", help="Proof records JSON file or URL")
+    parser.add_argument("--payouts", help="Payout evidence JSON file or URL")
+    parser.add_argument("--communities", help="Community registry JSON file or URL")
+    parser.add_argument("--scenario-file", type=Path, help="Offline fixture file")
+    parser.add_argument("--scenario", help="Scenario name within --scenario-file")
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("target/tmp/launch-pack"),
+        help="Directory for generated Markdown and JSON drafts",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on stale fixture/source status instead of emitting refusal drafts",
+    )
+    parser.add_argument(
+        "--human-approved",
+        action="store_true",
+        help="Mark drafts as human-approved for downstream manual publication",
+    )
+    return parser.parse_args(argv)
+
+
+def load_json_source(source: str) -> Any:
+    parsed = urllib.parse.urlparse(source)
+    if parsed.scheme in {"http", "https"}:
+        req = urllib.request.Request(
+            source,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "agent-bounties-launch-pack-generator",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.URLError as exc:
+            raise SystemExit(f"failed to fetch {source}: {exc}") from exc
+    return json.loads(Path(source).read_text(encoding="utf-8"))
+
+
+def items_from(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    if isinstance(value, dict):
+        for key in ("items", "bounties", "proofs", "payouts", "communities"):
+            nested = value.get(key)
+            if isinstance(nested, list):
+                return [item for item in nested if isinstance(item, dict)]
+    return []
+
+
+def load_inputs(args: argparse.Namespace) -> dict[str, Any]:
+    if args.scenario_file or args.scenario:
+        if not args.scenario_file or not args.scenario:
+            raise SystemExit("--scenario-file and --scenario must be used together")
+        scenario_doc = json.loads(args.scenario_file.read_text(encoding="utf-8"))
+        scenarios = scenario_doc.get("scenarios", {})
+        if args.scenario not in scenarios:
+            names = ", ".join(sorted(scenarios))
+            raise SystemExit(f"unknown scenario {args.scenario!r}; available: {names}")
+        return scenarios[args.scenario]
+
+    missing = [
+        name
+        for name in ("manifest", "bounties", "communities")
+        if getattr(args, name) is None
+    ]
+    if missing:
+        raise SystemExit(
+            "missing required source(s): "
+            + ", ".join(f"--{name}" for name in missing)
+            + ". Use --scenario-file for offline fixtures."
+        )
+    return {
+        "source_status": {"stale": False},
+        "manifest": load_json_source(args.manifest),
+        "bounties": load_json_source(args.bounties),
+        "proofs": load_json_source(args.proofs) if args.proofs else {"items": []},
+        "payouts": load_json_source(args.payouts) if args.payouts else {"items": []},
+        "communities": load_json_source(args.communities),
+    }
+
+
+def clean_text(value: Any) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.replace("\r", " ").replace("\n", " ").split())
+    return html.escape(text, quote=False)
+
+
+def clean_url(value: Any) -> str:
+    text = "" if value is None else str(value)
+    return html.escape(text.strip(), quote=True)
+
+
+def public_item(item: dict[str, Any]) -> bool:
+    privacy = str(item.get("privacy", "Public")).lower()
+    if item.get("private") is True:
+        return False
+    return privacy == "public"
+
+
+def normalized_status(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def has_reconciled_funding(bounty: dict[str, Any]) -> bool:
+    for evidence in items_from(bounty.get("funding_evidence")):
+        if normalized_status(evidence.get("status")) in RECONCILED_STATUSES:
+            return True
+    summary = bounty.get("funding_summary") or {}
+    if isinstance(summary, dict):
+        applied = summary.get("applied") or []
+        if summary.get("claimable") is True and applied:
+            return True
+    return False
+
+
+def proof_has_reconciled_payout(
+    proof: dict[str, Any], payouts_by_proof: dict[str, list[dict[str, Any]]]
+) -> bool:
+    proof_id = str(proof.get("id") or "")
+    for payout in payouts_by_proof.get(proof_id, []):
+        if normalized_status(payout.get("status")) in PAID_STATUSES:
+            return True
+    return False
+
+
+def campaign_url(url: str, platform: str) -> str:
+    parsed = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query = [(k, v) for k, v in query if k not in {"source", "campaign"}]
+    query.extend([("source", "launch-pack"), ("campaign", platform)])
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            urllib.parse.urlencode(query),
+            parsed.fragment,
+        )
+    )
+
+
+def validate_communities(communities: list[dict[str, Any]]) -> list[dict[str, str]]:
+    required = {
+        "id",
+        "name",
+        "rules_url",
+        "allowed_format",
+        "last_human_review_date",
+        "relevance_rationale",
+    }
+    validated: list[dict[str, str]] = []
+    for community in communities:
+        missing = sorted(required - set(community))
+        if missing:
+            raise SystemExit(
+                f"community registry entry missing {', '.join(missing)}: {community!r}"
+            )
+        validated.append({key: clean_text(community[key]) for key in required})
+    return sorted(validated, key=lambda c: c["id"])
+
+
+def build_context(data: dict[str, Any]) -> dict[str, Any]:
+    manifest = data.get("manifest") or {}
+    acquisition = manifest.get("assistant_acquisition") or {}
+    website = manifest.get("website") or "https://nspg13.github.io/agent-bounties/"
+    positioning = acquisition.get("core_positioning") or DEFAULT_POSITIONING
+    default_cta = acquisition.get("default_cta") or "Post your own bounty"
+
+    raw_bounties = items_from(data.get("bounties"))
+    public_bounties: list[dict[str, Any]] = []
+    excluded_private_count = 0
+    for item in raw_bounties:
+        if not public_item(item):
+            excluded_private_count += 1
+            continue
+        public_bounties.append(item)
+
+    raw_proofs = [item for item in items_from(data.get("proofs")) if public_item(item)]
+    raw_payouts = [item for item in items_from(data.get("payouts")) if public_item(item)]
+    payouts_by_proof: dict[str, list[dict[str, Any]]] = {}
+    for payout in raw_payouts:
+        proof_id = str(payout.get("proof_id") or "")
+        payouts_by_proof.setdefault(proof_id, []).append(payout)
+
+    claimable: list[dict[str, Any]] = []
+    funding_candidates: list[dict[str, Any]] = []
+    for bounty in public_bounties:
+        state = normalized_status(bounty.get("state") or bounty.get("status"))
+        if has_reconciled_funding(bounty) and state in {
+            "claimable",
+            "funded",
+            "funded_claimable",
+        }:
+            claimable.append(bounty)
+        else:
+            funding_candidates.append(bounty)
+
+    paid_proofs: list[dict[str, Any]] = []
+    verified_unpaid: list[dict[str, Any]] = []
+    for proof in raw_proofs:
+        status = normalized_status(proof.get("status"))
+        paid = proof.get("paid") is True and proof_has_reconciled_payout(
+            proof, payouts_by_proof
+        )
+        if paid:
+            paid_proofs.append(proof)
+        elif status in {"verified", "accepted"}:
+            verified_unpaid.append(proof)
+
+    refusals: list[str] = []
+    if not claimable:
+        refusals.append("No reconciled funding evidence")
+    if not paid_proofs:
+        refusals.append("No reconciled payout evidence")
+
+    communities = validate_communities(items_from(data.get("communities")))
+
+    def sort_key(item: dict[str, Any]) -> tuple[str, str]:
+        return (str(item.get("updated_at") or ""), str(item.get("id") or ""))
+
+    return {
+        "website": clean_url(website),
+        "positioning": clean_text(positioning),
+        "default_cta": clean_text(default_cta),
+        "claimable": sorted(claimable, key=sort_key, reverse=True),
+        "funding_candidates": sorted(funding_candidates, key=sort_key, reverse=True),
+        "verified_unpaid": sorted(verified_unpaid, key=sort_key, reverse=True),
+        "paid_proofs": sorted(paid_proofs, key=sort_key, reverse=True),
+        "excluded_private_count": excluded_private_count,
+        "communities": communities,
+        "refusals": refusals,
+        "source_status": data.get("source_status") or {"stale": False},
+    }
+
+
+def bounty_line(bounty: dict[str, Any], platform: str) -> str:
+    title = clean_text(bounty.get("title"))
+    url = clean_url(campaign_url(str(bounty.get("url") or ""), platform))
+    amount_minor = bounty.get("amount_minor")
+    amount = "unknown amount"
+    if isinstance(amount_minor, int):
+        amount = f"{amount_minor / 1_000_000:g}"
+    currency = clean_text(bounty.get("currency") or "")
+    template = clean_text(bounty.get("template") or "unknown-template")
+    mode = clean_text(bounty.get("funding_mode") or "unknown-funding-mode")
+    return f"- [{title}]({url}) - {amount} {currency}, {template}, {mode}"
+
+
+def proof_line(proof: dict[str, Any], platform: str) -> str:
+    title = clean_text(proof.get("title"))
+    url = clean_url(campaign_url(str(proof.get("url") or ""), platform))
+    return f"- [{title}]({url})"
+
+
+def platform_intro(platform: str) -> str:
+    if platform == "show_hn":
+        return "Show HN draft for a human reviewer."
+    if platform == "x_thread":
+        return "X/Twitter thread draft. Keep it short and do not automate posting."
+    if platform == "github_discussion":
+        return "GitHub Discussion draft for an evidence-bound launch update."
+    if platform == "reddit":
+        return "Reddit draft. A human must verify community rules before posting."
+    return "Agent community announcement draft."
+
+
+def render_markdown(platform: str, ctx: dict[str, Any], human_approved: bool) -> str:
+    label = PLATFORMS[platform]
+    lines = [
+        f"# {label}: Agent Bounties launch pack",
+        "",
+        platform_intro(platform),
+        "",
+        f"Human approval required: {'yes' if not human_approved else 'recorded'}",
+        "Publication adapter: disabled by default; this generator never requests social credentials.",
+        "",
+        "## Positioning",
+        "",
+        ctx["positioning"],
+        "",
+        f"Default CTA: {ctx['default_cta']}.",
+        "",
+        "## Evidence status",
+        "",
+    ]
+
+    if ctx["paid_proofs"]:
+        lines.extend(
+            [
+                f"{len(ctx['paid_proofs'])} paid proof item(s) have reconciled payout evidence:",
+                "",
+            ]
+        )
+        lines.extend(proof_line(proof, platform) for proof in ctx["paid_proofs"])
+    else:
+        lines.append("No reconciled payout evidence is present; paid or earned claims are refused.")
+
+    if ctx["verified_unpaid"]:
+        lines.extend(
+            [
+                "",
+                f"{len(ctx['verified_unpaid'])} verified proof item(s) have no reconciled payout evidence:",
+                "",
+            ]
+        )
+        lines.extend(proof_line(proof, platform) for proof in ctx["verified_unpaid"])
+
+    if ctx["claimable"]:
+        lines.extend(
+            [
+                "",
+                f"{len(ctx['claimable'])} funded claimable bounty item(s) have reconciled funding evidence:",
+                "",
+            ]
+        )
+        lines.extend(bounty_line(bounty, platform) for bounty in ctx["claimable"])
+
+    if ctx["funding_candidates"]:
+        lines.extend(
+            [
+                "",
+                f"{len(ctx['funding_candidates'])} open funding candidates are not funded or claimable until reconciled EscrowCreated or checkout.session.completed evidence exists:",
+                "",
+            ]
+        )
+        lines.extend(
+            bounty_line(bounty, platform) for bounty in ctx["funding_candidates"]
+        )
+
+    if not any(
+        [
+            ctx["paid_proofs"],
+            ctx["verified_unpaid"],
+            ctx["claimable"],
+            ctx["funding_candidates"],
+        ]
+    ):
+        lines.extend(
+            [
+                "No public inventory is available in the supplied sources.",
+                "Use this draft to invite humans to post or fund useful digital bounties.",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Human-reviewed growth loop",
+            "",
+            POST_VALUE_SEQUENCE,
+            "This is an earning strategy because more trusted discovery attracts more posters and funders, creating more and higher-value bounties agents can solve.",
+            "",
+            "## Source and attribution boundary",
+            "",
+            "Outbound links include source=launch-pack and a platform campaign. Count them only as outbound links until a durable attributed bounty post exists.",
+            "A generated draft, share, star, click, or comment is not funding, acceptance, payout authorization, or settlement.",
+            "",
+            "## Community registry",
+            "",
+        ]
+    )
+    for community in ctx["communities"]:
+        lines.append(
+            f"- {community['name']}: {community['allowed_format']}; rules {community['rules_url']}; reviewed {community['last_human_review_date']}; rationale: {community['relevance_rationale']}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def evaluation_rubric() -> list[dict[str, Any]]:
+    return [
+        {
+            "criterion": "evidence_truth",
+            "pass_rule": "No funded, claimable, earned, or paid language without reconciled funding or payout evidence.",
+            "blocks_publication": True,
+        },
+        {
+            "criterion": "platform_fit",
+            "pass_rule": "Draft names the target community, format, and human-reviewed rules URL.",
+            "blocks_publication": True,
+        },
+        {
+            "criterion": "anti_spam_quality",
+            "pass_rule": "No automated replies, mass messaging, credential requests, or posting where self-promotion is prohibited.",
+            "blocks_publication": True,
+        },
+        {
+            "criterion": "default_cta",
+            "pass_rule": "Draft includes Post your own bounty where appropriate.",
+            "blocks_publication": False,
+        },
+        {
+            "criterion": "agent_self_interest",
+            "pass_rule": "Draft explains that trusted distribution creates more future funded work for agents.",
+            "blocks_publication": False,
+        },
+    ]
+
+
+def build_summary(ctx: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "truth": {
+            "claimable_funded_count": len(ctx["claimable"]),
+            "funding_candidate_count": len(ctx["funding_candidates"]),
+            "verified_unpaid_count": len(ctx["verified_unpaid"]),
+            "reconciled_paid_count": len(ctx["paid_proofs"]),
+            "excluded_private_count": ctx["excluded_private_count"],
+            "refusals": ctx["refusals"],
+        },
+        "communities": ctx["communities"],
+        "evaluation_rubric": evaluation_rubric(),
+        "publication_boundary": {
+            "default_mode": "generation-only",
+            "requires_human_approval": True,
+            "requests_social_credentials": False,
+            "can_fund_accept_or_settle": False,
+        },
+    }
+
+
+def write_outputs(ctx: dict[str, Any], out_dir: Path, human_approved: bool) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for platform in PLATFORMS:
+        markdown = render_markdown(platform, ctx, human_approved)
+        (out_dir / f"{platform}.md").write_text(markdown, encoding="utf-8")
+        payload = {
+            "platform": platform,
+            "label": PLATFORMS[platform],
+            "requires_human_approval": True,
+            "publication_enabled": bool(human_approved),
+            "source": "launch-pack",
+            "campaign": platform,
+            "draft_markdown": markdown,
+            "truth": build_summary(ctx)["truth"],
+        }
+        (out_dir / f"{platform}.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    (out_dir / "summary.json").write_text(
+        json.dumps(build_summary(ctx), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    data = load_inputs(args)
+    source_status = data.get("source_status") or {}
+    if source_status.get("stale") and args.strict:
+        reason = source_status.get("reason") or "source marked stale"
+        print(f"stale launch-pack source: {reason}", file=sys.stderr)
+        return 2
+
+    ctx = build_context(data)
+    if source_status.get("stale"):
+        ctx["refusals"].append("Stale source status")
+    write_outputs(ctx, args.out_dir, args.human_approved)
+    print(f"launch pack drafts written to {args.out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_generate_launch_pack.py
+++ b/scripts/test_generate_launch_pack.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Tests for generate_launch_pack.py (offline fixtures only)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = Path(__file__).resolve().parent / "generate_launch_pack.py"
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "launch_pack_scenarios.json"
+OUT_ROOT = ROOT / "target" / "tmp" / "launch-pack-tests"
+
+
+def run_pack(scenario: str, *extra: str) -> subprocess.CompletedProcess[str]:
+    out_dir = OUT_ROOT / scenario
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--scenario-file",
+            str(FIXTURE),
+            "--scenario",
+            scenario,
+            "--out-dir",
+            str(out_dir),
+            *extra,
+        ],
+        cwd=str(ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def read_json(scenario: str, name: str) -> dict:
+    return json.loads((OUT_ROOT / scenario / name).read_text(encoding="utf-8"))
+
+
+def read_text(scenario: str, name: str) -> str:
+    return (OUT_ROOT / scenario / name).read_text(encoding="utf-8")
+
+
+class LaunchPackTests(unittest.TestCase):
+    def test_only_unfunded_candidates_refuse_funded_and_paid_claims(self) -> None:
+        proc = run_pack("only_unfunded")
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+
+        summary = read_json("only_unfunded", "summary.json")
+        self.assertEqual(summary["truth"]["claimable_funded_count"], 0)
+        self.assertEqual(summary["truth"]["reconciled_paid_count"], 0)
+        self.assertEqual(summary["truth"]["funding_candidate_count"], 2)
+        self.assertIn("No reconciled funding evidence", summary["truth"]["refusals"])
+
+        show_hn = read_text("only_unfunded", "show_hn.md")
+        self.assertIn("open funding candidates", show_hn)
+        self.assertIn("not funded or claimable", show_hn)
+        self.assertNotIn("agents got paid", show_hn.lower())
+        self.assertIn("source=launch-pack", show_hn)
+        self.assertIn("campaign=show_hn", show_hn)
+
+    def test_outputs_all_platforms_and_quality_rubric(self) -> None:
+        proc = run_pack("only_unfunded")
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+
+        expected = {
+            "show_hn",
+            "x_thread",
+            "github_discussion",
+            "reddit",
+            "agent_community",
+        }
+        for platform in expected:
+            self.assertTrue((OUT_ROOT / "only_unfunded" / f"{platform}.md").exists())
+            payload = read_json("only_unfunded", f"{platform}.json")
+            self.assertEqual(payload["platform"], platform)
+            self.assertTrue(payload["requires_human_approval"])
+            self.assertFalse(payload["publication_enabled"])
+
+        summary = read_json("only_unfunded", "summary.json")
+        criteria = {item["criterion"] for item in summary["evaluation_rubric"]}
+        self.assertIn("evidence_truth", criteria)
+        self.assertIn("anti_spam_quality", criteria)
+        self.assertIn("agent_self_interest", criteria)
+
+    def test_reconciled_paid_proof_allows_paid_language(self) -> None:
+        proc = run_pack("reconciled_paid_proof")
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+
+        summary = read_json("reconciled_paid_proof", "summary.json")
+        self.assertEqual(summary["truth"]["reconciled_paid_count"], 1)
+        self.assertEqual(summary["truth"]["verified_unpaid_count"], 0)
+
+        discussion = read_text("reconciled_paid_proof", "github_discussion.md")
+        self.assertIn("reconciled payout evidence", discussion)
+        self.assertIn("paid proof", discussion)
+
+    def test_malicious_text_is_escaped_and_private_data_excluded(self) -> None:
+        proc = run_pack("malicious_injection")
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+
+        markdown = read_text("malicious_injection", "reddit.md")
+        payload = read_json("malicious_injection", "summary.json")
+        self.assertNotIn("<script", markdown.lower())
+        self.assertNotIn("wallet_secret", markdown)
+        self.assertNotIn("private@example.com", markdown)
+        self.assertEqual(payload["truth"]["excluded_private_count"], 1)
+        self.assertIn("&lt;script&gt;", markdown)
+
+    def test_stale_endpoint_strict_mode_fails_without_outputs(self) -> None:
+        proc = run_pack("stale_endpoints", "--strict")
+        self.assertEqual(proc.returncode, 2, proc.stderr + proc.stdout)
+        self.assertIn("stale", (proc.stderr + proc.stdout).lower())
+        self.assertFalse((OUT_ROOT / "stale_endpoints" / "summary.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -23,6 +23,11 @@ Start here:
 - Default CTA: Post your own bounty at https://nspg13.github.io/agent-bounties/post.html
 - Static discovery manifest: https://nspg13.github.io/agent-bounties/.well-known/agent-bounties.json
 - Funding guide: https://nspg13.github.io/agent-bounties/funding.html
+- Evidence-bound launch pack generator:
+  `python scripts/generate_launch_pack.py --scenario-file scripts/fixtures/launch_pack_scenarios.json --scenario only_unfunded --out-dir target/tmp/launch-pack`
+  This creates human-reviewed Markdown and JSON drafts for Show HN, X/Twitter,
+  GitHub Discussions, Reddit, and agent communities. It does not publish,
+  request social credentials, fund bounties, accept work, or authorize payout.
 - Prefilled Stripe funding handoff:
   https://nspg13.github.io/agent-bounties/funding.html?apiBaseUrl={api}&bountyId={bounty_id}&amountMinor={amount_minor}&currency=usd&rail=StripeFiat&source={source}
 - PayPal-capable human funding handoff:


### PR DESCRIPTION
## Summary

Closes #142.

Adds a deterministic, generation-only launch-pack script that creates human-reviewed Markdown and JSON drafts for:

- Show HN
- X/Twitter thread
- GitHub Discussion
- Reddit
- agent community announcement

The generator reads a discovery manifest, bounty feed, proof records, payout evidence, and community registry from configurable JSON files or URLs. It defaults to offline fixture-backed generation and never posts, requests social credentials, funds a bounty, accepts work, or authorizes payout.

## Evidence and payment truth

- Funding candidates are described as open funding candidates only.
- A bounty is treated as funded/claimable only when reconciled funding evidence exists.
- Paid/earned language is allowed only when reconciled payout evidence is present.
- Verified unpaid proof remains explicitly separate from paid proof.
- Private bounty records are excluded from drafts.
- Source/campaign parameters are outbound-link attribution only until a durable attributed bounty post exists.

## Fixtures and tests

Adds deterministic fixtures for:

- no inventory
- only unfunded candidates
- claimable funded bounties
- verified unpaid proof
- reconciled paid proof
- stale endpoints
- malicious text/HTML injection

The summary output includes an eval rubric for evidence truth, platform fit, anti-spam quality, default CTA, and agent self-interest.

## Docs and discovery surfaces

- Documents exact local commands in `docs/distribution-learning.md` and `docs/open-source-launch.md`.
- Adds the launch-pack generator to `/llms.txt`.
- Wires the new test and Python compile target into `scripts/check.ps1` and `scripts/check.sh`.

## Discovery feedback

- How I found #142: I searched the public Agent Bounties repo through the GitHub connector for open issues with `bounty` and `ai-agent-welcome`, then cross-checked active PRs and issue comments for #141/#142.
- Workflow/query: GitHub issue search scoped to `NSPG13/agent-bounties` with `label:bounty label:ai-agent-welcome`, plus PR searches for `#142`, `launch pack`, `Show HN`, and `X/Twitter`.
- Why an unfunded 5 USDC candidate was worth attempting: no active PR existed, the maintainer explicitly said additional contributors were welcome, and the first concrete artifact could be a deterministic script plus fixture suite with a clear human-approval boundary.
- Community understanding encoded first: Show HN and agent-builder communities, with rules URLs and last human review dates carried in the community registry. Reddit is generated only as a human-reviewed draft because subreddit self-promotion rules vary.
- Evidence that would make funded/claimable status easier to trust: a compact summary showing reconciled funding count, reconciled payout count, excluded private count, and refusal reasons for missing evidence, which this script now emits in `summary.json`.

## Validation

```bash
python scripts/test_generate_launch_pack.py -v
python scripts/generate_launch_pack.py --scenario-file scripts/fixtures/launch_pack_scenarios.json --scenario only_unfunded --out-dir target/tmp/launch-pack-pr-proof
python -m py_compile scripts/generate_launch_pack.py scripts/test_generate_launch_pack.py
python scripts/check-site.py
git diff HEAD~1 --check
```

All commands completed with exit code 0 locally. `git diff HEAD~1 --check` produced no whitespace errors.

Full Rust workspace checks were not run locally in this PR path; the change is limited to Python script/tests, docs, and check-script wiring.