### PR TITLE
Add non-custodial autonomous activation console

### DIFF
--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -59,6 +59,8 @@ Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\check-migration-his
 Invoke-Checked { node --check skills\agent-bounties\scripts\check-in.mjs }
 Invoke-Checked { node --test scripts\test_agent_bounties_openclaw_skill.mjs }
 Invoke-Checked { node scripts\test-autonomous-wallet-flow.js }
+Invoke-Checked { node --check tools\autonomous-activation.js }
+Invoke-Checked { node scripts\test-autonomous-activation-console.js }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m pip install -r scripts\requirements-attest.txt }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_base_deployment_attest.py -v }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\check-render-blueprint.py }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -92,6 +92,8 @@ cargo run -p cli -- discovery-report \
 node --check skills/agent-bounties/scripts/check-in.mjs
 node --test scripts/test_agent_bounties_openclaw_skill.mjs
 node scripts/test-autonomous-wallet-flow.js
+node --check tools/autonomous-activation.js
+node scripts/test-autonomous-activation-console.js
 "${python_cmd[@]}" -m pip install -r scripts/requirements-attest.txt
 "${python_cmd[@]}" scripts/test_base_deployment_attest.py -v
 "${python_cmd[@]}" scripts/check-render-blueprint.py

--- a/scripts/test-autonomous-activation-console.js
+++ b/scripts/test-autonomous-activation-console.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "..");
+const html = fs.readFileSync(path.join(root, "tools", "autonomous-activation.html"), "utf8");
+const script = fs.readFileSync(path.join(root, "tools", "autonomous-activation.js"), "utf8");
+const bundle = JSON.parse(fs.readFileSync(path.join(root, "deployments", "base-mainnet-activation.json"), "utf8"));
+
+for (const required of [
+  "/deployments/base-mainnet-activation.json",
+  "wallet_sendCalls",
+  "eth_estimateGas",
+  "eth_getTransactionCount",
+  "eth_getCode",
+  "eth_sendTransaction",
+  "0xdb021126",
+  "Indexer reconciliation is still required",
+  "127.0.0.1",
+  "localhost",
+]) {
+  assert.ok(script.includes(required), `activation console must include ${required}`);
+}
+
+for (const forbidden of ["privateKey", "private_key", "seed phrase", "mnemonic", "eth_sign"]) {
+  assert.ok(!script.toLowerCase().includes(forbidden.toLowerCase()), `activation console must exclude ${forbidden}`);
+  assert.ok(!html.toLowerCase().includes(forbidden.toLowerCase()), `activation page must exclude ${forbidden}`);
+}
+
+assert.ok(html.includes("Content-Security-Policy"));
+assert.ok(html.includes("Use sequential fallback"));
+assert.ok(!html.includes("https://cdn."));
+assert.ok(!html.includes("<input"), "activation console must not accept transaction overrides");
+assert.equal(bundle.deployment.from, "0x884834e884d6e93462655a2820140ad03e6747bc");
+assert.equal(bundle.deployment.deployer_nonce, 4);
+assert.equal(bundle.deployment.expected_factory, "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9");
+assert.equal(bundle.deployment.expected_implementation, "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9");
+assert.equal(bundle.creation_batch.wallet_calls.length, 5);
+assert.equal(bundle.creation_batch.wallet_calls[0].function, "approve(address,uint256)");
+assert.ok(bundle.creation_batch.wallet_calls[0].data.startsWith("0x095ea7b3"));
+assert.ok(bundle.creation_batch.wallet_calls[0].data.endsWith("00000000000000000000000000000000000000000000000000000000003d0900"));
+for (const call of bundle.creation_batch.wallet_calls.slice(1)) {
+  assert.equal(call.to, bundle.deployment.expected_factory);
+  assert.ok(call.data.startsWith("0x9d2e414c"));
+}
+console.log("autonomous activation console contract passed");

