### PR TITLE
Measure verified claimable bounty liquidity

### DIFF
--- a/.github/workflows/bounty-inventory-guard.yml
+++ b/.github/workflows/bounty-inventory-guard.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/bounty_inventory_guard.py"
       - "scripts/test_bounty_inventory_guard.py"
       - "scripts/fixtures/bounty_inventory_*.json"
+      - "skills/agent-bounties/scripts/check-in.mjs"
       - ".github/workflows/bounty-inventory-guard.yml"
 
 permissions:
@@ -34,19 +35,25 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Count open bounty issues
+      - name: Build canonical claimable inventory report
+        run: node skills/agent-bounties/scripts/check-in.mjs > claimable-inventory.json
+      - name: Enforce verified claimable inventory floor
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           BOUNTY_INVENTORY_THRESHOLD: "5"
         run: |
           python scripts/bounty_inventory_guard.py \
+            --claimable-report claimable-inventory.json \
+            --fail-below \
             --json-out bounty-inventory-report.json \
             --md-out bounty-inventory-report.md
       - name: Upload report artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: bounty-inventory-report
           path: |
             bounty-inventory-report.json
             bounty-inventory-report.md
+            claimable-inventory.json

--- a/docs/agent-contribution-starter.md
+++ b/docs/agent-contribution-starter.md
@@ -64,28 +64,32 @@ at `/public/bounties`, `GET /v1/bounties/feed`, and MCP
 
 ## Bounty inventory guard (distribution)
 
-Maintainers and agents can check whether the repository has enough **open public
-issues labeled `bounty`** for organic solver traffic:
+Maintainers and agents can separately inspect open candidate issues and enforce
+a floor of **verified canonical claimable bounties** for organic solver traffic:
 
 ```powershell
-python scripts/bounty_inventory_guard.py
-python scripts/bounty_inventory_guard.py --threshold 5 --fail-below
+node skills/agent-bounties/scripts/check-in.mjs > target/tmp/claimable-inventory.json
+python scripts/bounty_inventory_guard.py --claimable-report target/tmp/claimable-inventory.json
+python scripts/bounty_inventory_guard.py --claimable-report target/tmp/claimable-inventory.json --threshold 5 --fail-below
 python scripts/test_bounty_inventory_guard.py -v
 ```
 
 On Unix-like shells:
 
 ```bash
-python scripts/bounty_inventory_guard.py
-python scripts/bounty_inventory_guard.py --threshold 5 --fail-below
+node skills/agent-bounties/scripts/check-in.mjs > target/tmp/claimable-inventory.json
+python scripts/bounty_inventory_guard.py --claimable-report target/tmp/claimable-inventory.json
+python scripts/bounty_inventory_guard.py --claimable-report target/tmp/claimable-inventory.json --threshold 5 --fail-below
 python scripts/test_bounty_inventory_guard.py -v
 ```
 
-The guard prints Markdown and JSON. It **does not** mark any issue as funded,
-claimable, accepted, payable, or paid. Threshold defaults to `5` and can be set
-with `--threshold` or `BOUNTY_INVENTORY_THRESHOLD`. A scheduled workflow
-`.github/workflows/bounty-inventory-guard.yml` runs unit tests on PRs and a live
-report on a schedule / manual dispatch.
+The guard prints Markdown and JSON. Open GitHub issues are candidate supply and
+never satisfy the threshold. Claimable entries must pass the portable skill's
+active-factory, terms, economics, funding, and canonical-event checks. The
+threshold defaults to `5` and can be set with `--threshold` or
+`BOUNTY_INVENTORY_THRESHOLD`. The scheduled workflow fails below that floor but
+still uploads both the raw verified inventory and summary reports. Only a
+confirmed canonical `BountySettled` event proves payout.
 
 ## Picking Work
 

--- a/scripts/bounty_inventory_guard.py
+++ b/scripts/bounty_inventory_guard.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Count open public GitHub issues labeled `bounty` and report inventory health.
+"""Report candidate bounty supply and verified claimable earning inventory.
 
-Does not claim any issue is funded, claimable, accepted, payable, or paid.
+The threshold applies only to fail-closed output from the portable skill's
+canonical inventory verifier. GitHub issue labels remain candidate telemetry.
 """
 
 from __future__ import annotations
