### PR TITLE
feat: add GitHub main-ruleset drift checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ruleset-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Ruleset drift checker offline fixtures
+        run: python scripts/test_ruleset_drift_check.py -v
+
   full-check:
     runs-on: ubuntu-latest
     steps:

--- a/docs/main-branch-ruleset.md
+++ b/docs/main-branch-ruleset.md
@@ -37,3 +37,21 @@ gh api repos/NSPG13/agent-bounties/rulesets
 If a ruleset with this name already exists, update its numeric endpoint with
 `PUT` instead of creating a duplicate. Any future required check must first run
 successfully on a pull request and must be bound to its expected GitHub App.
+
+## Drift Check
+
+`scripts/ruleset_drift_check.py` is a read-only checker that confirms the live
+ruleset still matches this canonical file. It authenticates through `gh`, reads
+(never writes) the live ruleset, ignores only server-owned fields (ids,
+timestamps, and source links), and semantically validates every protection
+listed above. A maintainer with `gh` authenticated runs:
+
+```bash
+python scripts/ruleset_drift_check.py
+```
+
+It exits non-zero and prints each difference when the live ruleset drifts from
+the canonical file or when either side stops encoding a documented protection.
+Offline fixture coverage runs on every pull request via the `ruleset-drift` CI
+job (`python scripts/test_ruleset_drift_check.py`), so no live credentials are
+needed in CI.

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -51,6 +51,7 @@ Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\github_proof_commen
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_sync_hosted_bounty_inventory.py -v }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_diagnose_hosted_api.py -v }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_github_audience_audit.py -v }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\test_ruleset_drift_check.py -v }
 Invoke-Checked { cargo run -p cli -- github-proof-comment-plan --bounty-id 00000000-0000-0000-0000-000000000001 --proof-url https://agentbounties.local/public/proofs/example --verifier-summary "GitHub CI passed" }
 Invoke-Checked { cargo run -p cli -- discovery --public-base-url https://agentbounties.local --mcp-base-url https://agentbounties.local/mcp }
 Invoke-Checked { cargo run -p cli -- discovery-report --input-fixture crates\cli\fixtures\discovery_answers.json --json-out target\tmp\discovery-report.json --markdown-out target\tmp\discovery-report.md }
@@ -69,7 +70,7 @@ Invoke-Checked { cargo run -p cli -- docs-contract-check }
 Invoke-Checked { cargo run -p cli -- demo }
 Invoke-Checked { cargo run -p cli -- pooled-funding-demo }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile crates\sdk-python\agent_bounties\client.py crates\sdk-python\agent_bounties\smoke.py crates\sdk-python\agent_bounties\__init__.py }
-Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\diagnose_hosted_api.py scripts\test_diagnose_hosted_api.py scripts\github_audience_audit.py scripts\test_github_audience_audit.py scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py scripts\sync_hosted_bounty_inventory.py scripts\test_sync_hosted_bounty_inventory.py scripts\validate_real_funding_rehearsal.py }
+Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\diagnose_hosted_api.py scripts\test_diagnose_hosted_api.py scripts\github_audience_audit.py scripts\test_github_audience_audit.py scripts\ruleset_drift_check.py scripts\test_ruleset_drift_check.py scripts\github_issue_plan_comment.py scripts\github_funding_comment.py scripts\github_claim_comment.py scripts\github_proof_comment.py scripts\sync_hosted_bounty_inventory.py scripts\test_sync_hosted_bounty_inventory.py scripts\validate_real_funding_rehearsal.py }
 Invoke-Checked { & $pythonCommand.Source @pythonArgs -m py_compile scripts\check-site.py scripts\check-migration-history.py scripts\check-render-blueprint.py scripts\stage_review_contract_root.py scripts\test_stage_review_contract_root.py scripts\base_deployment_attest.py scripts\test_base_deployment_attest.py scripts\build_base_attest_fixtures.py scripts\rehearse_autonomous_activation.py }
 Pop-Location
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -76,6 +76,7 @@ cargo run -p cli -- github-claim-comment-plan \
 "${python_cmd[@]}" scripts/test_sync_hosted_bounty_inventory.py -v
 "${python_cmd[@]}" scripts/test_diagnose_hosted_api.py -v
 "${python_cmd[@]}" scripts/test_github_audience_audit.py -v