--- a/tools/autonomous-activation.html
+++ b/tools/autonomous-activation.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://mainnet.base.org; script-src 'self'; style-src 'unsafe-inline'">
+    <title>Autonomous V1 Activation</title>
+    <style>
+      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #111315; color: #f4f5f5; }
+      * { box-sizing: border-box; }
+      body { margin: 0; min-height: 100vh; background: #111315; }
+      main { width: min(920px, calc(100% - 32px)); margin: 0 auto; padding: 40px 0 64px; }
+      header { display: flex; align-items: end; justify-content: space-between; gap: 24px; padding-bottom: 20px; border-bottom: 1px solid #34383b; }
+      h1 { margin: 0; font-size: 30px; line-height: 1.1; letter-spacing: 0; }
+      h2 { margin: 0 0 14px; font-size: 17px; letter-spacing: 0; }
+      p { color: #b8bec2; line-height: 1.55; }
+      code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; color: #d9e7df; overflow-wrap: anywhere; }
+      .badge { padding: 6px 9px; border: 1px solid #4c5256; border-radius: 4px; color: #d9dddf; font-size: 12px; white-space: nowrap; }
+      section { padding: 24px 0; border-bottom: 1px solid #2b2f32; }
+      .facts { display: grid; grid-template-columns: 180px minmax(0, 1fr); gap: 10px 18px; margin: 0; }
+      .facts dt { color: #8f989e; }
+      .facts dd { margin: 0; }
+      .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 18px; }
+      button { min-height: 42px; border: 1px solid #4b5358; border-radius: 6px; padding: 0 15px; background: #252a2d; color: #f8f9f9; font: inherit; font-weight: 650; cursor: pointer; }
+      button.primary { background: #e9f4ed; border-color: #e9f4ed; color: #152019; }
+      button.warning { background: #35291e; border-color: #876a42; color: #f5dfc2; }
+      button:disabled { cursor: not-allowed; opacity: .42; }
+      output { display: block; min-height: 104px; margin-top: 16px; padding: 14px; border: 1px solid #343a3e; border-radius: 6px; background: #0b0d0e; color: #c8ced1; white-space: pre-wrap; overflow-wrap: anywhere; font: 13px/1.55 ui-monospace, SFMono-Regular, Consolas, monospace; }
+      output[data-tone="success"] { border-color: #3e7654; color: #cce8d4; }
+      output[data-tone="error"] { border-color: #8a4b4b; color: #f2c9c9; }
+      .fine { font-size: 13px; color: #929ba0; }
+      [hidden] { display: none !important; }
+      @media (max-width: 620px) { main { width: min(100% - 24px, 920px); padding-top: 24px; } header { align-items: start; flex-direction: column; } .facts { grid-template-columns: 1fr; gap: 4px; } .facts dd { margin-bottom: 10px; } button { flex: 1 1 100%; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <h1>Autonomous V1 Activation</h1>
+          <p>Local, non-custodial bootstrap for the committed Base mainnet canary.</p>
+        </div>
+        <span class="badge">Unsigned bundle</span>
+      </header>
+
+      <section>
+        <h2>Committed Scope</h2>
+        <dl class="facts">
+          <dt>Factory</dt><dd><code data-factory>Loading...</code></dd>
+          <dt>Implementation</dt><dd><code data-implementation>Loading...</code></dd>
+          <dt>Creator</dt><dd><code data-creator>Loading...</code></dd>
+          <dt>Bounties</dt><dd data-bounties>Loading...</dd>
+          <dt>Total funding</dt><dd data-funding>Loading...</dd>
+        </dl>
+        <p class="fine">This console accepts no address, amount, calldata, RPC, or contract override. It reads the checked-in bundle from this repository.</p>
+      </section>
+
+      <section>
+        <h2>1. Inspect Wallet And Chain</h2>
+        <p>Connect the exact creator wallet. The console checks Base chain ID, nonce, predicted address occupancy, balances, and deployment gas before enabling a transaction.</p>
+        <div class="actions">
+          <button class="primary" id="inspect">Connect and inspect</button>
+        </div>
+        <output id="inspect-output">Waiting for wallet inspection.</output>
+      </section>
+
+      <section>
+        <h2>2. Deploy Canonical Factory</h2>
+        <p>One wallet confirmation deploys the immutable factory and its immutable bounty implementation.</p>
+        <div class="actions">
+          <button id="deploy" disabled>Deploy factory</button>
+        </div>
+        <output id="deploy-output">Deployment is disabled until inspection passes.</output>
+      </section>
+
+      <section>
+        <h2>3. Fund Four Bounties</h2>
+        <p>The preferred action is one EIP-5792 wallet batch: an exact 4 USDC approval followed by four 1 USDC canonical creations.</p>
+        <div class="actions">
+          <button id="activate" disabled>Send wallet batch</button>
+          <button class="warning" id="sequential" disabled hidden>Use sequential fallback</button>
+          <button id="verify" disabled>Verify activation</button>
+        </div>
+        <output id="activate-output">Funding is disabled until the factory is verified.</output>
+      </section>
+    </main>
+    <script src="autonomous-activation.js"></script>
+  </body>
+</html>

--- a/tools/autonomous-activation.js
+++ b/tools/autonomous-activation.js
@@ -1,0 +1,266 @@
+(() => {
+  "use strict";
+
+  const BASE_CHAIN_ID = "0x2105";
+  const BUNDLE_URL = "/deployments/base-mainnet-activation.json";
+  const state = { bundle: null, account: null, inspected: false, factoryVerified: false };
+  const byId = (id) => document.getElementById(id);
+  const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+  function write(target, value, tone = "") {
+    target.textContent = Array.isArray(value) ? value.join("\n") : value;
+    target.dataset.tone = tone;
+  }
+
+  function requireLocalOrigin() {
+    if (!new Set(["127.0.0.1", "localhost"]).has(location.hostname)) {
+      throw new Error("Activation console must be served from localhost.");
+    }
+  }
+
+  async function loadBundle() {
+    requireLocalOrigin();
+    const response = await fetch(BUNDLE_URL, { cache: "no-store" });
+    if (!response.ok) throw new Error("The checked-in activation bundle is unavailable.");
+    const bundle = await response.json();
+    if (
+      bundle.schema_version !== "agent-bounties/autonomous-activation-bundle-v1"
+      || bundle.network !== "base-mainnet"
+      || bundle.chain_id !== 8453
+      || bundle.deployment.to !== null
+      || bundle.deployment.value_wei !== 0
+      || bundle.creation_batch.total_initial_funding !== "4000000"
+      || bundle.bounties.length !== 4
+      || bundle.creation_batch.wallet_calls.length !== 5
+    ) {
+      throw new Error("Activation bundle violates the capped autonomous-v1 contract.");
+    }
+    state.bundle = bundle;
+    document.querySelector("[data-factory]").textContent = bundle.deployment.expected_factory;
+    document.querySelector("[data-implementation]").textContent = bundle.deployment.expected_implementation;
+    document.querySelector("[data-creator]").textContent = bundle.deployment.from;
+    document.querySelector("[data-bounties]").textContent = bundle.bounties.map((item) => `#${item.issue}`).join(", ");
+    document.querySelector("[data-funding]").textContent = `${Number(bundle.creation_batch.total_initial_funding) / 1_000_000} USDC`;
+    return bundle;
+  }
+
+  async function wallet(method, params = []) {
+    if (!window.ethereum) throw new Error("Open this page in a browser with MetaMask or another EIP-1193 wallet.");
+    return window.ethereum.request({ method, params });
+  }
+
+  async function connect() {
+    const accounts = await wallet("eth_requestAccounts");
+    if (!accounts || !accounts[0]) throw new Error("The wallet returned no account.");
+    const account = accounts[0].toLowerCase();
+    if (account !== state.bundle.deployment.from.toLowerCase()) {
+      throw new Error(`Select the committed creator wallet ${state.bundle.deployment.from}.`);
+    }
+    if ((await wallet("eth_chainId")).toLowerCase() !== BASE_CHAIN_ID) {
+      await wallet("wallet_switchEthereumChain", [{ chainId: BASE_CHAIN_ID }]);
+    }
+    state.account = account;
+    return account;
+  }
+
+  function addressWord(address) {
+    return address.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+  }
+
+  function uintResult(value) {
+    return BigInt(value || "0x0");
+  }
+
+  function addressResult(value) {
+    return `0x${String(value).replace(/^0x/, "").slice(-40)}`.toLowerCase();
+  }
+
+  async function call(to, data) {
+    return wallet("eth_call", [{ to, data }, "latest"]);
+  }
+
+  async function tokenBalance(address) {
+    return uintResult(await call(state.bundle.deployment.settlement_token, `0x70a08231${addressWord(address)}`));
+  }
+
+  async function verifyFactory() {
+    const deployment = state.bundle.deployment;
+    const code = await wallet("eth_getCode", [deployment.expected_factory, "latest"]);
+    if (!code || code === "0x") return false;
+    const implementation = addressResult(await call(deployment.expected_factory, "0x5c60da1b"));
+    const token = addressResult(await call(deployment.expected_factory, "0x7b9e618d"));
+    if (implementation !== deployment.expected_implementation.toLowerCase()) {
+      throw new Error(`Factory implementation mismatch: ${implementation}`);
+    }
+    if (token !== deployment.settlement_token.toLowerCase()) {
+      throw new Error(`Factory settlement token mismatch: ${token}`);
+    }
+    state.factoryVerified = true;
+    byId("activate").disabled = false;
+    byId("verify").disabled = false;
+    return true;
+  }
+
+  async function inspect() {
+    const target = byId("inspect-output");
+    try {
+      const account = await connect();
+      const deployment = state.bundle.deployment;
+      const nonce = Number.parseInt(await wallet("eth_getTransactionCount", [account, "latest"]), 16);
+      const eth = uintResult(await wallet("eth_getBalance", [account, "latest"]));
+      const usdc = await tokenBalance(account);
+      const factoryExists = await verifyFactory();
+      if (!factoryExists && nonce !== deployment.deployer_nonce) {
+        throw new Error(`Nonce drift: bundle requires ${deployment.deployer_nonce}, wallet is ${nonce}. Regenerate the bundle before signing.`);
+      }
+      if (!factoryExists && usdc < BigInt(state.bundle.creation_batch.total_initial_funding)) {
+        throw new Error(`Wallet has ${Number(usdc) / 1_000_000} USDC; 4 USDC is required.`);
+      }
+      let estimatedGas = 0n;
+      if (!factoryExists) {
+        estimatedGas = uintResult(await wallet("eth_estimateGas", [{ from: account, data: deployment.data, value: "0x0" }]));
+      }
+      state.inspected = true;
+      byId("deploy").disabled = factoryExists;
+      write(target, [
+        `Account: ${account}`,
+        `Chain: Base mainnet (${BASE_CHAIN_ID})`,
+        `Nonce: ${nonce}`,
+        `ETH: ${(Number(eth) / 1e18).toFixed(6)}`,
+        `USDC: ${(Number(usdc) / 1_000_000).toFixed(6)}`,
+        factoryExists ? "Factory: deployed and configuration verified" : `Factory: empty predicted address; estimated deployment gas ${estimatedGas}`,
+      ], "success");
+    } catch (error) {
+      state.inspected = false;
+      byId("deploy").disabled = true;
+      write(target, error.message || String(error), "error");
+    }
+  }
+
+  async function waitReceipt(transactionHash, timeoutMilliseconds = 180_000) {
+    const deadline = Date.now() + timeoutMilliseconds;
+    while (Date.now() < deadline) {
+      const receipt = await wallet("eth_getTransactionReceipt", [transactionHash]);
+      if (receipt) {
+        if (receipt.status !== "0x1") throw new Error(`Transaction reverted: ${transactionHash}`);
+        return receipt;
+      }
+      await sleep(1_500);
+    }
+    throw new Error(`Transaction confirmation timed out: ${transactionHash}`);
+  }
+
+  async function deploy() {
+    const target = byId("deploy-output");
+    try {
+      await inspect();
+      if (!state.inspected || state.factoryVerified) return;
+      write(target, ["Wallet confirmation requested for the exact factory deployment.", `Expected: ${state.bundle.deployment.expected_factory}`]);
+      const hash = await wallet("eth_sendTransaction", [{
+        from: state.account,
+        data: state.bundle.deployment.data,
+        value: "0x0",
+      }]);
+      const receipt = await waitReceipt(hash);
+      if (String(receipt.contractAddress).toLowerCase() !== state.bundle.deployment.expected_factory.toLowerCase()) {
+        throw new Error(`Receipt contract mismatch: ${receipt.contractAddress}`);
+      }
+      if (!(await verifyFactory())) throw new Error("Factory receipt succeeded but code is unavailable.");
+      byId("deploy").disabled = true;
+      write(target, ["Factory deployment confirmed and configuration verified.", `Transaction: https://base.blockscout.com/tx/${hash}`], "success");
+    } catch (error) {
+      write(target, error.message || String(error), "error");
+    }
+  }
+
+  async function verifyActivation(timeoutMilliseconds = 0) {
+    const deadline = Date.now() + timeoutMilliseconds;
+    do {
+      try {
+        if (!(await verifyFactory())) throw new Error("Canonical factory is not deployed.");
+        const results = [];
+        for (const bounty of state.bundle.bounties) {
+          const contract = bounty.predicted_bounty_contract;
+          const canonical = uintResult(await call(state.bundle.deployment.expected_factory, `0xdb021126${addressWord(contract)}`));
+          const bountyId = (await call(contract, "0xc17bd75e")).toLowerCase();
+          const funded = uintResult(await call(contract, "0x820a5f50"));
+          const target = uintResult(await call(contract, "0x953b8fb8"));
+          const status = uintResult(await call(contract, "0x200d2ed2"));
+          const balance = await tokenBalance(contract);
+          if (canonical !== 1n || bountyId !== bounty.bounty_id.toLowerCase() || funded !== 1_000_000n || target !== 1_000_000n || balance !== 1_000_000n || status !== 1n) {
+            throw new Error(`Issue #${bounty.issue} is not yet canonical, fully funded, and claimable.`);
+          }
+          results.push(`#${bounty.issue}: ${contract} | 1 USDC | claimable`);
+        }
+        return results;
+      } catch (error) {
+        if (Date.now() >= deadline) throw error;
+        await sleep(2_000);
+      }
+    } while (true);
+  }
+
+  async function showVerifiedActivation(timeoutMilliseconds = 0) {
+    const target = byId("activate-output");
+    try {
+      const results = await verifyActivation(timeoutMilliseconds);
+      write(target, ["Canonical activation verified from chain state.", ...results, "Indexer reconciliation is still required before hosted funded/claimable language."], "success");
+    } catch (error) {
+      write(target, error.message || String(error), "error");
+    }
+  }
+
+  async function activateBatch() {
+    const target = byId("activate-output");
+    try {
+      await connect();
+      if (!(await verifyFactory())) throw new Error("Deploy and verify the factory first.");
+      write(target, "Wallet confirmation requested for one exact five-call batch.");
+      await wallet("wallet_sendCalls", [{
+        version: "2.0.0",
+        chainId: BASE_CHAIN_ID,
+        from: state.account,
+        calls: state.bundle.creation_batch.wallet_calls.map((item) => ({ to: item.to, data: item.data, value: "0x0" })),
+      }]);
+      await showVerifiedActivation(180_000);
+    } catch (error) {
+      byId("sequential").hidden = false;
+      byId("sequential").disabled = false;
+      write(target, [`Wallet batch was not completed: ${error.message || String(error)}`, "Use the explicit sequential fallback only if the wallet does not support EIP-5792 batching."], "error");
+    }
+  }
+
+  async function activateSequential() {
+    const target = byId("activate-output");
+    byId("sequential").disabled = true;
+    try {
+      await connect();
+      for (const transaction of state.bundle.creation_batch.wallet_calls) {
+        write(target, `Wallet confirmation requested: ${transaction.function}`);
+        const hash = await wallet("eth_sendTransaction", [{ from: state.account, to: transaction.to, data: transaction.data, value: "0x0" }]);
+        await waitReceipt(hash);
+      }
+      await showVerifiedActivation(90_000);
+    } catch (error) {
+      byId("sequential").disabled = false;
+      write(target, error.message || String(error), "error");
+    }
+  }
+
+  async function initialize() {
+    try {
+      await loadBundle();
+    } catch (error) {
+      write(byId("inspect-output"), error.message || String(error), "error");
+      byId("inspect").disabled = true;
+      return;
+    }
+    byId("inspect").addEventListener("click", inspect);
+    byId("deploy").addEventListener("click", deploy);
+    byId("activate").addEventListener("click", activateBatch);
+    byId("sequential").addEventListener("click", activateSequential);
+    byId("verify").addEventListener("click", () => showVerifiedActivation());
+  }
+
+  document.addEventListener("DOMContentLoaded", initialize);
+})();


### PR DESCRIPTION
## Summary
- adds a localhost-only, non-custodial activation console for the merged unsigned bundle
- verifies exact creator, Base chain, nonce, address occupancy, ETH/USDC balances, gas, factory implementation, and settlement token before enabling actions
- requests one deployment confirmation and one EIP-5792 five-call batch; sequential transactions are an explicit fallback only
- verifies four canonical bounty IDs, 1 USDC balances, funded targets, and claimable status directly from chain state
- accepts no transaction or RPC overrides and never requests key material

## Checks
- `node --check tools/autonomous-activation.js`
- `node scripts/test-autonomous-activation-console.js`
- `cargo run -p cli -- docs-contract-check`
- desktop and 390px mobile visual pass

## Contributor impact
Notice: https://github.com/NSPG13/agent-bounties/issues/72#issuecomment-4943220394

No open contributor PR files are changed.

## Evidence boundary
This console is a local bootstrap helper. Wallet requests and receipts are not hosted funding or payout evidence; canonical indexed events remain required.