### PR TITLE
Add fail-closed sandboxed regression verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5298,9 +5298,11 @@ dependencies = [
  "chrono",
  "db",
  "domain",
+ "hex",
  "ledger",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "verifier-sdk",
 ]

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ only live canonical submissions with matching terms and evidence preimages.
 Judges request scoped EIP-712 payloads, sign one verdict, and let any relayer
 submit a matching quorum.
 
+The repository also includes a local `sandboxed_regression_v1` runner for the
+coding beachhead. It emits unsigned, fully scoped verdict candidates from
+precommitted content-addressed tests; it is not yet a hosted verifier, signer,
+or verification-readiness signal. See
+[`docs/sandboxed-regression-verifier.md`](docs/sandboxed-regression-verifier.md).
+
 ## Agent Interfaces
 
 Core MCP tools include:
@@ -303,7 +309,8 @@ documented in
   verification jobs.
 - `crates/payments-x402`: x402 v2 Base USDC funding challenges, strict payload
   validation, and canonical relay inputs.
-- `crates/worker`: confirmed-log indexing with batched canonical address scans.
+- `crates/worker`: confirmed-log indexing plus the local, no-secrets sandboxed
+  regression runner; these are separate deployment trust boundaries.
 - `crates/db`: Postgres persistence for terms, evidence, events, and product
   graph records.
 - `crates/verifier-sdk`: verifier plugin contracts.

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -3329,12 +3329,26 @@ async fn submit_result(
     Ok(Json(submission))
 }
 
