### PR TITLE
Add funded bounty terms acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ as funded, claimable, or paid. See `docs/openclaw-distribution.md`.
 
 1. A blocked agent calls the bounty router.
 2. The router recommends a template, quote, verifier, or bounty.
-3. A paid bounty is funded before it becomes claimable.
-4. Deterministic risk policy checks keep high-risk work out of automatic flows.
-5. A solver agent claims and submits work.
-6. Claim ownership and submission policy are checked before verification.
-7. A verifier or operator accepts the submission.
-8. Base payouts stay pending until an indexed escrow release event is reconciled.
-9. Proof, settlement, reputation, and reusable template signals are created.
-10. After verified value, the agent grows its future earning supply: it shares
+3. The default paid path is funded on creation; explicitly crowdfunded bounties
+   can be posted unfunded until real contributions arrive.
+4. A paid bounty is funded before it becomes claimable.
+5. Deterministic risk policy checks keep high-risk work out of automatic flows.
+6. A solver agent signs the bounty terms with its payout wallet, then claims and
+   submits work.
+7. Claim ownership and submission policy are checked before verification.
+8. A deterministic verifier or operator accepts the submission.
+9. Base payouts stay pending until an indexed escrow release event is reconciled.
+10. Proof, settlement, reputation, and reusable template signals are created.
+11. After verified value, the agent grows its future earning supply: it shares
     the evidence, tells its human or operator, asks for a repo star and bounty
     upvote, invites a useful new bounty, and returns to funded work.
 
@@ -307,6 +310,7 @@ Useful REST paths:
 - `POST /v1/base/transaction-receipt`
 - `POST /v1/base/log-query`
 - `POST /v1/base/funding-plan`
+- `POST /v1/base/terms-acceptance-plan`
 - `POST /v1/base/release-queue`
 - `POST /v1/base/release-plan`
 - `POST /v1/base/refund-plan`
@@ -413,7 +417,7 @@ The MCP server exposes matching local tools on port `8090`, including
 `reconcile_base_evm_logs`, `plan_base_log_query`, `reconcile_base_rpc_logs`,
 `fetch_base_rpc_logs`, `broadcast_base_signed_transaction`,
 `get_base_transaction_receipt`, `plan_base_funding`, `plan_base_release`,
-`list_base_release_queue`, `plan_base_refund`, `plan_base_dispute`,
+`plan_base_terms_acceptance`, `list_base_release_queue`, `plan_base_refund`, `plan_base_dispute`,
 `plan_stripe_checkout_top_up`, `plan_stripe_connect_account`,
 `plan_stripe_connect_transfer`, `execute_stripe_checkout_top_up`,
 `execute_stripe_connect_account`, `execute_stripe_connect_transfer`,

--- a/contracts/base-escrow/src/AgentBountyEscrow.sol
+++ b/contracts/base-escrow/src/AgentBountyEscrow.sol
@@ -83,7 +83,7 @@ contract AgentBountyEscrow {
         emit EscrowCreated(escrowId, bountyId, msg.sender, token, amount, termsHash);
     }
 
