### PR TITLE
fix: default bounties to deterministic settlement

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1036,8 +1036,28 @@ fn live_money_readiness_config(state: &SharedState, network: &str) -> LiveMoneyR
 fn autonomous_factory_for_chain(chain_id: u64) -> Option<String> {
     match chain_id {
         84_532 => env_nonempty_value("BASE_SEPOLIA_BOUNTY_FACTORY"),
-        8_453 => env_nonempty_value("BASE_MAINNET_BOUNTY_FACTORY"),
+        8_453 => canonical_mainnet_factory(
+            env_nonempty_value("BASE_MAINNET_BOUNTY_FACTORY"),
+            env_nonempty_value("BASE_MAINNET_BOUNTY_IMPLEMENTATION"),
+        ),
         _ => None,
+    }
+}
+
+fn canonical_mainnet_factory(
+    configured_factory: Option<String>,
+    configured_implementation: Option<String>,
+) -> Option<String> {
+    if configured_factory
+        .as_deref()
+        .is_some_and(|address| !address.eq_ignore_ascii_case(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY))
+        || configured_implementation.as_deref().is_some_and(|address| {
+            !address.eq_ignore_ascii_case(CANONICAL_BASE_MAINNET_BOUNTY_IMPLEMENTATION)
+        })
+    {
+        None
+    } else {
+        Some(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY.to_string())
     }
 }
 
@@ -5627,6 +5647,10 @@ mod tests {
         assert!(report
             .checks
             .iter()
+            .any(|check| { check.name == "Autonomous bounty factory" && check.configured }));
+        assert!(report
+            .checks
+            .iter()
             .any(|check| check.name == "Stripe live-money execution gate"));
         assert!(report
             .checks
@@ -5709,6 +5733,36 @@ mod tests {
                 None,
             ),
             Err(StatusCode::SERVICE_UNAVAILABLE)
+        );
+    }
+
+    #[test]
+    fn mainnet_readiness_uses_canonical_factory_and_rejects_drift() {
+        assert_eq!(
+            canonical_mainnet_factory(None, None).as_deref(),
+            Some(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY)
+        );
+        assert_eq!(
+            canonical_mainnet_factory(
+                Some(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY.to_uppercase()),
+                Some(CANONICAL_BASE_MAINNET_BOUNTY_IMPLEMENTATION.to_uppercase()),
+            )
+            .as_deref(),
+            Some(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY)
+        );
+        assert_eq!(
+            canonical_mainnet_factory(
+                Some("0x1111111111111111111111111111111111111111".to_string()),
+                None,
+            ),
+            None
+        );
+        assert_eq!(
+            canonical_mainnet_factory(
+                None,
+                Some("0x2222222222222222222222222222222222222222".to_string()),
+            ),
+            None
         );
     }
 

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -3023,15 +3023,57 @@ fn configured_autonomous_planner(network: &str) -> Result<AutonomousBountyTxPlan
         ),
         _ => return Err("unsupported Base network".to_string()),
     };
