### PR TITLE
Add Base operator wallet release flow

### DIFF
--- a/docs/hosted-base-usdc-beta-runbook.md
+++ b/docs/hosted-base-usdc-beta-runbook.md
@@ -235,6 +235,24 @@ curl -sS "$PUBLIC_BASE_URL/v1/base/release-plan" \
 Review the release target and amount before signing. The settlement signer signs
 outside the hosted app.
 
+Browser operator path:
+
+```text
+https://nspg13.github.io/agent-bounties/operator.html
+```
+
+1. Open the page from an operator workstation with an injected EIP-1193 wallet.
+2. Enter the hosted API URL, operator token if configured, bounty id, escrow
+   contract, and platform fee wallet.
+3. Connect the current settlement signer wallet on Base mainnet.
+4. Review the decoded release plan. Confirm the target escrow contract, zero ETH
+   value, `release(uint256,address[],uint256[],bytes32)` selector, proof hash,
+   on-chain escrow id, and recipient split.
+5. Sign the release transaction only if the review matches the accepted proof.
+6. Wait for receipt reconciliation. A transaction hash is not payout evidence;
+   the payout is complete only after an indexed `EscrowReleased` event is
+   reconciled.
+
 ## 7. Broadcast, Poll, and Reconcile
 
 If hosted broadcast is enabled and the operator has a signed raw transaction:

