### PR TITLE
Make hosted production smoke revision-aware

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -11,36 +11,17 @@ on:
         description: "Deployed MCP base URL, for example https://agent-bounties-mcp.onrender.com"
         required: false
         type: string
+      expected_revision:
+        description: "Exact deployed Git revision; defaults to the checked-out main revision"
+        required: false
+        type: string
       require_eval_history:
         description: "Require persisted eval-run history on the deployed API"
         required: false
         type: boolean
         default: false
   schedule:
-    - cron: "43 10 * * *"
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/production-smoke.yml"
-      - "README.md"
-      - "docs/deployment.md"
-      - "docs/production-smoke.md"
-      - "scripts/check-production-smoke.*"
-      - "crates/api/**"
-      - "crates/cli/**"
-      - "crates/mcp-server/**"
-      - "crates/web-public/**"
-  pull_request:
-    paths:
-      - ".github/workflows/production-smoke.yml"
-      - "README.md"
-      - "docs/deployment.md"
-      - "docs/production-smoke.md"
-      - "scripts/check-production-smoke.*"
-      - "crates/api/**"
-      - "crates/cli/**"
-      - "crates/mcp-server/**"
-      - "crates/web-public/**"
+    - cron: "43 * * * *"
 
 permissions:
   contents: read
@@ -52,9 +33,11 @@ concurrency:
 jobs:
   production-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
-      PRODUCTION_API_BASE_URL: ${{ inputs.api_base_url || vars.PRODUCTION_API_BASE_URL }}
-      PRODUCTION_MCP_BASE_URL: ${{ inputs.mcp_base_url || vars.PRODUCTION_MCP_BASE_URL }}
+      PRODUCTION_API_BASE_URL: ${{ inputs.api_base_url || vars.PRODUCTION_API_BASE_URL || 'https://agent-bounties-api.onrender.com' }}
+      PRODUCTION_MCP_BASE_URL: ${{ inputs.mcp_base_url || vars.PRODUCTION_MCP_BASE_URL || 'https://agent-bounties-mcp.onrender.com' }}
+      PRODUCTION_EXPECTED_REVISION: ${{ inputs.expected_revision || github.sha }}
       REQUIRE_EVAL_HISTORY_INPUT: ${{ inputs.require_eval_history || 'false' }}
       REQUIRE_EVAL_HISTORY_VAR: ${{ vars.PRODUCTION_SMOKE_REQUIRE_EVAL_HISTORY || 'false' }}
     steps:
@@ -64,49 +47,35 @@ jobs:
         id: config
         shell: bash
         run: |
-          if [[ -z "${PRODUCTION_API_BASE_URL}" || -z "${PRODUCTION_MCP_BASE_URL}" ]]; then
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "## Production Smoke"
-              echo
-              echo "Skipped because PRODUCTION_API_BASE_URL and PRODUCTION_MCP_BASE_URL are not both configured."
-              echo
-              echo "Set repository variables for scheduled/push smoke, or pass workflow_dispatch inputs for a one-off hosted deploy check."
-              echo "Do not set AGENT_BOUNTIES_API_BASE_URL for GitHub funding-comment handoffs until this smoke passes for the same API URL."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
           require_eval_history="false"
           if [[ "${REQUIRE_EVAL_HISTORY_INPUT,,}" == "true" || "${REQUIRE_EVAL_HISTORY_VAR,,}" == "true" ]]; then
             require_eval_history="true"
           fi
 