@@ -9,11 +10,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -27,8 +30,14 @@ NON_ACTIONABLE_LABELS = frozenset(
         "not actionable",
         "spam",
         "closed",
+        "activation-blocked",
     }
 )
+
+ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
+BYTES32 = re.compile(r"^0x[0-9a-fA-F]{64}$")
+CLAIMABLE_EVIDENCE = "confirmed_canonical_autonomous_bounty"
+MAX_REPORT_AGE_SECONDS = 900
 
 
 @dataclass
@@ -36,10 +45,14 @@ class InventoryReport:
     repository: str
     threshold: int
     open_bounty_count: int
+    verified_claimable_count: int
     missing_count: int
     below_threshold: bool
     issue_urls: list[str]
+    claimable_bounty_ids: list[str]
     excluded_count: int
+    protocol_status: str
+    inventory_evidence_valid: bool
     suggested_next_action: str
     disclaimer: str
 
@@ -49,15 +62,23 @@ class InventoryReport:
             f"# Bounty inventory guard — {status}",
             "",
             f"- Repository: `{self.repository}`",
-            f"- Open actionable `bounty` issues: **{self.open_bounty_count}**",
-            f"- Threshold: **{self.threshold}**",
-            f"- Missing to threshold: **{self.missing_count}**",
+            f"- Open actionable `bounty` issues (candidate supply): **{self.open_bounty_count}**",
+            f"- Verified canonical claimable bounties: **{self.verified_claimable_count}**",
+            f"- Claimable threshold: **{self.threshold}**",
+            f"- Missing claimable bounties: **{self.missing_count}**",
             f"- Excluded (non-actionable labels): **{self.excluded_count}**",
+            f"- Protocol status: `{self.protocol_status}`",
+            f"- Inventory evidence valid: **{str(self.inventory_evidence_valid).lower()}**",
             "",
             "## Issue URLs",
         ]
         if self.issue_urls:
             lines.extend(f"- {url}" for url in self.issue_urls)