-    let required = |key: &str| {
-        env::var(key)
-            .ok()
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| format!("hosted autonomous protocol is not configured: set {key}"))
-    };
-    AutonomousBountyTxPlanner::new(required(factory_env)?, required(implementation_env)?)
-        .map_err(|error| error.to_string())
+    let (factory, implementation) = autonomous_planner_addresses(
+        descriptor.chain_id,
+        env::var(factory_env).ok(),
+        env::var(implementation_env).ok(),
+    )?;
+    AutonomousBountyTxPlanner::new(factory, implementation).map_err(|error| error.to_string())
+}
+
+const CANONICAL_BASE_MAINNET_BOUNTY_FACTORY: &str = "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9";
+const CANONICAL_BASE_MAINNET_BOUNTY_IMPLEMENTATION: &str =
+    "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9";
+
+fn configured_address(value: Option<String>) -> Option<String> {
+    value
+        .map(|item| item.trim().to_string())
+        .filter(|item| !item.is_empty())
+}
+
+fn autonomous_planner_addresses(
+    chain_id: u64,
+    configured_factory: Option<String>,
+    configured_implementation: Option<String>,
+) -> Result<(String, String), String> {
+    let factory = configured_address(configured_factory);
+    let implementation = configured_address(configured_implementation);
+    if chain_id == 8_453 {
+        if factory.as_deref().is_some_and(|address| {
+            !address.eq_ignore_ascii_case(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY)
+        }) || implementation.as_deref().is_some_and(|address| {
+            !address.eq_ignore_ascii_case(CANONICAL_BASE_MAINNET_BOUNTY_IMPLEMENTATION)
+        }) {
+            return Err("configured Base mainnet autonomous deployment does not match the canonical attested deployment".to_string());
+        }
+        return Ok((
+            CANONICAL_BASE_MAINNET_BOUNTY_FACTORY.to_string(),
+            CANONICAL_BASE_MAINNET_BOUNTY_IMPLEMENTATION.to_string(),
+        ));
+    }
+    if chain_id == 84_532 {
+        return Ok((
+            factory.ok_or_else(|| {
+                "hosted autonomous protocol is not configured: set BASE_SEPOLIA_BOUNTY_FACTORY"
+                    .to_string()
+            })?,
+            implementation.ok_or_else(|| {
+                "hosted autonomous protocol is not configured: set BASE_SEPOLIA_BOUNTY_IMPLEMENTATION"
+                    .to_string()
+            })?,
+        ));
+    }
+    Err("unsupported Base network".to_string())
 }
 
 async fn require_indexed_canonical_bounty(
@@ -3792,8 +3834,28 @@ fn live_money_readiness_config(state: &SharedState, network: &str) -> LiveMoneyR
 fn autonomous_factory_for_chain(chain_id: u64) -> Option<String> {
     match chain_id {
         84_532 => env_nonempty_value("BASE_SEPOLIA_BOUNTY_FACTORY"),
-        8_453 => env_nonempty_value("BASE_MAINNET_BOUNTY_FACTORY"),
+        8_453 => canonical_mainnet_factory(
+            env_nonempty_value("BASE_MAINNET_BOUNTY_FACTORY"),
+            env_nonempty_value("BASE_MAINNET_BOUNTY_IMPLEMENTATION"),
+        ),
         _ => None,
+    }
+}
+
+fn canonical_mainnet_factory(
+    configured_factory: Option<String>,
+    configured_implementation: Option<String>,
+) -> Option<String> {
+    if configured_factory
+        .as_deref()
+        .is_some_and(|address| !address.eq_ignore_ascii_case(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY))
+        || configured_implementation.as_deref().is_some_and(|address| {
+            !address.eq_ignore_ascii_case(CANONICAL_BASE_MAINNET_BOUNTY_IMPLEMENTATION)
+        })
+    {
+        None
+    } else {
+        Some(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY.to_string())
     }
 }
 
@@ -4517,6 +4579,9 @@ mod tests {
         assert_eq!(body["supplied_usdc_token_matches_native"], true);
         assert_eq!(body["live_money_ready"], false);
         assert!(body["checks"].as_array().unwrap().iter().any(|check| {
+            check["name"] == "Autonomous bounty factory" && check["configured"] == true
+        }));
+        assert!(body["checks"].as_array().unwrap().iter().any(|check| {
             check["name"]
                 .as_str()
                 .unwrap()
@@ -4528,6 +4593,38 @@ mod tests {
                 .unwrap()
                 .contains("payment-method configuration")
         }));
+    }
+
+    #[test]
+    fn mainnet_planner_and_readiness_pin_the_attested_deployment() {
+        let expected = autonomous_planner_addresses(8_453, None, None).unwrap();
+        assert_eq!(expected.0, CANONICAL_BASE_MAINNET_BOUNTY_FACTORY);
+        assert_eq!(expected.1, CANONICAL_BASE_MAINNET_BOUNTY_IMPLEMENTATION);
+        assert_eq!(
+            canonical_mainnet_factory(None, None).as_deref(),
+            Some(CANONICAL_BASE_MAINNET_BOUNTY_FACTORY)
+        );
+
+        assert!(autonomous_planner_addresses(
+            8_453,
+            Some("0x1111111111111111111111111111111111111111".to_string()),
+            None,
+        )
+        .is_err());
+        assert_eq!(
+            canonical_mainnet_factory(
+                Some("0x1111111111111111111111111111111111111111".to_string()),
+                None,
+            ),
+            None
+        );
+        assert_eq!(
+            canonical_mainnet_factory(
+                None,
+                Some("0x2222222222222222222222222222222222222222".to_string()),
+            ),
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -495,23 +495,29 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
         verification_modes: vec![
             serde_json::json!({
                 "name": "deterministic_module",
+                "default_for_new_bounties": true,
+                "default_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
                 "earning_inventory": "ready when terms are valid and a nonzero module is committed on-chain",
                 "settlement": "Any caller supplies proof to the immutable on-chain verifier module; pass settles and fail reopens atomically. The verifier receives the same committed reward for either verdict."
             }),
             serde_json::json!({
                 "name": "signed_quorum",
+                "default_for_new_bounties": false,
                 "earning_inventory": "fails closed until verifier-service availability is canonically attestable",
                 "settlement": "Committed verifier wallets sign the exact round, solver, submission, evidence, result, response, and deadline. A valid pass or fail quorum receives the same reward."
             }),
             serde_json::json!({
                 "name": "ai_judge_quorum",
                 "minimum_threshold": 2,
+                "default_for_new_bounties": false,
                 "earning_inventory": "fails closed until every required judge service is canonically attestable",
                 "settlement": "At least two independent committed judge wallets sign under the model, prompt, rubric, decoding, benchmark, and evidence commitments fixed before funding. A valid pass or fail quorum receives the same reward."
             }),
         ],
         funding: serde_json::json!({
             "default": "fully funded on creation",
+            "default_verification": "deterministic_module",
+            "default_verifier_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
             "crowdfunding": "zero-funded bounties may be created; any wallet may contribute until the target is reached",
             "eoa_fast_path": "Circle USDC EIP-3009 bounded authorization",
             "smart_account_path": "wallet_sendCalls approve plus create or fund batch",
@@ -536,7 +542,7 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
             PaymentRailDescriptor {
                 name: "Base native USDC".to_string(),
                 currency: "usdc".to_string(),
-                status: "requires active autonomous-v1 deployment configuration".to_string(),
+                status: "active on Base mainnet for externally signed wallet transactions".to_string(),
                 settlement: "Canonical per-bounty contracts fund and settle atomically; BountySettled is payout evidence.".to_string(),
                 funding_required_before_claim: true,
                 automatic_release_limit_minor: None,
@@ -2917,6 +2923,23 @@ mod tests {
             .verification_modes
             .iter()
             .any(|mode| { mode["name"] == "ai_judge_quorum" && mode["minimum_threshold"] == 2 }));
+        let deterministic = manifest
+            .verification_modes
+            .iter()
+            .find(|mode| mode["name"] == "deterministic_module")
+            .unwrap();
+        assert_eq!(deterministic["default_for_new_bounties"], true);
+        assert_eq!(
+            deterministic["default_module"],
+            "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e"
+        );
+        assert_eq!(
+            manifest.funding["default_verification"],
+            "deterministic_module"
+        );
+        assert!(manifest.payment_rails.iter().any(|rail| {
+            rail.name == "Base native USDC" && rail.status.contains("active on Base mainnet")
+        }));
         assert!(manifest
             .evidence_boundaries
             .iter()

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -179,8 +179,9 @@ def main() -> int:
         [
             "Sign and post bounty",
             "Create unfunded and open it for pooled funding",
-            "Deterministic signed verifier",
-            "AI judge quorum",
+            "Permissionless on-chain verifier",
+            "Verifier wallet quorum (advanced)",
+            "AI judge quorum (advanced)",
             "Benchmark JSON",
             "Evidence schema JSON",
             "How did you find Agent Bounties?",
@@ -297,6 +298,15 @@ def main() -> int:
         fail("static discovery manifest must not advertise a settlement operator")
     if manifest_protocol.get("payout_authority") != "confirmed canonical BountySettled event":
         fail("static discovery manifest must bind payout to BountySettled")
+    default_verification = protocol.get("default_verification", {})
+    if default_verification.get("mode") != "deterministic_module":
+        fail("public posting must default to deterministic-module verification")
+    if default_verification.get("module_id") not in protocol.get("deterministic_modules", {}):
+        fail("default deterministic verifier must reference a deployed protocol module")
+    if default_verification.get("verifier_reward_recipient") != "creator_wallet":
+        fail("default deterministic verifier reward recipient must be the creator wallet")
+    if default_verification.get("threshold") != 1:
+        fail("default deterministic verifier threshold must be one")
     tools = discovery.get("agent_tools", [])
     for tool in [
         "list_autonomous_bounties",
@@ -313,6 +323,31 @@ def main() -> int:
             fail(f"static discovery manifest missing autonomous tool: {tool}")
     if any(tool in tools for tool in ["plan_base_funding", "plan_base_release", "plan_base_refund"]):
         fail("static discovery manifest advertises retired escrow tools")
+    modes = {mode.get("name"): mode for mode in discovery.get("verification_modes", [])}
+    deterministic_mode = modes.get("deterministic_module", {})
+    if deterministic_mode.get("default_for_new_bounties") is not True:
+        fail("discovery must default new bounties to deterministic verification")
+    expected_module = protocol["deterministic_modules"]["leading_zero_work_v1"]["contract"]
+    if deterministic_mode.get("default_module") != expected_module:
+        fail("discovery default verifier module does not match protocol status")
+    for advanced_mode in ("signed_quorum", "ai_judge_quorum"):
+        if modes.get(advanced_mode, {}).get("default_for_new_bounties") is not False:
+            fail(f"advanced verifier mode must not be a posting default: {advanced_mode}")
+    funding = discovery.get("funding", {})
+    if funding.get("default_verification") != "deterministic_module":
+        fail("discovery funding policy has the wrong verification default")
+    if funding.get("default_verifier_module") != expected_module:
+        fail("discovery funding policy has the wrong default verifier module")
+    base_rail = next(
+        (
+            rail
+            for rail in discovery.get("payment_rails", [])
+            if rail.get("name") == "Base native USDC"
+        ),
+        {},
+    )
+    if "active on Base mainnet" not in base_rail.get("status", ""):
+        fail("static discovery manifest does not advertise active Base USDC")
     ai_mode = next(
         (item for item in discovery.get("verification_modes", []) if item.get("name") == "ai_judge_quorum"),
         None,

--- a/scripts/test-autonomous-wallet-flow.js
+++ b/scripts/test-autonomous-wallet-flow.js
@@ -2,6 +2,7 @@ const assert = require("assert");
 const fs = require("fs");
 const path = require("path");
 const vm = require("vm");
+const { webcrypto } = require("crypto");
 
 const repoRoot = path.resolve(__dirname, "..");
 const source = fs.readFileSync(path.join(repoRoot, "site", "autonomous.js"), "utf8");
@@ -29,6 +30,8 @@ for (const required of [
   "BountyClaimed",
   "submission_added",
   "BountySettled",
+  "default_verification",
+  "configurePostVerification",
 ]) {
   assert(source.includes(required), `autonomous wallet flow missing ${required}`);
 }
@@ -52,6 +55,17 @@ assert.strictEqual(protocol.chain_id, 8453);
 assert.strictEqual(protocol.status, "active");
 assert.strictEqual(protocol.factory, "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9");
 assert.strictEqual(protocol.implementation, "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9");
+assert.strictEqual(protocol.default_verification.mode, "deterministic_module");
+assert.strictEqual(protocol.default_verification.module_id, "leading_zero_work_v1");
+assert.strictEqual(protocol.default_verification.verifier_reward_recipient, "creator_wallet");
+assert.strictEqual(protocol.default_verification.threshold, 1);
+
+const postHtml = fs.readFileSync(path.join(repoRoot, "site", "post.html"), "utf8");
+assert(
+  postHtml.indexOf('value="deterministic_module"') < postHtml.indexOf('value="signed_quorum"'),
+  "public posting must default to deterministic verification",
+);
+assert(postHtml.includes("Verifier wallet quorum (advanced)"));
 
 for (const page of ["index.html", "post.html", "funding.html", "earn.html", "operator.html"]) {
   const html = fs.readFileSync(path.join(repoRoot, "site", page), "utf8");
@@ -65,4 +79,92 @@ for (const page of ["post.html", "funding.html", "earn.html"]) {
   assert(html.includes("Connect wallet"), `${page} does not use connect-wallet onboarding`);
 }
 
-console.log("autonomous wallet flow contract passed");
+async function testDeterministicPostingDefaults() {
+  const documentListeners = {};
+  const formListeners = {};
+  const controlListeners = {};
+  const elements = {
+    verificationMode: {
+      value: "deterministic_module",
+      addEventListener(name, handler) {
+        controlListeners[name] = handler;
+      },
+    },
+    verifierModule: { value: "", readOnly: false, disabled: false },
+    verifierRewardRecipient: { value: "", disabled: false },
+    verifiers: { value: "", disabled: false },
+    threshold: { value: "8", readOnly: false },
+  };
+  const form = {
+    id: "autonomous-post-form",
+    elements,
+    addEventListener(name, handler) {
+      formListeners[name] = handler;
+    },
+    querySelector() {
+      return null;
+    },
+  };
+  const document = {
+    addEventListener(name, handler) {
+      documentListeners[name] = handler;
+    },
+    getElementById(id) {
+      return id === "autonomous-post-form" ? form : null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  };
+  const window = {
+    addEventListener() {},
+    dispatchEvent() {},
+    ethereum: null,
+  };
+  const context = vm.createContext({
+    console,
+    crypto: webcrypto,
+    document,
+    window,
+    Event,
+    URLSearchParams,
+    location: { search: "" },
+    fetch: async () => ({ ok: true, json: async () => protocol }),
+    setTimeout: (callback) => {
+      callback();
+      return 1;
+    },
+  });
+  new vm.Script(source, { filename: "site/autonomous.js" }).runInContext(context);
+  await documentListeners.DOMContentLoaded();
+
+  assert.strictEqual(
+    elements.verifierModule.value,
+    protocol.deterministic_modules.leading_zero_work_v1.contract,
+  );
+  assert.strictEqual(elements.verifierModule.readOnly, true);
+  assert.strictEqual(elements.verifierModule.disabled, false);
+  assert.strictEqual(elements.verifiers.disabled, true);
+  assert.strictEqual(elements.threshold.value, "1");
+  assert.strictEqual(elements.threshold.readOnly, true);
+
+  elements.verificationMode.value = "signed_quorum";
+  controlListeners.change();
+  assert.strictEqual(elements.verifierModule.disabled, true);
+  assert.strictEqual(elements.verifierRewardRecipient.disabled, true);
+  assert.strictEqual(elements.verifiers.disabled, false);
+  assert.strictEqual(elements.threshold.readOnly, false);
+
+  elements.verificationMode.value = "deterministic_module";
+  controlListeners.change();
+  assert.strictEqual(elements.verifierModule.disabled, false);
+  assert.strictEqual(elements.verifiers.disabled, true);
+  assert.strictEqual(elements.threshold.value, "1");
+}
+
+testDeterministicPostingDefaults()
+  .then(() => console.log("autonomous wallet flow contract passed"))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -85,20 +85,29 @@
   "verification_modes": [
     {
       "name": "deterministic_module",
+      "default_for_new_bounties": true,
+      "default_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
+      "earning_inventory": "ready when terms are valid and a nonzero module is committed on-chain",
       "settlement": "Any caller supplies proof to the immutable on-chain verifier module; pass settles and fail reopens atomically. The verifier receives the same committed reward for either verdict."
     },
     {
       "name": "signed_quorum",
+      "default_for_new_bounties": false,
+      "earning_inventory": "fails closed until verifier-service availability is canonically attestable",
       "settlement": "The immutable verifier set signs the exact bounty, round, solver, submission, evidence, result, response, and deadline. A valid pass or fail quorum receives the same reward."
     },
     {
       "name": "ai_judge_quorum",
       "minimum_threshold": 2,
+      "default_for_new_bounties": false,
+      "earning_inventory": "fails closed until every required judge service is canonically attestable",
       "settlement": "At least two independent committed judge wallets sign under the model, prompt, rubric, decoding, benchmark, and evidence commitments fixed before funding. A valid pass or fail quorum receives the same reward."
     }
   ],
   "funding": {
     "default": "fully funded on creation",
+    "default_verification": "deterministic_module",
+    "default_verifier_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
     "crowdfunding": "zero-funded bounties may be created; any wallet may contribute until the target is reached",
     "eoa_fast_path": "Circle USDC EIP-3009 bounded authorization",
     "smart_account_path": "wallet_sendCalls approve plus create or fund batch",
@@ -122,13 +131,14 @@
     "content-addressed terms and all contract commitments match",
     "confirmed BountyBecameClaimable evidence exists, or exact same-block status, target funding, and token balance reads prove claimability",
     "status remains claimable at the latest accepted observation",
+    "the feed reports verification_ready=true for an executable committed verification path",
     "solver can produce the committed evidence before the deadline",
     "solver wallet can post the indexed USDC claim bond"
   ],
   "payment_rails": [
     {
       "name": "Base native USDC",
-      "status": "pending autonomous-v1 mainnet deployment",
+      "status": "active on Base mainnet for externally signed wallet transactions",
       "role": "open funding, escrow, verifier rewards, and solver payouts"
     },
     {

--- a/site/autonomous.js
+++ b/site/autonomous.js
@@ -172,6 +172,43 @@
     return address ? requiredAddress(address, "Address") : null;
   }
 
+  function defaultVerification(protocol) {
+    const config = protocol.default_verification;
+    if (!config || config.mode !== "deterministic_module" || config.threshold !== 1) {
+      throw new Error("The active protocol does not declare a safe deterministic default.");
+    }
+    const module = protocol.deterministic_modules && protocol.deterministic_modules[config.module_id];
+    if (!module) throw new Error("The default deterministic verifier is unavailable.");
+    return {
+      ...config,
+      contract: requiredAddress(module.contract || "", "Deterministic verifier module"),
+    };
+  }
+
+  function configurePostVerification(form, protocol, account = null) {
+    if (!form) return;
+    const defaults = defaultVerification(protocol);
+    const mode = form.elements.verificationMode.value;
+    const deterministic = mode === "deterministic_module";
+    const module = form.elements.verifierModule;
+    const recipient = form.elements.verifierRewardRecipient;
+    const verifiers = form.elements.verifiers;
+    const threshold = form.elements.threshold;
+
+    module.value = defaults.contract;
+    module.readOnly = true;
+    module.disabled = !deterministic;
+    recipient.disabled = !deterministic;
+    verifiers.disabled = deterministic;
+    threshold.readOnly = deterministic;
+    if (deterministic) {
+      threshold.value = String(defaults.threshold);
+      if (defaults.verifier_reward_recipient === "creator_wallet" && account && !recipient.value.trim()) {
+        recipient.value = account;
+      }
+    }
+  }
+
   function parseJson(value, label) {
     try {
       return JSON.parse(value);
@@ -225,6 +262,13 @@
     const accounts = await walletRequest("eth_requestAccounts");
     if (!accounts || !accounts[0]) throw new Error("No wallet account was returned.");
     state.account = accounts[0];
+    configurePostVerification(
+      context.querySelector && context.querySelector("#autonomous-post-form")
+        ? context.querySelector("#autonomous-post-form")
+        : (context.id === "autonomous-post-form" ? context : byId("autonomous-post-form")),
+      protocol,
+      state.account,
+    );
     const current = await walletRequest("eth_chainId");
     if (String(current).toLowerCase() !== protocol.chain_id_hex.toLowerCase()) {
       try {
@@ -777,8 +821,10 @@
   }
 
   async function initialize() {
+    const postForm = byId("autonomous-post-form");
     try {
       const protocol = await loadProtocol();
+      configurePostVerification(postForm, protocol, state.account);
       document.querySelectorAll("[data-protocol-status]").forEach((element) => {
         element.textContent = protocol.status === "active" ? "Base mainnet active" : "Deployment pending review";
         element.dataset.tone = protocol.status === "active" ? "success" : "pending";
@@ -791,8 +837,16 @@
     } catch (_error) {
       // Individual actions surface configuration errors.
     }
-    const postForm = byId("autonomous-post-form");
-    if (postForm) postForm.addEventListener("submit", postBounty);
+    if (postForm) {
+      postForm.addEventListener("submit", postBounty);
+      postForm.elements.verificationMode.addEventListener("change", () => {
+        try {
+          configurePostVerification(postForm, state.protocol, state.account);
+        } catch (error) {
+          output(byId("autonomous-post-output"), error.message || String(error), "error");
+        }
+      });
+    }
     const fundForm = byId("autonomous-fund-form");
     if (fundForm) fundForm.addEventListener("submit", fundBounty);
     const submitForm = byId("autonomous-submit-form");

--- a/site/post.html
+++ b/site/post.html
@@ -91,9 +91,11 @@
               <label>
                 Mechanism
                 <select name="verificationMode">
-                  <option value="signed_quorum">Deterministic signed verifier</option>
-                  <option value="ai_judge_quorum">AI judge quorum</option>
-                  <option value="deterministic_module">On-chain verifier module</option>
+                  <option value="deterministic_module">Permissionless on-chain verifier</option>
+                  <optgroup label="Advanced verifier services">
+                    <option value="signed_quorum">Verifier wallet quorum (advanced)</option>
+                    <option value="ai_judge_quorum">AI judge quorum (advanced)</option>
+                  </optgroup>
                 </select>
               </label>
               <label>
@@ -108,7 +110,7 @@
             <div class="form-row">
               <label>
                 On-chain verifier module
-                <input name="verifierModule" placeholder="0x...">
+                <input name="verifierModule" placeholder="Loaded from active protocol" readonly>
               </label>
               <label>
                 Module reward wallet

--- a/site/protocol.json
+++ b/site/protocol.json
@@ -9,6 +9,12 @@
   "implementation": "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
   "deployment_transaction": "0x8c172a34188cc68cf61f7293825e3c93e025a029b878436d34aafd2103c2e70e",
   "deployment_block": 48496662,
+  "default_verification": {
+    "mode": "deterministic_module",
+    "module_id": "leading_zero_work_v1",
+    "verifier_reward_recipient": "creator_wallet",
+    "threshold": 1
+  },
   "deterministic_modules": {
     "leading_zero_work_v1": {
       "contract": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",


### PR DESCRIPTION
## Summary

- make the deployed permissionless deterministic verifier the default for new public bounties
- move signed and AI-judge quorum modes behind explicit advanced choices
- pin API and MCP Base-mainnet readiness/planning to the attested canonical factory and implementation, failing closed on configured-address drift
- publish the active Base USDC rail and verification-ready claimability requirement in machine-readable discovery
- add behavioral browser-form coverage for the wallet-first posting flow

## Contributor coordination

Maintainer notice: #209

Open contributor PRs were reviewed before this change. #206 and #167 had fresh constructive feedback; #158, #151, and #139 remain changes-requested. This change does not modify their primary files and no known conflict is expected.

Existing deployed bounty contracts are immutable and unchanged. This migration changes the default for newly posted bounties only.

## Verification

- `cargo test -p api`
- `cargo test -p mcp-server`
- `cargo test -p web-public`
- `node scripts/test-autonomous-wallet-flow.js`
- `python scripts/check-site.py`
- `cargo fmt --all -- --check`
- `powershell -ExecutionPolicy Bypass -File scripts/check.ps1`
- `RUN_MAINNET_FORK=true BASE_MAINNET_RPC_URL=https://mainnet.base.org forge test --root contracts/base-escrow --match-test testCanonicalMainnetPermissionlessPaidLoop -vv`
- desktop and mobile Playwright inspection of the posting form

Closes #209