### PR TITLE
Enforce a standing funded post-and-complete meta-bounty

### DIFF
--- a/.github/workflows/bounty-inventory-guard.yml
+++ b/.github/workflows/bounty-inventory-guard.yml
@@ -2,7 +2,7 @@ name: Bounty inventory guard
 
 on:
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "*/15 * * * *"
   workflow_dispatch:
   pull_request:
     paths:
@@ -10,6 +10,7 @@ on:
       - "scripts/test_bounty_inventory_guard.py"
       - "scripts/fixtures/bounty_inventory_*.json"
       - "skills/agent-bounties/scripts/check-in.mjs"
+      - "docs/standing-meta-bounty-invariant.md"
       - ".github/workflows/bounty-inventory-guard.yml"
 
 permissions:
@@ -42,12 +43,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           BOUNTY_INVENTORY_THRESHOLD: "5"
+          META_BOUNTY_INVENTORY_THRESHOLD: "1"
+          META_BOUNTY_REPLENISHMENT_TARGET: "2"
         run: |
           python scripts/bounty_inventory_guard.py \
             --claimable-report claimable-inventory.json \
             --json-out bounty-inventory-report.json \
             --md-out bounty-inventory-report.md
-      - name: Publish liquidity status without blocking deployment
+      - name: Enforce claimable and standing meta-bounty floors
         run: |
           python - <<'PY'
           import json
@@ -60,15 +63,29 @@ jobs:
               f"{report['threshold']}; protocol={report['protocol_status']}; "
               f"evidence_valid={str(report['inventory_evidence_valid']).lower()}"
           )
+          meta_status = (
+              f"standing meta-bounties: {report['verified_meta_claimable_count']}/"
+              f"{report['meta_threshold']} floor; "
+              f"target={report['meta_replenishment_target']}"
+          )
           if report["below_threshold"]:
-              print(f"::warning title=Claimable bounty floor not met::{status}")
+              print(f"::error title=Bounty inventory invariant not met::{status}; {meta_status}")
+          elif report["meta_replenishment_required"]:
+              print(f"::warning title=Standing meta-bounty buffer needs replenishment::{meta_status}")
           else:
-              print(status)
+              print(f"{status}; {meta_status}")
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
               summary.write("## Claimable bounty liquidity\n\n")
               summary.write(f"- {status}\n")
+              summary.write(f"- {meta_status}\n")
               summary.write(f"- below threshold: {str(report['below_threshold']).lower()}\n")
+              summary.write(
+                  "- meta replenishment required: "
+                  f"{str(report['meta_replenishment_required']).lower()}\n"
+              )
               summary.write("- GitHub issues are candidate supply, not funding evidence.\n")
+          if report["below_threshold"]:
+              raise SystemExit(2)
           PY
       - name: Upload report artifacts
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ digital work, and receive settlement through trusted payment rails.
 ## Payment Invariants
 
 - A paid bounty must be funded before claim.
+- Maintain at least one canonically funded, claimable standing meta-bounty that
+  pays only after its solver posts a qualifying child bounty and a different
+  wallet completes that child and receives canonical settlement. Replenish at
+  two; see `docs/standing-meta-bounty-invariant.md`.
 - The solver bond equals one positive verifier reward. Pass and fail verdicts
   pay verifiers equally; rejection must leave the bounty fully funded.
 - Claim timeout forfeits the bond to the completion/refund bonus pool;

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -982,6 +982,8 @@ If hosted protocol status is not active, run the portable inventory helper. Do n
 
 For a distribution-loop bounty, call `plan_autonomous_canonical_child_terms` first. It derives the task-specific criteria and parent-round benchmark. The parent passes only after the child preserves the parent solver reward, is fully funded, and a different wallet completes it and receives canonical settlement.
 
+Agent Bounties maintains a standing funded post-and-complete meta-bounty when canonical inventory is available. Claiming it rewards you for posting useful funded work that another wallet completes and gets paid for. Look for the `standing_meta_bounty` marker in verified claimable inventory; never infer it from a GitHub label alone.
+
 If hosted planning is unavailable, the repository CLI command above verifies exact factory code and immutable getters at one Base `safe` block, validates terms against that block time, and emits the same unsigned wallet batch plus registration payload. It refuses a pending or mismatched deployment and never treats output as funding.
 
 ## Verify

--- a/deployments/canonical-child-verifier-base-mainnet-deployment.json
+++ b/deployments/canonical-child-verifier-base-mainnet-deployment.json
@@ -4,7 +4,7 @@
   "network": "base-mainnet",
   "chain_id": 8453,
   "source": "contracts/base-escrow/src/CanonicalChildBountyVerifier.sol:CanonicalChildBountyVerifier",
-  "source_commit": "9f44018ae56c6d3ad8cbf93c2c24e2edfd4cd644",
+  "source_commit": "eea06e72dbdc1f647ad4aa3dac2a9f5ed93f67c8",
   "canonical_factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
   "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
   "acceptance_criteria_hash": "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de",