+        else:
+            lines.append("- _(none)_")
+        lines.extend(["", "## Verified claimable bounty IDs"])
+        if self.claimable_bounty_ids:
+            lines.extend(f"- `{bounty_id}`" for bounty_id in self.claimable_bounty_ids)
         else:
             lines.append("- _(none)_")
         lines.extend(
@@ -87,7 +108,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--threshold",
         type=int,
         default=int(os.environ.get("BOUNTY_INVENTORY_THRESHOLD", "5")),
-        help="Minimum open actionable bounty issues (default 5)",
+        help="Minimum verified canonical claimable bounties (default 5)",
+    )
+    p.add_argument(
+        "--claimable-report",
+        type=Path,
+        default=None,
+        help="JSON output from skills/agent-bounties/scripts/check-in.mjs",
     )
     p.add_argument(
         "--fixture",
@@ -146,6 +173,91 @@ def issue_url(issue: dict[str, Any], repository: str) -> str:
     return f"https://github.com/{repository}/issues/{number}"
 
 
+def _credential_free_https(value: object) -> bool:
+    try:
+        url = urllib.parse.urlparse(str(value))
+        return (
+            url.scheme == "https"
+            and bool(url.hostname)
+            and url.username is None
+            and url.password is None
+        )
+    except ValueError:
+        return False
+
+
+def verified_claimable_entries(report: object) -> tuple[list[dict[str, Any]], bool, str]:
+    if not isinstance(report, dict):
+        return [], False, "unavailable"
+    protocol_status = str(report.get("protocol_status") or "unavailable")
+    try:
+        observed_at = datetime.fromisoformat(
+            str(report.get("observed_at") or "").replace("Z", "+00:00")
+        )
+        if observed_at.tzinfo is None:
+            return [], False, protocol_status
+        age_seconds = (datetime.now(timezone.utc) - observed_at).total_seconds()
+    except ValueError:
+        return [], False, protocol_status
+    if age_seconds < -60 or age_seconds > MAX_REPORT_AGE_SECONDS:
+        return [], False, protocol_status
+    raw_warnings = report.get("warnings") or []
+    if not isinstance(raw_warnings, list) or not all(
+        isinstance(item, str) for item in raw_warnings
+    ):
+        return [], False, protocol_status
+    warnings = set(raw_warnings)
+    if (
+        report.get("hosted_api_healthy") is not True
+        or protocol_status != "active"
+        or not ADDRESS.fullmatch(str(report.get("active_factory") or ""))
+        or warnings
+        & {
+            "hosted_api_health_not_confirmed",
+            "autonomous_feed_unavailable",
+            "autonomous_protocol_not_active",
+        }
+    ):
+        return [], False, protocol_status
+
+    items = report.get("verified_claimable_bounties")
+    if not isinstance(items, list):
+        return [], False, protocol_status
+    ids: set[str] = set()
+    contracts: set[str] = set()
+    verified: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            return [], False, protocol_status
+        bounty_id = str(item.get("id") or "").lower()
+        contract = str(item.get("contract") or "").lower()
+        solver_reward = item.get("solver_reward_minor")
+        claim_bond = item.get("claim_bond_minor")
+        valid = (
+            BYTES32.fullmatch(bounty_id)
+            and ADDRESS.fullmatch(contract)
+            and bounty_id not in ids
+            and contract not in contracts
+            and item.get("status") == "claimable"
+            and item.get("evidence") == CLAIMABLE_EVIDENCE
+            and item.get("currency") == "usdc"
+            and isinstance(solver_reward, int)
+            and not isinstance(solver_reward, bool)
+            and solver_reward > 0
+            and isinstance(claim_bond, int)
+            and not isinstance(claim_bond, bool)
+            and claim_bond > 0
+            and _credential_free_https(item.get("terms_url"))
+            and _credential_free_https(item.get("claim_plan_url"))
+        )
+        if not valid:
+            return [], False, protocol_status
+        ids.add(bounty_id)
+        contracts.add(contract)
+        verified.append(item)
+    return verified, True, protocol_status
+
+
 def fetch_open_issues(repository: str, token: str | None) -> list[dict[str, Any]]:
     """Paginate GitHub REST issues with label bounty, state open."""
     owner, _, repo = repository.partition("/")
@@ -191,6 +303,7 @@ def build_report(
     repository: str,
     threshold: int,
     issues: list[dict[str, Any]],
+    claimable_report: object = None,
 ) -> InventoryReport:
     actionable: list[dict[str, Any]] = []
     excluded = 0
@@ -203,33 +316,46 @@ def build_report(
                 excluded += 1
 
     urls = [issue_url(i, repository) for i in actionable]
-    count = len(actionable)
-    missing = max(0, threshold - count)
-    below = count < threshold
-    if below:
+    issue_count = len(actionable)
+    claimable, evidence_valid, protocol_status = verified_claimable_entries(claimable_report)
+    claimable_count = len(claimable)
+    missing = max(0, threshold - claimable_count)
+    below = not evidence_valid or claimable_count < threshold
+    if not evidence_valid:
         action = (
-            f"Open or fund at least {missing} more public actionable bounty issue(s) "
-            f"(label `bounty`, keep open, avoid non-actionable labels) so organic "
-            f"solvers have inventory. This report does not mark any issue as funded."
+            "Restore a fresh, active protocol and canonical inventory feed before "
+            "counting liquidity. Candidate issues cannot substitute for missing or "
+            "invalid on-chain evidence."
+        )
+    elif below:
+        action = (
+            f"Activate, fund, and canonically index at least {missing} more claimable "
+            f"bounty contract(s). Open GitHub issues are candidate supply and do not "
+            f"satisfy this liquidity threshold."
         )
     else:
         action = (
-            "Inventory is at or above threshold. Keep monitoring; this report does "
-            "not imply any listed issue is funded or claimable."
+            "Verified canonical claimable inventory is at or above threshold. Keep "
+            "monitoring funding, claims, deadlines, and settlement events."
         )
     disclaimer = (
-        "Counts open GitHub issues labeled `bounty` only. This report does not "
-        "imply any bounty is funded, claimable, accepted, payable, or paid unless "
-        "verified platform payment evidence exists separately."
+        "The GitHub candidate issue count does not imply funding or claimability. "
+        "Claimable inventory requires an active canonical factory plus matching "
+        "terms, economics, funding, and events. Only a confirmed canonical "
+        "BountySettled event proves payout."
     )
     return InventoryReport(
         repository=repository,
         threshold=threshold,
-        open_bounty_count=count,
+        open_bounty_count=issue_count,
+        verified_claimable_count=claimable_count,
         missing_count=missing,
         below_threshold=below,
         issue_urls=urls,
+        claimable_bounty_ids=[str(item["id"]) for item in claimable],
         excluded_count=excluded,
+        protocol_status=protocol_status,
+        inventory_evidence_valid=evidence_valid,
         suggested_next_action=action,
         disclaimer=disclaimer,
     )
@@ -244,6 +370,12 @@ def load_fixture(path: Path) -> list[dict[str, Any]]:
     return data
 
 
+def load_claimable_report(path: Path | None) -> object:
+    if path is None:
+        return None
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.threshold < 0:
@@ -255,7 +387,12 @@ def main(argv: list[str] | None = None) -> int:
         token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
         issues = fetch_open_issues(args.repository, token)
 
-    report = build_report(args.repository, args.threshold, issues)
+    report = build_report(
+        args.repository,
+        args.threshold,
+        issues,
+        load_claimable_report(args.claimable_report),
+    )
     payload = asdict(report)
     md = report.to_markdown()
 

--- a/scripts/fixtures/bounty_inventory_claimable_above.json
+++ b/scripts/fixtures/bounty_inventory_claimable_above.json
@@ -1,0 +1,13 @@
+{
+  "hosted_api_healthy": true,
+  "protocol_status": "active",
+  "active_factory": "0x1111111111111111111111111111111111111111",
+  "warnings": [],
+  "verified_claimable_bounties": [
+    {"id":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1","contract":"0x2222222222222222222222222222222222222221","solver_reward_minor":900000,"claim_bond_minor":100000,"currency":"usdc","status":"claimable","evidence":"confirmed_canonical_autonomous_bounty","terms_url":"https://api.example.test/terms/1","claim_plan_url":"https://api.example.test/claim"},
+    {"id":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2","contract":"0x2222222222222222222222222222222222222222","solver_reward_minor":900000,"claim_bond_minor":100000,"currency":"usdc","status":"claimable","evidence":"confirmed_canonical_autonomous_bounty","terms_url":"https://api.example.test/terms/2","claim_plan_url":"https://api.example.test/claim"},
+    {"id":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3","contract":"0x2222222222222222222222222222222222222223","solver_reward_minor":900000,"claim_bond_minor":100000,"currency":"usdc","status":"claimable","evidence":"confirmed_canonical_autonomous_bounty","terms_url":"https://api.example.test/terms/3","claim_plan_url":"https://api.example.test/claim"},
+    {"id":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4","contract":"0x2222222222222222222222222222222222222224","solver_reward_minor":900000,"claim_bond_minor":100000,"currency":"usdc","status":"claimable","evidence":"confirmed_canonical_autonomous_bounty","terms_url":"https://api.example.test/terms/4","claim_plan_url":"https://api.example.test/claim"},
+    {"id":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa5","contract":"0x2222222222222222222222222222222222222225","solver_reward_minor":900000,"claim_bond_minor":100000,"currency":"usdc","status":"claimable","evidence":"confirmed_canonical_autonomous_bounty","terms_url":"https://api.example.test/terms/5","claim_plan_url":"https://api.example.test/claim"}
+  ]
+}

--- a/scripts/fixtures/bounty_inventory_claimable_below.json
+++ b/scripts/fixtures/bounty_inventory_claimable_below.json
@@ -1,0 +1,10 @@
+{
+  "hosted_api_healthy": true,
+  "protocol_status": "active",
+  "active_factory": "0x1111111111111111111111111111111111111111",
+  "warnings": [],
+  "verified_claimable_bounties": [
+    {"id":"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb1","contract":"0x3333333333333333333333333333333333333331","solver_reward_minor":900000,"claim_bond_minor":100000,"currency":"usdc","status":"claimable","evidence":"confirmed_canonical_autonomous_bounty","terms_url":"https://api.example.test/terms/1","claim_plan_url":"https://api.example.test/claim"},
+    {"id":"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2","contract":"0x3333333333333333333333333333333333333332","solver_reward_minor":900000,"claim_bond_minor":100000,"currency":"usdc","status":"claimable","evidence":"confirmed_canonical_autonomous_bounty","terms_url":"https://api.example.test/terms/2","claim_plan_url":"https://api.example.test/claim"}
+  ]
+}

--- a/scripts/fixtures/bounty_inventory_claimable_malformed.json
+++ b/scripts/fixtures/bounty_inventory_claimable_malformed.json
@@ -1,0 +1,9 @@
+{
+  "hosted_api_healthy": true,
+  "protocol_status": "active",
+  "active_factory": "0x1111111111111111111111111111111111111111",
+  "warnings": [],
+  "verified_claimable_bounties": [
+    {"id":"0xccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc1","contract":"0x4444444444444444444444444444444444444441","solver_reward_minor":900000,"claim_bond_minor":100000,"currency":"usdc","status":"claimable","evidence":"transaction_hash_only","terms_url":"https://api.example.test/terms/1","claim_plan_url":"https://api.example.test/claim"}
+  ]
+}

--- a/scripts/fixtures/bounty_inventory_claimable_unavailable.json
+++ b/scripts/fixtures/bounty_inventory_claimable_unavailable.json
@@ -1,0 +1,7 @@
+{
+  "hosted_api_healthy": true,
+  "protocol_status": "pending_external_review_and_deployment",
+  "active_factory": null,
+  "warnings": ["autonomous_feed_unavailable", "autonomous_protocol_not_active"],
+  "verified_claimable_bounties": []
+}

--- a/scripts/fixtures/bounty_inventory_noisy.json
+++ b/scripts/fixtures/bounty_inventory_noisy.json
@@ -8,6 +8,7 @@
     {"number": 6, "state": "open", "html_url": "https://github.com/example/repo/issues/6", "labels": [{"name": "bounty"}, {"name": "invalid"}]},
     {"number": 7, "state": "open", "html_url": "https://github.com/example/repo/issues/7", "labels": [{"name": "bounty"}]},
     {"number": 8, "state": "open", "html_url": "https://github.com/example/repo/issues/8", "labels": [{"name": "bounty"}]},
-    {"number": 9, "state": "open", "html_url": "https://github.com/example/repo/issues/9", "labels": [{"name": "bounty"}]}
+    {"number": 9, "state": "open", "html_url": "https://github.com/example/repo/issues/9", "labels": [{"name": "bounty"}]},
+    {"number": 10, "state": "open", "html_url": "https://github.com/example/repo/issues/10", "labels": [{"name": "bounty"}, {"name": "activation-blocked"}]}
   ]
 }

--- a/scripts/test_bounty_inventory_guard.py
+++ b/scripts/test_bounty_inventory_guard.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -24,13 +25,42 @@ def run_guard(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def current_claimable_report(name: str, *, bom: bool = False) -> Path:
+    data = json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+    data["observed_at"] = datetime.now(timezone.utc).isoformat()
+    target = ROOT / "target" / "tmp" / f"current-{name}"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(data),
+        encoding="utf-8-sig" if bom else "utf-8",
+    )
+    return target
+
+
 class BountyInventoryGuardTests(unittest.TestCase):
+    def test_claimable_report_accepts_utf8_bom(self) -> None:
+        bom_report = current_claimable_report(
+            "bounty_inventory_claimable_above.json", bom=True
+        )
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--claimable-report",
+            str(bom_report),
+            "--threshold",
+            "5",
+            "--fail-below",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+
     def test_above_threshold(self) -> None:
         proc = run_guard(
             "--fixture",
             str(FIXTURES / "bounty_inventory_above.json"),
             "--threshold",
             "5",
+            "--claimable-report",
+            str(current_claimable_report("bounty_inventory_claimable_above.json")),
             "--repository",
             "example/repo",
         )
@@ -39,6 +69,8 @@ class BountyInventoryGuardTests(unittest.TestCase):
         # JSON section
         payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
         self.assertEqual(payload["open_bounty_count"], 6)
+        self.assertEqual(payload["verified_claimable_count"], 5)
+        self.assertTrue(payload["inventory_evidence_valid"])
         self.assertFalse(payload["below_threshold"])
         self.assertEqual(payload["missing_count"], 0)
         self.assertIn("does not imply", payload["disclaimer"].lower())
@@ -49,11 +81,14 @@ class BountyInventoryGuardTests(unittest.TestCase):
             str(FIXTURES / "bounty_inventory_below.json"),
             "--threshold",
             "5",
+            "--claimable-report",
+            str(current_claimable_report("bounty_inventory_claimable_below.json")),
             "--fail-below",
         )
         self.assertEqual(proc.returncode, 2, proc.stderr + proc.stdout)
         payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
         self.assertEqual(payload["open_bounty_count"], 2)
+        self.assertEqual(payload["verified_claimable_count"], 2)
         self.assertTrue(payload["below_threshold"])
         self.assertEqual(payload["missing_count"], 3)
 
@@ -63,14 +98,73 @@ class BountyInventoryGuardTests(unittest.TestCase):
             str(FIXTURES / "bounty_inventory_noisy.json"),
             "--threshold",
             "5",
+            "--claimable-report",
+            str(current_claimable_report("bounty_inventory_claimable_unavailable.json")),
         )
         self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
         payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
-        # 1,7,8,9 actionable = 4; 2 duplicate, 3 closed, 4 no bounty, 5 PR, 6 invalid
+        # 1,7,8,9 actionable = 4; 10 is activation-blocked.
         self.assertEqual(payload["open_bounty_count"], 4)
+        self.assertEqual(payload["verified_claimable_count"], 0)
+        self.assertFalse(payload["inventory_evidence_valid"])
         self.assertTrue(payload["below_threshold"])
-        self.assertEqual(payload["missing_count"], 1)
+        self.assertEqual(payload["missing_count"], 5)
         self.assertEqual(len(payload["issue_urls"]), 4)
+        self.assertEqual(payload["excluded_count"], 6)
+
+    def test_malformed_claimable_entry_fails_closed(self) -> None:
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "1",
+            "--claimable-report",
+            str(current_claimable_report("bounty_inventory_claimable_malformed.json")),
+            "--fail-below",
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr + proc.stdout)
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        self.assertEqual(payload["verified_claimable_count"], 0)
+        self.assertFalse(payload["inventory_evidence_valid"])
+
+    def test_stale_claimable_report_fails_closed(self) -> None:
+        report = json.loads(
+            (FIXTURES / "bounty_inventory_claimable_above.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        report["observed_at"] = "2000-01-01T00:00:00+00:00"
+        stale = ROOT / "target" / "tmp" / "stale-claimable-inventory.json"
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_text(json.dumps(report), encoding="utf-8")
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "1",
+            "--claimable-report",
+            str(stale),
+            "--fail-below",
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr + proc.stdout)
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        self.assertEqual(payload["verified_claimable_count"], 0)
+        self.assertFalse(payload["inventory_evidence_valid"])
+
+    def test_zero_threshold_cannot_override_invalid_evidence(self) -> None:
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "0",
+            "--claimable-report",
+            str(current_claimable_report("bounty_inventory_claimable_unavailable.json")),
+            "--fail-below",
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr + proc.stdout)
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        self.assertTrue(payload["below_threshold"])
+        self.assertEqual(payload["missing_count"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- distinguish open GitHub bounty specifications from verified canonical claimable liquidity
- make the five-bounty threshold depend on the portable skill's fail-closed inventory report
- reject inactive protocols, unhealthy or stale feeds, malformed entries, duplicate identities, unsafe URLs, and non-canonical evidence
- exclude `activation-blocked` issues from actionable candidate supply
- fail the scheduled guard below the claimable floor while always preserving raw and summary artifacts

## Current measured state

The live dry run now reports:

- 8 open actionable candidate issues
- 0 verified canonical claimable bounties
- protocol `pending_external_review_and_deployment`
- invalid liquidity evidence
- expected threshold exit code 2

This replaces a false-green metric that counted issue labels as live earning inventory.

## Verification

- `python scripts/test_bounty_inventory_guard.py -v` (7 passed)
- live fail-closed report against current public services
- `.tools/actionlint/actionlint.exe .github/workflows/bounty-inventory-guard.yml`
- `python -m py_compile scripts/bounty_inventory_guard.py scripts/test_bounty_inventory_guard.py`
- `scripts/check.ps1`

## Evidence boundary

Open issues and this report do not prove funding or payout. Claimability requires the active canonical factory and matching terms, economics, funding, and events. Only confirmed canonical `BountySettled` proves payout.