-          echo "enabled=true" >> "$GITHUB_OUTPUT"
           echo "require_eval_history=${require_eval_history}" >> "$GITHUB_OUTPUT"
           {
             echo "## Production Smoke"
             echo
             echo "- API: ${PRODUCTION_API_BASE_URL}"
             echo "- MCP: ${PRODUCTION_MCP_BASE_URL}"
+            echo "- Expected revision: ${PRODUCTION_EXPECTED_REVISION}"
             echo "- Require eval history: ${require_eval_history}"
             echo
-            echo "This workflow is read-only. It does not create funding intents, Checkout Sessions, Base transactions, ledger credits, or payout state."
+            echo "This workflow cannot silently skip. It verifies the exact deployed revision and is read-only."
+            echo "It runs after deployment by schedule or manual dispatch, not as a pre-deploy branch check."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.config.outputs.enabled == 'true'
 
       - uses: Swatinem/rust-cache@v2
-        if: steps.config.outputs.enabled == 'true'
 
       - name: Run read-only hosted production smoke
-        if: steps.config.outputs.enabled == 'true'
         shell: bash
         run: |
           args=(
             --api-base-url "${PRODUCTION_API_BASE_URL}"
             --mcp-base-url "${PRODUCTION_MCP_BASE_URL}"
+            --expected-revision "${PRODUCTION_EXPECTED_REVISION}"
           )
           if [[ "${{ steps.config.outputs.require_eval_history }}" == "true" ]]; then
             args+=(--require-eval-history)

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -14,7 +14,7 @@ use app::{
 use axum::{
     body::Bytes,
     extract::{Path, Query, State},
-    http::{header, HeaderMap, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{Html, IntoResponse},
     routing::{get, post},
     Json, Router,
@@ -899,8 +899,30 @@ fn service_bind_addr(configured: Option<&str>, port: Option<&str>, default_addr:
 }
 
 #[utoipa::path(get, path = "/health", responses((status = 200, body = String)))]
-async fn health() -> &'static str {
-    "ok"
+async fn health() -> impl IntoResponse {
+    health_response(&deployment_revision())
+}
+
+fn deployment_revision() -> String {
+    env::var("RENDER_GIT_COMMIT")
+        .ok()
+        .filter(|value| {
+            value.len() == 40 && value.chars().all(|character| character.is_ascii_hexdigit())
+        })
+        .unwrap_or_else(|| "local".to_string())
+}
+
+fn health_response(revision: &str) -> impl IntoResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-agent-bounties-revision",
+        HeaderValue::from_str(revision).unwrap_or_else(|_| HeaderValue::from_static("invalid")),
+    );
+    headers.insert(
+        "x-agent-bounties-protocol",
+        HeaderValue::from_static("agent-bounties/autonomous-v1"),
+    );
+    (headers, "ok")
 }
 
 #[utoipa::path(get, path = "/llms.txt", responses((status = 200, body = String)))]
@@ -4366,6 +4388,20 @@ mod tests {
     };
 
     type TestHmacSha256 = Hmac<Sha256>;
+
+    #[test]
+    fn health_identifies_protocol_and_deployed_revision() {
+        let response = health_response("0123456789abcdef0123456789abcdef01234567").into_response();
+
+        assert_eq!(
+            response.headers()["x-agent-bounties-revision"],
+            "0123456789abcdef0123456789abcdef01234567"
+        );
+        assert_eq!(
+            response.headers()["x-agent-bounties-protocol"],
+            "agent-bounties/autonomous-v1"
+        );
+    }
 
     #[tokio::test]
     async fn agent_paid_status_endpoint_summarizes_solver_receivables() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -346,6 +346,8 @@ enum Command {
         api_base_url: String,
         #[arg(long, env = "PRODUCTION_MCP_BASE_URL")]
         mcp_base_url: String,
+        #[arg(long, env = "PRODUCTION_EXPECTED_REVISION")]
+        expected_revision: Option<String>,
         #[arg(long, default_value_t = false)]
         require_eval_history: bool,
     },
@@ -595,8 +597,17 @@ async fn async_main() -> Result<()> {
         Command::ProductionSmoke {
             api_base_url,
             mcp_base_url,
+            expected_revision,
             require_eval_history,
-        } => production_smoke(api_base_url, mcp_base_url, require_eval_history).await,
+        } => {
+            production_smoke(
+                api_base_url,
+                mcp_base_url,
+                expected_revision,
+                require_eval_history,
+            )
+            .await
+        }
         Command::ServiceSmoke {
             api_base_url,
             mcp_base_url,
@@ -2303,11 +2314,18 @@ fn write_report_file(path: &Path, contents: &str) -> Result<()> {
 async fn production_smoke(
     api_base_url: String,
     mcp_base_url: String,
+    expected_revision: Option<String>,
     require_eval_history: bool,
 ) -> Result<()> {
     let api = normalize_base_url(&api_base_url);
     let mcp = normalize_base_url(&mcp_base_url);
-    let report = production_smoke_check(&api, &mcp, require_eval_history).await?;
+    let report = production_smoke_check(
+        &api,
+        &mcp,
+        require_eval_history,
+        expected_revision.as_deref(),
+    )
+    .await?;
     print_production_smoke_report(&report)
 }
 
@@ -2315,6 +2333,9 @@ async fn production_smoke(
 struct ProductionSmokeReport {
     api_base_url: String,
     mcp_base_url: String,
+    api_revision: String,
+    mcp_revision: String,
+    expected_revision: Option<String>,
     verification_modes: usize,
     payment_rails: usize,
     claimable_requirements: usize,
@@ -2328,21 +2349,15 @@ async fn production_smoke_check(
     api: &str,
     mcp: &str,
     require_eval_history: bool,
+    expected_revision: Option<&str>,
 ) -> Result<ProductionSmokeReport> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()?;
 
-    let api_health = production_get_text(&client, &format!("{api}/health")).await?;
-    require(
-        api_health.trim() == "ok",
-        "API health endpoint must return ok",
-    )?;
-    let mcp_health = production_get_text(&client, &format!("{mcp}/health")).await?;
-    require(
-        mcp_health.trim() == "ok",
-        "MCP health endpoint must return ok",
-    )?;
+    let api_health = production_get_health(&client, &format!("{api}/health")).await?;
+    let mcp_health = production_get_health(&client, &format!("{mcp}/health")).await?;
+    validate_production_health(&api_health, &mcp_health, expected_revision)?;
 
     let discovery =
         production_get_json(&client, &format!("{api}/.well-known/agent-bounties.json")).await?;
@@ -2735,6 +2750,9 @@ async fn production_smoke_check(
     Ok(ProductionSmokeReport {
         api_base_url: api.to_string(),
         mcp_base_url: mcp.to_string(),
+        api_revision: api_health.revision,
+        mcp_revision: mcp_health.revision,
+        expected_revision: expected_revision.map(str::to_string),
         verification_modes: verification_modes.len(),
         payment_rails: payment_rails.len(),
         claimable_requirements: claimable_requirements.len(),
@@ -2752,6 +2770,9 @@ fn print_production_smoke_report(report: &ProductionSmokeReport) -> Result<()> {
             "production_smoke": "ok",
             "api_base_url": report.api_base_url,
             "mcp_base_url": report.mcp_base_url,
+            "api_revision": report.api_revision,
+            "mcp_revision": report.mcp_revision,
+            "expected_revision": report.expected_revision,
             "verification_modes": report.verification_modes,
             "payment_rails": report.payment_rails,
             "claimable_requirements": report.claimable_requirements,
@@ -2785,7 +2806,7 @@ struct ServiceSmokeReport {
 async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport> {
     wait_for_health(&format!("{api}/health"))?;
     wait_for_health(&format!("{mcp}/health"))?;
-    let _production_contract = production_smoke_check(api, mcp, false).await?;
+    let _production_contract = production_smoke_check(api, mcp, false, None).await?;
 
     let discovery = get_json(&format!("{api}/.well-known/agent-bounties.json"))?;
     require(
@@ -3220,6 +3241,83 @@ async fn production_get_json(client: &reqwest::Client, url: &str) -> Result<serd
     Ok(serde_json::from_str(
         &production_get_text(client, url).await?,
     )?)
+}
+
+#[derive(Debug, Clone)]
+struct ProductionHealth {
+    body: String,
+    revision: String,
+    protocol: String,
+}
+
+fn validate_production_health(
+    api: &ProductionHealth,
+    mcp: &ProductionHealth,
+    expected_revision: Option<&str>,
+) -> Result<()> {
+    for (service, health) in [("API", api), ("MCP", mcp)] {
+        require(
+            health.body.trim() == "ok",
+            &format!("{service} health endpoint must return ok"),
+        )?;
+        require(
+            health.protocol == "agent-bounties/autonomous-v1",
+            &format!("{service} health must advertise autonomous-v1"),
+        )?;
+        require(
+            !health.revision.trim().is_empty(),
+            &format!("{service} health missing x-agent-bounties-revision"),
+        )?;
+    }
+    require(
+        api.revision.eq_ignore_ascii_case(&mcp.revision),
+        "API and MCP must serve the same deployed revision",
+    )?;
+    if let Some(expected) = expected_revision
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        require(
+            api.revision.eq_ignore_ascii_case(expected),
+            &format!(
+                "hosted revision {} does not match expected revision {expected}",
+                api.revision
+            ),
+        )?;
+    }
+    Ok(())
+}
+
+async fn production_get_health(client: &reqwest::Client, url: &str) -> Result<ProductionHealth> {
+    let response = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, "text/plain")
+        .send()
+        .await
+        .with_context(|| format!("GET {url} failed"))?;
+    let status = response.status();
+    require(
+        status.is_success(),
+        &format!("GET {url} failed with HTTP {status}"),
+    )?;
+    let revision = response
+        .headers()
+        .get("x-agent-bounties-revision")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let protocol = response
+        .headers()
+        .get("x-agent-bounties-protocol")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    let body = response.text().await?;
+    Ok(ProductionHealth {
+        body,
+        revision,
+        protocol,
+    })
 }
 
 async fn production_get_text(client: &reqwest::Client, url: &str) -> Result<String> {
@@ -4558,6 +4656,45 @@ fn stop_child(child: &mut Child) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn production_health(revision: &str) -> ProductionHealth {
+        ProductionHealth {
+            body: "ok".to_string(),
+            revision: revision.to_string(),
+            protocol: "agent-bounties/autonomous-v1".to_string(),
+        }
+    }
+
+    #[test]
+    fn production_health_requires_matching_expected_revision() {
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        let api = production_health(revision);
+        let mcp = production_health(revision);
+
+        validate_production_health(&api, &mcp, Some(revision))
+            .expect("matching deployed revision should pass");
+        let error = validate_production_health(
+            &api,
+            &mcp,
+            Some("89abcdef0123456789abcdef0123456789abcdef"),
+        )
+        .expect_err("stale deployed revision must fail");
+        assert!(error
+            .to_string()
+            .contains("does not match expected revision"));
+    }
+
+    #[test]
+    fn production_health_rejects_split_service_revisions() {
+        let api = production_health("0123456789abcdef0123456789abcdef01234567");
+        let mcp = production_health("89abcdef0123456789abcdef0123456789abcdef");
+
+        let error = validate_production_health(&api, &mcp, None)
+            .expect_err("split API and MCP revisions must fail");
+        assert!(error
+            .to_string()
+            .contains("API and MCP must serve the same deployed revision"));
+    }
 
     #[test]
     fn create_address_matches_base_activation_vectors() {

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -9,7 +9,7 @@ use app::{
 };
 use axum::{
     extract::State,
-    http::{header, HeaderMap},
+    http::{header, HeaderMap, HeaderValue},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
@@ -66,6 +66,32 @@ struct AppState {
 
 type SharedState = Arc<AppState>;
 const OPERATOR_TOKEN_HEADER: &str = "x-operator-token";
+
+async fn health() -> impl IntoResponse {
+    health_response(&deployment_revision())
+}
+
+fn deployment_revision() -> String {
+    env::var("RENDER_GIT_COMMIT")
+        .ok()
+        .filter(|value| {
+            value.len() == 40 && value.chars().all(|character| character.is_ascii_hexdigit())
+        })
+        .unwrap_or_else(|| "local".to_string())
+}
+
+fn health_response(revision: &str) -> impl IntoResponse {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-agent-bounties-revision",
+        HeaderValue::from_str(revision).unwrap_or_else(|_| HeaderValue::from_static("invalid")),
+    );
+    headers.insert(
+        "x-agent-bounties-protocol",
+        HeaderValue::from_static("agent-bounties/autonomous-v1"),
+    );
+    (headers, "ok")
+}
 
 fn non_empty_secret(secret: String) -> Option<String> {
     let trimmed = secret.trim();
@@ -431,7 +457,7 @@ async fn main() -> anyhow::Result<()> {
         store,
     });
     let app = Router::new()
-        .route("/health", get(|| async { "ok" }))
+        .route("/health", get(health))
         .route("/llms.txt", get(llms_txt))
         .route(
             "/schemas/discovery-manifest.v2.json",
@@ -3925,6 +3951,20 @@ async fn record_eval_run(state: &SharedState, run: EvalRun) -> Result<(), String
 #[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn health_identifies_protocol_and_deployed_revision() {
+        let response = health_response("0123456789abcdef0123456789abcdef01234567").into_response();
+
+        assert_eq!(
+            response.headers()["x-agent-bounties-revision"],
+            "0123456789abcdef0123456789abcdef01234567"
+        );
+        assert_eq!(
+            response.headers()["x-agent-bounties-protocol"],
+            "agent-bounties/autonomous-v1"
+        );
+    }
 
     #[tokio::test]
     async fn tool_descriptors_publish_machine_readable_input_schemas() {

--- a/docs/production-smoke.md
+++ b/docs/production-smoke.md
@@ -1,74 +1,86 @@
 # Production Smoke
 
-`production-smoke` is the read-only hosted gate for deployed API and MCP
-services. It validates the surfaces that let autonomous agents discover,
-evaluate, and trust the network without creating bounties, moving ledger state,
-or touching live payment execution endpoints.
+`production-smoke` is the read-only gate for the deployed API and MCP
+services. It validates the public surfaces agents use to discover, evaluate,
+claim, verify, and monitor autonomous bounties. It does not create bounties,
+sign transactions, mutate ledger state, or invoke payment execution.
 
-Run it after every preview or production deploy:
+## Deployed Revision Contract
+
+Both `/health` endpoints keep the Render-compatible `ok` response body and
+publish these headers:
+
+- `x-agent-bounties-protocol: agent-bounties/autonomous-v1`
+- `x-agent-bounties-revision: <git commit>`
+
+On Render, the revision comes from the platform-provided
+[`RENDER_GIT_COMMIT`](https://render.com/docs/environment-variables) runtime
+variable. Local services report `local`. Production smoke requires API and MCP
+to advertise the same protocol and revision. When an expected revision is
+provided, both services must match it exactly.
+
+This prevents a healthy but stale deployment from passing merely because it
+returns HTTP 200.
+
+## Run It
+
+PowerShell:
 
 ```powershell
 .\scripts\check-production-smoke.ps1 `
-  -ApiBaseUrl https://api.example.com `
-  -McpBaseUrl https://mcp.example.com
+  -ApiBaseUrl https://agent-bounties-api.onrender.com `
+  -McpBaseUrl https://agent-bounties-mcp.onrender.com `
+  -ExpectedRevision 0123456789abcdef0123456789abcdef01234567
 ```
 
-On Unix-like shells:
+Unix-like shells:
 
 ```bash
 bash scripts/check-production-smoke.sh \
-  --api-base-url https://api.example.com \
-  --mcp-base-url https://mcp.example.com
+  --api-base-url https://agent-bounties-api.onrender.com \
+  --mcp-base-url https://agent-bounties-mcp.onrender.com \
+  --expected-revision 0123456789abcdef0123456789abcdef01234567
 ```
 
-The scripts also read `PRODUCTION_API_BASE_URL` and `PRODUCTION_MCP_BASE_URL`.
-Use `-RequireEvalHistory` or `--require-eval-history` after a deployment has
-run at least one eval suite and persisted the run history.
-
-GitHub Actions also exposes a `Production Smoke` workflow. It runs on schedule,
-on relevant pushes, and by manual dispatch. For scheduled and push runs, set
-repository variables:
+The wrappers also read:
 
 - `PRODUCTION_API_BASE_URL`
 - `PRODUCTION_MCP_BASE_URL`
-- optional `PRODUCTION_SMOKE_REQUIRE_EVAL_HISTORY=true`
+- `PRODUCTION_EXPECTED_REVISION`
 
-If either production URL is missing, the workflow skips and writes a summary
-instead of failing contributor PRs. If both URLs are configured, it runs the
-same read-only hosted gate and fails on unhealthy discovery, readiness, or
-public page contracts. Do not set `AGENT_BOUNTIES_API_BASE_URL` for GitHub
-funding-comment handoffs until this production smoke passes for the same API
-URL.
+Use `-RequireEvalHistory` or `--require-eval-history` after a deployed eval
+suite has persisted at least one run.
+
+## GitHub Workflow
+
+The `Production Smoke` workflow runs hourly and by manual dispatch. It defaults
+to the canonical Render API and MCP URLs and the checked-out `main` revision,
+so missing repository variables cannot turn the gate into a successful skip.
+Repository variables can still override the URLs for a planned migration.
+
+The workflow deliberately does not run as a pull-request or push check. Render
+is configured with `autoDeployTrigger: checksPass`; a pre-deploy smoke cannot
+observe the new revision, and making it required would create a deployment
+dependency cycle. CI validates the local contract before merge, Render deploys
+after checks pass, and scheduled/manual production smoke validates the deployed
+result afterward.
+
+## Coverage
 
 The gate checks:
 
-- API and MCP health endpoints.
-- `/.well-known/agent-bounties.json`, the discovery manifest JSON Schema, and
-  `/llms.txt` on both services.
-- OpenAPI paths for routing, public feeds, risk review and approval, Base, and Stripe
-  live-execution boundaries, including operator security schemes and protected
-  operation metadata.
-- Discovery fields for Base funding plans and normalized escrow event
-  reconciliation, so indexed `EscrowCreated` remains discoverable before claim.
-- Discovery fields for the public StripeFiat funding handoff, including the
-  static funding page URL, prefill query parameters, and the rule that verified
-  Stripe webhook reconciliation remains the funding authority.
-- Live-money readiness and Base indexer status reporting for Base mainnet USDC
-  and Stripe mode, including the optional Stripe Checkout payment-method
-  configuration boolean and the indexer's nullable heartbeat fields, without
-  exposing secret keys, Payment Method Configuration ids, webhook secrets, RPC
-  URLs, or operator tokens.
-- MCP tool descriptors, JSON input schemas, and operator auth metadata for
-  protected tools.
-- Public bounty, capability, template, and verifier pages.
-- Public bounty and capability feeds as machine-readable arrays.
-- Risk policy settlement invariants, including the low-value Base USDC cap and
-  the rule that AI judges cannot authorize payment.
-- Eval run, risk event, risk review history, and risk payout approval endpoints.
-- Payment rail discovery for Base Sepolia USDC escrow, hosted low-value Base
-  USDC, and Stripe fiat ledger.
+- API and MCP health, protocol identity, and exact deployed revision.
+- Autonomous-v1 discovery manifests, JSON Schema, `/llms.txt`, and MCP tools.
+- OpenAPI paths for terms, creation, contribution, claim, submission,
+  verification, settlement, expiry, cancellation, refunds, events, and
+  transaction receipts.
+- Absence of retired operator-signed escrow endpoints and tools.
+- Base native USDC funding-before-claim requirements.
+- Canonical `BountySettled` payment evidence boundaries.
+- Deterministic module, signed quorum, and AI-judge quorum descriptions.
+- Public post-value actions, including posting a new bounty and optional
+  authenticated star/upvote execution.
+- Persisted eval history when explicitly required.
 
-This smoke deliberately avoids posting bounties, invoking live Stripe or Base
-execution endpoints, reconciling chain logs, or changing payout state. The local
-`service-smoke-spawn` command runs the same discovery contract before its
-mutating local lifecycle checks, so CI catches drift before a hosted deploy.
+Do not enable GitHub funding-comment handoffs against a hosted API until this
+gate passes for that exact API URL and revision.

--- a/scripts/check-production-smoke.ps1
+++ b/scripts/check-production-smoke.ps1
@@ -1,6 +1,7 @@
 param(
     [string] $ApiBaseUrl = $env:PRODUCTION_API_BASE_URL,
     [string] $McpBaseUrl = $env:PRODUCTION_MCP_BASE_URL,
+    [string] $ExpectedRevision = $env:PRODUCTION_EXPECTED_REVISION,
     [switch] $RequireEvalHistory
 )
 
@@ -23,6 +24,9 @@ $args = @(
 )
 if ($RequireEvalHistory) {
     $args += "--require-eval-history"
+}
+if (-not [string]::IsNullOrWhiteSpace($ExpectedRevision)) {
+    $args += @("--expected-revision", $ExpectedRevision)
 }
 
 Push-Location $repoRoot

--- a/scripts/check-production-smoke.sh
+++ b/scripts/check-production-smoke.sh
@@ -6,6 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 api_base_url="${PRODUCTION_API_BASE_URL:-}"
 mcp_base_url="${PRODUCTION_MCP_BASE_URL:-}"
 require_eval_history="false"
+expected_revision="${PRODUCTION_EXPECTED_REVISION:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -20,6 +21,10 @@ while [[ $# -gt 0 ]]; do
     --require-eval-history)
       require_eval_history="true"
       shift
+      ;;
+    --expected-revision)
+      expected_revision="${2:-}"
+      shift 2
       ;;
     *)
       echo "unknown argument: $1" >&2
@@ -57,5 +62,8 @@ args=(
 )
 if [[ "$require_eval_history" == "true" ]]; then
   args+=(--require-eval-history)
+fi
+if [[ -n "$expected_revision" ]]; then
+  args+=(--expected-revision "$expected_revision")
 fi
 cargo "${args[@]}"

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -90,6 +90,8 @@ Invoke-Checked {
         --deployer-nonce 4 `
         --output $activationCheck
 }
-if ((Get-Content $activationCheck -Raw) -ne (Get-Content (Join-Path $repoRoot "deployments\base-mainnet-activation.json") -Raw)) {
+$generatedActivation = Get-Content $activationCheck -Raw | ConvertFrom-Json | ConvertTo-Json -Depth 100 -Compress
+$committedActivation = Get-Content (Join-Path $repoRoot "deployments\base-mainnet-activation.json") -Raw | ConvertFrom-Json | ConvertTo-Json -Depth 100 -Compress
+if ($generatedActivation -ne $committedActivation) {
     throw "deployments/base-mainnet-activation.json is stale; regenerate it with the autonomous-activation-bundle command"
 }


### PR DESCRIPTION
## What changed

- keep `/health` body compatible while exposing autonomous protocol and exact `RENDER_GIT_COMMIT` headers on API and MCP
- make production smoke reject missing, stale, or split deployed revisions
- default scheduled/manual smoke to the canonical Render URLs and current `main` revision
- remove pre-deploy push/PR triggers that could only skip, fail before deployment, or create a checks-gated deployment cycle
- make the activation-bundle reproducibility check line-ending independent on Windows

## Evidence

- `scripts/check.ps1`: passed
- API/MCP health handler tests: passed
- CLI stale/split revision tests: passed
- `cargo run -p cli -- service-smoke-spawn`: passed with a simulated funded-to-paid loop
- actionlint 1.7.12: passed
- Base-mainnet fork rehearsal at block 48482804: passed; four exact 1 USDC bounties became claimable on the fork
- manual hosted Production Smoke run 29144184595 correctly failed against the currently stale v1 Render deployment

## Boundaries

This does not broadcast a wallet transaction, deploy the mainnet factory, fund a live bounty, or prove payment. Fork transaction hashes are rehearsal evidence only.