### PR TITLE
fix: make recovery reservations fail closed

### DIFF
--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -2687,9 +2687,26 @@ pub struct AutonomousBountyFeedItem {
 pub const RECOVERY_RESERVED_VERIFICATION_REASON: &str =
     "incident recovery reservation is active; do not claim, sign, or post a bond";
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub const BUILTIN_RECOVERY_RESERVED_BOUNTY_CONTRACTS: [&str; 3] = [
+    "0x680030abf3ffffbc8d0a550b6355a8713c54d3c8",
+    "0x3137e6c0f44b940580ea7efc5f8cc6c6c0bda3f1",
+    "0xb35b94e1225b66e50644a331feccdab0439e63d7",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AutonomousBountyRecoveryReservations {
     contracts: HashSet<String>,
+}
+
+impl Default for AutonomousBountyRecoveryReservations {
+    fn default() -> Self {
+        Self {
+            contracts: BUILTIN_RECOVERY_RESERVED_BOUNTY_CONTRACTS
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        }
+    }
 }
 
 impl AutonomousBountyRecoveryReservations {
@@ -2697,7 +2714,7 @@ impl AutonomousBountyRecoveryReservations {
         let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
             return Ok(Self::default());
         };
-        let mut contracts = HashSet::new();
+        let mut contracts = Self::default().contracts;
         for candidate in value.split(',') {
             let candidate = candidate.trim();
             if candidate.is_empty() {
@@ -6449,6 +6466,12 @@ mod tests {
         .unwrap();
         assert!(reservations.contains(reserved_contract));
         assert!(reservations.contains(&available_contract.to_ascii_uppercase()));
+        assert!(BUILTIN_RECOVERY_RESERVED_BOUNTY_CONTRACTS
+            .iter()
+            .all(|contract| reservations.contains(contract)));
+        assert!(BUILTIN_RECOVERY_RESERVED_BOUNTY_CONTRACTS
+            .iter()
+            .all(|contract| AutonomousBountyRecoveryReservations::default().contains(contract)));
         assert!(matches!(
             AutonomousBountyRecoveryReservations::parse_csv(Some(&format!("{reserved_contract},"))),
             Err(ChainBaseError::InvalidVerificationConfiguration(_))


### PR DESCRIPTION
## Summary
- compile the three active incident-recovery bounty reservations into the hosted protocol default
- treat `BASE_RECOVERY_RESERVED_BOUNTY_CONTRACTS` as additive so missing or stale Render configuration cannot reopen quarantined inventory
- prove both configured and built-in reservations fail closed in the focused harness

## Production evidence
PR #322 and exact revision `5a6a399b7291c06fcaa82ee7f527306ee3a1ee37` deployed successfully. Render recorded an environment update and redeploy, but the live claimable feed continued to advertise contract `0xb35b94e1225b66e50644a331feccdab0439e63d7`. This patch removes that configuration-only failure mode.

No contract state or custody changes. Reserved bounties remain visible in the full audit feed and are excluded only from earning and verification-job surfaces.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p chain-base recovery_reservations`
- `cargo test -p chain-base` (45 passed, 2 environment-gated tests ignored)
- `cargo check -p api -p mcp-server`
- `git diff --check`