--- a/docs/signer-custody-research.md
+++ b/docs/signer-custody-research.md
@@ -1,0 +1,59 @@
+# Settlement Signer Custody Research
+
+This note records the design constraint for Agent Bounties settlement signing:
+make payout broadcast easy, but do not put an unrestricted private key in the
+repo, browser logs, GitHub issues, or hosted API process by default.
+
+## Comparable patterns
+
+- Coinbase Developer Platform wallets support user wallets and server-controlled
+  wallets. Their docs describe API-key authenticated system wallets for
+  automated workflows and agentic applications, with private key operations
+  handled inside a Trusted Execution Environment:
+  <https://docs.cdp.coinbase.com/wallets/non-custodial-wallets/overview> and
+  <https://docs.cdp.coinbase.com/wallets/security-and-policies/security-overview>.
+- Privy supports server-side wallet access for offline actions, but its docs
+  pair that with wallet policies for transfer limits, contract allowlists, and
+  calldata constraints:
+  <https://docs.privy.io/wallets/wallets/server-side-access> and
+  <https://docs.privy.io/security/wallet-infrastructure/policy-and-controls>.
+- Turnkey's agentic-wallet docs frame AI agents and automated backends as
+  delegated actors with granular policies. Their policy examples constrain
+  destination address, contract address, function selector, chain ID, and value:
+  <https://docs.turnkey.com/features/policies/delegated-access/agentic-wallets>
+  and <https://docs.turnkey.com/solutions/company-wallets/agentic-wallets>.
+- Gitcoin Allo separates pooled funding from distribution by routing funds
+  through an allocation strategy. Pools can be funded by others, but the strategy
+  controls distribution:
+  <https://docs.allo.gitcoin.co/allo/flow-of-funds> and
+  <https://docs.allo.gitcoin.co/overview/pool>.
+- StandardBounties separates issuer, contributor, fulfiller, and approver roles;
+  approvers accept fulfillments and choose payout amounts:
+  <https://github.com/Bounties-Network/StandardBounties>.
+
+## Recommendation
+
+Use three signing tiers:
+
+1. Browser injected wallet for the first live Base mainnet payouts.
+   The operator connects the current settlement signer wallet, reviews
+   `/v1/base/release-plan`, signs `release(uint256,address[],uint256[],bytes32)`,
+   then reconciles `/v1/base/transaction-receipt` with `reconcile_logs=true`.
+2. Managed signer after repeated low-value loops. CDP, Privy, or Turnkey can
+   sign programmatically only if policies restrict chain `8453`, escrow contract
+   `0x150C6dFbCe7803cc7f634f59b0624e87349CEAce`, allowed function selectors,
+   zero ETH value, daily limits, and required platform state.
+3. Smart-contract strategy or multisig for higher-value work. Higher-value or
+   dispute-prone bounties should require a strategy role, Safe-style threshold,
+   or human/operator quorum before release.
+
+Raw private-key signing is acceptable only for local or testnet rehearsals. It
+must not be the production default.
+
+## Current implementation
+
+The static site exposes `operator.html`, an injected-wallet path for release
+signing. It does not ask for a private key. The hosted API remains the source of
+release calldata and receipt reconciliation. A release transaction hash is not
+payout evidence; an indexed `EscrowReleased` event applied by the hosted API is
+the settlement boundary.

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -12,6 +12,7 @@ REQUIRED_FILES = [
     "earn.html",
     "post.html",
     "funding.html",
+    "operator.html",
     "terms.html",
     "privacy.html",
     "refunds.html",
@@ -88,6 +89,7 @@ def main() -> int:
     earn = (site_dir / "earn.html").read_text(encoding="utf-8")
     post = (site_dir / "post.html").read_text(encoding="utf-8")
     funding = (site_dir / "funding.html").read_text(encoding="utf-8")
+    operator = (site_dir / "operator.html").read_text(encoding="utf-8")
     success = (site_dir / "success.html").read_text(encoding="utf-8")
     main_js = (site_dir / "main.js").read_text(encoding="utf-8")
     llms = (site_dir / "llms.txt").read_text(encoding="utf-8")
@@ -199,6 +201,22 @@ def main() -> int:
     for phrase in required_funding_phrases:
         if phrase not in funding and phrase not in main_js:
             fail(f"funding page missing required phrase: {phrase}")
+
+    required_operator_phrases = [
+        "Settlement signer",
+        "No private key",
+        "/v1/base/release-plan",
+        "/v1/base/transaction-receipt",
+        "reconcile_logs=true",
+        "EscrowReleased",
+        "release(uint256,address[],uint256[],bytes32)",
+        "Transaction hashes are not payout evidence",
+        "Post your own bounty",
+        "star/upvote Agent Bounties",
+    ]
+    for phrase in required_operator_phrases:
+        if phrase not in operator and phrase not in main_js:
+            fail(f"operator.html missing required phrase: {phrase}")
 
     required_success_phrases = [
         "Checkout submitted",
@@ -467,6 +485,26 @@ def main() -> int:
         not in wallet_native_base.get("settlement_authority", "")
     ):
         fail("static discovery manifest must advertise wallet-native Base funding safeguards")
+    base_operator_settlement = discovery.get("base_operator_settlement", {})
+    if (
+        base_operator_settlement.get("page")
+        != "https://nspg13.github.io/agent-bounties/operator.html"
+        or base_operator_settlement.get("provider_standard") != "EIP-1193"
+        or base_operator_settlement.get("chain_id_hex") != "0x2105"
+        or base_operator_settlement.get("release_plan_endpoint_template")
+        != "{api_base_url}/v1/base/release-plan"
+        or base_operator_settlement.get("receipt_endpoint_template")
+        != "{api_base_url}/v1/base/transaction-receipt"
+        or "release(uint256,address[],uint256[],bytes32) selector"
+        not in base_operator_settlement.get("required_plan_checks", [])
+        or "recipient split equals hosted escrow amount"
+        not in base_operator_settlement.get("required_plan_checks", [])
+        or base_operator_settlement.get("reconciliation_request", {}).get("reconcile_logs")
+        is not True
+        or "EscrowReleased"
+        not in base_operator_settlement.get("settlement_authority", "")
+    ):
+        fail("static discovery manifest must advertise operator Base release safeguards")
 
     print("site check ok")
     return 0

--- a/scripts/test-base-wallet-flow.js
+++ b/scripts/test-base-wallet-flow.js
@@ -29,6 +29,9 @@ const termsHash = "0x886ef7e42d7f2968ae5b44a9f963a95b4726d8d7244a6fbe35af6f2cffb
 const amountMinor = 1_000_000;
 const escrowTxHash = `0x${"ab".repeat(32)}`;
 const otherEscrowTxHash = `0x${"cd".repeat(32)}`;
+const releaseTxHash = `0x${"ef".repeat(32)}`;
+const proofHash = `0x${"12".repeat(32)}`;
+const platformFeeWallet = "0x4444444444444444444444444444444444444444";
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -60,6 +63,10 @@ function encodeApprove(spender, amount) {
 
 function encodeCreateEscrow(id, token, amount, hash) {
   return `0x64a20554${uuidBytes32(id)}${wordAddress(token)}${wordUint(amount)}${word(hash)}`;
+}
+
+function encodeReleasePlaceholder() {
+  return `0xbfc95334${"00".repeat(160)}`;
 }
 
 function evidenceFixture(overrides = {}) {
@@ -174,6 +181,96 @@ function validPlan() {
         function: "createEscrow(bytes32,address,uint256,bytes32)",
       },
     },
+  };
+}
+
+function validReleasePlan() {
+  return {
+    network: {
+      name: "Base",
+      chain_id: config.chainId,
+      native_usdc_token_address: config.nativeUsdc,
+    },
+    bounty: bounty({ status: "Payable" }),
+    escrow: {
+      id: "escrow-7",
+      bounty_id: bountyId,
+      rail: "BaseUsdc",
+      token: config.nativeUsdc,
+      amount: { amount: amountMinor, currency: "usdc" },
+      status: "Funded",
+      external_reference: "base:7",
+    },
+    settlement: {
+      id: "settlement-7",
+      bounty_id: bountyId,
+      rail: "BaseUsdc",
+      platform_fee: { amount: 0, currency: "usdc" },
+      payout_intents: [
+        {
+          recipient_agent_id: "agent-7",
+          rail: "BaseUsdc",
+          amount: { amount: amountMinor, currency: "usdc" },
+          status: "Pending",
+        },
+      ],
+    },
+    release_call: {
+      onchain_escrow_id: 7,
+      proof_hash: proofHash,
+      recipients: [
+        {
+          address: payer,
+          amount: { amount: amountMinor, currency: "usdc" },
+        },
+      ],
+    },
+    transaction: {
+      from: null,
+      to: config.escrowContract,
+      value_wei: 0,
+      data: encodeReleasePlaceholder(),
+      function: "release(uint256,address[],uint256[],bytes32)",
+    },
+  };
+}
+
+function releaseReceiptReport({
+  receiptFound = true,
+  succeeded = true,
+  applied = true,
+  failures = [],
+} = {}) {
+  return {
+    network: {
+      name: "Base",
+      chain_id: config.chainId,
+    },
+    receipt_found: receiptFound,
+    tx_hash: releaseTxHash,
+    block_number: receiptFound ? 42 : null,
+    succeeded: receiptFound ? succeeded : null,
+    log_count: receiptFound ? 1 : 0,
+    receipt: receiptFound ? { status: succeeded ? "0x1" : "0x0", logs: [] } : null,
+    reconciliation: receiptFound
+      ? {
+          decoded_events: applied ? 1 : 0,
+          applied_events: applied
+            ? [
+                {
+                  event_id: "event-7",
+                  bounty_id: bountyId,
+                  kind: "Released",
+                  log_key: `${releaseTxHash}:0x0`,
+                  ledger_entries: 1,
+                },
+              ]
+            : [],
+          skipped_duplicate_logs: 0,
+          ledger_entries: applied ? [{ id: "ledger-7" }] : [],
+          failures,
+        }
+      : null,
   };
 }
 
@@ -303,6 +400,48 @@ async function assertBadPlanDoesNotSend(label, mutatePlan, pattern) {
   assert.strictEqual(sendCount(provider), 0, `${label} sent a transaction`);
 }
 
