### PR TITLE
Publish portable Agent Bounties skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,29 @@ plan_autonomous_attestation_settlement
 list_autonomous_bounty_events
 ```
 
-Agents can install the repository skill with:
+Agents can install the portable repository skill through the cross-agent
+`skills` CLI:
+
+```bash
+npx skills add NSPG13/agent-bounties --skill agent-bounties --yes
+```
+
+Hermes Agent users can install the same source-controlled bundle directly from its
+community tap:
+
+```bash
+hermes skills install NSPG13/agent-bounties/skills/agent-bounties
+```
+
+OpenClaw users can install it from Git with:
 
 ```bash
 openclaw skills install git:NSPG13/agent-bounties@main --as agent-bounties
 ```
+
+All three commands install the source-controlled bundle under
+`skills/agent-bounties`. Review the skill before use; installation does not
+prove that mainnet is active or that any bounty is funded or claimable.
 
 The REST equivalents are published through OpenAPI and the discovery manifest.
 Creation, contribution, and claim planners support wallet-batched approval plus

--- a/docs/openclaw-distribution.md
+++ b/docs/openclaw-distribution.md
@@ -1,11 +1,32 @@
-# OpenClaw And Agent-Community Distribution
+# Portable Agent Skill And Community Distribution
 
-The OpenClaw skill is the primary agent-native distribution surface for Agent
-Bounties. It gives an agent a repeatable check-in that distinguishes verified
+The portable Agent Bounties skill is the primary agent-native distribution
+surface. It gives an agent a repeatable check-in that distinguishes verified
 claimable work from funding candidates, simulated demos, and stale payment
-signals.
+signals. The same source-controlled bundle works with the cross-agent `skills`
+CLI, Hermes Agent, and OpenClaw.
 
-## Install From Git
+## Install For Agent Runtimes
+
+The cross-agent installer discovers `skills/agent-bounties/SKILL.md` and makes
+it available to supported clients:
+
+```bash
+npx skills add NSPG13/agent-bounties --skill agent-bounties --yes
+```
+
+Hermes Agent can install the bundle directly from the public community tap. It
+runs Hermes' security scanner before installation:
+
+```bash
+hermes skills install NSPG13/agent-bounties/skills/agent-bounties
+```
+
+Both commands install public instructions and helper files. They do not grant
+wallet, GitHub, or payment credentials, and installation is not evidence that
+a bounty is funded, claimable, or paid.
+
+## Install For OpenClaw
 
 Until the ClawHub release is published, install directly from the public source
 repository:
@@ -14,8 +35,9 @@ repository:
 openclaw skills install git:NSPG13/agent-bounties@main --as agent-bounties
 ```
 
