### PR TITLE
Fix Render auto-deploy response handling

### DIFF
--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -150,6 +150,10 @@ def deploy_commit(deploy: dict[str, Any]) -> str | None:
     return commit_id.lower() if isinstance(commit_id, str) else None
 
 
+def auto_deploy_disabled(value: object) -> bool:
+    return value is False or value == "no"
+
+
 def existing_deploy(payload: object, revision: str) -> dict[str, Any] | None:
     if not isinstance(payload, list):
         raise RecoveryError("Render deploy-list response must be an array")
@@ -236,7 +240,7 @@ class RenderClient:
         return select_service(spec, self._read_with_retry(f"/services?{query}"))
 
     def disable_native_auto_deploy(self, service: dict[str, Any]) -> None:
-        if service.get("autoDeploy") is False:
+        if auto_deploy_disabled(service.get("autoDeploy")):
             return
         service_id = service["id"]
         updated = None
@@ -254,7 +258,9 @@ class RenderClient:
                     raise
             self._sleep(float(attempt * 2))
         updated_service = updated.get("service", updated) if isinstance(updated, dict) else None
-        if not isinstance(updated_service, dict) or updated_service.get("autoDeploy") is not False:
+        if not isinstance(updated_service, dict) or not auto_deploy_disabled(
+            updated_service.get("autoDeploy")
+        ):
             raise RecoveryError(f"Render did not disable native auto-deploy for {service['name']}")
 
     def list_deploys(self, service_id: str) -> Any:

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -154,6 +154,29 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             response={
                 "id": "srv-api",
                 "name": "agent-bounties-api",
+                "autoDeploy": "no",
+            }
+        )
+        client.disable_native_auto_deploy(
+            {"id": "srv-api", "name": "agent-bounties-api", "autoDeploy": True}
+        )
+        self.assertEqual(
+            client.requests,
+            [("PATCH", "/services/srv-api", {"autoDeploy": "no"})],
+        )
+
+    def test_disabled_render_enum_skips_redundant_update(self) -> None:
+        client = RecordingClient(response=None)
+        client.disable_native_auto_deploy(
+            {"id": "srv-api", "name": "agent-bounties-api", "autoDeploy": "no"}
+        )
+        self.assertEqual(client.requests, [])
+
+    def test_legacy_boolean_disabled_response_remains_compatible(self) -> None:
+        client = RecordingClient(
+            response={
+                "id": "srv-api",
+                "name": "agent-bounties-api",
                 "autoDeploy": False,
             }
         )


### PR DESCRIPTION
## Summary
- accept Render's documented `autoDeploy: no` response when disabling native deploys
- skip the PATCH when a service already reports the disabled enum
- retain compatibility with the legacy boolean `false` response

## Live failure addressed
The first post-CI controller run triggered correctly for `e53d16bb7a0662cec663e22529f312f165c7a65b`, then failed before creating any deploy because the controller expected boolean `false` after sending the documented string enum: https://github.com/NSPG13/agent-bounties/actions/runs/29380071691

Maintainer notice and open-PR impact audit: https://github.com/NSPG13/agent-bounties/issues/268#issuecomment-4975640016

## Verification
- `python -m unittest scripts/test_render_deploy_recovery.py` (16 passed)
- `scripts/check.ps1` (passed)
- `git diff --check origin/main...HEAD` (passed)

This changes only deployment orchestration. It cannot mutate contracts, payment state, or bounty settlement.