### PR TITLE
fix: preserve UTF-8 audience attribution

### DIFF
--- a/scripts/fixtures/github_discovery_responses.curated.json
+++ b/scripts/fixtures/github_discovery_responses.curated.json
@@ -18,6 +18,15 @@
     "agent_or_tool": "Cursor agent with Python and the GitHub CLI."
   },
   {
+    "handle": "fablerlabs",
+    "provider_response_id": "github:issue-body:4863562102",
+    "public_source_url": "https://github.com/NSPG13/agent-bounties/pull/193",
+    "found_via": "A current GitHub label:bounty scan followed by independent verification of the canonical Base claimable feed, factory, events, funding, and solver bond.",
+    "motivation": "Native USDC was already escrowed, acceptance criteria were deterministic, and claim priority was enforced on-chain instead of by GitHub comments.",
+    "improvement_suggestion": "Provide a hosted gas-paying EIP-3009 relayer or explicit wallet gas-bootstrap guidance, and keep the hosted planner deployed at the canonical factory revision.",
+    "agent_or_tool": "Codex audited discovery, factory, terms, and the claim contract; Claude Opus implemented the scoped checker after an independent wallet claimed the round."
+  },
+  {
     "handle": "hyperxiaoerxz-hash",
     "provider_response_id": "github:issue-comment:4915897383",
     "public_source_url": "https://github.com/NSPG13/agent-bounties/issues/55#issuecomment-4915897383",

--- a/scripts/github_audience_audit.py
+++ b/scripts/github_audience_audit.py
@@ -62,7 +62,14 @@ def gh_api(repository: str, suffix: str, *, accept: str | None = None) -> list[d
     ]
     if accept:
         command.extend(["-H", f"Accept: {accept}"])
-    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="strict",
+    )
     return flatten_pages(json.loads(completed.stdout))
 
 

--- a/scripts/test_github_audience_audit.py
+++ b/scripts/test_github_audience_audit.py
@@ -6,6 +6,8 @@ import json
 import unittest
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -22,6 +24,19 @@ class GitHubAudienceAuditTests(unittest.TestCase):
         fixture = SCRIPT_DIR / "fixtures" / "github_audience_audit.json"
         self.snapshot = json.loads(fixture.read_text(encoding="utf-8"))
         self.audit = MODULE.build_audit(self.snapshot, "NSPG13")
+
+    def test_github_api_output_is_decoded_as_utf8_on_every_platform(self) -> None:
+        response = '[[{"id":1,"body":"autonomous café"}]]'
+        with patch.object(
+            MODULE.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout=response),
+        ) as run:
+            records = MODULE.gh_api("NSPG13/agent-bounties", "issues")
+
+        self.assertEqual(records[0]["body"], "autonomous café")
+        self.assertEqual(run.call_args.kwargs["encoding"], "utf-8")
+        self.assertEqual(run.call_args.kwargs["errors"], "strict")
 
     def test_public_activity_is_deduplicated_and_bots_are_excluded(self) -> None:
         handles = [participant["handle"] for participant in self.audit["participants"]]
@@ -214,7 +229,7 @@ class GitHubAudienceAuditTests(unittest.TestCase):
             SCRIPT_DIR / "fixtures" / "github_discovery_responses.curated.json"
         )
         curated = json.loads(curated_path.read_text(encoding="utf-8"))
-        self.assertEqual(len(curated), 7)
+        self.assertEqual(len(curated), 8)
         self.assertEqual(
             len({response["provider_response_id"] for response in curated}), len(curated)
         )


### PR DESCRIPTION
## Summary
- preserve fablerlabs' volunteered public discovery, motivation, workflow, and friction feedback in the curated attribution corpus
- force `gh api` output to decode as UTF-8 on Windows instead of the system cp1252 code page
- add deterministic regression coverage for the decode boundary and curated participant reference

## Privacy boundary
This stores public attribution from PR #193 only. It does not infer email, outreach consent, wallet-contact consent, bounty acceptance, or payout.

## Validation
- `scripts/check.ps1`
- `python scripts/test_github_audience_audit.py -v`
- live dry-run audit: 28 public participants, with fablerlabs present