+"${python_cmd[@]}" scripts/test_ruleset_drift_check.py -v
 cargo run -p cli -- github-proof-comment-plan \
   --bounty-id 00000000-0000-0000-0000-000000000001 \
   --proof-url https://agentbounties.local/public/proofs/example \
@@ -115,6 +116,8 @@ cargo run -p cli -- pooled-funding-demo
   scripts/test_diagnose_hosted_api.py \
   scripts/github_audience_audit.py \
   scripts/test_github_audience_audit.py \
+  scripts/ruleset_drift_check.py \
+  scripts/test_ruleset_drift_check.py \
   scripts/check-site.py \
   scripts/check-migration-history.py \
   scripts/check-render-blueprint.py \

--- a/scripts/fixtures/ruleset_drift/live_ruleset.json
+++ b/scripts/fixtures/ruleset_drift/live_ruleset.json
@@ -1,0 +1,86 @@
+{
+  "id": 987654,
+  "name": "Protect main without blocking contributors",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "NSPG13/agent-bounties",
+  "enforcement": "active",
+  "node_id": "RRS_l0EEx00PdV4",
+  "created_at": "2026-05-01T12:00:00Z",
+  "updated_at": "2026-06-15T09:30:00Z",
+  "current_user_can_bypass": "always",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/NSPG13/agent-bounties/rulesets/987654"
+    },
+    "html": {
+      "href": "https://github.com/NSPG13/agent-bounties/rules/987654"
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "~DEFAULT_BRANCH"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "ruleset_source_type": "Repository",
+      "ruleset_source": "NSPG13/agent-bounties",
+      "ruleset_id": 987654,
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "postgres-sync",
+            "integration_id": 15368
+          },
+          {
+            "context": "full-check",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "non_fast_forward",
+      "ruleset_source_type": "Repository",
+      "ruleset_source": "NSPG13/agent-bounties",
+      "ruleset_id": 987654
+    },
+    {
+      "type": "pull_request",
+      "ruleset_source_type": "Repository",
+      "ruleset_source": "NSPG13/agent-bounties",
+      "ruleset_id": 987654,
+      "parameters": {
+        "allowed_merge_methods": [
+          "squash"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": true,
+        "required_approving_review_count": 1,
+        "required_reviewers": [],
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "deletion",
+      "ruleset_source_type": "Repository",
+      "ruleset_source": "NSPG13/agent-bounties",
+      "ruleset_id": 987654
+    }
+  ]
+}