-    function release(uint256 escrowId, address[] calldata recipients, uint256[] calldata amounts, bytes32 proofHash) external onlySettlementSigner {
+    function release(uint256 escrowId, address[] calldata recipients, uint256[] calldata amounts, bytes32 proofHash) public virtual onlySettlementSigner {
         Escrow storage escrow = escrows[escrowId];
         require(escrow.status == EscrowStatus.Funded || escrow.status == EscrowStatus.Disputed, "not releasable");
         require(recipients.length == amounts.length && recipients.length > 0, "bad split");
@@ -119,4 +119,3 @@ contract AgentBountyEscrow {
         emit EscrowDisputed(escrowId, disputeHash);
     }
 }
-

--- a/contracts/base-escrow/src/AgentBountyEscrowV2.sol
+++ b/contracts/base-escrow/src/AgentBountyEscrowV2.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./AgentBountyEscrow.sol";
+
+contract AgentBountyEscrowV2 is AgentBountyEscrow {
+    struct TermsAcceptance {
+        bool accepted;
+        bytes32 termsHash;
+        address payoutWallet;
+    }
+
+    mapping(uint256 => mapping(address => TermsAcceptance)) public termsAcceptances;
+
+    event TermsAccepted(
+        uint256 indexed escrowId,
+        address indexed participant,
+        address indexed payoutWallet,
+        bytes32 termsHash
+    );
+
+    constructor(address settlementSigner_) AgentBountyEscrow(settlementSigner_) {}
+
+    function acceptTerms(uint256 escrowId, bytes32 termsHash, address payoutWallet) external {
+        Escrow storage escrow = escrows[escrowId];
+        require(
+            escrow.status == EscrowStatus.Funded || escrow.status == EscrowStatus.Disputed,
+            "not active"
+        );
+        require(escrow.termsHash == termsHash, "terms mismatch");
+        require(payoutWallet != address(0), "payout wallet zero");
+        require(payoutWallet == msg.sender, "wallet must sign");
+
+        termsAcceptances[escrowId][msg.sender] = TermsAcceptance({
+            accepted: true,
+            termsHash: termsHash,
+            payoutWallet: payoutWallet
+        });
+
+        emit TermsAccepted(escrowId, msg.sender, payoutWallet, termsHash);
+    }
+
+    function hasAcceptedTerms(
+        uint256 escrowId,
+        address participant,
+        bytes32 termsHash
+    ) public view returns (bool) {
+        TermsAcceptance storage acceptance = termsAcceptances[escrowId][participant];
+        return acceptance.accepted && acceptance.termsHash == termsHash;
+    }
+
+    function release(
+        uint256 escrowId,
+        address[] calldata recipients,
+        uint256[] calldata amounts,
+        bytes32 proofHash
+    ) public override onlySettlementSigner {
+        Escrow storage escrow = escrows[escrowId];
+        require(escrow.status == EscrowStatus.Funded || escrow.status == EscrowStatus.Disputed, "not releasable");
+        require(recipients.length == amounts.length && recipients.length > 0, "bad split");
+
+        uint256 total;
+        for (uint256 i = 0; i < recipients.length; i++) {
+            require(recipients[i] != address(0), "recipient zero");
+            require(hasAcceptedTerms(escrowId, recipients[i], escrow.termsHash), "recipient not accepted");
+            total += amounts[i];
+        }
+        require(total == escrow.amount, "split mismatch");
+
+        escrow.status = EscrowStatus.Released;
+        for (uint256 i = 0; i < recipients.length; i++) {
+            require(IERC20(escrow.token).transfer(recipients[i], amounts[i]), "transfer failed");
+        }
+
+        emit EscrowReleased(escrowId, proofHash);
+    }
+}

--- a/contracts/base-escrow/test/AgentBountyEscrow.t.sol
+++ b/contracts/base-escrow/test/AgentBountyEscrow.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.26;
 
 import "../src/AgentBountyEscrow.sol";
+import "../src/AgentBountyEscrowV2.sol";
 
 contract TestToken {
     mapping(address => uint256) public balanceOf;
@@ -30,6 +31,12 @@ contract TestToken {
         balanceOf[msg.sender] -= amount;
         balanceOf[to] += amount;
         return true;
+    }
+}
+
+contract TermsSigner {
+    function accept(AgentBountyEscrowV2 escrow, uint256 escrowId, bytes32 termsHash) external {
+        escrow.acceptTerms(escrowId, termsHash, address(this));
     }
 }
 
@@ -142,5 +149,58 @@ contract AgentBountyEscrowTest {
         } catch Error(string memory reason) {
             require(keccak256(bytes(reason)) == keccak256(bytes("not settlement signer")), "wrong reason");
         }
+    }
+}
+
+contract AgentBountyEscrowV2Test {
+    AgentBountyEscrowV2 escrow;
+    TestToken token;
+    TermsSigner solver;
+    bytes32 termsHash = bytes32("terms");
+
+    function setUp() public {
+        escrow = new AgentBountyEscrowV2(address(this));
+        token = new TestToken();
+        solver = new TermsSigner();
+        token.mint(address(this), 1000);
+        token.approve(address(escrow), 1000);
+    }
+
+    function testRecipientMustAcceptTermsBeforeRelease() public {
+        uint256 escrowId = escrow.createEscrow(bytes32("bounty"), address(token), 1000, termsHash);
+        address[] memory recipients = new address[](1);
+        recipients[0] = address(solver);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1000;
+
+        try escrow.release(escrowId, recipients, amounts, bytes32("proof")) {
+            revert("expected recipient acceptance revert");
+        } catch Error(string memory reason) {
+            require(keccak256(bytes(reason)) == keccak256(bytes("recipient not accepted")), "wrong reason");
+        }
+    }
+
+    function testWrongTermsCannotBeAccepted() public {
+        uint256 escrowId = escrow.createEscrow(bytes32("bounty"), address(token), 1000, termsHash);
+
+        try solver.accept(escrow, escrowId, bytes32("other")) {
+            revert("expected terms mismatch");
+        } catch Error(string memory reason) {
+            require(keccak256(bytes(reason)) == keccak256(bytes("terms mismatch")), "wrong reason");
+        }
+    }
+
+    function testAcceptedRecipientCanBeReleased() public {
+        uint256 escrowId = escrow.createEscrow(bytes32("bounty"), address(token), 1000, termsHash);
+        solver.accept(escrow, escrowId, termsHash);
+
+        address[] memory recipients = new address[](1);
+        recipients[0] = address(solver);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1000;
+
+        escrow.release(escrowId, recipients, amounts, bytes32("proof"));
+
+        require(token.balanceOf(address(solver)) == 1000, "solver payout");
     }
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -3,17 +3,17 @@ use app::{
     hash_artifact, stripe_secret_key_mode_from_secret, AddFundingContributionRequest,
     ApproveRiskBountyRequest, ApproveRiskPayoutRequest, BaseEscrowReconciliation,
     BaseIndexerHeartbeatStatus, BaseIndexerScanCursor, BaseIndexerStatusConfig,
-    BaseIndexerStatusReport, BaseReleaseQueueRequest, BountyNetwork, BountyStatusResponse,
-    ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
-    FundingIntentReport, LiveMoneyReadinessConfig, LiveMoneyReadinessReport,
+    BaseIndexerStatusReport, BaseReleaseQueueRequest, BountyFundingPolicy, BountyNetwork,
+    BountyStatusResponse, ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest,
+    FundQuoteRequest, FundingIntentReport, LiveMoneyReadinessConfig, LiveMoneyReadinessReport,
     OpenPooledBountyRequest, PlanBaseDisputeRequest, PlanBaseFundingRequest, PlanBaseRefundRequest,
-    PlanBaseReleaseRequest, PlanStripeTransferRequest as AppPlanStripeTransferRequest,
-    PooledFundingReport, PostBountyRequest, QuoteSet, RecordAudienceInteractionRequest,
-    RecordDiscoveryResponseRequest, RecordOutreachAttemptRequest, RegisterAgentRequest,
-    RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
-    ReviewedBountyApproval, RiskEventFilter, StripeTransferPlan, StripeTransferReconciliation,
-    SubmitResultRequest, UpsertAudienceMemberRequest, UpsertContributorContactRequest,
-    VerifySubmissionRequest,
+    PlanBaseReleaseRequest, PlanBaseTermsAcceptanceRequest,
+    PlanStripeTransferRequest as AppPlanStripeTransferRequest, PooledFundingReport,
+    PostBountyRequest, QuoteSet, RecordAudienceInteractionRequest, RecordDiscoveryResponseRequest,
+    RecordOutreachAttemptRequest, RegisterAgentRequest, RegisterCapabilityRequest,
+    RejectRiskEventRequest, RequestQuotesRequest, ReviewedBountyApproval, RiskEventFilter,
+    StripeTransferPlan, StripeTransferReconciliation, SubmitResultRequest,
+    UpsertAudienceMemberRequest, UpsertContributorContactRequest, VerifySubmissionRequest,
 };
 use axum::{
     body::Bytes,
@@ -120,6 +120,7 @@ use worker::BaseEscrowLogWorker;
         get_base_transaction_receipt,
         plan_base_funding,
         list_base_release_queue,
+        plan_base_terms_acceptance,
         plan_stripe_checkout_top_up,
         plan_stripe_connect_account,
         plan_stripe_connect_transfer,
@@ -607,6 +608,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/v1/base/log-query", post(plan_base_log_query))
         .route("/v1/base/funding-plan", post(plan_base_funding))
         .route("/v1/base/release-queue", post(list_base_release_queue))
+        .route(
+            "/v1/base/terms-acceptance-plan",
+            post(plan_base_terms_acceptance),
+        )
         .route("/v1/base/release-plan", post(plan_base_release))
         .route("/v1/base/refund-plan", post(plan_base_refund))
         .route("/v1/base/dispute-plan", post(plan_base_dispute))
@@ -2364,6 +2369,18 @@ async fn plan_base_funding(
         .map_err(|_| StatusCode::BAD_REQUEST)
 }
 
+#[utoipa::path(post, path = "/v1/base/terms-acceptance-plan", responses((status = 200, description = "Unsigned Base escrow v2 terms acceptance transaction plan")))]
+async fn plan_base_terms_acceptance(
+    State(state): State<SharedState>,
+    Json(request): Json<PlanBaseTermsAcceptanceRequest>,
+) -> Result<Json<app::BaseTermsAcceptancePlan>, StatusCode> {
+    let network = state.network.lock().expect("state poisoned");
+    network
+        .plan_base_terms_acceptance(request)
+        .map(Json)
+        .map_err(|_| StatusCode::BAD_REQUEST)
+}
+
 #[utoipa::path(post, path = "/v1/base/release-plan", responses((status = 200, description = "Unsigned Base escrow release transaction plan")))]
 async fn plan_base_release(
     State(state): State<SharedState>,
@@ -2919,6 +2936,9 @@ async fn sync_github_issue_api_bounty(
         currency: parsed.amount.currency,
         funding_mode: parsed.funding_mode,
         privacy: parsed.privacy,
+        funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+        verification_contract: None,
+        automatic_release: false,
         funding_targets: vec![],
     };
 
@@ -3994,9 +4014,10 @@ fn expected_digest_for_body(body: &str) -> String {
 mod tests {
     use super::*;
     use app::{
-        AddFundingContributionRequest, ClaimBountyRequest, CreateFundingIntentRequest,
-        OpenPooledBountyRequest, PostBountyRequest, RegisterAgentRequest,
-        RegisterCapabilityRequest, SubmitResultRequest, VerifySubmissionRequest,
+        AddFundingContributionRequest, BountyFundingPolicy, ClaimBountyRequest,
+        CreateFundingIntentRequest, OpenPooledBountyRequest, PostBountyRequest,
+        RegisterAgentRequest, RegisterCapabilityRequest, SubmitResultRequest,
+        VerifySubmissionRequest,
     };
     use chain_base::{
         evm_address_word, evm_bytes32_word, evm_event_topic, evm_uint256_word, evm_words_data,
@@ -4028,6 +4049,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         let state = test_state(network);
@@ -4241,6 +4265,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         network
@@ -4302,6 +4329,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         network
@@ -4628,6 +4658,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: domain::FundingMode::StripeFiatLedger,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             })
             .unwrap();
@@ -4786,6 +4819,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: domain::FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             }),
         )
@@ -4807,6 +4843,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: domain::FundingMode::Simulated,
                 privacy: PrivacyLevel::Private,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             }),
         )
