### PR TITLE
Publish native Claude Code bounty plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "agent-bounties",
+  "description": "Agent-native tools for finding, posting, funding, verifying, and earning from evidence-bound digital bounties.",
+  "owner": {
+    "name": "Agent Bounties contributors"
+  },
+  "plugins": [
+    {
+      "name": "agent-bounties",
+      "source": "./skills/agent-bounties",
+      "description": "Find verified claimable bounties, earn from digital work, post or fund bounties, and check canonical Base USDC evidence.",
+      "category": "productivity",
+      "tags": [
+        "agents",
+        "bounties",
+        "base",
+        "usdc",
+        "payments",
+        "verification"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/claude-plugin.yml
+++ b/.github/workflows/claude-plugin.yml
@@ -1,0 +1,36 @@
+name: Claude plugin
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/**"
+      - "skills/agent-bounties/**"
+      - "scripts/test_agent_bounties_openclaw_skill.mjs"
+      - ".github/workflows/claude-plugin.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".claude-plugin/**"
+      - "skills/agent-bounties/**"
+      - "scripts/test_agent_bounties_openclaw_skill.mjs"
+      - ".github/workflows/claude-plugin.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Run portable skill contract tests
+        run: node --test scripts/test_agent_bounties_openclaw_skill.mjs
+      - name: Validate Claude plugin
+        run: npx --yes @anthropic-ai/claude-code@2.1.207 plugin validate skills/agent-bounties --strict
+      - name: Validate Claude marketplace
+        run: npx --yes @anthropic-ai/claude-code@2.1.207 plugin validate . --strict

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Agents can install the portable repository skill through the cross-agent
 npx skills add NSPG13/agent-bounties --skill agent-bounties --yes
 ```
 
+Claude Code users can install the native plugin from the repository
+marketplace:
+
+```bash
+claude plugin marketplace add NSPG13/agent-bounties
+claude plugin install agent-bounties@agent-bounties --scope user
+```
+
 Hermes Agent users can install the same source-controlled bundle directly from its
 community tap:
 
@@ -130,7 +138,7 @@ OpenClaw users can install it from Git with:
 openclaw skills install git:NSPG13/agent-bounties@main --as agent-bounties
 ```
 
-All three commands install the source-controlled bundle under
+All four install paths use the source-controlled bundle under
 `skills/agent-bounties`. Review the skill before use; installation does not
 prove that mainnet is active or that any bounty is funded or claimable.
 

--- a/docs/openclaw-distribution.md
+++ b/docs/openclaw-distribution.md
@@ -3,10 +3,23 @@
 The portable Agent Bounties skill is the primary agent-native distribution
 surface. It gives an agent a repeatable check-in that distinguishes verified
 claimable work from funding candidates, simulated demos, and stale payment
-signals. The same source-controlled bundle works with the cross-agent `skills`
-CLI, Hermes Agent, and OpenClaw.
+signals. The same source-controlled bundle works with Claude Code, the
+cross-agent `skills` CLI, Hermes Agent, and OpenClaw.
 
 ## Install For Agent Runtimes
+
+Claude Code can install the bundle as a native plugin from the repository's
+public marketplace:
+
+```bash
+claude plugin marketplace add NSPG13/agent-bounties
+claude plugin install agent-bounties@agent-bounties --scope user
+```
+
+After restarting Claude Code or running `/reload-plugins`, invoke
+`/agent-bounties:agent-bounties` or ask Claude to find, post, fund, solve, or
+verify a bounty. The plugin does not bundle an MCP server, hook, monitor, or
+wallet credential.
 
 The cross-agent installer discovers `skills/agent-bounties/SKILL.md` and makes
 it available to supported clients:
@@ -22,9 +35,14 @@ runs Hermes' security scanner before installation:
 hermes skills install NSPG13/agent-bounties/skills/agent-bounties
 ```
 
-Both commands install public instructions and helper files. They do not grant
+These commands install public instructions and helper files. They do not grant
 wallet, GitHub, or payment credentials, and installation is not evidence that
 a bounty is funded, claimable, or paid.
+
+The Claude plugin is also prepared for submission to Anthropic's public
+`claude-community` marketplace. Until that independent review completes, use
+the repository marketplace above. Do not describe a submission as listed until
+`agent-bounties@claude-community` is actually installable.
 
 ## Install For OpenClaw
 

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -26,6 +26,21 @@ test("portable skill metadata and install contracts remain publishable", async (
   const grouping = JSON.parse(
     await readFile(new URL("../skills.sh.json", import.meta.url), "utf8"),
   );
+  const plugin = JSON.parse(
+    await readFile(
+      new URL(
+        "../skills/agent-bounties/.claude-plugin/plugin.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+  const marketplace = JSON.parse(
+    await readFile(
+      new URL("../.claude-plugin/marketplace.json", import.meta.url),
+      "utf8",
+    ),
+  );
 
   assert.match(skill, /^---\r?\nname: agent-bounties\r?\n/);
   assert.match(skill, /\r?\nversion: 1\.0\.0\r?\n/);
@@ -41,8 +56,28 @@ test("portable skill metadata and install contracts remain publishable", async (
   );
   assert.deepEqual(categories.map((item) => item.title), ["Agent Commerce"]);
 
+  assert.equal(plugin.name, "agent-bounties");
+  assert.equal(plugin.displayName, "Agent Bounties");
+  assert.equal(plugin.version, "1.0.0");
+  assert.equal(plugin.license, "MIT");
+  assert.equal(plugin.repository, "https://github.com/NSPG13/agent-bounties");
+  assert.equal(plugin.homepage, "https://nspg13.github.io/agent-bounties/");
+  assert.equal(plugin.mcpServers, undefined);
+  assert.equal(plugin.hooks, undefined);
+  assert.equal(plugin.experimental, undefined);
+
+  assert.equal(marketplace.name, "agent-bounties");
+  assert.deepEqual(marketplace.owner, { name: "Agent Bounties contributors" });
+  assert.equal(marketplace.plugins.length, 1);
+  assert.equal(marketplace.plugins[0].name, "agent-bounties");
+  assert.equal(marketplace.plugins[0].source, "./skills/agent-bounties");
+  assert.equal(marketplace.plugins[0].mcpServers, undefined);
+  assert.equal(marketplace.plugins[0].hooks, undefined);
+
   const commands = [
     "npx skills add NSPG13/agent-bounties --skill agent-bounties --yes",
+    "claude plugin marketplace add NSPG13/agent-bounties",
+    "claude plugin install agent-bounties@agent-bounties --scope user",
     "hermes skills install NSPG13/agent-bounties/skills/agent-bounties",
     "openclaw skills install git:NSPG13/agent-bounties@main --as agent-bounties",
   ];
@@ -53,6 +88,8 @@ test("portable skill metadata and install contracts remain publishable", async (
 
   const bundleFiles = [
     "LICENSE",
+    ".claude-plugin/plugin.json",
+    "README.md",
     "SKILL.md",
     "fixtures/unavailable.json",
     "fixtures/verified-claimable.json",

--- a/skills/agent-bounties/.claude-plugin/plugin.json
+++ b/skills/agent-bounties/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "agent-bounties",
+  "displayName": "Agent Bounties",
+  "version": "1.0.0",
+  "description": "Find verified claimable bounties, earn from digital work, post or fund bounties, and check canonical Base USDC evidence.",
+  "author": {
+    "name": "Agent Bounties contributors",
+    "url": "https://github.com/NSPG13/agent-bounties"
+  },
+  "homepage": "https://nspg13.github.io/agent-bounties/",
+  "repository": "https://github.com/NSPG13/agent-bounties",
+  "license": "MIT",
+  "keywords": [
+    "agents",
+    "bounties",
+    "base",
+    "usdc",
+    "payments",
+    "verification"
+  ]
+}

--- a/skills/agent-bounties/README.md
+++ b/skills/agent-bounties/README.md
@@ -1,0 +1,42 @@
+# Agent Bounties Plugin
+
+Agent Bounties helps Claude find verified claimable digital work, inspect exact
+terms, post or fund bounties, verify submissions, and distinguish canonical
+Base USDC evidence from intent or simulation.
+
+## Install In Claude Code
+
+Add the repository marketplace and install the plugin:
+
+```bash
+claude plugin marketplace add NSPG13/agent-bounties
+claude plugin install agent-bounties@agent-bounties --scope user
+```
+
+Restart Claude Code or run `/reload-plugins`, then ask Claude to find paid agent
+work or invoke:
+
+```text
+/agent-bounties:agent-bounties
+```
+
+Claude can also select the skill automatically when a request involves earning
+from, posting, funding, claiming, solving, or verifying a digital bounty.
+
+## Trust Boundary
+
+This plugin contains instructions, read-only fixtures, and a Node.js inventory
+helper. It has no hook, MCP server, background monitor, wallet key, or payment
+credential. It does not authorize signatures or settlement.
+
+The inventory helper performs HTTPS reads against the public protocol and API
+URLs selected by the user or published by the project. Read its JSON output
+before making claims about available work. Only canonical active inventory is
+earnable, and only a confirmed `BountySettled` event proves payment.
+
+Wallet signatures still require the wallet owner's approval unless the owner
+has already granted an explicit bounded signing policy. Never paste a seed
+phrase or private key into Claude, this plugin, an issue, or a bounty artifact.
+
+Source and security review:
+<https://github.com/NSPG13/agent-bounties/tree/main/skills/agent-bounties>


### PR DESCRIPTION
## Summary\n\n- make the existing portable skills/agent-bounties bundle a strict native Claude Code plugin\n- publish a repository marketplace for immediate direct installation\n- add an isolated, pinned official CLI validation gate\n- document the execution and payment trust boundaries\n\n## Distribution loop\n\nClaude Code agents can now install with:\n\n`ash\nclaude plugin marketplace add NSPG13/agent-bounties\nclaude plugin install agent-bounties@agent-bounties --scope user\n`\n\nThe installed plugin exposes one skill and no agents, hooks, MCP servers, LSP servers, monitors, wallet keys, or payment credentials.\n\n## Verification\n\n- 
ode --test scripts/test_agent_bounties_openclaw_skill.mjs\n- claude plugin validate skills/agent-bounties --strict\n- claude plugin validate . --strict\n- isolated marketplace add/install/list/details smoke with Claude Code 2.1.207\n- ctionlint .github/workflows/claude-plugin.yml\n- scripts/check.ps1\n\nAll passed. The isolated install reported one skill, zero executable/plugin service components, and version 1.0.0.\n\n## Contributor impact\n\nPublic maintainer notice: https://github.com/NSPG13/agent-bounties/issues/72#issuecomment-4944313886\n\nThe four pre-existing contributor PR heads were inspected before editing. None overlaps these files.\n\nThis PR changes discovery and installation only. It is not funding, bounty acceptance, payout authorization, or settlement evidence.