--- a/docs/evidence/canonical-child-seeds-mainnet-fork-2026-07-13.json
+++ b/docs/evidence/canonical-child-seeds-mainnet-fork-2026-07-13.json
@@ -1,8 +1,8 @@
 {
   "bounties": [
     {
-      "bounty_id": "0xb08f071ebf886f151b9b1d1b86b80df8c2d975bf1141406a4b92184252a873cb",
-      "contract": "0xdf31fff9b19eb36e57fcde60ae24900355097f77",
+      "bounty_id": "0x051117b7e4b2804155c40a3ea5b575c002e82a6ef0f916c5a0b8e06a00981225",
+      "contract": "0xc003cd82625fd04741894f35673a26db8a1f4437",
       "funded": 1000000,
       "issue": 217,
       "status": "claimable",
@@ -10,8 +10,8 @@
       "verifier_module": "0x40adac5a1d00a725f77682f8940b893eaed31ecf"
     },
     {
-      "bounty_id": "0x367fa664e51a8e98a38209a4d825956a3bd0b328e83d2eed7ef24fe15e9b152a",
-      "contract": "0x93a35019a30c175b504fbc03fb0a56a58da5b8bf",
+      "bounty_id": "0xc8639e6246dd69888ef49b9bf1d523a0d1c948631159a83e49a75a1714f0ba5d",
+      "contract": "0x0e919fd268ce865fc8e434022a2c7d410d26afae",
       "funded": 1000000,
       "issue": 218,
       "status": "claimable",
@@ -19,8 +19,8 @@
       "verifier_module": "0x40adac5a1d00a725f77682f8940b893eaed31ecf"
     },
     {
-      "bounty_id": "0xa36f90cbe94060c3032de41fe14f2a273791ae7e780951f916b1741f2b5ee61f",
-      "contract": "0x2103f61fa3764b8dffd5f48aa5f8e93b97e0d6d6",
+      "bounty_id": "0x74c85776463c5498f8ddec328791499794fbd93744c14e49a21c843991717fe2",
+      "contract": "0x4340ec8281a5fe9628a504d2de2115345b516cea",
       "funded": 1000000,
       "issue": 219,
       "status": "claimable",
@@ -28,8 +28,8 @@
       "verifier_module": "0x40adac5a1d00a725f77682f8940b893eaed31ecf"
     },
     {
-      "bounty_id": "0xd5e4987aba1cac651207b917c298e0d13e42d760c526191c621142d2119ed5f7",
-      "contract": "0x0e8c005a4adc18179f3eeea508f4806a8246d796",
+      "bounty_id": "0x687cbb2519e509df727f7491ecb3a9d186d6528a482bac337124a521fd0e6630",
+      "contract": "0xafac1296f884373b8362df88db6d75c997bc79d2",
       "funded": 1000000,
       "issue": 220,
       "status": "claimable",
@@ -45,14 +45,14 @@
   "evidence_boundary": "Fork transaction hashes are rehearsal evidence only and do not prove mainnet funding or payout.",
   "factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
   "factory_source": "existing",
-  "fork_block": 48568276,
+  "fork_block": 48567240,
   "implementation": "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
   "network": "base-mainnet-fork",
   "portable_creation_plan": {
-    "bounty_id": "0xb08f071ebf886f151b9b1d1b86b80df8c2d975bf1141406a4b92184252a873cb",
+    "bounty_id": "0x051117b7e4b2804155c40a3ea5b575c002e82a6ef0f916c5a0b8e06a00981225",
     "evidence_boundary": "The checked-in Rust-generated batch is replayed below. Production safe-block factory attestation is verified separately because Anvil historical account proofs are incomplete after local fork mutation.",
     "issue": 217,
-    "predicted_bounty_contract": "0xdf31fff9b19eb36e57fcde60ae24900355097f77",
+    "predicted_bounty_contract": "0xc003cd82625fd04741894f35673a26db8a1f4437",
     "schema_version": "agent-bounties/autonomous-activation-bundle-v1",
     "wallet_call_count": 2
   },
@@ -65,17 +65,17 @@
     },
     {
       "function": "createBounty((uint256,uint256,bytes32,bytes32,bytes32,bytes32,bytes32,uint64,uint64,uint64,uint8,address,address,uint8),address[],uint256,bytes32)",
-      "gas_used": 625354,
+      "gas_used": 625378,
       "log_count": 7
     },
     {
       "function": "createBounty((uint256,uint256,bytes32,bytes32,bytes32,bytes32,bytes32,uint64,uint64,uint64,uint8,address,address,uint8),address[],uint256,bytes32)",
-      "gas_used": 625354,
+      "gas_used": 625378,
       "log_count": 7
     },
     {
       "function": "createBounty((uint256,uint256,bytes32,bytes32,bytes32,bytes32,bytes32,uint64,uint64,uint64,uint8,address,address,uint8),address[],uint256,bytes32)",
-      "gas_used": 625354,
+      "gas_used": 625342,
       "log_count": 7
     },
     {
@@ -86,8 +86,8 @@
   ],
   "verifier": {
     "contract": "0x40adac5a1d00a725f77682f8940b893eaed31ecf",
-    "gas_used": 1643013,
-    "runtime_code_hash": "0x6a76885f5bc79fced62a954c158aa3a9666c5f1dc4959b3ea4971719f948f4e3",
-    "transaction": "0x377f7e9eb4004529b2aff9e0f97b5d7f6580782120823c5fa4758368da058887"
+    "gas_used": 1593538,
+    "runtime_code_hash": "0xbb6d6df11b85f59b5010aa61f4caf499fb27b94a0f5978aff85fa97ed2bbd2c3",
+    "transaction": "0xc25cccbde058d552cac518cd49230f89abb69fcf052c1b1b60ce8d6daacc1f42"
   }
 }

--- a/docs/standing-meta-bounty-invariant.md
+++ b/docs/standing-meta-bounty-invariant.md
@@ -1,0 +1,68 @@
+# Standing Meta-Bounty Invariant
+
+Agent Bounties maintains a funded incentive for participants to create useful
+bounties that a different participant completes.
+
+## Inventory Rule
+
+- Hard floor: at least one canonical, fully funded, claimable standing
+  meta-bounty on Base mainnet.
+- Replenishment target: at least two qualifying meta-bounties. The second
+  bounty preserves claimable supply while the first is being claimed.
+- A GitHub issue, unsigned transaction plan, wallet signature, broadcast hash,
+  or indexed bounty without canonical funding evidence does not count.
+- An ordinary funded bounty does not count toward the standing meta-bounty
+  floor.
+
+The inventory guard runs every 15 minutes. Zero qualifying meta-bounties fails
+the workflow. One satisfies the hard floor but raises a replenishment warning.
+Two or more satisfies the current operating target.
+
+## Qualifying Outcome
+
+A qualifying standing meta-bounty uses the exact deployed
+`CanonicalChildBountyVerifier` runtime and locked acceptance criteria. Its
+solver is paid only after all of these conditions are true:
+
+1. The solver creates a canonical autonomous-v1 child bounty.
+2. The child is fully funded to at least the parent solver reward. Pooled
+   funding is allowed.
+3. The child benchmark is bound to the parent bounty and round, and the child
+   uses its own explicit deterministic verifier.
+4. A different wallet completes the child and receives canonical settlement
+   before the parent verification deadline.
+
+This makes posting new funded work and attracting another participant the
+measurable work product. A solver cannot complete the required child loop with
+the same wallet. This address-level separation does not prove unrelated
+beneficial ownership, so standing rewards remain deliberately small and public
+analytics should flag repeated wallet clusters rather than claiming Sybil
+resistance.
+
+## Evidence Boundary
+
+The portable inventory verifier marks a bounty as `standing_meta_bounty` only
+after it verifies:
+
+- canonical claimability and complete funding;
+- content-addressed terms matching the on-chain commitments;
+- the canonical child verifier address and acceptance criteria;
+- the verifier's exact runtime code hash at a Base `safe` block; and
+- the explicit different-wallet and settled-child requirements.
+
+The guard rejects malformed or spoofed standing-meta descriptors. Only a
+confirmed canonical `BountySettled` event proves eventual payout.
+
+## Replenishment
+
+When inventory falls below two, replenishment is the highest-priority liquidity
+operation. Create and fully fund another canonical child-loop bounty, publish
+its terms, and wait for canonical indexing before counting it.
+
+The current autonomous-v1 contracts do not atomically reserve a replacement
+when the final claimable meta-bounty is claimed. The two-bounty target and
+15-minute fail-closed monitor reduce that gap but cannot eliminate simultaneous
+claim risk. An absolute always-claimable guarantee requires a future on-chain
+inventory coordinator or preauthorized replenishment reserve. Until then,
+public status must distinguish the hard monitored floor from an atomic
+guarantee.

--- a/scripts/bounty_inventory_guard.py
+++ b/scripts/bounty_inventory_guard.py
@@ -38,18 +38,36 @@ ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
 BYTES32 = re.compile(r"^0x[0-9a-fA-F]{64}$")
 CLAIMABLE_EVIDENCE = "confirmed_canonical_autonomous_bounty"
 MAX_REPORT_AGE_SECONDS = 900
+STANDING_META_SCHEMA = "agent-bounties/standing-meta-bounty-v1"
+STANDING_META_CLASS = "post_bounty_third_party_completion"
+STANDING_META_PROTOCOL = "agent-bounties/canonical-child-v1"
+STANDING_META_VERIFIER = "0x40adac5a1d00a725f77682f8940b893eaed31ecf"
+STANDING_META_VERIFIER_CODE_HASH = (
+    "0xbb6d6df11b85f59b5010aa61f4caf499fb27b94a0f5978aff85fa97ed2bbd2c3"
+)
+STANDING_META_ACCEPTANCE_HASH = (
+    "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de"
+)
 
 
 @dataclass
 class InventoryReport:
     repository: str
     threshold: int
+    meta_threshold: int
+    meta_replenishment_target: int
     open_bounty_count: int
     verified_claimable_count: int
+    verified_meta_claimable_count: int
     missing_count: int
+    meta_missing_count: int
+    meta_replenishment_count: int
     below_threshold: bool
+    meta_below_threshold: bool
+    meta_replenishment_required: bool
     issue_urls: list[str]
     claimable_bounty_ids: list[str]
+    meta_claimable_bounty_ids: list[str]
     excluded_count: int
     protocol_status: str
     inventory_evidence_valid: bool
@@ -59,13 +77,18 @@ class InventoryReport:
     def to_markdown(self) -> str:
         status = "BELOW THRESHOLD" if self.below_threshold else "OK"
         lines = [
-            f"# Bounty inventory guard — {status}",
+            f"# Bounty inventory guard - {status}",
             "",
             f"- Repository: `{self.repository}`",
             f"- Open actionable `bounty` issues (candidate supply): **{self.open_bounty_count}**",
             f"- Verified canonical claimable bounties: **{self.verified_claimable_count}**",
             f"- Claimable threshold: **{self.threshold}**",
             f"- Missing claimable bounties: **{self.missing_count}**",
+            f"- Verified standing meta-bounties: **{self.verified_meta_claimable_count}**",
+            f"- Standing meta-bounty floor: **{self.meta_threshold}**",
+            f"- Standing meta-bounty replenishment target: **{self.meta_replenishment_target}**",
+            f"- Missing from hard meta floor: **{self.meta_missing_count}**",
+            f"- Missing from meta replenishment target: **{self.meta_replenishment_count}**",
             f"- Excluded (non-actionable labels): **{self.excluded_count}**",
             f"- Protocol status: `{self.protocol_status}`",
             f"- Inventory evidence valid: **{str(self.inventory_evidence_valid).lower()}**",
@@ -79,6 +102,11 @@ class InventoryReport:
         lines.extend(["", "## Verified claimable bounty IDs"])
         if self.claimable_bounty_ids:
             lines.extend(f"- `{bounty_id}`" for bounty_id in self.claimable_bounty_ids)
+        else:
+            lines.append("- _(none)_")
+        lines.extend(["", "## Verified standing meta-bounty IDs"])
+        if self.meta_claimable_bounty_ids:
+            lines.extend(f"- `{bounty_id}`" for bounty_id in self.meta_claimable_bounty_ids)
         else:
             lines.append("- _(none)_")
         lines.extend(
@@ -109,6 +137,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=int(os.environ.get("BOUNTY_INVENTORY_THRESHOLD", "5")),
         help="Minimum verified canonical claimable bounties (default 5)",
+    )
+    p.add_argument(
+        "--meta-threshold",
+        type=int,
+        default=int(os.environ.get("META_BOUNTY_INVENTORY_THRESHOLD", "1")),
+        help="Hard floor for funded, claimable standing meta-bounties (default 1)",
+    )
+    p.add_argument(
+        "--meta-replenishment-target",
+        type=int,
+        default=int(os.environ.get("META_BOUNTY_REPLENISHMENT_TARGET", "2")),
+        help="Target that creates a buffer above the standing meta-bounty floor (default 2)",
     )
     p.add_argument(
         "--claimable-report",
@@ -294,6 +334,55 @@ def verified_claimable_entries(report: object) -> tuple[list[dict[str, Any]], bo
     return verified, True, protocol_status
 
 
+def standing_meta_entries(
+    claimable: list[dict[str, Any]],
+    *,
+    direct_block: object = None,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Return exact-code canonical child-loop inventory; reject malformed claims."""
+    direct = direct_block if isinstance(direct_block, dict) else None
+    meta: list[dict[str, Any]] = []
+    for item in claimable:
+        descriptor = item.get("standing_meta_bounty")
+        if descriptor is None:
+            continue
+        if not isinstance(descriptor, dict):
+            return [], False
+        block_number = descriptor.get("observed_block_number")
+        block_hash = str(descriptor.get("observed_block_hash") or "").lower()
+        valid = (
+            descriptor.get("schema_version") == STANDING_META_SCHEMA
+            and descriptor.get("inventory_class") == STANDING_META_CLASS
+            and descriptor.get("verifier_protocol") == STANDING_META_PROTOCOL
+            and str(descriptor.get("verifier_module") or "").lower()
+            == STANDING_META_VERIFIER
+            and str(descriptor.get("verifier_runtime_code_hash") or "").lower()
+            == STANDING_META_VERIFIER_CODE_HASH
+            and str(descriptor.get("acceptance_criteria_hash") or "").lower()
+            == STANDING_META_ACCEPTANCE_HASH
+            and descriptor.get("requires_funded_canonical_child") is True
+            and descriptor.get("requires_different_solver_wallet") is True
+            and descriptor.get("required_child_status") == "settled"
+            and item.get("verification_mode") == "deterministic_module"
+            and str(item.get("verifier_module") or "").lower()
+            == STANDING_META_VERIFIER
+            and item.get("verification_ready") is True
+            and isinstance(block_number, int)
+            and not isinstance(block_number, bool)
+            and block_number > 0
+            and BYTES32.fullmatch(block_hash)
+        )
+        if direct is not None:
+            valid = valid and (
+                block_number == direct.get("number")
+                and block_hash == str(direct.get("hash") or "").lower()
+            )
+        if not valid:
+            return [], False
+        meta.append(item)
+    return meta, True
+
+
 def fetch_open_issues(repository: str, token: str | None) -> list[dict[str, Any]]:
     """Paginate GitHub REST issues with label bounty, state open."""
     owner, _, repo = repository.partition("/")
@@ -338,6 +427,8 @@ def fetch_open_issues(repository: str, token: str | None) -> list[dict[str, Any]
 def build_report(
     repository: str,
     threshold: int,
+    meta_threshold: int,
+    meta_replenishment_target: int,
     issues: list[dict[str, Any]],
     claimable_report: object = None,
 ) -> InventoryReport:
@@ -354,20 +445,47 @@ def build_report(
     urls = [issue_url(i, repository) for i in actionable]
     issue_count = len(actionable)
     claimable, evidence_valid, protocol_status = verified_claimable_entries(claimable_report)
+    direct_block = (
+        claimable_report.get("direct_chain_observed_block")
+        if isinstance(claimable_report, dict)
+        and claimable_report.get("protocol_source") == "direct_safe_chain"
+        else None
+    )
+    meta_claimable, meta_evidence_valid = standing_meta_entries(
+        claimable, direct_block=direct_block
+    )
+    evidence_valid = evidence_valid and meta_evidence_valid
     claimable_count = len(claimable)
+    meta_claimable_count = len(meta_claimable)
     missing = max(0, threshold - claimable_count)
-    below = not evidence_valid or claimable_count < threshold
+    meta_missing = max(0, meta_threshold - meta_claimable_count)
+    meta_replenishment = max(0, meta_replenishment_target - meta_claimable_count)
+    meta_below = not evidence_valid or meta_claimable_count < meta_threshold
+    below = not evidence_valid or claimable_count < threshold or meta_below
     if not evidence_valid:
         action = (
             "Restore a fresh, active protocol and canonical inventory feed before "
             "counting liquidity. Candidate issues cannot substitute for missing or "
             "invalid on-chain evidence."
         )
-    elif below:
+    elif meta_below:
+        action = (
+            f"Activate, fully fund, and canonically index at least {meta_missing} "
+            "standing meta-bounty contract(s). Each must use the exact canonical "
+            "child-loop verifier and pay only after a different wallet completes "
+            "the solver-created child bounty and receives canonical settlement."
+        )
+    elif claimable_count < threshold:
         action = (
             f"Activate, fund, and canonically index at least {missing} more claimable "
             f"bounty contract(s). Open GitHub issues are candidate supply and do not "
             f"satisfy this liquidity threshold."
+        )
+    elif meta_replenishment:
+        action = (
+            f"The hard standing meta-bounty floor is satisfied. Replenish "
+            f"{meta_replenishment} additional standing meta-bounty contract(s) to "
+            "restore the buffer before the live one is claimed."
         )
     else:
         action = (
@@ -384,12 +502,20 @@ def build_report(
     return InventoryReport(
         repository=repository,
         threshold=threshold,
+        meta_threshold=meta_threshold,
+        meta_replenishment_target=meta_replenishment_target,
         open_bounty_count=issue_count,
         verified_claimable_count=claimable_count,
+        verified_meta_claimable_count=meta_claimable_count,
         missing_count=missing,
+        meta_missing_count=meta_missing,
+        meta_replenishment_count=meta_replenishment,
         below_threshold=below,
+        meta_below_threshold=meta_below,
+        meta_replenishment_required=meta_replenishment > 0,
         issue_urls=urls,
         claimable_bounty_ids=[str(item["id"]) for item in claimable],
+        meta_claimable_bounty_ids=[str(item["id"]) for item in meta_claimable],
         excluded_count=excluded,
         protocol_status=protocol_status,
         inventory_evidence_valid=evidence_valid,
@@ -417,6 +543,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.threshold < 0:
         raise SystemExit("threshold must be >= 0")
+    if args.meta_threshold < 0:
+        raise SystemExit("meta-threshold must be >= 0")
+    if args.meta_replenishment_target < args.meta_threshold:
+        raise SystemExit("meta-replenishment-target must be >= meta-threshold")
 
     if args.fixture:
         issues = load_fixture(args.fixture)
@@ -427,6 +557,8 @@ def main(argv: list[str] | None = None) -> int:
     report = build_report(
         args.repository,
         args.threshold,
+        args.meta_threshold,
+        args.meta_replenishment_target,
         issues,
         load_claimable_report(args.claimable_report),
     )

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   collectInventory,
   normalizeApiBaseUrl,
+  STANDING_META_BOUNTY,
   verifyClaimableItem,
   verifyDirectChainInventory,
 } from "../skills/agent-bounties/scripts/check-in.mjs";
@@ -41,6 +42,7 @@ async function permissionlessDirectManifest() {
   for (const bounty of manifest.bounties) {
     bounty.verification_mode = "deterministic_module";
     bounty.verifier_module = "0x8888888888888888888888888888888888888888";
+    bounty.verifier_runtime_code_hash = `0x${"77".repeat(32)}`;
   }
   return manifest;
 }
@@ -100,6 +102,7 @@ function directTransport(manifest, mutate = null) {
           verifier_module: abiAddress(
             bounty.verifier_module || "0x0000000000000000000000000000000000000000",
           ),
+          verifier_proof: { codeHash: bounty.verifier_runtime_code_hash },
           token_balance: abiWord(bounty.target_minor),
           solver_balance: abiWord(500000),
           allowance: abiWord(0),
@@ -111,6 +114,39 @@ function directTransport(manifest, mutate = null) {
     }
     return results;
   };
+}
+
+function standingMetaTransport(runtimeCodeHash = STANDING_META_BOUNTY.verifierRuntimeCodeHash) {
+  return async (_rpcUrl, calls) => new Map(calls.map((call) => {
+    if (call.key === "standing_meta_safe_block") {
+      return [call.key, {
+        number: "0x12345",
+        hash: `0x${"dd".repeat(32)}`,
+      }];
+    }
+    assert.equal(call.key, "standing_meta_verifier_proof");
+    return [call.key, { codeHash: runtimeCodeHash }];
+  }));
+}
+
+function makeHostedStandingMetaCandidate(item) {
+  item.verifier_module = STANDING_META_BOUNTY.verifierModule;
+  item.terms.document.acceptance_criteria = [...STANDING_META_BOUNTY.acceptanceCriteria];
+  item.terms.document.benchmark = {
+    engine: "canonical_child_loop_v1",
+    required_child_status: "settled",
+    verifier_module: STANDING_META_BOUNTY.verifierModule,
+  };
+  item.terms.document.evidence_schema = {
+    type: "object",
+    required: ["child_bounty_contract"],
+  };
+  item.terms.document.verification_policy = {
+    mechanism: "deterministic_module",
+    verifier_module: STANDING_META_BOUNTY.verifierModule,
+    threshold: 1,
+  };
+  return item;
 }
 
 test("portable skill metadata and install contracts remain publishable", async () => {
@@ -344,6 +380,40 @@ test("direct safe-chain verifier excludes one bounty with altered terms", async 
   assert.deepEqual(report.excluded.map((item) => item.id), [manifest.bounties[0].bounty_id]);
 });
 
+test("direct safe-chain inventory marks only the exact canonical child verifier as meta", async () => {
+  const manifest = await permissionlessDirectManifest();
+  const bounty = manifest.bounties[0];
+  bounty.verifier_module = STANDING_META_BOUNTY.verifierModule;
+  bounty.verifier_runtime_code_hash = STANDING_META_BOUNTY.verifierRuntimeCodeHash;
+  bounty.acceptance_criteria_hash = STANDING_META_BOUNTY.acceptanceCriteriaHash;
+  const report = await verifyDirectChainInventory({
+    manifest,
+    rpcUrl: "https://rpc.example.test",
+    rpcTransport: directTransport(manifest),
+  });
+
+  assert.equal(report.verified.length, 1);
+  assert.equal(
+    report.verified[0].standing_meta_bounty.inventory_class,
+    STANDING_META_BOUNTY.inventoryClass,
+  );
+  assert.equal(report.verified[0].standing_meta_bounty.requires_different_solver_wallet, true);
+});
+
+test("direct safe-chain inventory rejects deterministic verifier bytecode drift", async () => {
+  const manifest = await permissionlessDirectManifest();
+  const report = await verifyDirectChainInventory({
+    manifest,
+    rpcUrl: "https://rpc.example.test",
+    rpcTransport: directTransport(manifest, (key, value) => (
+      key.endsWith("_verifier_proof") ? { codeHash: `0x${"66".repeat(32)}` } : value
+    )),
+  });
+
+  assert.equal(report.verified.length, 0);
+  assert.equal(report.excluded.length, manifest.bounties.length);
+});
+
 test("unavailable hosted services fall back to direct safe-chain inventory", async () => {
   const manifest = await permissionlessDirectManifest();
   const report = await collectInventory({
@@ -418,6 +488,38 @@ test("only active canonical autonomous inventory is claimable", async () => {
   assert.equal(report.recommended_action, "claim_verified_bounty");
   assert.equal(report.funding_candidates.length, 1);
   assert.equal(report.live_verification_jobs.length, 1);
+});
+
+test("hosted inventory emits a standing meta marker after exact-code safe-block attestation", async () => {
+  const input = await fixture("verified-claimable.json");
+  makeHostedStandingMetaCandidate(input.autonomous_feed.body[0]);
+  const report = await collectInventory({
+    apiBaseUrl: "https://api.example.test",
+    fixture: input,
+    baseRpcUrl: "https://rpc.example.test",
+    rpcTransport: standingMetaTransport(),
+  });
+
+  const meta = report.verified_claimable_bounties[0].standing_meta_bounty;
+  assert.equal(meta.schema_version, STANDING_META_BOUNTY.schemaVersion);
+  assert.equal(meta.inventory_class, STANDING_META_BOUNTY.inventoryClass);
+  assert.equal(meta.observed_block_number, 0x12345);
+  assert.ok(!report.warnings.includes("standing_meta_verifier_attestation_failed"));
+});
+
+test("hosted meta-looking terms do not count when verifier bytecode differs", async () => {
+  const input = await fixture("verified-claimable.json");
+  makeHostedStandingMetaCandidate(input.autonomous_feed.body[0]);
+  const report = await collectInventory({
+    apiBaseUrl: "https://api.example.test",
+    fixture: input,
+    baseRpcUrl: "https://rpc.example.test",
+    rpcTransport: standingMetaTransport(`0x${"66".repeat(32)}`),
+  });
+
+  assert.equal(report.verified_claimable_bounties.length, 1);
+  assert.equal(report.verified_claimable_bounties[0].standing_meta_bounty, undefined);
+  assert.ok(report.warnings.includes("standing_meta_verifier_code_mismatch"));
 });
 
 test("hosted quorum bounty is excluded without a service availability attestation", async () => {

--- a/scripts/test_bounty_inventory_guard.py
+++ b/scripts/test_bounty_inventory_guard.py
@@ -16,8 +16,13 @@ FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 
 def run_guard(*args: str) -> subprocess.CompletedProcess[str]:
+    resolved = list(args)
+    if "--meta-threshold" not in resolved:
+        resolved.extend(["--meta-threshold", "0"])
+    if "--meta-replenishment-target" not in resolved:
+        resolved.extend(["--meta-replenishment-target", "0"])
     return subprocess.run(
-        [sys.executable, str(SCRIPT), *args],
+        [sys.executable, str(SCRIPT), *resolved],
         cwd=str(ROOT),
         capture_output=True,
         text=True,
@@ -34,6 +39,46 @@ def current_claimable_report(name: str, *, bom: bool = False) -> Path:
         json.dumps(data),
         encoding="utf-8-sig" if bom else "utf-8",
     )
+    return target
+
+
+def standing_meta_report(*, corrupt_code_hash: bool = False) -> Path:
+    data = json.loads(
+        (FIXTURES / "bounty_inventory_claimable_above.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    data["observed_at"] = datetime.now(timezone.utc).isoformat()
+    item = data["verified_claimable_bounties"][0]
+    item.update(
+        {
+            "verification_mode": "deterministic_module",
+            "verifier_module": "0x40adac5a1d00a725f77682f8940b893eaed31ecf",
+            "verification_ready": True,
+            "standing_meta_bounty": {
+                "schema_version": "agent-bounties/standing-meta-bounty-v1",
+                "inventory_class": "post_bounty_third_party_completion",
+                "verifier_protocol": "agent-bounties/canonical-child-v1",
+                "verifier_module": "0x40adac5a1d00a725f77682f8940b893eaed31ecf",
+                "verifier_runtime_code_hash": (
+                    "0x" + "66" * 32
+                    if corrupt_code_hash
+                    else "0xbb6d6df11b85f59b5010aa61f4caf499fb27b94a0f5978aff85fa97ed2bbd2c3"
+                ),
+                "acceptance_criteria_hash": "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de",
+                "requires_funded_canonical_child": True,
+                "requires_different_solver_wallet": True,
+                "required_child_status": "settled",
+                "observed_block_number": 74565,
+                "observed_block_hash": "0x" + "dd" * 32,
+            },
+        }
+    )
+    target = ROOT / "target" / "tmp" / (
+        "standing-meta-corrupt.json" if corrupt_code_hash else "standing-meta.json"
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(data), encoding="utf-8")
     return target
 
 
@@ -74,6 +119,67 @@ class BountyInventoryGuardTests(unittest.TestCase):
         self.assertFalse(payload["below_threshold"])
         self.assertEqual(payload["missing_count"], 0)
         self.assertIn("does not imply", payload["disclaimer"].lower())
+
+    def test_standing_meta_floor_and_replenishment_buffer(self) -> None:
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "5",
+            "--meta-threshold",
+            "1",
+            "--meta-replenishment-target",
+            "2",
+            "--claimable-report",
+            str(standing_meta_report()),
+            "--fail-below",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr + proc.stdout)
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        self.assertEqual(payload["verified_meta_claimable_count"], 1)
+        self.assertFalse(payload["meta_below_threshold"])
+        self.assertTrue(payload["meta_replenishment_required"])
+        self.assertEqual(payload["meta_replenishment_count"], 1)
+        self.assertFalse(payload["below_threshold"])
+
+    def test_general_inventory_cannot_substitute_for_standing_meta_floor(self) -> None:
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "5",
+            "--meta-threshold",
+            "1",
+            "--meta-replenishment-target",
+            "2",
+            "--claimable-report",
+            str(current_claimable_report("bounty_inventory_claimable_above.json")),
+            "--fail-below",
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr + proc.stdout)
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        self.assertEqual(payload["verified_claimable_count"], 5)
+        self.assertEqual(payload["verified_meta_claimable_count"], 0)
+        self.assertTrue(payload["meta_below_threshold"])
+
+    def test_spoofed_standing_meta_descriptor_invalidates_evidence(self) -> None:
+        proc = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "5",
+            "--meta-threshold",
+            "1",
+            "--meta-replenishment-target",
+            "2",
+            "--claimable-report",
+            str(standing_meta_report(corrupt_code_hash=True)),
+            "--fail-below",
+        )
+        self.assertEqual(proc.returncode, 2, proc.stderr + proc.stdout)
+        payload = json.loads(proc.stdout.split("--- JSON ---", 1)[1])
+        self.assertFalse(payload["inventory_evidence_valid"])
+        self.assertEqual(payload["verified_meta_claimable_count"], 0)
 
     def test_below_threshold_fail_below(self) -> None:
         proc = run_guard(

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -71,6 +71,8 @@ Relay the emitted `module_settlement_request` through `plan_autonomous_module_se
 
 For a post-and-complete meta-bounty, call `plan_autonomous_canonical_child_terms` first. It derives the parent-bound benchmark and validates the child's explicit task criteria. The parent passes only after the child target preserves the parent solver reward and a different wallet completes the child through its deterministic verifier and receives canonical settlement.
 
+Agent Bounties maintains a standing funded post-and-complete meta-bounty when canonical inventory is available. Claiming it rewards you for posting useful funded work that another wallet completes and gets paid for. Look for the `standing_meta_bounty` marker in verified claimable inventory; never infer it from a GitHub label alone.
+
 If hosted planning is unavailable, the repository CLI command above verifies exact factory code and immutable getters at one Base `safe` block, validates terms against that block time, and emits the same unsigned wallet batch plus registration payload. It refuses a pending or mismatched deployment and never treats output as funding.
 
 Each canonical bounty is an isolated deterministic minimal-proxy contract. Its terms and verifier policy cannot be changed after creation. A valid pass pays the solver and verifiers; a valid fail pays verifiers, uses the solver bond to replace the verifier reserve, and reopens the still-funded bounty. Acceptance or verifier timeout returns the bond. A no-submission claim timeout forfeits it into the next solver's completion bonus, or pro-rata funder refunds after cancellation. No settlement operator is involved.

--- a/skills/agent-bounties/scripts/check-in.mjs
+++ b/skills/agent-bounties/scripts/check-in.mjs
@@ -10,6 +10,21 @@ export const DEFAULT_BASE_RPC_URL = "https://mainnet.base.org";
 const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
 const HASH = /^0x[0-9a-fA-F]{64}$/;
 const EMPTY_CODE_HASH = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+const TERMS_SOURCE_COMMIT = "eea06e72dbdc1f647ad4aa3dac2a9f5ed93f67c8";
+export const STANDING_META_BOUNTY = Object.freeze({
+  schemaVersion: "agent-bounties/standing-meta-bounty-v1",
+  inventoryClass: "post_bounty_third_party_completion",
+  verifierProtocol: "agent-bounties/canonical-child-v1",
+  verifierModule: "0x40adac5a1d00a725f77682f8940b893eaed31ecf",
+  verifierRuntimeCodeHash: "0xbb6d6df11b85f59b5010aa61f4caf499fb27b94a0f5978aff85fa97ed2bbd2c3",
+  acceptanceCriteriaHash: "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de",
+  acceptanceCriteria: Object.freeze([
+    "Post a canonical autonomous-v1 child bounty whose creator is the active solver.",
+    "Fully fund the child to at least the parent solver reward; pooled contributors are allowed.",
+    "Bind the child benchmark to the parent bounty ID and round and use an explicit deterministic verifier.",
+    "Have a different wallet complete the child and receive canonical settlement before the parent verification deadline.",
+  ]),
+});
 const CHAIN_MANIFEST_URL = new URL("../fixtures/base-mainnet-canaries.json", import.meta.url);
 const SELECTOR = Object.freeze({
   acceptanceCriteriaHash: "0x8a2b02be",
@@ -237,7 +252,10 @@ function validateChainManifest(manifest) {
       || !["deterministic_module", "signed_quorum", "ai_judge_quorum"]
         .includes(bounty.verification_mode)
       || (bounty.verification_mode === "deterministic_module"
-        && !ADDRESS.test(bounty.verifier_module || ""))
+        && (
+          !ADDRESS.test(bounty.verifier_module || "")
+          || !HASH.test(bounty.verifier_runtime_code_hash || "")
+        ))
       || amounts.some((amount) => !Number.isSafeInteger(amount) || amount <= 0)
       || bounty.claim_bond_minor !== bounty.verifier_reward_minor
       || bounty.target_minor !== bounty.solver_reward_minor + bounty.verifier_reward_minor
@@ -290,7 +308,7 @@ function directClaimPlan(manifest, bounty, solverWallet, solverBalance, allowanc
 }
 
 function normalizedDirectBounty(manifest, bounty, observedBlock, timeoutBonus, claimPlan) {
-  return {
+  const normalized = {
     id: bounty.bounty_id.toLowerCase(),
     contract: bounty.contract.toLowerCase(),
     issue: bounty.issue,
@@ -306,7 +324,7 @@ function normalizedDirectBounty(manifest, bounty, observedBlock, timeoutBonus, c
     observed_block_hash: observedBlock.hash,
     terms_hash: bounty.terms_hash.toLowerCase(),
     terms_path: bounty.terms_path,
-    terms_url: `https://github.com/NSPG13/agent-bounties/blob/dbfc94cca3c582b89126869d80bc42a004c927ed/bounties/autonomous-v1/${bounty.issue}.json`,
+    terms_url: `https://github.com/NSPG13/agent-bounties/blob/${TERMS_SOURCE_COMMIT}/bounties/autonomous-v1/${bounty.issue}.json`,
     source_url: bounty.source_url,
     claim_plan_url: null,
     claim_plan: claimPlan,
@@ -315,6 +333,14 @@ function normalizedDirectBounty(manifest, bounty, observedBlock, timeoutBonus, c
     verifier_module: bounty.verifier_module?.toLowerCase() || null,
     verification_ready: true,
   };
+  const standingMeta = standingMetaDescriptor({
+    verifierModule: bounty.verifier_module,
+    verifierRuntimeCodeHash: bounty.verifier_runtime_code_hash,
+    acceptanceCriteriaHash: bounty.acceptance_criteria_hash,
+    observedBlock,
+  });
+  if (standingMeta) normalized.standing_meta_bounty = standingMeta;
+  return normalized;
 }
 
 export async function verifyDirectChainInventory({
@@ -416,8 +442,16 @@ export async function verifyDirectChainInventory({
     const results = await rpcTransport(rpc, requests);
     for (const bounty of checked.bounties) {
       const key = `bounty_${bounty.issue}_proof`;
-      const proof = await rpcTransport(rpc, [proofRequest(key, bounty.contract, blockNumber)]);
-      results.set(key, proof.get(key));
+      const proofRequests = [proofRequest(key, bounty.contract, blockNumber)];
+      if (bounty.verification_mode === "deterministic_module") {
+        proofRequests.push(proofRequest(
+          `bounty_${bounty.issue}_verifier_proof`,
+          bounty.verifier_module,
+          blockNumber,
+        ));
+      }
+      const proofs = await rpcTransport(rpc, proofRequests);
+      for (const request of proofRequests) results.set(request.key, proofs.get(request.key));
     }
     const verified = [];
     const excluded = [];
@@ -458,6 +492,12 @@ export async function verifyDirectChainInventory({
           decodedAddress(results.get(`${prefix}_verifier_module`), "verifier module") === expectedModule,
           tokenBalance >= funded + timeoutBonus,
         ];
+        if (bounty.verification_mode === "deterministic_module") {
+          matches.push(
+            proofCodeHash(results.get(`${prefix}_verifier_proof`), `bounty #${bounty.issue} verifier`)
+              === bounty.verifier_runtime_code_hash.toLowerCase(),
+          );
+        }
         if (!matches.every(Boolean)) throw new Error("safe chain state does not match committed bounty");
         if (bounty.verification_mode !== "deterministic_module") {
           excluded.push({
@@ -547,6 +587,106 @@ function activeProtocol(protocol) {
   );
 }
 
+function exactStrings(actual, expected) {
+  return Array.isArray(actual)
+    && actual.length === expected.length
+    && actual.every((value, index) => value === expected[index]);
+}
+
+function hostedStandingMetaCandidate(item) {
+  const document = item?.terms?.document;
+  const policy = document?.verification_policy;
+  const benchmark = document?.benchmark;
+  const requiredEvidence = document?.evidence_schema?.required;
+  return Boolean(
+    item?.verification_mode === "deterministic_module"
+      && String(item?.verifier_module || "").toLowerCase() === STANDING_META_BOUNTY.verifierModule
+      && exactStrings(document?.acceptance_criteria, STANDING_META_BOUNTY.acceptanceCriteria)
+      && policy?.mechanism === "deterministic_module"
+      && String(policy?.verifier_module || "").toLowerCase() === STANDING_META_BOUNTY.verifierModule
+      && policy?.threshold === 1
+      && benchmark?.engine === "canonical_child_loop_v1"
+      && benchmark?.required_child_status === "settled"
+      && String(benchmark?.verifier_module || "").toLowerCase() === STANDING_META_BOUNTY.verifierModule
+      && Array.isArray(requiredEvidence)
+      && requiredEvidence.includes("child_bounty_contract"),
+  );
+}
+
+function standingMetaDescriptor({
+  verifierModule,
+  verifierRuntimeCodeHash,
+  acceptanceCriteriaHash,
+  observedBlock,
+}) {
+  if (
+    String(verifierModule || "").toLowerCase() !== STANDING_META_BOUNTY.verifierModule
+    || String(verifierRuntimeCodeHash || "").toLowerCase()
+      !== STANDING_META_BOUNTY.verifierRuntimeCodeHash
+    || String(acceptanceCriteriaHash || "").toLowerCase()
+      !== STANDING_META_BOUNTY.acceptanceCriteriaHash
+    || !Number.isSafeInteger(observedBlock?.number)
+    || observedBlock.number <= 0
+    || !HASH.test(observedBlock?.hash || "")
+  ) return null;
+  return {
+    schema_version: STANDING_META_BOUNTY.schemaVersion,
+    inventory_class: STANDING_META_BOUNTY.inventoryClass,
+    verifier_protocol: STANDING_META_BOUNTY.verifierProtocol,
+    verifier_module: STANDING_META_BOUNTY.verifierModule,
+    verifier_runtime_code_hash: STANDING_META_BOUNTY.verifierRuntimeCodeHash,
+    acceptance_criteria_hash: STANDING_META_BOUNTY.acceptanceCriteriaHash,
+    requires_funded_canonical_child: true,
+    requires_different_solver_wallet: true,
+    required_child_status: "settled",
+    observed_block_number: observedBlock.number,
+    observed_block_hash: observedBlock.hash.toLowerCase(),
+  };
+}
+
+async function attestStandingMetaVerifier(rpcUrl, rpcTransport) {
+  try {
+    const rpc = normalizeRpcUrl(rpcUrl);
+    const blocks = await rpcTransport(rpc, [
+      { key: "standing_meta_safe_block", method: "eth_getBlockByNumber", params: ["safe", false] },
+    ]);
+    const block = blocks.get("standing_meta_safe_block");
+    const blockNumber = String(block?.number || "").toLowerCase();
+    const blockHash = String(block?.hash || "").toLowerCase();
+    if (!/^0x[0-9a-f]+$/.test(blockNumber) || !HASH.test(blockHash)) {
+      throw new Error("Base RPC did not return a safe block identity");
+    }
+    const proofs = await rpcTransport(rpc, [
+      proofRequest("standing_meta_verifier_proof", STANDING_META_BOUNTY.verifierModule, blockNumber),
+    ]);
+    const codeHash = proofCodeHash(
+      proofs.get("standing_meta_verifier_proof"),
+      "standing meta verifier",
+    );
+    const observedBlock = {
+      tag: "safe",
+      number: safeNumber(BigInt(blockNumber), "safe block number"),
+      hash: blockHash,
+    };
+    return {
+      ready: codeHash === STANDING_META_BOUNTY.verifierRuntimeCodeHash,
+      codeHash,
+      observedBlock,
+      warning: codeHash === STANDING_META_BOUNTY.verifierRuntimeCodeHash
+        ? null
+        : "standing_meta_verifier_code_mismatch",
+    };
+  } catch (error) {
+    return {
+      ready: false,
+      codeHash: null,
+      observedBlock: null,
+      warning: "standing_meta_verifier_attestation_failed",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export function verifyClaimableItem(item, protocol) {
   if (!activeProtocol(protocol)) return { ok: false, reason: "autonomous_protocol_not_active" };
   if (!item || item.status !== "claimable") {
@@ -615,8 +755,8 @@ export function verifyClaimableItem(item, protocol) {
   return { ok: true, reason: "confirmed_canonical_autonomous_bounty" };
 }
 
-function normalizedBounty(item, apiBaseUrl) {
-  return {
+function normalizedBounty(item, apiBaseUrl, standingMetaAttestation = null) {
+  const normalized = {
     id: item.bounty_id,
     contract: item.bounty_contract,
     title: item.terms.document.title,
@@ -628,7 +768,19 @@ function normalizedBounty(item, apiBaseUrl) {
     evidence: "confirmed_canonical_autonomous_bounty",
     terms_url: `${apiBaseUrl}/v1/base/autonomous-bounties/terms/${item.terms_hash}`,
     claim_plan_url: `${apiBaseUrl}/v1/base/autonomous-bounties/claim-plan`,
+    verification_mode: item.verification_mode,
+    verifier_module: item.verifier_module?.toLowerCase() || null,
+    verification_ready: item.verification_ready === true,
   };
+  if (hostedStandingMetaCandidate(item) && standingMetaAttestation?.ready) {
+    normalized.standing_meta_bounty = standingMetaDescriptor({
+      verifierModule: item.verifier_module,
+      verifierRuntimeCodeHash: standingMetaAttestation.codeHash,
+      acceptanceCriteriaHash: STANDING_META_BOUNTY.acceptanceCriteriaHash,
+      observedBlock: standingMetaAttestation.observedBlock,
+    });
+  }
+  return normalized;
 }
 
 function normalizedFundingCandidate(item) {
@@ -670,6 +822,7 @@ export async function collectInventory({
 
   const protocol = protocolResponse?.status === 200 ? protocolResponse.body : null;
   const verified = [];
+  const hostedVerified = [];
   const excluded = [];
   const fundingCandidates = [];
   for (const item of itemsFrom(feedResponse?.body)) {
@@ -679,10 +832,18 @@ export async function collectInventory({
     if (item?.status !== "claimable") continue;
     const verdict = verifyClaimableItem(item, protocol);
     if (verdict.ok) {
-      verified.push(normalizedBounty(item, api));
+      hostedVerified.push(item);
     } else {
       excluded.push({ id: item?.bounty_id || null, reason: verdict.reason });
     }
+  }
+
+  const hasStandingMetaCandidate = hostedVerified.some(hostedStandingMetaCandidate);
+  const standingMetaAttestation = hasStandingMetaCandidate
+    ? await attestStandingMetaVerifier(baseRpcUrl, rpcTransport)
+    : null;
+  for (const item of hostedVerified) {
+    verified.push(normalizedBounty(item, api, standingMetaAttestation));
   }
 
   let direct = {
@@ -720,6 +881,7 @@ export async function collectInventory({
   if (feedResponse?.status !== 200) warnings.push("autonomous_feed_unavailable");
   if (!effectiveProtocol) warnings.push("autonomous_protocol_not_active");
   if (direct.warning) warnings.push(direct.warning);
+  if (standingMetaAttestation?.warning) warnings.push(standingMetaAttestation.warning);
   if (!verified.length) warnings.push("no_verified_funded_bounty_is_claimable");
 
   return {


### PR DESCRIPTION
## Summary
- require at least one canonically funded, claimable post-and-complete meta-bounty and target a two-bounty buffer
- classify qualifying inventory only after exact verifier bytecode and safe-block evidence
- require the child bounty to settle and pay a different wallet before the parent meta reward can settle
- expose task-specific child acceptance criteria through API and MCP
- regenerate and rehearse the verifier and four 1 USDC seed bundles

## Verification
- `scripts/check.ps1`
- `forge test --fuzz-runs 1000` (38 passed, 3 opt-in fork tests skipped)
- Base mainnet fork: all 3 fork tests passed, including the settled-child payout loop
- verifier deployment rehearsal passed at block 48567240
- four-seed activation rehearsal produced four fully funded, claimable 1 USDC contracts on the fork
- inventory helper: 15 tests passed
- inventory guard: 14 tests passed

## Evidence boundary
This PR contains deterministic unsigned deployment and funding inputs plus fork evidence. It does not claim that the verifier or seed bounties are deployed or funded on Base mainnet. Mainnet status changes only after confirmed canonical events.

## Contributor impact
A maintainer notice was posted before edits. PR #151 overlaps `site/llms.txt`; its contributor was notified before the necessary protocol wording change.