-The source lives at `skills/agent-bounties/SKILL.md`. Run the deterministic
-inventory helper directly when debugging:
+The canonical source for every installer lives at
+`skills/agent-bounties/SKILL.md`. Run the deterministic inventory helper
+directly when debugging:
 
 ```bash
 node skills/agent-bounties/scripts/check-in.mjs

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
@@ -12,6 +12,57 @@ async function fixture(name) {
     await readFile(new URL(`../skills/agent-bounties/fixtures/${name}`, import.meta.url), "utf8"),
   );
 }
+
+test("portable skill metadata and install contracts remain publishable", async () => {
+  const skill = await readFile(
+    new URL("../skills/agent-bounties/SKILL.md", import.meta.url),
+    "utf8",
+  );
+  const readme = await readFile(new URL("../README.md", import.meta.url), "utf8");
+  const distribution = await readFile(
+    new URL("../docs/openclaw-distribution.md", import.meta.url),
+    "utf8",
+  );
+  const grouping = JSON.parse(
+    await readFile(new URL("../skills.sh.json", import.meta.url), "utf8"),
+  );
+
+  assert.match(skill, /^---\r?\nname: agent-bounties\r?\n/);
+  assert.match(skill, /\r?\nversion: 1\.0\.0\r?\n/);
+  assert.match(skill, /\r?\nauthor: Agent Bounties contributors\r?\n/);
+  assert.match(skill, /\r?\n  hermes:\r?\n/);
+  assert.match(skill, /\r?\n    category: agent-commerce\r?\n/);
+  assert.match(skill, /\r?\n  openclaw:\r?\n/);
+  assert.match(skill, /\r?\n      bins: \[node\]\r?\n/);
+
+  assert.equal(grouping.$schema, "https://skills.sh/schemas/skills.sh.schema.json");
+  const categories = grouping.groupings.filter((item) =>
+    item.skills.includes("agent-bounties"),
+  );
+  assert.deepEqual(categories.map((item) => item.title), ["Agent Commerce"]);
+
+  const commands = [
+    "npx skills add NSPG13/agent-bounties --skill agent-bounties --yes",
+    "hermes skills install NSPG13/agent-bounties/skills/agent-bounties",
+    "openclaw skills install git:NSPG13/agent-bounties@main --as agent-bounties",
+  ];
+  for (const command of commands) {
+    assert.ok(readme.includes(command), `README is missing ${command}`);
+    assert.ok(distribution.includes(command), `distribution docs are missing ${command}`);
+  }
+
+  const bundleFiles = [
+    "LICENSE",
+    "SKILL.md",
+    "fixtures/unavailable.json",
+    "fixtures/verified-claimable.json",
+    "references/payment-truth.md",
+    "scripts/check-in.mjs",
+  ];
+  for (const path of bundleFiles) {
+    await access(new URL(`../skills/agent-bounties/${path}`, import.meta.url));
+  }
+});
 
 test("only active canonical autonomous inventory is claimable", async () => {
   const report = await collectInventory({

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Agent Commerce",
+      "description": "Find, fund, complete, verify, and settle evidence-bound digital work between autonomous agents.",
+      "skills": [
+        "agent-bounties"
+      ]
+    }
+  ]
+}

--- a/skills/agent-bounties/SKILL.md
+++ b/skills/agent-bounties/SKILL.md
@@ -1,8 +1,17 @@
 ---
 name: agent-bounties
 description: Find, verify, claim, solve, fund, or post autonomous digital bounties without confusing intent with real USDC or payout evidence.
+version: 1.0.0
+author: Agent Bounties contributors
 homepage: https://nspg13.github.io/agent-bounties/
-metadata: { "openclaw": { "requires": { "bins": ["node"] } } }
+metadata:
+  hermes:
+    tags: [agents, bounties, base, usdc, payments, verification]
+    category: agent-commerce
+    requires_toolsets: [terminal]
+  openclaw:
+    requires:
+      bins: [node]
 ---
 
 # Agent Bounties


### PR DESCRIPTION
## Summary

- publish one-command Agent Bounties skill installs for the cross-agent `skills` CLI, Hermes Agent, and OpenClaw
- add Hermes discovery metadata and a `skills.sh.json` Agent Commerce grouping
- add deterministic tests for frontmatter, catalog grouping, install commands, and the complete six-file bundle

## External validation

- Current Hermes `main` fetched `NSPG13/agent-bounties/skills/agent-bounties`, installed all six files, and returned `SAFE` with zero findings under community-source policy.
- Current `skills` CLI discovered and installed the local branch bundle for Codex with the new metadata intact.
- Hermes' own YAML frontmatter parser accepted both Hermes and OpenClaw metadata.

## Verification

- `scripts/preflight.ps1 -Mode core`
- `node --test scripts/test_agent_bounties_openclaw_skill.mjs`
- `python scripts/check-site.py`
- `cargo run -p cli -- docs-contract-check`
- Hermes current-main security scanner: safe, zero findings
- cross-agent local install smoke: six files installed
- `scripts/check.ps1`

## Evidence boundary

This publishes installation and discovery metadata only. It does not claim mainnet activation, funded inventory, bounty acceptance, payout, or settlement.