### PR TITLE
chore(ruleset): require recovery gate

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -49,6 +49,10 @@
           {
             "context": "postgres-sync",
             "integration_id": 15368
+          },
+          {
+            "context": "sdlc-recovery",
+            "integration_id": 15368
           }
         ],
         "strict_required_status_checks_policy": false

--- a/docs/main-branch-ruleset.md
+++ b/docs/main-branch-ruleset.md
@@ -8,7 +8,9 @@ the default branch; contributor branches and forks remain unrestricted.
 - Every update to `main` has a pull request audit trail.
 - The latest reviewable push needs one independent approval.
 - Review threads must be resolved before merge.
-- `full-check` and `postgres-sync` must come from GitHub Actions and pass.
+- `full-check`, `postgres-sync`, and `sdlc-recovery` must come from GitHub
+  Actions and pass. The recovery context validates the reviewed machine policy
+  and deterministic incident corpus without contacting production.
 - Force pushes and deletion of `main` are blocked.
 - Only squash merges are accepted.
 
@@ -37,12 +39,10 @@ gh api repos/NSPG13/agent-bounties/rulesets
 If a ruleset with this name already exists, update its numeric endpoint with
 `PUT` instead of creating a duplicate. Any future required check must first run
 successfully on a pull request and must be bound to its expected GitHub App.
-The `sdlc-recovery` job validates the machine policy and deterministic incident
-corpus without contacting production. Activate it as a required context in a
-separate, announced ruleset change only after the workflow is merged to `main`,
-has completed successfully there, and active contributor PRs have been checked
-for compatibility. This prevents a nonexistent context from blocking older
-branches.
+`sdlc-recovery` was activated under maintainer notice #241 only after workflow
+run `29296032142` passed on the exact merged `main` revision and every active
+pre-workflow contributor PR received a compatibility and repair-path comment.
+Future contexts must follow the same stage, prove, notify, then enforce order.
 
 ## Drift Check
 

--- a/scripts/fixtures/ruleset_drift/live_ruleset.json
+++ b/scripts/fixtures/ruleset_drift/live_ruleset.json
@@ -49,6 +49,10 @@
           {
             "context": "full-check",
             "integration_id": 15368
+          },
+          {
+            "context": "sdlc-recovery",
+            "integration_id": 15368
           }
         ]
       }

--- a/scripts/ruleset_drift_check.py
+++ b/scripts/ruleset_drift_check.py
@@ -56,7 +56,7 @@ SERVER_OWNED_RULE_FIELDS = frozenset(
 # Semantic expectations documented in docs/main-branch-ruleset.md.
 GITHUB_ACTIONS_INTEGRATION_ID = 15368
 ADMIN_REPOSITORY_ROLE_ID = 5
-REQUIRED_STATUS_CONTEXTS = ("full-check", "postgres-sync")
+REQUIRED_STATUS_CONTEXTS = ("full-check", "postgres-sync", "sdlc-recovery")
 DEFAULT_BRANCH_TARGET = "~DEFAULT_BRANCH"
 GH_TIMEOUT_SECONDS = 30
 

--- a/scripts/test_ruleset_drift_check.py
+++ b/scripts/test_ruleset_drift_check.py
@@ -65,6 +65,23 @@ class RulesetDriftCheckTests(unittest.TestCase):
             )
         )
 
+    def test_missing_sdlc_recovery_gate_is_flagged(self) -> None:
+        live = deepcopy(self.live)
+        checks = _rule(live, "required_status_checks")["parameters"]["required_status_checks"]
+        _rule(live, "required_status_checks")["parameters"]["required_status_checks"] = [
+            check for check in checks if check["context"] != "sdlc-recovery"
+        ]
+
+        result = MODULE.evaluate(self.canonical, live)
+
+        self.assertTrue(result["drift"])
+        self.assertTrue(
+            any(
+                "sdlc-recovery" in problem
+                for problem in result["live_semantic_problems"]
+            )
+        )
+
     def test_strict_status_mode_is_flagged(self) -> None:
         live = deepcopy(self.live)
         _rule(live, "required_status_checks")["parameters"][


### PR DESCRIPTION
## What changed

Require the already-merged and proven `sdlc-recovery` GitHub Actions context in the canonical `main` ruleset, drift contract, fixtures, tests, and activation documentation.

## Notice and compatibility

- Maintainer notice: #241
- Proven on exact `main` revision `896e070`: https://github.com/NSPG13/agent-bounties/actions/runs/29296032142
- Active PR queue inspected before edits.
- Compatibility comments posted on pre-workflow PRs #139, #151, #158, #206, #214, and #227.
- New PRs #230-#240 already emit `sdlc-recovery`.

The older PRs were told explicitly that a missing context is not a defect in their work and were given update/rebase plus collaboration-branch repair paths.

## Risk and verification

- Change class: R1 repository governance; no runtime or payment behavior.
- `python scripts/test_ruleset_drift_check.py -v`: 16 passed
- RecoveryBench: 15/15
- docs contract: passed
- `git diff --check`: passed

The live ruleset will be updated only after this PR itself emits a successful `sdlc-recovery` check. The live drift check will then be rerun before merge.