### PR TITLE
Keep liquidity warning nonblocking

### DIFF
--- a/.github/workflows/bounty-inventory-guard.yml
+++ b/.github/workflows/bounty-inventory-guard.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: "3.12"
       - name: Build canonical claimable inventory report
         run: node skills/agent-bounties/scripts/check-in.mjs > claimable-inventory.json
-      - name: Enforce verified claimable inventory floor
+      - name: Report verified claimable inventory floor
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -45,9 +45,31 @@ jobs:
         run: |
           python scripts/bounty_inventory_guard.py \
             --claimable-report claimable-inventory.json \
-            --fail-below \
             --json-out bounty-inventory-report.json \
             --md-out bounty-inventory-report.md
+      - name: Publish liquidity status without blocking deployment
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path("bounty-inventory-report.json").read_text())
+          status = (
+              f"verified claimable bounties: {report['verified_claimable_count']}/"
+              f"{report['threshold']}; protocol={report['protocol_status']}; "
+              f"evidence_valid={str(report['inventory_evidence_valid']).lower()}"
+          )
+          if report["below_threshold"]:
+              print(f"::warning title=Claimable bounty floor not met::{status}")
+          else:
+              print(status)
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## Claimable bounty liquidity\n\n")
+              summary.write(f"- {status}\n")
+              summary.write(f"- below threshold: {str(report['below_threshold']).lower()}\n")
+              summary.write("- GitHub issues are candidate supply, not funding evidence.\n")
+          PY
       - name: Upload report artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/agent-contribution-starter.md
+++ b/docs/agent-contribution-starter.md
@@ -87,9 +87,11 @@ The guard prints Markdown and JSON. Open GitHub issues are candidate supply and
 never satisfy the threshold. Claimable entries must pass the portable skill's
 active-factory, terms, economics, funding, and canonical-event checks. The
 threshold defaults to `5` and can be set with `--threshold` or
-`BOUNTY_INVENTORY_THRESHOLD`. The scheduled workflow fails below that floor but
-still uploads both the raw verified inventory and summary reports. Only a
-confirmed canonical `BountySettled` event proves payout.
+`BOUNTY_INVENTORY_THRESHOLD`. The scheduled workflow emits a warning below the
+floor and uploads both the raw verified inventory and summary reports without
+blocking Render's `checksPass` deployment trigger. Use explicit `--fail-below`
+for local or release enforcement. Only a confirmed canonical `BountySettled`
+event proves payout.
 
 ## Picking Work
 


### PR DESCRIPTION
## Summary

- keep verified claimable inventory data fail-closed
- change the scheduled monitor from a failing check to an explicit GitHub warning and Actions summary
- preserve `--fail-below` for intentional local and release enforcement
- avoid deadlocking Render services configured with `autoDeployTrigger: checksPass`

## Verification

- actionlint passes
- seven inventory guard tests pass
- warning/summary rendering tested against the current `0/5` live report
- Python compilation and diff checks pass

The measured state remains 0 verified claimable bounties. This PR changes only whether monitoring blocks deployment; it does not weaken inventory validation or payment evidence boundaries.