@@ -5176,6 +5215,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         let other_bounty = api_network
@@ -5186,6 +5228,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         api_store.upsert_bounty(&bounty).await.unwrap();
@@ -6078,6 +6123,9 @@ mod tests {
             currency: "usdc".to_string(),
             funding_mode: FundingMode::BaseUsdcEscrow,
             privacy: PrivacyLevel::Public,
+            funding_policy: BountyFundingPolicy::FundOnCreation,
+            verification_contract: None,
+            automatic_release: false,
         });
         assert!(matches!(result, Err(app::AppError::RiskNeedsReview(_))));
         let state = test_state(network);
@@ -6109,6 +6157,9 @@ mod tests {
             currency: "usdc".to_string(),
             funding_mode: FundingMode::BaseUsdcEscrow,
             privacy: PrivacyLevel::Public,
+            funding_policy: BountyFundingPolicy::FundOnCreation,
+            verification_contract: None,
+            automatic_release: false,
         });
         assert!(matches!(result, Err(app::AppError::RiskNeedsReview(_))));
         let risk_event_id = network
@@ -6179,6 +6230,9 @@ mod tests {
             currency: "usdc".to_string(),
             funding_mode: FundingMode::BaseUsdcEscrow,
             privacy: PrivacyLevel::Public,
+            funding_policy: BountyFundingPolicy::FundOnCreation,
+            verification_contract: None,
+            automatic_release: false,
         });
         assert!(matches!(result, Err(app::AppError::RiskNeedsReview(_))));
         let bounty_event_id = network
@@ -6274,6 +6328,9 @@ mod tests {
             currency: "usdc".to_string(),
             funding_mode: FundingMode::BaseUsdcEscrow,
             privacy: PrivacyLevel::Public,
+            funding_policy: BountyFundingPolicy::FundOnCreation,
+            verification_contract: None,
+            automatic_release: false,
         });
         assert!(matches!(result, Err(app::AppError::RiskNeedsReview(_))));
         let risk_event_id = network
@@ -6332,6 +6389,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         apply_base_funding_event(&mut network, &public, 1);
@@ -6343,6 +6403,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::StripeFiatLedger,
                 privacy: PrivacyLevel::Private,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         let state = test_state(network);
@@ -6376,6 +6439,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             }),
         )
@@ -6409,6 +6475,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::MixedRails,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![
                     app::FundingPartitionTargetRequest {
                         rail: PaymentRail::StripeFiat,
@@ -6437,6 +6506,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Private,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             }),
         )
@@ -6454,6 +6526,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             }),
         )
@@ -6517,6 +6592,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         apply_base_funding_event(&mut network, &bounty, 1);
@@ -6555,6 +6633,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             }),
         )
@@ -6609,6 +6690,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::StripeFiatLedger,
                 privacy: PrivacyLevel::Private,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         let state = test_state(network);
@@ -6686,6 +6770,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         let other_bounty = network
@@ -6696,6 +6783,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         let state = test_state(network);
@@ -6963,6 +7053,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             }),
         )