--- a/scripts/ruleset_drift_check.py
+++ b/scripts/ruleset_drift_check.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Check that the live GitHub branch ruleset has not drifted from canonical.
+
+The canonical configuration lives in ``.github/rulesets/main.json``. This script
+is read-only: it authenticates through the ``gh`` CLI to fetch the live ruleset,
+but it never writes to GitHub, never posts comments, and never touches payment
+code. It performs two independent checks and exits non-zero if either fails:
+
+1. Structural drift - compare the canonical ruleset to the live ruleset after
+   removing only server-owned bookkeeping fields (numeric ids, timestamps, and
+   the source links GitHub attaches when it returns a ruleset). Any remaining
+   difference is real drift a maintainer must reconcile.
+2. Semantic validation - confirm the ruleset still encodes the documented main
+   branch protections. This runs against both the canonical file and the live
+   ruleset, so a hand-edit to either side is caught.
+
+Point it at a fixture with ``--live-fixture`` to run fully offline. Without a
+fixture it calls ``gh api`` to read (never modify) the live ruleset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANONICAL_PATH = REPO_ROOT / ".github" / "rulesets" / "main.json"
+
+# Fields GitHub owns and attaches to a ruleset when it returns one. They carry
+# no policy meaning, so ignore exactly these and nothing else when diffing.
+SERVER_OWNED_TOP_LEVEL = frozenset(
+    {
+        "id",
+        "node_id",
+        "source",
+        "source_type",
+        "created_at",
+        "updated_at",
+        "_links",
+        "current_user_can_bypass",
+    }
+)
+SERVER_OWNED_RULE_FIELDS = frozenset(
+    {
+        "ruleset_source_type",
+        "ruleset_source",
+        "ruleset_id",
+    }
+)
+
+# Semantic expectations documented in docs/main-branch-ruleset.md.
+GITHUB_ACTIONS_INTEGRATION_ID = 15368
+ADMIN_REPOSITORY_ROLE_ID = 5
+REQUIRED_STATUS_CONTEXTS = ("full-check", "postgres-sync")
+DEFAULT_BRANCH_TARGET = "~DEFAULT_BRANCH"
+
+
+def normalize_ruleset(ruleset: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``ruleset`` with only server-owned fields removed."""
+    normalized = {
+        key: value
+        for key, value in ruleset.items()
+        if key not in SERVER_OWNED_TOP_LEVEL
+    }
+    rules = normalized.get("rules")
+    if isinstance(rules, list):
+        normalized["rules"] = [_strip_rule(rule) for rule in rules]
+    return normalized
+
+
+def _strip_rule(rule: Any) -> Any:
+    if not isinstance(rule, dict):
+        return rule
+    normalized = {
+        key: value
+        for key, value in rule.items()
+        if key not in SERVER_OWNED_RULE_FIELDS
+    }
+    # GitHub materializes this API default even when the submitted canonical
+    # JSON omits it. Preserve non-empty values because they change policy.
+    if normalized.get("type") == "pull_request":
+        parameters = normalized.get("parameters")
+        if isinstance(parameters, dict):
+            parameters = dict(parameters)
+            parameters.setdefault("required_reviewers", [])
+            normalized["parameters"] = parameters
+    return normalized
+
+
+def _canonical_form(value: Any) -> Any:
+    """Recursively sort dict keys and lists so ordering never masquerades as drift."""
+    if isinstance(value, dict):
+        return {key: _canonical_form(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        items = [_canonical_form(item) for item in value]
+        return sorted(items, key=lambda item: json.dumps(item, sort_keys=True))
+    return value
+
+
+def _diff(expected: Any, actual: Any, path: str, out: list[str]) -> None:
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        for key in sorted(set(expected) | set(actual)):
+            child = f"{path}.{key}" if path else key
+            if key not in expected:
+                out.append(f"{child}: present live but not in canonical ({actual[key]!r})")
+            elif key not in actual:
+                out.append(f"{child}: in canonical but missing live ({expected[key]!r})")
+            else:
+                _diff(expected[key], actual[key], child, out)
+    elif isinstance(expected, list) and isinstance(actual, list):
+        if len(expected) != len(actual):
+            out.append(
+                f"{path or 'rules'}: canonical has {len(expected)} entries, live has {len(actual)}"
+            )
+        for index, (exp_item, act_item) in enumerate(zip(expected, actual)):
+            _diff(exp_item, act_item, f"{path}[{index}]", out)
+    elif expected != actual:
+        out.append(f"{path}: canonical {expected!r} != live {actual!r}")
+
+
+def compare_rulesets(canonical: dict[str, Any], live: dict[str, Any]) -> list[str]:
+    """Return human-readable drift entries, ignoring only server-owned fields."""
+    expected = _canonical_form(normalize_ruleset(canonical))
+    actual = _canonical_form(normalize_ruleset(live))
+    differences: list[str] = []
+    _diff(expected, actual, "", differences)
+    return differences
+
+
+def validate_semantics(ruleset: dict[str, Any]) -> list[str]:
+    """Return the list of documented protections this ruleset fails to encode."""
+    problems: list[str] = []
+
+    if ruleset.get("target") != "branch":
+        problems.append("target must be 'branch'")
+    if ruleset.get("enforcement") != "active":
+        problems.append("enforcement must be 'active'")
+
+    ref_name = ruleset.get("conditions", {}).get("ref_name", {})
+    include = ref_name.get("include", [])
+    exclude = ref_name.get("exclude", [])
+    if include != [DEFAULT_BRANCH_TARGET]:
+        problems.append(
+            f"ref_name.include must target only [{DEFAULT_BRANCH_TARGET!r}], found {include!r}"
+        )
+    if exclude:
+        problems.append(f"ref_name.exclude must be empty, found {exclude!r}")
+
+    bypass_actors = ruleset.get("bypass_actors", [])
+    if len(bypass_actors) != 1:
+        problems.append(f"expected exactly one bypass actor, found {len(bypass_actors)}")
+    else:
+        actor = bypass_actors[0]
+        if actor.get("actor_type") != "RepositoryRole":
+            problems.append("bypass actor must be a RepositoryRole")
+        if actor.get("actor_id") != ADMIN_REPOSITORY_ROLE_ID:
+            problems.append(
+                f"bypass actor must be the admin repository role (id {ADMIN_REPOSITORY_ROLE_ID})"
+            )
+        if actor.get("bypass_mode") != "pull_request":
+            problems.append("admin bypass must use pull_request mode only")
+
+    rules_by_type: dict[str, dict[str, Any]] = {}
+    for rule in ruleset.get("rules", []):
+        if isinstance(rule, dict) and isinstance(rule.get("type"), str):
+            rules_by_type.setdefault(rule["type"], rule)
+
+    if "deletion" not in rules_by_type:
+        problems.append("deletion protection rule is missing")
+    if "non_fast_forward" not in rules_by_type:
+        problems.append("non-fast-forward protection rule is missing")
+
+    pull_request = rules_by_type.get("pull_request")
+    if pull_request is None:
+        problems.append("pull_request rule is missing")
+    else:
+        params = pull_request.get("parameters", {})
+        if params.get("required_approving_review_count") != 1:
+            problems.append("pull request rule must require exactly one approval")
+        if params.get("require_last_push_approval") is not True:
+            problems.append("pull request rule must require latest-push approval")
+        if params.get("required_review_thread_resolution") is not True:
+            problems.append("pull request rule must require review thread resolution")
+
+    checks_rule = rules_by_type.get("required_status_checks")
+    if checks_rule is None:
+        problems.append("required_status_checks rule is missing")
+    else:
+        params = checks_rule.get("parameters", {})
+        if params.get("strict_required_status_checks_policy") is not False:
+            problems.append("status checks must use loose mode (strict policy must be false)")
+        checks_by_context: dict[Any, dict[str, Any]] = {}
+        for check in params.get("required_status_checks", []):
+            if isinstance(check, dict):
+                checks_by_context.setdefault(check.get("context"), check)
+        for context in REQUIRED_STATUS_CONTEXTS:
+            check = checks_by_context.get(context)
+            if check is None:
+                problems.append(f"required status check {context!r} is missing")
+            elif check.get("integration_id") != GITHUB_ACTIONS_INTEGRATION_ID:
+                problems.append(
+                    f"required status check {context!r} must be bound to GitHub Actions "
+                    f"integration {GITHUB_ACTIONS_INTEGRATION_ID}, found "
+                    f"{check.get('integration_id')!r}"
+                )
+
+    return problems
+
+
+def evaluate(canonical: dict[str, Any], live: dict[str, Any]) -> dict[str, list[str]]:
+    """Run every offline check and return the collected findings."""
+    return {
+        "drift": compare_rulesets(canonical, live),
+        "canonical_semantic_problems": validate_semantics(canonical),
+        "live_semantic_problems": validate_semantics(live),
+    }
+
+
+def is_clean(result: dict[str, list[str]]) -> bool:
+    return not any(result.values())
+
+
+def _gh_json(args: list[str]) -> Any:
+    completed = subprocess.run(
+        ["gh", "api", *args], check=True, capture_output=True, text=True
+    )
+    return json.loads(completed.stdout)
+
+
+def fetch_live_ruleset(repository: str, name: str) -> dict[str, Any]:
+    """Read-only fetch of the live ruleset named ``name`` via the gh CLI."""
+    listing = _gh_json([f"repos/{repository}/rulesets"])
+    if not isinstance(listing, list):
+        raise RuntimeError("unexpected rulesets listing response")
+    match = next(
+        (item for item in listing if isinstance(item, dict) and item.get("name") == name),
+        None,
+    )
+    if match is None:
+        raise RuntimeError(f"no live ruleset named {name!r} on {repository}")
+    ruleset_id = match.get("id")
+    if not isinstance(ruleset_id, int):
+        raise RuntimeError("live ruleset is missing a numeric id")
+    return _gh_json([f"repos/{repository}/rulesets/{ruleset_id}"])
+
+
+def format_report(result: dict[str, list[str]]) -> str:
+    lines: list[str] = []
+    if result["drift"]:
+        lines.append("Structural drift from canonical ruleset:")
+        lines.extend(f"  - {entry}" for entry in result["drift"])
+    if result["canonical_semantic_problems"]:
+        lines.append("Canonical ruleset fails semantic validation:")
+        lines.extend(f"  - {entry}" for entry in result["canonical_semantic_problems"])
+    if result["live_semantic_problems"]:
+        lines.append("Live ruleset fails semantic validation:")
+        lines.extend(f"  - {entry}" for entry in result["live_semantic_problems"])
+    if not lines:
+        lines.append("Live ruleset matches canonical and satisfies every documented protection.")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", default="NSPG13/agent-bounties")
+    parser.add_argument("--canonical", type=Path, default=CANONICAL_PATH)
+    parser.add_argument(
+        "--live-fixture",
+        type=Path,
+        help="Read the live ruleset from a JSON file instead of calling gh (offline).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    canonical = json.loads(args.canonical.read_text(encoding="utf-8"))
+    if args.live_fixture:
+        live = json.loads(args.live_fixture.read_text(encoding="utf-8"))
+    else:
+        live = fetch_live_ruleset(args.repository, canonical["name"])
+
+    result = evaluate(canonical, live)
+    print(format_report(result))
+    return 0 if is_clean(result) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ruleset_drift_check.py
+++ b/scripts/ruleset_drift_check.py
@@ -58,6 +58,7 @@ GITHUB_ACTIONS_INTEGRATION_ID = 15368
 ADMIN_REPOSITORY_ROLE_ID = 5
 REQUIRED_STATUS_CONTEXTS = ("full-check", "postgres-sync")
 DEFAULT_BRANCH_TARGET = "~DEFAULT_BRANCH"
+GH_TIMEOUT_SECONDS = 30
 
 
 def normalize_ruleset(ruleset: dict[str, Any]) -> dict[str, Any]:
@@ -226,10 +227,26 @@ def is_clean(result: dict[str, list[str]]) -> bool:
 
 
 def _gh_json(args: list[str]) -> Any:
-    completed = subprocess.run(
-        ["gh", "api", *args], check=True, capture_output=True, text=True
-    )
-    return json.loads(completed.stdout)
+    try:
+        completed = subprocess.run(
+            ["gh", "api", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        raise RuntimeError("gh command is unavailable") from None
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            f"gh api timed out after {GH_TIMEOUT_SECONDS} seconds"
+        ) from None
+    if completed.returncode != 0:
+        raise RuntimeError(f"gh api failed with exit code {completed.returncode}")
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        raise RuntimeError("gh api returned invalid JSON") from None
 
 
 def fetch_live_ruleset(repository: str, name: str) -> dict[str, Any]:
@@ -237,16 +254,34 @@ def fetch_live_ruleset(repository: str, name: str) -> dict[str, Any]:
     listing = _gh_json([f"repos/{repository}/rulesets"])
     if not isinstance(listing, list):
         raise RuntimeError("unexpected rulesets listing response")
-    match = next(
-        (item for item in listing if isinstance(item, dict) and item.get("name") == name),
-        None,
-    )
-    if match is None:
-        raise RuntimeError(f"no live ruleset named {name!r} on {repository}")
+    repository_key = repository.strip().casefold()
+    matches = [
+        item
+        for item in listing
+        if isinstance(item, dict)
+        and item.get("name") == name
+        and item.get("source_type") == "Repository"
+        and isinstance(item.get("source"), str)
+        and item["source"].strip().casefold() == repository_key
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected exactly one repository-owned live ruleset named {name!r} "
+            f"on {repository}, found {len(matches)}"
+        )
+    match = matches[0]
     ruleset_id = match.get("id")
     if not isinstance(ruleset_id, int):
         raise RuntimeError("live ruleset is missing a numeric id")
-    return _gh_json([f"repos/{repository}/rulesets/{ruleset_id}"])
+    live = _gh_json([f"repos/{repository}/rulesets/{ruleset_id}"])
+    if (
+        not isinstance(live, dict)
+        or live.get("source_type") != "Repository"
+        or not isinstance(live.get("source"), str)
+        or live["source"].strip().casefold() != repository_key
+    ):
+        raise RuntimeError("fetched ruleset source does not match the requested repository")
+    return live
 
 
 def format_report(result: dict[str, list[str]]) -> str:
@@ -279,11 +314,15 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    canonical = json.loads(args.canonical.read_text(encoding="utf-8"))
-    if args.live_fixture:
-        live = json.loads(args.live_fixture.read_text(encoding="utf-8"))
-    else:
-        live = fetch_live_ruleset(args.repository, canonical["name"])
+    try:
+        canonical = json.loads(args.canonical.read_text(encoding="utf-8"))
+        if args.live_fixture:
+            live = json.loads(args.live_fixture.read_text(encoding="utf-8"))
+        else:
+            live = fetch_live_ruleset(args.repository, canonical["name"])
+    except (OSError, json.JSONDecodeError, KeyError, RuntimeError) as error:
+        print(f"ruleset drift check failed: {error}", file=sys.stderr)
+        return 2
 
     result = evaluate(canonical, live)
     print(format_report(result))

--- a/scripts/ruleset_drift_check.py
+++ b/scripts/ruleset_drift_check.py
@@ -233,6 +233,8 @@ def _gh_json(args: list[str]) -> Any:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="strict",
             timeout=GH_TIMEOUT_SECONDS,
         )
     except FileNotFoundError:

--- a/scripts/test_ruleset_drift_check.py
+++ b/scripts/test_ruleset_drift_check.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "ruleset_drift_check", SCRIPT_DIR / "ruleset_drift_check.py"
+)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _rule(ruleset: dict, rule_type: str) -> dict:
+    return next(rule for rule in ruleset["rules"] if rule["type"] == rule_type)
+
+
+class RulesetDriftCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        canonical_path = SCRIPT_DIR.parent / ".github" / "rulesets" / "main.json"
+        live_path = SCRIPT_DIR / "fixtures" / "ruleset_drift" / "live_ruleset.json"
+        self.canonical = json.loads(canonical_path.read_text(encoding="utf-8"))
+        self.live = json.loads(live_path.read_text(encoding="utf-8"))
+
+    def test_equal_ruleset_reports_no_drift_and_no_problems(self) -> None:
+        # The live fixture carries server-owned ids, timestamps, links, per-rule
+        # source metadata, and a shuffled rule order. None of that is drift.
+        result = MODULE.evaluate(self.canonical, self.live)
+        self.assertEqual(result["drift"], [])
+        self.assertEqual(result["canonical_semantic_problems"], [])
+        self.assertEqual(result["live_semantic_problems"], [])
+        self.assertTrue(MODULE.is_clean(result))
+
+    def test_missing_rule_is_flagged_as_drift_and_semantic_gap(self) -> None:
+        live = deepcopy(self.live)
+        live["rules"] = [rule for rule in live["rules"] if rule["type"] != "non_fast_forward"]
+        result = MODULE.evaluate(self.canonical, live)
+        self.assertTrue(result["drift"])
+        self.assertIn(
+            "non-fast-forward protection rule is missing",
+            result["live_semantic_problems"],
+        )
+        self.assertFalse(MODULE.is_clean(result))
+
+    def test_wrong_integration_id_is_flagged(self) -> None:
+        live = deepcopy(self.live)
+        checks = _rule(live, "required_status_checks")["parameters"]["required_status_checks"]
+        for check in checks:
+            if check["context"] == "full-check":
+                check["integration_id"] = 99999
+        result = MODULE.evaluate(self.canonical, live)
+        self.assertTrue(result["drift"])
+        self.assertTrue(
+            any(
+                "full-check" in problem and "15368" in problem
+                for problem in result["live_semantic_problems"]
+            )
+        )
+
+    def test_strict_status_mode_is_flagged(self) -> None:
+        live = deepcopy(self.live)
+        _rule(live, "required_status_checks")["parameters"][
+            "strict_required_status_checks_policy"
+        ] = True
+        result = MODULE.evaluate(self.canonical, live)
+        self.assertTrue(result["drift"])
+        self.assertIn(
+            "status checks must use loose mode (strict policy must be false)",
+            result["live_semantic_problems"],
+        )
+
+    def test_over_broad_target_is_flagged(self) -> None:
+        live = deepcopy(self.live)
+        live["conditions"]["ref_name"]["include"] = ["~ALL"]
+        result = MODULE.evaluate(self.canonical, live)
+        self.assertTrue(result["drift"])
+        self.assertTrue(
+            any("~DEFAULT_BRANCH" in problem for problem in result["live_semantic_problems"])
+        )
+
+    def test_normalize_strips_only_server_owned_fields(self) -> None:
+        normalized = MODULE.normalize_ruleset(self.live)
+        self.assertNotIn("id", normalized)
+        self.assertNotIn("_links", normalized)
+        self.assertNotIn("updated_at", normalized)
+        for rule in normalized["rules"]:
+            self.assertNotIn("ruleset_id", rule)
+            self.assertNotIn("ruleset_source", rule)
+        # Policy-bearing fields survive normalization.
+        self.assertEqual(normalized["enforcement"], "active")
+        self.assertEqual(len(normalized["rules"]), len(self.live["rules"]))
+
+    def test_nonempty_required_reviewers_remain_policy_drift(self) -> None:
+        live = deepcopy(self.live)
+        _rule(live, "pull_request")["parameters"]["required_reviewers"] = [
+            {"file_patterns": ["src/**"], "minimum_approvals": 1}
+        ]
+        result = MODULE.evaluate(self.canonical, live)
+        self.assertTrue(result["drift"])
+
+    def test_admin_bypass_must_be_pull_request_mode_only(self) -> None:
+        live = deepcopy(self.live)
+        live["bypass_actors"][0]["bypass_mode"] = "always"
+        result = MODULE.evaluate(self.canonical, live)
+        self.assertIn(
+            "admin bypass must use pull_request mode only",
+            result["live_semantic_problems"],
+        )
+
+    def test_latest_push_and_single_approval_required(self) -> None:
+        live = deepcopy(self.live)
+        params = _rule(live, "pull_request")["parameters"]
+        params["require_last_push_approval"] = False
+        params["required_approving_review_count"] = 2
+        result = MODULE.evaluate(self.canonical, live)
+        self.assertIn(
+            "pull request rule must require exactly one approval",
+            result["live_semantic_problems"],
+        )
+        self.assertIn(
+            "pull request rule must require latest-push approval",
+            result["live_semantic_problems"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_ruleset_drift_check.py
+++ b/scripts/test_ruleset_drift_check.py
@@ -6,6 +6,8 @@ import json
 import unittest
 from copy import deepcopy
 from pathlib import Path
+from subprocess import CompletedProcess, TimeoutExpired
+from unittest.mock import patch
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -127,6 +129,76 @@ class RulesetDriftCheckTests(unittest.TestCase):
             "pull request rule must require latest-push approval",
             result["live_semantic_problems"],
         )
+
+    def test_fetch_requires_one_repository_owned_match(self) -> None:
+        owned = {
+            "id": 10,
+            "name": self.canonical["name"],
+            "source_type": "Repository",
+            "source": "NSPG13/agent-bounties",
+        }
+        with patch.object(MODULE, "_gh_json", return_value=[owned, {**owned, "id": 11}]):
+            with self.assertRaisesRegex(RuntimeError, "found 2"):
+                MODULE.fetch_live_ruleset("NSPG13/agent-bounties", self.canonical["name"])
+
+    def test_fetch_rejects_zero_repository_owned_matches(self) -> None:
+        inherited = {
+            "id": 10,
+            "name": self.canonical["name"],
+            "source_type": "Organization",
+            "source": "NSPG13",
+        }
+        with patch.object(MODULE, "_gh_json", return_value=[inherited]):
+            with self.assertRaisesRegex(RuntimeError, "found 0"):
+                MODULE.fetch_live_ruleset("NSPG13/agent-bounties", self.canonical["name"])
+
+    def test_fetch_ignores_same_named_inherited_ruleset(self) -> None:
+        owned = {
+            "id": 10,
+            "name": self.canonical["name"],
+            "source_type": "Repository",
+            "source": "nspg13/AGENT-BOUNTIES",
+        }
+        inherited = {
+            "id": 20,
+            "name": self.canonical["name"],
+            "source_type": "Organization",
+            "source": "NSPG13",
+        }
+        detail = {**self.live, "source_type": "Repository", "source": "NSPG13/agent-bounties"}
+        with patch.object(MODULE, "_gh_json", side_effect=[[inherited, owned], detail]) as gh_json:
+            result = MODULE.fetch_live_ruleset("NSPG13/agent-bounties", self.canonical["name"])
+        self.assertIs(result, detail)
+        self.assertEqual(
+            gh_json.call_args_list[1].args[0],
+            ["repos/NSPG13/agent-bounties/rulesets/10"],
+        )
+
+    def test_gh_timeout_fails_closed(self) -> None:
+        with patch.object(
+            MODULE.subprocess,
+            "run",
+            side_effect=TimeoutExpired(cmd=["gh", "api"], timeout=MODULE.GH_TIMEOUT_SECONDS),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "timed out"):
+                MODULE._gh_json(["repos/owner/repo/rulesets"])
+
+    def test_gh_nonzero_exit_fails_closed_without_stderr(self) -> None:
+        completed = CompletedProcess(
+            args=["gh", "api"], returncode=7, stdout="", stderr="sensitive detail"
+        )
+        with patch.object(MODULE.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(RuntimeError, "exit code 7") as error:
+                MODULE._gh_json(["repos/owner/repo/rulesets"])
+        self.assertNotIn("sensitive", str(error.exception))
+
+    def test_gh_invalid_json_fails_closed(self) -> None:
+        completed = CompletedProcess(
+            args=["gh", "api"], returncode=0, stdout="not-json", stderr=""
+        )
+        with patch.object(MODULE.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(RuntimeError, "invalid JSON"):
+                MODULE._gh_json(["repos/owner/repo/rulesets"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_ruleset_drift_check.py
+++ b/scripts/test_ruleset_drift_check.py
@@ -196,9 +196,11 @@ class RulesetDriftCheckTests(unittest.TestCase):
         completed = CompletedProcess(
             args=["gh", "api"], returncode=0, stdout="not-json", stderr=""
         )
-        with patch.object(MODULE.subprocess, "run", return_value=completed):
+        with patch.object(MODULE.subprocess, "run", return_value=completed) as run:
             with self.assertRaisesRegex(RuntimeError, "invalid JSON"):
                 MODULE._gh_json(["repos/owner/repo/rulesets"])
+        self.assertEqual(run.call_args.kwargs["encoding"], "utf-8")
+        self.assertEqual(run.call_args.kwargs["errors"], "strict")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What Changed

Add a read-only GitHub main-ruleset drift checker that compares the canonical JSON with the live ruleset after normalizing GitHub-owned response fields and its empty `required_reviewers` API default. It separately validates the documented branch, bypass, review, status-check integration, loose-mode, deletion, and force-push protections.

Nine offline fixture tests cover equal, missing-rule, wrong-integration, strict-mode, over-broad-target, bypass, approval, and normalization behavior. A narrow Python-only CI job runs them on every pull request, and the full local check includes them.

## Linked Bounty Or Issue

Refs https://github.com/NSPG13/agent-bounties/issues/169

Canonical round-1 claim: https://base.blockscout.com/tx/0x6c785dd1abc3510a11d4dbb4812ed021a9c9d7508977cfe85d2415627c227b19

## Maintainer Change Notice

- Notice issue/comment: not maintainer-owned
- Open PR queue checked before edits: yes; generic `/attempt` comments did not hold an onchain claim
- Active PR impact or repair path: none identified
- Collaboration branch impact, if any: none

## Discovery Feedback

- How did you find Agent Bounties? A current GitHub `label:bounty` scan, followed by the canonical Base claimable feed.
- What made this bounty or project worth participating in? The buyer had already escrowed native USDC, the acceptance criteria were deterministic, and claim priority was onchain rather than comment-based.
- What agent workflow led here? Codex audited the feed, factory, terms, and claim contract; Claude Opus implemented the scoped checker after the independent wallet claimed the round.
- What would make the project easier or more trustworthy? A hosted gas-paying EIP-3009 relay or explicit wallet gas bootstrap guidance. The hosted claim planner also returned `503` during this claim. Once the wallet had Base gas, the canonical contract path worked cleanly.

The new live command already identifies a real current mismatch: the live ruleset lacks the canonical PR-only admin bypass. The empty `required_reviewers` field returned by GitHub is normalized as an API default, while any non-empty reviewer policy remains detectable drift.

## Acceptance Criteria

- [x] The PR has a clear verifier or review path.
- [x] Deterministic behavior has tests or a documented manual check.
- [x] Payment, settlement, and payout behavior is unchanged.

## Local Checks

```bash
python3 scripts/test_ruleset_drift_check.py -v
python3 scripts/ruleset_drift_check.py --live-fixture scripts/fixtures/ruleset_drift/live_ruleset.json
GH_TOKEN=... python3 scripts/ruleset_drift_check.py  # exits 1 on the current missing admin bypass
PATH=/root/.cargo/bin:$PATH bash scripts/preflight.sh core
python3 -m py_compile scripts/ruleset_drift_check.py scripts/test_ruleset_drift_check.py
git diff --check
```

Results: 9/9 fixture tests pass; offline equal comparison passes; core preflight passes with only the existing optional-Docker warning; live read-only comparison reports only the missing canonical bypass actor.

## Review Lane

- [x] I believe this is ready for `main`.
- [x] If useful but not main-ready, I am comfortable with maintainers preserving this work on a `collab/pr-<number>-<topic>` branch for follow-up PRs.
- [ ] This touches risky paths and needs manual maintainer security review.

Code review, CI approval, and collaboration-branch preservation do not approve bounty acceptance, payout, or payment settlement.