### PR TITLE
test: prove autonomous payout on Base mainnet fork

### DIFF
--- a/contracts/base-escrow/test/AgentBountyMainnetFork.t.sol
+++ b/contracts/base-escrow/test/AgentBountyMainnetFork.t.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../src/AgentBountyFactory.sol";
+import "../src/LeadingZeroWorkVerifier.sol";
+
+interface VmFork {
+    function createSelectFork(string calldata urlOrAlias) external returns (uint256 forkId);
+    function envOr(string calldata name, bool defaultValue) external returns (bool value);
+    function envString(string calldata name) external returns (string memory value);
+    function prank(address sender) external;
+    function skip(bool skipTest) external;
+}
+
+interface MainnetUsdc {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+}
+
+/// @notice Opt-in integration test against the actual Base mainnet contracts on an Anvil fork.
+/// Set RUN_MAINNET_FORK=true and BASE_MAINNET_RPC_URL to execute it. No transaction is broadcast.
+contract AgentBountyMainnetForkTest {
+    VmFork private constant vm = VmFork(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    address private constant FACTORY = 0x082C52131aaF0C56e76b075f895EAB6fcaB6d2F9;
+    address private constant IMPLEMENTATION = 0x2fa36D2b2327642db3a6Cc8CDD91544ad7484EB9;
+    address private constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    address private constant MODULE = 0xcc6059cEedA5bc4ba8a97ecFbFFa7488C8FD579E;
+    address private constant FUNDING_SOURCE = 0x786be3f994365fCD417a1b502A83300ea87d9b34;
+    address private constant BOND_SOURCE = 0x680030aBf3FffFBc8d0A550b6355A8713C54d3C8;
+    address private constant CREATOR = 0x1000000000000000000000000000000000000001;
+    address private constant SOLVER = 0x2000000000000000000000000000000000000002;
+    address private constant RELAYER = 0x3000000000000000000000000000000000000003;
+
+    bytes32 private constant FACTORY_RUNTIME_HASH = 0x06f810de7b46f854ecc29e9c0c28156edab4b0d3e0bbe2bf5be8876687bebfc6;
+    bytes32 private constant IMPLEMENTATION_RUNTIME_HASH =
+        0xc36fcba5176b2cd8b57a9fd0cbf931177dc8b36cf8367c1568ccebe5f03be3f6;
+    bytes32 private constant MODULE_RUNTIME_HASH = 0xbaa3a8305c4b65d0dc20131d0ef207fdaf4763f345393a831370cd04077df9b3;
+
+    bytes32 private constant TERMS_HASH = 0xd970470bb6adaaa98139740db3362dfd40b00110561dda9c1c7a9e1659ab915e;
+    bytes32 private constant POLICY_HASH = 0xb9aaf9ae7bc757288fc72119f1230a82a4c592519cddeb69bea4ab7790e40dc7;
+    bytes32 private constant CRITERIA_HASH = 0x8788ae8d44013e65172f494c054361906cc4974eda69f0e184211c7032d8bc78;
+    bytes32 private constant BENCHMARK_HASH = 0xf561db43183cd283b1ed059eeb64f6524ff92de33001616882d31071e2086d2c;
+    bytes32 private constant EVIDENCE_SCHEMA_HASH = 0x21521c3eac6143dc56fd2c8d1aaf9831057d6c40c18b542fea77102a6c6d2244;
+    bytes32 private constant SUBMISSION_HASH = keccak256("mainnet-fork-artifact");
+    bytes32 private constant EVIDENCE_HASH = keccak256("mainnet-fork-evidence");
+
+    function testCanonicalMainnetPermissionlessPaidLoop() public {
+        if (!vm.envOr("RUN_MAINNET_FORK", false)) {
+            vm.skip(true);
+            return;
+        }
+        vm.createSelectFork(vm.envString("BASE_MAINNET_RPC_URL"));
+
+        require(block.chainid == 8453, "wrong chain");
+        require(keccak256(FACTORY.code) == FACTORY_RUNTIME_HASH, "factory code drift");
+        require(keccak256(IMPLEMENTATION.code) == IMPLEMENTATION_RUNTIME_HASH, "implementation code drift");
+        require(keccak256(MODULE.code) == MODULE_RUNTIME_HASH, "module code drift");
+
+        AgentBountyFactory factory = AgentBountyFactory(FACTORY);
+        LeadingZeroWorkVerifier module = LeadingZeroWorkVerifier(MODULE);
+        MainnetUsdc usdc = MainnetUsdc(USDC);
+        require(factory.settlementToken() == USDC, "factory token drift");
+        require(factory.implementation() == IMPLEMENTATION, "factory implementation drift");
+        require(module.difficultyBits() == 16, "module difficulty drift");
+
+        uint256 creatorBefore = usdc.balanceOf(CREATOR);
+        uint256 solverBefore = usdc.balanceOf(SOLVER);
+        uint256 recipientBefore = usdc.balanceOf(CREATOR);
+        vm.prank(FUNDING_SOURCE);
+        require(usdc.transfer(CREATOR, 1_000_000), "fork funding source transfer failed");
+        vm.prank(BOND_SOURCE);
+        require(usdc.transfer(SOLVER, 100_000), "fork bond source transfer failed");
+
+        AgentBountyFactory.CreateBountyParams memory params = AgentBountyFactory.CreateBountyParams({
+            solverReward: 900_000,
+            verifierReward: 100_000,
+            termsHash: TERMS_HASH,
+            policyHash: POLICY_HASH,
+            acceptanceCriteriaHash: CRITERIA_HASH,
+            benchmarkHash: BENCHMARK_HASH,
+            evidenceSchemaHash: EVIDENCE_SCHEMA_HASH,
+            fundingDeadline: uint64(block.timestamp + 30 days),
+            claimWindowSeconds: 1 days,
+            verificationWindowSeconds: 2 hours,
+            verificationMode: AgentBounty.VerificationMode.DeterministicModule,
+            verifierModule: MODULE,
+            verifierRewardRecipient: CREATOR,
+            threshold: 1
+        });
+        bytes32 creationNonce = keccak256("agent-bounties/mainnet-fork/module-loop/v1");
+        vm.prank(CREATOR);
+        require(usdc.approve(FACTORY, 1_000_000), "creator approval failed");
+        vm.prank(CREATOR);
+        (address bountyAddress, bytes32 bountyId) =
+            factory.createBounty(params, new address[](0), 1_000_000, creationNonce);
+        AgentBounty bounty = AgentBounty(bountyAddress);
+
+        require(factory.isCanonicalBounty(bountyAddress), "bounty not canonical");
+        require(bounty.bountyId() == bountyId, "bounty id mismatch");
+        require(bounty.bountyStatus() == AgentBounty.BountyStatus.Claimable, "not claimable");
+        require(usdc.balanceOf(bountyAddress) == 1_000_000, "initial funding missing");
+
+        vm.prank(SOLVER);
+        require(usdc.approve(bountyAddress, 100_000), "solver bond approval failed");
+        vm.prank(SOLVER);
+        bounty.claim();
+        vm.prank(SOLVER);
+        bounty.submit(SUBMISSION_HASH, EVIDENCE_HASH);
+
+        uint256 nonce;
+        bytes32 responseHash;
+        do {
+            responseHash = keccak256(
+                abi.encode(bountyId, bounty.round(), SOLVER, SUBMISSION_HASH, EVIDENCE_HASH, POLICY_HASH, nonce)
+            );
+            nonce += 1;
+        } while (uint256(responseHash) >> 240 != 0);
+
+        vm.prank(RELAYER);
+        bounty.verifyAndSettle(abi.encode(nonce - 1));
+
+        require(bounty.bountyStatus() == AgentBounty.BountyStatus.Settled, "not settled");
+        require(usdc.balanceOf(bountyAddress) == 0, "settled balance remains");
+        require(usdc.balanceOf(SOLVER) == solverBefore + 1_000_000, "solver payout mismatch");
+        require(usdc.balanceOf(CREATOR) == recipientBefore + 100_000, "verifier reward mismatch");
+        require(creatorBefore == recipientBefore, "creator baseline drift");
+    }
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -131,6 +131,26 @@ recorded in
 [`docs/evidence/autonomous-v1-mainnet-canaries-2026-07-11.json`](evidence/autonomous-v1-mainnet-canaries-2026-07-11.json).
 Neither record proves completion or payout; only `BountySettled` does.
 
+The permissionless deterministic verifier has a separate full-loop fork test in
+[`contracts/base-escrow/test/AgentBountyMainnetFork.t.sol`](../contracts/base-escrow/test/AgentBountyMainnetFork.t.sol).
+It forks current Base mainnet state, checks the exact deployed runtime hashes,
+creates and funds a canonical bounty with native USDC, claims from an independent
+address, submits hashes, mines the committed 16-bit proof, and settles from an
+unrelated relayer. It is opt-in so routine offline test runs do not depend on a
+public RPC:
+
+```powershell
+$env:RUN_MAINNET_FORK = "true"
+$env:BASE_MAINNET_RPC_URL = "https://your-base-mainnet-rpc"
+cd contracts/base-escrow
+forge test --match-contract AgentBountyMainnetForkTest `
+  --match-test testCanonicalMainnetPermissionlessPaidLoop -vv
+```
+
+The reproducible run record is
+[`docs/evidence/permissionless-module-mainnet-fork-2026-07-11.json`](evidence/permissionless-module-mainnet-fork-2026-07-11.json).
+The harness never broadcasts and fork settlement is not live payout evidence.
+
 After a confirmed, verified deployment:
 
 1. Update `deployments/base-mainnet.json` with factory, implementation,

--- a/docs/evidence/permissionless-module-mainnet-fork-2026-07-11.json
+++ b/docs/evidence/permissionless-module-mainnet-fork-2026-07-11.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "agent-bounties/mainnet-fork-evidence-v1",
+  "result": "pass",
+  "executed_at": "2026-07-11T17:46:03Z",
+  "network": "base-mainnet-fork",
+  "chain_id": 8453,
+  "fork": {
+    "block_number": 48501308,
+    "block_hash": "0xeb9547e6ad5869b5cf8b92c2bd8dc4f8593cab2a2255fe529e1048f3519508f0",
+    "state_root": "0x79798ccd0800ffbec0dc8bd0d6e083a8ce35e8012e0a7ba11e4b87f057ecb36a",
+    "timestamp": 1783791963
+  },
+  "test": {
+    "path": "contracts/base-escrow/test/AgentBountyMainnetFork.t.sol",
+    "contract": "AgentBountyMainnetForkTest",
+    "function": "testCanonicalMainnetPermissionlessPaidLoop",
+    "gas": 157251969,
+    "command": "RUN_MAINNET_FORK=true BASE_MAINNET_RPC_URL=<base-mainnet-rpc> forge test --match-contract AgentBountyMainnetForkTest --match-test testCanonicalMainnetPermissionlessPaidLoop -vv"
+  },
+  "contracts": {
+    "factory": {
+      "address": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
+      "runtime_code_hash": "0x06f810de7b46f854ecc29e9c0c28156edab4b0d3e0bbe2bf5be8876687bebfc6"
+    },
+    "implementation": {
+      "address": "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
+      "runtime_code_hash": "0xc36fcba5176b2cd8b57a9fd0cbf931177dc8b36cf8367c1568ccebe5f03be3f6"
+    },
+    "native_usdc": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "verifier_module": {
+      "address": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
+      "runtime_code_hash": "0xbaa3a8305c4b65d0dc20131d0ef207fdaf4763f345393a831370cd04077df9b3",
+      "difficulty_bits": 16
+    }
+  },
+  "terms_commitments": {
+    "terms_hash": "0xd970470bb6adaaa98139740db3362dfd40b00110561dda9c1c7a9e1659ab915e",
+    "policy_hash": "0xb9aaf9ae7bc757288fc72119f1230a82a4c592519cddeb69bea4ab7790e40dc7",
+    "acceptance_criteria_hash": "0x8788ae8d44013e65172f494c054361906cc4974eda69f0e184211c7032d8bc78",
+    "benchmark_hash": "0xf561db43183cd283b1ed059eeb64f6524ff92de33001616882d31071e2086d2c",
+    "evidence_schema_hash": "0x21521c3eac6143dc56fd2c8d1aaf9831057d6c40c18b542fea77102a6c6d2244"
+  },
+  "economics_minor_usdc": {
+    "initial_funding": 1000000,
+    "solver_reward": 900000,
+    "verifier_reward": 100000,
+    "claim_bond": 100000,
+    "solver_final_receipt": 1000000
+  },
+  "flow": [
+    "assert exact mainnet runtime hashes and immutable factory/module configuration",
+    "source test USDC from two already-funded contracts on the isolated fork",
+    "create and fully fund one canonical deterministic-module bounty",
+    "post the solver bond and claim from an independent address",
+    "submit nonzero artifact and evidence hashes",
+    "mine a scope-bound 16-leading-zero-bit nonce",
+    "relay verifyAndSettle(bytes) from an unrelated address",
+    "assert Settled, zero bounty balance, full solver reward plus bond return, and verifier reward"
+  ],
+  "funding_fixture": {
+    "fork_only": true,
+    "initial_funding_source": "0x786be3f994365fcd417a1b502a83300ea87d9b34",
+    "claim_bond_source": "0x680030abf3ffffbc8d0a550b6355a8713c54d3c8"
+  },
+  "broadcast_transactions": 0,
+  "evidence_boundary": "This proves the full permissionless protocol loop against exact Base mainnet bytecode and state on an isolated fork. Fork transfers, transactions, and settlement are not live funding or payout evidence. Only confirmed canonical mainnet events can prove a live bounty was funded or paid."
+}


### PR DESCRIPTION
## Summary
- add an opt-in Base mainnet fork test for the canonical factory, implementation, native USDC, and permissionless verifier module
- exercise create, fully fund, claim, submit, deterministic verification, relayed settlement, and exact payout accounting without broadcasting
- publish a block-pinned evidence record and reproducible deployment documentation

## Evidence boundary
This test mutates only an isolated fork. It is not evidence of a live bounty payout; only confirmed canonical Base mainnet events prove live funding or settlement.

## Validation
- `scripts/check.ps1`
- `RUN_MAINNET_FORK=true BASE_MAINNET_RPC_URL=<rpc> forge test --match-contract AgentBountyMainnetForkTest --match-test testCanonicalMainnetPermissionlessPaidLoop -vv`
- fork block `48501308`, hash `0xeb9547e6ad5869b5cf8b92c2bd8dc4f8593cab2a2255fe529e1048f3519508f0`
