### PR TITLE
feat: add permissionless deterministic work verifier

### DIFF
--- a/contracts/base-escrow/src/LeadingZeroWorkVerifier.sol
+++ b/contracts/base-escrow/src/LeadingZeroWorkVerifier.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./IAgentBounty.sol";
+
+/// @notice Permissionless deterministic work verifier for end-to-end bounty loops.
+/// The work hash is bound to the exact bounty round, solver, submitted hashes,
+/// and immutable policy. Anyone can mine and relay a proof, but it cannot be
+/// reused for another solver, round, or submission.
+contract LeadingZeroWorkVerifier is IAgentBountyVerifier {
+    uint8 public immutable difficultyBits;
+
+    constructor(uint8 difficultyBits_) {
+        require(difficultyBits_ > 0 && difficultyBits_ <= 32, "difficulty out of bounds");
+        difficultyBits = difficultyBits_;
+    }
+
+    function workHash(
+        bytes32 bountyId,
+        uint64 round,
+        address solver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        uint256 nonce
+    ) public pure returns (bytes32) {
+        return keccak256(abi.encode(bountyId, round, solver, submissionHash, evidenceHash, policyHash, nonce));
+    }
+
+    function verify(
+        bytes32 bountyId,
+        uint64 round,
+        address solver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        bytes calldata proof
+    ) external view returns (bool passed, bytes32 responseHash) {
+        if (proof.length != 32) {
+            return (false, keccak256(abi.encode("malformed-leading-zero-work-proof", keccak256(proof))));
+        }
+
+        uint256 nonce = abi.decode(proof, (uint256));
+        responseHash = workHash(bountyId, round, solver, submissionHash, evidenceHash, policyHash, nonce);
+        passed = uint256(responseHash) >> (256 - difficultyBits) == 0;
+    }
+}

--- a/contracts/base-escrow/test/AgentBountyProtocol.t.sol
+++ b/contracts/base-escrow/test/AgentBountyProtocol.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.26;
 
 import "../src/AgentBountyFactory.sol";
