### PR TITLE
Fix locked meta-bounty activation hashes

### DIFF
--- a/scripts/test-autonomous-activation-console.js
+++ b/scripts/test-autonomous-activation-console.js
@@ -51,6 +51,8 @@ assert.equal(bundle.deployment.expected_factory, "0x082c52131aaf0c56e76b075f895e
 assert.equal(bundle.deployment.expected_implementation, "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9");
 assert.deepEqual(bundle.bounties.map((item) => item.issue), [217, 218, 219, 220]);
 assert.equal(verifierBundle.deployment.expected_contract, "0x40adac5a1d00a725f77682f8940b893eaed31ecf");
+assert.ok(script.includes(`const ACCEPTANCE_CRITERIA_HASH = "${verifierBundle.acceptance_criteria_hash}";`));
+assert.ok(script.includes(`bundle.manifest_canonical_json_keccak256 !== "${bundle.manifest_canonical_json_keccak256}"`));
 assert.equal(bundle.creation_batch.wallet_calls.length, 5);
 assert.equal(bundle.creation_batch.wallet_calls[0].function, "approve(address,uint256)");
 assert.ok(bundle.creation_batch.wallet_calls[0].data.startsWith("0x095ea7b3"));

--- a/scripts/test-canonical-child-verifier-deployment-console.js
+++ b/scripts/test-canonical-child-verifier-deployment-console.js
@@ -39,6 +39,7 @@ assert.equal(bundle.chain_id, 8453);
 assert.equal(bundle.canonical_factory, "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9");
 assert.equal(bundle.settlement_token, "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
 assert.equal(bundle.acceptance_criteria_hash, "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de");
+assert.ok(script.includes(`const ACCEPTANCE_CRITERIA_HASH = "${bundle.acceptance_criteria_hash}";`));
 assert.equal(bundle.deployment.to, null);
 assert.equal(bundle.deployment.value_wei, 0);
 assert.ok(bundle.deployment.data.startsWith("0x60c06040"));

--- a/tools/autonomous-activation.js
+++ b/tools/autonomous-activation.js
@@ -5,7 +5,7 @@
   const BUNDLE_URL = "/deployments/canonical-child-seeds-base-mainnet.json";
   const VERIFIER_BUNDLE_URL = "/deployments/canonical-child-verifier-base-mainnet-deployment.json";
   const VERIFIER_MODULE = "0x40adac5a1d00a725f77682f8940b893eaed31ecf";
-  const ACCEPTANCE_CRITERIA_HASH = "0x005f591a8549549698e7c028b78ddc84076e0996ef07e19dd543ebdb12cb4553";
+  const ACCEPTANCE_CRITERIA_HASH = "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de";
   const EXPECTED_ISSUES = [217, 218, 219, 220];
   const state = { bundle: null, account: null, provider: null, providers: [], pendingBounties: [], inspected: false };
   const announcedProviders = [];
@@ -36,7 +36,7 @@
       bundle.schema_version !== "agent-bounties/autonomous-activation-bundle-v1"
       || bundle.network !== "base-mainnet"
       || bundle.chain_id !== 8453
-      || bundle.manifest_canonical_json_keccak256 !== "0x67e77578481d2ef5015643c880a3810b018681ccb2f1d7571d4b573601095a74"
+      || bundle.manifest_canonical_json_keccak256 !== "0x5247f873889a63c273ec0531137c7723463d9943251b32c49b0843e39433c3b6"
       || bundle.creation_batch.total_initial_funding !== "4000000"
       || bundle.bounties.length !== 4
       || bundle.creation_batch.wallet_calls.length !== 5

--- a/tools/canonical-child-verifier-deployment.js
+++ b/tools/canonical-child-verifier-deployment.js
@@ -4,7 +4,7 @@
   const BASE_CHAIN_ID = "0x2105";
   const FACTORY = "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9";
   const USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
-  const ACCEPTANCE_CRITERIA_HASH = "0x005f591a8549549698e7c028b78ddc84076e0996ef07e19dd543ebdb12cb4553";
+  const ACCEPTANCE_CRITERIA_HASH = "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de";
   const BUNDLE_URL = "/deployments/canonical-child-verifier-base-mainnet-deployment.json";
   const state = { bundle: null, account: null, provider: null, providers: [], inspected: false, deployed: false };
   const announcedProviders = [];


### PR DESCRIPTION
## Summary
- refresh the canonical-child acceptance hash pinned by both wallet consoles
- refresh the seed-manifest hash pinned by the activation console
- make console tests compare pinned hashes to committed deployment artifacts

## Why
The protocol correction regenerated the deployment artifacts, but the browser consoles retained old lock constants and therefore failed closed before any transaction could be signed.

## Verification
- 
ode scripts/test-canonical-child-verifier-deployment-console.js
- 
ode scripts/test-autonomous-activation-console.js
- scripts/check.ps1 (passed, 71.9s)

No funds moved while diagnosing this mismatch.