### PR TITLE
Make Render deploys deterministic after CI

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -1,0 +1,175 @@
+name: Render Deploy Recovery
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/render-deploy-recovery.yml"
+      - "render.yaml"
+      - "scripts/check-render-blueprint.py"
+      - "scripts/render_deploy_recovery.py"
+      - "scripts/test_render_deploy_recovery.py"
+      - "docs/deployment.md"
+      - "docs/software-development-lifecycle.md"
+      - "docs/self-healing-operations.md"
+      - "ops/self-healing-policy.json"
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: "Exact current main SHA; defaults to the dispatch revision"
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  controller-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || inputs.revision || github.sha }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify deterministic deploy controller
+        run: |
+          python scripts/test_render_deploy_recovery.py -v
+          python scripts/check-render-blueprint.py
+          python -m py_compile \
+            scripts/render_deploy_recovery.py \
+            scripts/test_render_deploy_recovery.py
+
+  deploy-exact-main-revision:
+    if: >-
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.head_repository.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
+    needs: controller-contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    concurrency:
+      group: render-production-deploy
+      cancel-in-progress: false
+    env:
+      TARGET_REVISION: ${{ github.event.workflow_run.head_sha || inputs.revision || github.sha }}
+      PRODUCTION_API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://agent-bounties-api.onrender.com' }}
+      PRODUCTION_MCP_BASE_URL: ${{ vars.PRODUCTION_MCP_BASE_URL || 'https://agent-bounties-mcp.onrender.com' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_REVISION }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Select latest successful main revision
+        id: target
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ ! "${TARGET_REVISION}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "TARGET_REVISION must be an exact 40-character Git SHA" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          current_main="$(git rev-parse refs/remotes/origin/main)"
+          if ! git merge-base --is-ancestor "${TARGET_REVISION}" "${current_main}"; then
+            echo "TARGET_REVISION is not reachable from current main" >&2
+            exit 1
+          fi
+
+          latest_successful=""
+          for attempt in 1 2 3; do
+            latest_successful="$(
+              gh api \
+                -H "Accept: application/vnd.github+json" \
+                "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=main&event=push&status=success&per_page=20" \
+                --jq '.workflow_runs | map(select(.conclusion == "success")) | .[0].head_sha // empty'
+            )"
+            if [[ "${attempt}" -lt 3 ]]; then
+              sleep $((attempt * 2))
+            fi
+          done
+          if [[ ! "${latest_successful}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "GitHub did not return a successful main CI revision" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${latest_successful}" "${current_main}"; then
+            echo "Latest successful CI revision is not reachable from current main" >&2
+            exit 1
+          fi
+          if [[ "${TARGET_REVISION,,}" != "${latest_successful,,}" ]]; then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Latest successful main CI is ${latest_successful}; that revision owns deployment." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy and attest exact revision
+        if: steps.target.outputs.deploy == 'true'
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          python scripts/render_deploy_recovery.py \
+            --revision "${TARGET_REVISION}" \
+            --api-url "${PRODUCTION_API_BASE_URL%/}/health" \
+            --mcp-url "${PRODUCTION_MCP_BASE_URL%/}/health" \
+            --output target/operations/render-deploy.json
+
+      - name: Publish deployment evidence summary
+        if: always() && steps.target.outputs.deploy == 'true'
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          evidence_path = Path("target/operations/render-deploy.json")
+          summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          if not evidence_path.exists():
+              summary_path.write_text(
+                  "# Render deployment\n\nNo evidence was produced. Inspect the deploy step.\n",
+                  encoding="utf-8",
+              )
+              raise SystemExit(0)
+          evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+          lines = [
+              "# Render deployment",
+              "",
+              f"- Revision: `{evidence['revision']}`",
+              f"- Verified: `{str(evidence['success']).lower()}`",
+              f"- Services live: `{sum(item['status'] == 'live' for item in evidence['services'])}/3`",
+              f"- Exact health attestations: `{len(evidence['health'])}/2`",
+              "",
+              "The controller can deploy application services only. It cannot deploy contracts, sign wallet transactions, or authorize settlement.",
+          ]
+          if evidence.get("error"):
+              lines.extend(["", f"Failure: `{evidence['error']}`"])
+          summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload redacted deployment evidence
+        if: always() && steps.target.outputs.deploy == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: render-deploy-${{ github.run_id }}
+          path: target/operations/render-deploy.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/adr/0002-github-controlled-render-deploys.md
+++ b/docs/adr/0002-github-controlled-render-deploys.md
@@ -1,0 +1,50 @@
+# ADR 0002: GitHub-Controlled Render Deploys
+
+- Status: accepted
+- Date: 2026-07-14
+- Change class: R2, with R3-R4 exclusions
+
+## Context
+
+The Blueprint declared commit-triggered Render deploys, but Render did not
+receive or act on reviewed main commits consistently. The scheduled operations
+workflow detected revision skew but had no bounded application-deploy action.
+Manual dashboard deploys restored service but were slow, unaudited, and not a
+self-healing release path.
+
+## Decision
+
+- Disable native Render auto-deploy for API, MCP, and worker.
+- Trigger deployment from a dedicated GitHub Actions `workflow_run` only after
+  `CI` succeeds for a same-repository push to `main`.
+- Require the target to be the latest successful CI SHA reachable from current
+  main. A newer failed commit does not suppress the last known-good release.
+- Resolve services by exact name and verify repository, branch, and type before
+  mutation.
+- Use Render's API to deploy the exact SHA and poll all three service deploys
+  to terminal `live`.
+- Verify API and MCP `/health` body, protocol, and exact revision headers.
+- Keep the Render API key only in GitHub Actions and retain redacted evidence.
+- Leave the scheduled public observer read-only and fail-closed.
+
+## Consequences
+
+Deployment no longer depends on Render receiving a GitHub commit event. CI is
+the single release gate, and the application revision is explicit. The worker
+has provider-level terminal evidence even though it has no public endpoint.
+
+The GitHub secret can deploy application services and therefore requires
+rotation and repository-administration controls. Provisioning, rotating, or
+revoking it is R3; bounded exact-SHA application deploy use is R2. A missing or
+revoked key stops deployment visibly. The controller cannot deploy contracts,
+sign wallet transactions, move money, verify work, or settle bounties.
+
+## Rejected Alternatives
+
+- **Keep native commit deploys only:** already failed without a repository-side
+  recovery path and deploys before CI completes.
+- **Use per-service deploy hooks:** narrower credentials, but hook acceptance
+  alone cannot prove the background worker reached `live`.
+- **Run deployment from the scheduled observer:** would expose mutation
+  credentials to a broad runtime-diagnosis surface and blur detection with
+  release authority.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,6 +30,46 @@ Validate before synchronizing:
 python scripts\check-render-blueprint.py
 ```
 
+Application deployment authority lives in the `Render Deploy Recovery` GitHub
+Actions workflow. Native Render auto-deploy is off because the Git provider
+event stream failed to deliver reviewed main commits reliably. After `CI`
+succeeds on a push to `main`, the workflow:
+
+1. checks out the exact successful-CI SHA;
+2. verifies it is the latest successful CI revision reachable from `main`;
+3. resolves all three Render services by exact name and verifies repository,
+   branch, and service type;
+4. disables any drifted native auto-deploy setting;
+5. calls Render's deploy API with the exact commit for API, MCP, and worker;
+6. waits for all three deploys to reach `live` and fails on terminal errors;
+7. verifies exact revision and protocol headers from API and MCP `/health`;
+8. stores a redacted 30-day deployment evidence artifact.
+
+Configure one GitHub Actions secret named `RENDER_API_KEY`. Create it in the
+Render Dashboard for the workspace that owns these three services, then store
+it only under repository **Settings > Secrets and variables > Actions**. Never
+put the key in Render variables, workflow inputs, logs, issues, or Git. A
+missing key is a visible workflow failure, not a silent manual-deploy fallback.
+The key can deploy application services, so rotate it after suspected exposure.
+Creating, rotating, or revoking the credential is an explicit R3 access change;
+using the already-provisioned credential for the bounded exact-SHA application
+deploy is R2.
+
+The controller can be rehearsed without credentials:
+
+```powershell
+python scripts\test_render_deploy_recovery.py -v
+python scripts\check-render-blueprint.py
+```
+
+After the secret exists, `workflow_dispatch` can recover the latest successful
+CI revision reachable from `main`. An older successful SHA skips when a newer
+successful SHA exists, while a newer failed commit cannot suppress deployment
+of the last known-good revision. The scheduled `Operational Control Loop` stays
+read-only and continues to fail closed on revision skew; it does not possess
+the Render key. If current `main` is newer and failing, pass the latest
+successful 40-character SHA in the manual `revision` input.
+
 The API and MCP services need the same `DATABASE_URL`, public URLs, factory,
 implementation, and Base RPC configuration. Canonical planners fail closed
 without Postgres and the active protocol addresses.
@@ -67,6 +107,9 @@ Secrets belong in Render environment groups, never in Git:
 - managed RPC credentials,
 - optional `OPERATOR_API_TOKEN` for non-protocol administrative surfaces,
 - future Stripe secrets and verified webhook secret.
+
+The separate `RENDER_API_KEY` belongs only in GitHub Actions and is never
+injected into an application container.
 
 The autonomous contracts do not need a hosted private key, settlement signer,
 or owner key. Agents and relayers submit their own wallet transactions.

--- a/docs/self-healing-operations.md
+++ b/docs/self-healing-operations.md
@@ -38,7 +38,21 @@ Base indexer -> poll -> persist heartbeat/events/cursor
 
 malformed log/cursor/config/integrity failure -> failed heartbeat -> halt ingestion
                                                     +-> contain + incident
+
+successful main CI -> exact-SHA Render deploy controller -> API/MCP/worker live
+                                                       +-> exact web revision proof
 ```
+
+The deploy controller is separate from the public observer. It is allowed to
+deploy the latest successful reviewed application revision reachable from
+main. It resolves services against the canonical repository and branch,
+disables native commit-trigger deploys, polls all three Render deploy records,
+and writes redacted evidence. A newer failed main commit cannot suppress the
+last known-good release, and an older successful run skips after a newer
+successful run exists. It cannot deploy an unrelated branch, contract, wallet,
+or payment action. A missing credential, ambiguous service, failed build,
+timeout, or health revision mismatch fails the workflow and leaves the
+read-only operational control loop in its existing fail-closed state.
 
 Render probes web services every few seconds, stops routing after sustained
 failure, and automatically restarts an instance after 60 seconds of failed
@@ -92,6 +106,7 @@ days, feature releases pause until the cause is fixed.
 | primary RPC unavailable | switch only to preconfigured attested RPC | chain id, safe block, factory and implementation hashes | no attested endpoint |
 | verifier service unavailable | remove affected bounty from earning feed | read-model-only change | verifier policy or contract mismatch |
 | delayed Stripe webhook | replay one verified event | signature, event id, amount and destination binding | any missing binding |
+| reviewed main revision not deployed | deploy latest successful-CI application SHA once | reachable main commit, canonical service binding, terminal `live`, exact web health revision | failed build, timeout, service ambiguity, or revision mismatch |
 | low claimable inventory | publish alert and creation plan | canonical inventory count | wallet funding always needs authority |
 | database unavailable/corrupt | none | backup and migration evidence | restore or failover approval |
 | payment/ledger/hash mismatch | none | independent canonical reconciliation | SEV0 incident |
@@ -100,6 +115,12 @@ days, feature releases pause until the cause is fixed.
 but their runtime adapters must remain disabled until their required telemetry
 is available and their own failure fixtures pass. Policy eligibility is not
 proof that an adapter is deployed.
+
+`deploy_reviewed_application_revision` is implemented by the dedicated GitHub
+Actions workflow, not by the public observer. Its only secret is the GitHub
+Actions `RENDER_API_KEY`; application containers and scheduled probes do not
+receive it. Provisioning or rotating that credential remains an explicit R3
+access change; bounded use for an already-reviewed application SHA is R2.
 
 ## Prohibited Automatic Repair
 

--- a/docs/software-development-lifecycle.md
+++ b/docs/software-development-lifecycle.md
@@ -182,6 +182,19 @@ R3 changes start disabled, then progress through test mode, internal canary,
 low-value public canary, and bounded expansion. R4 changes never deploy or
 activate from an unattended CI wallet.
 
+Reviewed application releases use the `Render Deploy Recovery` workflow as an
+R2 action. It runs only after successful `CI` for a same-repository push to
+`main`, requires the latest successful SHA reachable from current `main`,
+deploys that exact SHA through Render's API, waits for API, MCP, and worker to
+reach terminal `live`, and verifies API/MCP revision headers.
+Native provider commit triggers are disabled so two independent deploy
+authorities cannot race. The Render credential is isolated to this workflow;
+the scheduled observer and application containers never receive it. This
+authority does not extend to contracts, wallets, payments, verification, or
+settlement. Provisioning, rotating, or revoking the Render credential remains
+an explicit R3 access change; unattended use is limited to the allowlisted R2
+application deployment.
+
 Exit: zero-downtime deployment reports the expected revision and post-deploy
 smoke passes before traffic or feature scope expands.
 

--- a/ops/self-healing-policy.json
+++ b/ops/self-healing-policy.json
@@ -16,7 +16,8 @@
   "automatic_action_budget": {
     "read_retries_per_cycle": 3,
     "service_restarts_per_component_per_hour": 1,
-    "indexer_restarts_per_hour": 2
+    "indexer_restarts_per_hour": 2,
+    "application_deploys_per_revision": 1
   },
   "automatic_actions": {
     "retry_probe": {
@@ -70,6 +71,18 @@
         "event_idempotency_key_present",
         "amount_binding_valid",
         "destination_binding_valid"
+      ]
+    },
+    "deploy_reviewed_application_revision": {
+      "risk_class": "R2",
+      "executor": "github_actions_render_controller",
+      "requires": [
+        "successful_main_ci",
+        "latest_successful_main_revision",
+        "canonical_repository_and_service_binding",
+        "application_services_only",
+        "terminal_live_status",
+        "exact_web_health_revision"
       ]
     }
   },

--- a/render.yaml
+++ b/render.yaml
@@ -51,7 +51,8 @@ services:
     plan: starter
     region: oregon
     branch: main
-    autoDeployTrigger: commit
+    # GitHub Actions deploys the exact successful-CI main SHA through Render's API.
+    autoDeployTrigger: off
     dockerfilePath: ./Dockerfile
     dockerContext: .
     healthCheckPath: /health
@@ -112,7 +113,8 @@ services:
     plan: starter
     region: oregon
     branch: main
-    autoDeployTrigger: commit
+    # GitHub Actions deploys the exact successful-CI main SHA through Render's API.
+    autoDeployTrigger: off
     dockerfilePath: ./Dockerfile
     dockerContext: .
     healthCheckPath: /health
@@ -150,7 +152,8 @@ services:
     plan: starter
     region: oregon
     branch: main
-    autoDeployTrigger: commit
+    # GitHub Actions deploys the exact successful-CI main SHA through Render's API.
+    autoDeployTrigger: off
     dockerfilePath: ./Dockerfile
     dockerContext: .
     maxShutdownDelaySeconds: 60

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -237,9 +237,29 @@ def main() -> int:
             fail(f"{service_name} must build from the root Dockerfile")
         if "dockerContext: ." not in block:
             fail(f"{service_name} must build from the repo root context")
-        if "autoDeployTrigger: commit" not in block:
-            fail(f"{service_name} must deploy each reviewed main commit")
+        if "autoDeployTrigger: off" not in block:
+            fail(f"{service_name} must reserve deploy authority for the post-CI controller")
         require_database_ref(block)
+
+    deploy_workflow_path = repo_root / ".github" / "workflows" / "render-deploy-recovery.yml"
+    if not deploy_workflow_path.exists():
+        fail("missing deterministic Render deployment workflow")
+    deploy_workflow = deploy_workflow_path.read_text(encoding="utf-8")
+    workflow_contract = [
+        'workflows: ["CI"]',
+        "github.event.workflow_run.conclusion == 'success'",
+        "github.event.workflow_run.event == 'push'",
+        "github.event.workflow_run.head_branch == 'main'",
+        "github.event.workflow_run.head_repository.full_name == github.repository",
+        "cancel-in-progress: false",
+        "actions: read",
+        "Select latest successful main revision",
+        "RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}",
+        "scripts/render_deploy_recovery.py",
+    ]
+    for required in workflow_contract:
+        if required not in deploy_workflow:
+            fail(f"Render deployment workflow missing contract: {required}")
 
     api = named_block(services, "agent-bounties-api")
     require_env_value(api, "APP_PACKAGE", "api")

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA = "agent-bounties/render-deploy-evidence-v1"
+REPOSITORY = "github.com/nspg13/agent-bounties"
+PROTOCOL = "agent-bounties/autonomous-v1"
+ACTIVE_STATUSES = {
+    "created",
+    "queued",
+    "build_in_progress",
+    "pre_deploy_in_progress",
+    "update_in_progress",
+}
+FAILED_STATUSES = {
+    "build_failed",
+    "pre_deploy_failed",
+    "update_failed",
+    "canceled",
+    "deactivated",
+}
+TRANSIENT_HTTP_STATUSES = {429, 500, 503}
+
+
+class RecoveryError(RuntimeError):
+    pass
+
+
+class RenderHttpError(RecoveryError):
+    def __init__(self, status: int, body: str) -> None:
+        self.status = status
+        super().__init__(f"Render API returned HTTP {status}: {redact(body)}")
+
+
+class RenderTransportError(RecoveryError):
+    pass
+
+
+@dataclass(frozen=True)
+class ServiceSpec:
+    name: str
+    service_type: str
+    health_url: str | None
+
+
+SERVICE_SPECS = (
+    ServiceSpec(
+        "agent-bounties-api",
+        "web_service",
+        "https://agent-bounties-api.onrender.com/health",
+    ),
+    ServiceSpec(
+        "agent-bounties-mcp",
+        "web_service",
+        "https://agent-bounties-mcp.onrender.com/health",
+    ),
+    ServiceSpec("agent-bounties-base-indexer", "background_worker", None),
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def redact(value: str) -> str:
+    value = re.sub(r"(?i)(authorization:\s*bearer\s+)[^\s]+", r"\1[redacted]", value)
+    value = re.sub(r"(?i)([?&](?:key|token)=)[^&\s]+", r"\1[redacted]", value)
+    value = re.sub(r"(?i)(render_api_key\s*[=:]\s*)[^\s,;]+", r"\1[redacted]", value)
+    return value[:1000]
+
+
+def validate_revision(revision: str) -> str:
+    normalized = revision.strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", normalized):
+        raise RecoveryError("revision must be an exact 40-character Git SHA")
+    return normalized
+
+
+def normalize_repo(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    normalized = value.strip().lower().removesuffix(".git")
+    normalized = re.sub(r"^(?:https?://|git@)", "", normalized)
+    return normalized.replace(":", "/", 1) if normalized.startswith("github.com:") else normalized
+
+
+def unwrap_service_entries(payload: object) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise RecoveryError("Render service-list response must be an array")
+    services: list[dict[str, Any]] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        service = entry.get("service", entry)
+        if isinstance(service, dict):
+            services.append(service)
+    return services
+
+
+def select_service(spec: ServiceSpec, payload: object) -> dict[str, Any]:
+    matches = [
+        service
+        for service in unwrap_service_entries(payload)
+        if service.get("name") == spec.name
+    ]
+    if len(matches) != 1:
+        raise RecoveryError(
+            f"expected exactly one Render service named {spec.name}; found {len(matches)}"
+        )
+    service = matches[0]
+    if service.get("type") != spec.service_type:
+        raise RecoveryError(f"{spec.name} has unexpected Render service type")
+    if service.get("branch") != "main":
+        raise RecoveryError(f"{spec.name} is not connected to the main branch")
+    if normalize_repo(service.get("repo")) != REPOSITORY:
+        raise RecoveryError(f"{spec.name} is connected to an unexpected repository")
+    service_id = service.get("id")
+    if not isinstance(service_id, str) or not re.fullmatch(r"srv-[0-9a-z]+", service_id):
+        raise RecoveryError(f"{spec.name} has an invalid Render service id")
+    return service
+
+
+def unwrap_deploy(payload: object) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RecoveryError("Render deploy response must be an object")
+    deploy = payload.get("deploy", payload)
+    if not isinstance(deploy, dict):
+        raise RecoveryError("Render deploy response is missing deploy metadata")
+    return deploy
+
+
+def deploy_commit(deploy: dict[str, Any]) -> str | None:
+    commit = deploy.get("commit")
+    if not isinstance(commit, dict):
+        return None
+    commit_id = commit.get("id")
+    return commit_id.lower() if isinstance(commit_id, str) else None
+
+
+def existing_deploy(payload: object, revision: str) -> dict[str, Any] | None:
+    if not isinstance(payload, list):
+        raise RecoveryError("Render deploy-list response must be an array")
+    deploys: list[dict[str, Any]] = []
+    for entry in payload:
+        try:
+            deploy = unwrap_deploy(entry)
+        except RecoveryError:
+            continue
+        deploys.append(deploy)
+        if deploy_commit(deploy) == revision and deploy.get("status") in ACTIVE_STATUSES:
+            return deploy
+    if deploys and deploy_commit(deploys[0]) == revision and deploys[0].get("status") == "live":
+        return deploys[0]
+    return None
+
+
+class RenderClient:
+    def __init__(
+        self,
+        token: str,
+        *,
+        api_base: str = "https://api.render.com/v1",
+        timeout_seconds: float = 20,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if not token.strip():
+            raise RecoveryError("RENDER_API_KEY is required")
+        self._token = token.strip()
+        self._api_base = api_base.rstrip("/")
+        self._timeout_seconds = timeout_seconds
+        self._sleep = sleeper
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._api_base}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+                "User-Agent": "agent-bounties-render-recovery/1",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout_seconds) as response:
+                response_body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as error:
+            error_body = error.read().decode("utf-8", errors="replace")
+            raise RenderHttpError(error.code, error_body) from None
+        except (urllib.error.URLError, TimeoutError) as error:
+            raise RenderTransportError(
+                f"Render API transport failed: {redact(str(error))}"
+            ) from None
+        try:
+            return json.loads(response_body) if response_body else {}
+        except json.JSONDecodeError as error:
+            raise RecoveryError(f"Render API returned invalid JSON: {error}") from None
+
+    def _read_with_retry(self, path: str, attempts: int = 3) -> Any:
+        for attempt in range(1, attempts + 1):
+            try:
+                return self._request_json("GET", path)
+            except RenderHttpError as error:
+                if error.status not in TRANSIENT_HTTP_STATUSES or attempt == attempts:
+                    raise
+            except RenderTransportError:
+                if attempt == attempts:
+                    raise
+            self._sleep(float(attempt * 2))
+        raise AssertionError("unreachable")
+
+    def resolve_service(self, spec: ServiceSpec) -> dict[str, Any]:
+        query = urllib.parse.urlencode(
+            {"name": spec.name, "includePreviews": "false", "limit": "20"}
+        )
+        return select_service(spec, self._read_with_retry(f"/services?{query}"))
+
+    def disable_native_auto_deploy(self, service: dict[str, Any]) -> None:
+        if service.get("autoDeploy") is False:
+            return
+        service_id = service["id"]
+        updated = None
+        for attempt in range(1, 4):
+            try:
+                updated = self._request_json(
+                    "PATCH", f"/services/{service_id}", {"autoDeploy": "no"}
+                )
+                break
+            except RenderHttpError as error:
+                if error.status not in TRANSIENT_HTTP_STATUSES or attempt == 3:
+                    raise
+            except RenderTransportError:
+                if attempt == 3:
+                    raise
+            self._sleep(float(attempt * 2))
+        updated_service = updated.get("service", updated) if isinstance(updated, dict) else None
+        if not isinstance(updated_service, dict) or updated_service.get("autoDeploy") is not False:
+            raise RecoveryError(f"Render did not disable native auto-deploy for {service['name']}")
+
+    def list_deploys(self, service_id: str) -> Any:
+        return self._read_with_retry(f"/services/{service_id}/deploys?limit=20")
+
+    def get_deploy(self, service_id: str, deploy_id: str) -> dict[str, Any]:
+        return unwrap_deploy(
+            self._read_with_retry(f"/services/{service_id}/deploys/{deploy_id}")
+        )
+
+    def ensure_deploy(self, service: dict[str, Any], revision: str) -> dict[str, Any]:
+        service_id = service["id"]
+        matched = existing_deploy(self.list_deploys(service_id), revision)
+        if matched is not None:
+            return matched
+
+        for attempt in range(1, 4):
+            try:
+                return unwrap_deploy(
+                    self._request_json(
+                        "POST",
+                        f"/services/{service_id}/deploys",
+                        {"clearCache": "do_not_clear", "commitId": revision},
+                    )
+                )
+            except RenderHttpError as error:
+                if error.status not in TRANSIENT_HTTP_STATUSES or attempt == 3:
+                    raise
+            except RenderTransportError:
+                if attempt == 3:
+                    raise
+            self._sleep(float(attempt * 2))
+            matched = existing_deploy(self.list_deploys(service_id), revision)
+            if matched is not None:
+                return matched
+        raise AssertionError("unreachable")
+
+
+def validate_deploy(deploy: dict[str, Any], revision: str, service_name: str) -> tuple[str, str]:
+    deploy_id = deploy.get("id")
+    status = deploy.get("status")
+    if not isinstance(deploy_id, str) or not deploy_id.startswith("dep-"):
+        raise RecoveryError(f"{service_name} deploy is missing an id")
+    if deploy_commit(deploy) != revision:
+        raise RecoveryError(f"{service_name} deploy does not attest the requested revision")
+    if not isinstance(status, str):
+        raise RecoveryError(f"{service_name} deploy is missing status")
+    return deploy_id, status
+
+
+def poll_deploys(
+    client: RenderClient,
+    pending: dict[str, tuple[str, str]],
+    revision: str,
+    *,
+    timeout_seconds: float,
+    poll_seconds: float,
+    clock: Callable[[], float] = time.monotonic,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> dict[str, dict[str, Any]]:
+    deadline = clock() + timeout_seconds
+    completed: dict[str, dict[str, Any]] = {}
+    while pending:
+        for service_name, (service_id, deploy_id) in list(pending.items()):
+            deploy = client.get_deploy(service_id, deploy_id)
+            _, status = validate_deploy(deploy, revision, service_name)
+            if status == "live":
+                completed[service_name] = deploy
+                pending.pop(service_name)
+            elif status in FAILED_STATUSES:
+                raise RecoveryError(f"{service_name} deploy ended with status {status}")
+            elif status not in ACTIVE_STATUSES:
+                raise RecoveryError(f"{service_name} deploy has unknown status {status}")
+        if not pending:
+            break
+        if clock() >= deadline:
+            names = ", ".join(sorted(pending))
+            raise RecoveryError(f"timed out waiting for Render deploys: {names}")
+        sleeper(poll_seconds)
+    return completed
+
+
+def fetch_health(url: str, timeout_seconds: float) -> tuple[int, str, dict[str, str]]:
+    request = urllib.request.Request(
+        url,
+        method="GET",
+        headers={"Accept": "text/plain", "User-Agent": "agent-bounties-render-recovery/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return (
+                response.status,
+                response.read().decode("utf-8", errors="replace"),
+                {key.lower(): value for key, value in response.headers.items()},
+            )
+    except urllib.error.HTTPError as error:
+        return error.code, error.read().decode("utf-8", errors="replace"), {}
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise RecoveryError(f"health probe transport failed: {redact(str(error))}") from None
+
+
+def validate_health(
+    service_name: str,
+    revision: str,
+    response: tuple[int, str, dict[str, str]],
+) -> dict[str, Any]:
+    status, body, headers = response
+    observed_revision = headers.get("x-agent-bounties-revision")
+    observed_protocol = headers.get("x-agent-bounties-protocol")
+    if status != 200 or body.strip() != "ok":
+        raise RecoveryError(f"{service_name} health contract is not ready")
+    if observed_revision != revision:
+        raise RecoveryError(f"{service_name} health reports a different revision")
+    if observed_protocol != PROTOCOL:
+        raise RecoveryError(f"{service_name} health reports a different protocol")
+    return {
+        "service": service_name,
+        "status": status,
+        "body": "ok",
+        "revision": observed_revision,
+        "protocol": observed_protocol,
+    }
+
+
+def wait_for_health(
+    spec: ServiceSpec,
+    revision: str,
+    *,
+    timeout_seconds: float,
+    poll_seconds: float,
+    probe: Callable[[str, float], tuple[int, str, dict[str, str]]] = fetch_health,
+    clock: Callable[[], float] = time.monotonic,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    if spec.health_url is None:
+        raise RecoveryError(f"{spec.name} has no public health contract")
+    deadline = clock() + timeout_seconds
+    last_error = "health did not become ready"
+    while True:
+        try:
+            return validate_health(spec.name, revision, probe(spec.health_url, 10))
+        except RecoveryError as error:
+            last_error = str(error)
+        if clock() >= deadline:
+            raise RecoveryError(f"{spec.name} health verification timed out: {last_error}")
+        sleeper(poll_seconds)
+
+
+def write_evidence(path: Path, evidence: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def deploy(
+    client: RenderClient,
+    revision: str,
+    *,
+    specs: tuple[ServiceSpec, ...] = SERVICE_SPECS,
+    deploy_timeout_seconds: float,
+    health_timeout_seconds: float,
+    poll_seconds: float,
+) -> dict[str, Any]:
+    services: list[tuple[ServiceSpec, dict[str, Any]]] = []
+    pending: dict[str, tuple[str, str]] = {}
+    initial: dict[str, dict[str, Any]] = {}
+
+    for spec in specs:
+        services.append((spec, client.resolve_service(spec)))
+
+    for spec, service in services:
+        client.disable_native_auto_deploy(service)
+
+    for spec, service in services:
+        created = client.ensure_deploy(service, revision)
+        deploy_id, status = validate_deploy(created, revision, spec.name)
+        initial[spec.name] = created
+        if status == "live":
+            continue
+        if status in FAILED_STATUSES:
+            raise RecoveryError(f"{spec.name} deploy ended with status {status}")
+        if status not in ACTIVE_STATUSES:
+            raise RecoveryError(f"{spec.name} deploy has unknown status {status}")
+        pending[spec.name] = (service["id"], deploy_id)
+
+    completed = {
+        name: deploy_record
+        for name, deploy_record in initial.items()
+        if deploy_record.get("status") == "live"
+    }
+    completed.update(
+        poll_deploys(
+            client,
+            pending,
+            revision,
+            timeout_seconds=deploy_timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+    )
+
+    health = [
+        wait_for_health(
+            spec,
+            revision,
+            timeout_seconds=health_timeout_seconds,
+            poll_seconds=poll_seconds,
+        )
+        for spec, _ in services
+        if spec.health_url is not None
+    ]
+    service_evidence = []
+    for spec, service in services:
+        deployed = completed[spec.name]
+        deploy_id, status = validate_deploy(deployed, revision, spec.name)
+        service_evidence.append(
+            {
+                "name": spec.name,
+                "service_id": service["id"],
+                "service_type": spec.service_type,
+                "deploy_id": deploy_id,
+                "status": status,
+                "commit": revision,
+                "trigger": deployed.get("trigger"),
+                "native_auto_deploy": "disabled",
+            }
+        )
+    return {"services": service_evidence, "health": health}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Deploy and attest an exact reviewed main revision on Render."
+    )
+    parser.add_argument("--revision", required=True)
+    parser.add_argument(
+        "--api-url",
+        default="https://agent-bounties-api.onrender.com/health",
+    )
+    parser.add_argument(
+        "--mcp-url",
+        default="https://agent-bounties-mcp.onrender.com/health",
+    )
+    parser.add_argument("--deploy-timeout-seconds", type=float, default=2400)
+    parser.add_argument("--health-timeout-seconds", type=float, default=300)
+    parser.add_argument("--poll-seconds", type=float, default=10)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("target/operations/render-deploy.json"),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    evidence: dict[str, Any] = {
+        "schema": SCHEMA,
+        "started_at": utc_now(),
+        "completed_at": None,
+        "revision": args.revision,
+        "success": False,
+        "services": [],
+        "health": [],
+        "error": None,
+    }
+    try:
+        revision = validate_revision(args.revision)
+        specs = list(SERVICE_SPECS)
+        specs[0] = ServiceSpec(specs[0].name, specs[0].service_type, args.api_url)
+        specs[1] = ServiceSpec(specs[1].name, specs[1].service_type, args.mcp_url)
+        client = RenderClient(os.environ.get("RENDER_API_KEY", ""))
+        result = deploy(
+            client,
+            revision,
+            specs=tuple(specs),
+            deploy_timeout_seconds=args.deploy_timeout_seconds,
+            health_timeout_seconds=args.health_timeout_seconds,
+            poll_seconds=args.poll_seconds,
+        )
+        evidence.update(result)
+        evidence["revision"] = revision
+        evidence["success"] = True
+    except (RecoveryError, ValueError) as error:
+        evidence["error"] = redact(str(error))
+    finally:
+        evidence["completed_at"] = utc_now()
+        write_evidence(args.output, evidence)
+
+    if not evidence["success"]:
+        print(f"render deploy recovery failed: {evidence['error']}", file=sys.stderr)
+        return 1
+    print(f"render deploy recovery verified {evidence['revision']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("render_deploy_recovery.py")
+SPEC = importlib.util.spec_from_file_location("render_deploy_recovery", SCRIPT)
+assert SPEC and SPEC.loader
+recovery = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = recovery
+SPEC.loader.exec_module(recovery)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class FakeClient:
+    def __init__(self, statuses: list[str]) -> None:
+        self.statuses = statuses
+        self.calls = 0
+
+    def get_deploy(self, service_id: str, deploy_id: str):
+        status = self.statuses[min(self.calls, len(self.statuses) - 1)]
+        self.calls += 1
+        return {
+            "id": deploy_id,
+            "status": status,
+            "commit": {"id": "a" * 40},
+            "trigger": "api",
+        }
+
+
+class RecordingClient(recovery.RenderClient):
+    def __init__(self, *, deploys=None, response=None, error=None) -> None:
+        self.deploys = [] if deploys is None else deploys
+        self.response = response
+        self.error = error
+        self.requests = []
+        self._sleep = lambda _seconds: None
+
+    def list_deploys(self, service_id: str):
+        return self.deploys
+
+    def _request_json(self, method: str, path: str, payload=None):
+        self.requests.append((method, path, payload))
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+class ResolutionFailureClient:
+    def __init__(self) -> None:
+        self.resolved = []
+        self.mutations = []
+
+    def resolve_service(self, spec):
+        self.resolved.append(spec.name)
+        if spec.name == "agent-bounties-base-indexer":
+            raise recovery.RecoveryError("unexpected repository")
+        return {
+            "id": f"srv-{len(self.resolved)}",
+            "name": spec.name,
+            "autoDeploy": False,
+        }
+
+    def disable_native_auto_deploy(self, service):
+        self.mutations.append(("disable", service["name"]))
+
+    def ensure_deploy(self, service, revision):
+        self.mutations.append(("deploy", service["name"]))
+
+
+class RenderDeployRecoveryTests(unittest.TestCase):
+    def test_revision_requires_full_sha(self) -> None:
+        self.assertEqual(recovery.validate_revision("A" * 40), "a" * 40)
+        for value in ("a" * 39, "a" * 41, "main", "g" * 40):
+            with self.subTest(value=value), self.assertRaises(recovery.RecoveryError):
+                recovery.validate_revision(value)
+
+    def test_service_resolution_is_exact_and_repository_bound(self) -> None:
+        spec = recovery.SERVICE_SPECS[0]
+        service = {
+            "id": "srv-abc123",
+            "name": spec.name,
+            "type": spec.service_type,
+            "branch": "main",
+            "repo": "https://github.com/NSPG13/agent-bounties.git",
+        }
+        self.assertEqual(recovery.select_service(spec, [{"service": service}]), service)
+        wrong = dict(service, repo="https://github.com/attacker/fork")
+        with self.assertRaisesRegex(recovery.RecoveryError, "unexpected repository"):
+            recovery.select_service(spec, [{"service": wrong}])
+        with self.assertRaisesRegex(recovery.RecoveryError, "exactly one"):
+            recovery.select_service(spec, [{"service": service}, {"service": service}])
+
+    def test_existing_deploy_reuses_only_active_exact_revision(self) -> None:
+        revision = "a" * 40
+        payload = [
+            {"deploy": {"id": "dep-old", "status": "live", "commit": {"id": "b" * 40}}},
+            {"deploy": {"id": "dep-failed", "status": "build_failed", "commit": {"id": revision}}},
+            {"deploy": {"id": "dep-current", "status": "queued", "commit": {"id": revision}}},
+        ]
+        self.assertEqual(recovery.existing_deploy(payload, revision)["id"], "dep-current")
+
+    def test_historical_live_deploy_is_not_current_evidence(self) -> None:
+        revision = "a" * 40
+        payload = [
+            {"deploy": {"id": "dep-new", "status": "live", "commit": {"id": "b" * 40}}},
+            {"deploy": {"id": "dep-old", "status": "live", "commit": {"id": revision}}},
+        ]
+        self.assertIsNone(recovery.existing_deploy(payload, revision))
+
+    def test_trigger_binds_exact_commit_and_does_not_clear_cache(self) -> None:
+        revision = "a" * 40
+        client = RecordingClient(
+            response={
+                "id": "dep-new",
+                "status": "created",
+                "commit": {"id": revision},
+            }
+        )
+        result = client.ensure_deploy({"id": "srv-api"}, revision)
+        self.assertEqual(result["id"], "dep-new")
+        self.assertEqual(
+            client.requests,
+            [
+                (
+                    "POST",
+                    "/services/srv-api/deploys",
+                    {"clearCache": "do_not_clear", "commitId": revision},
+                )
+            ],
+        )
+
+    def test_rejected_trigger_fails_without_unbounded_retry(self) -> None:
+        client = RecordingClient(error=recovery.RenderHttpError(401, "unauthorized"))
+        with self.assertRaises(recovery.RenderHttpError):
+            client.ensure_deploy({"id": "srv-api"}, "a" * 40)
+        self.assertEqual(len(client.requests), 1)
+
+    def test_disable_native_auto_deploy_is_explicit(self) -> None:
+        client = RecordingClient(
+            response={
+                "id": "srv-api",
+                "name": "agent-bounties-api",
+                "autoDeploy": False,
+            }
+        )
+        client.disable_native_auto_deploy(
+            {"id": "srv-api", "name": "agent-bounties-api", "autoDeploy": True}
+        )
+        self.assertEqual(
+            client.requests,
+            [("PATCH", "/services/srv-api", {"autoDeploy": "no"})],
+        )
+
+    def test_missing_render_key_fails_before_network_access(self) -> None:
+        with self.assertRaisesRegex(recovery.RecoveryError, "RENDER_API_KEY"):
+            recovery.RenderClient("")
+
+    def test_all_service_bindings_validate_before_any_mutation(self) -> None:
+        client = ResolutionFailureClient()
+        with self.assertRaisesRegex(recovery.RecoveryError, "unexpected repository"):
+            recovery.deploy(
+                client,
+                "a" * 40,
+                deploy_timeout_seconds=1,
+                health_timeout_seconds=1,
+                poll_seconds=0,
+            )
+        self.assertEqual(len(client.resolved), 3)
+        self.assertEqual(client.mutations, [])
+
+    def test_poll_succeeds_only_after_exact_deploy_is_live(self) -> None:
+        client = FakeClient(["build_in_progress", "live"])
+        clock = FakeClock()
+        result = recovery.poll_deploys(
+            client,
+            {"agent-bounties-api": ("srv-api", "dep-api")},
+            "a" * 40,
+            timeout_seconds=20,
+            poll_seconds=2,
+            clock=clock,
+            sleeper=clock.sleep,
+        )
+        self.assertEqual(result["agent-bounties-api"]["status"], "live")
+
+    def test_poll_fails_closed_on_build_failure(self) -> None:
+        client = FakeClient(["build_failed"])
+        with self.assertRaisesRegex(recovery.RecoveryError, "build_failed"):
+            recovery.poll_deploys(
+                client,
+                {"agent-bounties-api": ("srv-api", "dep-api")},
+                "a" * 40,
+                timeout_seconds=20,
+                poll_seconds=2,
+            )
+
+    def test_poll_timeout_is_bounded(self) -> None:
+        client = FakeClient(["queued"])
+        clock = FakeClock()
+        with self.assertRaisesRegex(recovery.RecoveryError, "timed out"):
+            recovery.poll_deploys(
+                client,
+                {"agent-bounties-api": ("srv-api", "dep-api")},
+                "a" * 40,
+                timeout_seconds=3,
+                poll_seconds=2,
+                clock=clock,
+                sleeper=clock.sleep,
+            )
+
+    def test_health_contract_requires_exact_revision_and_protocol(self) -> None:
+        revision = "a" * 40
+        response = (
+            200,
+            "ok\n",
+            {
+                "x-agent-bounties-revision": revision,
+                "x-agent-bounties-protocol": recovery.PROTOCOL,
+            },
+        )
+        result = recovery.validate_health("api", revision, response)
+        self.assertEqual(result["revision"], revision)
+        wrong = (200, "ok", {**response[2], "x-agent-bounties-revision": "b" * 40})
+        with self.assertRaisesRegex(recovery.RecoveryError, "different revision"):
+            recovery.validate_health("api", revision, wrong)
+
+    def test_redaction_removes_credentials(self) -> None:
+        value = recovery.redact(
+            "Authorization: Bearer secret-token https://api.render.com/deploy/srv-x?key=secret"
+        )
+        self.assertNotIn("secret-token", value)
+        self.assertNotIn("key=secret", value)
+        self.assertIn("[redacted]", value)
+        self.assertEqual(
+            recovery.redact("RENDER_API_KEY is required"),
+            "RENDER_API_KEY is required",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #268.

## What changed

- replaces unreliable Render commit triggers with one GitHub-controlled post-CI deployment authority;
- deploys the latest successful main CI SHA through Render's API and rejects unrelated/out-of-order targets;
- validates all service/repository bindings before mutation, disables competing native auto-deploys, and polls API/MCP/worker to terminal `live`;
- verifies API/MCP health protocol and exact revision, then retains redacted deployment evidence;
- adds deterministic fixtures for auth rejection, service ambiguity, historical deploy confusion, build failure, timeout, revision mismatch, and secret redaction;
- records the R2 application-deploy boundary and R3 credential-provisioning boundary.

The workflow cannot deploy contracts, access wallets, move funds, authorize verification, or settle bounties.

## Contributor impact

No active human PR overlaps these files. Dependabot #235 edits existing action versions; this PR adds a separate workflow and does not supersede that update.

## Verification

- `python scripts/test_render_deploy_recovery.py -v` (14 passed)
- `python scripts/check-render-blueprint.py`
- `python scripts/test_self_heal.py -v` (6 passed)
- `python scripts/self_heal.py bench --policy ops/self-healing-policy.json --fixtures ops/fixtures/recovery-cases.json`
- `actionlint .github/workflows/render-deploy-recovery.yml`
- `scripts/check.ps1` (2,461 output lines; exit 0 after clean full build)

## Activation

After review and merge, provision `RENDER_API_KEY` as a GitHub Actions secret, then dispatch the workflow and require all three Render deploy records plus both exact web revision attestations. No secret value belongs in this PR or its logs.