### PR TITLE
fix: require stable exact-revision Render rollouts

### DIFF
--- a/docs/adr/0002-github-controlled-render-deploys.md
+++ b/docs/adr/0002-github-controlled-render-deploys.md
@@ -23,7 +23,9 @@ self-healing release path.
   mutation.
 - Use Render's API to deploy the exact SHA and poll all three service deploys
   to terminal `live`.
-- Verify API and MCP `/health` body, protocol, and exact revision headers.
+- Verify API and MCP `/health` body, protocol, and exact revision headers over
+  eight consecutive cache-bypassed probes. Any stale instance resets the
+  bounded stability window.
 - Keep the Render API key only in GitHub Actions and retain redacted evidence.
 - Leave the scheduled public observer read-only and fail-closed.
 

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -18,6 +18,7 @@ from typing import Any, Callable
 SCHEMA = "agent-bounties/render-deploy-evidence-v1"
 REPOSITORY = "github.com/nspg13/agent-bounties"
 PROTOCOL = "agent-bounties/autonomous-v1"
+HEALTH_STABILITY_PROBES = 8
 ACTIVE_STATUSES = {
     "created",
     "queued",
@@ -344,10 +345,18 @@ def poll_deploys(
 
 
 def fetch_health(url: str, timeout_seconds: float) -> tuple[int, str, dict[str, str]]:
+    separator = "&" if "?" in url else "?"
+    probe_url = f"{url}{separator}_agent_bounties_probe={time.time_ns()}"
     request = urllib.request.Request(
-        url,
+        probe_url,
         method="GET",
-        headers={"Accept": "text/plain", "User-Agent": "agent-bounties-render-recovery/1"},
+        headers={
+            "Accept": "text/plain",
+            "Cache-Control": "no-cache, no-store",
+            "Connection": "close",
+            "Pragma": "no-cache",
+            "User-Agent": "agent-bounties-render-recovery/1",
+        },
     )
     try:
         with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
@@ -394,16 +403,26 @@ def wait_for_health(
     probe: Callable[[str, float], tuple[int, str, dict[str, str]]] = fetch_health,
     clock: Callable[[], float] = time.monotonic,
     sleeper: Callable[[float], None] = time.sleep,
+    required_consecutive: int = HEALTH_STABILITY_PROBES,
 ) -> dict[str, Any]:
     if spec.health_url is None:
         raise RecoveryError(f"{spec.name} has no public health contract")
+    if required_consecutive < 1:
+        raise RecoveryError("health stability probe count must be positive")
     deadline = clock() + timeout_seconds
     last_error = "health did not become ready"
+    consecutive = 0
     while True:
         try:
-            return validate_health(spec.name, revision, probe(spec.health_url, 10))
+            evidence = validate_health(spec.name, revision, probe(spec.health_url, 10))
+            consecutive += 1
+            if consecutive >= required_consecutive:
+                evidence["consecutive_exact_probes"] = consecutive
+                evidence["stability_window_seconds"] = (consecutive - 1) * poll_seconds
+                return evidence
         except RecoveryError as error:
             last_error = str(error)
+            consecutive = 0
         if clock() >= deadline:
             raise RecoveryError(f"{spec.name} health verification timed out: {last_error}")
         sleeper(poll_seconds)

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("render_deploy_recovery.py")
@@ -259,6 +260,109 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         wrong = (200, "ok", {**response[2], "x-agent-bounties-revision": "b" * 40})
         with self.assertRaisesRegex(recovery.RecoveryError, "different revision"):
             recovery.validate_health("api", revision, wrong)
+
+    def test_health_transport_bypasses_cache_and_closes_each_connection(self) -> None:
+        class Response:
+            status = 200
+            headers = {
+                "X-Agent-Bounties-Revision": "a" * 40,
+                "X-Agent-Bounties-Protocol": recovery.PROTOCOL,
+            }
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            @staticmethod
+            def read():
+                return b"ok"
+
+        with mock.patch.object(
+            recovery.urllib.request, "urlopen", return_value=Response()
+        ) as urlopen:
+            status, body, _headers = recovery.fetch_health(
+                "https://example.test/health?existing=1", 5
+            )
+
+        request = urlopen.call_args.args[0]
+        self.assertEqual(status, 200)
+        self.assertEqual(body, "ok")
+        self.assertIn("existing=1&_agent_bounties_probe=", request.full_url)
+        self.assertEqual(request.get_header("Cache-control"), "no-cache, no-store")
+        self.assertEqual(request.get_header("Connection"), "close")
+
+    def test_health_wait_requires_a_stable_exact_revision_window(self) -> None:
+        revision = "a" * 40
+        exact = (
+            200,
+            "ok",
+            {
+                "x-agent-bounties-revision": revision,
+                "x-agent-bounties-protocol": recovery.PROTOCOL,
+            },
+        )
+        stale = (
+            200,
+            "ok",
+            {
+                "x-agent-bounties-revision": "b" * 40,
+                "x-agent-bounties-protocol": recovery.PROTOCOL,
+            },
+        )
+        responses = [exact, exact, stale, exact, exact, exact]
+        clock = FakeClock()
+
+        def probe(_url, _timeout):
+            return responses.pop(0)
+
+        result = recovery.wait_for_health(
+            recovery.SERVICE_SPECS[0],
+            revision,
+            timeout_seconds=20,
+            poll_seconds=1,
+            probe=probe,
+            clock=clock,
+            sleeper=clock.sleep,
+            required_consecutive=3,
+        )
+
+        self.assertEqual(result["consecutive_exact_probes"], 3)
+        self.assertEqual(result["stability_window_seconds"], 2)
+        self.assertEqual(responses, [])
+
+    def test_health_wait_fails_when_old_and_new_revisions_keep_alternating(self) -> None:
+        revision = "a" * 40
+        calls = 0
+        clock = FakeClock()
+
+        def probe(_url, _timeout):
+            nonlocal calls
+            calls += 1
+            observed = revision if calls % 2 else "b" * 40
+            return (
+                200,
+                "ok",
+                {
+                    "x-agent-bounties-revision": observed,
+                    "x-agent-bounties-protocol": recovery.PROTOCOL,
+                },
+            )
+
+        with self.assertRaisesRegex(recovery.RecoveryError, "timed out"):
+            recovery.wait_for_health(
+                recovery.SERVICE_SPECS[0],
+                revision,
+                timeout_seconds=4,
+                poll_seconds=1,
+                probe=probe,
+                clock=clock,
+                sleeper=clock.sleep,
+                required_consecutive=3,
+            )
+
+        self.assertGreaterEqual(calls, 5)
 
     def test_redaction_removes_credentials(self) -> None:
         value = recovery.redact(


### PR DESCRIPTION
## Summary
- require eight consecutive cache-bypassed exact-revision health probes before a Render rollout is attested
- reset the bounded stability window whenever any old or invalid instance responds
- record exact probe count and stability-window duration in deployment evidence

## Production evidence
After #284, the controller reported success while 12 no-cache API probes still returned 7 new and 5 old revisions. After Render drained the old instance, 16/16 probes returned the new SHA. The prior single-sample check could therefore produce a false positive during blue/green overlap.

## Validation
- `python scripts/test_render_deploy_recovery.py` (19 passed)
- `scripts/check.ps1` (pass, 160s)
- production readiness success/failure matrix on `6fdc2ec` (pass)

## Impact
Deployment verification only. No bounty, contract, API, MCP, wallet, contributor, or settlement interface changes.