-#[utoipa::path(post, path = "/v1/bounties/{id}/verify")]
+#[utoipa::path(
+    post,
+    path = "/v1/bounties/{id}/verify",
+    responses(
+        (status = 200, description = "Operator-authorized legacy verification result"),
+        (status = 401, description = "Operator token required"),
+        (status = 503, description = "Legacy verification is disabled until an operator token is configured")
+    ),
+    security(("operator_api_token" = []), ("operator_bearer" = []))
+)]
 async fn verify_submission(
     State(state): State<SharedState>,
     Path(id): Path<Uuid>,
+    headers: HeaderMap,
     Json(mut request): Json<VerifySubmissionRequest>,
 ) -> Result<Json<domain::ProofRecord>, StatusCode> {
+    if state.operator_api_token.is_none() {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    require_operator(&state, &headers)?;
     request.bounty_id = id;
     let mut network = {
         let mut guard = state.network.lock().expect("state poisoned");
@@ -10716,6 +10730,48 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(error, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn legacy_verification_requires_configured_operator_authorization() {
+        let bounty_id = Uuid::new_v4();
+        let request = VerifySubmissionRequest {
+            bounty_id: Uuid::nil(),
+            submission_id: Uuid::new_v4(),
+            expected_artifact_digest: "0xdeadbeef".to_string(),
+            verifier_kind: Some(VerifierKind::JsonSchema),
+            rubric: None,
+            evidence: None,
+            approved_risk_event_id: None,
+        };
+
+        let error = verify_submission(
+            State(test_state(BountyNetwork::default())),
+            Path(bounty_id),
+            HeaderMap::new(),
+            Json(request.clone()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error, StatusCode::SERVICE_UNAVAILABLE);
+
+        let state = test_state_with_operator_token(BountyNetwork::default(), "secret-token");
+        let error = verify_submission(
+            State(state.clone()),
+            Path(bounty_id),
+            HeaderMap::new(),
+            Json(request.clone()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error, StatusCode::UNAUTHORIZED);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer secret-token".parse().unwrap());
+        let error = verify_submission(State(state), Path(bounty_id), headers, Json(request))
+            .await
+            .unwrap_err();
+        assert_eq!(error, StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -4835,7 +4835,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ci_bounty_uses_github_ci_verifier_by_default() {
+    async fn ci_bounty_does_not_pay_from_caller_supplied_github_json() {
         let mut network = BountyNetwork::default();
         let solver = network.register_agent(RegisterAgentRequest {
             handle: "solver".to_string(),
@@ -4866,7 +4866,7 @@ mod tests {
             })
             .unwrap();
 
-        network
+        let error = network
             .verify_submission(VerifySubmissionRequest {
                 bounty_id: bounty.id,
                 submission_id: submission.id,
@@ -4877,15 +4877,19 @@ mod tests {
                 approved_risk_event_id: None,
             })
             .await
-            .unwrap();
+            .unwrap_err();
+        assert!(matches!(error, AppError::VerificationNotAccepted(_)));
 
         let status = network.status(bounty.id).unwrap();
-        assert_eq!(status.bounty.status, BountyStatus::Paid);
+        assert_eq!(status.bounty.status, BountyStatus::Verifying);
         assert_eq!(status.verifier_results[0].kind, VerifierKind::GitHubCi);
         assert_eq!(
             status.verifier_results[0].decision,
-            VerificationDecision::Accepted
+            VerificationDecision::NeedsReview
         );
+        assert!(status.proofs.is_empty());
+        assert!(status.settlements.is_empty());
+        assert!(status.reputation_events.is_empty());
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3457,7 +3457,8 @@ fn print_production_smoke_report(report: &ProductionSmokeReport) -> Result<()> {
 async fn service_smoke(api_base_url: String, mcp_base_url: String) -> Result<()> {
     let api = normalize_base_url(&api_base_url);
     let mcp = normalize_base_url(&mcp_base_url);
-    let report = service_smoke_check(&api, &mcp).await?;
+    let operator_token = env::var("OPERATOR_API_TOKEN").ok();
+    let report = service_smoke_check(&api, &mcp, operator_token.as_deref()).await?;
     print_service_smoke_report(&report)
 }
 
@@ -3472,7 +3473,11 @@ struct ServiceSmokeReport {
     mcp_tools: usize,
 }
 
-async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport> {
+async fn service_smoke_check(
+    api: &str,
+    mcp: &str,
+    operator_token: Option<&str>,
+) -> Result<ServiceSmokeReport> {
     wait_for_health(&format!("{api}/health"))?;
     wait_for_health(&format!("{mcp}/health"))?;
     let _production_contract = production_smoke_check(api, mcp, false, None).await?;
@@ -3589,7 +3594,7 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
     )?;
     let submission_id =
         value_str(&submission, "/id").context("service smoke submission id missing")?;
-    let proof = post_json(
+    let proof = post_json_with_operator_token(
         &format!("{api}/v1/bounties/{bounty_id}/verify"),
         serde_json::json!({
             "bounty_id": bounty_id,
@@ -3600,6 +3605,9 @@ async fn service_smoke_check(api: &str, mcp: &str) -> Result<ServiceSmokeReport>
             "evidence": null,
             "approved_risk_event_id": null
         }),
+        operator_token.context(
+            "OPERATOR_API_TOKEN is required for the legacy simulated verification smoke step",
+        )?,
     )?;
     require(
         value_str(&proof, "/proof_hash").is_some(),
@@ -3692,6 +3700,7 @@ async fn service_smoke_spawn(
     database_url: Option<String>,
     verify_restart_persistence: bool,
 ) -> Result<()> {
+    const SMOKE_OPERATOR_TOKEN: &str = "agent-bounties-local-service-smoke";
     let api = normalize_base_url(&api_base_url);
     let mcp = normalize_base_url(&mcp_base_url);
     if verify_restart_persistence && database_url.is_none() {
@@ -3708,6 +3717,7 @@ async fn service_smoke_spawn(
             ("API_BIND_ADDR", api_bind.as_str()),
             ("PUBLIC_BASE_URL", api.as_str()),
             ("MCP_BASE_URL", mcp.as_str()),
+            ("OPERATOR_API_TOKEN", SMOKE_OPERATOR_TOKEN),
         ],
         database_url.as_deref(),
     )
@@ -3728,7 +3738,7 @@ async fn service_smoke_spawn(
         }
     };
 
-    let result = service_smoke_check(&api, &mcp).await;
+    let result = service_smoke_check(&api, &mcp, Some(SMOKE_OPERATOR_TOKEN)).await;
     stop_child(&mut api_child);
     stop_child(&mut mcp_child);
     let report = result?;
@@ -3739,6 +3749,7 @@ async fn service_smoke_spawn(
             &mcp,
             database_url.as_deref().unwrap(),
             &report,
+            SMOKE_OPERATOR_TOKEN,
         )?;
     }
 
@@ -3750,6 +3761,7 @@ fn verify_service_smoke_restart_persistence(
     mcp: &str,
     database_url: &str,
     report: &ServiceSmokeReport,
+    operator_token: &str,
 ) -> Result<()> {
     let api_bind = bind_addr_from_base_url(api)?;
     let mcp_bind = bind_addr_from_base_url(mcp)?;
@@ -3762,6 +3774,7 @@ fn verify_service_smoke_restart_persistence(
             ("API_BIND_ADDR", api_bind.as_str()),
             ("PUBLIC_BASE_URL", api),
             ("MCP_BASE_URL", mcp),
+            ("OPERATOR_API_TOKEN", operator_token),
         ],
         Some(database_url),
     )
@@ -3875,6 +3888,22 @@ fn post_json(url: &str, body: serde_json::Value) -> Result<serde_json::Value> {
         "POST",
         url,
         Some(body.to_string()),
+    )?)?)
+}
+
+fn post_json_with_operator_token(
+    url: &str,
+    body: serde_json::Value,
+    operator_token: &str,
+) -> Result<serde_json::Value> {
+    if operator_token.is_empty() || operator_token.bytes().any(|byte| byte.is_ascii_control()) {
+        bail!("operator token cannot be empty or contain control characters");
+    }
+    Ok(serde_json::from_str(&http_request_with_headers(
+        "POST",
+        url,
+        Some(body.to_string()),
+        &[("x-operator-token", operator_token)],
     )?)?)
 }
 
@@ -4008,6 +4037,15 @@ async fn production_get_text(client: &reqwest::Client, url: &str) -> Result<Stri
 }
 
 fn http_request(method: &str, url: &str, body: Option<String>) -> Result<String> {
+    http_request_with_headers(method, url, body, &[])
+}
+
+fn http_request_with_headers(
+    method: &str,
+    url: &str,
+    body: Option<String>,
+    headers: &[(&str, &str)],
+) -> Result<String> {
     let parsed = parse_http_url(url)?;
     let body = body.unwrap_or_default();
     let content_headers = if method == "POST" {
@@ -4018,10 +4056,25 @@ fn http_request(method: &str, url: &str, body: Option<String>) -> Result<String>
     } else {
         String::new()
     };
+    let mut extra_headers = String::new();
+    for (name, value) in headers {
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+            || value.bytes().any(|byte| byte.is_ascii_control())
+        {
+            bail!("service smoke HTTP header is invalid");
+        }
+        extra_headers.push_str(name);
+        extra_headers.push_str(": ");
+        extra_headers.push_str(value);
+        extra_headers.push_str("\r\n");
+    }
     let request = format!(
         "{method} {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept: application/json\r\n{}\
-         \r\n{}",
-        parsed.path, parsed.authority, content_headers, body
+         {}\r\n{}",
+        parsed.path, parsed.authority, content_headers, extra_headers, body
     );
     let mut stream = TcpStream::connect((parsed.host.as_str(), parsed.port))
         .with_context(|| format!("failed to connect to {}", parsed.authority))?;

--- a/crates/eval-harness/src/lib.rs
+++ b/crates/eval-harness/src/lib.rs
@@ -1245,7 +1245,7 @@ async fn verifier_suite() -> Result<EvalSuiteResult, EvalError> {
         )
         .await?,
         verifier_case(
-            "github_ci_accepts_success",
+            "github_ci_requires_authenticated_provenance_for_success",
             VerifierKind::GitHubCi,
             "abc123abc123abc123",
             None,
@@ -1254,11 +1254,11 @@ async fn verifier_suite() -> Result<EvalSuiteResult, EvalError> {
                 "success",
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             )),
-            VerificationDecision::Accepted,
+            VerificationDecision::NeedsReview,
         )
         .await?,
         verifier_case(
-            "github_ci_rejects_failure",
+            "github_ci_requires_authenticated_provenance_for_failure",
             VerifierKind::GitHubCi,
             "abc123abc123abc123",
             None,
@@ -1267,7 +1267,7 @@ async fn verifier_suite() -> Result<EvalSuiteResult, EvalError> {
                 "failure",
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             )),
-            VerificationDecision::Rejected,
+            VerificationDecision::NeedsReview,
         )
         .await?,
         verifier_case(
@@ -1286,23 +1286,23 @@ async fn verifier_suite() -> Result<EvalSuiteResult, EvalError> {
         )
         .await?,
         verifier_case(
-            "docker_accepts_zero_exit_and_digest",
+            "docker_self_reported_success_needs_sandbox",
             VerifierKind::DockerCommand,
             "abc123abc123abc123",
             Some("abc123abc123abc123".to_string()),
             None,
             Some(serde_json::json!({ "exit_code": 0 })),
-            VerificationDecision::Accepted,
+            VerificationDecision::NeedsReview,
         )
         .await?,
         verifier_case(
-            "docker_rejects_nonzero_exit",
+            "docker_self_reported_failure_needs_sandbox",
             VerifierKind::DockerCommand,
             "abc123abc123abc123",
             Some("abc123abc123abc123".to_string()),
             None,
             Some(serde_json::json!({ "exit_code": 1 })),
-            VerificationDecision::Rejected,
+            VerificationDecision::NeedsReview,
         )
         .await?,
         verifier_case(

--- a/crates/sdk-typescript/examples/cofund-claim.ts
+++ b/crates/sdk-typescript/examples/cofund-claim.ts
@@ -2,6 +2,7 @@ import { AgentBountiesClient, hashArtifact } from "../src/index.js";
 
 declare const process: {
   argv: string[];
+  env: Record<string, string | undefined>;
 };
 
 type JsonObject = Record<string, unknown>;
@@ -202,5 +203,10 @@ async function runExample(client: AgentBountiesClient): Promise<JsonObject> {
   };
 }
 
-const result = await runExample(new AgentBountiesClient({ baseUrl: baseUrlFromArgs() }));
+const result = await runExample(
+  new AgentBountiesClient({
+    baseUrl: baseUrlFromArgs(),
+    operatorApiToken: process.env.OPERATOR_API_TOKEN,
+  }),
+);
 console.log(JSON.stringify(result, null, 2));

--- a/crates/sdk-typescript/src/smoke.ts
+++ b/crates/sdk-typescript/src/smoke.ts
@@ -1,6 +1,9 @@
 import { AgentBountiesClient, hashArtifact } from "./index.js";
 
-declare const process: { argv: string[] };
+declare const process: {
+  argv: string[];
+  env: Record<string, string | undefined>;
+};
 
 type JsonObject = Record<string, unknown>;
 
@@ -207,7 +210,12 @@ async function exerciseSurface(client: AgentBountiesClient): Promise<JsonObject>
 
 console.log(
   JSON.stringify(
-    await exerciseSurface(new AgentBountiesClient({ baseUrl: baseUrlFromArgs() })),
+    await exerciseSurface(
+      new AgentBountiesClient({
+        baseUrl: baseUrlFromArgs(),
+        operatorApiToken: process.env.OPERATOR_API_TOKEN,
+      }),
+    ),
     null,
     2,
   ),

--- a/crates/verifier-sdk/src/lib.rs
+++ b/crates/verifier-sdk/src/lib.rs
@@ -188,6 +188,443 @@ pub trait Verifier: Send + Sync {
     async fn verify(&self, input: VerificationInput) -> VerifierResultType<VerifierResult>;
 }
 
+pub const REGRESSION_SANDBOX_POLICY_VERSION: &str = "agent-bounties/regression-sandbox-v1";
+pub const REGRESSION_SANDBOX_RECEIPT_VERSION: &str = "agent-bounties/regression-sandbox-receipt-v1";
+const MIB: u64 = 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegressionSandboxPolicy {
+    pub schema_version: String,
+    pub image: String,
+    pub command: Vec<String>,
+    pub workdir: String,
+    pub benchmark_digest: String,
+    pub timeout_seconds: u64,
+    pub cpu_millis: u32,
+    pub memory_bytes: u64,
+    pub pids_limit: u32,
+    pub max_output_bytes: u64,
+    pub tmpfs_bytes: u64,
+    pub max_source_bytes: u64,
+    pub max_source_files: u32,
+    pub max_benchmark_bytes: u64,
+    pub max_benchmark_files: u32,
+    pub platform: String,
+    pub test_seed: u64,
+}
+
+impl RegressionSandboxPolicy {
+    pub fn validate(&self) -> VerifierResultType<()> {
+        if self.schema_version != REGRESSION_SANDBOX_POLICY_VERSION {
+            return Err(VerifierError::InvalidInput(
+                "unsupported regression sandbox policy version".to_string(),
+            ));
+        }
+        validate_pinned_image(&self.image)?;
+        validate_sha256_digest("benchmark_digest", &self.benchmark_digest)?;
+        if self.workdir != "/workspace" {
+            return Err(VerifierError::InvalidInput(
+                "regression sandbox workdir must be /workspace".to_string(),
+            ));
+        }
+        if self.command.is_empty() || self.command.len() > 64 {
+            return Err(VerifierError::InvalidInput(
+                "regression command must contain 1 to 64 argv entries".to_string(),
+            ));
+        }
+        let mut command_bytes = 0usize;
+        for argument in &self.command {
+            if argument.is_empty()
+                || argument.len() > 4_096
+                || argument.contains('\0')
+                || argument.contains('\n')
+                || argument.contains('\r')
+            {
+                return Err(VerifierError::InvalidInput(
+                    "regression command contains an empty, oversized, or control-bearing argv entry"
+                        .to_string(),
+                ));
+            }
+            command_bytes = command_bytes.saturating_add(argument.len());
+        }
+        if command_bytes > 16_384 {
+            return Err(VerifierError::InvalidInput(
+                "regression command exceeds the argv byte limit".to_string(),
+            ));
+        }
+        let executable = self.command[0]
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        if matches!(
+            executable.as_str(),
+            "sh" | "bash" | "dash" | "zsh" | "cmd" | "cmd.exe" | "powershell" | "pwsh"
+        ) {
+            return Err(VerifierError::InvalidInput(
+                "regression sandbox v1 requires direct argv and forbids shell entrypoints"
+                    .to_string(),
+            ));
+        }
+        if !(1..=900).contains(&self.timeout_seconds)
+            || !(100..=4_000).contains(&self.cpu_millis)
+            || !(64 * MIB..=4 * 1024 * MIB).contains(&self.memory_bytes)
+            || !(16..=512).contains(&self.pids_limit)
+            || !(1_024..=16 * MIB).contains(&self.max_output_bytes)
+            || !(64 * MIB..=4 * 1024 * MIB).contains(&self.tmpfs_bytes)
+            || self.tmpfs_bytes > self.memory_bytes
+            || !(1..=2 * 1024 * MIB).contains(&self.max_source_bytes)
+            || !(1..=100_000).contains(&self.max_source_files)
+            || !(1..=512 * MIB).contains(&self.max_benchmark_bytes)
+            || !(1..=50_000).contains(&self.max_benchmark_files)
+        {
+            return Err(VerifierError::InvalidInput(
+                "regression sandbox resource limits are outside protocol bounds".to_string(),
+            ));
+        }
+        if !matches!(self.platform.as_str(), "linux/amd64" | "linux/arm64") {
+            return Err(VerifierError::InvalidInput(
+                "regression sandbox platform must be linux/amd64 or linux/arm64".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn runner_manifest_hash(&self) -> VerifierResultType<String> {
+        self.validate()?;
+        canonical_sha256_digest(self)
+    }
+
+    pub fn command_hash(&self) -> VerifierResultType<String> {
+        self.validate()?;
+        canonical_sha256_digest(&self.command)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegressionSandboxExecution {
+    pub exit_code: i32,
+    pub stdout_sha256: String,
+    pub stderr_sha256: String,
+    pub stdout_bytes: u64,
+    pub stderr_bytes: u64,
+    pub isolation: RegressionSandboxIsolation,
+}
+
+impl RegressionSandboxExecution {
+    fn validate(&self, policy: &RegressionSandboxPolicy) -> VerifierResultType<()> {
+        validate_sha256_digest("stdout_sha256", &self.stdout_sha256)?;
+        validate_sha256_digest("stderr_sha256", &self.stderr_sha256)?;
+        if !(0..=124).contains(&self.exit_code)
+            || self
+                .stdout_bytes
+                .checked_add(self.stderr_bytes)
+                .is_none_or(|bytes| bytes > policy.max_output_bytes)
+        {
+            return Err(VerifierError::Failed(
+                "sandbox reported a runtime-reserved exit or output above the committed limit; no verdict was produced"
+                    .to_string(),
+            ));
+        }
+        self.isolation.validate()?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegressionSandboxIsolation {
+    pub runtime: String,
+    pub network: String,
+    pub rootfs_read_only: bool,
+    pub source_read_only: bool,
+    pub benchmark_read_only: bool,
+    pub capabilities: String,
+    pub no_new_privileges: bool,
+    pub user: String,
+}
+
+impl Default for RegressionSandboxIsolation {
+    fn default() -> Self {
+        Self {
+            runtime: "docker".to_string(),
+            network: "none".to_string(),
+            rootfs_read_only: true,
+            source_read_only: true,
+            benchmark_read_only: true,
+            capabilities: "none".to_string(),
+            no_new_privileges: true,
+            user: "65532:65532".to_string(),
+        }
+    }
+}
+
+impl RegressionSandboxIsolation {
+    fn validate(&self) -> VerifierResultType<()> {
+        if self.runtime != "docker"
+            || self.network != "none"
+            || !self.rootfs_read_only
+            || !self.source_read_only
+            || !self.benchmark_read_only
+            || self.capabilities != "none"
+            || !self.no_new_privileges
+            || self.user != "65532:65532"
+        {
+            return Err(VerifierError::Failed(
+                "sandbox isolation evidence does not satisfy regression-sandbox-v1; no verdict was produced"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegressionVerificationScope {
+    pub network: String,
+    pub bounty_id: String,
+    pub bounty_contract: String,
+    pub round: u64,
+    pub solver_wallet: String,
+    pub submission_hash: String,
+    pub evidence_hash: String,
+    pub terms_hash: String,
+    pub committed_policy_hash: String,
+    pub verification_expires_at: u64,
+}
+
+impl RegressionVerificationScope {
+    pub fn validate(&self) -> VerifierResultType<()> {
+        if self.network.is_empty()
+            || self.network.len() > 64
+            || self
+                .network
+                .bytes()
+                .any(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+        {
+            return Err(VerifierError::InvalidInput(
+                "regression verification network is invalid".to_string(),
+            ));
+        }
+        for (field, value) in [
+            ("bounty_id", &self.bounty_id),
+            ("submission_hash", &self.submission_hash),
+            ("evidence_hash", &self.evidence_hash),
+            ("terms_hash", &self.terms_hash),
+            ("committed_policy_hash", &self.committed_policy_hash),
+        ] {
+            if !is_bytes32_hash(value) {
+                return Err(VerifierError::InvalidInput(format!(
+                    "regression verification {field} must be a 0x-prefixed bytes32 value"
+                )));
+            }
+        }
+        if !is_evm_address(&self.bounty_contract) || !is_evm_address(&self.solver_wallet) {
+            return Err(VerifierError::InvalidInput(
+                "regression verification contract and solver must be EVM addresses".to_string(),
+            ));
+        }
+        if self.round == 0 || self.verification_expires_at == 0 {
+            return Err(VerifierError::InvalidInput(
+                "regression verification round and expiry must be positive".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegressionVerificationTask {
+    pub scope: RegressionVerificationScope,
+    pub source_digest: String,
+}
+
+impl RegressionVerificationTask {
+    pub fn validate(&self) -> VerifierResultType<()> {
+        self.scope.validate()?;
+        validate_sha256_digest("source_digest", &self.source_digest)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegressionVerdict {
+    Passed,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegressionSandboxReceipt {
+    pub schema_version: String,
+    pub scope: RegressionVerificationScope,
+    pub runner_manifest_hash: String,
+    pub command_hash: String,
+    pub source_digest: String,
+    pub benchmark_digest: String,
+    pub image: String,
+    pub execution: RegressionSandboxExecution,
+}
+
+#[derive(Debug, Clone, Copy, Error, PartialEq, Eq)]
+pub enum RegressionSandboxExecutorError {
+    #[error("sandbox runtime is unavailable")]
+    RuntimeUnavailable,
+    #[error("sandbox input is unavailable or does not match its committed digest")]
+    InputUnavailable,
+    #[error("sandbox exceeded its committed timeout")]
+    TimedOut,
+    #[error("sandbox exceeded its committed output limit")]
+    OutputLimitExceeded,
+    #[error("sandbox was killed by a resource or runtime limit")]
+    ResourceLimitExceeded,
+    #[error("sandbox execution failed closed")]
+    FailedClosed,
+}
+
+#[async_trait]
+pub trait RegressionSandboxExecutor: Send + Sync {
+    async fn execute(
+        &self,
+        policy: &RegressionSandboxPolicy,
+        source_digest: &str,
+    ) -> Result<RegressionSandboxExecution, RegressionSandboxExecutorError>;
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RegressionVerificationOutcome {
+    pub verdict: RegressionVerdict,
+    pub receipt: RegressionSandboxReceipt,
+    pub response_hash: String,
+}
+
+pub struct SandboxedRegressionVerifier<E> {
+    pub executor: E,
+    pub policy: RegressionSandboxPolicy,
+}
+
+impl<E: RegressionSandboxExecutor> SandboxedRegressionVerifier<E> {
+    pub async fn verify(
+        &self,
+        task: RegressionVerificationTask,
+    ) -> VerifierResultType<RegressionVerificationOutcome> {
+        self.policy.validate()?;
+        task.validate()?;
+
+        let execution = self
+            .executor
+            .execute(&self.policy, &task.source_digest)
+            .await
+            .map_err(|error| VerifierError::Failed(format!("{error}; no verdict was produced")))?;
+        execution.validate(&self.policy)?;
+        let receipt = RegressionSandboxReceipt {
+            schema_version: REGRESSION_SANDBOX_RECEIPT_VERSION.to_string(),
+            scope: task.scope,
+            runner_manifest_hash: self.policy.runner_manifest_hash()?,
+            command_hash: self.policy.command_hash()?,
+            source_digest: task.source_digest,
+            benchmark_digest: self.policy.benchmark_digest.clone(),
+            image: self.policy.image.clone(),
+            execution,
+        };
+        let verdict = if receipt.execution.exit_code == 0 {
+            RegressionVerdict::Passed
+        } else {
+            RegressionVerdict::Failed
+        };
+        #[derive(Serialize)]
+        struct ResponsePreimage<'a> {
+            schema_version: &'static str,
+            verdict: RegressionVerdict,
+            receipt: &'a RegressionSandboxReceipt,
+        }
+        let response_hash = canonical_sha256_bytes32(&ResponsePreimage {
+            schema_version: REGRESSION_SANDBOX_RECEIPT_VERSION,
+            verdict,
+            receipt: &receipt,
+        })?;
+        Ok(RegressionVerificationOutcome {
+            verdict,
+            receipt,
+            response_hash,
+        })
+    }
+}
+
+fn validate_pinned_image(image: &str) -> VerifierResultType<()> {
+    if image.starts_with('-') || image.matches('@').count() != 1 {
+        return Err(VerifierError::InvalidInput(
+            "regression image must be a non-option OCI reference pinned by one sha256 digest"
+                .to_string(),
+        ));
+    }
+    let Some((name, digest)) = image.split_once("@sha256:") else {
+        return Err(VerifierError::InvalidInput(
+            "regression image must be pinned by sha256 digest".to_string(),
+        ));
+    };
+    if name.is_empty()
+        || name.bytes().any(|byte| {
+            !matches!(
+                byte,
+                b'a'..=b'z'
+                    | b'0'..=b'9'
+                    | b'.'
+                    | b'/'
+                    | b':'
+                    | b'_'
+                    | b'-'
+            )
+        })
+        || name.contains("..")
+        || digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(VerifierError::InvalidInput(
+            "regression image has an invalid immutable digest".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_sha256_digest(field: &str, value: &str) -> VerifierResultType<()> {
+    let Some(digest) = value.strip_prefix("sha256:") else {
+        return Err(VerifierError::InvalidInput(format!(
+            "{field} must use sha256:<64 lowercase hex>"
+        )));
+    };
+    if digest.len() != 64
+        || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || digest.bytes().any(|byte| byte.is_ascii_uppercase())
+    {
+        return Err(VerifierError::InvalidInput(format!(
+            "{field} must use sha256:<64 lowercase hex>"
+        )));
+    }
+    Ok(())
+}
+
+fn canonical_sha256_digest<T: Serialize>(value: &T) -> VerifierResultType<String> {
+    let encoded = serde_json::to_vec(value).map_err(|_| {
+        VerifierError::Failed("failed to encode canonical verifier evidence".to_string())
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(encoded);
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+fn canonical_sha256_bytes32<T: Serialize>(value: &T) -> VerifierResultType<String> {
+    let encoded = serde_json::to_vec(value).map_err(|_| {
+        VerifierError::Failed("failed to encode canonical verifier evidence".to_string())
+    })?;
+    Ok(format!("0x{}", hex::encode(Sha256::digest(encoded))))
+}
+
 #[derive(Debug, Clone)]
 pub struct ManualVerifier {
     pub verifier_agent_id: Option<Id>,
@@ -281,104 +718,52 @@ impl Verifier for GitHubCiVerifier {
     }
 
     async fn verify(&self, input: VerificationInput) -> VerifierResultType<VerifierResult> {
-        let Some(evidence) = input.evidence.as_ref() else {
-            return Ok(make_result(
-                input.bounty_id,
-                input.submission.id,
+        let (summary, payload) = match input.evidence.as_ref() {
+            None => (
+                "caller-supplied GitHub CI JSON has no authenticated provenance and cannot authorize acceptance or rejection; structured evidence is also missing".to_string(),
                 None,
-                VerifierKind::GitHubCi,
-                VerificationDecision::NeedsReview,
-                "GitHub CI evidence needs review: structured evidence is required",
-                0.35,
-            ));
+            ),
+            Some(evidence) => match GitHubCiEvidence::from_value(evidence, &input.submission) {
+                Err(reason) => (
+                    format!(
+                        "caller-supplied GitHub CI JSON has no authenticated provenance and cannot authorize acceptance or rejection; advisory parse failed: {reason}"
+                    ),
+                    Some(evidence.to_string()),
+                ),
+                Ok(parsed) => {
+                    let ownership_reason = parsed.validate_ownership(&input.submission).err();
+                    let acceptance_reason = parsed.automatic_acceptance_review_reason();
+                    let advisory = ownership_reason
+                        .or(acceptance_reason)
+                        .unwrap_or_else(|| "the untrusted fields are internally consistent".to_string());
+                    let pr = parsed
+                        .pull_request_number()
+                        .map(|number| format!("PR #{number}"))
+                        .unwrap_or_else(|| "repository evidence".to_string());
+                    (
+                        format!(
+                            "caller-supplied GitHub CI JSON has no authenticated provenance and cannot authorize acceptance or rejection; parsed {} {} commit {} check {}#{}; advisory: {}",
+                            parsed.repository,
+                            pr,
+                            short_sha(&parsed.commit_sha),
+                            parsed.check_name,
+                            parsed.check_run_id,
+                            advisory
+                        ),
+                        Some(parsed.canonical_payload()),
+                    )
+                }
+            },
         };
-
-        let parsed = match GitHubCiEvidence::from_value(evidence, &input.submission) {
-            Ok(parsed) => parsed,
-            Err(message) => {
-                return Ok(make_result(
-                    input.bounty_id,
-                    input.submission.id,
-                    None,
-                    VerifierKind::GitHubCi,
-                    VerificationDecision::NeedsReview,
-                    format!("GitHub CI evidence needs review: {message}"),
-                    0.35,
-                ));
-            }
-        };
-
-        if let Err(reason) = parsed.validate_ownership(&input.submission) {
-            return Ok(make_result_with_payload(ResultSeed {
-                bounty_id: input.bounty_id,
-                submission_id: input.submission.id,
-                verifier_agent_id: None,
-                kind: VerifierKind::GitHubCi,
-                decision: VerificationDecision::Rejected,
-                summary: format!("GitHub CI evidence rejected: {reason}"),
-                confidence: 0.0,
-                payload: Some(&parsed.canonical_payload()),
-            }));
-        }
-
-        let status = parsed.check_status.to_ascii_lowercase();
-        let conclusion = parsed.check_conclusion.to_ascii_lowercase();
-        let completed = matches!(status.as_str(), "completed" | "success" | "passed");
-        let succeeded = matches!(conclusion.as_str(), "success" | "passed");
-        let accepted = completed && succeeded;
-        let short_sha = short_sha(&parsed.commit_sha);
-        let payload = parsed.canonical_payload();
-        if accepted {
-            if let Some(reason) = parsed.automatic_acceptance_review_reason() {
-                return Ok(make_result_with_payload(ResultSeed {
-                    bounty_id: input.bounty_id,
-                    submission_id: input.submission.id,
-                    verifier_agent_id: None,
-                    kind: VerifierKind::GitHubCi,
-                    decision: VerificationDecision::NeedsReview,
-                    summary: format!("GitHub CI evidence needs review: {reason}"),
-                    confidence: 0.62,
-                    payload: Some(&payload),
-                }));
-            }
-        }
-        let summary = if accepted {
-            format!(
-                "GitHub CI evidence accepted: {} {} commit {} check {}#{} succeeded",
-                parsed.repository,
-                parsed
-                    .pull_request_number()
-                    .map(|number| format!("PR #{number}"))
-                    .unwrap_or_else(|| "repository evidence".to_string()),
-                short_sha,
-                parsed.check_name,
-                parsed.check_run_id
-            )
-        } else {
-            format!(
-                "GitHub CI evidence rejected: check {}#{} for {} commit {} ended with status `{}` and conclusion `{}`",
-                parsed.check_name,
-                parsed.check_run_id,
-                parsed.repository,
-                short_sha,
-                parsed.check_status,
-                parsed.check_conclusion
-            )
-        };
-
         Ok(make_result_with_payload(ResultSeed {
             bounty_id: input.bounty_id,
             submission_id: input.submission.id,
             verifier_agent_id: None,
             kind: VerifierKind::GitHubCi,
-            decision: if accepted {
-                VerificationDecision::Accepted
-            } else {
-                VerificationDecision::Rejected
-            },
+            decision: VerificationDecision::NeedsReview,
             summary,
-            confidence: if accepted { 0.98 } else { 0.0 },
-            payload: Some(&payload),
+            confidence: 0.0,
+            payload: payload.as_deref(),
         }))
     }
 }
@@ -723,32 +1108,14 @@ impl Verifier for DockerCommandVerifier {
     }
 
     async fn verify(&self, input: VerificationInput) -> VerifierResultType<VerifierResult> {
-        let evidence = required_evidence(&input)?;
-        let exit_code = evidence_i64(evidence, "exit_code").ok_or_else(|| {
-            VerifierError::InvalidInput("docker evidence requires exit_code".to_string())
-        })?;
-        let digest_matches = match &input.expected_artifact_digest {
-            Some(expected) => expected == &input.submission.artifact_digest,
-            None => true,
-        };
-        let accepted = exit_code == 0 && digest_matches;
-
         Ok(make_result(
             input.bounty_id,
             input.submission.id,
             None,
             VerifierKind::DockerCommand,
-            if accepted {
-                VerificationDecision::Accepted
-            } else {
-                VerificationDecision::Rejected
-            },
-            if accepted {
-                "Docker command exited successfully"
-            } else {
-                "Docker command evidence failed"
-            },
-            if accepted { 0.96 } else { 0.0 },
+            VerificationDecision::NeedsReview,
+            "self-reported Docker exit evidence cannot authorize acceptance; run the committed policy through SandboxedRegressionVerifier",
+            0.0,
         ))
     }
 }
@@ -1045,7 +1412,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn github_ci_verifier_accepts_success_evidence() {
+    async fn github_ci_verifier_needs_authenticated_success_evidence() {
         let bounty_id = Uuid::new_v4();
         let submission = Submission {
             artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/42".to_string(),
@@ -1064,13 +1431,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.kind, VerifierKind::GitHubCi);
-        assert_eq!(result.decision, VerificationDecision::Accepted);
-        assert!(result.summary.contains("PR #42"));
+        assert_eq!(result.decision, VerificationDecision::NeedsReview);
+        assert!(result.summary.contains("authenticated provenance"));
         assert_eq!(result.signed_payload_hash.len(), 64);
     }
 
     #[tokio::test]
-    async fn github_ci_verifier_rejects_mismatched_commit_evidence() {
+    async fn github_ci_verifier_does_not_trust_mismatched_commit_json() {
         let bounty_id = Uuid::new_v4();
         let submission = Submission {
             artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/42".to_string(),
@@ -1091,12 +1458,12 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.decision, VerificationDecision::Rejected);
-        assert!(result.summary.contains("does not match submitted commit"));
+        assert_eq!(result.decision, VerificationDecision::NeedsReview);
+        assert!(result.summary.contains("authenticated provenance"));
     }
 
     #[tokio::test]
-    async fn github_ci_verifier_rejects_failed_check_evidence() {
+    async fn github_ci_verifier_does_not_trust_failure_json() {
         let bounty_id = Uuid::new_v4();
         let submission = Submission {
             artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/42".to_string(),
@@ -1116,8 +1483,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.decision, VerificationDecision::Rejected);
-        assert!(result.summary.contains("conclusion `failure`"));
+        assert_eq!(result.decision, VerificationDecision::NeedsReview);
+        assert!(result.summary.contains("authenticated provenance"));
     }
 
     #[tokio::test]
@@ -1142,7 +1509,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.decision, VerificationDecision::NeedsReview);
-        assert!(result.summary.contains("pull_request metadata"));
+        assert!(result.summary.contains("authenticated provenance"));
     }
 
     #[tokio::test]
@@ -1167,7 +1534,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.decision, VerificationDecision::NeedsReview);
-        assert!(result.summary.contains("merged by its author"));
+        assert!(result.summary.contains("authenticated provenance"));
     }
 
     #[tokio::test]
@@ -1197,7 +1564,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.decision, VerificationDecision::NeedsReview);
-        assert!(result.summary.contains("non-author reviewer"));
+        assert!(result.summary.contains("authenticated provenance"));
     }
 
     #[tokio::test]
@@ -1217,11 +1584,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.decision, VerificationDecision::NeedsReview);
-        assert!(result.summary.contains("structured evidence is required"));
+        assert!(result.summary.contains("authenticated provenance"));
     }
 
     #[tokio::test]
-    async fn github_ci_verifier_rejects_replayed_pr_evidence() {
+    async fn github_ci_verifier_does_not_trust_replayed_pr_json() {
         let bounty_id = Uuid::new_v4();
         let submission = Submission {
             artifact_uri: "https://github.com/agent-bounties/agent-bounties/pull/43".to_string(),
@@ -1239,8 +1606,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.decision, VerificationDecision::Rejected);
-        assert!(result.summary.contains("does not match submitted PR"));
+        assert_eq!(result.decision, VerificationDecision::NeedsReview);
+        assert!(result.summary.contains("authenticated provenance"));
     }
 
     #[tokio::test]
@@ -1274,13 +1641,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(first.decision, VerificationDecision::Accepted);
-        assert_eq!(second.decision, VerificationDecision::Accepted);
+        assert_eq!(first.decision, VerificationDecision::NeedsReview);
+        assert_eq!(second.decision, VerificationDecision::NeedsReview);
         assert_ne!(first.signed_payload_hash, second.signed_payload_hash);
     }
 
     #[tokio::test]
-    async fn docker_verifier_requires_zero_exit_and_digest_match() {
+    async fn self_reported_docker_exit_code_cannot_authorize_acceptance() {
         let bounty_id = Uuid::new_v4();
         let submission = submission_for(bounty_id, "abc123abc123abc123");
 
@@ -1296,7 +1663,133 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.kind, VerifierKind::DockerCommand);
-        assert_eq!(result.decision, VerificationDecision::Accepted);
+        assert_eq!(result.decision, VerificationDecision::NeedsReview);
+        assert!(result.summary.contains("self-reported"));
+    }
+
+    #[test]
+    fn regression_policy_requires_immutable_direct_execution() {
+        let policy = regression_policy();
+        policy.validate().expect("valid regression policy");
+        assert_eq!(
+            policy.runner_manifest_hash().unwrap(),
+            policy.runner_manifest_hash().unwrap()
+        );
+        assert_eq!(
+            policy.command_hash().unwrap(),
+            policy.command_hash().unwrap()
+        );
+
+        let mut mutable_image = policy.clone();
+        mutable_image.image = "ghcr.io/agent-bounties/rust-verifier:latest".to_string();
+        assert!(mutable_image.validate().is_err());
+
+        let mut option_injection = policy.clone();
+        option_injection.image = format!("--volume@sha256:{}", "b".repeat(64));
+        assert!(option_injection.validate().is_err());
+
+        let mut uppercase = policy.clone();
+        uppercase.image = format!("GHCR.IO/owner/image@sha256:{}", "b".repeat(64));
+        assert!(uppercase.validate().is_err());
+
+        let mut shell = policy;
+        shell.command = vec!["sh".to_string(), "-c".to_string(), "cargo test".to_string()];
+        assert!(shell.validate().is_err());
+    }
+
+    #[tokio::test]
+    async fn sandboxed_regression_accepts_only_runner_execution_and_hashes_receipt() {
+        let verifier = SandboxedRegressionVerifier {
+            executor: StubRegressionExecutor::completed(0),
+            policy: regression_policy(),
+        };
+        let task = regression_task();
+
+        let first = verifier.verify(task.clone()).await.unwrap();
+        let second = verifier.verify(task).await.unwrap();
+
+        assert_eq!(first.verdict, RegressionVerdict::Passed);
+        assert_eq!(first.receipt.execution.exit_code, 0);
+        assert_eq!(first.response_hash, second.response_hash);
+        assert!(first.response_hash.starts_with("0x"));
+        assert_eq!(first.response_hash.len(), 66);
+        assert_eq!(first.receipt.scope, regression_scope());
+    }
+
+    #[tokio::test]
+    async fn sandboxed_regression_emits_failure_only_for_completed_nonzero_exit() {
+        let failed = SandboxedRegressionVerifier {
+            executor: StubRegressionExecutor::completed(1),
+            policy: regression_policy(),
+        }
+        .verify(regression_task())
+        .await
+        .unwrap();
+        assert_eq!(failed.verdict, RegressionVerdict::Failed);
+
+        let timed_out = SandboxedRegressionVerifier {
+            executor: StubRegressionExecutor {
+                outcome: Err(RegressionSandboxExecutorError::TimedOut),
+            },
+            policy: regression_policy(),
+        }
+        .verify(regression_task())
+        .await
+        .unwrap_err();
+        assert!(timed_out.to_string().contains("no verdict was produced"));
+
+        let reserved_exit = SandboxedRegressionVerifier {
+            executor: StubRegressionExecutor::completed(137),
+            policy: regression_policy(),
+        }
+        .verify(regression_task())
+        .await
+        .unwrap_err();
+        assert!(reserved_exit
+            .to_string()
+            .contains("no verdict was produced"));
+
+        let mut combined_output = StubRegressionExecutor::completed(0);
+        let execution = combined_output.outcome.as_mut().unwrap();
+        execution.stdout_bytes = 700;
+        execution.stderr_bytes = 700;
+        let mut bounded_policy = regression_policy();
+        bounded_policy.max_output_bytes = 1_024;
+        let bounded_output = SandboxedRegressionVerifier {
+            executor: combined_output,
+            policy: bounded_policy,
+        }
+        .verify(regression_task())
+        .await
+        .unwrap_err();
+        assert!(bounded_output
+            .to_string()
+            .contains("no verdict was produced"));
+    }
+
+    #[tokio::test]
+    async fn sandbox_runner_failure_produces_no_verdict() {
+        let verifier = SandboxedRegressionVerifier {
+            executor: StubRegressionExecutor {
+                outcome: Err(RegressionSandboxExecutorError::RuntimeUnavailable),
+            },
+            policy: regression_policy(),
+        };
+        let error = verifier.verify(regression_task()).await.unwrap_err();
+
+        assert!(error.to_string().contains("no verdict was produced"));
+    }
+
+    #[tokio::test]
+    async fn sandboxed_regression_rejects_malformed_payment_scope_before_execution() {
+        let verifier = SandboxedRegressionVerifier {
+            executor: StubRegressionExecutor::completed(0),
+            policy: regression_policy(),
+        };
+        let mut task = regression_task();
+        task.scope.submission_hash = hash("f");
+        task.scope.bounty_contract = "not-an-address".to_string();
+        assert!(verifier.verify(task).await.is_err());
     }
 
     #[tokio::test]
@@ -1377,6 +1870,94 @@ mod tests {
             artifact_uri: "s3://bucket/artifact".to_string(),
             submitted_at: Utc::now(),
         }
+    }
+
+    #[derive(Clone)]
+    struct StubRegressionExecutor {
+        outcome: Result<RegressionSandboxExecution, RegressionSandboxExecutorError>,
+    }
+
+    impl StubRegressionExecutor {
+        fn completed(exit_code: i32) -> Self {
+            Self {
+                outcome: Ok(RegressionSandboxExecution {
+                    exit_code,
+                    stdout_sha256: sha256_digest('d'),
+                    stderr_sha256: sha256_digest('e'),
+                    stdout_bytes: 12,
+                    stderr_bytes: 0,
+                    isolation: RegressionSandboxIsolation::default(),
+                }),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RegressionSandboxExecutor for StubRegressionExecutor {
+        async fn execute(
+            &self,
+            _policy: &RegressionSandboxPolicy,
+            _source_digest: &str,
+        ) -> Result<RegressionSandboxExecution, RegressionSandboxExecutorError> {
+            self.outcome.clone()
+        }
+    }
+
+    fn regression_policy() -> RegressionSandboxPolicy {
+        RegressionSandboxPolicy {
+            schema_version: REGRESSION_SANDBOX_POLICY_VERSION.to_string(),
+            image: format!(
+                "ghcr.io/agent-bounties/rust-verifier@sha256:{}",
+                "b".repeat(64)
+            ),
+            command: vec![
+                "cargo".to_string(),
+                "test".to_string(),
+                "--locked".to_string(),
+                "--target-dir".to_string(),
+                "/tmp/target".to_string(),
+            ],
+            workdir: "/workspace".to_string(),
+            benchmark_digest: sha256_digest('a'),
+            timeout_seconds: 120,
+            cpu_millis: 1_000,
+            memory_bytes: 512 * MIB,
+            pids_limit: 128,
+            max_output_bytes: MIB,
+            tmpfs_bytes: 256 * MIB,
+            max_source_bytes: 512 * MIB,
+            max_source_files: 50_000,
+            max_benchmark_bytes: 64 * MIB,
+            max_benchmark_files: 10_000,
+            platform: "linux/amd64".to_string(),
+            test_seed: 1,
+        }
+    }
+
+    fn regression_task() -> RegressionVerificationTask {
+        RegressionVerificationTask {
+            scope: regression_scope(),
+            source_digest: sha256_digest('c'),
+        }
+    }
+
+    fn regression_scope() -> RegressionVerificationScope {
+        RegressionVerificationScope {
+            network: "base-mainnet".to_string(),
+            bounty_id: hash("a"),
+            bounty_contract: address("2"),
+            round: 3,
+            solver_wallet: address("3"),
+            submission_hash: hash("4"),
+            evidence_hash: hash("5"),
+            terms_hash: hash("6"),
+            committed_policy_hash: hash("7"),
+            verification_expires_at: 2_000_000_000,
+        }
+    }
+
+    fn sha256_digest(character: char) -> String {
+        format!("sha256:{}", character.to_string().repeat(64))
     }
 
     fn github_ci_evidence() -> Value {

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -14,10 +14,12 @@ chain-base = { path = "../chain-base" }
 chrono.workspace = true
 db = { path = "../db" }
 domain = { path = "../domain" }
+hex.workspace = true
 ledger = { path = "../ledger" }
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+sha2.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "process"] }
 verifier-sdk = { path = "../verifier-sdk" }
 
 [dev-dependencies]

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -14,6 +14,9 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fmt};
 use verifier_sdk::{VerificationInput, Verifier, VerifierResultType};
 
+mod regression_sandbox;
+pub use regression_sandbox::*;
+
 const AUTONOMOUS_LOG_ADDRESS_BATCH_SIZE: usize = 500;
 const INDEXER_HEARTBEAT_SUCCESS: &str = "success";
 const INDEXER_HEARTBEAT_SKIPPED: &str = "skipped";

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -4,14 +4,80 @@ use std::{env, time::Duration};
 use tokio::time::sleep;
 use worker::{
     indexer_error_is_retryable, poll_autonomous_indexer_once_with_heartbeat,
-    redact_operational_error, AutonomousIndexerConfig, IndexerRecoveryDecision,
-    IndexerRecoveryPolicy,
+    redact_operational_error, run_regression_sandbox_request, snapshot_directory,
+    stage_regression_input, AutonomousIndexerConfig, IndexerRecoveryDecision,
+    IndexerRecoveryPolicy, RegressionInputKind, RegressionSandboxRunRequest,
+    REGRESSION_SANDBOX_DOCKER_BINARY_ENV, REGRESSION_SANDBOX_STAGING_ROOT_ENV,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let arguments = env::args().skip(1).collect::<Vec<_>>();
+    if arguments
+        .first()
+        .is_some_and(|value| value == "--snapshot-directory")
+    {
+        if arguments.len() != 4 {
+            anyhow::bail!("usage: worker --snapshot-directory <path> <max-bytes> <max-files>");
+        }
+        let max_bytes = arguments[2]
+            .parse::<u64>()
+            .context("max-bytes must be a positive integer")?;
+        let max_files = arguments[3]
+            .parse::<u32>()
+            .context("max-files must be a positive integer")?;
+        let snapshot = snapshot_directory(arguments[1].as_ref(), max_bytes, max_files)?;
+        println!("{}", serde_json::to_string_pretty(&snapshot)?);
+        return Ok(());
+    }
+    if arguments
+        .first()
+        .is_some_and(|value| value == "--run-regression")
+    {
+        if arguments.len() != 2 {
+            anyhow::bail!("usage: worker --run-regression <request.json>");
+        }
+        let request = std::fs::read_to_string(&arguments[1])
+            .context("failed to read regression sandbox request")?;
+        let request: RegressionSandboxRunRequest =
+            serde_json::from_str(&request).context("failed to parse regression sandbox request")?;
+        let staging_root = env::var(REGRESSION_SANDBOX_STAGING_ROOT_ENV)
+            .with_context(|| format!("{REGRESSION_SANDBOX_STAGING_ROOT_ENV} is required"))?;
+        let docker_binary =
+            env::var(REGRESSION_SANDBOX_DOCKER_BINARY_ENV).unwrap_or_else(|_| "docker".to_string());
+        let outcome =
+            run_regression_sandbox_request(request, staging_root.as_ref(), docker_binary).await?;
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+        return Ok(());
+    }
+    if arguments
+        .first()
+        .is_some_and(|value| value == "--stage-regression-input")
+    {
+        if arguments.len() != 6 {
+            anyhow::bail!(
+                "usage: worker --stage-regression-input <source|benchmark> <input-dir> <staging-root> <max-bytes> <max-files>"
+            );
+        }
+        let kind = RegressionInputKind::parse(&arguments[1])?;
+        let max_bytes = arguments[4]
+            .parse::<u64>()
+            .context("max-bytes must be a positive integer")?;
+        let max_files = arguments[5]
+            .parse::<u32>()
+            .context("max-files must be a positive integer")?;
+        let staged = stage_regression_input(
+            arguments[2].as_ref(),
+            arguments[3].as_ref(),
+            kind,
+            max_bytes,
+            max_files,
+        )?;
+        println!("{}", serde_json::to_string_pretty(&staged)?);
+        return Ok(());
+    }
     let once =
-        env_flag("BASE_INDEXER_ONCE") || env::args().skip(1).any(|argument| argument == "--once");
+        env_flag("BASE_INDEXER_ONCE") || arguments.iter().any(|argument| argument == "--once");
     let database_url = env::var("DATABASE_URL")
         .context("DATABASE_URL is required for the Base USDC indexer worker")?;
     let store = PostgresStore::connect(&database_url).await?;

--- a/crates/worker/src/regression_sandbox.rs
+++ b/crates/worker/src/regression_sandbox.rs
@@ -643,7 +643,7 @@ pub fn stage_regression_input(
         if copied != source_snapshot {
             return Err(anyhow!("sandbox input changed while it was being staged"));
         }
-        make_tree_read_only(&temporary)?;
+        make_tree_contents_read_only(&temporary)?;
         Ok(copied)
     });
     let copied = match copy_result {
@@ -654,7 +654,12 @@ pub fn stage_regression_input(
         }
     };
     match fs::rename(&temporary, &target) {
-        Ok(()) => {}
+        Ok(()) => {
+            if let Err(error) = make_directory_read_only(&target) {
+                remove_tree_best_effort(&target);
+                return Err(error).context("failed to secure staged regression input");
+            }
+        }
         Err(_) if target.exists() => {
             remove_tree_best_effort(&temporary);
             let existing = snapshot_directory(&target, max_bytes, max_files)?;
@@ -814,7 +819,7 @@ fn copy_directory_tree(source: &Path, destination: &Path) -> anyhow::Result<()> 
     Ok(())
 }
 
-fn make_tree_read_only(root: &Path) -> anyhow::Result<()> {
+fn make_tree_contents_read_only(root: &Path) -> anyhow::Result<()> {
     let mut directories = vec![root.to_path_buf()];
     let mut all_directories = Vec::new();
     while let Some(directory) = directories.pop() {
@@ -836,14 +841,46 @@ fn make_tree_read_only(root: &Path) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        for directory in all_directories.into_iter().rev() {
+        for directory in all_directories
+            .into_iter()
+            .rev()
+            .filter(|directory| directory != root)
+        {
             fs::set_permissions(directory, fs::Permissions::from_mode(0o555))?;
         }
     }
     Ok(())
 }
 
+#[cfg(unix)]
+fn make_directory_read_only(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o555))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_directory_read_only(_path: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
 fn remove_tree_best_effort(path: &Path) {
+    #[cfg(unix)]
+    fn clear(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = fs::symlink_metadata(path) {
+            if metadata.is_dir() {
+                if let Ok(entries) = fs::read_dir(path) {
+                    for entry in entries.flatten() {
+                        clear(&entry.path());
+                    }
+                }
+                let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+            } else if metadata.is_file() {
+                let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+            }
+        }
+    }
     #[cfg(windows)]
     #[allow(clippy::permissions_set_readonly_false)]
     fn clear(path: &Path) {
@@ -860,7 +897,7 @@ fn remove_tree_best_effort(path: &Path) {
             let _ = fs::set_permissions(path, permissions);
         }
     }
-    #[cfg(windows)]
+    #[cfg(any(unix, windows))]
     clear(path);
     let _ = fs::remove_dir_all(path);
 }
@@ -954,7 +991,9 @@ mod tests {
     fn staged_inputs_are_digest_derived_and_immutable() {
         let input = temp_directory("stage-input");
         let staging = temp_directory("stage-root");
+        fs::create_dir(input.join("nested")).unwrap();
         fs::write(input.join("result.txt"), b"expected").unwrap();
+        fs::write(input.join("nested").join("details.txt"), b"stable").unwrap();
 
         let staged =
             stage_regression_input(&input, &staging, RegressionInputKind::Source, 1_024, 10)
@@ -971,9 +1010,18 @@ mod tests {
             .unwrap()
             .permissions()
             .readonly());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&staged.path).unwrap().permissions().mode() & 0o222,
+                0
+            );
+        }
 
         remove_tree_best_effort(&input);
         remove_tree_best_effort(&staging);
+        assert!(!staging.exists());
     }
 
     #[test]

--- a/crates/worker/src/regression_sandbox.rs
+++ b/crates/worker/src/regression_sandbox.rs
@@ -1,0 +1,1335 @@
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+use chain_base::{
+    base_network_descriptor, keccak256_canonical_json, sha256_canonical_json, sha256_utf8,
+    AutonomousVerificationJob,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tokio::{io::AsyncReadExt, process::Command, task, time::Instant};
+use verifier_sdk::{
+    RegressionSandboxExecution, RegressionSandboxExecutor, RegressionSandboxExecutorError,
+    RegressionSandboxIsolation, RegressionSandboxPolicy, RegressionVerificationOutcome,
+    RegressionVerificationScope, RegressionVerificationTask, SandboxedRegressionVerifier,
+};
+
+pub const REGRESSION_SANDBOX_ENGINE: &str = "sandboxed_regression_v1";
+pub const REGRESSION_SANDBOX_STAGING_ROOT_ENV: &str = "REGRESSION_SANDBOX_STAGING_ROOT";
+pub const REGRESSION_SANDBOX_DOCKER_BINARY_ENV: &str = "REGRESSION_SANDBOX_DOCKER_BINARY";
+const DIRECTORY_DIGEST_DOMAIN: &[u8] = b"agent-bounties/directory-v1\0";
+static RUN_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegressionSandboxRunRequest {
+    pub job: AutonomousVerificationJob,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegressionInputKind {
+    Source,
+    Benchmark,
+}
+
+impl RegressionInputKind {
+    pub fn parse(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "source" => Ok(Self::Source),
+            "benchmark" => Ok(Self::Benchmark),
+            _ => Err(anyhow!("input kind must be source or benchmark")),
+        }
+    }
+
+    fn directory_name(self) -> &'static str {
+        match self {
+            Self::Source => "sources",
+            Self::Benchmark => "benchmarks",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectorySnapshot {
+    pub digest: String,
+    pub file_count: u32,
+    pub total_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StagedRegressionInput {
+    pub kind: RegressionInputKind,
+    pub path: PathBuf,
+    pub snapshot: DirectorySnapshot,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedRegressionRun {
+    pub policy: RegressionSandboxPolicy,
+    pub task: RegressionVerificationTask,
+    pub source_path: PathBuf,
+    pub benchmark_path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct DockerCliRegressionExecutor {
+    docker_binary: PathBuf,
+    source_path: PathBuf,
+    benchmark_path: PathBuf,
+}
+
+impl DockerCliRegressionExecutor {
+    pub fn new(
+        docker_binary: impl Into<PathBuf>,
+        source_path: impl AsRef<Path>,
+        benchmark_path: impl AsRef<Path>,
+    ) -> anyhow::Result<Self> {
+        let source_path = canonical_sandbox_root(source_path.as_ref(), "source")?;
+        let benchmark_path = canonical_sandbox_root(benchmark_path.as_ref(), "benchmark")?;
+        if source_path == benchmark_path
+            || source_path.starts_with(&benchmark_path)
+            || benchmark_path.starts_with(&source_path)
+        {
+            return Err(anyhow!(
+                "source and benchmark roots must be distinct and non-nested"
+            ));
+        }
+        Ok(Self {
+            docker_binary: docker_binary.into(),
+            source_path,
+            benchmark_path,
+        })
+    }
+
+    fn docker_arguments(&self, policy: &RegressionSandboxPolicy, name: &str) -> Vec<String> {
+        let cpu_limit = format!(
+            "{}.{:03}",
+            policy.cpu_millis / 1_000,
+            policy.cpu_millis % 1_000
+        );
+        vec![
+            "run".to_string(),
+            "--pull".to_string(),
+            "never".to_string(),
+            "--name".to_string(),
+            name.to_string(),
+            "--platform".to_string(),
+            policy.platform.clone(),
+            "--network".to_string(),
+            "none".to_string(),
+            "--ipc".to_string(),
+            "none".to_string(),
+            "--read-only".to_string(),
+            "--cap-drop".to_string(),
+            "ALL".to_string(),
+            "--security-opt".to_string(),
+            "no-new-privileges=true".to_string(),
+            "--user".to_string(),
+            "65532:65532".to_string(),
+            "--pids-limit".to_string(),
+            policy.pids_limit.to_string(),
+            "--cpus".to_string(),
+            cpu_limit,
+            "--memory".to_string(),
+            policy.memory_bytes.to_string(),
+            "--memory-swap".to_string(),
+            policy.memory_bytes.to_string(),
+            "--stop-timeout".to_string(),
+            "1".to_string(),
+            "--log-driver".to_string(),
+            "none".to_string(),
+            "--tmpfs".to_string(),
+            format!("/tmp:rw,nosuid,nodev,size={}", policy.tmpfs_bytes),
+            "--mount".to_string(),
+            format!(
+                "type=bind,src={},dst=/workspace,readonly",
+                docker_mount_source(&self.source_path)
+            ),
+            "--mount".to_string(),
+            format!(
+                "type=bind,src={},dst=/benchmark,readonly",
+                docker_mount_source(&self.benchmark_path)
+            ),
+            "--workdir".to_string(),
+            policy.workdir.clone(),
+            "--env".to_string(),
+            "HOME=/tmp/home".to_string(),
+            "--env".to_string(),
+            "LANG=C.UTF-8".to_string(),
+            "--env".to_string(),
+            "LC_ALL=C.UTF-8".to_string(),
+            "--env".to_string(),
+            "TZ=UTC".to_string(),
+            "--env".to_string(),
+            "SOURCE_DATE_EPOCH=0".to_string(),
+            "--env".to_string(),
+            format!("AGENT_BOUNTIES_TEST_SEED={}", policy.test_seed),
+            "--".to_string(),
+            policy.image.clone(),
+        ]
+        .into_iter()
+        .chain(policy.command.iter().cloned())
+        .collect()
+    }
+
+    async fn remove_container(&self, name: &str) {
+        let _ = Command::new(&self.docker_binary)
+            .args(["rm", "--force", name])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+    }
+}
+
+#[async_trait]
+impl RegressionSandboxExecutor for DockerCliRegressionExecutor {
+    async fn execute(
+        &self,
+        policy: &RegressionSandboxPolicy,
+        source_digest: &str,
+    ) -> Result<RegressionSandboxExecution, RegressionSandboxExecutorError> {
+        let source_path = self.source_path.clone();
+        let source_max_bytes = policy.max_source_bytes;
+        let source_max_files = policy.max_source_files;
+        let source_snapshot = task::spawn_blocking(move || {
+            snapshot_directory(&source_path, source_max_bytes, source_max_files)
+        })
+        .await
+        .map_err(|_| RegressionSandboxExecutorError::FailedClosed)?
+        .map_err(|_| RegressionSandboxExecutorError::InputUnavailable)?;
+        let benchmark_path = self.benchmark_path.clone();
+        let benchmark_max_bytes = policy.max_benchmark_bytes;
+        let benchmark_max_files = policy.max_benchmark_files;
+        let benchmark_snapshot = task::spawn_blocking(move || {
+            snapshot_directory(&benchmark_path, benchmark_max_bytes, benchmark_max_files)
+        })
+        .await
+        .map_err(|_| RegressionSandboxExecutorError::FailedClosed)?
+        .map_err(|_| RegressionSandboxExecutorError::InputUnavailable)?;
+        if source_snapshot.digest != source_digest
+            || benchmark_snapshot.digest != policy.benchmark_digest
+        {
+            return Err(RegressionSandboxExecutorError::InputUnavailable);
+        }
+
+        let name = format!(
+            "agent-bounties-regression-{}-{}",
+            std::process::id(),
+            RUN_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut child = Command::new(&self.docker_binary)
+            .args(self.docker_arguments(policy, &name))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|_| RegressionSandboxExecutorError::RuntimeUnavailable)?;
+        let Some(stdout) = child.stdout.take() else {
+            self.remove_container(&name).await;
+            return Err(RegressionSandboxExecutorError::FailedClosed);
+        };
+        let Some(stderr) = child.stderr.take() else {
+            self.remove_container(&name).await;
+            return Err(RegressionSandboxExecutorError::FailedClosed);
+        };
+        let output_exceeded = Arc::new(AtomicBool::new(false));
+        let total_output_bytes = Arc::new(AtomicU64::new(0));
+        let stdout_task = tokio::spawn(hash_stream(
+            stdout,
+            policy.max_output_bytes,
+            Arc::clone(&total_output_bytes),
+            Arc::clone(&output_exceeded),
+        ));
+        let stderr_task = tokio::spawn(hash_stream(
+            stderr,
+            policy.max_output_bytes,
+            Arc::clone(&total_output_bytes),
+            Arc::clone(&output_exceeded),
+        ));
+
+        enum Completion {
+            Status(std::process::ExitStatus),
+            TimedOut,
+            OutputLimitExceeded,
+        }
+        let deadline = Instant::now() + Duration::from_secs(policy.timeout_seconds);
+        let completion = loop {
+            if output_exceeded.load(Ordering::Acquire) {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                break Completion::OutputLimitExceeded;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                break Completion::TimedOut;
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => break Completion::Status(status),
+                Ok(None) => tokio::time::sleep(Duration::from_millis(10)).await,
+                Err(_) => {
+                    let _ = child.kill().await;
+                    let _ = child.wait().await;
+                    self.remove_container(&name).await;
+                    return Err(RegressionSandboxExecutorError::FailedClosed);
+                }
+            }
+        };
+        self.remove_container(&name).await;
+        let stdout = stdout_task
+            .await
+            .map_err(|_| RegressionSandboxExecutorError::FailedClosed)?
+            .map_err(|_| RegressionSandboxExecutorError::FailedClosed)?;
+        let stderr = stderr_task
+            .await
+            .map_err(|_| RegressionSandboxExecutorError::FailedClosed)?
+            .map_err(|_| RegressionSandboxExecutorError::FailedClosed)?;
+
+        match completion {
+            Completion::TimedOut => return Err(RegressionSandboxExecutorError::TimedOut),
+            Completion::OutputLimitExceeded => {
+                return Err(RegressionSandboxExecutorError::OutputLimitExceeded)
+            }
+            Completion::Status(status) => {
+                let code = status
+                    .code()
+                    .ok_or(RegressionSandboxExecutorError::ResourceLimitExceeded)?;
+                if matches!(code, 125..=127) {
+                    return Err(RegressionSandboxExecutorError::FailedClosed);
+                }
+                if code >= 128 {
+                    return Err(RegressionSandboxExecutorError::ResourceLimitExceeded);
+                }
+                Ok(RegressionSandboxExecution {
+                    exit_code: code,
+                    stdout_sha256: stdout.digest,
+                    stderr_sha256: stderr.digest,
+                    stdout_bytes: stdout.bytes,
+                    stderr_bytes: stderr.bytes,
+                    isolation: RegressionSandboxIsolation::default(),
+                })
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StreamDigest {
+    digest: String,
+    bytes: u64,
+}
+
+async fn hash_stream(
+    mut stream: impl tokio::io::AsyncRead + Unpin,
+    limit: u64,
+    total_bytes: Arc<AtomicU64>,
+    exceeded: Arc<AtomicBool>,
+) -> std::io::Result<StreamDigest> {
+    let mut hasher = Sha256::new();
+    let mut bytes = 0u64;
+    let mut buffer = [0u8; 8 * 1024];
+    loop {
+        let read = stream.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        bytes = bytes.saturating_add(read as u64);
+        let previous_total = total_bytes.fetch_add(read as u64, Ordering::AcqRel);
+        if previous_total
+            .checked_add(read as u64)
+            .is_none_or(|total| total > limit)
+        {
+            exceeded.store(true, Ordering::Release);
+        }
+    }
+    Ok(StreamDigest {
+        digest: format!("sha256:{}", hex::encode(hasher.finalize())),
+        bytes,
+    })
+}
+
+pub fn prepare_regression_run(
+    job: AutonomousVerificationJob,
+    observed_at_unix: u64,
+    staging_root: &Path,
+) -> anyhow::Result<PreparedRegressionRun> {
+    let network =
+        base_network_descriptor(&job.network).context("verification job network is unsupported")?;
+    let evidence_network = base_network_descriptor(&job.submission_evidence.network)
+        .context("submission evidence network is unsupported")?;
+    if network.chain_id != evidence_network.chain_id {
+        return Err(anyhow!("verification job and evidence networks differ"));
+    }
+    let canonical_network = if network.chain_id == 8_453 {
+        "base-mainnet"
+    } else if network.chain_id == 84_532 {
+        "base-sepolia"
+    } else {
+        return Err(anyhow!(
+            "regression verification supports only Base networks"
+        ));
+    };
+    if job.verification_mode != "signed_quorum" || job.verifier_module.is_some() {
+        return Err(anyhow!(
+            "sandboxed regression verification requires signed_quorum without a verifier module"
+        ));
+    }
+    if job.threshold < 2
+        || job.eligible_verifiers.len() < usize::from(job.threshold)
+        || job.verification_expires_at <= observed_at_unix
+    {
+        return Err(anyhow!(
+            "sandboxed regression verification requires a live quorum threshold of at least two"
+        ));
+    }
+    let mut distinct_verifiers = HashSet::new();
+    for verifier in &job.eligible_verifiers {
+        validate_evm_address("eligible verifier", verifier)?;
+        if !distinct_verifiers.insert(verifier.to_ascii_lowercase()) {
+            return Err(anyhow!("eligible regression verifiers must be distinct"));
+        }
+    }
+
+    validate_terms_hashes(&job)?;
+    let evidence = &job.submission_evidence;
+    if !evidence
+        .bounty_contract
+        .eq_ignore_ascii_case(&job.bounty_contract)
+        || !evidence.bounty_id.eq_ignore_ascii_case(&job.bounty_id)
+        || evidence.round != job.round
+        || !evidence
+            .solver_wallet
+            .eq_ignore_ascii_case(&job.solver_wallet)
+        || !evidence
+            .artifact_hash
+            .eq_ignore_ascii_case(&sha256_utf8(&evidence.artifact_reference))
+        || !evidence
+            .evidence_hash
+            .eq_ignore_ascii_case(&sha256_canonical_json(&evidence.evidence)?)
+    {
+        return Err(anyhow!(
+            "verification job scope or published submission preimages do not match"
+        ));
+    }
+
+    let verification_policy = job
+        .terms
+        .document
+        .verification_policy
+        .as_object()
+        .ok_or_else(|| anyhow!("verification policy must be an object"))?;
+    if verification_policy
+        .get("mechanism")
+        .and_then(serde_json::Value::as_str)
+        != Some("signed_quorum")
+        || verification_policy
+            .get("engine")
+            .and_then(serde_json::Value::as_str)
+            != Some(REGRESSION_SANDBOX_ENGINE)
+        || verification_policy
+            .get("threshold")
+            .and_then(serde_json::Value::as_u64)
+            != Some(u64::from(job.threshold))
+    {
+        return Err(anyhow!(
+            "verification policy does not commit sandboxed_regression_v1 signed quorum"
+        ));
+    }
+    let policy_verifiers = verification_policy
+        .get("verifiers")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow!("verification policy verifiers are unavailable"))?;
+    if policy_verifiers.len() != job.eligible_verifiers.len()
+        || policy_verifiers
+            .iter()
+            .zip(&job.eligible_verifiers)
+            .any(|(committed, indexed)| {
+                !committed
+                    .as_str()
+                    .is_some_and(|value| value.eq_ignore_ascii_case(indexed))
+            })
+    {
+        return Err(anyhow!(
+            "indexed eligible verifiers differ from the immutable policy"
+        ));
+    }
+
+    let benchmark = job
+        .terms
+        .document
+        .benchmark
+        .as_object()
+        .ok_or_else(|| anyhow!("regression benchmark must be an object"))?;
+    if benchmark.get("engine").and_then(serde_json::Value::as_str)
+        != Some(REGRESSION_SANDBOX_ENGINE)
+    {
+        return Err(anyhow!("benchmark does not commit sandboxed_regression_v1"));
+    }
+    let policy: RegressionSandboxPolicy = serde_json::from_value(
+        benchmark
+            .get("runner_manifest")
+            .cloned()
+            .ok_or_else(|| anyhow!("benchmark runner_manifest is unavailable"))?,
+    )
+    .context("benchmark runner_manifest is invalid")?;
+    policy.validate()?;
+    let source_digest = evidence
+        .evidence
+        .get("source_snapshot_digest")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("submission evidence source_snapshot_digest is unavailable"))?
+        .to_string();
+
+    validate_bytes32("bounty_id", &job.bounty_id)?;
+    validate_evm_address("bounty_contract", &job.bounty_contract)?;
+    validate_evm_address("solver_wallet", &job.solver_wallet)?;
+    let task = RegressionVerificationTask {
+        scope: RegressionVerificationScope {
+            network: canonical_network.to_string(),
+            bounty_id: job.bounty_id,
+            bounty_contract: job.bounty_contract.to_ascii_lowercase(),
+            round: job.round,
+            solver_wallet: job.solver_wallet.to_ascii_lowercase(),
+            submission_hash: evidence.artifact_hash.to_ascii_lowercase(),
+            evidence_hash: evidence.evidence_hash.to_ascii_lowercase(),
+            terms_hash: job.terms.terms_hash.to_ascii_lowercase(),
+            committed_policy_hash: job.terms.policy_hash.to_ascii_lowercase(),
+            verification_expires_at: job.verification_expires_at,
+        },
+        source_digest: source_digest.clone(),
+    };
+    task.validate()?;
+    Ok(PreparedRegressionRun {
+        source_path: staged_input_path(staging_root, RegressionInputKind::Source, &source_digest)?,
+        benchmark_path: staged_input_path(
+            staging_root,
+            RegressionInputKind::Benchmark,
+            &policy.benchmark_digest,
+        )?,
+        policy,
+        task,
+    })
+}
+
+fn validate_terms_hashes(job: &AutonomousVerificationJob) -> anyhow::Result<()> {
+    let document = serde_json::to_value(&job.terms.document)?;
+    let acceptance = serde_json::to_value(&job.terms.document.acceptance_criteria)?;
+    for (field, actual, expected) in [
+        (
+            "terms_hash",
+            job.terms.terms_hash.as_str(),
+            keccak256_canonical_json(&document)?,
+        ),
+        (
+            "policy_hash",
+            job.terms.policy_hash.as_str(),
+            keccak256_canonical_json(&job.terms.document.verification_policy)?,
+        ),
+        (
+            "acceptance_criteria_hash",
+            job.terms.acceptance_criteria_hash.as_str(),
+            keccak256_canonical_json(&acceptance)?,
+        ),
+        (
+            "benchmark_hash",
+            job.terms.benchmark_hash.as_str(),
+            keccak256_canonical_json(&job.terms.document.benchmark)?,
+        ),
+        (
+            "evidence_schema_hash",
+            job.terms.evidence_schema_hash.as_str(),
+            keccak256_canonical_json(&job.terms.document.evidence_schema)?,
+        ),
+    ] {
+        validate_bytes32(field, actual)?;
+        if !actual.eq_ignore_ascii_case(&expected) {
+            return Err(anyhow!("{field} does not match its immutable preimage"));
+        }
+    }
+    let contract_network = job
+        .terms
+        .document
+        .contract_terms
+        .get("network")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("contract terms network is unavailable"))?;
+    if base_network_descriptor(contract_network)?.chain_id
+        != base_network_descriptor(&job.network)?.chain_id
+    {
+        return Err(anyhow!("contract terms network differs from the job"));
+    }
+    Ok(())
+}
+
+pub async fn run_regression_sandbox_request(
+    request: RegressionSandboxRunRequest,
+    staging_root: &Path,
+    docker_binary: impl Into<PathBuf>,
+) -> anyhow::Result<RegressionVerificationOutcome> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_secs();
+    let prepared = prepare_regression_run(request.job, now, staging_root)?;
+    let executor = DockerCliRegressionExecutor::new(
+        docker_binary,
+        &prepared.source_path,
+        &prepared.benchmark_path,
+    )?;
+    SandboxedRegressionVerifier {
+        executor,
+        policy: prepared.policy,
+    }
+    .verify(prepared.task)
+    .await
+    .context("sandboxed regression verification failed closed")
+}
+
+pub fn stage_regression_input(
+    input: &Path,
+    staging_root: &Path,
+    kind: RegressionInputKind,
+    max_bytes: u64,
+    max_files: u32,
+) -> anyhow::Result<StagedRegressionInput> {
+    let source_snapshot = snapshot_directory(input, max_bytes, max_files)?;
+    fs::create_dir_all(staging_root).context("failed to create regression staging root")?;
+    let staging_root = canonical_sandbox_root(staging_root, "staging")?;
+    let target = staged_input_path(&staging_root, kind, &source_snapshot.digest)?;
+    if target.exists() {
+        let existing = snapshot_directory(&target, max_bytes, max_files)?;
+        if existing != source_snapshot {
+            return Err(anyhow!(
+                "content-addressed staging target does not match its digest"
+            ));
+        }
+        return Ok(StagedRegressionInput {
+            kind,
+            path: target,
+            snapshot: existing,
+        });
+    }
+
+    let parent = target
+        .parent()
+        .ok_or_else(|| anyhow!("staging target has no parent"))?;
+    fs::create_dir_all(parent).context("failed to create content-addressed staging namespace")?;
+    let temporary = staging_root.join(".tmp").join(format!(
+        "{}-{}",
+        std::process::id(),
+        RUN_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    if let Some(parent) = temporary.parent() {
+        fs::create_dir_all(parent).context("failed to create temporary staging namespace")?;
+    }
+    fs::create_dir(&temporary).context("failed to create temporary staging directory")?;
+    let copy_result = copy_directory_tree(input, &temporary).and_then(|()| {
+        let copied = snapshot_directory(&temporary, max_bytes, max_files)?;
+        if copied != source_snapshot {
+            return Err(anyhow!("sandbox input changed while it was being staged"));
+        }
+        make_tree_read_only(&temporary)?;
+        Ok(copied)
+    });
+    let copied = match copy_result {
+        Ok(copied) => copied,
+        Err(error) => {
+            remove_tree_best_effort(&temporary);
+            return Err(error);
+        }
+    };
+    match fs::rename(&temporary, &target) {
+        Ok(()) => {}
+        Err(_) if target.exists() => {
+            remove_tree_best_effort(&temporary);
+            let existing = snapshot_directory(&target, max_bytes, max_files)?;
+            if existing != source_snapshot {
+                return Err(anyhow!(
+                    "concurrent content-addressed staging target is inconsistent"
+                ));
+            }
+        }
+        Err(error) => {
+            remove_tree_best_effort(&temporary);
+            return Err(error).context("failed to publish staged regression input");
+        }
+    }
+    Ok(StagedRegressionInput {
+        kind,
+        path: target,
+        snapshot: copied,
+    })
+}
+
+fn staged_input_path(
+    staging_root: &Path,
+    kind: RegressionInputKind,
+    digest: &str,
+) -> anyhow::Result<PathBuf> {
+    let digest = digest
+        .strip_prefix("sha256:")
+        .filter(|value| {
+            value.len() == 64
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        })
+        .ok_or_else(|| anyhow!("staged input digest must be sha256:<64 lowercase hex>"))?;
+    Ok(staging_root
+        .join(kind.directory_name())
+        .join("sha256")
+        .join(digest))
+}
+
+pub fn snapshot_directory(
+    root: &Path,
+    max_bytes: u64,
+    max_files: u32,
+) -> anyhow::Result<DirectorySnapshot> {
+    if max_bytes == 0 || max_files == 0 {
+        return Err(anyhow!("directory snapshot limits must be positive"));
+    }
+    let root = canonical_sandbox_root(root, "snapshot")?;
+    let files = enumerate_regular_files(&root, max_bytes, max_files)?;
+    let mut hasher = Sha256::new();
+    hasher.update(DIRECTORY_DIGEST_DOMAIN);
+    for file in &files {
+        let path_bytes = file.relative.as_bytes();
+        hasher.update((path_bytes.len() as u64).to_be_bytes());
+        hasher.update(path_bytes);
+        hasher.update(file.size.to_be_bytes());
+        let mut input = fs::File::open(&file.path).context("failed to open sandbox input file")?;
+        std::io::copy(&mut input, &mut HashWriter(&mut hasher))
+            .context("failed to hash sandbox input file")?;
+    }
+    Ok(DirectorySnapshot {
+        digest: format!("sha256:{}", hex::encode(hasher.finalize())),
+        file_count: files.len() as u32,
+        total_bytes: files.iter().map(|file| file.size).sum(),
+    })
+}
+
+struct RegularFile {
+    relative: String,
+    path: PathBuf,
+    size: u64,
+}
+
+fn enumerate_regular_files(
+    root: &Path,
+    max_bytes: u64,
+    max_files: u32,
+) -> anyhow::Result<Vec<RegularFile>> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut files = Vec::new();
+    let mut total_bytes = 0u64;
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(&directory).context("failed to enumerate sandbox input")? {
+            let entry = entry.context("failed to read sandbox directory entry")?;
+            let path = entry.path();
+            let metadata =
+                fs::symlink_metadata(&path).context("failed to inspect sandbox directory entry")?;
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() {
+                return Err(anyhow!("sandbox inputs cannot contain symbolic links"));
+            }
+            if file_type.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if !file_type.is_file() {
+                return Err(anyhow!("sandbox inputs cannot contain special files"));
+            }
+            let relative = path
+                .strip_prefix(root)
+                .context("sandbox entry escaped its root")?
+                .to_str()
+                .ok_or_else(|| anyhow!("sandbox input paths must be UTF-8"))?
+                .replace('\\', "/");
+            if relative.is_empty()
+                || relative.split('/').any(|part| {
+                    part.is_empty() || part == "." || part == ".." || part.contains('\0')
+                })
+            {
+                return Err(anyhow!("sandbox input path is invalid"));
+            }
+            total_bytes = total_bytes
+                .checked_add(metadata.len())
+                .ok_or_else(|| anyhow!("sandbox input size overflow"))?;
+            if total_bytes > max_bytes || files.len() >= max_files as usize {
+                return Err(anyhow!("sandbox input exceeds its committed size limits"));
+            }
+            files.push(RegularFile {
+                relative,
+                path,
+                size: metadata.len(),
+            });
+        }
+    }
+    files.sort_by(|left, right| left.relative.cmp(&right.relative));
+    Ok(files)
+}
+
+fn copy_directory_tree(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let source = canonical_sandbox_root(source, "source")?;
+    let mut pending = vec![source.clone()];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(&directory).context("failed to enumerate staged input")? {
+            let entry = entry.context("failed to read staged input entry")?;
+            let path = entry.path();
+            let metadata =
+                fs::symlink_metadata(&path).context("failed to inspect staged input entry")?;
+            if metadata.file_type().is_symlink() {
+                return Err(anyhow!("sandbox inputs cannot contain symbolic links"));
+            }
+            let relative = path
+                .strip_prefix(&source)
+                .context("staged input escaped its root")?;
+            let target = destination.join(relative);
+            if metadata.is_dir() {
+                fs::create_dir(&target).context("failed to create staged input directory")?;
+                pending.push(path);
+            } else if metadata.is_file() {
+                fs::copy(&path, &target).context("failed to copy staged input file")?;
+            } else {
+                return Err(anyhow!("sandbox inputs cannot contain special files"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn make_tree_read_only(root: &Path) -> anyhow::Result<()> {
+    let mut directories = vec![root.to_path_buf()];
+    let mut all_directories = Vec::new();
+    while let Some(directory) = directories.pop() {
+        all_directories.push(directory.clone());
+        for entry in fs::read_dir(&directory).context("failed to secure staged input")? {
+            let path = entry?.path();
+            let metadata = fs::symlink_metadata(&path)?;
+            if metadata.is_dir() {
+                directories.push(path);
+            } else if metadata.is_file() {
+                let mut permissions = metadata.permissions();
+                permissions.set_readonly(true);
+                fs::set_permissions(path, permissions)?;
+            } else {
+                return Err(anyhow!("staged input contains a special file"));
+            }
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for directory in all_directories.into_iter().rev() {
+            fs::set_permissions(directory, fs::Permissions::from_mode(0o555))?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_tree_best_effort(path: &Path) {
+    #[cfg(windows)]
+    #[allow(clippy::permissions_set_readonly_false)]
+    fn clear(path: &Path) {
+        if let Ok(metadata) = fs::symlink_metadata(path) {
+            if metadata.is_dir() {
+                if let Ok(entries) = fs::read_dir(path) {
+                    for entry in entries.flatten() {
+                        clear(&entry.path());
+                    }
+                }
+            }
+            let mut permissions = metadata.permissions();
+            permissions.set_readonly(false);
+            let _ = fs::set_permissions(path, permissions);
+        }
+    }
+    #[cfg(windows)]
+    clear(path);
+    let _ = fs::remove_dir_all(path);
+}
+
+struct HashWriter<'a>(&'a mut Sha256);
+
+impl std::io::Write for HashWriter<'_> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.0.update(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn canonical_sandbox_root(path: &Path, kind: &str) -> anyhow::Result<PathBuf> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect {kind} sandbox root"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(anyhow!("{kind} sandbox root must be a real directory"));
+    }
+    let canonical =
+        fs::canonicalize(path).with_context(|| format!("failed to resolve {kind} sandbox root"))?;
+    let text = canonical
+        .to_str()
+        .ok_or_else(|| anyhow!("{kind} sandbox root must be UTF-8"))?;
+    if text.contains(',') || text.contains('\n') || text.contains('\r') {
+        return Err(anyhow!(
+            "{kind} sandbox root cannot contain mount delimiters"
+        ));
+    }
+    Ok(canonical)
+}
+
+fn docker_mount_source(path: &Path) -> String {
+    let text = path.to_string_lossy();
+    #[cfg(windows)]
+    let text = text.strip_prefix("\\\\?\\").unwrap_or(&text);
+    text.to_string()
+}
+
+fn validate_bytes32(field: &str, value: &str) -> anyhow::Result<()> {
+    if value.len() != 66
+        || !value.starts_with("0x")
+        || !value[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(anyhow!("{field} must be a 0x-prefixed bytes32 value"));
+    }
+    Ok(())
+}
+
+fn validate_evm_address(field: &str, value: &str) -> anyhow::Result<()> {
+    if value.len() != 42
+        || !value.starts_with("0x")
+        || !value[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err(anyhow!("{field} must be an EVM address"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chain_base::{build_autonomous_bounty_terms_record, BASE_MAINNET_USDC_TOKEN_ADDRESS};
+    use chrono::{TimeZone, Utc};
+    use domain::{AutonomousBountyTermsDocument, AutonomousSubmissionEvidenceRecord};
+    use serde_json::json;
+
+    #[test]
+    fn directory_snapshot_is_stable_and_content_addressed() {
+        let root = temp_directory("snapshot");
+        fs::create_dir_all(root.join("nested")).unwrap();
+        fs::write(root.join("b.txt"), b"two").unwrap();
+        fs::write(root.join("nested").join("a.txt"), b"one").unwrap();
+
+        let first = snapshot_directory(&root, 1_024, 10).unwrap();
+        let second = snapshot_directory(&root, 1_024, 10).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.file_count, 2);
+
+        fs::write(root.join("nested").join("a.txt"), b"changed").unwrap();
+        let changed = snapshot_directory(&root, 1_024, 10).unwrap();
+        assert_ne!(first.digest, changed.digest);
+        remove_tree_best_effort(&root);
+    }
+
+    #[test]
+    fn staged_inputs_are_digest_derived_and_immutable() {
+        let input = temp_directory("stage-input");
+        let staging = temp_directory("stage-root");
+        fs::write(input.join("result.txt"), b"expected").unwrap();
+
+        let staged =
+            stage_regression_input(&input, &staging, RegressionInputKind::Source, 1_024, 10)
+                .unwrap();
+        let canonical_staging = fs::canonicalize(&staging).unwrap();
+        assert!(staged
+            .path
+            .starts_with(canonical_staging.join("sources").join("sha256")));
+        assert_eq!(
+            snapshot_directory(&staged.path, 1_024, 10).unwrap(),
+            staged.snapshot
+        );
+        assert!(fs::metadata(staged.path.join("result.txt"))
+            .unwrap()
+            .permissions()
+            .readonly());
+
+        remove_tree_best_effort(&input);
+        remove_tree_best_effort(&staging);
+    }
+
+    #[test]
+    fn docker_arguments_enforce_the_isolation_contract_and_end_options() {
+        let source = temp_directory("source");
+        let benchmark = temp_directory("benchmark");
+        let executor = DockerCliRegressionExecutor::new("docker", &source, &benchmark).unwrap();
+        let policy = regression_policy(
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
+        let args = executor.docker_arguments(&policy, "agent-bounties-test");
+        let joined = args.join(" ");
+
+        for required in [
+            "--network none",
+            "--ipc none",
+            "--read-only",
+            "--cap-drop ALL",
+            "no-new-privileges=true",
+            "--user 65532:65532",
+            "dst=/workspace,readonly",
+            "dst=/benchmark,readonly",
+            "--pull never",
+            "--log-driver none",
+        ] {
+            assert!(joined.contains(required), "missing {required}: {joined}");
+        }
+        assert!(!joined.contains("docker.sock"));
+        assert!(!joined.contains("--privileged"));
+        let separator = args.iter().position(|argument| argument == "--").unwrap();
+        assert_eq!(args[separator + 1], policy.image);
+        assert_eq!(&args[separator + 2..], policy.command);
+        remove_tree_best_effort(&source);
+        remove_tree_best_effort(&benchmark);
+    }
+
+    #[test]
+    fn autonomous_job_adapter_binds_every_payment_relevant_scope() {
+        let staging = temp_directory("adapter");
+        let job = verification_job();
+        let prepared = prepare_regression_run(job.clone(), 1_800_000_000, &staging).unwrap();
+        assert_eq!(prepared.task.scope.bounty_id, job.bounty_id);
+        assert_eq!(
+            prepared.task.scope.committed_policy_hash,
+            job.terms.policy_hash
+        );
+        assert_eq!(prepared.task.source_digest, source_digest());
+
+        type JobMutation = Box<dyn Fn(&mut AutonomousVerificationJob)>;
+        let mut mutations: Vec<JobMutation> = vec![
+            Box::new(|job| job.submission_evidence.network = "base-sepolia".to_string()),
+            Box::new(|job| job.submission_evidence.bounty_contract = address('9')),
+            Box::new(|job| job.submission_evidence.bounty_id = bytes32('9')),
+            Box::new(|job| job.submission_evidence.round += 1),
+            Box::new(|job| job.submission_evidence.solver_wallet = address('9')),
+            Box::new(|job| job.submission_evidence.artifact_hash = bytes32('9')),
+            Box::new(|job| job.submission_evidence.evidence_hash = bytes32('9')),
+            Box::new(|job| job.terms.policy_hash = bytes32('9')),
+            Box::new(|job| job.verification_expires_at = 1_800_000_000),
+        ];
+        for mutate in mutations.drain(..) {
+            let mut invalid = job.clone();
+            mutate(&mut invalid);
+            assert!(prepare_regression_run(invalid, 1_800_000_000, &staging).is_err());
+        }
+        remove_tree_best_effort(&staging);
+    }
+
+    #[test]
+    fn autonomous_job_adapter_rejects_weak_or_wrong_verification_policy() {
+        let staging = temp_directory("policy-adapter");
+        let mut threshold_one = verification_job();
+        threshold_one.threshold = 1;
+        assert!(prepare_regression_run(threshold_one, 1_800_000_000, &staging).is_err());
+
+        let mut duplicate = verification_job();
+        duplicate.eligible_verifiers[1] = duplicate.eligible_verifiers[0].clone();
+        assert!(prepare_regression_run(duplicate, 1_800_000_000, &staging).is_err());
+
+        let mut wrong_engine = verification_job();
+        wrong_engine.terms.document.verification_policy["engine"] = json!("github_ci");
+        assert!(prepare_regression_run(wrong_engine, 1_800_000_000, &staging).is_err());
+
+        let mut missing_source = verification_job();
+        missing_source
+            .submission_evidence
+            .evidence
+            .as_object_mut()
+            .unwrap()
+            .remove("source_snapshot_digest");
+        missing_source.submission_evidence.evidence_hash =
+            sha256_canonical_json(&missing_source.submission_evidence.evidence).unwrap();
+        assert!(prepare_regression_run(missing_source, 1_800_000_000, &staging).is_err());
+        remove_tree_best_effort(&staging);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a local Docker daemon and the pinned Alpine image"]
+    async fn docker_rehearsal_passes_fails_and_produces_no_infrastructure_verdicts() {
+        let fixture_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("regression");
+        let staging = temp_directory("docker-rehearsal");
+        let benchmark = stage_regression_input(
+            &fixture_root.join("benchmark"),
+            &staging,
+            RegressionInputKind::Benchmark,
+            1_024 * 1_024,
+            100,
+        )
+        .unwrap();
+        let good = stage_regression_input(
+            &fixture_root.join("source"),
+            &staging,
+            RegressionInputKind::Source,
+            1_024 * 1_024,
+            100,
+        )
+        .unwrap();
+        let bad = stage_regression_input(
+            &fixture_root.join("source-bad"),
+            &staging,
+            RegressionInputKind::Source,
+            1_024 * 1_024,
+            100,
+        )
+        .unwrap();
+        let observed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut policy = regression_policy(&benchmark.snapshot.digest);
+        policy.image = pinned_alpine_image();
+        policy.command = vec![
+            "cmp".to_string(),
+            "/workspace/result.txt".to_string(),
+            "/benchmark/expected.txt".to_string(),
+        ];
+
+        let passed = run_regression_sandbox_request(
+            RegressionSandboxRunRequest {
+                job: verification_job_with(observed, &good.snapshot.digest, policy.clone()),
+            },
+            &staging,
+            "docker",
+        )
+        .await
+        .unwrap();
+        assert_eq!(passed.verdict, verifier_sdk::RegressionVerdict::Passed);
+
+        let failed = run_regression_sandbox_request(
+            RegressionSandboxRunRequest {
+                job: verification_job_with(observed, &bad.snapshot.digest, policy.clone()),
+            },
+            &staging,
+            "docker",
+        )
+        .await
+        .unwrap();
+        assert_eq!(failed.verdict, verifier_sdk::RegressionVerdict::Failed);
+
+        let mut timeout_policy = policy.clone();
+        timeout_policy.command = vec!["sleep".to_string(), "2".to_string()];
+        timeout_policy.timeout_seconds = 1;
+        let timeout_error = run_regression_sandbox_request(
+            RegressionSandboxRunRequest {
+                job: verification_job_with(observed, &good.snapshot.digest, timeout_policy),
+            },
+            &staging,
+            "docker",
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{timeout_error:#}").contains("no verdict"));
+
+        let mut output_policy = policy;
+        output_policy.command = vec!["yes".to_string()];
+        output_policy.max_output_bytes = 1_024;
+        let output_error = run_regression_sandbox_request(
+            RegressionSandboxRunRequest {
+                job: verification_job_with(observed, &good.snapshot.digest, output_policy),
+            },
+            &staging,
+            "docker",
+        )
+        .await
+        .unwrap_err();
+        assert!(format!("{output_error:#}").contains("no verdict"));
+        remove_tree_best_effort(&staging);
+    }
+
+    #[test]
+    fn nested_roots_and_size_overruns_are_rejected() {
+        let source = temp_directory("nested-source");
+        let benchmark = source.join("benchmark");
+        fs::create_dir_all(&benchmark).unwrap();
+        assert!(DockerCliRegressionExecutor::new("docker", &source, &benchmark).is_err());
+        fs::write(source.join("large.bin"), [0u8; 16]).unwrap();
+        assert!(snapshot_directory(&source, 8, 10).is_err());
+        remove_tree_best_effort(&source);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symbolic_links_are_rejected() {
+        use std::os::unix::fs::symlink;
+        let root = temp_directory("symlink");
+        fs::write(root.join("target"), b"target").unwrap();
+        symlink(root.join("target"), root.join("link")).unwrap();
+        assert!(snapshot_directory(&root, 1_024, 10).is_err());
+        remove_tree_best_effort(&root);
+    }
+
+    fn verification_job() -> AutonomousVerificationJob {
+        verification_job_with(
+            1_800_000_000,
+            &source_digest(),
+            regression_policy(&benchmark_digest()),
+        )
+    }
+
+    fn verification_job_with(
+        observed: u64,
+        source_digest: &str,
+        manifest: RegressionSandboxPolicy,
+    ) -> AutonomousVerificationJob {
+        let document = AutonomousBountyTermsDocument {
+            schema_version: "agent-bounties/terms-v1".to_string(),
+            contract_terms: json!({
+                "protocol_version": "agent-bounties/autonomous-v1",
+                "creator_wallet": address('4'),
+                "network": "base-mainnet",
+                "settlement_token": BASE_MAINNET_USDC_TOKEN_ADDRESS,
+                "solver_reward": {"amount": 1_900_000, "currency": "usdc"},
+                "verifier_reward": {"amount": 100_000, "currency": "usdc"},
+                "claim_bond": {"amount": 100_000, "currency": "usdc"},
+                "initial_funding": {"amount": 2_000_000, "currency": "usdc"},
+                "funding_deadline": observed + 86_400,
+                "claim_window_seconds": 3_600,
+                "verification_window_seconds": 1_800,
+                "creation_nonce": bytes32('1'),
+            }),
+            title: "Run immutable regression tests".to_string(),
+            goal: "Verify a submitted source snapshot".to_string(),
+            acceptance_criteria: vec!["committed tests pass".to_string()],
+            benchmark: json!({
+                "engine": REGRESSION_SANDBOX_ENGINE,
+                "runner_manifest": manifest,
+            }),
+            evidence_schema: json!({
+                "type": "object",
+                "required": ["source_snapshot_digest"]
+            }),
+            verification_policy: json!({
+                "mechanism": "signed_quorum",
+                "engine": REGRESSION_SANDBOX_ENGINE,
+                "verifiers": [address('5'), address('6')],
+                "threshold": 2
+            }),
+            source_url: None,
+            discovery_source: None,
+            agent_eligibility: None,
+            claim_coordination: None,
+        };
+        let created_at = Utc.timestamp_opt(observed as i64, 0).unwrap();
+        let terms = build_autonomous_bounty_terms_record(&address('4'), document, created_at)
+            .expect("valid terms fixture");
+        let evidence = json!({"source_snapshot_digest": source_digest});
+        let artifact_reference = "https://example.com/source.tar".to_string();
+        let submission_evidence = AutonomousSubmissionEvidenceRecord {
+            network: "base-mainnet".to_string(),
+            bounty_contract: address('2'),
+            bounty_id: bytes32('a'),
+            round: 1,
+            solver_wallet: address('3'),
+            artifact_hash: sha256_utf8(&artifact_reference),
+            artifact_reference,
+            evidence_hash: sha256_canonical_json(&evidence).unwrap(),
+            evidence,
+            created_at,
+        };
+        AutonomousVerificationJob {
+            job_id: format!("base-mainnet:{}:1", address('2')),
+            network: "base-mainnet".to_string(),
+            bounty_id: bytes32('a'),
+            bounty_contract: address('2'),
+            round: 1,
+            solver_wallet: address('3'),
+            verification_mode: "signed_quorum".to_string(),
+            verifier_module: None,
+            eligible_verifiers: vec![address('5'), address('6')],
+            threshold: 2,
+            verifier_reward: "100000".to_string(),
+            current_solver_payout: "1900000".to_string(),
+            verification_expires_at: observed + 1_800,
+            terms,
+            submission_evidence,
+            required_action: "run committed regression verifier".to_string(),
+            payout_boundary: "only BountySettled proves payment".to_string(),
+        }
+    }
+
+    fn regression_policy(benchmark_digest: &str) -> RegressionSandboxPolicy {
+        RegressionSandboxPolicy {
+            schema_version: verifier_sdk::REGRESSION_SANDBOX_POLICY_VERSION.to_string(),
+            image: format!("docker.io/library/alpine@sha256:{}", "b".repeat(64)),
+            command: vec!["true".to_string()],
+            workdir: "/workspace".to_string(),
+            benchmark_digest: benchmark_digest.to_string(),
+            timeout_seconds: 30,
+            cpu_millis: 500,
+            memory_bytes: 128 * 1024 * 1024,
+            pids_limit: 32,
+            max_output_bytes: 64 * 1024,
+            tmpfs_bytes: 64 * 1024 * 1024,
+            max_source_bytes: 1024 * 1024,
+            max_source_files: 100,
+            max_benchmark_bytes: 1024 * 1024,
+            max_benchmark_files: 100,
+            platform: "linux/amd64".to_string(),
+            test_seed: 7,
+        }
+    }
+
+    fn source_digest() -> String {
+        format!("sha256:{}", "c".repeat(64))
+    }
+
+    fn benchmark_digest() -> String {
+        format!("sha256:{}", "d".repeat(64))
+    }
+
+    fn pinned_alpine_image() -> String {
+        "docker.io/library/alpine@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d"
+            .to_string()
+    }
+
+    fn bytes32(character: char) -> String {
+        format!("0x{}", character.to_string().repeat(64))
+    }
+
+    fn address(character: char) -> String {
+        format!("0x{}", character.to_string().repeat(40))
+    }
+
+    fn temp_directory(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "agent-bounties-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+}

--- a/crates/worker/tests/fixtures/regression/benchmark/expected.txt
+++ b/crates/worker/tests/fixtures/regression/benchmark/expected.txt
@@ -1,0 +1,1 @@
+expected-output

--- a/crates/worker/tests/fixtures/regression/source-bad/result.txt
+++ b/crates/worker/tests/fixtures/regression/source-bad/result.txt
@@ -1,0 +1,1 @@
+unexpected-output

--- a/crates/worker/tests/fixtures/regression/source/result.txt
+++ b/crates/worker/tests/fixtures/regression/source/result.txt
@@ -1,0 +1,1 @@
+expected-output

--- a/docs/autonomous-protocol.md
+++ b/docs/autonomous-protocol.md
@@ -260,6 +260,30 @@ The contract rejects unauthorized, duplicate, expired, invalid, or mixed
 verdict signatures. Any caller may relay exactly one threshold through
 `settleWithAttestations`.
 
+#### Sandboxed Regression Candidates
+
+Coding bounties may commit `sandboxed_regression_v1` under `signed_quorum` with
+a threshold of at least two. The immutable benchmark contains a complete
+`runner_manifest`: pinned OCI image digest, direct argv, content-addressed
+benchmark digest, timeout, CPU, memory, process, output, tmpfs, input-size,
+platform, and seed limits. Submission evidence must include the exact source
+snapshot digest.
+
+The no-secrets runner binds its receipt to network, bounty id and contract,
+round, solver, submission and evidence hashes, terms and policy hashes, and the
+verification expiry. Exit zero produces a `passed` candidate; a completed
+ordinary nonzero exit produces `failed`. Timeout, output overflow, resource
+kill, missing input, digest mismatch, malformed policy, or runtime failure
+produces no verdict. The candidate is unsigned and cannot settle funds. Each
+precommitted verifier must independently evaluate and sign the exact current
+scope before the contract can settle.
+
+The repository currently contains the local runner and abuse harness only. It
+does not advertise quorum bounties as verification-ready, deploy a Docker
+runner beside the indexer, hold verifier keys, or sign/relay a verdict. Those
+require separately reviewed independent runner and signer services. See
+[`sandboxed-regression-verifier.md`](sandboxed-regression-verifier.md).
+
 ### AI Judge Quorum
 
 AI judging uses the signed-quorum path and requires threshold two or greater.

--- a/docs/bounty-templates.md
+++ b/docs/bounty-templates.md
@@ -104,11 +104,19 @@ Output: logs, screenshot/artifact digest, observed result.
 ## Verifier Evidence
 
 `JsonSchema` verifies the submitted artifact digest against the expected digest.
-`GitHubCi` accepts structured successful GitHub check evidence. `DockerCommand`
-accepts a zero exit code and, when provided, a matching artifact digest.
-`HttpCallback` requires a 2xx callback, an `accepted` decision, and a valid
-signature flag. `Manual` and `AiJudgeFilter` are review-only and never authorize
-payment directly.
+The legacy `GitHubCi` and `DockerCommand` adapters treat request JSON as
+unauthenticated, return `NeedsReview`, and cannot authorize acceptance or
+rejection. `HttpCallback` and other legacy verification are operator-gated and
+are not autonomous-v1 settlement evidence. `Manual` and `AiJudgeFilter` are
+review-only.
+
+Autonomous coding bounties may instead commit
+`sandboxed_regression_v1`: a pinned OCI image, direct argv, benchmark digest,
+and bounded resources are published before funding. A separate no-secrets
+runner executes content-addressed inputs and emits an unsigned, scope-bound
+verdict candidate. Only the bounty's precommitted verifier quorum may sign and
+settle that candidate. See
+[`sandboxed-regression-verifier.md`](sandboxed-regression-verifier.md).
 
 ### GitHub CI Evidence Shape
 
@@ -135,6 +143,6 @@ submission `artifact_uri` to the pull request URL and pass evidence like:
 }
 ```
 
-The verifier rejects evidence when the check-run repository, check-run head SHA,
-or pull request number does not match the submitted work. Missing structured
-evidence returns `NeedsReview` rather than authorizing payment.
+The adapter checks the internal consistency of this shape for review routing,
+but it does not authenticate GitHub provenance. Every such payload returns
+`NeedsReview`; missing or inconsistent evidence also cannot authorize payment.

--- a/docs/sandboxed-regression-verifier.md
+++ b/docs/sandboxed-regression-verifier.md
@@ -1,0 +1,123 @@
+# Sandboxed Regression Verifier
+
+`sandboxed_regression_v1` is the deterministic coding-verification runner. It
+executes a source snapshot against tests committed before bounty funding and
+emits an unsigned verifier candidate. It does not sign, relay, settle, or prove
+payment.
+
+## Current Status
+
+Implemented and tested locally:
+
+- exact autonomous verification-job validation;
+- content-addressed source and benchmark staging;
+- immutable OCI image and direct-argv validation;
+- network-disabled, read-only, non-root Docker execution;
+- CPU, memory, process, time, output, and tmpfs bounds;
+- scope-bound receipt and `0x` bytes32 response hash;
+- pass/fail candidates only for completed ordinary exits;
+- no verdict on timeout, output overflow, resource kill, input mismatch, or
+  runtime failure.
+
+Not enabled in production:
+
+- a hosted runner service;
+- verifier keys or signatures;
+- independent quorum operators;
+- attestation relay;
+- verifier-readiness publication.
+
+Until those pieces pass a separate deployment review, quorum bounties remain
+absent from earning-ready inventory.
+
+## Immutable Terms
+
+The verification policy must name the engine and at least two distinct verifier
+wallets:
+
+```json
+{
+  "mechanism": "signed_quorum",
+  "engine": "sandboxed_regression_v1",
+  "verifiers": ["0xVerifierOne", "0xVerifierTwo"],
+  "threshold": 2
+}
+```
+
+The benchmark commits the full runner manifest:
+
+```json
+{
+  "engine": "sandboxed_regression_v1",
+  "runner_manifest": {
+    "schema_version": "agent-bounties/regression-sandbox-v1",
+    "image": "registry.example/verifier@sha256:<64-lowercase-hex>",
+    "command": ["cargo", "test", "--locked", "--target-dir", "/tmp/target"],
+    "workdir": "/workspace",
+    "benchmark_digest": "sha256:<64-lowercase-hex>",
+    "timeout_seconds": 120,
+    "cpu_millis": 1000,
+    "memory_bytes": 536870912,
+    "pids_limit": 128,
+    "max_output_bytes": 1048576,
+    "tmpfs_bytes": 268435456,
+    "max_source_bytes": 536870912,
+    "max_source_files": 50000,
+    "max_benchmark_bytes": 67108864,
+    "max_benchmark_files": 10000,
+    "platform": "linux/amd64",
+    "test_seed": 1
+  }
+}
+```
+
+Shell entrypoints and mutable image tags are invalid. Submission evidence must
+contain `source_snapshot_digest` using the same directory-digest algorithm as
+the worker.
+
+## Local Rehearsal
+
+Stage operator-provided directories into the runner-owned store:
+
+```powershell
+cargo run -p worker -- --stage-regression-input source `
+  path\to\source target\regression-staging 536870912 50000
+cargo run -p worker -- --stage-regression-input benchmark `
+  path\to\benchmark target\regression-staging 67108864 10000
+```
+
+Fetch one canonical job from
+`GET /v1/base/autonomous-bounties/verification-jobs`, save only the returned job
+inside `{"job": ...}`, and run:
+
+```powershell
+$env:REGRESSION_SANDBOX_STAGING_ROOT = "$PWD\target\regression-staging"
+$env:REGRESSION_SANDBOX_DOCKER_BINARY = "docker"
+cargo run -p worker -- --run-regression path\to\request.json
+```
+
+The request cannot choose host paths or override policy. The worker recomputes
+terms, policy, benchmark, evidence, artifact, and staging digests before
+execution.
+
+Run the deterministic and live-Docker harnesses with:
+
+```powershell
+cargo test -p verifier-sdk
+cargo test -p worker
+cargo test -p worker `
+  docker_rehearsal_passes_fails_and_produces_no_infrastructure_verdicts `
+  -- --ignored
+```
+
+## Deployment Boundary
+
+Do not mount a Docker socket into the Base indexer or any service holding RPC,
+database, wallet, Stripe, or operator secrets. A hosted runner must be a
+separate no-secrets service with a runner-owned staging volume. Signing must be
+a separate capability that verifies a fresh candidate against the current
+canonical job and requires at least two distinct precommitted verifier paths.
+
+Only confirmed canonical `BountySettled` is payout evidence. A runner receipt,
+response hash, verifier signature, quorum plan, relay transaction hash, or
+hosted database row is not payment evidence.

--- a/scripts/check-sdk-live.ps1
+++ b/scripts/check-sdk-live.ps1
@@ -44,11 +44,13 @@ try {
     $oldMcpBase = $env:MCP_BASE_URL
     $oldDatabaseUrl = $env:DATABASE_URL
     $oldPythonPath = $env:PYTHONPATH
+    $oldOperatorApiToken = $env:OPERATOR_API_TOKEN
 
     $env:API_BIND_ADDR = "127.0.0.1:18280"
     $env:PUBLIC_BASE_URL = $apiBaseUrl
     $env:MCP_BASE_URL = "http://127.0.0.1:18290"
     $env:PYTHONPATH = Join-Path $repoRoot "crates\sdk-python"
+    $env:OPERATOR_API_TOKEN = "agent-bounties-local-sdk-smoke"
     Remove-Item Env:DATABASE_URL -ErrorAction SilentlyContinue
 
     $apiPath = Join-Path $repoRoot "target\debug\api.exe"
@@ -101,6 +103,7 @@ try {
         if ($null -ne $oldMcpBase) { $env:MCP_BASE_URL = $oldMcpBase } else { Remove-Item Env:MCP_BASE_URL -ErrorAction SilentlyContinue }
         if ($null -ne $oldDatabaseUrl) { $env:DATABASE_URL = $oldDatabaseUrl } else { Remove-Item Env:DATABASE_URL -ErrorAction SilentlyContinue }
         if ($null -ne $oldPythonPath) { $env:PYTHONPATH = $oldPythonPath } else { Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue }
+        if ($null -ne $oldOperatorApiToken) { $env:OPERATOR_API_TOKEN = $oldOperatorApiToken } else { Remove-Item Env:OPERATOR_API_TOKEN -ErrorAction SilentlyContinue }
     }
 }
 finally {

--- a/scripts/check-sdk-live.sh
+++ b/scripts/check-sdk-live.sh
@@ -39,6 +39,7 @@ fi
 api_bind_addr="127.0.0.1:18280"
 api_base_url="http://127.0.0.1:18280"
 sdk_python_path="$repo_root/crates/sdk-python"
+export OPERATOR_API_TOKEN="agent-bounties-local-sdk-smoke"
 if [[ "$api_bin" == *.exe ]] && [[ -f /proc/version ]] && grep -qi microsoft /proc/version; then
   echo "scripts/check-sdk-live.sh needs a native Unix API binary under WSL; use scripts/check-sdk-live.ps1 with the Windows Rust toolchain, or install Rust inside WSL." >&2
   exit 2


### PR DESCRIPTION
## Summary
- add a no-secrets, content-addressed Docker runner for deterministic coding regression tests
- bind unsigned pass/fail candidates to the exact canonical bounty, submission, evidence, terms, policy, expiry, image, command, source, and benchmark
- fail closed on timeout, output overflow, resource kill, missing inputs, digest mismatch, and runtime errors
- prevent caller-supplied GitHub CI or Docker JSON from authorizing legacy payment verification
- require operator authorization for the legacy verification endpoint

## Trust boundary
This PR does **not** deploy a hosted runner, verifier keys, signatures, quorum operators, or an attestation relay. It does not advertise regression bounties as verification-ready and cannot settle funds. A separate reviewed deployment slice is required.

## Verification
- `scripts/check.ps1` (full repository gate)
- `cargo test -p verifier-sdk` (20 passed)
- `cargo test -p worker` (15 passed, 1 live-Docker test ignored by default)
- live-Docker rehearsal: pass, fail, timeout/no-verdict, output-limit/no-verdict
- `cargo test -p app`
- `cargo test -p eval-harness`
- `cargo test -p api`
- `cargo test -p cli`
- Clippy with `-D warnings`
- `python scripts/check-site.py`

Closes #295.