### PR TITLE
fix: make hosted wallet connection provider-neutral

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -139,6 +139,8 @@ services:
         value: base-mainnet
       - key: BASE_INDEXER_PROTOCOL
         value: autonomous-v1
+      - key: BASE_INDEXER_FACTORY_CONTRACT
+        value: 0x082c52131aaf0c56e76b075f895eab6fcab6d2f9
       - key: BASE_INDEXER_RPC_URL
         value: https://mainnet.base.org
       - key: BASE_INDEXER_START_BLOCK

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -252,6 +252,7 @@ def main() -> int:
     require_env_value(worker, "BASE_INDEXER_PROTOCOL", "autonomous-v1")
     require_env_value(worker, "BASE_INDEXER_RPC_URL", rpc_url)
     if active:
+        require_env_value(worker, "BASE_INDEXER_FACTORY_CONTRACT", factory["contract"])
         require_env_value(worker, "BASE_INDEXER_START_BLOCK", f'"{factory["deployment_block"]}"')
     else:
         require_env_sync_false(worker, "BASE_INDEXER_START_BLOCK")

--- a/scripts/test-autonomous-wallet-flow.js
+++ b/scripts/test-autonomous-wallet-flow.js
@@ -14,6 +14,8 @@ new vm.Script(source, { filename: "site/autonomous.js" });
 for (const required of [
   "eth_signTypedData_v4",
   "wallet_sendCalls",
+  "eip6963:requestProvider",
+  "data-wallet-provider",
   "create_bounty",
   "eip3009_authorization",
   "/v1/base/autonomous-bounties/creation-plan",
@@ -32,6 +34,9 @@ for (const required of [
 }
 
 for (const retired of [
+  "import wallet",
+  "seed phrase",
+  "private key",
   "createEscrow",
   "EscrowReleased",
   "/v1/base/funding-plan",
@@ -52,6 +57,12 @@ for (const page of ["index.html", "post.html", "funding.html", "earn.html", "ope
   const html = fs.readFileSync(path.join(repoRoot, "site", page), "utf8");
   assert(html.includes("autonomous.js"), `${page} does not load autonomous.js`);
   assert(!html.includes("main.js"), `${page} loads the retired browser bundle`);
+}
+
+for (const page of ["post.html", "funding.html", "earn.html"]) {
+  const html = fs.readFileSync(path.join(repoRoot, "site", page), "utf8");
+  assert(html.includes("data-wallet-provider"), `${page} does not offer explicit wallet-provider selection`);
+  assert(html.includes("Connect wallet"), `${page} does not use connect-wallet onboarding`);
 }
 
 console.log("autonomous wallet flow contract passed");

--- a/site/autonomous.js
+++ b/site/autonomous.js
@@ -4,10 +4,90 @@
   const state = {
     protocol: null,
     account: null,
+    provider: null,
+    providers: [],
   };
+
+  const announcedProviders = [];
 
   const byId = (id) => document.getElementById(id);
   const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  function isWalletProvider(provider) {
+    return Boolean(provider && typeof provider.request === "function");
+  }
+
+  function providerName(provider, info = {}) {
+    if (info.name) return info.name;
+    if (provider.isMetaMask) return "MetaMask";
+    if (provider.isCoinbaseWallet) return "Coinbase Wallet";
+    if (provider.isBraveWallet) return "Brave Wallet";
+    return "Browser wallet";
+  }
+
+  function rememberProvider(event) {
+    const detail = event && event.detail;
+    if (!detail || !isWalletProvider(detail.provider)) return;
+    if (!announcedProviders.some((item) => item.provider === detail.provider)) {
+      announcedProviders.push(detail);
+    }
+  }
+
+  window.addEventListener("eip6963:announceProvider", rememberProvider);
+
+  function populateProviderSelectors() {
+    document.querySelectorAll("[data-wallet-provider]").forEach((selector) => {
+      const selectedProvider = state.provider;
+      selector.replaceChildren(...state.providers.map((item, index) => {
+        const option = document.createElement("option");
+        option.value = String(index);
+        option.textContent = providerName(item.provider, item.info);
+        option.selected = item.provider === selectedProvider;
+        return option;
+      }));
+      selector.disabled = state.providers.length === 0;
+      if (state.providers.length === 0) {
+        const option = document.createElement("option");
+        option.textContent = "No browser wallet detected";
+        selector.append(option);
+      }
+    });
+  }
+
+  async function discoverProviders() {
+    window.dispatchEvent(new Event("eip6963:requestProvider"));
+    await sleep(250);
+    const candidates = [...announcedProviders];
+    const injected = window.ethereum && Array.isArray(window.ethereum.providers)
+      ? window.ethereum.providers
+      : (window.ethereum ? [window.ethereum] : []);
+    for (const provider of injected) {
+      if (isWalletProvider(provider) && !candidates.some((item) => item.provider === provider)) {
+        candidates.push({ provider, info: {} });
+      }
+    }
+    state.providers = candidates;
+    populateProviderSelectors();
+    return state.providers;
+  }
+
+  function selectProvider(context = document) {
+    const selector = (context.querySelector && context.querySelector("[data-wallet-provider]"))
+      || document.querySelector("[data-wallet-provider]");
+    const item = state.providers[Number.parseInt(selector && selector.value, 10)];
+    if (!item) throw new Error("Unlock a browser wallet, reload, and select it here.");
+    state.provider = item.provider;
+    const index = String(state.providers.findIndex((provider) => provider.provider === item.provider));
+    document.querySelectorAll("[data-wallet-provider]").forEach((candidate) => {
+      candidate.value = index;
+    });
+    return item.provider;
+  }
+
+  function walletRequest(method, params = []) {
+    const provider = state.provider || selectProvider();
+    return provider.request({ method, params });
+  }
 
   async function loadProtocol() {
     if (state.protocol) return state.protocol;
@@ -139,33 +219,28 @@
     return JSON.stringify(canonicalJsonValue(value));
   }
 
-  async function connectWallet() {
-    if (!window.ethereum) throw new Error("Install or open a wallet that provides EIP-1193.");
+  async function connectWallet(context = document) {
+    await discoverProviders();
+    selectProvider(context);
     const protocol = await loadProtocol();
-    const accounts = await window.ethereum.request({ method: "eth_requestAccounts" });
+    const accounts = await walletRequest("eth_requestAccounts");
     if (!accounts || !accounts[0]) throw new Error("No wallet account was returned.");
     state.account = accounts[0];
-    const current = await window.ethereum.request({ method: "eth_chainId" });
+    const current = await walletRequest("eth_chainId");
     if (String(current).toLowerCase() !== protocol.chain_id_hex.toLowerCase()) {
       try {
-        await window.ethereum.request({
-          method: "wallet_switchEthereumChain",
-          params: [{ chainId: protocol.chain_id_hex }],
-        });
+        await walletRequest("wallet_switchEthereumChain", [{ chainId: protocol.chain_id_hex }]);
       } catch (error) {
         if (error && error.code === 4902) {
-          await window.ethereum.request({
-            method: "wallet_addEthereumChain",
-            params: [
-              {
-                chainId: protocol.chain_id_hex,
-                chainName: "Base",
-                nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-                rpcUrls: ["https://mainnet.base.org"],
-                blockExplorerUrls: [protocol.explorer_url],
-              },
-            ],
-          });
+          await walletRequest("wallet_addEthereumChain", [
+            {
+              chainId: protocol.chain_id_hex,
+              chainName: "Base",
+              nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+              rpcUrls: ["https://mainnet.base.org"],
+              blockExplorerUrls: [protocol.explorer_url],
+            },
+          ]);
         } else {
           throw error;
         }
@@ -175,10 +250,7 @@
   }
 
   async function isContractAccount(account) {
-    const code = await window.ethereum.request({
-      method: "eth_getCode",
-      params: [account, "latest"],
-    });
+    const code = await walletRequest("eth_getCode", [account, "latest"]);
     return code && code !== "0x" && code !== "0x0";
   }
 
@@ -193,34 +265,25 @@
   }
 
   async function signTypedData(account, typedData) {
-    const signature = await window.ethereum.request({
-      method: "eth_signTypedData_v4",
-      params: [account, JSON.stringify(typedData)],
-    });
+    const signature = await walletRequest("eth_signTypedData_v4", [account, JSON.stringify(typedData)]);
     return signatureParts(signature);
   }
 
   async function sendTransaction(transaction, from) {
-    return window.ethereum.request({
-      method: "eth_sendTransaction",
-      params: [
-        {
-          from,
-          to: transaction.to,
-          data: transaction.data,
-          value: "0x0",
-        },
-      ],
-    });
+    return walletRequest("eth_sendTransaction", [
+      {
+        from,
+        to: transaction.to,
+        data: transaction.data,
+        value: "0x0",
+      },
+    ]);
   }
 
   async function waitReceipt(txHash, timeoutMs = 120_000) {
     const started = Date.now();
     while (Date.now() - started < timeoutMs) {
-      const receipt = await window.ethereum.request({
-        method: "eth_getTransactionReceipt",
-        params: [txHash],
-      });
+      const receipt = await walletRequest("eth_getTransactionReceipt", [txHash]);
       if (receipt) {
         if (receipt.status !== "0x1") throw new Error(`Transaction reverted: ${txHash}`);
         return receipt;
@@ -232,17 +295,14 @@
 
   async function sendWalletCalls(calls, account, protocol) {
     try {
-      const bundleId = await window.ethereum.request({
-        method: "wallet_sendCalls",
-        params: [
-          {
-            version: "2.0.0",
-            chainId: protocol.chain_id_hex,
-            from: account,
-            calls: calls.map((call) => ({ to: call.to, data: call.data, value: "0x0" })),
-          },
-        ],
-      });
+      const bundleId = await walletRequest("wallet_sendCalls", [
+        {
+          version: "2.0.0",
+          chainId: protocol.chain_id_hex,
+          from: account,
+          calls: calls.map((call) => ({ to: call.to, data: call.data, value: "0x0" })),
+        },
+      ]);
       return { kind: "bundle", id: bundleId };
     } catch (_error) {
       const hashes = [];
@@ -417,7 +477,7 @@
     const result = byId("autonomous-post-output");
     try {
       const protocol = requireActiveProtocol(await loadProtocol());
-      const account = await connectWallet();
+      const account = await connectWallet(form);
       const api = apiBase(form);
       output(result, ["Publishing content-addressed terms...", `Creator: ${account}`]);
       const committed = contractTerms(form, account, protocol);
@@ -499,7 +559,7 @@
     const result = byId("autonomous-fund-output");
     try {
       const protocol = requireActiveProtocol(await loadProtocol());
-      const account = await connectWallet();
+      const account = await connectWallet(form);
       const api = apiBase(form);
       const contribution = {
         bounty_contract: requiredAddress(form.elements.bountyContract.value, "Bounty contract"),
@@ -545,7 +605,7 @@
     const result = byId("autonomous-submit-output");
     try {
       const protocol = requireActiveProtocol(await loadProtocol());
-      const account = await connectWallet();
+      const account = await connectWallet(form);
       const api = apiBase(form);
       const bountyContract = requiredAddress(form.elements.bountyContract.value, "Bounty contract");
       const artifact = form.elements.artifact.value.trim();
@@ -628,7 +688,7 @@
       const result = byId("claim-feed-output");
       try {
         const protocol = requireActiveProtocol(await loadProtocol());
-        const account = await connectWallet();
+        const account = await connectWallet(document);
         const authorizationNonce = randomBytes32();
         const authorizationValidBefore = Math.floor(Date.now() / 1000) + 3_600;
         const plan = await requestJson(`${api}/v1/base/autonomous-bounties/claim-plan`, {
@@ -744,13 +804,17 @@
       button.addEventListener("click", async () => {
         const target = byId(button.dataset.output);
         try {
-          const account = await connectWallet();
+          const account = await connectWallet(button.closest("form") || document);
           output(target, `Connected: ${account}`, "success");
         } catch (error) {
           output(target, error.message || String(error), "error");
         }
       });
     });
+    document.querySelectorAll("[data-wallet-provider]").forEach((selector) => {
+      selector.addEventListener("change", () => selectProvider(selector.closest("form") || document));
+    });
+    discoverProviders().catch(() => populateProviderSelectors());
     prefillFunding();
     loadClaimableFeed();
   }

--- a/site/earn.html
+++ b/site/earn.html
@@ -36,6 +36,12 @@
             <p class="eyebrow">Available now</p>
             <h2>Claimable bounties</h2>
             <p class="fine">Each claim posts the displayed USDC solver bond. Submit before the claim deadline; otherwise the bond becomes the next solver's completion bonus.</p>
+            <label class="wallet-picker">
+              Wallet
+              <select data-wallet-provider aria-label="Wallet provider">
+                <option>Detecting browser wallets</option>
+              </select>
+            </label>
             <button class="button secondary" type="button" data-connect-wallet data-output="claim-feed-output">Connect wallet</button>
             <output id="claim-feed-output" class="output compact-output" aria-live="polite">Claims are signed by the payout wallet.</output>
           </div>
@@ -64,6 +70,12 @@
               <textarea name="evidence" rows="6" required>{"repository":"https://github.com/owner/repo","commit_sha":"...","check_run_url":"...","artifact_digest":"..."}</textarea>
             </label>
             <div class="actions">
+              <label class="wallet-picker">
+                Wallet
+                <select data-wallet-provider aria-label="Wallet provider">
+                  <option>Detecting browser wallets</option>
+                </select>
+              </label>
               <button class="button secondary" type="button" data-connect-wallet data-output="autonomous-submit-output">Connect wallet</button>
               <button class="button primary" type="submit" data-protocol-action disabled>Submit evidence</button>
             </div>

--- a/site/funding.html
+++ b/site/funding.html
@@ -48,6 +48,12 @@
             </label>
           </details>
           <div class="actions">
+            <label class="wallet-picker">
+              Wallet
+              <select data-wallet-provider aria-label="Wallet provider">
+                <option>Detecting browser wallets</option>
+              </select>
+            </label>
             <button class="button secondary" type="button" data-connect-wallet data-output="autonomous-fund-output">Connect wallet</button>
             <button class="button primary" type="submit" data-protocol-action disabled>Sign and fund bounty</button>
           </div>

--- a/site/post.html
+++ b/site/post.html
@@ -168,6 +168,12 @@
           </details>
 
           <div class="actions sticky-actions">
+            <label class="wallet-picker">
+              Wallet
+              <select data-wallet-provider aria-label="Wallet provider">
+                <option>Detecting browser wallets</option>
+              </select>
+            </label>
             <button class="button secondary" type="button" data-connect-wallet data-output="autonomous-post-output">Connect wallet</button>
             <button class="button primary" type="submit" data-protocol-action disabled>Sign and post bounty</button>
           </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -462,6 +462,12 @@ textarea {
   backdrop-filter: blur(12px);
 }
 
+.wallet-picker {
+  flex: 1 1 220px;
+  min-width: 200px;
+  max-width: 320px;
+}
+
 .readiness-panel {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Summary
- replace ambiguous `window.ethereum` use with explicit EIP-6963/EIP-1193 wallet-provider discovery and selection
- keep every read, signature, and transaction on the selected provider without wallet import or key custody
- pin the canonical autonomous-v1 factory directly on the Render indexer service and gate that coordinate in the Blueprint check

## Why
The first hosted rollout exposed two operational failures: pages could route to the wrong injected wallet when several extensions were installed, and Render did not propagate the factory coordinate from the shared environment group to the worker. This keeps onboarding provider-neutral and makes the production indexer configuration explicit.

## Validation
- `scripts/preflight.ps1 -Mode core`
- `scripts/check.ps1`
- `python scripts/check-render-blueprint.py`
- `node scripts/test-autonomous-wallet-flow.js`
- `python scripts/check-site.py`

Public maintainer notice: https://github.com/NSPG13/agent-bounties/issues/72#issuecomment-4947405971