### PR TITLE
Bind known verifier to exact benchmark semantics

### DIFF
--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -1566,6 +1566,8 @@ pub struct BaseNetworkDescriptor {
 
 pub const BASE_MAINNET_USDC_TOKEN_ADDRESS: &str = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 pub const BASE_SEPOLIA_USDC_TOKEN_ADDRESS: &str = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+pub const BASE_MAINNET_LEADING_ZERO_WORK_VERIFIER: &str =
+    "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e";
 pub const AUTONOMOUS_BOUNTY_PROTOCOL_HASH: &str =
     "0x0afcbf01041498cc301207aa5cd21a838c522d8c057d9b29c2dd83d7d94053e7";
 pub const AUTONOMOUS_SUBMISSION_AUTHORIZATION_TTL_SECONDS: u64 = 1_800;
@@ -3877,8 +3879,11 @@ pub fn build_autonomous_bounty_feed(
         let verifier_module =
             (!verifier_module.eq_ignore_ascii_case(zero_address)).then_some(verifier_module);
         let terms_record = terms.get(&terms_hash.to_ascii_lowercase()).cloned();
-        let validation_errors =
+        let mut validation_errors =
             validate_autonomous_terms_against_creation(&creation_data, terms_record.as_ref());
+        if let Some(error) = active_terms_semantic_error(status, terms_record.as_ref()) {
+            validation_errors.push(error);
+        }
         let terms_valid = validation_errors.is_empty();
         let (verification_ready, verification_readiness_reason) = if !terms_valid {
             (false, "content-addressed terms are invalid or unavailable")
@@ -3992,6 +3997,7 @@ pub fn build_autonomous_bounty_terms_record(
         ));
     }
     validate_contract_terms_document(&normalized_creator, &document.contract_terms, created_at)?;
+    validate_known_deterministic_module_semantics(&document)?;
     validate_claim_metadata(&mut document)?;
     let document_value = serde_json::to_value(&document)
         .map_err(|error| ChainBaseError::InvalidCanonicalJson(error.to_string()))?;
@@ -4013,6 +4019,85 @@ pub fn build_autonomous_bounty_terms_record(
         creator_wallet: normalized_creator,
         document,
         created_at,
+    })
+}
+
+fn leading_zero_work_v1_benchmark() -> Value {
+    json!({
+        "engine": "leading_zero_work_v1",
+        "difficulty_bits": 16,
+        "hash_function": "keccak256",
+        "preimage_abi_types": [
+            "bytes32",
+            "uint64",
+            "address",
+            "bytes32",
+            "bytes32",
+            "bytes32",
+            "uint256"
+        ],
+        "proof_encoding": "abi.encode(uint256 nonce)",
+        "verifier_module": BASE_MAINNET_LEADING_ZERO_WORK_VERIFIER,
+        "reference_command": "cargo run -p cli -- autonomous-mine-work-proof"
+    })
+}
+
+fn validate_known_deterministic_module_semantics(
+    document: &AutonomousBountyTermsDocument,
+) -> Result<(), ChainBaseError> {
+    let Some(policy) = document.verification_policy.as_object() else {
+        return Ok(());
+    };
+    if policy.get("mechanism").and_then(Value::as_str) != Some("deterministic_module") {
+        return Ok(());
+    }
+    let Some(module) = policy.get("verifier_module").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let Some(contract_terms) = document.contract_terms.as_object() else {
+        return Ok(());
+    };
+    let network = contract_terms_string(contract_terms, "network")?;
+    if base_network_descriptor(network)?.chain_id != 8_453
+        || !module.eq_ignore_ascii_case(BASE_MAINNET_LEADING_ZERO_WORK_VERIFIER)
+    {
+        return Ok(());
+    }
+    let Some(benchmark) = document.benchmark.as_object() else {
+        return Err(ChainBaseError::InvalidTermsDocument(
+            "the known leading-zero verifier benchmark must be an object".to_string(),
+        ));
+    };
+    let mut semantic_benchmark = benchmark.clone();
+    if semantic_benchmark
+        .remove("suggested_interface")
+        .is_some_and(|value| !value.is_string())
+    {
+        return Err(ChainBaseError::InvalidTermsDocument(
+            "the leading-zero verifier suggested_interface annotation must be a string".to_string(),
+        ));
+    }
+    if Value::Object(semantic_benchmark) != leading_zero_work_v1_benchmark() {
+        return Err(ChainBaseError::InvalidTermsDocument(
+            "the known leading-zero verifier must use its exact 16-bit scope-bound work benchmark; it cannot verify GitHub CI, task quality, acceptance criteria, or artifact contents"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn active_terms_semantic_error(
+    status: &str,
+    terms: Option<&AutonomousBountyTermsRecord>,
+) -> Option<String> {
+    // Preserve settled history while failing closed before any future earning action.
+    if status == "paid" || status == "cancelled" {
+        return None;
+    }
+    terms.and_then(|record| {
+        validate_known_deterministic_module_semantics(&record.document)
+            .err()
+            .map(|error| error.to_string())
     })
 }
 
@@ -4735,6 +4820,7 @@ pub fn validate_autonomous_creation_against_terms(
     create: &AutonomousBountyCreate,
     terms: &AutonomousBountyTermsRecord,
 ) -> Result<(), ChainBaseError> {
+    validate_known_deterministic_module_semantics(&terms.document)?;
     let hashes_match = create.terms_hash.eq_ignore_ascii_case(&terms.terms_hash)
         && create.policy_hash.eq_ignore_ascii_case(&terms.policy_hash)
         && create
@@ -4877,6 +4963,7 @@ pub fn validate_autonomous_creation_against_terms(
 pub fn autonomous_bounty_create_from_terms(
     terms: &AutonomousBountyTermsRecord,
 ) -> Result<AutonomousBountyCreate, ChainBaseError> {
+    validate_known_deterministic_module_semantics(&terms.document)?;
     let contract_terms = terms.document.contract_terms.as_object().ok_or_else(|| {
         ChainBaseError::InvalidTermsDocument("published contract_terms are unavailable".to_string())
     })?;
@@ -6114,6 +6201,60 @@ mod tests {
         assert!(
             validate_autonomous_creation_against_terms("base-mainnet", &create, &record).is_err()
         );
+    }
+
+    #[test]
+    fn known_leading_zero_module_rejects_mismatched_benchmarks_everywhere() {
+        let now = Utc::now();
+        let mut document: AutonomousBountyTermsDocument =
+            serde_json::from_str(include_str!("../../../bounties/autonomous-v1/244.json")).unwrap();
+        document.contract_terms["funding_deadline"] = json!(now.timestamp() + 86_400);
+
+        let valid = build_autonomous_bounty_terms_record(
+            "0x884834E884d6e93462655A2820140aD03E6747bC",
+            document.clone(),
+            now,
+        )
+        .unwrap();
+        let valid_create = autonomous_bounty_create_from_terms(&valid).unwrap();
+
+        document.benchmark = json!({
+            "engine": "github_ci",
+            "required_checks": ["ci"],
+            "required_conclusion": "success"
+        });
+        let publication_error = build_autonomous_bounty_terms_record(
+            "0x884834E884d6e93462655A2820140aD03E6747bC",
+            document.clone(),
+            now,
+        )
+        .unwrap_err();
+        assert!(publication_error.to_string().contains(
+            "known leading-zero verifier must use its exact 16-bit scope-bound work benchmark"
+        ));
+
+        let mut legacy_record = valid;
+        legacy_record.document = document;
+        legacy_record.benchmark_hash =
+            keccak256_canonical_json(&legacy_record.document.benchmark).unwrap();
+        legacy_record.terms_hash =
+            keccak256_canonical_json(&serde_json::to_value(&legacy_record.document).unwrap())
+                .unwrap();
+        let mut legacy_create = valid_create;
+        legacy_create.benchmark_hash = legacy_record.benchmark_hash.clone();
+        legacy_create.terms_hash = legacy_record.terms_hash.clone();
+
+        assert!(validate_autonomous_creation_against_terms(
+            "base-mainnet",
+            &legacy_create,
+            &legacy_record,
+        )
+        .is_err());
+        assert!(autonomous_bounty_create_from_terms(&legacy_record).is_err());
+        assert!(active_terms_semantic_error("claimable", Some(&legacy_record)).is_some());
+        assert!(active_terms_semantic_error("submitted", Some(&legacy_record)).is_some());
+        assert!(active_terms_semantic_error("paid", Some(&legacy_record)).is_none());
+        assert!(active_terms_semantic_error("cancelled", Some(&legacy_record)).is_none());
     }
 
     #[test]

--- a/docs/autonomous-protocol.md
+++ b/docs/autonomous-protocol.md
@@ -53,6 +53,14 @@ The API refuses to produce creation calldata unless every hash, economic value,
 deadline, address, verifier, threshold, network, token, and nonce matches the
 published document.
 
+Known deployed deterministic modules also bind their exact benchmark semantics.
+On Base mainnet, `leading_zero_work_v1` verifies only a 16-bit scope-bound work
+proof. Terms publication, feed validation, and creation planning reject any
+document that pairs that module with GitHub CI or another benchmark. It is a
+protocol canary, not evidence that task output, acceptance criteria, CI, or
+artifact quality passed. Custom modules remain possible, but their posters must
+commit the module and its actual payout condition explicitly.
+
 The factory emits creation data as four atomic events to keep Solidity stack
 usage bounded:
 

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -221,11 +221,12 @@ def main() -> int:
         [
             "Sign and post bounty",
             "Create unfunded and open it for pooled funding",
-            "Permissionless on-chain verifier",
+            "16-bit work-proof canary",
             "Verifier wallet quorum (advanced)",
             "AI judge quorum (advanced)",
-            "Benchmark JSON",
-            "Evidence schema JSON",
+            "Benchmark JSON (payout condition)",
+            "Evidence record schema (hash-bound context)",
+            "does not evaluate task output, acceptance criteria, GitHub CI, or artifact quality",
             "How did you find Agent Bounties?",
         ],
     )
@@ -317,6 +318,7 @@ def main() -> int:
             "/agent-bounty relay",
             "list_autonomous_verification_jobs",
             "solver bond",
+            "protocol canary, not a code-quality verifier",
             "ai_judge_quorum",
             "at least two",
             "BountySettled",
@@ -353,6 +355,30 @@ def main() -> int:
         fail("default deterministic verifier reward recipient must be the creator wallet")
     if default_verification.get("threshold") != 1:
         fail("default deterministic verifier threshold must be one")
+    default_module = protocol["deterministic_modules"][default_verification["module_id"]]
+    expected_work_benchmark = {
+        "engine": "leading_zero_work_v1",
+        "difficulty_bits": 16,
+        "hash_function": "keccak256",
+        "preimage_abi_types": [
+            "bytes32",
+            "uint64",
+            "address",
+            "bytes32",
+            "bytes32",
+            "bytes32",
+            "uint256",
+        ],
+        "proof_encoding": "abi.encode(uint256 nonce)",
+        "verifier_module": default_module.get("contract"),
+        "reference_command": "cargo run -p cli -- autonomous-mine-work-proof",
+    }
+    if default_module.get("usage") != "protocol_canary_only":
+        fail("default work verifier must be scoped to protocol canaries")
+    if default_module.get("benchmark") != expected_work_benchmark:
+        fail("default work verifier benchmark does not match its exact contract semantics")
+    if '{"engine":"github_ci"' in pages["post.html"]:
+        fail("public posting must not pair GitHub CI with the leading-zero work verifier")
     tools = discovery.get("agent_tools", [])
     for tool in [
         "list_autonomous_bounties",

--- a/scripts/test-autonomous-wallet-flow.js
+++ b/scripts/test-autonomous-wallet-flow.js
@@ -68,6 +68,16 @@ assert.strictEqual(protocol.default_verification.mode, "deterministic_module");
 assert.strictEqual(protocol.default_verification.module_id, "leading_zero_work_v1");
 assert.strictEqual(protocol.default_verification.verifier_reward_recipient, "creator_wallet");
 assert.strictEqual(protocol.default_verification.threshold, 1);
+assert.strictEqual(protocol.deterministic_modules.leading_zero_work_v1.usage, "protocol_canary_only");
+assert.strictEqual(
+  protocol.deterministic_modules.leading_zero_work_v1.benchmark.engine,
+  "leading_zero_work_v1",
+);
+assert.strictEqual(protocol.deterministic_modules.leading_zero_work_v1.benchmark.difficulty_bits, 16);
+assert.strictEqual(
+  protocol.deterministic_modules.leading_zero_work_v1.benchmark.verifier_module,
+  protocol.deterministic_modules.leading_zero_work_v1.contract,
+);
 
 const postHtml = fs.readFileSync(path.join(repoRoot, "site", "post.html"), "utf8");
 assert(
@@ -75,6 +85,9 @@ assert(
   "public posting must default to deterministic verification",
 );
 assert(postHtml.includes("Verifier wallet quorum (advanced)"));
+assert(postHtml.includes("16-bit work-proof canary"));
+assert(postHtml.includes("does not evaluate task output, acceptance criteria, GitHub CI, or artifact quality"));
+assert(!postHtml.includes('{"engine":"github_ci"'));
 assert(postHtml.includes('name="solverReward" type="number" min="0.01" step="0.01" value="2.00"'));
 assert(postHtml.includes('name="verifierReward" type="number" min="0.01" step="0.01" value="0.01"'));
 
@@ -100,6 +113,7 @@ async function testDeterministicPostingDefaults() {
   const documentListeners = {};
   const formListeners = {};
   const controlListeners = {};
+  const scope = { textContent: "" };
   const elements = {
     verificationMode: {
       value: "deterministic_module",
@@ -111,6 +125,19 @@ async function testDeterministicPostingDefaults() {
     verifierRewardRecipient: { value: "", disabled: false },
     verifiers: { value: "", disabled: false },
     threshold: { value: "8", readOnly: false },
+    benchmark: { value: '{"engine":"tampered"}', readOnly: false },
+    title: { value: "Canary" },
+    goal: { value: "Complete the exact work proof." },
+    acceptance: { value: "The scope-bound proof passes." },
+    evidenceSchema: { value: '{"type":"object","additionalProperties":true}' },
+    aiProvider: { value: "" },
+    aiModel: { value: "" },
+    aiModelVersion: { value: "" },
+    systemPrompt: { value: "" },
+    rubric: { value: "" },
+    decodingParameters: { value: '{"temperature":0,"seed":0}' },
+    sourceUrl: { value: "" },
+    discoverySource: { value: "" },
   };
   const form = {
     id: "autonomous-post-form",
@@ -118,8 +145,8 @@ async function testDeterministicPostingDefaults() {
     addEventListener(name, handler) {
       formListeners[name] = handler;
     },
-    querySelector() {
-      return null;
+    querySelector(selector) {
+      return selector === "[data-verifier-scope]" ? scope : null;
     },
   };
   const document = {
@@ -152,7 +179,11 @@ async function testDeterministicPostingDefaults() {
       return 1;
     },
   });
-  new vm.Script(source, { filename: "site/autonomous.js" }).runInContext(context);
+  const instrumentedSource = source.replace(
+    /\}\)\(\);\s*$/,
+    "globalThis.__agentBountiesTest = { termsDocument }; })();",
+  );
+  new vm.Script(instrumentedSource, { filename: "site/autonomous.js" }).runInContext(context);
   await documentListeners.DOMContentLoaded();
 
   assert.strictEqual(
@@ -164,6 +195,15 @@ async function testDeterministicPostingDefaults() {
   assert.strictEqual(elements.verifiers.disabled, true);
   assert.strictEqual(elements.threshold.value, "1");
   assert.strictEqual(elements.threshold.readOnly, true);
+  assert.strictEqual(elements.benchmark.readOnly, true);
+  assert.deepStrictEqual(
+    JSON.parse(elements.benchmark.value),
+    protocol.deterministic_modules.leading_zero_work_v1.benchmark,
+  );
+  assert.strictEqual(
+    scope.textContent,
+    protocol.deterministic_modules.leading_zero_work_v1.scope_notice,
+  );
 
   elements.verificationMode.value = "signed_quorum";
   controlListeners.change();
@@ -171,12 +211,33 @@ async function testDeterministicPostingDefaults() {
   assert.strictEqual(elements.verifierRewardRecipient.disabled, true);
   assert.strictEqual(elements.verifiers.disabled, false);
   assert.strictEqual(elements.threshold.readOnly, false);
+  assert.strictEqual(elements.benchmark.readOnly, false);
 
+  elements.benchmark.value = '{"engine":"github_ci"}';
   elements.verificationMode.value = "deterministic_module";
   controlListeners.change();
   assert.strictEqual(elements.verifierModule.disabled, false);
   assert.strictEqual(elements.verifiers.disabled, true);
   assert.strictEqual(elements.threshold.value, "1");
+  assert.strictEqual(elements.benchmark.readOnly, true);
+  assert.deepStrictEqual(
+    JSON.parse(elements.benchmark.value),
+    protocol.deterministic_modules.leading_zero_work_v1.benchmark,
+  );
+
+  elements.benchmark.value = '{"engine":"github_ci"}';
+  elements.verifierRewardRecipient.value = "0x1111111111111111111111111111111111111111";
+  const terms = context.__agentBountiesTest.termsDocument(
+    form,
+    { verifier_reward: { amount: 10_000, currency: "usdc" } },
+    protocol,
+  );
+  assert.deepStrictEqual(
+    JSON.parse(JSON.stringify(terms.benchmark)),
+    protocol.deterministic_modules.leading_zero_work_v1.benchmark,
+  );
+  assert.strictEqual(terms.verification_policy.module_id, "leading_zero_work_v1");
+  assert.strictEqual(terms.verification_policy.settlement_scope, "protocol_canary_only");
 }
 
 testDeterministicPostingDefaults()

--- a/site/autonomous.js
+++ b/site/autonomous.js
@@ -205,9 +205,15 @@
     }
     const module = protocol.deterministic_modules && protocol.deterministic_modules[config.module_id];
     if (!module) throw new Error("The default deterministic verifier is unavailable.");
+    if (!module.benchmark || module.benchmark.engine !== config.module_id) {
+      throw new Error("The default deterministic verifier has no exact benchmark commitment.");
+    }
     return {
       ...config,
       contract: requiredAddress(module.contract || "", "Deterministic verifier module"),
+      benchmark: module.benchmark,
+      scope_notice: module.scope_notice || "The selected module controls payout.",
+      usage: module.usage || "custom",
     };
   }
 
@@ -220,6 +226,8 @@
     const recipient = form.elements.verifierRewardRecipient;
     const verifiers = form.elements.verifiers;
     const threshold = form.elements.threshold;
+    const benchmark = form.elements.benchmark;
+    const scope = form.querySelector("[data-verifier-scope]");
 
     module.value = defaults.contract;
     module.readOnly = true;
@@ -227,11 +235,16 @@
     recipient.disabled = !deterministic;
     verifiers.disabled = deterministic;
     threshold.readOnly = deterministic;
+    benchmark.readOnly = deterministic;
     if (deterministic) {
       threshold.value = String(defaults.threshold);
+      benchmark.value = canonicalJsonString(defaults.benchmark);
+      if (scope) scope.textContent = defaults.scope_notice;
       if (defaults.verifier_reward_recipient === "creator_wallet" && account && !recipient.value.trim()) {
         recipient.value = account;
       }
+    } else if (scope) {
+      scope.textContent = "Advanced modes pay only from the verifier wallets and threshold committed in the terms. Confirm verifier availability before funding.";
     }
   }
 
@@ -640,8 +653,11 @@
     };
   }
 
-  function termsDocument(form, committed) {
+  function termsDocument(form, committed, protocol) {
     const mode = form.elements.verificationMode.value;
+    const deterministicDefaults = mode === "deterministic_module"
+      ? defaultVerification(protocol)
+      : null;
     const verifiers = splitAddresses(form.elements.verifiers.value);
     const threshold = Number(form.elements.threshold.value);
     const module = optionalAddress(form.elements.verifierModule.value);
@@ -672,10 +688,16 @@
       title: form.elements.title.value.trim(),
       goal: form.elements.goal.value.trim(),
       acceptance_criteria: splitLines(form.elements.acceptance.value),
-      benchmark: parseJson(form.elements.benchmark.value, "Benchmark"),
+      benchmark: deterministicDefaults
+        ? deterministicDefaults.benchmark
+        : parseJson(form.elements.benchmark.value, "Benchmark"),
       evidence_schema: parseJson(form.elements.evidenceSchema.value, "Evidence schema"),
       verification_policy: {
         mechanism: mode,
+        ...(deterministicDefaults ? {
+          module_id: deterministicDefaults.module_id,
+          settlement_scope: deterministicDefaults.usage,
+        } : {}),
         verifier_module: mode === "deterministic_module" ? module : null,
         verifier_reward_recipient: mode === "deterministic_module" ? verifierRecipient : null,
         verifiers: mode === "deterministic_module" ? [] : verifiers,
@@ -702,7 +724,7 @@
       const api = apiBase(form);
       output(result, ["Publishing content-addressed terms...", `Creator: ${account}`]);
       const committed = contractTerms(form, account, protocol);
-      const document = termsDocument(form, committed);
+      const document = termsDocument(form, committed, protocol);
       const terms = await requestJson(`${api}/v1/base/autonomous-bounties/terms`, {
         method: "POST",
         body: JSON.stringify({ creator_wallet: account, document }),

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -64,11 +64,13 @@ For `leading_zero_work_v1` bounties, mine the exact scope-bound proof after subm
 
 Relay the emitted `module_settlement_request` through `plan_autonomous_module_settlement`, sign the returned `verifyAndSettle(bytes)` transaction with any Base wallet, and call it paid only after indexed `BountySettled` evidence.
 
+`leading_zero_work_v1` is a protocol canary, not a code-quality verifier. Its exact 16-bit benchmark is locked by the API and website; it does not evaluate task output, acceptance criteria, GitHub CI, or artifact contents. Do not post a coding-quality bounty with this module. Use a precommitted verifier quorum until a sandboxed regression-test verifier is operationally attested.
+
 ## Posting And Pooled Funding
 
 1. Publish exact public terms through `publish_autonomous_bounty_terms`.
 2. Choose one immutable verification policy:
-   - `deterministic_module`: an on-chain verifier returns pass or fail.
+   - `deterministic_module`: an on-chain verifier returns pass or fail. The known `leading_zero_work_v1` module accepts only its exact scope-bound work benchmark.
    - `signed_quorum`: committed verifier wallets sign the exact round, solver, submission hash, evidence hash, result, response hash, and deadline.
    - `ai_judge_quorum`: at least two committed independent judge wallets must sign; provider, model version, system prompt, rubric, decoding parameters, benchmark, and evidence schema are committed before funding.
 3. Call `plan_autonomous_bounty_creation`.

--- a/site/post.html
+++ b/site/post.html
@@ -91,7 +91,7 @@
               <label>
                 Mechanism
                 <select name="verificationMode">
-                  <option value="deterministic_module">Permissionless on-chain verifier</option>
+                  <option value="deterministic_module">16-bit work-proof canary</option>
                   <optgroup label="Advanced verifier services">
                     <option value="signed_quorum">Verifier wallet quorum (advanced)</option>
                     <option value="ai_judge_quorum">AI judge quorum (advanced)</option>
@@ -103,6 +103,7 @@
                 <input name="threshold" type="number" min="1" max="8" value="1" required>
               </label>
             </div>
+            <output class="fine" data-verifier-scope aria-live="polite">This module verifies only the locked 16-bit scope-bound work proof. It does not evaluate task output, acceptance criteria, GitHub CI, or artifact quality.</output>
             <label>
               Verifier wallets, comma or space separated
               <textarea name="verifiers" rows="2" placeholder="0x... 0x..."></textarea>
@@ -118,12 +119,12 @@
               </label>
             </div>
             <label>
-              Benchmark JSON
-              <textarea name="benchmark" rows="5" required>{"engine":"github_ci","required_checks":["ci"],"required_conclusion":"success"}</textarea>
+              Benchmark JSON (payout condition)
+              <textarea name="benchmark" rows="8" readonly required>{"engine":"leading_zero_work_v1","difficulty_bits":16,"hash_function":"keccak256","preimage_abi_types":["bytes32","uint64","address","bytes32","bytes32","bytes32","uint256"],"proof_encoding":"abi.encode(uint256 nonce)","verifier_module":"0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e","reference_command":"cargo run -p cli -- autonomous-mine-work-proof"}</textarea>
             </label>
             <label>
-              Evidence schema JSON
-              <textarea name="evidenceSchema" rows="5" required>{"type":"object","required":["repository","commit_sha","check_run_url","artifact_digest"]}</textarea>
+              Evidence record schema (hash-bound context)
+              <textarea name="evidenceSchema" rows="5" required>{"type":"object","description":"Hash-bound public context; not evaluated by leading_zero_work_v1.","additionalProperties":true}</textarea>
             </label>
           </div>
 

--- a/site/protocol.json
+++ b/site/protocol.json
@@ -17,8 +17,28 @@
   },
   "deterministic_modules": {
     "leading_zero_work_v1": {
+      "label": "16-bit scope-bound work proof",
       "contract": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
       "difficulty_bits": 16,
+      "usage": "protocol_canary_only",
+      "scope_notice": "This module verifies only the locked 16-bit scope-bound work proof. It does not evaluate task output, acceptance criteria, GitHub CI, or artifact quality.",
+      "benchmark": {
+        "engine": "leading_zero_work_v1",
+        "difficulty_bits": 16,
+        "hash_function": "keccak256",
+        "preimage_abi_types": [
+          "bytes32",
+          "uint64",
+          "address",
+          "bytes32",
+          "bytes32",
+          "bytes32",
+          "uint256"
+        ],
+        "proof_encoding": "abi.encode(uint256 nonce)",
+        "verifier_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
+        "reference_command": "cargo run -p cli -- autonomous-mine-work-proof"
+      },
       "deployment_transaction": "0xd1cc22fbd07aaaf19ccd7bf78f1ad452349303c3ba17229500398eab91f6b44e",
       "deployment_block": 48499521,
       "runtime_code_hash": "0xbaa3a8305c4b65d0dc20131d0ef207fdaf4763f345393a831370cd04077df9b3"


### PR DESCRIPTION
## What changed

- binds the known Base-mainnet `leading_zero_work_v1` module to its exact 16-bit scope-bound benchmark at terms publication and creation planning
- marks mismatched nonterminal bounties verification-unready while preserving paid/cancelled historical evidence
- derives and locks the same benchmark in the public posting form, including tamper-resistant document construction
- states clearly that the module is a protocol canary, not GitHub CI or task-quality verification

## Compatibility

Committed direct canaries may retain the historical informational `suggested_interface` annotation. Custom deterministic modules remain allowed. No contract, wallet permission, bounty state, or funds change in this PR.

Closes #292.

## Verification

- `cargo test -p chain-base`
- `node scripts/test-autonomous-wallet-flow.js`
- `python scripts/check-site.py`
- `./scripts/check.ps1` (passed, 297 seconds)