### PR TITLE
Deploy reviewed main commits on Render

### DIFF
--- a/docs/agent-contribution-starter.md
+++ b/docs/agent-contribution-starter.md
@@ -88,10 +88,10 @@ never satisfy the threshold. Claimable entries must pass the portable skill's
 active-factory, terms, economics, funding, and canonical-event checks. The
 threshold defaults to `5` and can be set with `--threshold` or
 `BOUNTY_INVENTORY_THRESHOLD`. The scheduled workflow emits a warning below the
-floor and uploads both the raw verified inventory and summary reports without
-blocking Render's `checksPass` deployment trigger. Use explicit `--fail-below`
-for local or release enforcement. Only a confirmed canonical `BountySettled`
-event proves payout.
+floor and uploads both the raw verified inventory and summary reports. Render
+deploys reviewed `main` commits independently; use explicit `--fail-below` for
+local or release enforcement. Only a confirmed canonical `BountySettled` event
+proves payout.
 
 ## Picking Work
 

--- a/docs/production-smoke.md
+++ b/docs/production-smoke.md
@@ -59,11 +59,12 @@ so missing repository variables cannot turn the gate into a successful skip.
 Repository variables can still override the URLs for a planned migration.
 
 The workflow deliberately does not run as a pull-request or push check. Render
-is configured with `autoDeployTrigger: checksPass`; a pre-deploy smoke cannot
-observe the new revision, and making it required would create a deployment
-dependency cycle. CI validates the local contract before merge, Render deploys
-after checks pass, and scheduled/manual production smoke validates the deployed
-result afterward.
+is configured with `autoDeployTrigger: commit` because `main` is already
+protected by required pre-merge CI. A pre-deploy smoke cannot observe the new
+revision, and making it required would create a deployment dependency cycle.
+CI validates the local contract before merge, Render deploys the reviewed main
+commit, and scheduled/manual production smoke validates the deployed result
+afterward.
 
 ## Coverage
 

--- a/render.yaml
+++ b/render.yaml
@@ -44,7 +44,7 @@ services:
     plan: starter
     region: oregon
     branch: main
-    autoDeployTrigger: checksPass
+    autoDeployTrigger: commit
     dockerfilePath: ./Dockerfile
     dockerContext: .
     healthCheckPath: /health
@@ -82,7 +82,7 @@ services:
     plan: starter
     region: oregon
     branch: main
-    autoDeployTrigger: checksPass
+    autoDeployTrigger: commit
     dockerfilePath: ./Dockerfile
     dockerContext: .
     healthCheckPath: /health
@@ -120,7 +120,7 @@ services:
     plan: starter
     region: oregon
     branch: main
-    autoDeployTrigger: checksPass
+    autoDeployTrigger: commit
     dockerfilePath: ./Dockerfile
     dockerContext: .
     maxShutdownDelaySeconds: 60

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -221,8 +221,8 @@ def main() -> int:
             fail(f"{service_name} must build from the root Dockerfile")
         if "dockerContext: ." not in block:
             fail(f"{service_name} must build from the repo root context")
-        if "autoDeployTrigger: checksPass" not in block:
-            fail(f"{service_name} must deploy only after checks pass")
+        if "autoDeployTrigger: commit" not in block:
+            fail(f"{service_name} must deploy each reviewed main commit")
         require_database_ref(block)
 
     api = named_block(services, "agent-bounties-api")


### PR DESCRIPTION
## Summary

- switch API, MCP, and indexer Render services from `checksPass` to `commit`
- retain required pre-merge CI, Render health checks, and revision-aware post-deploy smoke
- update the deterministic Blueprint contract and deployment docs

## Evidence

- all checks on main `0801a99` passed
- API and MCP were polled every 20 seconds for ten minutes afterward and remained on the legacy build with no revision/protocol headers
- Render's current Blueprint reference defines `commit` as the default deploy-on-linked-branch behavior

## Verification

- `python scripts/check-render-blueprint.py`
- `python scripts/check-site.py`
- `cargo run -p cli -- docs-contract-check`
- `scripts/check.ps1`

The Render CLI's remote Blueprint validator could not run because this machine has no authenticated/default Render workspace. The repository's deterministic validator and complete local gate pass.

This does not activate Stripe, Base broadcasting, the factory, funding, or payouts.