@@ -7035,6 +7128,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::MixedRails,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![
                     app::FundingPartitionTargetRequest {
                         rail: PaymentRail::StripeFiat,
@@ -7402,6 +7498,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         apply_base_funding_event(&mut network, &bounty, 7);

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,8 +1,9 @@
 use bounty_router::{template_for_class, BountyRouter};
 use chain_base::{
     base_network_descriptor, BaseEscrowCreate, BaseEscrowEvent, BaseEscrowEventKind,
-    BaseEscrowFundingPlan, BaseEscrowRelease, BaseEscrowReleaseCall, BaseEscrowTxPlanner,
-    BaseNetworkDescriptor, ChainBaseError, EscrowRecipient, EvmTransactionIntent,
+    BaseEscrowFundingPlan, BaseEscrowRelease, BaseEscrowReleaseCall, BaseEscrowTermsAcceptance,
+    BaseEscrowTxPlanner, BaseNetworkDescriptor, ChainBaseError, EscrowRecipient,
+    EvmTransactionIntent,
 };
 use chrono::{DateTime, Utc};
 use domain::{
@@ -74,6 +75,8 @@ pub enum AppError {
     InvalidFundingContribution(String),
     #[error("invalid funding intent: {0}")]
     InvalidFundingIntent(String),
+    #[error("invalid bounty terms: {0}")]
+    InvalidBountyTerms(String),
     #[error("invalid Stripe payout reconciliation: {0}")]
     InvalidStripePayout(String),
     #[error("invalid contributor contact: {0}")]
@@ -873,6 +876,27 @@ pub struct RecordOutreachAttemptRequest {
     pub sent_at: Option<DateTime<Utc>>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BountyFundingPolicy {
+    #[default]
+    FundOnCreation,
+    CrowdfundUntilFunded,
+}
+
+fn default_crowdfunding_policy() -> BountyFundingPolicy {
+    BountyFundingPolicy::CrowdfundUntilFunded
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BountyVerificationContractRequest {
+    pub acceptance_criteria: String,
+    pub evidence_requirements: String,
+    #[serde(default)]
+    pub verifier_kind: Option<VerifierKind>,
+    #[serde(default)]
+    pub human_release_gate: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PostBountyRequest {
     pub title: String,
@@ -881,6 +905,12 @@ pub struct PostBountyRequest {
     pub currency: String,
     pub funding_mode: FundingMode,
     pub privacy: PrivacyLevel,
+    #[serde(default)]
+    pub funding_policy: BountyFundingPolicy,
+    #[serde(default)]
+    pub verification_contract: Option<BountyVerificationContractRequest>,
+    #[serde(default)]
+    pub automatic_release: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -895,6 +925,12 @@ pub struct OpenPooledBountyRequest {
     pub currency: String,
     pub funding_mode: FundingMode,
     pub privacy: PrivacyLevel,
+    #[serde(default = "default_crowdfunding_policy")]
+    pub funding_policy: BountyFundingPolicy,
+    #[serde(default)]
+    pub verification_contract: Option<BountyVerificationContractRequest>,
+    #[serde(default)]
+    pub automatic_release: bool,
     #[serde(default)]
     pub funding_targets: Vec<FundingPartitionTargetRequest>,
 }
@@ -1022,6 +1058,15 @@ pub struct PlanBaseReleaseRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanBaseTermsAcceptanceRequest {
+    pub bounty_id: Id,
+    pub escrow_contract: String,
+    pub solver_agent_id: Id,
+    #[serde(default)]
+    pub network: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanBaseRefundRequest {
     pub bounty_id: Id,
     pub escrow_contract: String,
@@ -1079,6 +1124,20 @@ pub struct BaseReleasePlan {
     pub escrow: Escrow,
     pub settlement: Settlement,
     pub release_call: BaseEscrowReleaseCall,
+    pub transaction: EvmTransactionIntent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseTermsAcceptancePlan {
+    pub network: BaseNetworkDescriptor,
+    pub bounty: Bounty,
+    pub escrow: Escrow,
+    pub onchain_escrow_id: u128,
+    pub terms_hash: String,
+    pub participant: String,
+    pub payout_wallet: String,
+    pub contract_function: String,
+    pub contract_requirement: String,
     pub transaction: EvmTransactionIntent,
 }
 
@@ -1975,6 +2034,9 @@ impl BountyNetwork {
             currency: quote.price.currency,
             funding_mode: request.funding_mode.unwrap_or(route.funding_mode),
             privacy: help_request.privacy,
+            funding_policy: BountyFundingPolicy::FundOnCreation,
+            verification_contract: None,
+            automatic_release: false,
         })?;
         bounty.help_request_id = Some(help_request.id);
         self.bounties.insert(bounty.id, bounty.clone());
@@ -1982,25 +2044,49 @@ impl BountyNetwork {
     }
 
     pub fn post_funded_bounty(&mut self, request: PostBountyRequest) -> AppResult<Bounty> {
-        let amount = Money::new(request.amount_minor, request.currency)?;
-        let funding_mode = request.funding_mode.clone();
+        let PostBountyRequest {
+            title,
+            template_slug,
+            amount_minor,
+            currency,
+            funding_mode,
+            privacy,
+            funding_policy,
+            verification_contract,
+            automatic_release,
+        } = request;
+        validate_bounty_posting_terms(
+            &template_slug,
+            automatic_release,
+            verification_contract.as_ref(),
+        )?;
+        let amount = Money::new(amount_minor, currency)?;
         let mut bounty = Bounty::new(
-            request.title,
-            request.template_slug,
+            title,
+            template_slug,
             amount.clone(),
             funding_mode.clone(),
-            request.privacy.clone(),
+            privacy.clone(),
         );
         let risk = self.risk_policy.evaluate_bounty(&BountyRiskInput {
             title: bounty.title.clone(),
             template_slug: bounty.template_slug.clone(),
             amount: amount.clone(),
             funding_mode: funding_mode.clone(),
-            privacy: request.privacy,
+            privacy,
         });
         self.enforce_risk(risk, bounty.id, None, Some(bounty.id))?;
-        let terms_hash = hash_terms(&bounty.title, &bounty.template_slug, &amount);
-        if funding_mode == FundingMode::BaseUsdcEscrow {
+        let terms_hash = hash_terms_with_policy(
+            &bounty.title,
+            &bounty.template_slug,
+            &amount,
+            &funding_policy,
+            verification_contract.as_ref(),
+            automatic_release,
+        );
+        if funding_policy == BountyFundingPolicy::CrowdfundUntilFunded
+            || funding_mode == FundingMode::BaseUsdcEscrow
+        {
             bounty.terms_hash = Some(terms_hash);
             self.bounties.insert(bounty.id, bounty.clone());
             return Ok(bounty);
@@ -2142,17 +2228,35 @@ impl BountyNetwork {
         request: OpenPooledBountyRequest,
         existing_created_at: Option<chrono::DateTime<Utc>>,
     ) -> AppResult<Bounty> {
-        let amount = Money::new(request.target_amount_minor, request.currency)?;
-        let funding_mode = request.funding_mode.clone();
+        let OpenPooledBountyRequest {
+            bounty_id,
+            idempotency_key: _,
+            title,
+            template_slug,
+            target_amount_minor,
+            currency,
+            funding_mode,
+            privacy,
+            funding_policy,
+            verification_contract,
+            automatic_release,
+            funding_targets,
+        } = request;
+        validate_bounty_posting_terms(
+            &template_slug,
+            automatic_release,
+            verification_contract.as_ref(),
+        )?;
+        let amount = Money::new(target_amount_minor, currency)?;
         let funding_targets =
-            funding_targets_from_request(&funding_mode, &amount, &request.funding_targets)?;
-        let requested_bounty_id = request.bounty_id;
+            funding_targets_from_request(&funding_mode, &amount, &funding_targets)?;
+        let requested_bounty_id = bounty_id;
         let mut bounty = Bounty::new(
-            request.title,
-            request.template_slug,
+            title,
+            template_slug,
             amount.clone(),
             funding_mode.clone(),
-            request.privacy.clone(),
+            privacy.clone(),
         )
         .with_funding_targets(funding_targets);
         if let Some(bounty_id) = requested_bounty_id {
@@ -2166,10 +2270,17 @@ impl BountyNetwork {
             template_slug: bounty.template_slug.clone(),
             amount: amount.clone(),
             funding_mode,
-            privacy: request.privacy,
+            privacy,
         });
         self.enforce_risk(risk, bounty.id, None, Some(bounty.id))?;
-        bounty.terms_hash = Some(hash_terms(&bounty.title, &bounty.template_slug, &amount));
+        bounty.terms_hash = Some(hash_terms_with_policy(
+            &bounty.title,
+            &bounty.template_slug,
+            &amount,
+            &funding_policy,
+            verification_contract.as_ref(),
+            automatic_release,
+        ));
         Ok(bounty)
     }
 
@@ -3688,6 +3799,74 @@ impl BountyNetwork {
         })
     }
 
+    pub fn plan_base_terms_acceptance(
+        &self,
+        request: PlanBaseTermsAcceptanceRequest,
+    ) -> AppResult<BaseTermsAcceptancePlan> {
+        let network = base_plan_network(request.network.as_deref(), "terms acceptance")?;
+        let bounty = self
+            .bounties
+            .get(&request.bounty_id)
+            .ok_or(AppError::BountyNotFound)?
+            .clone();
+        let terms_hash = bounty.terms_hash.clone().ok_or_else(|| {
+            AppError::InvalidBaseEscrowPlan(
+                "bounty has no terms hash to accept on-chain".to_string(),
+            )
+        })?;
+        let escrow = self
+            .escrows
+            .values()
+            .find(|escrow| {
+                escrow.bounty_id == request.bounty_id
+                    && escrow.rail == PaymentRail::BaseUsdc
+                    && is_releasable_base_escrow_status(&escrow.status)
+            })
+            .cloned()
+            .ok_or_else(|| {
+                AppError::InvalidBaseEscrowPlan(
+                    "bounty has no funded or disputed Base USDC escrow for terms acceptance"
+                        .to_string(),
+                )
+            })?;
+        let onchain_escrow_id = parse_base_escrow_reference(&escrow.external_reference)?;
+        let agent = self
+            .agents
+            .get(&request.solver_agent_id)
+            .ok_or(AppError::AgentNotFound)?;
+        let payout_wallet = agent.payout_wallet.clone().ok_or_else(|| {
+            AppError::InvalidBaseEscrowPlan(format!(
+                "solver agent {} has no payout wallet",
+                agent.id
+            ))
+        })?;
+        let acceptance = BaseEscrowTermsAcceptance {
+            onchain_escrow_id,
+            participant: payout_wallet.clone(),
+            payout_wallet: payout_wallet.clone(),
+            terms_hash: ensure_0x_hash(&terms_hash),
+        };
+        let transaction = BaseEscrowTxPlanner::new(request.escrow_contract)
+            .map_err(|error| AppError::InvalidBaseEscrowPlan(error.to_string()))?
+            .accept_terms(&acceptance)
+            .map_err(|error| AppError::InvalidBaseEscrowPlan(error.to_string()))?;
+
+        Ok(BaseTermsAcceptancePlan {
+            network,
+            bounty,
+            escrow,
+            onchain_escrow_id,
+            terms_hash: acceptance.terms_hash,
+            participant: acceptance.participant,
+            payout_wallet,
+            contract_function: "acceptTerms(uint256,bytes32,address)".to_string(),
+            contract_requirement:
+                "AgentBountyEscrowV2 recipients must call acceptTerms before escrow release."
+                    .to_string(),
+            transaction,
+        })
+    }
+
     pub fn plan_base_refund(&self, request: PlanBaseRefundRequest) -> AppResult<BaseRefundPlan> {
         let network = base_plan_network(request.network.as_deref(), "refund")?;
         let bounty = self
@@ -4494,10 +4673,87 @@ fn hash_terms(title: &str, template_slug: &str, amount: &Money) -> String {
     hex::encode(hasher.finalize())
 }
 
+fn hash_terms_with_policy(
+    title: &str,
+    template_slug: &str,
+    amount: &Money,
+    funding_policy: &BountyFundingPolicy,
+    verification_contract: Option<&BountyVerificationContractRequest>,
+    automatic_release: bool,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(format!(
+        "{}:{}:{}:{}:{:?}:{}",
+        title, template_slug, amount.amount, amount.currency, funding_policy, automatic_release
+    ));
+    if let Some(contract) = verification_contract {
+        hasher.update(contract.acceptance_criteria.trim().as_bytes());
+        hasher.update(contract.evidence_requirements.trim().as_bytes());
+        hasher.update(format!(
+            ":{:?}:{}",
+            contract.verifier_kind, contract.human_release_gate
+        ));
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn validate_bounty_posting_terms(
+    template_slug: &str,
+    automatic_release: bool,
+    verification_contract: Option<&BountyVerificationContractRequest>,
+) -> AppResult<()> {
+    if !automatic_release {
+        return Ok(());
+    }
+    let contract = verification_contract.ok_or_else(|| {
+        AppError::InvalidBountyTerms(
+            "automatic_release requires explicit acceptance criteria and evidence requirements"
+                .to_string(),
+        )
+    })?;
+    if contract.acceptance_criteria.trim().is_empty() {
+        return Err(AppError::InvalidBountyTerms(
+            "automatic_release requires non-empty acceptance_criteria".to_string(),
+        ));
+    }
+    if contract.evidence_requirements.trim().is_empty() {
+        return Err(AppError::InvalidBountyTerms(
+            "automatic_release requires non-empty evidence_requirements".to_string(),
+        ));
+    }
+    if contract.human_release_gate {
+        return Err(AppError::InvalidBountyTerms(
+            "automatic_release cannot also require a human release gate".to_string(),
+        ));
+    }
+    let verifier_kind = contract
+        .verifier_kind
+        .clone()
+        .unwrap_or_else(|| verifier_kind_for_template(template_slug));
+    if matches!(
+        verifier_kind,
+        VerifierKind::Manual | VerifierKind::AiJudgeFilter
+    ) {
+        return Err(AppError::InvalidBountyTerms(format!(
+            "automatic_release requires deterministic verifier evidence, not {:?}",
+            verifier_kind
+        )));
+    }
+    Ok(())
+}
+
 fn hash_proof(artifact_digest: &str, verifier_hash: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(format!("{artifact_digest}:{verifier_hash}"));
     hex::encode(hasher.finalize())
+}
+
+fn ensure_0x_hash(hash: &str) -> String {
+    if hash.starts_with("0x") || hash.starts_with("0X") {
+        hash.to_string()
+    } else {
+        format!("0x{hash}")
+    }
 }
 
 fn payment_rail_for_funding_mode(funding_mode: &FundingMode) -> AppResult<PaymentRail> {
@@ -5153,6 +5409,9 @@ mod tests {
             currency: "usdc".to_string(),
             funding_mode: FundingMode::Simulated,
             privacy: PrivacyLevel::Public,
+            funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+            verification_contract: None,
+            automatic_release: false,
             funding_targets: vec![],
         }
     }
@@ -5687,6 +5946,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::MixedRails,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![
                     FundingPartitionTargetRequest {
                         rail: PaymentRail::StripeFiat,
@@ -5892,6 +6154,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::MixedRails,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![
                     FundingPartitionTargetRequest {
                         rail: PaymentRail::StripeFiat,
@@ -5972,6 +6237,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
 
@@ -6164,6 +6432,212 @@ mod tests {
         assert_eq!(network.ledger.entries().len(), 2);
     }
 
+    #[test]
+    fn base_terms_acceptance_plan_requires_solver_payout_wallet() {
+        let mut network = BountyNetwork::default();
+        let solver = network.register_agent(RegisterAgentRequest {
+            handle: "solver".to_string(),
+            payout_wallet: Some("0x2222222222222222222222222222222222222222".to_string()),
+        });
+        let no_wallet_solver = network.register_agent(RegisterAgentRequest {
+            handle: "no-wallet".to_string(),
+            payout_wallet: None,
+        });
+        let bounty = network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Sign payout terms".to_string(),
+                template_slug: "extract-data-to-schema".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
+            })
+            .unwrap();
+        fund_base_bounty(&mut network, &bounty, 7);
+
+        let plan = network
+            .plan_base_terms_acceptance(PlanBaseTermsAcceptanceRequest {
+                bounty_id: bounty.id,
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                solver_agent_id: solver.id,
+                network: Some("base-mainnet".to_string()),
+            })
+            .unwrap();
+
+        assert_eq!(plan.network.chain_id, 8_453);
+        assert_eq!(plan.onchain_escrow_id, 7);
+        assert_eq!(
+            plan.participant,
+            "0x2222222222222222222222222222222222222222"
+        );
+        assert_eq!(plan.participant, plan.payout_wallet);
+        assert_eq!(
+            plan.terms_hash,
+            ensure_0x_hash(bounty.terms_hash.as_ref().unwrap())
+        );
+        assert_eq!(
+            plan.transaction.function,
+            "acceptTerms(uint256,bytes32,address)"
+        );
+        assert!(plan.transaction.data.starts_with("0x6e2a4357"));
+        assert!(plan.transaction.data.contains(
+            &bounty
+                .terms_hash
+                .as_ref()
+                .expect("terms hash")
+                .to_ascii_lowercase()
+        ));
+
+        let err = network
+            .plan_base_terms_acceptance(PlanBaseTermsAcceptanceRequest {
+                bounty_id: bounty.id,
+                escrow_contract: "0x1111111111111111111111111111111111111111".to_string(),
+                solver_agent_id: no_wallet_solver.id,
+                network: None,
+            })
+            .unwrap_err();
+        assert!(matches!(err, AppError::InvalidBaseEscrowPlan(_)));
+    }
+
+    #[test]
+    fn crowdfunded_policy_posts_unfunded_until_real_contribution_arrives() {
+        let mut network = BountyNetwork::default();
+        let bounty = network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Crowdfund useful verifier".to_string(),
+                template_slug: "extract-data-to-schema".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::Simulated,
+                privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
+            })
+            .unwrap();
+
+        assert_eq!(bounty.status, BountyStatus::Unfunded);
+        assert!(bounty.terms_hash.is_some());
+        assert!(network.list_claimable_bounties().is_empty());
+        assert!(network.ledger.entries().is_empty());
+    }
+
+    #[test]
+    fn automatic_release_requires_explicit_deterministic_verification_terms() {
+        let mut network = BountyNetwork::default();
+        let missing_terms = network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Unsafe auto release".to_string(),
+                template_slug: "extract-data-to-schema".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: true,
+            })
+            .unwrap_err();
+        assert!(matches!(missing_terms, AppError::InvalidBountyTerms(_)));
+
+        let manual_verifier = network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Manual release must stay gated".to_string(),
+                template_slug: "write-docs-for-area".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: Some(BountyVerificationContractRequest {
+                    acceptance_criteria: "maintainer approves prose quality".to_string(),
+                    evidence_requirements: "merged PR".to_string(),
+                    verifier_kind: Some(VerifierKind::AiJudgeFilter),
+                    human_release_gate: false,
+                }),
+                automatic_release: true,
+            })
+            .unwrap_err();
+        assert!(matches!(manual_verifier, AppError::InvalidBountyTerms(_)));
+
+        let deterministic = network
+            .post_funded_bounty(PostBountyRequest {
+                title: "Safe auto release".to_string(),
+                template_slug: "extract-data-to-schema".to_string(),
+                amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: Some(BountyVerificationContractRequest {
+                    acceptance_criteria: "JSON artifact exactly matches the published schema"
+                        .to_string(),
+                    evidence_requirements: "schema verifier returns accepted".to_string(),
+                    verifier_kind: Some(VerifierKind::JsonSchema),
+                    human_release_gate: false,
+                }),
+                automatic_release: true,
+            })
+            .unwrap();
+        assert_eq!(deterministic.status, BountyStatus::Unfunded);
+        assert!(deterministic.terms_hash.is_some());
+    }
+
+    #[test]
+    fn pooled_automatic_release_requires_deterministic_terms() {
+        let mut network = BountyNetwork::default();
+        let ai_judge_only = network
+            .open_pooled_bounty(OpenPooledBountyRequest {
+                bounty_id: None,
+                idempotency_key: None,
+                title: "Crowdfund unsafe automatic release".to_string(),
+                template_slug: "write-docs-for-area".to_string(),
+                target_amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: Some(BountyVerificationContractRequest {
+                    acceptance_criteria: "AI judge says the docs are good".to_string(),
+                    evidence_requirements: "review comment".to_string(),
+                    verifier_kind: Some(VerifierKind::AiJudgeFilter),
+                    human_release_gate: false,
+                }),
+                automatic_release: true,
+                funding_targets: vec![],
+            })
+            .unwrap_err();
+        assert!(matches!(ai_judge_only, AppError::InvalidBountyTerms(_)));
+
+        let deterministic = network
+            .open_pooled_bounty(OpenPooledBountyRequest {
+                bounty_id: None,
+                idempotency_key: None,
+                title: "Crowdfund deterministic automatic release".to_string(),
+                template_slug: "fix-ci-failure".to_string(),
+                target_amount_minor: 1_000_000,
+                currency: "usdc".to_string(),
+                funding_mode: FundingMode::BaseUsdcEscrow,
+                privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: Some(BountyVerificationContractRequest {
+                    acceptance_criteria: "GitHub Actions passes on the submitted PR".to_string(),
+                    evidence_requirements: "merged PR URL and passing check-run URL".to_string(),
+                    verifier_kind: Some(VerifierKind::GitHubCi),
+                    human_release_gate: false,
+                }),
+                automatic_release: true,
+                funding_targets: vec![],
+            })
+            .unwrap();
+
+        assert_eq!(deterministic.status, BountyStatus::Unfunded);
+        assert!(deterministic.terms_hash.is_some());
+    }
+
     #[tokio::test]
     async fn open_beta_pays_even_one_minor_unit_in_full_to_solver() {
         let mut network = BountyNetwork::default();
@@ -6179,6 +6653,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         network
@@ -6234,6 +6711,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
 
@@ -6368,6 +6848,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             })
             .unwrap();
@@ -6460,6 +6943,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             })
             .unwrap();
@@ -6528,6 +7014,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::Simulated,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             })
             .unwrap();
@@ -6593,6 +7082,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::StripeFiatLedger,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             })
             .unwrap();
@@ -6719,6 +7211,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         fund_base_bounty(&mut network, &bounty, 1);
@@ -6781,6 +7276,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         fund_base_bounty(&mut network, &bounty, 9);
@@ -6918,6 +7416,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         fund_base_bounty(&mut network, &bounty, 1);
@@ -6973,6 +7474,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         let second = network
@@ -6983,6 +7487,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         fund_base_bounty(&mut network, &first, 1);
@@ -7040,6 +7547,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::StripeFiatLedger,
                 privacy: PrivacyLevel::Private,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![],
             })
             .unwrap();
@@ -7212,6 +7722,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::MixedRails,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![
                     FundingPartitionTargetRequest {
                         rail: PaymentRail::StripeFiat,
@@ -7424,6 +7937,9 @@ mod tests {
                 currency: "usd".to_string(),
                 funding_mode: FundingMode::MixedRails,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+                verification_contract: None,
+                automatic_release: false,
                 funding_targets: vec![
                     FundingPartitionTargetRequest {
                         rail: PaymentRail::StripeFiat,
@@ -7551,6 +8067,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
 
@@ -7586,6 +8105,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap_err();
 
@@ -7615,6 +8137,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap_err();
         assert!(matches!(err, AppError::RiskNeedsReview(_)));
@@ -7672,6 +8197,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap_err();
         assert!(matches!(err, AppError::RiskNeedsReview(_)));
@@ -7788,6 +8316,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap_err();
         assert!(matches!(err, AppError::RiskNeedsReview(_)));
@@ -7841,6 +8372,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
 
@@ -7878,6 +8412,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         fund_base_bounty(&mut network, &bounty, 7);
@@ -7912,6 +8449,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         network
@@ -7984,6 +8524,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         network

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -88,6 +88,14 @@ pub struct BaseEscrowReleaseCall {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseEscrowTermsAcceptance {
+    pub onchain_escrow_id: u128,
+    pub participant: String,
+    pub payout_wallet: String,
+    pub terms_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvmTransactionIntent {
     pub from: Option<String>,
     pub to: String,
@@ -208,6 +216,32 @@ impl BaseEscrowTxPlanner {
                 proof_hash,
             ),
             function: "release(uint256,address[],uint256[],bytes32)".to_string(),
+        })
+    }
+
+    pub fn accept_terms(
+        &self,
+        acceptance: &BaseEscrowTermsAcceptance,
+    ) -> Result<EvmTransactionIntent, ChainBaseError> {
+        if acceptance.onchain_escrow_id == 0 {
+            return Err(ChainBaseError::InvalidEscrowId);
+        }
+        let participant = normalize_address(&acceptance.participant)?;
+        let payout_wallet = normalize_address(&acceptance.payout_wallet)?;
+        let terms_hash = parse_bytes32(&acceptance.terms_hash)?;
+        Ok(EvmTransactionIntent {
+            from: Some(participant),
+            to: self.escrow_contract.clone(),
+            value_wei: 0,
+            data: encode_call(
+                "acceptTerms(uint256,bytes32,address)",
+                vec![
+                    encode_uint256(acceptance.onchain_escrow_id)?,
+                    terms_hash,
+                    encode_address(&payout_wallet)?,
+                ],
+            ),
+            function: "acceptTerms(uint256,bytes32,address)".to_string(),
         })
     }
 
@@ -1687,6 +1721,29 @@ mod tests {
         assert!(tx
             .data
             .contains("00000000000000000000000000000000000000000000000000000000000000e0"));
+    }
+
+    #[test]
+    fn plans_terms_acceptance_for_solver_wallet() {
+        let planner =
+            BaseEscrowTxPlanner::new("0x1111111111111111111111111111111111111111").unwrap();
+        let acceptance = BaseEscrowTermsAcceptance {
+            onchain_escrow_id: 7,
+            participant: "0x2222222222222222222222222222222222222222".to_string(),
+            payout_wallet: "0x2222222222222222222222222222222222222222".to_string(),
+            terms_hash: format!("0x{}", "ab".repeat(32)),
+        };
+
+        let tx = planner.accept_terms(&acceptance).unwrap();
+
+        assert_eq!(tx.from.as_deref(), Some(acceptance.participant.as_str()));
+        assert_eq!(tx.to, planner.escrow_contract);
+        assert_eq!(tx.function, "acceptTerms(uint256,bytes32,address)");
+        assert!(tx.data.starts_with("0x6e2a4357"));
+        assert!(tx.data.contains(&"ab".repeat(32)));
+        assert!(tx
+            .data
+            .contains("0000000000000000000000002222222222222222222222222222222222222222"));
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, bail, Context, Result};
 use app::{
     build_live_money_readiness_report, hash_artifact, stripe_secret_key_mode_from_secret,
-    AddFundingContributionRequest, BaseReleaseQueueRequest, BountyNetwork, ClaimBountyRequest,
-    CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
+    AddFundingContributionRequest, BaseReleaseQueueRequest, BountyFundingPolicy, BountyNetwork,
+    ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
     FundingIntentNextAction, FundingPartitionTargetRequest, LiveMoneyReadinessConfig,
     OpenPooledBountyRequest, PlanBaseReleaseRequest, PlanStripeTransferRequest, PostBountyRequest,
     RegisterAgentRequest, RegisterCapabilityRequest, RequestQuotesRequest, SubmitResultRequest,
@@ -840,6 +840,9 @@ fn pooled_funding_demo() -> Result<()> {
         currency: "usdc".to_string(),
         funding_mode: FundingMode::Simulated,
         privacy: PrivacyLevel::Public,
+        funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+        verification_contract: None,
+        automatic_release: false,
         funding_targets: vec![],
     })?;
     let first = network.add_funding_contribution(AddFundingContributionRequest {
@@ -896,6 +899,9 @@ async fn funding_rehearsal_demo() -> Result<()> {
         currency: "usd".to_string(),
         funding_mode: FundingMode::MixedRails,
         privacy: PrivacyLevel::Public,
+        funding_policy: BountyFundingPolicy::CrowdfundUntilFunded,
+        verification_contract: None,
+        automatic_release: false,
         funding_targets: vec![
             FundingPartitionTargetRequest {
                 rail: PaymentRail::StripeFiat,
@@ -1673,6 +1679,9 @@ async fn base_release_queue_demo(
         currency: "usdc".to_string(),
         funding_mode: FundingMode::BaseUsdcEscrow,
         privacy: PrivacyLevel::Public,
+        funding_policy: BountyFundingPolicy::FundOnCreation,
+        verification_contract: None,
+        automatic_release: false,
     })?;
     let created = simulated_created_event(
         bounty.id,

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -6,9 +6,10 @@ use app::{
     ClaimBountyRequest, CreateFundingIntentRequest, CreateHelpRequestRequest, FundQuoteRequest,
     FundingIntentReport, LiveMoneyReadinessConfig, OpenPooledBountyRequest, PlanBaseDisputeRequest,
     PlanBaseFundingRequest, PlanBaseRefundRequest, PlanBaseReleaseRequest,
-    PlanStripeTransferRequest, PooledFundingReport, PostBountyRequest, RegisterAgentRequest,
-    RegisterCapabilityRequest, RejectRiskEventRequest, RequestQuotesRequest,
-    ReviewedBountyApproval, RiskEventFilter, SubmitResultRequest, VerifySubmissionRequest,
+    PlanBaseTermsAcceptanceRequest, PlanStripeTransferRequest, PooledFundingReport,
+    PostBountyRequest, RegisterAgentRequest, RegisterCapabilityRequest, RejectRiskEventRequest,
+    RequestQuotesRequest, ReviewedBountyApproval, RiskEventFilter, SubmitResultRequest,
+    VerifySubmissionRequest,
 };
 use axum::{
     extract::State,
@@ -438,6 +439,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/tools/list_base_release_queue",
             post(list_base_release_queue),
+        )
+        .route(
+            "/tools/plan_base_terms_acceptance",
+            post(plan_base_terms_acceptance),
         )
         .route("/tools/plan_base_release", post(plan_base_release))
         .route("/tools/plan_base_refund", post(plan_base_refund))
@@ -1125,6 +1130,19 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                     "network": nullable_enum_property(&["base-sepolia", "base-mainnet"], "Optional Base network; defaults to base-sepolia.")
                 }),
                 &["bounty_id", "escrow_contract", "payer", "token"],
+            ),
+        ),
+        tool(
+            "plan_base_terms_acceptance",
+            "Build an unsigned AgentBountyEscrowV2 acceptTerms transaction. Agents that want to get paid sign this with their payout wallet before release; it never approves review, acceptance, or settlement by itself.",
+            object_tool_schema(
+                json!({
+                    "bounty_id": uuid_property("Base USDC bounty UUID with indexed funded escrow."),
+                    "escrow_contract": string_property("AgentBountyEscrowV2 contract address."),
+                    "solver_agent_id": uuid_property("Registered solver agent whose payout wallet will sign the terms."),
+                    "network": nullable_enum_property(&["base-sepolia", "base-mainnet"], "Optional Base network; defaults to base-sepolia.")
+                }),
+                &["bounty_id", "escrow_contract", "solver_agent_id"],
             ),
         ),
         tool(
@@ -2840,6 +2858,17 @@ async fn plan_base_release(
     }
 }
 
+async fn plan_base_terms_acceptance(
+    State(state): State<SharedState>,
+    Json(args): Json<PlanBaseTermsAcceptanceRequest>,
+) -> Json<serde_json::Value> {
+    let network = state.network.lock().expect("state poisoned");
+    match network.plan_base_terms_acceptance(args) {
+        Ok(plan) => mcp_json(plan),
+        Err(error) => mcp_error(error),
+    }
+}
+
 async fn plan_base_refund(
     State(state): State<SharedState>,
     Json(args): Json<PlanBaseRefundRequest>,
@@ -3198,6 +3227,7 @@ async fn record_eval_run(state: &SharedState, run: EvalRun) -> Result<(), String
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
+    use app::BountyFundingPolicy;
 
     #[tokio::test]
     async fn tool_descriptors_publish_machine_readable_input_schemas() {
@@ -3731,6 +3761,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: domain::FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         network
@@ -3982,6 +4015,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: domain::FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             });
             assert!(matches!(result, Err(app::AppError::RiskNeedsReview(_))));
         }
@@ -4019,6 +4055,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: domain::FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             });
             assert!(matches!(result, Err(app::AppError::RiskNeedsReview(_))));
             network.risk_events.values().next().unwrap().id
@@ -4089,6 +4128,9 @@ mod tests {
             currency: "usdc".to_string(),
             funding_mode: domain::FundingMode::BaseUsdcEscrow,
             privacy: PrivacyLevel::Public,
+            funding_policy: BountyFundingPolicy::FundOnCreation,
+            verification_contract: None,
+            automatic_release: false,
         });
         assert!(matches!(result, Err(app::AppError::RiskNeedsReview(_))));
         let bounty_event_id = network.risk_events.values().next().unwrap().id;
@@ -4184,6 +4226,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: domain::FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             });
             assert!(matches!(result, Err(app::AppError::RiskNeedsReview(_))));
             network.risk_events.values().next().unwrap().id
@@ -4308,6 +4353,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: domain::FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         let other_bounty = reader_network
@@ -4318,6 +4366,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: domain::FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         reader_store.upsert_bounty(&bounty).await.unwrap();

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -828,8 +828,8 @@ fn nonempty(value: &str) -> bool {
 mod tests {
     use super::*;
     use app::{
-        hash_artifact, ClaimBountyRequest, PostBountyRequest, RegisterAgentRequest,
-        SubmitResultRequest, VerifySubmissionRequest,
+        hash_artifact, BountyFundingPolicy, ClaimBountyRequest, PostBountyRequest,
+        RegisterAgentRequest, SubmitResultRequest, VerifySubmissionRequest,
     };
     use chain_base::{
         evm_address_word, evm_bytes32_word, evm_event_topic, evm_uint256_word, evm_words_data,
@@ -1076,6 +1076,9 @@ mod tests {
                 currency: "usdc".to_string(),
                 funding_mode: FundingMode::BaseUsdcEscrow,
                 privacy: PrivacyLevel::Public,
+                funding_policy: BountyFundingPolicy::FundOnCreation,
+                verification_contract: None,
+                automatic_release: false,
             })
             .unwrap();
         network

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -125,6 +125,10 @@ curl -X POST http://127.0.0.1:8090/tools/add_bounty_funding \
 
 A paid bounty must be funded before claim. Simulated funding is local-only and
 does not imply any real payout.
+The default paid posting policy is `FundOnCreation`; use
+`CrowdfundUntilFunded` only when the bounty is intentionally public inventory
+waiting for contributors. Crowdfunded bounties can be shared and funded, but
+they are not claimable paid work until enough funding is reconciled.
 For `StripeFiat` pooled bounty funding, `source_organization_id` must point to
 an organization with previously reconciled Stripe Checkout top-up balance; the
 funding call reserves that verified balance and fails if the balance is
@@ -246,6 +250,16 @@ curl -X POST http://127.0.0.1:8080/v1/bounties/pooled \
   --data '{"title":"Patch a small verifiable docs issue","template_slug":"write-docs-for-area","target_amount_minor":1000000,"currency":"usdc","funding_mode":"BaseUsdcEscrow","privacy":"Public"}'
 ```
 
+When posting a bounty intended for automatic release, make the verification
+contract explicit in the bounty terms. Automatic release rejects manual or
+AI-judge-only gates because payout must be tied to deterministic evidence:
+
+```bash
+curl -X POST http://127.0.0.1:8080/v1/bounties/pooled \
+  -H "content-type: application/json" \
+  --data '{"title":"Add a deterministic CI fixture for escrow terms acceptance","template_slug":"fix-ci-failure","target_amount_minor":1000000,"currency":"usdc","funding_mode":"BaseUsdcEscrow","privacy":"Public","funding_policy":"FundOnCreation","verification_contract":{"acceptance_criteria":"The PR adds a failing-before/passing-after test for terms acceptance and CI passes.","evidence_requirements":"Merged PR URL, commit SHA, and passing GitHub Actions run URL.","verifier_kind":"GitHubCi","human_release_gate":false},"automatic_release":true}'
+```
+
 Plan unsigned approval and escrow creation transactions. API endpoint:
 `/v1/base/funding-plan`. MCP tool: `plan_base_funding`.
 
@@ -292,6 +306,19 @@ curl -X POST http://127.0.0.1:8080/v1/base/escrow-events \
 Only after the indexed `EscrowCreated` event is reconciled can Base escrow work
 become claimable. Later `Released`, `Refunded`, or `Disputed` states also depend
 on indexed escrow logs, not on AI-judge decisions or transaction broadcasts.
+
+On `AgentBountyEscrowV2`, each payout recipient must also sign the exact bounty
+terms with its payout wallet before release. API endpoint:
+`/v1/base/terms-acceptance-plan`. MCP tool: `plan_base_terms_acceptance`.
+
+```bash
+curl -X POST http://127.0.0.1:8080/v1/base/terms-acceptance-plan \
+  -H "content-type: application/json" \
+  --data '{"bounty_id":"00000000-0000-0000-0000-000000000301","escrow_contract":"0x1111111111111111111111111111111111111111","solver_agent_id":"00000000-0000-0000-0000-000000000201","network":"base-sepolia"}'
+```
+
+Sign the returned transaction from the solver payout wallet. This accepts terms
+only; it does not verify the work or authorize payout by itself.
 
 ## 8. Copy-paste prompt
 

--- a/docs/live-money-activation.md
+++ b/docs/live-money-activation.md
@@ -17,6 +17,26 @@ secrets in the hosted environment.
 - Pooled and mixed funding: each funding partition is reconciled independently.
   USD and USDC are never netted into a synthetic balance.
 
+## Funded-On-Creation And Terms Acceptance
+
+The default paid bounty path is funded on creation. Unfunded bounties are still
+allowed, but they must be explicit crowdfunding inventory and must not appear in
+claimable paid feeds until Stripe webhook evidence, Base escrow logs, or another
+configured rail proves enough funding arrived.
+
+For Base USDC escrow, new deployments should use `AgentBountyEscrowV2`. It keeps
+the existing settlement-signer release boundary and adds
+`acceptTerms(uint256,bytes32,address)`. Any wallet that wants to receive a payout
+must sign the exact bounty `termsHash` from the payout wallet before release.
+This signature is consent to the bounty terms only; it is not verification,
+acceptance, or payment evidence.
+
+Automatic release can be enabled only when the bounty terms state explicit,
+deterministic acceptance criteria, required evidence, and a non-human verifier
+kind such as GitHub CI, Docker command, JSON schema, or HTTP callback. Manual
+review and AI-judge filters can request revision or route review, but they must
+not be the sole authority for automatic smart-contract settlement.
+
 ## Required Configuration
 
 Use `.env.example` as the shape for hosted secrets and deployment settings.
@@ -228,12 +248,15 @@ separately, not attributed to the Checkout return.
 
 1. Solver submits an artifact.
 2. Deterministic verifier or operator accepts it and creates settlement intents.
-3. For Base payouts, inspect `POST /v1/base/release-queue`, then generate a
+3. For Base payouts on `AgentBountyEscrowV2`, the solver first signs the bounty
+   terms through `POST /v1/base/terms-acceptance-plan` or MCP
+   `plan_base_terms_acceptance`.
+4. Inspect `POST /v1/base/release-queue`, then generate a
    release plan with `POST /v1/base/release-plan`.
-4. Sign and send the release transaction, then reconcile the indexed
+5. Sign and send the release transaction, then reconcile the indexed
    `EscrowReleased` log. The hosted `base-indexer` worker can reconcile this
    automatically; the transaction hash alone is not payout evidence.
-5. For Stripe payouts, confirm Connect eligibility, execute the transfer
+6. For Stripe payouts, confirm Connect eligibility, execute the transfer
    request, then reconcile the signed `transfer.created` event. Transfer
    planning alone is not payout evidence.
 


### PR DESCRIPTION
## Summary

- Add `AgentBountyEscrowV2`, which keeps settlement-signer release control and requires each payout recipient wallet to call `acceptTerms(uint256,bytes32,address)` before release.
- Add funded-posting terms to the app layer: direct paid bounty posting defaults to `FundOnCreation`; pooled public posting defaults to `CrowdfundUntilFunded`; automatic release requires explicit deterministic acceptance criteria and evidence.
- Add Base terms-acceptance transaction planning through REST and MCP, plus docs for funded-on-creation, crowdfunding, wallet-signed terms, and automatic release boundaries.

## Payment status

I prepared the public release plan for the existing 1 USDC bounty loop in issue #127, but did not broadcast it because this environment does not have the settlement signer private key, CDP signer, or injected wallet access. Current on-chain check still shows escrow #1 funded, contract balance 1 USDC, and recipient balance 0.

## Validation

- `forge test` in `contracts/base-escrow`
- `cargo test -p app -- --nocapture`
- `cargo test -p chain-base plans_terms_acceptance_for_solver_wallet -- --nocapture`
- `cargo test -p api openapi -- --nocapture`
- `cargo test -p mcp-server tool_descriptors -- --nocapture`
- `cargo run -p cli -- docs-contract-check`
- `cargo check -p api -p mcp-server -p cli`
- `git diff --check`

## Public coordination

Maintainer notice: #150