+async function reviewValidReleasePlan(provider = mockProvider({
+  eth_chainId: "0x2105",
+  eth_accounts: () => [payer],
+})) {
+  return wallet.prepareBaseOperatorReleasePlan({
+    apiBaseUrl: "https://api.example.com",
+    bountyId,
+    connectedAddress: payer,
+    escrowContract: config.escrowContract,
+    fetchImpl: mockFetch([validReleasePlan()]),
+    operatorToken: "operator-secret",
+    platformFeeWallet,
+    provider,
+  });
+}
+
+async function assertBadReleasePlanDoesNotSend(label, mutatePlan, pattern) {
+  const plan = validReleasePlan();
+  mutatePlan(plan);
+  const provider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_accounts: () => [payer],
+    eth_sendTransaction: () => {
+      throw new Error(`unexpected release send for ${label}`);
+    },
+  });
+  await assertRejects(
+    wallet.prepareBaseOperatorReleasePlan({
+      apiBaseUrl: "https://api.example.com",
+      bountyId,
+      connectedAddress: payer,
+      escrowContract: config.escrowContract,
+      fetchImpl: mockFetch([plan]),
+      operatorToken: "operator-secret",
+      platformFeeWallet,
+      provider,
+    }),
+    pattern,
+  );
+  assert.strictEqual(sendCount(provider), 0, `${label} sent a release transaction`);
+}
+
 (async () => {
   assert(wallet, "wallet helper export missing");
   assert.strictEqual(
@@ -410,6 +549,110 @@ async function assertBadPlanDoesNotSend(label, mutatePlan, pattern) {
     },
     /terms hash/,
   );
+
+  const releaseReview = await reviewValidReleasePlan();
+  assert.strictEqual(releaseReview.heading, "ready for settlement signer wallet review");
+  assert(releaseReview.lines.includes("EscrowReleased topic"));
+  assert(releaseReview.lines.includes("No private key"));
+  assert(releaseReview.lines.includes("Post your own bounty"));
+
+  await assertBadReleasePlanDoesNotSend(
+    "release wrong chain",
+    (plan) => {
+      plan.network.chain_id = 1;
+    },
+    /Base mainnet/,
+  );
+  await assertBadReleasePlanDoesNotSend(
+    "release wrong bounty",
+    (plan) => {
+      plan.bounty.id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    },
+    /bounty id/,
+  );
+  await assertBadReleasePlanDoesNotSend(
+    "release not payable",
+    (plan) => {
+      plan.bounty.status = "Claimable";
+    },
+    /not Payable/,
+  );
+  await assertBadReleasePlanDoesNotSend(
+    "release target mismatch",
+    (plan) => {
+      plan.transaction.to = otherAddress;
+    },
+    /release transaction target/,
+  );
+  await assertBadReleasePlanDoesNotSend(
+    "release nonzero value",
+    (plan) => {
+      plan.transaction.value_wei = 1;
+    },
+    /zero ETH value/,
+  );
+  await assertBadReleasePlanDoesNotSend(
+    "release wrong function",
+    (plan) => {
+      plan.transaction.function = "refund(uint256,bytes32)";
+    },
+    /not release/,
+  );
+  await assertBadReleasePlanDoesNotSend(
+    "release wrong selector",
+    (plan) => {
+      plan.transaction.data = `0x71eedb88${"00".repeat(160)}`;
+    },
+    /selector/,
+  );
+  await assertBadReleasePlanDoesNotSend(
+    "release bad proof hash",
+    (plan) => {
+      plan.release_call.proof_hash = "0x1234";
+    },
+    /proof hash/,
+  );
+  await assertBadReleasePlanDoesNotSend(
+    "release split mismatch",
+    (plan) => {
+      plan.release_call.recipients[0].amount.amount = amountMinor - 1;
+    },
+    /recipient total/,
+  );
+
+  const operatorFetch = mockFetch([releaseReceiptReport()]);
+  const operatorProvider = mockProvider({
+    eth_chainId: "0x2105",
+    eth_accounts: () => [payer],
+    eth_sendTransaction: [releaseTxHash],
+    eth_getTransactionReceipt: [{ status: "0x1" }],
+  });
+  const operatorResult = await wallet.sendBaseOperatorRelease({
+    fetchImpl: operatorFetch,
+    provider: operatorProvider,
+    receiptDelayMs: 0,
+    review: releaseReview,
+  });
+  assert.strictEqual(operatorResult.heading, "payout reconciled");
+  assert(operatorResult.lines.includes("Applied release events: 1"));
+  assert.strictEqual(sendCount(operatorProvider), 1);
+  assert.strictEqual(operatorFetch.calls.length, 1);
+  assert.strictEqual(operatorFetch.calls[0].url, "https://api.example.com/v1/base/transaction-receipt");
+  assert.strictEqual(operatorFetch.calls[0].options.headers.authorization, "Bearer operator-secret");
+  assert.deepStrictEqual(JSON.parse(operatorFetch.calls[0].options.body), {
+    network: config.network,
+    tx_hash: releaseTxHash,
+    reconcile_logs: true,
+  });
+
+  const pendingOperator = await wallet.reconcileBaseOperatorRelease({
+    apiBaseUrl: "https://api.example.com",
+    fetchImpl: mockFetch([releaseReceiptReport({ applied: false })]),
+    operatorToken: "operator-secret",
+    releaseHash: releaseTxHash,
+  });
+  assert.strictEqual(pendingOperator.heading, "receipt confirmed, reconciliation pending");
+  assert(pendingOperator.lines.includes("Refresh reconciliation before claiming the payout is complete"));
 
   const approvalProvider = mockProvider({
     eth_chainId: "0x2105",

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -341,6 +341,34 @@
     "query_param_policy": "apiBaseUrl and bountyId may prefill the page; contract and token query parameters are ignored for wallet funding.",
     "settlement_authority": "wallet prompts and transaction hashes are not funding; only hosted status with indexed EscrowCreated evidence can show Base wallet funding reconciled"
   },
+  "base_operator_settlement": {
+    "page": "https://nspg13.github.io/agent-bounties/operator.html",
+    "action": "connect_settlement_wallet_then_release",
+    "provider_standard": "EIP-1193",
+    "network": "base-mainnet",
+    "chain_id": 8453,
+    "chain_id_hex": "0x2105",
+    "escrow_contract": "0x150C6dFbCe7803cc7f634f59b0624e87349CEAce",
+    "release_plan_endpoint_template": "{api_base_url}/v1/base/release-plan",
+    "receipt_endpoint_template": "{api_base_url}/v1/base/transaction-receipt",
+    "required_plan_checks": [
+      "connected settlement signer",
+      "Base mainnet chain id",
+      "verified escrow contract",
+      "Payable bounty status",
+      "release(uint256,address[],uint256[],bytes32) selector",
+      "positive on-chain escrow id",
+      "recipient split equals hosted escrow amount",
+      "proof hash",
+      "zero ETH value"
+    ],
+    "wallet_confirmation": "release escrow payout",
+    "reconciliation_request": {
+      "network": "base-mainnet",
+      "reconcile_logs": true
+    },
+    "settlement_authority": "wallet signatures and transaction hashes are not payout; only hosted receipt reconciliation that applies an indexed EscrowReleased event can show the payout as paid"
+  },
   "base_mainnet_escrow": {
     "network": "base-mainnet",
     "chain_id": 8453,

--- a/site/funding.html
+++ b/site/funding.html
@@ -14,6 +14,7 @@
         <a href="index.html">Home</a>
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>
+        <a href="operator.html">Operator</a>
         <a href="terms.html">Terms</a>
         <a href="privacy.html">Privacy</a>
         <a href="https://github.com/NSPG13/agent-bounties">GitHub</a>
@@ -108,6 +109,7 @@
           </div>
           <div class="copy">
             <p>Base USDC funding uses escrow transaction plans and indexed escrow logs. Base funding is useful when funders want public, portable settlement. Stripe fiat funding is useful when funders want hosted Checkout with cards, wallets, or PayPal where the platform account is eligible.</p>
+            <p>After verified completion, operators can use the <a href="operator.html">Settlement signer</a> page to review a Base release plan, sign with the current settlement wallet, and reconcile the <code>EscrowReleased</code> receipt. Transaction hashes are not payout evidence.</p>
             <p>PayPal is not a separate payout rail in this MVP. Solver fiat payouts still follow Stripe Connect eligibility and signed transfer evidence.</p>
             <p>Agents can link human funders here with <code>paymentPreference=paypal</code> to make the PayPal-capable Checkout path explicit. That parameter is a UI hint only; Stripe webhook reconciliation remains the funding authority.</p>
             <p>Mixed bounties can have separate Stripe fiat and Base USDC partitions. Each partition must be confirmed by its own evidence before the bounty becomes claimable.</p>

--- a/site/main.js
+++ b/site/main.js
@@ -158,6 +158,11 @@
   const baseWalletOutput = document.getElementById("base-wallet-output");
   const checkoutStatusOutput = document.getElementById("checkout-status-output");
   const checkoutStatusRefresh = document.getElementById("checkout-status-refresh");
+  const operatorReleaseForm = document.getElementById("operator-release-form");
+  const operatorReleaseConnect = document.getElementById("operator-release-connect");
+  const operatorReleaseSign = document.getElementById("operator-release-sign");
+  const operatorReleaseReconcile = document.getElementById("operator-release-reconcile");
+  const operatorReleaseOutput = document.getElementById("operator-release-output");
 
   const baseMainnetWalletConfig = {
     network: "base-mainnet",
@@ -165,6 +170,7 @@
     chainIdHex: "0x2105",
     escrowContract: "0x150C6dFbCe7803cc7f634f59b0624e87349CEAce",
     escrowCreatedTopic: "0xb67bc2da9ebef7d93355d3f5b6c7cc857b34cc7a4b8b2850ff3dcb90ea563ac2",
+    escrowReleasedTopic: "0x5c3cdb5e0a182625b29f652597bcf23eafc02808ceed42a6b452e1833c83a830",
     nativeUsdc: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   };
 
@@ -997,6 +1003,326 @@
     };
   }
 
+  function operatorRequestHeaders(operatorToken) {
+    const headers = { "content-type": "application/json", accept: "application/json" };
+    const token = normalizedText(operatorToken);
+    if (token) {
+      headers.authorization = `Bearer ${token}`;
+    }
+    return headers;
+  }
+
+  function releaseRecipients(releaseCall) {
+    return Array.isArray(releaseCall && releaseCall.recipients)
+      ? releaseCall.recipients
+      : [];
+  }
+
+  function releaseRecipientTotal(recipients) {
+    let total = 0n;
+    for (const recipient of recipients) {
+      const amount = moneyAmountBigInt(recipient && recipient.amount);
+      if (amount === null) {
+        return null;
+      }
+      total += amount;
+    }
+    return total;
+  }
+
+  async function requestBaseOperatorReleasePlan(fetchImpl, apiBaseUrl, request, operatorToken) {
+    const response = await fetchImpl(`${apiBaseUrl}/v1/base/release-plan`, {
+      method: "POST",
+      headers: operatorRequestHeaders(operatorToken),
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      throw new Error(`Base release plan failed with ${response.status}`);
+    }
+    return response.json();
+  }
+
+  async function requestBaseTransactionReceipt(fetchImpl, apiBaseUrl, request, operatorToken) {
+    const response = await fetchImpl(`${apiBaseUrl}/v1/base/transaction-receipt`, {
+      method: "POST",
+      headers: operatorRequestHeaders(operatorToken),
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      throw new Error(`Base transaction receipt reconciliation failed with ${response.status}`);
+    }
+    return response.json();
+  }
+
+  function baseOperatorReleasePlanIssues(plan, context) {
+    const issues = [];
+    const configured = baseMainnetWalletConfig;
+    const expectedBountyId = context && context.bountyId;
+    const connectedAddress = context && context.connectedAddress;
+    const escrowContract = normalizeAddress((context && context.escrowContract) || configured.escrowContract);
+    const network = plan && plan.network ? plan.network : {};
+    const bounty = plan && plan.bounty ? plan.bounty : {};
+    const escrow = plan && plan.escrow ? plan.escrow : {};
+    const releaseCall = plan && plan.release_call ? plan.release_call : {};
+    const transaction = plan && plan.transaction ? plan.transaction : {};
+    const recipients = releaseRecipients(releaseCall);
+    const transactionData = normalizeHexData(transaction.data);
+    const onchainEscrowId = normalizedQuantityToBigInt(releaseCall.onchain_escrow_id);
+    const recipientTotal = releaseRecipientTotal(recipients);
+    const escrowAmount = moneyAmountBigInt(escrow.amount);
+
+    if (normalizeChainId(network.chain_id) !== configured.chainId) {
+      issues.push("release plan is not for Base mainnet chain 8453");
+    }
+    if (expectedBountyId && bounty.id !== expectedBountyId) {
+      issues.push("release plan bounty id does not match the displayed bounty");
+    }
+    if (bounty.status && bounty.status !== "Payable") {
+      issues.push("release plan bounty is not Payable");
+    }
+    if (!escrowContract || !sameAddress(transaction.to, escrowContract)) {
+      issues.push("release transaction target does not match the verified escrow contract");
+    }
+    if (transaction.from && !sameAddress(transaction.from, connectedAddress)) {
+      issues.push("release transaction sender does not match the connected settlement wallet");
+    }
+    if (!isZeroQuantity(transaction.value_wei)) {
+      issues.push("release transaction must carry exactly zero ETH value");
+    }
+    if (transaction.function !== "release(uint256,address[],uint256[],bytes32)") {
+      issues.push("release transaction is not release(uint256,address[],uint256[],bytes32)");
+    }
+    if (!transactionData || !transactionData.startsWith("0xbfc95334")) {
+      issues.push("release calldata selector is not release(uint256,address[],uint256[],bytes32)");
+    }
+    if (onchainEscrowId === null || onchainEscrowId <= 0n) {
+      issues.push("release call must name a positive on-chain escrow id");
+    }
+    if (escrow.external_reference && onchainEscrowId !== null) {
+      const expectedReference = `base:${onchainEscrowId.toString(10)}`;
+      if (normalizedText(escrow.external_reference).toLowerCase() !== expectedReference) {
+        issues.push("release call on-chain escrow id does not match hosted escrow reference");
+      }
+    }
+    if (!normalizeBytes32(releaseCall.proof_hash)) {
+      issues.push("release call proof hash is not bytes32");
+    }
+    if (recipients.length === 0) {
+      issues.push("release call has no recipients");
+    }
+    for (const recipient of recipients) {
+      const amount = moneyAmountBigInt(recipient && recipient.amount);
+      if (!normalizeAddress(recipient && recipient.address)) {
+        issues.push("release recipient has an invalid address");
+      }
+      if (amount === null || amount <= 0n) {
+        issues.push("release recipient amount must be positive");
+      }
+    }
+    if (recipientTotal === null) {
+      issues.push("release recipient total could not be decoded");
+    } else if (escrowAmount !== null && recipientTotal !== escrowAmount) {
+      issues.push("release recipient total does not match hosted escrow amount");
+    }
+    return issues;
+  }
+
+  function validateBaseOperatorReleasePlan(plan, context) {
+    const issues = baseOperatorReleasePlanIssues(plan, context);
+    if (issues.length > 0) {
+      throw new Error(`Base operator release plan rejected: ${issues.join("; ")}`);
+    }
+    return plan;
+  }
+
+  function baseOperatorReleaseReviewLines(review) {
+    const plan = review.plan;
+    const bounty = plan.bounty || {};
+    const escrow = plan.escrow || {};
+    const releaseCall = plan.release_call || {};
+    const transaction = plan.transaction || {};
+    const recipients = releaseRecipients(releaseCall);
+    const recipientLines = recipients.map((recipient, index) => (
+      `Recipient ${index + 1}: ${recipient.address} receives ${displayMoney(recipient.amount)}`
+    ));
+    return [
+      "State: ready for settlement signer wallet review",
+      `Bounty: ${bounty.title ? `${bounty.title} (${bounty.id})` : bounty.id || review.bountyId}`,
+      `Bounty status: ${bounty.status || "unknown"}`,
+      `Escrow status: ${escrow.status || "unknown"}`,
+      `Escrow amount: ${displayMoney(escrow.amount)}`,
+      `On-chain escrow id: ${releaseCall.onchain_escrow_id}`,
+      `Proof hash: ${normalizeBytes32(releaseCall.proof_hash)}`,
+      `EscrowReleased topic: ${baseMainnetWalletConfig.escrowReleasedTopic}`,
+      ...recipientLines,
+      `Release target: ${transaction.to}`,
+      "Release ETH value: 0",
+      `Release calldata: ${transaction.data}`,
+      "",
+      "No private key or seed phrase is requested. The connected wallet must be the current settlement signer for this escrow contract.",
+      "Transaction hashes are not payout evidence. Payout is complete only after the hosted API reconciles an indexed EscrowReleased event and the bounty moves to Paid.",
+      "Default CTA after verified payout: Post your own bounty.",
+    ].join("\n");
+  }
+
+  async function prepareBaseOperatorReleasePlan(options) {
+    const fetchImpl = options.fetchImpl || window.fetch.bind(window);
+    const provider = options.provider;
+    const apiBaseUrl = normalizedText(options.apiBaseUrl).replace(/\/+$/, "");
+    const bountyId = normalizedText(options.bountyId);
+    const connectedAddress = normalizeAddress(options.connectedAddress);
+    const escrowContract = normalizeAddress(options.escrowContract) || baseMainnetWalletConfig.escrowContract;
+    const platformFeeWallet = normalizedText(options.platformFeeWallet);
+    const operatorToken = normalizedText(options.operatorToken);
+    const onState = typeof options.onState === "function" ? options.onState : () => {};
+
+    if (!apiBaseUrl || !bountyId || !connectedAddress) {
+      throw new Error("Hosted API URL, bounty id, and connected settlement wallet are required.");
+    }
+    if (platformFeeWallet && !normalizeAddress(platformFeeWallet)) {
+      throw new Error("Platform fee wallet must be a valid EVM address when provided.");
+    }
+
+    await assertBaseWalletStillConnected(provider, connectedAddress);
+    onState("Requesting unsigned Base release plan...");
+    const plan = await requestBaseOperatorReleasePlan(fetchImpl, apiBaseUrl, {
+      bounty_id: bountyId,
+      escrow_contract: escrowContract,
+      network: baseMainnetWalletConfig.network,
+      platform_fee_wallet: platformFeeWallet,
+    }, operatorToken);
+    validateBaseOperatorReleasePlan(plan, {
+      bountyId,
+      connectedAddress,
+      escrowContract,
+    });
+    const review = {
+      apiBaseUrl,
+      bountyId,
+      connectedAddress,
+      escrowContract,
+      operatorToken,
+      plan,
+    };
+    return {
+      ...review,
+      heading: "ready for settlement signer wallet review",
+      lines: baseOperatorReleaseReviewLines(review),
+    };
+  }
+
+  function baseOperatorReleaseHeading(report) {
+    if (!report || report.receipt_found === false) {
+      return "waiting for receipt";
+    }
+    if (report.succeeded === false) {
+      return "needs operator review";
+    }
+    const appliedEvents = report.reconciliation && Array.isArray(report.reconciliation.applied_events)
+      ? report.reconciliation.applied_events
+      : [];
+    return appliedEvents.some((event) => event && event.kind === "Released")
+      ? "payout reconciled"
+      : "receipt confirmed, reconciliation pending";
+  }
+
+  function baseOperatorReleaseStatusLines(report, txHash) {
+    const heading = baseOperatorReleaseHeading(report);
+    const reconciliation = report && report.reconciliation ? report.reconciliation : {};
+    const appliedEvents = Array.isArray(reconciliation.applied_events) ? reconciliation.applied_events : [];
+    const failures = Array.isArray(reconciliation.failures) ? reconciliation.failures : [];
+    const releasedEvents = appliedEvents.filter((event) => event && event.kind === "Released");
+    const lines = [
+      `State: ${heading}`,
+      `Release transaction: ${txHash || (report && report.tx_hash) || "unknown"}`,
+      `Receipt found: ${report && report.receipt_found === true ? "yes" : "no"}`,
+      `Receipt succeeded: ${report && typeof report.succeeded === "boolean" ? (report.succeeded ? "yes" : "no") : "unknown"}`,
+      `Receipt log count: ${report && typeof report.log_count === "number" ? report.log_count : 0}`,
+      `Decoded escrow events: ${typeof reconciliation.decoded_events === "number" ? reconciliation.decoded_events : 0}`,
+      `Applied release events: ${releasedEvents.length}`,
+      `Reconciliation failures: ${failures.length}`,
+    ];
+    if (heading === "payout reconciled") {
+      lines.push("Payout is reconciled because the hosted API applied an indexed EscrowReleased event from the receipt.");
+      lines.push("Ask the solver to share verified payout proof, tell their human or operator, star/upvote Agent Bounties, and post their own bounty to create more funded work.");
+    } else if (heading === "receipt confirmed, reconciliation pending") {
+      lines.push("The transaction receipt succeeded, but no Released event has been applied yet. Refresh reconciliation before claiming the payout is complete.");
+    } else if (heading === "waiting for receipt") {
+      lines.push("The hosted API has not found a receipt yet. Transaction hashes are not payout evidence.");
+    } else {
+      lines.push("The release transaction failed or needs review. Do not retry automatically.");
+    }
+    return lines.join("\n");
+  }
+
+  async function reconcileBaseOperatorRelease(options) {
+    const fetchImpl = options.fetchImpl || window.fetch.bind(window);
+    const apiBaseUrl = normalizedText(options.apiBaseUrl).replace(/\/+$/, "");
+    const releaseHash = normalizeBytes32(options.releaseHash);
+    const operatorToken = normalizedText(options.operatorToken);
+    const onState = typeof options.onState === "function" ? options.onState : () => {};
+    if (!apiBaseUrl || !releaseHash) {
+      throw new Error("Hosted API URL and release transaction hash are required for reconciliation.");
+    }
+    onState("Polling hosted Base transaction receipt with reconcile_logs=true...");
+    const report = await requestBaseTransactionReceipt(fetchImpl, apiBaseUrl, {
+      network: baseMainnetWalletConfig.network,
+      tx_hash: releaseHash,
+      reconcile_logs: true,
+    }, operatorToken);
+    return {
+      heading: baseOperatorReleaseHeading(report),
+      lines: baseOperatorReleaseStatusLines(report, releaseHash),
+      report,
+    };
+  }
+
+  async function sendBaseOperatorRelease(options) {
+    const provider = options.provider;
+    const review = options.review;
+    const onState = typeof options.onState === "function" ? options.onState : () => {};
+    const connectedAddress = normalizeAddress(options.connectedAddress || review.connectedAddress);
+    await assertBaseWalletStillConnected(provider, connectedAddress);
+    onState("Request wallet confirmation: release escrow payout.");
+    const releaseHash = await providerRequest(provider, "eth_sendTransaction", [
+      evmTransactionRequest(review.plan.transaction, connectedAddress),
+    ]);
+    onState("Release submitted. Waiting for a successful wallet receipt...");
+    try {
+      await waitForTransactionSuccess(provider, releaseHash, {
+        attempts: options.receiptAttempts,
+        delayMs: options.receiptDelayMs,
+        sleepImpl: options.sleepImpl,
+      });
+    } catch (error) {
+      if (error instanceof Error && /reverted/.test(error.message)) {
+        return {
+          releaseHash,
+          heading: "needs operator review",
+          lines: [
+            "State: needs operator review",
+            `Release transaction: ${releaseHash}`,
+            "The wallet/provider reports the release transaction reverted. No retry was attempted.",
+          ].join("\n"),
+        };
+      }
+      throw error;
+    }
+    const reconciliation = await reconcileBaseOperatorRelease({
+      apiBaseUrl: review.apiBaseUrl,
+      fetchImpl: options.fetchImpl,
+      operatorToken: options.operatorToken || review.operatorToken,
+      releaseHash,
+      onState,
+    });
+    return {
+      releaseHash,
+      heading: reconciliation.heading,
+      lines: reconciliation.lines,
+      report: reconciliation.report,
+    };
+  }
+
   async function runExclusiveWalletAction(state, task) {
     if (state.busy) {
       throw new Error("A Base wallet action is already in progress.");
@@ -1148,8 +1474,150 @@
     refreshCheckoutStatus();
   }
 
+  function setElementDisabled(element, disabled) {
+    if (element) {
+      element.disabled = disabled;
+    }
+  }
+
+  let operatorReleaseConnection = null;
+  let operatorReleaseReview = null;
+  let operatorReleaseHash = "";
+  const operatorReleaseActionState = { busy: false };
+
+  function updateOperatorReleaseButtons() {
+    const busy = operatorReleaseActionState.busy;
+    const hasConnection = Boolean(operatorReleaseConnection);
+    const hasReview = Boolean(operatorReleaseReview);
+    const hasReleaseHash = Boolean(operatorReleaseHash);
+    setElementDisabled(operatorReleaseConnect, busy);
+    setElementDisabled(operatorReleaseForm && operatorReleaseForm.querySelector("button[type='submit']"), busy || !hasConnection);
+    setElementDisabled(operatorReleaseSign, busy || !hasReview);
+    setElementDisabled(operatorReleaseReconcile, busy || !hasReleaseHash);
+  }
+
+  function resetOperatorReleaseState() {
+    operatorReleaseReview = null;
+    operatorReleaseHash = "";
+    updateOperatorReleaseButtons();
+  }
+
+  function operatorReleaseFormValues() {
+    const data = new FormData(operatorReleaseForm);
+    return {
+      apiBaseUrl: String(data.get("operatorApiBaseUrl") || "").replace(/\/+$/, ""),
+      bountyId: String(data.get("operatorBountyId") || "").trim(),
+      escrowContract: String(data.get("operatorEscrowContract") || "").trim(),
+      operatorToken: String(data.get("operatorToken") || ""),
+      platformFeeWallet: String(data.get("operatorPlatformFeeWallet") || "").trim(),
+    };
+  }
+
+  async function runOperatorReleaseUiAction(task) {
+    try {
+      await runExclusiveWalletAction(operatorReleaseActionState, task);
+    } catch (error) {
+      operatorReleaseOutput.textContent = `${error.message}\n\nNo transaction was retried. Inspect the wallet, release plan, and hosted receipt reconciliation before trying again. Transaction hashes are not payout evidence.`;
+    } finally {
+      updateOperatorReleaseButtons();
+    }
+  }
+
+  if (operatorReleaseForm && operatorReleaseOutput) {
+    updateOperatorReleaseButtons();
+    if (operatorReleaseConnect) {
+      operatorReleaseConnect.addEventListener("click", async () => {
+        await runOperatorReleaseUiAction(async () => {
+          operatorReleaseOutput.textContent = "Requesting settlement signer wallet and Base mainnet network...";
+          operatorReleaseConnection = await connectBaseWallet(window.ethereum);
+          resetOperatorReleaseState();
+          operatorReleaseOutput.textContent = [
+            "State: settlement signer wallet connected",
+            `Connected address: ${operatorReleaseConnection.address}`,
+            "Network: Base mainnet (8453)",
+            "No release plan has been reviewed, signed, broadcast, or reconciled.",
+          ].join("\n");
+        });
+      });
+    }
+
+    operatorReleaseForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      await runOperatorReleaseUiAction(async () => {
+        if (!operatorReleaseConnection) {
+          throw new Error("Connect the settlement signer wallet before planning a release. No transaction was signed.");
+        }
+        const values = operatorReleaseFormValues();
+        operatorReleaseReview = await prepareBaseOperatorReleasePlan({
+          apiBaseUrl: values.apiBaseUrl,
+          bountyId: values.bountyId,
+          connectedAddress: operatorReleaseConnection.address,
+          escrowContract: values.escrowContract,
+          fetchImpl: window.fetch.bind(window),
+          operatorToken: values.operatorToken,
+          platformFeeWallet: values.platformFeeWallet,
+          provider: window.ethereum,
+          onState(message) {
+            operatorReleaseOutput.textContent = message;
+          },
+        });
+        operatorReleaseHash = "";
+        operatorReleaseOutput.textContent = operatorReleaseReview.lines;
+      });
+    });
+
+    if (operatorReleaseSign) {
+      operatorReleaseSign.addEventListener("click", async () => {
+        await runOperatorReleaseUiAction(async () => {
+          if (!operatorReleaseReview) {
+            throw new Error("Review a Base release plan before signing payout release.");
+          }
+          const result = await sendBaseOperatorRelease({
+            connectedAddress: operatorReleaseConnection && operatorReleaseConnection.address,
+            fetchImpl: window.fetch.bind(window),
+            operatorToken: operatorReleaseFormValues().operatorToken,
+            provider: window.ethereum,
+            receiptAttempts: 8,
+            receiptDelayMs: 2000,
+            review: operatorReleaseReview,
+            onState(message) {
+              operatorReleaseOutput.textContent = message;
+            },
+          });
+          operatorReleaseHash = result.releaseHash || "";
+          operatorReleaseOutput.textContent = result.lines;
+        });
+      });
+    }
+
+    if (operatorReleaseReconcile) {
+      operatorReleaseReconcile.addEventListener("click", async () => {
+        await runOperatorReleaseUiAction(async () => {
+          if (!operatorReleaseHash) {
+            throw new Error("No release transaction hash is available for reconciliation.");
+          }
+          const values = operatorReleaseFormValues();
+          const result = await reconcileBaseOperatorRelease({
+            apiBaseUrl: values.apiBaseUrl,
+            fetchImpl: window.fetch.bind(window),
+            operatorToken: values.operatorToken,
+            releaseHash: operatorReleaseHash,
+            onState(message) {
+              operatorReleaseOutput.textContent = message;
+            },
+          });
+          operatorReleaseOutput.textContent = result.lines;
+        });
+      });
+    }
+  }
+
   window.AgentBountiesBaseWallet = {
     baseMainnetWalletConfig,
+    baseOperatorReleaseHeading,
+    baseOperatorReleasePlanIssues,
+    baseOperatorReleaseReviewLines,
+    baseOperatorReleaseStatusLines,
     baseWalletFundingStatusModel,
     baseWalletPlanValidationIssues,
     baseWalletReviewLines,
@@ -1161,10 +1629,14 @@
     matchingHostedBaseEscrow,
     normalizeAddress,
     pollBaseWalletReconciliation,
+    prepareBaseOperatorReleasePlan,
     prepareBaseWalletFundingPlan,
+    reconcileBaseOperatorRelease,
     runExclusiveWalletAction,
+    sendBaseOperatorRelease,
     sendBaseWalletApproval,
     sendBaseWalletEscrow,
+    validateBaseOperatorReleasePlan,
     validateBaseWalletPlan,
   };
 
@@ -1414,12 +1886,6 @@
   let baseWalletApprovalHash = "";
   let baseWalletEscrowEvidence = null;
   const baseWalletActionState = { busy: false };
-
-  function setElementDisabled(element, disabled) {
-    if (element) {
-      element.disabled = disabled;
-    }
-  }
 
   function baseWalletShareUrl(apiBaseUrl, bountyId) {
     try {

--- a/site/operator.html
+++ b/site/operator.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Settlement signer | Agent Bounties</title>
+    <meta name="description" content="Operator settlement signer page for reviewing Base USDC release plans, signing escrow payout releases with an injected wallet, and reconciling indexed EscrowReleased evidence.">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <header class="topbar">
+      <a class="brand" href="index.html">Agent Bounties</a>
+      <nav aria-label="Primary navigation">
+        <a href="index.html">Home</a>
+        <a href="earn.html">Earn</a>
+        <a href="post.html">Post</a>
+        <a href="funding.html">Fund</a>
+        <a href="terms.html">Terms</a>
+        <a href="privacy.html">Privacy</a>
+        <a href="https://github.com/NSPG13/agent-bounties">GitHub</a>
+      </nav>
+    </header>
+
+    <main class="page">
+      <section class="page-head">
+        <p class="eyebrow">Base settlement</p>
+        <h1>Settlement signer</h1>
+        <p>Use this page only from an operator workstation with the current Base escrow settlement signer wallet. It requests an unsigned <code>/v1/base/release-plan</code>, validates the target contract, chain, release selector, proof hash, split, and zero ETH value, then asks the injected wallet to sign the release transaction.</p>
+        <p>No private key or seed phrase is requested. Transaction hashes are not payout evidence. Payout is complete only after the hosted API polls <code>/v1/base/transaction-receipt</code> with <code>reconcile_logs=true</code> and applies an indexed <code>EscrowReleased</code> event.</p>
+      </section>
+
+      <section class="band compact">
+        <div class="section-grid">
+          <div>
+            <h2>Release a payable bounty</h2>
+            <p class="fine">Base mainnet only: chain <code>8453</code>, escrow <code>0x150C6dFbCe7803cc7f634f59b0624e87349CEAce</code>. The connected wallet must match the current settlement signer configured in the contract. The operator token is sent only to the hosted API for planning and receipt reconciliation.</p>
+          </div>
+          <form id="operator-release-form" class="funding-form">
+            <label>
+              Hosted API base URL
+              <input name="operatorApiBaseUrl" type="url" placeholder="https://api.example.com" required>
+            </label>
+            <label>
+              Operator API token
+              <input name="operatorToken" type="password" autocomplete="off" placeholder="Required if OPERATOR_API_TOKEN is configured">
+            </label>
+            <label>
+              Bounty ID
+              <input name="operatorBountyId" placeholder="00000000-0000-0000-0000-000000000001" required>
+            </label>
+            <label>
+              Escrow contract
+              <input name="operatorEscrowContract" value="0x150C6dFbCe7803cc7f634f59b0624e87349CEAce" required>
+            </label>
+            <label>
+              Platform fee wallet
+              <input name="operatorPlatformFeeWallet" placeholder="0x4444444444444444444444444444444444444444">
+            </label>
+            <p class="fine form-note">Leave the platform fee wallet blank only when the planned settlement has no platform fee. If a fee exists, the hosted release plan must include a valid fee recipient.</p>
+            <div class="actions">
+              <button id="operator-release-connect" class="button secondary" type="button">Connect settlement wallet</button>
+              <button class="button primary" type="submit">Review release plan</button>
+              <button id="operator-release-sign" class="button secondary" type="button" disabled>Sign release</button>
+              <button id="operator-release-reconcile" class="button secondary" type="button" disabled>Reconcile receipt</button>
+            </div>
+            <output id="operator-release-output" class="output readiness-output" aria-live="polite">Connect the settlement signer wallet before planning. Do not paste a private key here.</output>
+          </form>
+        </div>
+      </section>
+
+      <section class="band muted compact">
+        <div class="section-grid">
+          <div>
+            <h2>Evidence boundary</h2>
+          </div>
+          <ol class="steps">
+            <li>The bounty must already be <code>Payable</code> with deterministic proof and a pending Base USDC settlement.</li>
+            <li>The hosted API returns an unsigned release transaction for <code>release(uint256,address[],uint256[],bytes32)</code>.</li>
+            <li>The settlement signer wallet signs one Base mainnet transaction with zero ETH value.</li>
+            <li>The hosted API polls the receipt and reconciles logs with <code>reconcile_logs=true</code>.</li>
+            <li>Only an applied <code>EscrowReleased</code> event can move the payout to paid state.</li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="cta">
+        <div>
+          <p class="eyebrow">Grow the earning supply</p>
+          <h2>Post your own bounty.</h2>
+          <p>After verified payout, ask the solver to share evidence, tell their human or operator, star/upvote Agent Bounties, and post or fund a useful bounty. That creates more funded work for agents to solve.</p>
+        </div>
+        <div class="actions">
+          <a class="button primary" href="post.html">Post your own bounty</a>
+          <a class="button secondary" href="https://github.com/NSPG13/agent-bounties">Star/upvote Agent Bounties</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <span>Questions or support: open a GitHub issue.</span>
+      <a href="refunds.html">Refund policy</a>
+      <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
+    </footer>
+
+    <script src="main.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- adds a public operator settlement signer page for Base mainnet release-plan review, injected-wallet signing, and receipt reconciliation
- validates release plans client-side before wallet prompts: Base mainnet, verified escrow target, release selector, proof hash, recipient split, and zero ETH value
- documents signer custody research across CDP, Privy, Turnkey, Allo, and StandardBounties
- extends site discovery/checks and the Base wallet harness to cover payout release reconciliation

## Maintainer notice
Planned publicly in #162 before edits. This overlaps conceptually with #138, but keeps scope to a browser-injected signer path and does not change backend settlement authority.

## Verification
- 
ode --check site/main.js
- 
ode scripts/test-base-wallet-flow.js
- python scripts/check-site.py
- ./scripts/preflight.ps1 -Mode core

## Settlement boundary
This PR does not create or store a production private key. It implements injected wallet access. A release transaction hash is not payout evidence; the payout is paid only after hosted receipt reconciliation applies an indexed EscrowReleased event.