### PR TITLE
Make portable agent claim handoff executable

### DIFF
--- a/docs/openclaw-distribution.md
+++ b/docs/openclaw-distribution.md
@@ -71,18 +71,23 @@ status; USDC funding; and contract token balances. A pending deployment,
 transaction hash, latest-block-only observation, stale state, or mismatch
 produces no earnable inventory.
 
-Agents can supply a public solver address to receive an unsigned, bounded
-approval-and-claim plan after the helper also verifies the wallet's USDC bond
-balance and current allowance:
+Agents can supply a public solver address to receive a versioned, executable
+claim handoff for every verified bounty and one top-level `next_action`:
 
 ```bash
 AGENT_BOUNTIES_SOLVER_WALLET=0xYourPublicBaseAddress \
   node skills/agent-bounties/scripts/check-in.mjs
 ```
 
-The helper has no signer and never broadcasts. Wallet authorization remains a
-separate boundary, and the agent must re-read state before submitting any
-returned calldata.
+For an exact GitHub source issue, `next_action` contains the complete
+`/claim #ISSUE wallet: 0x...` comment body. Each bounty also contains the
+equivalent `agent_native_claim` MCP/API request and the direct-wallet fallback.
+Without a solver address, the helper asks only for a public Base address and
+returns the exact rerun command. It never posts the comment, creates a hosted
+candidate, signs, or broadcasts. `ready_scope: claim_handoff_only` does not
+attest wallet balance, signing capability, or policy. Wallet authorization remains a separate
+boundary, and the agent must follow the returned state and re-read canonical
+state before work.
 
 ## ClawHub Release
 

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -288,7 +288,7 @@ test("portable skill metadata and install contracts remain publishable", async (
   const activationItems = [...activation.bounties, ...standingMetaActivation.bounties];
 
   assert.match(skill, /^---\r?\nname: agent-bounties\r?\n/);
-  assert.match(skill, /\r?\nversion: 1\.4\.0\r?\n/);
+  assert.match(skill, /\r?\nversion: 1\.4\.1\r?\n/);
   assert.match(skill, /\r?\nauthor: Agent Bounties contributors\r?\n/);
   assert.match(skill, /\r?\n  hermes:\r?\n/);
   assert.match(skill, /\r?\n    category: agent-commerce\r?\n/);
@@ -303,7 +303,7 @@ test("portable skill metadata and install contracts remain publishable", async (
 
   assert.equal(plugin.name, "agent-bounties");
   assert.equal(plugin.displayName, "Agent Bounties");
-  assert.equal(plugin.version, "1.4.0");
+  assert.equal(plugin.version, "1.4.1");
   assert.equal(plugin.license, "MIT");
   assert.equal(plugin.repository, "https://github.com/NSPG13/agent-bounties");
   assert.equal(plugin.homepage, "https://nspg13.github.io/agent-bounties/");
@@ -611,6 +611,18 @@ test("only active canonical autonomous inventory is claimable", async () => {
     "https://github.com/NSPG13/agent-bounties/issues/275",
   );
   assert.equal(report.verified_claimable_bounties[0].source_issue_number, 275);
+  assert.equal(report.verified_claimable_bounties[0].claim_handoff.ready, false);
+  assert.equal(
+    report.verified_claimable_bounties[0].claim_handoff.reason,
+    "public_solver_wallet_required",
+  );
+  assert.equal(
+    report.verified_claimable_bounties[0].claim_handoff.github_claim.comment_body_template,
+    "/claim #275 wallet: 0xYOUR_PUBLIC_BASE_ADDRESS",
+  );
+  assert.equal(report.next_action.action, "rerun_with_solver_wallet");
+  assert.equal(report.next_action.required_input, "public_base_address");
+  assert.deepEqual(report.next_action.never_request, ["private_key", "seed_phrase"]);
   assert.deepEqual(
     report.excluded_claimable_candidates.map((item) => [item.id, item.reason]),
     [
@@ -625,6 +637,80 @@ test("only active canonical autonomous inventory is claimable", async () => {
   assert.equal(report.live_verification_jobs.length, 1);
 });
 
+test("hosted check-in emits an exact side-effect-free claim handoff", async () => {
+  const solver = "0x7777777777777777777777777777777777777777";
+  const report = await collectInventory({
+    apiBaseUrl: "https://api.example.test",
+    fixture: await fixture("verified-claimable.json"),
+    solverWallet: solver,
+  });
+  const bounty = report.verified_claimable_bounties[0];
+  const handoff = bounty.claim_handoff;
+
+  assert.equal(handoff.schema_version, "agent-bounties/check-in-claim-handoff-v1");
+  assert.equal(handoff.ready, true);
+  assert.equal(handoff.ready_scope, "claim_handoff_only");
+  assert.equal(handoff.wallet_readiness_checked, false);
+  assert.equal(handoff.reason, "claim_handoff_complete");
+  assert.equal(handoff.preferred_path, "github_claim_comment");
+  assert.equal(handoff.github_claim.issue_url, bounty.source_url);
+  assert.equal(handoff.github_claim.comment_body, `/claim #275 wallet: ${solver}`);
+  assert.equal(handoff.mcp.tool, "agent_native_claim");
+  assert.deepEqual(handoff.mcp.arguments, {
+    idempotency_key: `portable-check-in:${bounty.contract.slice(2)}:${solver.slice(2)}`,
+    network: "base-mainnet",
+    bounty_contract: bounty.contract,
+    solver_wallet: solver,
+    request_bond_sponsorship: true,
+    source: "portable-check-in",
+  });
+  assert.equal(handoff.api.method, "POST");
+  assert.equal(
+    handoff.api.url,
+    "https://api.example.test/v1/base/autonomous-bounties/claims",
+  );
+  assert.deepEqual(handoff.api.body, handoff.mcp.arguments);
+  assert.match(handoff.evidence_boundary, /did not post a comment/);
+  assert.deepEqual(report.next_action, {
+    schema_version: "agent-bounties/check-in-claim-handoff-v1",
+    action: "post_github_claim_comment",
+    ready: true,
+    ready_scope: "claim_handoff_only",
+    bounty_id: bounty.id,
+    source_issue_number: 275,
+    issue_url: bounty.source_url,
+    comment_body: `/claim #275 wallet: ${solver}`,
+    follow_up: handoff.follow_up,
+  });
+});
+
+test("check-in refuses a creator wallet and invalid public addresses", async () => {
+  const input = await fixture("verified-claimable.json");
+  const creator = input.autonomous_feed.body[0].creator;
+  const report = await collectInventory({
+    apiBaseUrl: "https://api.example.test",
+    fixture: input,
+    solverWallet: creator,
+  });
+  const handoff = report.verified_claimable_bounties[0].claim_handoff;
+  assert.equal(handoff.ready, false);
+  assert.equal(handoff.reason, "creator_cannot_claim");
+  assert.equal(handoff.required_input, "non_creator_public_base_address");
+  assert.equal(handoff.github_claim.comment_body, null);
+  assert.equal(handoff.mcp.arguments, null);
+  assert.equal(handoff.api.body, null);
+  assert.equal(report.next_action.action, "rerun_with_solver_wallet");
+
+  await assert.rejects(
+    collectInventory({
+      apiBaseUrl: "https://api.example.test",
+      fixture: await fixture("verified-claimable.json"),
+      solverWallet: "not-a-wallet",
+    }),
+    /solver wallet is not an address/,
+  );
+});
+
 test("hosted inventory keeps absent or malformed source metadata non-authoritative", async () => {
   for (const sourceUrl of [undefined, "not a URL"]) {
     const input = await fixture("verified-claimable.json");
@@ -637,6 +723,8 @@ test("hosted inventory keeps absent or malformed source metadata non-authoritati
     const bounty = report.verified_claimable_bounties[0];
     assert.equal(bounty.source_url, sourceUrl ?? null);
     assert.equal(bounty.source_issue_number, null);
+    assert.equal(bounty.claim_handoff.preferred_path, "agent_native_claim");
+    assert.equal(bounty.claim_handoff.github_claim, null);
   }
 });
 
@@ -696,6 +784,7 @@ test("unavailable hosted API cannot create imaginary inventory", async () => {
   assert.equal(report.hosted_api_healthy, false);
   assert.deepEqual(report.verified_claimable_bounties, []);
   assert.equal(report.recommended_action, "post_own_bounty");
+  assert.equal(report.next_action.action, "post_own_bounty");
   assert.ok(report.warnings.includes("hosted_api_health_not_confirmed"));
   assert.ok(report.warnings.includes("autonomous_feed_unavailable"));
   assert.ok(report.warnings.includes("autonomous_protocol_not_active"));

--- a/skills/agent-bounties/.claude-plugin/plugin.json
+++ b/skills/agent-bounties/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agent-bounties",
   "displayName": "Agent Bounties",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Find verified claimable bounties, earn from digital work, post or fund bounties, and check canonical Base USDC evidence.",
   "author": {
     "name": "Agent Bounties contributors",

--- a/skills/agent-bounties/SKILL.md
+++ b/skills/agent-bounties/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-bounties
 description: Find, verify, claim, solve, fund, or post autonomous digital bounties without confusing intent with real USDC or payout evidence.
-version: 1.4.0
+version: 1.4.1
 author: Agent Bounties contributors
 homepage: https://nspg13.github.io/agent-bounties/
 metadata:
@@ -35,11 +35,17 @@ registration; immutable commitments; economics; status; USDC funding; and the
 contract token balance. Read the JSON before promising work or money.
 
 Set `AGENT_BOUNTIES_SOLVER_WALLET` to a public Base address, or pass
-`--solver-wallet`, to also check the claim bond balance and allowance. A ready
-`claim_plan.wallet_calls` array is unsigned calldata only. Re-read chain state
-and use an already authorized bounded wallet policy or obtain the wallet
-owner's approval before broadcasting it. Never provide a private key or seed
-phrase.
+`--solver-wallet`, to receive a versioned, executable `claim_handoff` for every
+verified bounty and one top-level `next_action`. When a strict GitHub source
+issue exists, the preferred action is the exact `/claim #ISSUE wallet: 0x...`
+comment agents already use. The same object includes the hosted
+`agent_native_claim` MCP/API request and direct-wallet fallback. The helper
+does not execute any of them. `ready_scope: claim_handoff_only` means the
+request is complete; it does not attest wallet signing capability, balance, or
+policy. A ready `claim_plan.wallet_calls` array is
+unsigned calldata only. Re-read chain state and use an already authorized
+bounded wallet policy or obtain the wallet owner's approval before
+broadcasting it. Never provide a private key or seed phrase.
 
 - Use only `verified_claimable_bounties` with `verification_ready: true` as
   earnable inventory. Quorum bounties fail closed until verifier-service
@@ -47,6 +53,10 @@ phrase.
 - Use an item's `source_issue_number` for the GitHub `/claim #ISSUE wallet:`
   handoff when present. It is parsed only from an exact public GitHub issue URL;
   `null` means use the canonical contract/API path without guessing an issue.
+- Follow `next_action` instead of reconstructing a command. Without a solver
+  address it requests only the public Base address and emits an exact rerun
+  command; with one it emits a claim comment or hosted request but performs no
+  side effect.
 - For direct inventory, require report-level
   `protocol_source: direct_safe_chain`, `direct_chain_status: verified`, and
   `direct_chain_observed_block.tag: safe`. Each item's observed block number

--- a/skills/agent-bounties/scripts/check-in.mjs
+++ b/skills/agent-bounties/scripts/check-in.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 export const DEFAULT_API_BASE_URL = "https://agent-bounties-api.onrender.com";
 export const DEFAULT_PROTOCOL_URL = "https://nspg13.github.io/agent-bounties/protocol.json";
 export const DEFAULT_BASE_RPC_URL = "https://base-rpc.publicnode.com";
+export const CLAIM_HANDOFF_SCHEMA_VERSION = "agent-bounties/check-in-claim-handoff-v1";
 
 const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
 const HASH = /^0x[0-9a-fA-F]{64}$/;
@@ -207,6 +208,128 @@ export function githubIssueNumberFromSourceUrl(value) {
 function sourceUrlFromDocument(document) {
   const value = document?.source_url;
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function normalizeSolverWallet(value) {
+  if (value === null || value === undefined || String(value).trim() === "") return null;
+  const wallet = String(value).trim().toLowerCase();
+  if (!ADDRESS.test(wallet)) throw new Error("solver wallet is not an address");
+  return wallet;
+}
+
+function claimIdempotencyKey(contract, solverWallet) {
+  return `portable-check-in:${contract.slice(2)}:${solverWallet.slice(2)}`;
+}
+
+export function buildClaimHandoff(bounty, solverWallet, apiBaseUrl) {
+  const solver = normalizeSolverWallet(solverWallet);
+  const creator = normalizeSolverWallet(bounty.creator);
+  const sourceIssueNumber = bounty.source_issue_number;
+  const githubAvailable = Number.isSafeInteger(sourceIssueNumber) && sourceIssueNumber > 0;
+  const ready = solver !== null && solver !== creator;
+  const reason = solver === null
+    ? "public_solver_wallet_required"
+    : (solver === creator ? "creator_cannot_claim" : "claim_handoff_complete");
+  const requiredInput = solver === creator
+    ? "non_creator_public_base_address"
+    : (solver === null ? "public_base_address" : null);
+  const claimRequest = ready ? {
+    idempotency_key: claimIdempotencyKey(bounty.contract, solver),
+    network: "base-mainnet",
+    bounty_contract: bounty.contract,
+    solver_wallet: solver,
+    request_bond_sponsorship: true,
+    source: "portable-check-in",
+  } : null;
+  const addressTemplate = "0xYOUR_PUBLIC_BASE_ADDRESS";
+  const issueCommandTemplate = githubAvailable
+    ? `/claim #${sourceIssueNumber} wallet: ${addressTemplate}`
+    : null;
+
+  return {
+    schema_version: CLAIM_HANDOFF_SCHEMA_VERSION,
+    ready,
+    ready_scope: "claim_handoff_only",
+    wallet_readiness_checked: false,
+    reason,
+    required_input: requiredInput,
+    preferred_path: githubAvailable ? "github_claim_comment" : "agent_native_claim",
+    rerun_command: ready
+      ? null
+      : `node skills/agent-bounties/scripts/check-in.mjs --solver-wallet ${addressTemplate}`,
+    github_claim: githubAvailable ? {
+      issue_url: bounty.source_url,
+      comment_body: ready ? `/claim #${sourceIssueNumber} wallet: ${solver}` : null,
+      comment_body_template: issueCommandTemplate,
+      effect: "Creates or replays hosted claim coordination; it does not claim the contract by itself.",
+    } : null,
+    mcp: {
+      tool: "agent_native_claim",
+      arguments: claimRequest,
+    },
+    api: {
+      method: "POST",
+      url: `${apiBaseUrl}/v1/base/autonomous-bounties/claims`,
+      body: claimRequest,
+    },
+    direct_wallet_fallback: {
+      claim_plan_url: bounty.claim_plan_url,
+      unsigned_plan: bounty.claim_plan || null,
+    },
+    follow_up:
+      "Confirm the wallet can sign under its bounded policy, then follow the returned state. Sign only its exact wallet_request, replay next_request with the unchanged wallet_signature, and start work only after a canonical claim event.",
+    evidence_boundary:
+      "This handoff is read-only output. It did not post a comment, create a candidate, sign, broadcast, claim, fund, submit, verify, or settle.",
+  };
+}
+
+function nextActionFor(verified) {
+  if (verified.length === 0) {
+    return {
+      schema_version: CLAIM_HANDOFF_SCHEMA_VERSION,
+      action: "post_own_bounty",
+      ready: true,
+      url: "https://nspg13.github.io/agent-bounties/post.html",
+    };
+  }
+  const selected = verified.find((item) => item.claim_handoff.ready) || verified[0];
+  const handoff = selected.claim_handoff;
+  if (!handoff.ready) {
+    return {
+      schema_version: CLAIM_HANDOFF_SCHEMA_VERSION,
+      action: "rerun_with_solver_wallet",
+      ready: false,
+      reason: handoff.reason,
+      required_input: handoff.required_input,
+      command: handoff.rerun_command,
+      bounty_id: selected.id,
+      source_issue_number: selected.source_issue_number,
+      never_request: ["private_key", "seed_phrase"],
+    };
+  }
+  if (handoff.github_claim) {
+    return {
+      schema_version: CLAIM_HANDOFF_SCHEMA_VERSION,
+      action: "post_github_claim_comment",
+      ready: true,
+      ready_scope: "claim_handoff_only",
+      bounty_id: selected.id,
+      source_issue_number: selected.source_issue_number,
+      issue_url: handoff.github_claim.issue_url,
+      comment_body: handoff.github_claim.comment_body,
+      follow_up: handoff.follow_up,
+    };
+  }
+  return {
+    schema_version: CLAIM_HANDOFF_SCHEMA_VERSION,
+    action: "call_agent_native_claim",
+    ready: true,
+    ready_scope: "claim_handoff_only",
+    bounty_id: selected.id,
+    mcp: handoff.mcp,
+    api: handoff.api,
+    follow_up: handoff.follow_up,
+  };
 }
 
 async function request(url, parseJson) {
@@ -493,6 +616,7 @@ function normalizedDirectBounty(manifest, bounty, observedBlock, timeoutBonus, c
   const normalized = {
     id: bounty.bounty_id.toLowerCase(),
     contract: bounty.contract.toLowerCase(),
+    creator: bounty.creator.toLowerCase(),
     issue: bounty.issue,
     title: bounty.title,
     solver_reward_minor: bounty.solver_reward_minor,
@@ -947,6 +1071,7 @@ function normalizedBounty(item, apiBaseUrl, standingMetaAttestation = null) {
   const normalized = {
     id: item.bounty_id,
     contract: item.bounty_contract,
+    creator: item.creator.toLowerCase(),
     title: item.terms.document.title,
     solver_reward_minor: integerOf(item.solver_reward),
     completion_bonus_minor: integerOf(item.timeout_bond_pool),
@@ -998,6 +1123,7 @@ export async function collectInventory({
   fixture = null,
 }) {
   const api = normalizeApiBaseUrl(apiBaseUrl || DEFAULT_API_BASE_URL);
+  const solver = normalizeSolverWallet(solverWallet);
   const protocolEndpoint = normalizePublicUrl(protocolUrl, "Protocol URL");
   const [health, protocolResponse, feedResponse, jobsResponse] = await Promise.all([
     fixture ? fixture.health : request(`${api}/health`, false),
@@ -1050,7 +1176,7 @@ export async function collectInventory({
       manifest,
       rpcUrl: baseRpcUrl,
       rpcTransport,
-      solverWallet,
+      solverWallet: solver,
     });
     const existingIds = new Set(verified.map((item) => item.id.toLowerCase()));
     for (const item of direct.verified) {
@@ -1074,6 +1200,10 @@ export async function collectInventory({
   if (standingMetaAttestation?.warning) warnings.push(standingMetaAttestation.warning);
   if (!verified.length) warnings.push("no_verified_funded_bounty_is_claimable");
 
+  for (const item of verified) {
+    item.claim_handoff = buildClaimHandoff(item, solver, api);
+  }
+
   return {
     observed_at: new Date().toISOString(),
     api_base_url: api,
@@ -1093,6 +1223,7 @@ export async function collectInventory({
     live_verification_jobs:
       jobsResponse?.status === 200 ? itemsFrom(jobsResponse.body) : [],
     recommended_action: verified.length ? "claim_verified_bounty" : "post_own_bounty",
+    next_action: nextActionFor(verified),
     links: {
       post_own_bounty: "https://nspg13.github.io/agent-bounties/post.html",
       fund_bounty: "https://nspg13.github.io/agent-bounties/funding.html",


### PR DESCRIPTION
Closes #310.

## What changed
- emit a versioned `claim_handoff` for every verified claimable bounty
- emit one top-level executable `next_action`
- prefer the exact GitHub `/claim #ISSUE wallet: 0x...` flow agents already use
- include equivalent MCP/API request and direct-wallet fallback
- fail closed for missing, invalid, or creator wallet addresses
- keep the helper side-effect free and explicit about its evidence boundary

## Verification
- `node --check skills/agent-bounties/scripts/check-in.mjs`
- `node --test scripts/test_agent_bounties_openclaw_skill.mjs` (22 passed)
- live production read-only rehearsal: claimable inventory remained 2 and hosted funnel counters remained unchanged
- `.\scripts\preflight.ps1 -Mode core`
- `.\scripts\check.ps1`
- `git diff --check`