+import "../src/LeadingZeroWorkVerifier.sol";
 
 interface Vm {
     function warp(uint256) external;
@@ -157,6 +158,51 @@ contract AgentBountyProtocolTest {
         require(bounty.contributions(address(this)) == 1_000, "creator contribution missing");
         require(factory.isCanonicalBounty(address(bounty)), "not canonical");
         require(_codeSize(address(bounty)) < 100, "bounty is not a minimal proxy");
+    }
+
+    function testLeadingZeroWorkProofCompletesFullPaidLoop() public {
+        LeadingZeroWorkVerifier module = new LeadingZeroWorkVerifier(8);
+        AgentBounty bounty = _createDeterministic(module, 1_000);
+        _prepareSolverBond(bounty, 100);
+
+        solver.claim(bounty);
+        solver.submit(bounty, SUBMISSION_HASH, EVIDENCE_HASH);
+
+        uint256 nonce;
+        bytes32 responseHash;
+        do {
+            responseHash = module.workHash(
+                bounty.bountyId(),
+                bounty.round(),
+                address(solver),
+                SUBMISSION_HASH,
+                EVIDENCE_HASH,
+                POLICY_HASH,
+                nonce
+            );
+            nonce += 1;
+        } while (uint256(responseHash) >> 248 != 0);
+
+        bounty.verifyAndSettle(abi.encode(nonce - 1));
+
+        require(bounty.bountyStatus() == AgentBounty.BountyStatus.Settled, "not settled");
+        require(token.balanceOf(address(solver)) == 1_000, "solver payout mismatch");
+        require(token.balanceOf(address(verifierRecipient)) == 100, "verifier payout mismatch");
+        require(token.balanceOf(address(bounty)) == 0, "bounty retained funds");
+    }
+
+    function testLeadingZeroWorkVerifierRejectsMalformedProof() public {
+        LeadingZeroWorkVerifier module = new LeadingZeroWorkVerifier(8);
+        (bool passed,) = module.verify(
+            bytes32(uint256(1)),
+            1,
+            address(solver),
+            SUBMISSION_HASH,
+            EVIDENCE_HASH,
+            POLICY_HASH,
+            hex"01"
+        );
+        require(!passed, "malformed proof passed");
     }
 
     function testCreatorCannotClaimOwnBounty() public {
@@ -606,7 +652,7 @@ contract AgentBountyProtocolTest {
         require(!factory.isCanonicalBounty(address(externalBounty)), "external marked canonical");
     }
 
-    function _createDeterministic(ProofHashVerifier module, uint256 initialFunding)
+    function _createDeterministic(IAgentBountyVerifier module, uint256 initialFunding)
         private
         returns (AgentBounty bounty)
     {
@@ -620,7 +666,7 @@ contract AgentBountyProtocolTest {
         solver.approve(token, address(bounty), amount);
     }
 
-    function _deterministicParams(ProofHashVerifier module)
+    function _deterministicParams(IAgentBountyVerifier module)
         private
         view
         returns (AgentBountyFactory.CreateBountyParams memory)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -362,6 +362,30 @@ enum Command {
         #[arg(long)]
         output: Option<String>,
     },
+    AutonomousMineWorkProof {
+        #[arg(long)]
+        bounty_id: String,
+        #[arg(long)]
+        round: u64,
+        #[arg(long)]
+        solver: String,
+        #[arg(long)]
+        submission_hash: String,
+        #[arg(long)]
+        evidence_hash: String,
+        #[arg(long)]
+        policy_hash: String,
+        #[arg(long, default_value_t = 16)]
+        difficulty_bits: u8,
+        #[arg(long, default_value_t = 0)]
+        start_nonce: u64,
+        #[arg(long, default_value_t = 10_000_000)]
+        max_attempts: u64,
+        #[arg(long)]
+        bounty_contract: Option<String>,
+        #[arg(long, default_value = "base-mainnet")]
+        network: String,
+    },
     ProductionSmoke {
         #[arg(long, env = "PRODUCTION_API_BASE_URL")]
         api_base_url: String,
@@ -629,6 +653,31 @@ async fn async_main() -> Result<()> {
             )
             .await
         }
+        Command::AutonomousMineWorkProof {
+            bounty_id,
+            round,
+            solver,
+            submission_hash,
+            evidence_hash,
+            policy_hash,
+            difficulty_bits,
+            start_nonce,
+            max_attempts,
+            bounty_contract,
+            network,
+        } => autonomous_mine_work_proof(
+            bounty_id,
+            round,
+            solver,
+            submission_hash,
+            evidence_hash,
+            policy_hash,
+            difficulty_bits,
+            start_nonce,
+            max_attempts,
+            bounty_contract,
+            network,
+        ),
         Command::ProductionSmoke {
             api_base_url,
             mcp_base_url,
@@ -1387,6 +1436,152 @@ fn create_address(deployer: &str, nonce: u64) -> Result<String> {
 
 fn keccak_hex(bytes: &[u8]) -> String {
     format!("0x{}", hex::encode(Keccak256::digest(bytes)))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn autonomous_mine_work_proof(
+    bounty_id: String,
+    round: u64,
+    solver: String,
+    submission_hash: String,
+    evidence_hash: String,
+    policy_hash: String,
+    difficulty_bits: u8,
+    start_nonce: u64,
+    max_attempts: u64,
+    bounty_contract: Option<String>,
+    network: String,
+) -> Result<()> {
+    if !(1..=32).contains(&difficulty_bits) {
+        bail!("difficulty bits must be between 1 and 32");
+    }
+    if max_attempts == 0 {
+        bail!("max attempts must be positive");
+    }
+    let bounty_id_word = parse_cli_bytes32(&bounty_id, "bounty id")?;
+    let solver_word = parse_cli_address_word(&solver)?;
+    let submission_word = parse_cli_bytes32(&submission_hash, "submission hash")?;
+    let evidence_word = parse_cli_bytes32(&evidence_hash, "evidence hash")?;
+    let policy_word = parse_cli_bytes32(&policy_hash, "policy hash")?;
+    let normalized_solver = normalize_cli_address(&solver)?;
+    let normalized_contract = bounty_contract
+        .as_deref()
+        .map(normalize_cli_address)
+        .transpose()?;
+
+    let mut nonce = start_nonce;
+    let mut attempts = 0_u64;
+    let (proof, response_hash) = loop {
+        if attempts >= max_attempts {
+            bail!(
+                "no proof found after {max_attempts} attempts; continue from --start-nonce {}",
+                nonce
+            );
+        }
+        let encoded = leading_zero_work_preimage(
+            bounty_id_word,
+            round,
+            solver_word,
+            submission_word,
+            evidence_word,
+            policy_word,
+            nonce,
+        );
+        let digest = Keccak256::digest(encoded);
+        attempts += 1;
+        if has_leading_zero_bits(&digest, difficulty_bits) {
+            let mut proof = [0_u8; 32];
+            proof[24..].copy_from_slice(&nonce.to_be_bytes());
+            break (proof, digest.to_vec());
+        }
+        nonce = nonce
+            .checked_add(1)
+            .context("nonce overflow while mining work proof")?;
+    };
+
+    let proof_hex = format!("0x{}", hex::encode(proof));
+    let response_hash_hex = format!("0x{}", hex::encode(response_hash));
+    let module_settlement_request = normalized_contract.map(|contract| {
+        serde_json::json!({
+            "network": network.clone(),
+            "bounty_contract": contract,
+            "proof": proof_hex.clone(),
+        })
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema_version": "agent-bounties/leading-zero-work-proof-v1",
+            "bounty_id": format!("0x{}", hex::encode(bounty_id_word)),
+            "round": round,
+            "solver": normalized_solver,
+            "submission_hash": format!("0x{}", hex::encode(submission_word)),
+            "evidence_hash": format!("0x{}", hex::encode(evidence_word)),
+            "policy_hash": format!("0x{}", hex::encode(policy_word)),
+            "difficulty_bits": difficulty_bits,
+            "nonce": nonce.to_string(),
+            "proof": proof_hex,
+            "response_hash": response_hash_hex,
+            "attempts": attempts,
+            "module_settlement_request": module_settlement_request,
+            "evidence_boundary": "This proves only that the deterministic work target is met. Payment requires a confirmed canonical BountySettled event.",
+        }))?
+    );
+    Ok(())
+}
+
+fn parse_cli_bytes32(value: &str, label: &str) -> Result<[u8; 32]> {
+    let raw = value.strip_prefix("0x").unwrap_or(value);
+    if raw.len() != 64 || !raw.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("{label} must be exactly 32 hex bytes");
+    }
+    let decoded = hex::decode(raw)?;
+    let mut word = [0_u8; 32];
+    word.copy_from_slice(&decoded);
+    Ok(word)
+}
+
+fn parse_cli_address_word(value: &str) -> Result<[u8; 32]> {
+    let normalized = normalize_cli_address(value)?;
+    let decoded = hex::decode(&normalized[2..])?;
+    let mut word = [0_u8; 32];
+    word[12..].copy_from_slice(&decoded);
+    Ok(word)
+}
+
+fn leading_zero_work_preimage(
+    bounty_id: [u8; 32],
+    round: u64,
+    solver: [u8; 32],
+    submission_hash: [u8; 32],
+    evidence_hash: [u8; 32],
+    policy_hash: [u8; 32],
+    nonce: u64,
+) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(32 * 7);
+    encoded.extend_from_slice(&bounty_id);
+    let mut round_word = [0_u8; 32];
+    round_word[24..].copy_from_slice(&round.to_be_bytes());
+    encoded.extend_from_slice(&round_word);
+    encoded.extend_from_slice(&solver);
+    encoded.extend_from_slice(&submission_hash);
+    encoded.extend_from_slice(&evidence_hash);
+    encoded.extend_from_slice(&policy_hash);
+    let mut nonce_word = [0_u8; 32];
+    nonce_word[24..].copy_from_slice(&nonce.to_be_bytes());
+    encoded.extend_from_slice(&nonce_word);
+    encoded
+}
+
+fn has_leading_zero_bits(hash: &[u8], difficulty_bits: u8) -> bool {
+    let full_bytes = usize::from(difficulty_bits / 8);
+    let remaining_bits = difficulty_bits % 8;
+    hash.get(..full_bytes)
+        .is_some_and(|prefix| prefix.iter().all(|byte| *byte == 0))
+        && (remaining_bits == 0
+            || hash
+                .get(full_bytes)
+                .is_some_and(|byte| byte >> (8 - remaining_bits) == 0))
 }
 
 async fn demo() -> Result<()> {
@@ -5168,6 +5363,54 @@ mod tests {
             create_address(&factory, 1).expect("implementation address should derive"),
             "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9"
         );
+    }
+
+    #[test]
+    fn leading_zero_work_hash_matches_solidity_abi_vector() {
+        let bounty_id = parse_cli_bytes32(
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "bounty id",
+        )
+        .unwrap();
+        let solver = parse_cli_address_word("0x1111111111111111111111111111111111111111").unwrap();
+        let submission_hash = parse_cli_bytes32(
+            "0x2222222222222222222222222222222222222222222222222222222222222222",
+            "submission hash",
+        )
+        .unwrap();
+        let evidence_hash = parse_cli_bytes32(
+            "0x3333333333333333333333333333333333333333333333333333333333333333",
+            "evidence hash",
+        )
+        .unwrap();
+        let policy_hash = parse_cli_bytes32(
+            "0x4444444444444444444444444444444444444444444444444444444444444444",
+            "policy hash",
+        )
+        .unwrap();
+
+        let encoded = leading_zero_work_preimage(
+            bounty_id,
+            7,
+            solver,
+            submission_hash,
+            evidence_hash,
+            policy_hash,
+            42,
+        );
+
+        assert_eq!(
+            keccak_hex(&encoded),
+            "0x13b1a8b50c41287e8cbb49b66f5327c7cef3fefb33e6428c7588368eb1ef8fbe"
+        );
+    }
+
+    #[test]
+    fn leading_zero_bit_check_handles_partial_bytes() {
+        assert!(has_leading_zero_bits(&[0x00, 0x0f, 0xff], 12));
+        assert!(!has_leading_zero_bits(&[0x00, 0x10, 0x00], 12));
+        assert!(has_leading_zero_bits(&[0x00, 0x00, 0xff], 16));
+        assert!(!has_leading_zero_bits(&[0x00, 0x01, 0x00], 16));
     }
 
     #[test]

--- a/scripts/validate_real_funding_rehearsal.py
+++ b/scripts/validate_real_funding_rehearsal.py
@@ -5,6 +5,7 @@ from typing import Any
 
 
 EXPECTED_BASE_SEPOLIA_USDC = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+EXPECTED_BASE_MAINNET_USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 
 
 def expect(condition: bool, message: str) -> None:
@@ -14,6 +15,15 @@ def expect(condition: bool, message: str) -> None:
 
 def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def is_hex(value: Any, byte_length: int) -> bool:
+    if not isinstance(value, str) or not value.startswith("0x"):
+        return False
+    raw = value[2:]
+    return len(raw) == byte_length * 2 and all(
+        character in "0123456789abcdefABCDEF" for character in raw
+    )
 
 
 def check_discovery(discovery: dict[str, Any]) -> None:
@@ -127,11 +137,45 @@ def check_deployment(deployment: dict[str, Any]) -> None:
         deployment["protocol_version"] == "agent-bounties/autonomous-v1",
         "deployment manifest must identify autonomous-v1",
     )
-    expect(
-        deployment["status"] == "pending_external_review_and_deployment",
-        "rehearsal must not claim an undeployed protocol is active",
-    )
-    expect(deployment["factory"]["contract"] is None, "pending factory must be null")
+    status = deployment["status"]
+    factory = deployment["factory"]
+    if status == "pending_external_review_and_deployment":
+        expect(factory["contract"] is None, "pending factory must be null")
+        expect(factory["implementation"] is None, "pending implementation must be null")
+    elif status == "active":
+        expect(deployment["network"] == "base-mainnet", "active deployment must be Base mainnet")
+        expect(deployment["chain_id"] == 8453, "active deployment chain id is wrong")
+        expect(
+            deployment["native_usdc"].lower() == EXPECTED_BASE_MAINNET_USDC.lower(),
+            "active deployment must use native Base USDC",
+        )
+        expect(is_hex(factory["contract"], 20), "active factory address is invalid")
+        expect(
+            is_hex(factory["implementation"], 20),
+            "active implementation address is invalid",
+        )
+        expect(
+            factory["contract"].lower() != factory["implementation"].lower(),
+            "factory and implementation must be distinct",
+        )
+        expect(
+            is_hex(factory["deployment_transaction"], 32),
+            "active deployment transaction is invalid",
+        )
+        expect(
+            isinstance(factory["deployment_block"], int) and factory["deployment_block"] > 0,
+            "active deployment block is invalid",
+        )
+        expect(
+            is_hex(factory["runtime_code_hash"], 32),
+            "active factory runtime hash is invalid",
+        )
+        expect(
+            is_hex(factory["implementation_runtime_code_hash"], 32),
+            "active implementation runtime hash is invalid",
+        )
+    else:
+        raise AssertionError(f"unsupported deployment status: {status}")
     expect(
         deployment["policy"]["operator_settlement_signer"] is False,
         "deployment policy must not have an operator settlement signer",
@@ -153,7 +197,8 @@ def main() -> None:
     check_deployment(deployment)
     print(
         "validated autonomous funding rehearsal: v2 discovery, canonical Base USDC "
-        "configuration, immutable verifier modes, and BountySettled evidence boundaries"
+        "configuration, deployment-state evidence, immutable verifier modes, and "
+        "BountySettled evidence boundaries"
     )
 
 


### PR DESCRIPTION
## Summary
- add an immutable `LeadingZeroWorkVerifier` bound to bounty id, round, solver, submission hash, evidence hash, policy hash, and nonce
- add a CLI miner that reproduces Solidity ABI encoding and emits a ready module-settlement request
- add a full economic harness from funded creation through bonded claim, submission, deterministic verification, split payout, and terminal settlement

## Why
The first four mainnet bounties prove funding and claiming but depend on committed verifier wallets whose custody is not yet deployed. This permissionless module provides a separate fifth canary that can prove the complete loop without an operator, server signer, or advisory AI decision.

## Validation
- full `scripts/check.ps1`: passed
- `forge test --fuzz-runs 1000`: 25 passed
- `cargo test -p cli`: passed
- `cargo clippy -p cli -- -D warnings`: passed
- Solidity ABI vector: `0x13b1a8...f8fbe`
- CLI 12-bit mining smoke: proof found in 6,864 attempts

## Safety boundary
A work proof cannot be replayed across another bounty, round, solver, submission, evidence package, or policy. Invalid proofs use the existing reject/reopen economics. This PR moves no mainnet funds and proves no payout.

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/72#issuecomment-4947673808