### PR TITLE
feat: add portable autonomous creation planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,23 @@ The optional public address enables bond-balance and allowance checks. The
 helper returns unsigned calldata only; it never receives keys, signs, or
 broadcasts.
 
+Agents with a repository checkout can also generate a creation plan without a
+hosted planner:
+
+```bash
+cargo run -p cli -- autonomous-bounty-plan \
+  --terms-file path/to/terms.json \
+  --deployment-file deployments/base-mainnet.json \
+  --output target/bounty-plan.json
+```
+
+The command refuses any non-active manifest and verifies the exact factory and
+implementation code hashes, protocol hash, implementation address, and native
+USDC token at one Base `safe` block. It validates terms against that block's
+timestamp, then emits the content-addressed registration payload and exact
+unsigned `wallet_sendCalls` request. It never signs, broadcasts, or treats a
+plan as funding.
+
 The REST equivalents are published through OpenAPI and the discovery manifest.
 Creation, contribution, and claim planners support wallet-batched approval plus
 action calls. EOA flows also expose bounded Circle USDC EIP-3009 authorization

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -997,6 +997,39 @@ pub struct BaseNetworkDescriptor {
 
 pub const BASE_MAINNET_USDC_TOKEN_ADDRESS: &str = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 pub const BASE_SEPOLIA_USDC_TOKEN_ADDRESS: &str = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+pub const AUTONOMOUS_BOUNTY_PROTOCOL_HASH: &str =
+    "0x0afcbf01041498cc301207aa5cd21a838c522d8c057d9b29c2dd83d7d94053e7";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutonomousFactoryExpectedState {
+    pub protocol_version: String,
+    pub network: String,
+    pub chain_id: u64,
+    pub factory_contract: String,
+    pub implementation_contract: String,
+    pub native_usdc_token_address: String,
+    pub protocol_hash: String,
+    pub factory_runtime_code_hash: String,
+    pub implementation_runtime_code_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutonomousFactorySafeObservation {
+    pub protocol_version: String,
+    pub network: String,
+    pub chain_id: u64,
+    pub safe_block_number: u64,
+    pub safe_block_hash: String,
+    pub safe_block_timestamp: u64,
+    pub block_tag: String,
+    pub factory_contract: String,
+    pub implementation_contract: String,
+    pub native_usdc_token_address: String,
+    pub protocol_hash: String,
+    pub factory_runtime_code_hash: String,
+    pub implementation_runtime_code_hash: String,
+    pub evidence_boundary: String,
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct BaseRpcUrlConfig {
@@ -1395,7 +1428,18 @@ impl JsonRpcTransport for ReqwestJsonRpcTransport {
             .json(request)
             .send()
             .await
-            .map_err(|error| ChainBaseError::RpcTransport(error.to_string()))?;
+            .map_err(|error| {
+                let message = if error.is_timeout() {
+                    "request timed out"
+                } else if error.is_connect() {
+                    "connection failed"
+                } else if error.is_request() {
+                    "request could not be constructed"
+                } else {
+                    "request failed"
+                };
+                ChainBaseError::RpcTransport(message.to_string())
+            })?;
         let status = response.status();
         if !status.is_success() {
             return Err(ChainBaseError::RpcHttpStatus(status.as_u16()));
@@ -1405,6 +1449,293 @@ impl JsonRpcTransport for ReqwestJsonRpcTransport {
             .await
             .map_err(|error| ChainBaseError::InvalidRpcResponse(error.to_string()))
     }
+}
+
+pub async fn verify_autonomous_factory_safe_state(
+    rpc_url: &str,
+    expected: &AutonomousFactoryExpectedState,
+) -> Result<AutonomousFactorySafeObservation, ChainBaseError> {
+    verify_autonomous_factory_safe_state_with_transport(
+        rpc_url,
+        expected,
+        &ReqwestJsonRpcTransport::default(),
+    )
+    .await
+}
+
+pub async fn verify_autonomous_factory_safe_state_with_transport<T>(
+    rpc_url: &str,
+    expected: &AutonomousFactoryExpectedState,
+    transport: &T,
+) -> Result<AutonomousFactorySafeObservation, ChainBaseError>
+where
+    T: JsonRpcTransport + ?Sized,
+{
+    let network = base_network_descriptor(&expected.network)?;
+    if expected.protocol_version != "agent-bounties/autonomous-v1"
+        || network.chain_id != expected.chain_id
+    {
+        return Err(ChainBaseError::InvalidVerificationConfiguration(
+            "canonical factory manifest has an unsupported protocol or chain".to_string(),
+        ));
+    }
+
+    let factory_contract = normalize_address(&expected.factory_contract)?;
+    let implementation_contract = normalize_address(&expected.implementation_contract)?;
+    let native_usdc_token_address = normalize_address(&expected.native_usdc_token_address)?;
+    if native_usdc_token_address != normalize_address(&network.native_usdc_token_address)? {
+        return Err(ChainBaseError::InvalidVerificationConfiguration(
+            "canonical factory manifest settlement token does not match the Base network"
+                .to_string(),
+        ));
+    }
+    let protocol_hash = normalize_hash(&expected.protocol_hash)?;
+    if protocol_hash != AUTONOMOUS_BOUNTY_PROTOCOL_HASH {
+        return Err(ChainBaseError::InvalidVerificationConfiguration(
+            "canonical factory manifest protocol hash is not autonomous-v1".to_string(),
+        ));
+    }
+    let factory_runtime_code_hash = normalize_hash(&expected.factory_runtime_code_hash)?;
+    let implementation_runtime_code_hash =
+        normalize_hash(&expected.implementation_runtime_code_hash)?;
+
+    let safe_block = rpc_result(
+        transport
+            .post_json_value(
+                rpc_url,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "eth_getBlockByNumber",
+                    "params": ["safe", false]
+                }),
+            )
+            .await?,
+        1,
+        "eth_getBlockByNumber",
+    )?;
+    let safe_block_number_hex = safe_block
+        .get("number")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ChainBaseError::InvalidRpcResponse("safe block response is missing number".to_string())
+        })?;
+    let safe_block_number = parse_rpc_quantity(safe_block_number_hex)?;
+    let safe_block_hash = normalize_hash(
+        safe_block
+            .get("hash")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ChainBaseError::InvalidRpcResponse(
+                    "safe block response is missing hash".to_string(),
+                )
+            })?,
+    )?;
+    let safe_block_timestamp = parse_rpc_quantity(
+        safe_block
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ChainBaseError::InvalidRpcResponse(
+                    "safe block response is missing timestamp".to_string(),
+                )
+            })?,
+    )?;
+    let exact_block = hex_quantity(safe_block_number);
+
+    let factory_proof =
+        fetch_account_code_hash(rpc_url, &factory_contract, &exact_block, 2, transport).await?;
+    require_canonical_match(
+        "factory runtime code hash",
+        &factory_proof,
+        &factory_runtime_code_hash,
+    )?;
+
+    let implementation_proof = fetch_account_code_hash(
+        rpc_url,
+        &implementation_contract,
+        &exact_block,
+        3,
+        transport,
+    )
+    .await?;
+    require_canonical_match(
+        "implementation runtime code hash",
+        &implementation_proof,
+        &implementation_runtime_code_hash,
+    )?;
+
+    let observed_protocol_hash = fetch_contract_word(
+        rpc_url,
+        &factory_contract,
+        &encode_call("SUPPORTED_PROTOCOL_VERSION()", Vec::new()),
+        &exact_block,
+        4,
+        transport,
+    )
+    .await?;
+    require_canonical_match(
+        "factory protocol hash",
+        &observed_protocol_hash,
+        &protocol_hash,
+    )?;
+
+    let observed_implementation_word = fetch_contract_word(
+        rpc_url,
+        &factory_contract,
+        &encode_call("implementation()", Vec::new()),
+        &exact_block,
+        5,
+        transport,
+    )
+    .await?;
+    let observed_implementation = address_from_word(parse_bytes32(&observed_implementation_word)?);
+    require_canonical_match(
+        "factory implementation",
+        &observed_implementation,
+        &implementation_contract,
+    )?;
+
+    let observed_token_word = fetch_contract_word(
+        rpc_url,
+        &factory_contract,
+        &encode_call("settlementToken()", Vec::new()),
+        &exact_block,
+        6,
+        transport,
+    )
+    .await?;
+    let observed_token = address_from_word(parse_bytes32(&observed_token_word)?);
+    require_canonical_match(
+        "factory settlement token",
+        &observed_token,
+        &native_usdc_token_address,
+    )?;
+
+    Ok(AutonomousFactorySafeObservation {
+        protocol_version: expected.protocol_version.clone(),
+        network: expected.network.clone(),
+        chain_id: expected.chain_id,
+        safe_block_number,
+        safe_block_hash,
+        safe_block_timestamp,
+        block_tag: "safe".to_string(),
+        factory_contract,
+        implementation_contract,
+        native_usdc_token_address,
+        protocol_hash,
+        factory_runtime_code_hash,
+        implementation_runtime_code_hash,
+        evidence_boundary: "This observation proves exact factory code and immutable configuration at one Base safe block. It does not prove that any wallet call was authorized, broadcast, funded, claimable, accepted, paid, or settled.".to_string(),
+    })
+}
+
+fn rpc_result(value: Value, request_id: u64, method: &str) -> Result<Value, ChainBaseError> {
+    let object = value.as_object().ok_or_else(|| {
+        ChainBaseError::InvalidRpcResponse(format!("{method} response is not an object"))
+    })?;
+    if object.get("jsonrpc").and_then(Value::as_str) != Some("2.0")
+        || object.get("id").and_then(Value::as_u64) != Some(request_id)
+    {
+        return Err(ChainBaseError::InvalidRpcResponse(format!(
+            "{method} response has the wrong JSON-RPC version or id"
+        )));
+    }
+    if let Some(error) = object.get("error") {
+        let code = error.get("code").and_then(Value::as_i64).ok_or_else(|| {
+            ChainBaseError::InvalidRpcResponse(format!("{method} provider error is missing code"))
+        })?;
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("provider error")
+            .to_string();
+        return Err(ChainBaseError::RpcProviderError { code, message });
+    }
+    object.get("result").cloned().ok_or_else(|| {
+        ChainBaseError::InvalidRpcResponse(format!("{method} response is missing result"))
+    })
+}
+
+async fn fetch_account_code_hash<T>(
+    rpc_url: &str,
+    address: &str,
+    block: &str,
+    request_id: u64,
+    transport: &T,
+) -> Result<String, ChainBaseError>
+where
+    T: JsonRpcTransport + ?Sized,
+{
+    let result = rpc_result(
+        transport
+            .post_json_value(
+                rpc_url,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "eth_getProof",
+                    "params": [address, [], block]
+                }),
+            )
+            .await?,
+        request_id,
+        "eth_getProof",
+    )?;
+    normalize_hash(
+        result
+            .get("codeHash")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ChainBaseError::InvalidRpcResponse(
+                    "eth_getProof response is missing codeHash".to_string(),
+                )
+            })?,
+    )
+}
+
+async fn fetch_contract_word<T>(
+    rpc_url: &str,
+    contract: &str,
+    data: &str,
+    block: &str,
+    request_id: u64,
+    transport: &T,
+) -> Result<String, ChainBaseError>
+where
+    T: JsonRpcTransport + ?Sized,
+{
+    let result = rpc_result(
+        transport
+            .post_json_value(
+                rpc_url,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "eth_call",
+                    "params": [{ "to": contract, "data": data }, block]
+                }),
+            )
+            .await?,
+        request_id,
+        "eth_call",
+    )?;
+    normalize_hash(result.as_str().ok_or_else(|| {
+        ChainBaseError::InvalidRpcResponse("eth_call result is not one ABI word".to_string())
+    })?)
+}
+
+fn require_canonical_match(
+    field: &str,
+    observed: &str,
+    expected: &str,
+) -> Result<(), ChainBaseError> {
+    if observed != expected {
+        return Err(ChainBaseError::InvalidVerificationConfiguration(format!(
+            "canonical {field} mismatch: expected {expected}, observed {observed}"
+        )));
+    }
+    Ok(())
 }
 
 pub async fn fetch_base_contract_logs(
@@ -3982,6 +4313,7 @@ fn parse_hex_bytes(value: &str) -> Result<Vec<u8>, ChainBaseError> {
 mod tests {
     use super::*;
     use domain::Money;
+    use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -5185,6 +5517,149 @@ mod tests {
         let request = seen_request.lock().unwrap().clone().unwrap();
         assert_eq!(request["method"], "eth_getTransactionReceipt");
         assert_eq!(request["params"][0], format!("0x{}", "ef".repeat(32)));
+    }
+
+    fn canonical_factory_expected_state() -> AutonomousFactoryExpectedState {
+        AutonomousFactoryExpectedState {
+            protocol_version: "agent-bounties/autonomous-v1".to_string(),
+            network: "base-mainnet".to_string(),
+            chain_id: 8_453,
+            factory_contract: "0x1111111111111111111111111111111111111111".to_string(),
+            implementation_contract: "0x2222222222222222222222222222222222222222".to_string(),
+            native_usdc_token_address: BASE_MAINNET_USDC_TOKEN_ADDRESS.to_string(),
+            protocol_hash: AUTONOMOUS_BOUNTY_PROTOCOL_HASH.to_string(),
+            factory_runtime_code_hash: format!("0x{}", "33".repeat(32)),
+            implementation_runtime_code_hash: format!("0x{}", "44".repeat(32)),
+        }
+    }
+
+    fn canonical_factory_rpc_responses(
+        expected: &AutonomousFactoryExpectedState,
+    ) -> VecDeque<Value> {
+        let implementation_word = format!(
+            "0x{:0>64}",
+            expected.implementation_contract.trim_start_matches("0x")
+        );
+        let token_word = format!(
+            "0x{:0>64}",
+            expected.native_usdc_token_address.trim_start_matches("0x")
+        );
+        VecDeque::from(vec![
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "number": "0x10",
+                    "hash": format!("0x{}", "aa".repeat(32)),
+                    "timestamp": "0x669b8f00"
+                }
+            }),
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "result": { "codeHash": expected.factory_runtime_code_hash }
+            }),
+            json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "result": { "codeHash": expected.implementation_runtime_code_hash }
+            }),
+            json!({ "jsonrpc": "2.0", "id": 4, "result": expected.protocol_hash }),
+            json!({ "jsonrpc": "2.0", "id": 5, "result": implementation_word }),
+            json!({ "jsonrpc": "2.0", "id": 6, "result": token_word }),
+        ])
+    }
+
+    struct SequenceTransport {
+        seen_requests: Arc<Mutex<Vec<Value>>>,
+        responses: Mutex<VecDeque<Value>>,
+    }
+
+    #[async_trait::async_trait]
+    impl JsonRpcTransport for SequenceTransport {
+        async fn post_json_value(
+            &self,
+            _rpc_url: &str,
+            request: &Value,
+        ) -> Result<Value, ChainBaseError> {
+            self.seen_requests.lock().unwrap().push(request.clone());
+            self.responses.lock().unwrap().pop_front().ok_or_else(|| {
+                ChainBaseError::RpcTransport("mock response queue exhausted".to_string())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn safe_factory_verification_pins_exact_code_and_getters_to_one_block() {
+        let expected = canonical_factory_expected_state();
+        let seen_requests = Arc::new(Mutex::new(Vec::new()));
+        let transport = SequenceTransport {
+            seen_requests: seen_requests.clone(),
+            responses: Mutex::new(canonical_factory_rpc_responses(&expected)),
+        };
+
+        let observation = verify_autonomous_factory_safe_state_with_transport(
+            "https://mainnet.base.org",
+            &expected,
+            &transport,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(observation.safe_block_number, 16);
+        assert_eq!(
+            observation.safe_block_timestamp,
+            u64::from_str_radix("669b8f00", 16).unwrap()
+        );
+        assert_eq!(observation.block_tag, "safe");
+        assert_eq!(observation.factory_contract, expected.factory_contract);
+        assert_eq!(
+            observation.implementation_contract,
+            expected.implementation_contract
+        );
+        assert_eq!(
+            observation.factory_runtime_code_hash,
+            expected.factory_runtime_code_hash
+        );
+
+        let requests = seen_requests.lock().unwrap();
+        assert_eq!(requests.len(), 6);
+        assert_eq!(requests[0]["method"], "eth_getBlockByNumber");
+        assert_eq!(requests[0]["params"], json!(["safe", false]));
+        assert_eq!(requests[1]["method"], "eth_getProof");
+        assert_eq!(requests[1]["params"][2], "0x10");
+        assert_eq!(requests[2]["params"][2], "0x10");
+        for request in &requests[3..] {
+            assert_eq!(request["method"], "eth_call");
+            assert_eq!(request["params"][1], "0x10");
+        }
+    }
+
+    #[tokio::test]
+    async fn safe_factory_verification_fails_closed_on_token_mismatch() {
+        let expected = canonical_factory_expected_state();
+        let mut responses = canonical_factory_rpc_responses(&expected);
+        let wrong_token = format!("0x{:0>64}", "5555555555555555555555555555555555555555");
+        *responses.back_mut().unwrap() =
+            json!({ "jsonrpc": "2.0", "id": 6, "result": wrong_token });
+        let transport = SequenceTransport {
+            seen_requests: Arc::new(Mutex::new(Vec::new())),
+            responses: Mutex::new(responses),
+        };
+
+        let error = verify_autonomous_factory_safe_state_with_transport(
+            "https://mainnet.base.org",
+            &expected,
+            &transport,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ChainBaseError::InvalidVerificationConfiguration(message)
+                if message.contains("factory settlement token mismatch")
+        ));
     }
 
     struct MockTransport {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -46,6 +46,11 @@ use std::{
 };
 use uuid::Uuid;
 
+// Solc 0.8.26 keys immutable references by declaration id. Pinning both ids
+// makes compiler/source drift fail closed instead of swapping constructor values.
+const FACTORY_SETTLEMENT_TOKEN_IMMUTABLE_ID: &str = "2738";
+const FACTORY_IMPLEMENTATION_IMMUTABLE_ID: &str = "2740";
+
 #[derive(Parser)]
 #[command(name = "agent-bounties")]
 #[command(about = "Open-source agent bounty network CLI")]
@@ -834,8 +839,16 @@ fn autonomous_activation_bundle(
     let factory_runtime = artifact_runtime_with_immutables(
         &factory_artifact,
         &[
-            ("settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS),
-            ("implementation", &expected_implementation),
+            (
+                FACTORY_SETTLEMENT_TOKEN_IMMUTABLE_ID,
+                "settlementToken",
+                BASE_MAINNET_USDC_TOKEN_ADDRESS,
+            ),
+            (
+                FACTORY_IMPLEMENTATION_IMMUTABLE_ID,
+                "implementation",
+                &expected_implementation,
+            ),
         ],
     )?;
     let implementation_runtime =
@@ -1277,28 +1290,25 @@ fn artifact_hex<'a>(artifact: &'a serde_json::Value, pointer: &str) -> Result<&'
 
 fn artifact_runtime_with_immutables(
     artifact: &serde_json::Value,
-    immutable_addresses: &[(&str, &str)],
+    immutable_addresses: &[(&str, &str, &str)],
 ) -> Result<Vec<u8>> {
     let mut runtime = hex::decode(artifact_hex(artifact, "/deployedBytecode/object")?)?;
     let references = artifact
         .pointer("/deployedBytecode/immutableReferences")
         .and_then(serde_json::Value::as_object)
         .context("contract artifact is missing immutable references")?;
-    let ast = artifact
-        .get("ast")
-        .context("contract artifact is missing AST")?;
+    if references.len() != immutable_addresses.len() {
+        bail!(
+            "contract artifact immutable count drifted: expected {}, observed {}",
+            immutable_addresses.len(),
+            references.len()
+        );
+    }
     let mut patched = BTreeSet::new();
-    for (declaration_id, locations) in references {
-        let declaration_id = declaration_id
-            .parse::<u64>()
-            .with_context(|| format!("invalid immutable declaration id {declaration_id}"))?;
-        let name = ast_variable_name(ast, declaration_id).ok_or_else(|| {
-            anyhow!("immutable declaration {declaration_id} is absent from the artifact AST")
+    for (declaration_id, name, address) in immutable_addresses {
+        let locations = references.get(*declaration_id).ok_or_else(|| {
+            anyhow!("contract artifact has no immutable declaration {declaration_id} for {name}")
         })?;
-        let address = immutable_addresses
-            .iter()
-            .find_map(|(candidate, value)| (*candidate == name).then_some(*value))
-            .ok_or_else(|| anyhow!("no immutable value supplied for {name}"))?;
         let normalized = normalize_cli_address(address)?;
         let mut word = [0u8; 32];
         word[12..].copy_from_slice(&hex::decode(&normalized[2..])?);
@@ -1329,29 +1339,12 @@ fn artifact_runtime_with_immutables(
         }
         patched.insert(name.to_string());
     }
-    for (name, _) in immutable_addresses {
+    for (_, name, _) in immutable_addresses {
         if !patched.contains(*name) {
             bail!("contract artifact has no immutable references for {name}");
         }
     }
     Ok(runtime)
-}
-
-fn ast_variable_name(value: &serde_json::Value, declaration_id: u64) -> Option<&str> {
-    if value.get("id").and_then(serde_json::Value::as_u64) == Some(declaration_id)
-        && value.get("nodeType").and_then(serde_json::Value::as_str) == Some("VariableDeclaration")
-    {
-        return value.get("name").and_then(serde_json::Value::as_str);
-    }
-    match value {
-        serde_json::Value::Array(values) => values
-            .iter()
-            .find_map(|value| ast_variable_name(value, declaration_id)),
-        serde_json::Value::Object(values) => values
-            .values()
-            .find_map(|value| ast_variable_name(value, declaration_id)),
-        _ => None,
-    }
 }
 
 fn normalize_cli_address(value: &str) -> Result<String> {
@@ -5189,19 +5182,14 @@ mod tests {
                     ],
                     "2": [{ "start": 32, "length": 32 }]
                 }
-            },
-            "ast": {
-                "nodes": [
-                    { "id": 1, "nodeType": "VariableDeclaration", "name": "settlementToken" },
-                    { "id": 2, "nodeType": "VariableDeclaration", "name": "implementation" }
-                ]
             }
         });
         let runtime = artifact_runtime_with_immutables(
             &artifact,
             &[
-                ("settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS),
+                ("1", "settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS),
                 (
+                    "2",
                     "implementation",
                     "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
                 ),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,13 +9,15 @@ use chain_base::{
     autonomous_bounty_create_from_terms, base_network_descriptor, broadcast_signed_transaction,
     build_autonomous_bounty_terms_record, eth_get_transaction_receipt_request,
     eth_send_raw_transaction_request, fetch_transaction_receipt, keccak256_canonical_json,
-    AutonomousBountyCreationBatchPlan, AutonomousBountyTxPlanner, BaseRpcUrlConfig,
-    BASE_MAINNET_USDC_TOKEN_ADDRESS,
+    verify_autonomous_factory_safe_state, AutonomousBountyCreationBatchPlan,
+    AutonomousBountyCreationPlan, AutonomousBountyTxPlanner, AutonomousFactoryExpectedState,
+    AutonomousFactorySafeObservation, BaseRpcUrlConfig, EvmTransactionIntent,
+    AUTONOMOUS_BOUNTY_PROTOCOL_HASH, BASE_MAINNET_USDC_TOKEN_ADDRESS,
 };
 use clap::{Args as ClapArgs, Parser, Subcommand};
 use domain::{
-    AutonomousBountyTermsDocument, CapabilityClass, FundingMode, Money, PaymentRail, PrivacyLevel,
-    VerifierKind,
+    AutonomousBountyTermsDocument, AutonomousBountyTermsRecord, CapabilityClass, FundingMode,
+    Money, PaymentRail, PrivacyLevel, VerifierKind,
 };
 use eval_harness::{
     bundled_abuse_fixtures, bundled_fixtures, bundled_judge_fixtures, run_eval_loops, AbuseBench,
@@ -341,6 +343,20 @@ enum Command {
         #[arg(long)]
         output: Option<String>,
     },
+    AutonomousBountyPlan {
+        #[arg(long)]
+        terms_file: String,
+        #[arg(long, default_value = "deployments/base-mainnet.json")]
+        deployment_file: String,
+        #[arg(
+            long,
+            env = "BASE_MAINNET_RPC_URL",
+            default_value = "https://mainnet.base.org"
+        )]
+        rpc_url: String,
+        #[arg(long)]
+        output: Option<String>,
+    },
     ProductionSmoke {
         #[arg(long, env = "PRODUCTION_API_BASE_URL")]
         api_base_url: String,
@@ -594,6 +610,20 @@ async fn async_main() -> Result<()> {
             deployer_nonce,
             output.map(PathBuf::from),
         ),
+        Command::AutonomousBountyPlan {
+            terms_file,
+            deployment_file,
+            rpc_url,
+            output,
+        } => {
+            autonomous_bounty_plan(
+                PathBuf::from(terms_file),
+                PathBuf::from(deployment_file),
+                rpc_url,
+                output.map(PathBuf::from),
+            )
+            .await
+        }
         Command::ProductionSmoke {
             api_base_url,
             mcp_base_url,
@@ -801,7 +831,13 @@ fn autonomous_activation_bundle(
     let factory_artifact = read_json_file(&factory_artifact_path)?;
     let implementation_artifact = read_json_file(&implementation_artifact_path)?;
     let factory_creation = artifact_hex(&factory_artifact, "/bytecode/object")?;
-    let factory_runtime = artifact_hex(&factory_artifact, "/deployedBytecode/object")?;
+    let factory_runtime = artifact_runtime_with_immutables(
+        &factory_artifact,
+        &[
+            ("settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS),
+            ("implementation", &expected_implementation),
+        ],
+    )?;
     let implementation_runtime =
         artifact_hex(&implementation_artifact, "/deployedBytecode/object")?;
     let token = BASE_MAINNET_USDC_TOKEN_ADDRESS.trim_start_matches("0x");
@@ -812,7 +848,7 @@ fn autonomous_activation_bundle(
         to: None,
         value_wei: 0,
         factory_init_code_hash: keccak_hex(&hex::decode(&deployment_data[2..])?),
-        factory_runtime_code_hash: keccak_hex(&hex::decode(factory_runtime)?),
+        factory_runtime_code_hash: keccak_hex(&factory_runtime),
         implementation_runtime_code_hash: keccak_hex(&hex::decode(implementation_runtime)?),
         data: deployment_data,
         expected_factory,
@@ -858,6 +894,361 @@ fn autonomous_activation_bundle(
     Ok(())
 }
 
+#[derive(Debug, Deserialize)]
+struct PortableDeploymentManifest {
+    schema_version: u64,
+    protocol_version: String,
+    network: String,
+    chain_id: u64,
+    native_usdc: String,
+    status: String,
+    factory: PortableDeploymentFactory,
+}
+
+#[derive(Debug, Deserialize)]
+struct PortableDeploymentFactory {
+    contract: Option<String>,
+    implementation: Option<String>,
+    deployment_transaction: Option<String>,
+    deployment_block: Option<u64>,
+    deployer: Option<String>,
+    runtime_code_hash: Option<String>,
+    implementation_runtime_code_hash: Option<String>,
+    constructor_args: PortableDeploymentConstructor,
+}
+
+#[derive(Debug, Deserialize)]
+struct PortableDeploymentConstructor {
+    settlement_token: String,
+}
+
+#[derive(Debug)]
+struct ActiveDeploymentEvidence {
+    deployment_transaction: String,
+    deployment_block: u64,
+    deployer: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PortableDeploymentReference {
+    manifest_path: String,
+    manifest_canonical_json_keccak256: String,
+    deployment_transaction: String,
+    deployment_block: u64,
+    deployer: String,
+}
+
+#[derive(Debug, Serialize)]
+struct WalletCall {
+    to: String,
+    data: String,
+    value: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WalletSendCallsParameters {
+    version: String,
+    chain_id: String,
+    from: String,
+    calls: Vec<WalletCall>,
+}
+
+#[derive(Debug, Serialize)]
+struct WalletSendCallsRequest {
+    method: String,
+    params: Vec<WalletSendCallsParameters>,
+}
+
+#[derive(Debug, Serialize)]
+struct PortableTermsPublicationRequest {
+    creator_wallet: String,
+    document: AutonomousBountyTermsDocument,
+}
+
+#[derive(Debug, Serialize)]
+struct PortableRegistrationArtifact {
+    source_url: Option<String>,
+    terms_hash: String,
+    policy_hash: String,
+    acceptance_criteria_hash: String,
+    benchmark_hash: String,
+    evidence_schema_hash: String,
+    bounty_id: String,
+    predicted_bounty_contract: String,
+    terms_publication_method: String,
+    terms_publication_path: String,
+    terms_publication_request: PortableTermsPublicationRequest,
+}
+
+#[derive(Debug, Serialize)]
+struct PortableAutonomousBountyPlan {
+    schema_version: String,
+    protocol_version: String,
+    network: String,
+    chain_id: u64,
+    deployment: PortableDeploymentReference,
+    safe_chain_observation: AutonomousFactorySafeObservation,
+    terms_record: AutonomousBountyTermsRecord,
+    creation_plan: AutonomousBountyCreationPlan,
+    wallet_request: WalletSendCallsRequest,
+    registration: PortableRegistrationArtifact,
+    evidence_boundary: String,
+}
+
+async fn autonomous_bounty_plan(
+    terms_path: PathBuf,
+    deployment_path: PathBuf,
+    rpc_url: String,
+    output: Option<PathBuf>,
+) -> Result<()> {
+    let deployment_value = read_json_file(&deployment_path)?;
+    let (deployment, expected, deployment_evidence) =
+        active_factory_expected_state(&deployment_value)?;
+    let rpc_url = normalize_portable_rpc_url(&rpc_url)?;
+    let observation = verify_autonomous_factory_safe_state(&rpc_url, &expected)
+        .await
+        .context("verify canonical autonomous-v1 factory at one Base safe block")?;
+    let document: AutonomousBountyTermsDocument = serde_json::from_slice(
+        &fs::read(&terms_path)
+            .with_context(|| format!("read terms document {}", terms_path.display()))?,
+    )
+    .with_context(|| format!("parse terms document {}", terms_path.display()))?;
+    let artifact = build_portable_autonomous_bounty_plan(
+        document,
+        deployment,
+        expected,
+        observation,
+        PortableDeploymentReference {
+            manifest_path: deployment_path.to_string_lossy().replace('\\', "/"),
+            manifest_canonical_json_keccak256: keccak256_canonical_json(&deployment_value)?,
+            deployment_transaction: deployment_evidence.deployment_transaction,
+            deployment_block: deployment_evidence.deployment_block,
+            deployer: deployment_evidence.deployer,
+        },
+    )?;
+    let mut json = serde_json::to_string_pretty(&artifact)?;
+    json.push('\n');
+    if let Some(path) = output {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, json)
+            .with_context(|| format!("write portable bounty plan {}", path.display()))?;
+        println!("autonomous_bounty_plan={}", path.display());
+    } else {
+        print!("{json}");
+    }
+    Ok(())
+}
+
+fn active_factory_expected_state(
+    value: &serde_json::Value,
+) -> Result<(
+    PortableDeploymentManifest,
+    AutonomousFactoryExpectedState,
+    ActiveDeploymentEvidence,
+)> {
+    let deployment: PortableDeploymentManifest =
+        serde_json::from_value(value.clone()).context("decode Base deployment manifest")?;
+    if deployment.schema_version != 2
+        || deployment.protocol_version != "agent-bounties/autonomous-v1"
+        || deployment.network != "base-mainnet"
+        || deployment.chain_id != 8_453
+        || deployment.status != "active"
+    {
+        bail!(
+            "deployment manifest must be schema 2 autonomous-v1 Base mainnet with status `active`"
+        );
+    }
+    let token = normalize_cli_address(&deployment.native_usdc)?;
+    if !token.eq_ignore_ascii_case(BASE_MAINNET_USDC_TOKEN_ADDRESS)
+        || !normalize_cli_address(&deployment.factory.constructor_args.settlement_token)?
+            .eq_ignore_ascii_case(BASE_MAINNET_USDC_TOKEN_ADDRESS)
+    {
+        bail!("deployment manifest must use native Base USDC");
+    }
+    let factory = normalize_cli_address(
+        deployment
+            .factory
+            .contract
+            .as_deref()
+            .context("active deployment manifest is missing factory contract")?,
+    )?;
+    let implementation = normalize_cli_address(
+        deployment
+            .factory
+            .implementation
+            .as_deref()
+            .context("active deployment manifest is missing implementation contract")?,
+    )?;
+    let factory_runtime_code_hash = normalize_cli_bytes32(
+        deployment
+            .factory
+            .runtime_code_hash
+            .as_deref()
+            .context("active deployment manifest is missing factory runtime code hash")?,
+    )?;
+    let implementation_runtime_code_hash = normalize_cli_bytes32(
+        deployment
+            .factory
+            .implementation_runtime_code_hash
+            .as_deref()
+            .context("active deployment manifest is missing implementation runtime code hash")?,
+    )?;
+    let deployment_transaction = normalize_cli_bytes32(
+        deployment
+            .factory
+            .deployment_transaction
+            .as_deref()
+            .context("active deployment manifest is missing deployment transaction")?,
+    )?;
+    let deployment_block = deployment.factory.deployment_block.unwrap_or_default();
+    if deployment_block == 0 {
+        bail!("active deployment manifest is missing deployment block");
+    }
+    let deployer = normalize_cli_address(
+        deployment
+            .factory
+            .deployer
+            .as_deref()
+            .context("active deployment manifest is missing deployer")?,
+    )?;
+
+    let expected = AutonomousFactoryExpectedState {
+        protocol_version: deployment.protocol_version.clone(),
+        network: deployment.network.clone(),
+        chain_id: deployment.chain_id,
+        factory_contract: factory,
+        implementation_contract: implementation,
+        native_usdc_token_address: token,
+        protocol_hash: AUTONOMOUS_BOUNTY_PROTOCOL_HASH.to_string(),
+        factory_runtime_code_hash,
+        implementation_runtime_code_hash,
+    };
+    Ok((
+        deployment,
+        expected,
+        ActiveDeploymentEvidence {
+            deployment_transaction,
+            deployment_block,
+            deployer,
+        },
+    ))
+}
+
+fn build_portable_autonomous_bounty_plan(
+    document: AutonomousBountyTermsDocument,
+    deployment: PortableDeploymentManifest,
+    expected: AutonomousFactoryExpectedState,
+    observation: AutonomousFactorySafeObservation,
+    deployment_reference: PortableDeploymentReference,
+) -> Result<PortableAutonomousBountyPlan> {
+    if observation.factory_contract != expected.factory_contract
+        || observation.implementation_contract != expected.implementation_contract
+        || observation.factory_runtime_code_hash != expected.factory_runtime_code_hash
+        || observation.implementation_runtime_code_hash != expected.implementation_runtime_code_hash
+        || observation.protocol_hash != expected.protocol_hash
+        || observation.native_usdc_token_address != expected.native_usdc_token_address
+    {
+        bail!("safe chain observation does not match the active deployment manifest");
+    }
+    let creator = document
+        .contract_terms
+        .get("creator_wallet")
+        .and_then(serde_json::Value::as_str)
+        .context("terms contract_terms.creator_wallet must be a string")?
+        .to_string();
+    let observed_at = chrono::DateTime::from_timestamp(observation.safe_block_timestamp as i64, 0)
+        .context("safe block timestamp is outside the supported range")?;
+    let record = build_autonomous_bounty_terms_record(&creator, document, observed_at)
+        .context("validate portable bounty terms against safe block time")?;
+    let create = autonomous_bounty_create_from_terms(&record)
+        .context("derive autonomous-v1 creation input from terms")?;
+    let planner = AutonomousBountyTxPlanner::new(
+        &expected.factory_contract,
+        &expected.implementation_contract,
+    )?;
+    let creation_plan = planner.plan_creation(&deployment.network, &create)?;
+    let wallet_calls = creation_plan
+        .wallet_calls
+        .iter()
+        .map(wallet_call)
+        .collect::<Vec<_>>();
+    let wallet_request = WalletSendCallsRequest {
+        method: "wallet_sendCalls".to_string(),
+        params: vec![WalletSendCallsParameters {
+            version: "2.0.0".to_string(),
+            chain_id: format!("0x{:x}", deployment.chain_id),
+            from: create.creator.clone(),
+            calls: wallet_calls,
+        }],
+    };
+    let registration = PortableRegistrationArtifact {
+        source_url: record.document.source_url.clone(),
+        terms_hash: record.terms_hash.clone(),
+        policy_hash: record.policy_hash.clone(),
+        acceptance_criteria_hash: record.acceptance_criteria_hash.clone(),
+        benchmark_hash: record.benchmark_hash.clone(),
+        evidence_schema_hash: record.evidence_schema_hash.clone(),
+        bounty_id: creation_plan.bounty_id.clone(),
+        predicted_bounty_contract: creation_plan.predicted_bounty_contract.clone(),
+        terms_publication_method: "POST".to_string(),
+        terms_publication_path: "/v1/base/autonomous-bounties/terms".to_string(),
+        terms_publication_request: PortableTermsPublicationRequest {
+            creator_wallet: create.creator,
+            document: record.document.clone(),
+        },
+    };
+
+    Ok(PortableAutonomousBountyPlan {
+        schema_version: "agent-bounties/autonomous-portable-creation-plan-v1".to_string(),
+        protocol_version: deployment.protocol_version,
+        network: deployment.network,
+        chain_id: deployment.chain_id,
+        deployment: deployment_reference,
+        safe_chain_observation: observation,
+        terms_record: record,
+        creation_plan,
+        wallet_request,
+        registration,
+        evidence_boundary: "This artifact contains validated public terms and unsigned wallet calls. It is not wallet authorization, broadcast, funding, claimability, acceptance, payout, or settlement evidence. Reconcile confirmed canonical factory and bounty events before changing lifecycle state.".to_string(),
+    })
+}
+
+fn wallet_call(intent: &EvmTransactionIntent) -> WalletCall {
+    WalletCall {
+        to: intent.to.clone(),
+        data: intent.data.clone(),
+        value: format!("0x{:x}", intent.value_wei),
+    }
+}
+
+fn normalize_cli_bytes32(value: &str) -> Result<String> {
+    let trimmed = value.strip_prefix("0x").unwrap_or(value);
+    if trimmed.len() != 64 || !trimmed.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("invalid bytes32 value: {value}");
+    }
+    Ok(format!("0x{}", trimmed.to_ascii_lowercase()))
+}
+
+fn normalize_portable_rpc_url(value: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(value).context("Base RPC URL is invalid")?;
+    if !url.username().is_empty() || url.password().is_some() {
+        bail!("Base RPC URL must not contain credentials");
+    }
+    let host = url.host_str().context("Base RPC URL is missing a host")?;
+    let loopback = host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback());
+    if url.scheme() != "https" && !(url.scheme() == "http" && loopback) {
+        bail!("Base RPC URL must use HTTPS except for loopback development");
+    }
+    url.set_fragment(None);
+    Ok(url.to_string())
+}
+
 fn read_json_file(path: &Path) -> Result<serde_json::Value> {
     serde_json::from_slice(&fs::read(path).with_context(|| format!("read {}", path.display()))?)
         .with_context(|| format!("parse {}", path.display()))
@@ -882,6 +1273,85 @@ fn artifact_hex<'a>(artifact: &'a serde_json::Value, pointer: &str) -> Result<&'
         bail!("contract artifact {pointer} is not non-empty hex");
     }
     Ok(value)
+}
+
+fn artifact_runtime_with_immutables(
+    artifact: &serde_json::Value,
+    immutable_addresses: &[(&str, &str)],
+) -> Result<Vec<u8>> {
+    let mut runtime = hex::decode(artifact_hex(artifact, "/deployedBytecode/object")?)?;
+    let references = artifact
+        .pointer("/deployedBytecode/immutableReferences")
+        .and_then(serde_json::Value::as_object)
+        .context("contract artifact is missing immutable references")?;
+    let ast = artifact
+        .get("ast")
+        .context("contract artifact is missing AST")?;
+    let mut patched = BTreeSet::new();
+    for (declaration_id, locations) in references {
+        let declaration_id = declaration_id
+            .parse::<u64>()
+            .with_context(|| format!("invalid immutable declaration id {declaration_id}"))?;
+        let name = ast_variable_name(ast, declaration_id).ok_or_else(|| {
+            anyhow!("immutable declaration {declaration_id} is absent from the artifact AST")
+        })?;
+        let address = immutable_addresses
+            .iter()
+            .find_map(|(candidate, value)| (*candidate == name).then_some(*value))
+            .ok_or_else(|| anyhow!("no immutable value supplied for {name}"))?;
+        let normalized = normalize_cli_address(address)?;
+        let mut word = [0u8; 32];
+        word[12..].copy_from_slice(&hex::decode(&normalized[2..])?);
+        let locations = locations
+            .as_array()
+            .ok_or_else(|| anyhow!("immutable references for {name} are not an array"))?;
+        if locations.is_empty() {
+            bail!("immutable {name} has no runtime references");
+        }
+        for location in locations {
+            let start = location
+                .get("start")
+                .and_then(serde_json::Value::as_u64)
+                .context("immutable reference is missing start")? as usize;
+            let length = location
+                .get("length")
+                .and_then(serde_json::Value::as_u64)
+                .context("immutable reference is missing length")?
+                as usize;
+            if length != 32
+                || start
+                    .checked_add(length)
+                    .is_none_or(|end| end > runtime.len())
+            {
+                bail!("immutable reference for {name} is outside runtime bytecode");
+            }
+            runtime[start..start + length].copy_from_slice(&word);
+        }
+        patched.insert(name.to_string());
+    }
+    for (name, _) in immutable_addresses {
+        if !patched.contains(*name) {
+            bail!("contract artifact has no immutable references for {name}");
+        }
+    }
+    Ok(runtime)
+}
+
+fn ast_variable_name(value: &serde_json::Value, declaration_id: u64) -> Option<&str> {
+    if value.get("id").and_then(serde_json::Value::as_u64) == Some(declaration_id)
+        && value.get("nodeType").and_then(serde_json::Value::as_str) == Some("VariableDeclaration")
+    {
+        return value.get("name").and_then(serde_json::Value::as_str);
+    }
+    match value {
+        serde_json::Value::Array(values) => values
+            .iter()
+            .find_map(|value| ast_variable_name(value, declaration_id)),
+        serde_json::Value::Object(values) => values
+            .values()
+            .find_map(|value| ast_variable_name(value, declaration_id)),
+        _ => None,
+    }
 }
 
 fn normalize_cli_address(value: &str) -> Result<String> {
@@ -4704,6 +5174,147 @@ mod tests {
         assert_eq!(
             create_address(&factory, 1).expect("implementation address should derive"),
             "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9"
+        );
+    }
+
+    #[test]
+    fn factory_runtime_hash_includes_constructor_immutables() {
+        let artifact_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../contracts/base-escrow/out/AgentBountyFactory.sol/AgentBountyFactory.json");
+        let artifact = read_json_file(&artifact_path).unwrap();
+        let runtime = artifact_runtime_with_immutables(
+            &artifact,
+            &[
+                ("settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS),
+                (
+                    "implementation",
+                    "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
+                ),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            keccak_hex(&runtime),
+            "0x06f810de7b46f854ecc29e9c0c28156edab4b0d3e0bbe2bf5be8876687bebfc6"
+        );
+    }
+
+    fn active_deployment_fixture() -> serde_json::Value {
+        serde_json::json!({
+            "schema_version": 2,
+            "protocol_version": "agent-bounties/autonomous-v1",
+            "network": "base-mainnet",
+            "chain_id": 8453,
+            "native_usdc": BASE_MAINNET_USDC_TOKEN_ADDRESS,
+            "status": "active",
+            "factory": {
+                "contract": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
+                "implementation": "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
+                "deployment_transaction": format!("0x{}", "55".repeat(32)),
+                "deployment_block": 48_000_000,
+                "deployer": "0x884834E884d6e93462655A2820140aD03E6747bC",
+                "runtime_code_hash": "0x06f810de7b46f854ecc29e9c0c28156edab4b0d3e0bbe2bf5be8876687bebfc6",
+                "implementation_runtime_code_hash": "0xc36fcba5176b2cd8b57a9fd0cbf931177dc8b36cf8367c1568ccebe5f03be3f6",
+                "constructor_args": {
+                    "settlement_token": BASE_MAINNET_USDC_TOKEN_ADDRESS
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn portable_creation_plan_reproduces_activation_commitments_and_wallet_calls() {
+        let deployment_value = active_deployment_fixture();
+        let (deployment, expected, _) = active_factory_expected_state(&deployment_value).unwrap();
+        let safe_block_timestamp = chrono::DateTime::parse_from_rfc3339("2026-07-10T00:00:00Z")
+            .unwrap()
+            .timestamp() as u64;
+        let observation = AutonomousFactorySafeObservation {
+            protocol_version: expected.protocol_version.clone(),
+            network: expected.network.clone(),
+            chain_id: expected.chain_id,
+            safe_block_number: 48_000_100,
+            safe_block_hash: format!("0x{}", "66".repeat(32)),
+            safe_block_timestamp,
+            block_tag: "safe".to_string(),
+            factory_contract: expected.factory_contract.clone(),
+            implementation_contract: expected.implementation_contract.clone(),
+            native_usdc_token_address: expected.native_usdc_token_address.clone(),
+            protocol_hash: expected.protocol_hash.clone(),
+            factory_runtime_code_hash: expected.factory_runtime_code_hash.clone(),
+            implementation_runtime_code_hash: expected.implementation_runtime_code_hash.clone(),
+            evidence_boundary: "fixture observation".to_string(),
+        };
+        let document: AutonomousBountyTermsDocument =
+            serde_json::from_str(include_str!("../../../bounties/autonomous-v1/168.json")).unwrap();
+        let artifact = build_portable_autonomous_bounty_plan(
+            document,
+            deployment,
+            expected,
+            observation,
+            PortableDeploymentReference {
+                manifest_path: "deployment.json".to_string(),
+                manifest_canonical_json_keccak256: keccak256_canonical_json(&deployment_value)
+                    .unwrap(),
+                deployment_transaction: format!("0x{}", "55".repeat(32)),
+                deployment_block: 48_000_000,
+                deployer: "0x884834e884d6e93462655a2820140ad03e6747bc".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            artifact.schema_version,
+            "agent-bounties/autonomous-portable-creation-plan-v1"
+        );
+        assert_eq!(
+            artifact.creation_plan.bounty_id,
+            "0xb6f8d6983db3d16237cd896730ec8ac3d20734f5612744f60a15a3bc4c030a27"
+        );
+        assert_eq!(
+            artifact.creation_plan.predicted_bounty_contract,
+            "0x786be3f994365fcd417a1b502a83300ea87d9b34"
+        );
+        assert_eq!(artifact.creation_plan.wallet_calls.len(), 2);
+        assert_eq!(artifact.wallet_request.method, "wallet_sendCalls");
+        assert_eq!(artifact.wallet_request.params[0].chain_id, "0x2105");
+        assert_eq!(artifact.wallet_request.params[0].calls.len(), 2);
+        assert_eq!(artifact.wallet_request.params[0].calls[0].value, "0x0");
+        assert_eq!(
+            artifact.registration.terms_hash,
+            "0x83d7f1c75921cf11a3eb7530d72f26272b3a031c1ed73380b7d41e2bdb82c878"
+        );
+        assert_eq!(
+            artifact
+                .registration
+                .terms_publication_request
+                .creator_wallet,
+            "0x884834e884d6e93462655a2820140ad03e6747bc"
+        );
+    }
+
+    #[test]
+    fn portable_creation_plan_rejects_non_active_deployment_manifest() {
+        let mut deployment = active_deployment_fixture();
+        deployment["status"] = serde_json::json!("pending_external_review_and_deployment");
+
+        let error = active_factory_expected_state(&deployment).unwrap_err();
+
+        assert!(error.to_string().contains("status `active`"));
+    }
+
+    #[test]
+    fn portable_creation_planner_rejects_credential_bearing_or_insecure_rpc_urls() {
+        assert!(normalize_portable_rpc_url("https://key@example.com/rpc").is_err());
+        assert!(normalize_portable_rpc_url("http://rpc.example.com").is_err());
+        assert_eq!(
+            normalize_portable_rpc_url("http://127.0.0.1:8545/#ignored").unwrap(),
+            "http://127.0.0.1:8545/"
+        );
+        assert_eq!(
+            normalize_portable_rpc_url("https://rpc.example.com/v1?key=secret#ignored").unwrap(),
+            "https://rpc.example.com/v1?key=secret"
         );
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5178,10 +5178,25 @@ mod tests {
     }
 
     #[test]
-    fn factory_runtime_hash_includes_constructor_immutables() {
-        let artifact_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../contracts/base-escrow/out/AgentBountyFactory.sol/AgentBountyFactory.json");
-        let artifact = read_json_file(&artifact_path).unwrap();
+    fn factory_runtime_hash_patches_constructor_immutables_without_generated_files() {
+        let artifact = serde_json::json!({
+            "deployedBytecode": {
+                "object": format!("0x{}", "00".repeat(96)),
+                "immutableReferences": {
+                    "1": [
+                        { "start": 0, "length": 32 },
+                        { "start": 64, "length": 32 }
+                    ],
+                    "2": [{ "start": 32, "length": 32 }]
+                }
+            },
+            "ast": {
+                "nodes": [
+                    { "id": 1, "nodeType": "VariableDeclaration", "name": "settlementToken" },
+                    { "id": 2, "nodeType": "VariableDeclaration", "name": "implementation" }
+                ]
+            }
+        });
         let runtime = artifact_runtime_with_immutables(
             &artifact,
             &[
@@ -5194,10 +5209,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            keccak_hex(&runtime),
-            "0x06f810de7b46f854ecc29e9c0c28156edab4b0d3e0bbe2bf5be8876687bebfc6"
-        );
+        let settlement = hex::decode(&BASE_MAINNET_USDC_TOKEN_ADDRESS[2..]).unwrap();
+        let implementation = hex::decode("2fa36d2b2327642db3a6cc8cdd91544ad7484eb9").unwrap();
+        assert_eq!(&runtime[12..32], settlement);
+        assert_eq!(&runtime[44..64], implementation);
+        assert_eq!(&runtime[76..96], settlement);
     }
 
     fn active_deployment_fixture() -> serde_json::Value {

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -930,6 +930,7 @@ If hosted protocol status is not active, run the portable inventory helper. Do n
 - Portable inventory helper: {portable_inventory_helper}
 - Direct-chain canary manifest: {direct_chain_canary_manifest}
 - Check hosted inventory, then Base directly: `node skills/agent-bounties/scripts/check-in.mjs --solver-wallet 0xYourPublicBaseAddress`
+- Portable creation planner from a repository checkout: `cargo run -p cli -- autonomous-bounty-plan --terms-file path/to/terms.json --deployment-file deployments/base-mainnet.json --output target/bounty-plan.json`
 - Earn: {earn_page}
 - Post your own bounty: {post_page}
 - Fund a bounty: {funding_page}
@@ -953,6 +954,8 @@ If hosted protocol status is not active, run the portable inventory helper. Do n
 5. EOAs can use the Circle USDC EIP-3009 authorization returned by the plan. Smart accounts can batch approve and create.
 6. Anyone can pool USDC with `plan_autonomous_bounty_contribution` until the target is reached.
 7. Funding is real only after FundingAdded; claimability requires BountyBecameClaimable.
+
+If hosted planning is unavailable, the repository CLI command above verifies exact factory code and immutable getters at one Base `safe` block, validates terms against that block time, and emits the same unsigned wallet batch plus registration payload. It refuses a pending or mismatched deployment and never treats output as funding.
 
 ## Verify
 

--- a/deployments/base-mainnet-activation.json
+++ b/deployments/base-mainnet-activation.json
@@ -14,7 +14,7 @@
     "expected_factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     "expected_implementation": "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
     "factory_init_code_hash": "0xba3dbb77b8aafcf2bdcfc234aa1fe9711d3ee10870a4ffda66106d2faeaac122",
-    "factory_runtime_code_hash": "0x08460cbdf09ade3a42d71cb8efb4225bbbd5fb12e3f492ca3e4c25924bf68b5c",
+    "factory_runtime_code_hash": "0x06f810de7b46f854ecc29e9c0c28156edab4b0d3e0bbe2bf5be8876687bebfc6",
     "implementation_runtime_code_hash": "0xc36fcba5176b2cd8b57a9fd0cbf931177dc8b36cf8367c1568ccebe5f03be3f6",
     "settlement_token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
   },

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -97,6 +97,33 @@ without new poster funding.
 8. Wait for the factory creation events and `FundingAdded`. Claimability begins
    only at `BountyBecameClaimable`.
 
+If the hosted planner is unavailable, use the source-controlled planner from a
+repository checkout:
+
+```bash
+cargo run -p cli -- autonomous-bounty-plan \
+  --terms-file path/to/terms.json \
+  --deployment-file deployments/base-mainnet.json \
+  --output target/bounty-plan.json
+```
+
+This command fails closed unless the deployment manifest is active and its
+factory code, implementation code, protocol hash, implementation getter, and
+native-USDC getter all match at one Base `safe` block. It uses that block's
+timestamp for deadline validation and emits:
+
+- the canonical terms record and hashes;
+- the deterministic bounty id and predicted contract;
+- exact unsigned approval/create calls;
+- a `wallet_sendCalls` request for bounded smart-account execution;
+- the hosted terms-publication request for content-addressed registration.
+
+Publish the terms before creation when the hosted store is available. An agent
+with an explicit bounded wallet policy may submit the wallet request directly;
+otherwise it must ask the wallet owner. In either case, reconcile
+`CanonicalBountyCreated`, `FundingAdded`, and `BountyBecameClaimable` before
+advertising the bounty as funded or claimable.
+
 AI judge policies must commit at least two verifier wallets plus provider,
 immutable model version, system prompt, rubric, decoding parameters, benchmark,
 and evidence schema.

--- a/docs/autonomous-protocol.md
+++ b/docs/autonomous-protocol.md
@@ -24,6 +24,13 @@ The factory and bounty implementation are not upgradeable. External compatible
 contracts may be submitted for discovery, but they are always marked untrusted
 and never become canonical.
 
+Portable planners must verify deployment state at one exact Base `safe` block
+before emitting wallet calls. Required checks are the factory and implementation
+account code hashes plus `SUPPORTED_PROTOCOL_VERSION()`, `implementation()`,
+and `settlementToken()`. The factory runtime hash must be calculated from the
+deployed bytecode after constructor immutables are inserted; hashing the
+unpatched compiler artifact is invalid. Any mismatch fails closed.
+
 ## Committed Terms
 
 Before creation, the poster publishes canonical JSON with schema

--- a/scripts/rehearse_autonomous_activation.py
+++ b/scripts/rehearse_autonomous_activation.py
@@ -123,6 +123,101 @@ def validate_bundle(bundle: dict[str, Any]) -> None:
         raise ValueError("activation bundle must remain capped at 4 USDC total")
 
 
+def run_portable_creation_plan(
+    repo: Path,
+    temp: Path,
+    local_url: str,
+    bundle: dict[str, Any],
+    deploy_hash: str,
+    deploy_receipt: dict[str, Any],
+) -> dict[str, Any]:
+    deployment = bundle["deployment"]
+    active_manifest = json.loads((repo / "deployments/base-mainnet.json").read_text(encoding="utf-8"))
+    active_manifest["status"] = "active"
+    active_manifest["factory"].update(
+        {
+            "contract": deployment["expected_factory"],
+            "implementation": deployment["expected_implementation"],
+            "deployment_transaction": deploy_hash,
+            "deployment_block": uint_result(deploy_receipt["blockNumber"]),
+            "deployer": deployment["from"],
+            "runtime_code_hash": deployment["factory_runtime_code_hash"],
+            "implementation_runtime_code_hash": deployment[
+                "implementation_runtime_code_hash"
+            ],
+        }
+    )
+    manifest_path = temp / "active-base-mainnet.json"
+    plan_path = temp / "portable-bounty-168.json"
+    manifest_path.write_text(
+        json.dumps(active_manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    command = [
+        "cargo",
+        "run",
+        "--quiet",
+        "-p",
+        "cli",
+        "--",
+        "autonomous-bounty-plan",
+        "--terms-file",
+        "bounties/autonomous-v1/168.json",
+        "--deployment-file",
+        str(manifest_path),
+        "--rpc-url",
+        local_url,
+        "--output",
+        str(plan_path),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"portable creation planner failed on Base fork: {detail}")
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    expected_bounty = next(item for item in bundle["bounties"] if item["issue"] == 168)
+    expected_creation = next(
+        item
+        for item in bundle["creation_batch"]["creations"]
+        if item["bounty_id"].lower() == expected_bounty["bounty_id"].lower()
+    )
+    if (
+        plan.get("schema_version")
+        != "agent-bounties/autonomous-portable-creation-plan-v1"
+        or plan["safe_chain_observation"]["factory_contract"].lower()
+        != deployment["expected_factory"].lower()
+        or plan["safe_chain_observation"]["factory_runtime_code_hash"].lower()
+        != deployment["factory_runtime_code_hash"].lower()
+        or plan["safe_chain_observation"]["implementation_runtime_code_hash"].lower()
+        != deployment["implementation_runtime_code_hash"].lower()
+        or plan["creation_plan"]["bounty_id"].lower()
+        != expected_bounty["bounty_id"].lower()
+        or plan["creation_plan"]["predicted_bounty_contract"].lower()
+        != expected_bounty["predicted_bounty_contract"].lower()
+        or plan["creation_plan"]["create_bounty"]["data"].lower()
+        != expected_creation["create_bounty"]["data"].lower()
+        or len(plan["wallet_request"]["params"][0]["calls"]) != 2
+    ):
+        raise RuntimeError("portable creation planner output drifted from activation bundle")
+    return {
+        "schema_version": plan["schema_version"],
+        "safe_block_number": plan["safe_chain_observation"]["safe_block_number"],
+        "safe_block_hash": plan["safe_chain_observation"]["safe_block_hash"],
+        "bounty_id": plan["creation_plan"]["bounty_id"],
+        "predicted_bounty_contract": plan["creation_plan"][
+            "predicted_bounty_contract"
+        ],
+        "wallet_call_count": len(plan["wallet_request"]["params"][0]["calls"]),
+        "evidence_boundary": "Unsigned planner output and fork state are rehearsal evidence only.",
+    }
+
+
 def rehearse(repo: Path, bundle_path: Path, fork_url: str, anvil_path: str | None) -> dict[str, Any]:
     bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
     validate_bundle(bundle)
@@ -131,9 +226,10 @@ def rehearse(repo: Path, bundle_path: Path, fork_url: str, anvil_path: str | Non
     port = free_port()
     local_url = f"http://127.0.0.1:{port}"
     anvil = find_anvil(repo, anvil_path)
-    with tempfile.TemporaryDirectory(prefix="agent-bounties-activation-") as temp:
-        stdout_path = Path(temp) / "anvil.stdout.log"
-        stderr_path = Path(temp) / "anvil.stderr.log"
+    with tempfile.TemporaryDirectory(prefix="agent-bounties-activation-") as temp_name:
+        temp = Path(temp_name)
+        stdout_path = temp / "anvil.stdout.log"
+        stderr_path = temp / "anvil.stderr.log"
         creationflags = subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0
         with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
             process = subprocess.Popen(
@@ -189,6 +285,17 @@ def rehearse(repo: Path, bundle_path: Path, fork_url: str, anvil_path: str | Non
                 observed_token = address_result(call(local_url, observed_factory, "settlementToken()"))
                 if observed_token != deployment["settlement_token"].lower():
                     raise RuntimeError("factory settlement token mismatch")
+                # Anvil models safe/finalized tags behind latest. Advance the local fork so the
+                # deployment is visible through the same safe-block boundary used in production.
+                rpc(local_url, "anvil_mine", ["0x40"])
+                portable_plan = run_portable_creation_plan(
+                    repo,
+                    temp,
+                    local_url,
+                    bundle,
+                    deploy_hash,
+                    deploy_receipt,
+                )
 
                 transaction_summaries = []
                 for transaction in bundle["creation_batch"]["wallet_calls"]:
@@ -268,6 +375,7 @@ def rehearse(repo: Path, bundle_path: Path, fork_url: str, anvil_path: str | Non
                     "factory": observed_factory,
                     "implementation": observed_implementation,
                     "deployment_gas_used": uint_result(deploy_receipt["gasUsed"]),
+                    "portable_creation_plan": portable_plan,
                     "transactions": transaction_summaries,
                     "bounties": bounty_summaries,
                     "creator_usdc_before": wallet_usdc,

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -139,7 +139,7 @@ test("portable skill metadata and install contracts remain publishable", async (
   );
 
   assert.match(skill, /^---\r?\nname: agent-bounties\r?\n/);
-  assert.match(skill, /\r?\nversion: 1\.1\.0\r?\n/);
+  assert.match(skill, /\r?\nversion: 1\.2\.0\r?\n/);
   assert.match(skill, /\r?\nauthor: Agent Bounties contributors\r?\n/);
   assert.match(skill, /\r?\n  hermes:\r?\n/);
   assert.match(skill, /\r?\n    category: agent-commerce\r?\n/);
@@ -154,7 +154,7 @@ test("portable skill metadata and install contracts remain publishable", async (
 
   assert.equal(plugin.name, "agent-bounties");
   assert.equal(plugin.displayName, "Agent Bounties");
-  assert.equal(plugin.version, "1.1.0");
+  assert.equal(plugin.version, "1.2.0");
   assert.equal(plugin.license, "MIT");
   assert.equal(plugin.repository, "https://github.com/NSPG13/agent-bounties");
   assert.equal(plugin.homepage, "https://nspg13.github.io/agent-bounties/");
@@ -177,6 +177,8 @@ test("portable skill metadata and install contracts remain publishable", async (
   assert.ok(llms.includes(portableHelperUrl));
   assert.ok(llms.includes(directManifestUrl));
   assert.ok(llms.includes("--solver-wallet 0xYourPublicBaseAddress"));
+  assert.ok(llms.includes("autonomous-bounty-plan"));
+  assert.ok(skill.includes("autonomous-bounty-plan"));
 
   assert.equal(chainManifest.factory, activation.deployment.expected_factory);
   assert.equal(chainManifest.implementation, activation.deployment.expected_implementation);

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -31,6 +31,7 @@ Until `protocol.json` reports `status: active` with a verified factory address, 
 - Portable inventory helper: https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/scripts/check-in.mjs
 - Direct-chain canary manifest: https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/fixtures/base-mainnet-canaries.json
 - Check hosted inventory, then Base directly: `node skills/agent-bounties/scripts/check-in.mjs --solver-wallet 0xYourPublicBaseAddress`
+- Portable creation planner from a repository checkout: `cargo run -p cli -- autonomous-bounty-plan --terms-file path/to/terms.json --deployment-file deployments/base-mainnet.json --output target/bounty-plan.json`
 
 ## Agent Earning Loop
 
@@ -58,6 +59,8 @@ Why promotion is rational for the agent: verified shares, referrals, stars, and 
 5. An EOA can sign the returned Circle USDC EIP-3009 authorization for one bounded create-and-fund transaction. Smart accounts can batch approve and create.
 6. Anyone can add USDC with `plan_autonomous_bounty_contribution`; contributions are capped at the remaining target.
 7. Funding is real only after confirmed canonical `FundingAdded` evidence. Work becomes claimable only after `BountyBecameClaimable`.
+
+If hosted planning is unavailable, the repository CLI command above verifies exact factory code and immutable getters at one Base `safe` block, validates terms against that block time, and emits the same unsigned wallet batch plus registration payload. It refuses a pending or mismatched deployment and never treats output as funding.
 
 Each canonical bounty is an isolated deterministic minimal-proxy contract. Its terms and verifier policy cannot be changed after creation. A valid pass pays the solver and verifiers; a valid fail pays verifiers, uses the solver bond to replace the verifier reserve, and reopens the still-funded bounty. Acceptance or verifier timeout returns the bond. A no-submission claim timeout forfeits it into the next solver's completion bonus, or pro-rata funder refunds after cancellation. No settlement operator is involved.
 

--- a/skills/agent-bounties/.claude-plugin/plugin.json
+++ b/skills/agent-bounties/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agent-bounties",
   "displayName": "Agent Bounties",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Find verified claimable bounties, earn from digital work, post or fund bounties, and check canonical Base USDC evidence.",
   "author": {
     "name": "Agent Bounties contributors",

--- a/skills/agent-bounties/SKILL.md
+++ b/skills/agent-bounties/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bounties
 description: Find, verify, claim, solve, fund, or post autonomous digital bounties without confusing intent with real USDC or payout evidence.
-version: 1.1.0
+version: 1.2.0
 author: Agent Bounties contributors
 homepage: https://nspg13.github.io/agent-bounties/
 metadata:
@@ -105,6 +105,23 @@ acceptance criteria, benchmark, evidence schema, and verifier policy.
 Fully fund on creation by default. Use zero or partial initial funding only for
 intentional crowdfunding. Other wallets may contribute without gaining
 settlement authority.
+
+When the hosted planner is unavailable and a repository checkout is present,
+run:
+
+```bash
+cargo run -p cli -- autonomous-bounty-plan \
+  --terms-file path/to/terms.json \
+  --deployment-file deployments/base-mainnet.json \
+  --output target/bounty-plan.json
+```
+
+Use the result only if it reports one exact Base `safe` block and matching
+factory/implementation code and immutable getters. The artifact contains a
+terms-publication payload and unsigned `wallet_sendCalls`; it is not funding.
+An explicitly bounded wallet policy may authorize submission without a new
+human prompt. Otherwise ask the wallet owner. Require canonical creation and
+funding events before announcing the bounty as funded or claimable.
 
 Payment methods saved for ChatGPT, Claude, Gemini, or another assistant are not
 automatically available. Autonomous-v1 uses a Base wallet and native USDC.

--- a/skills/agent-bounties/fixtures/base-mainnet-canaries.json
+++ b/skills/agent-bounties/fixtures/base-mainnet-canaries.json
@@ -6,7 +6,7 @@
   "chain_id": 8453,
   "native_usdc": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
   "factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
-  "factory_runtime_code_hash": "0x08460cbdf09ade3a42d71cb8efb4225bbbd5fb12e3f492ca3e4c25924bf68b5c",
+  "factory_runtime_code_hash": "0x06f810de7b46f854ecc29e9c0c28156edab4b0d3e0bbe2bf5be8876687bebfc6",
   "implementation": "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
   "implementation_runtime_code_hash": "0xc36fcba5176b2cd8b57a9fd0cbf931177dc8b36cf8367c1568ccebe5f03be3f6",
   "bounty_proxy_runtime_code_hash": "0x6e7d6297e170d10e6484c9b72314bb0e2173cd967aa8e05231ee369dbde0c0a1",


### PR DESCRIPTION
## Summary

- add a fail-closed Base `safe`-block verifier for canonical factory/implementation code and immutable getters
- add `autonomous-bounty-plan`, which validates one terms document and emits exact unsigned `wallet_sendCalls` plus a registration payload without trusting hosted planning
- calculate factory runtime hashes after constructor immutables are inserted; update activation and portable canary manifests from the corrected hash
- extend the Base-mainnet-fork rehearsal to exercise the portable planner against deployed fork bytecode
- publish skill 1.2.0 and agent-facing fallback instructions

## Important finding

The previous activation bundle hashed the compiler artifact's zero-filled immutable placeholders. A fresh Base fork observed the real deployed factory hash as `0x06f810de7b46f854ecc29e9c0c28156edab4b0d3e0bbe2bf5be8876687bebfc6`. This PR derives that hash from immutable-patched runtime bytecode and binds it to a regression test. No mainnet factory is deployed, so this is a pre-activation correction, not a live migration.

## Evidence

- `scripts/check.ps1` passed
- `forge test --fuzz-runs 1000`: 23 passed
- final Base-mainnet-fork rehearsal at fork block `48495137`: pass
- portable planner verified safe block `48495170`
- all four exact 1 USDC canaries became canonical, fully funded, and claimable on the fork
- live Base helper at safe block `48495145`: `not_deployed`, zero claimable, `post_own_bounty`

Fork state and unsigned plans are rehearsal evidence only. They do not prove mainnet deployment, funding, claimability, payout, or settlement.

## Contributor sequencing

Planned publicly in #72 before edits. Open PRs #167, #158, #151, and #139 were checked before and after implementation; their heads did not change and this slice does not invalidate their requested repair paths.