### PR TITLE
feat: deploy independently verified standing meta v2

### DIFF
--- a/.github/workflows/participant-registration.yml
+++ b/.github/workflows/participant-registration.yml
@@ -1,0 +1,74 @@
+name: Participant Registration
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/participant-registration.yml"
+      - "scripts/register_participant.py"
+      - "scripts/test_register_participant.py"
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python scripts/test_register_participant.py -v
+
+  register:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/agent-bounty register ')
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: participant-registration-${{ github.event.sender.id }}
+      cancel-in-progress: false
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      PARTICIPANT_ATTESTER_PRIVATE_KEY: ${{ secrets.PARTICIPANT_ATTESTER_PRIVATE_KEY }}
+      PARTICIPANT_REGISTRY: ${{ vars.BASE_MAINNET_PARTICIPANT_REGISTRY }}
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - name: Register exact GitHub participant identity
+        id: register
+        continue-on-error: true
+        run: >-
+          python scripts/register_participant.py
+          --event "$GITHUB_EVENT_PATH"
+          --repository "$GITHUB_REPOSITORY"
+          --registry "$PARTICIPANT_REGISTRY"
+          --rpc-url "$BASE_MAINNET_RPC_URL"
+          --json-out target/participant-registration.json
+          --md-out target/participant-registration.md
+      - name: Publish constructive registration result
+        if: always()
+        run: gh issue comment "${{ github.event.issue.number }}" --repo "$GITHUB_REPOSITORY" --body-file target/participant-registration.md
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: participant-registration-${{ github.event.comment.id }}
+          path: target/participant-registration.json
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Preserve fail-closed status
+        if: steps.register.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -1,0 +1,76 @@
+name: Regression Verifier Runner
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/regression-verifier-runner.yml"
+      - ".github/workflows/regression-verifier-signer.yml"
+      - "crates/verifier-sdk/**"
+      - "crates/worker/**"
+      - "scripts/regression_verifier_pipeline.py"
+      - "scripts/test_regression_verifier_pipeline.py"
+  workflow_dispatch:
+  schedule:
+    - cron: "7,22,37,52 * * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: regression-verifier-runner-mainnet
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          python scripts/test_regression_verifier_pipeline.py -v
+          python -m py_compile scripts/regression_verifier_pipeline.py
+          cargo test -p verifier-sdk -p worker
+
+  run-no-secrets:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://agent-bounties-api.onrender.com' }}
+      VERIFIER_ONE: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
+      VERIFIER_TWO: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build isolated regression worker
+        run: cargo build --release -p worker
+
+      - name: Run canonical jobs without signing secrets
+        run: >-
+          python scripts/regression_verifier_pipeline.py run
+          --api-base "$API_BASE_URL"
+          --network base-mainnet
+          --verifier "$VERIFIER_ONE"
+          --verifier "$VERIFIER_TWO"
+          --worker target/release/worker
+          --staging "$RUNNER_TEMP/regression-staging"
+          --output target/regression-candidates
+          --max-jobs 5
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: regression-candidates-${{ github.run_id }}
+          path: target/regression-candidates
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -1,0 +1,132 @@
+name: Regression Verifier Signer
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/regression-verifier-runner.yml"
+      - ".github/workflows/regression-verifier-signer.yml"
+      - "scripts/regression_verifier_pipeline.py"
+      - "scripts/test_regression_verifier_pipeline.py"
+  workflow_run:
+    workflows: ["Regression Verifier Runner"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python scripts/test_regression_verifier_pipeline.py -v
+
+  authorize-run:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'schedule' ||
+       github.event.workflow_run.event == 'workflow_dispatch') &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    needs: contract
+    runs-on: ubuntu-latest
+    outputs:
+      revision: ${{ steps.main.outputs.revision }}
+      run_id: ${{ steps.main.outputs.run_id }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          fetch-depth: 0
+      - id: main
+        env:
+          CANDIDATE_REVISION: ${{ github.event.workflow_run.head_sha }}
+          CANDIDATE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          current_main="$(git rev-parse refs/remotes/origin/main)"
+          if [[ "$CANDIDATE_REVISION" != "$current_main" ]]; then
+            echo "Refusing to sign a candidate from stale main" >&2
+            exit 1
+          fi
+          echo "revision=$CANDIDATE_REVISION" >> "$GITHUB_OUTPUT"
+          echo "run_id=$CANDIDATE_RUN_ID" >> "$GITHUB_OUTPUT"
+
+  sign-one:
+    needs: authorize-run
+    uses: ./.github/workflows/regression-verifier-signing-reusable.yml
+    with:
+      revision: ${{ needs.authorize-run.outputs.revision }}
+      candidate_run_id: ${{ needs.authorize-run.outputs.run_id }}
+      signer_slot: one
+      expected_signer: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
+    secrets:
+      verifier_private_key: ${{ secrets.REGRESSION_VERIFIER_ONE_PRIVATE_KEY }}
+
+  sign-two:
+    needs: authorize-run
+    uses: ./.github/workflows/regression-verifier-signing-reusable.yml
+    with:
+      revision: ${{ needs.authorize-run.outputs.revision }}
+      candidate_run_id: ${{ needs.authorize-run.outputs.run_id }}
+      signer_slot: two
+      expected_signer: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}
+    secrets:
+      verifier_private_key: ${{ secrets.REGRESSION_VERIFIER_TWO_PRIVATE_KEY }}
+
+  relay:
+    needs: [authorize-run, sign-one, sign-two]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: regression-verifier-relay-mainnet
+      cancel-in-progress: false
+    env:
+      API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://agent-bounties-api.onrender.com' }}
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      VERIFIER_ONE: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
+      VERIFIER_TWO: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ needs.authorize-run.outputs.revision }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: Swatinem/rust-cache@v2
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - uses: actions/download-artifact@v4
+        with:
+          name: regression-candidates-${{ needs.authorize-run.outputs.run_id }}
+          path: target/regression-candidates
+          github-token: ${{ github.token }}
+          run-id: ${{ needs.authorize-run.outputs.run_id }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: regression-attestations-one
+          path: target/attestations-one
+      - uses: actions/download-artifact@v4
+        with:
+          name: regression-attestations-two
+          path: target/attestations-two
+      - run: cargo build --release -p worker
+      - name: Revalidate and relay exact quorum
+        run: >-
+          python scripts/regression_verifier_pipeline.py relay
+          --api-base "$API_BASE_URL"
+          --network base-mainnet
+          --rpc-url "$BASE_MAINNET_RPC_URL"
+          --candidates target/regression-candidates
+          --attestations target/attestations-one
+          --attestations target/attestations-two
+          --verifier "$VERIFIER_ONE"
+          --verifier "$VERIFIER_TWO"
+          --worker target/release/worker

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -1,0 +1,67 @@
+name: Regression Verifier Signing Slot
+
+on:
+  workflow_call:
+    inputs:
+      revision:
+        required: true
+        type: string
+      candidate_run_id:
+        required: true
+        type: string
+      signer_slot:
+        required: true
+        type: string
+      expected_signer:
+        required: true
+        type: string
+    secrets:
+      verifier_private_key:
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://agent-bounties-api.onrender.com' }}
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      REGRESSION_VERIFIER_PRIVATE_KEY: ${{ secrets.verifier_private_key }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ inputs.revision }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: Swatinem/rust-cache@v2
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - uses: actions/download-artifact@v4
+        with:
+          name: regression-candidates-${{ inputs.candidate_run_id }}
+          path: target/regression-candidates
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.candidate_run_id }}
+      - run: cargo build --release -p worker
+      - name: Re-fetch state and sign one exact candidate set
+        run: >-
+          python scripts/regression_verifier_pipeline.py sign
+          --api-base "$API_BASE_URL"
+          --network base-mainnet
+          --rpc-url "$BASE_MAINNET_RPC_URL"
+          --candidates target/regression-candidates
+          --output "target/attestations-${{ inputs.signer_slot }}"
+          --worker target/release/worker
+          --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY
+          --expected-signer "${{ inputs.expected_signer }}"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: regression-attestations-${{ inputs.signer_slot }}
+          path: target/attestations-${{ inputs.signer_slot }}
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/standing-meta-v2-deploy.yml
+++ b/.github/workflows/standing-meta-v2-deploy.yml
@@ -1,0 +1,102 @@
+name: Standing meta v2 deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_mainnet:
+        description: Deploy the tested v2 policy components to Base mainnet
+        required: true
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - ".github/workflows/standing-meta-v2-deploy.yml"
+      - "contracts/base-escrow/**"
+      - "scripts/standing_meta_v2_deploy.py"
+      - "scripts/test_standing_meta_v2_deploy.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/standing-meta-v2-deploy.yml"
+      - "contracts/base-escrow/**"
+      - "scripts/standing_meta_v2_deploy.py"
+      - "scripts/test_standing_meta_v2_deploy.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: standing-meta-v2-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deterministic-gates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Contract and deployment harnesses
+        run: |
+          python -m unittest scripts.test_standing_meta_v2_deploy -v
+          forge test --root contracts/base-escrow --match-contract CanonicalIndependentChildVerifierV2Test -vv
+          forge build --root contracts/base-escrow --sizes
+
+  base-sepolia-rehearsal:
+    if: github.event_name == 'workflow_dispatch'
+    needs: deterministic-gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      PARTICIPANT_ATTESTER_PRIVATE_KEY: ${{ secrets.PARTICIPANT_ATTESTER_PRIVATE_KEY }}
+      REGRESSION_VERIFIER_ONE_PRIVATE_KEY: ${{ secrets.REGRESSION_VERIFIER_ONE_PRIVATE_KEY }}
+      REGRESSION_VERIFIER_TWO_PRIVATE_KEY: ${{ secrets.REGRESSION_VERIFIER_TWO_PRIVATE_KEY }}
+      PARTICIPANT_ATTESTER_ADDRESS: ${{ vars.PARTICIPANT_ATTESTER_ADDRESS }}
+      REGRESSION_VERIFIER_ONE_ADDRESS: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
+      REGRESSION_VERIFIER_TWO_ADDRESS: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Execute full funded Base Sepolia loop
+        run: >-
+          python scripts/standing_meta_v2_deploy.py sepolia
+          --rpc-url https://sepolia.base.org
+          --output target/base-sepolia-standing-meta-v2-rehearsal.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: base-sepolia-standing-meta-v2-rehearsal
+          path: target/base-sepolia-standing-meta-v2-*.json
+          if-no-files-found: error
+
+  base-mainnet-deploy:
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy_mainnet
+    needs: base-sepolia-rehearsal
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      PARTICIPANT_ATTESTER_ADDRESS: ${{ vars.PARTICIPANT_ATTESTER_ADDRESS }}
+      REGRESSION_VERIFIER_ONE_ADDRESS: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
+      REGRESSION_VERIFIER_TWO_ADDRESS: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Deploy exact mainnet components after successful rehearsal
+        run: >-
+          python scripts/standing_meta_v2_deploy.py mainnet
+          --rpc-url https://mainnet.base.org
+          --output target/base-mainnet-standing-meta-v2-deployment.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: base-mainnet-standing-meta-v2-deployment
+          path: target/base-mainnet-standing-meta-v2-*.json
+          if-no-files-found: error

--- a/contracts/base-escrow/foundry.toml
+++ b/contracts/base-escrow/foundry.toml
@@ -6,3 +6,4 @@ solc_version = "0.8.26"
 optimizer = true
 optimizer_runs = 200
 evm_version = "cancun"
+fs_permissions = [{ access = "read-write", path = "../../target" }]

--- a/contracts/base-escrow/script/BaseSepoliaStandingMetaV2Rehearsal.s.sol
+++ b/contracts/base-escrow/script/BaseSepoliaStandingMetaV2Rehearsal.s.sol
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../src/AgentBountyFactory.sol";
+import "../src/CanonicalIndependentChildVerifierV2.sol";
+
+interface RehearsalSettlementToken {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+interface StandingMetaRehearsalVm {
+    function addr(uint256 privateKey) external returns (address);
+    function envAddress(string calldata name) external returns (address);
+    function envString(string calldata name) external returns (string memory);
+    function envUint(string calldata name) external returns (uint256);
+    function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+    function startBroadcast(uint256 privateKey) external;
+    function stopBroadcast() external;
+    function warp(uint256 timestamp) external;
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address value)
+        external
+        returns (string memory);
+    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32 value)
+        external
+        returns (string memory);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
+        external
+        returns (string memory);
+    function writeJson(string calldata json, string calldata path) external;
+}
+
+/// @notice Executes a real Base Sepolia deployment, funding, claim, submission,
+/// verifier quorum, child payout, and parent payout with canonical Base Sepolia
+/// USDC. The solver keys are testnet-only and cannot be used on another chain.
+contract BaseSepoliaStandingMetaV2Rehearsal {
+    StandingMetaRehearsalVm private constant vm =
+        StandingMetaRehearsalVm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    uint256 private constant BASE_SEPOLIA_CHAIN_ID = 84_532;
+    uint256 private constant PARENT_SOLVER_KEY = uint256(keccak256("agent-bounties/base-sepolia-parent-solver-v2"));
+    uint256 private constant CHILD_SOLVER_KEY = uint256(keccak256("agent-bounties/base-sepolia-child-solver-v2"));
+    bytes32 private constant SOURCE_HASH = keccak256("agent-bounties/base-sepolia-rehearsal-v2");
+    bytes32 private constant PARENT_PARTICIPANT = keccak256("base-sepolia-parent-participant-v2");
+    bytes32 private constant CHILD_PARTICIPANT = keccak256("base-sepolia-child-participant-v2");
+    bytes32 private constant CHILD_POLICY_HASH = keccak256("sandboxed-regression-policy-v1");
+    bytes32 private constant CHILD_CRITERIA_HASH = keccak256("base-sepolia-child-criteria-v2");
+    bytes32 private constant CHILD_BENCHMARK_HASH = keccak256("base-sepolia-child-benchmark-v2");
+    bytes32 private constant CHILD_EVIDENCE_SCHEMA_HASH = keccak256("base-sepolia-child-evidence-v2");
+    bytes private constant CHILD_TERMS = '{"schema":"agent-bounties/base-sepolia-child-v2"}';
+
+    struct Deployment {
+        RehearsalSettlementToken token;
+        AgentBountyFactory factory;
+        ParticipantEligibilityRegistry participants;
+        OnchainTermsRegistry terms;
+        CanonicalIndependentChildVerifierV2 module;
+    }
+
+    struct RehearsalActors {
+        uint256 deployerKey;
+        uint256 attesterKey;
+        uint256 verifierOneKey;
+        uint256 verifierTwoKey;
+        address deployer;
+        address attester;
+        address parentSolver;
+        address childSolver;
+        address[] verifiers;
+    }
+
+    function run() external {
+        require(block.chainid == BASE_SEPOLIA_CHAIN_ID, "Base Sepolia only");
+        RehearsalActors memory actors = _loadActors();
+        Deployment memory deployment = _loadDeployment(actors.attester, actors.verifiers);
+        bytes32 phase = keccak256(bytes(vm.envString("REHEARSAL_PHASE")));
+        if (phase == keccak256("prepare")) {
+            _fundActors(actors.deployerKey, deployment.token, actors.parentSolver, actors.childSolver);
+            _register(
+                actors.deployerKey, actors.attesterKey, deployment.participants, actors.parentSolver, PARENT_PARTICIPANT
+            );
+            _register(
+                actors.deployerKey, actors.attesterKey, deployment.participants, actors.childSolver, CHILD_PARTICIPANT
+            );
+            AgentBounty preparedParent = _createParent(actors.deployerKey, deployment);
+            _publishParentTerms(PARENT_SOLVER_KEY, deployment, preparedParent);
+            _writePreparationEvidence(
+                actors.deployer, deployment, preparedParent, actors.parentSolver, actors.childSolver, actors.verifiers
+            );
+            return;
+        }
+        require(phase == keccak256("complete"), "rehearsal phase must be prepare or complete");
+        _complete(actors, deployment);
+    }
+
+    function _complete(RehearsalActors memory actors, Deployment memory deployment) private {
+        AgentBounty parent = AgentBounty(vm.envAddress("REHEARSAL_PARENT_BOUNTY"));
+        require(deployment.factory.isCanonicalBounty(address(parent)), "prepared parent is not canonical");
+        require(parent.verifierModule() == address(deployment.module), "prepared parent module drift");
+        OnchainTermsRegistry.TermsCommitment memory published = deployment.terms.commitment(keccak256(CHILD_TERMS));
+        require(published.publisher == actors.parentSolver, "prepared terms publisher drift");
+        require(published.publishedAt < block.timestamp, "wait for a later Base timestamp before completion");
+        _claimParent(PARENT_SOLVER_KEY, deployment, parent);
+        AgentBounty child =
+            _createAndClaimChild(PARENT_SOLVER_KEY, CHILD_SOLVER_KEY, deployment, parent, actors.verifiers);
+        _submitAndSettleChild(actors, child);
+        _submitAndSettleParent(PARENT_SOLVER_KEY, actors.deployerKey, parent, child);
+
+        require(parent.bountyStatus() == AgentBounty.BountyStatus.Settled, "parent not settled");
+        require(child.bountyStatus() == AgentBounty.BountyStatus.Settled, "child not settled");
+        require(deployment.token.balanceOf(actors.parentSolver) == 1_000_000, "parent net payout mismatch");
+        require(deployment.token.balanceOf(actors.childSolver) == 1_000_000, "child net payout mismatch");
+        _writeEvidence(
+            actors.deployer, deployment, parent, child, actors.parentSolver, actors.childSolver, actors.verifiers
+        );
+    }
+
+    function _loadActors() private returns (RehearsalActors memory actors) {
+        actors.deployerKey = vm.envUint("BASE_KEEPER_PRIVATE_KEY");
+        actors.attesterKey = vm.envUint("PARTICIPANT_ATTESTER_PRIVATE_KEY");
+        actors.verifierOneKey = vm.envUint("REGRESSION_VERIFIER_ONE_PRIVATE_KEY");
+        actors.verifierTwoKey = vm.envUint("REGRESSION_VERIFIER_TWO_PRIVATE_KEY");
+        actors.deployer = vm.addr(actors.deployerKey);
+        actors.attester = vm.addr(actors.attesterKey);
+        address verifierOne = vm.addr(actors.verifierOneKey);
+        address verifierTwo = vm.addr(actors.verifierTwoKey);
+        require(actors.attester == vm.envAddress("PARTICIPANT_ATTESTER_ADDRESS"), "attester secret mismatch");
+        require(verifierOne == vm.envAddress("REGRESSION_VERIFIER_ONE_ADDRESS"), "verifier one secret mismatch");
+        require(verifierTwo == vm.envAddress("REGRESSION_VERIFIER_TWO_ADDRESS"), "verifier two secret mismatch");
+        actors.parentSolver = vm.addr(PARENT_SOLVER_KEY);
+        actors.childSolver = vm.addr(CHILD_SOLVER_KEY);
+        actors.verifiers = new address[](2);
+        actors.verifiers[0] = verifierOne;
+        actors.verifiers[1] = verifierTwo;
+    }
+
+    function _loadDeployment(address attester, address[] memory verifiers)
+        private
+        returns (Deployment memory deployment)
+    {
+        deployment.token = RehearsalSettlementToken(vm.envAddress("REHEARSAL_TOKEN"));
+        deployment.factory = AgentBountyFactory(vm.envAddress("REHEARSAL_FACTORY"));
+        deployment.participants = ParticipantEligibilityRegistry(vm.envAddress("REHEARSAL_PARTICIPANT_REGISTRY"));
+        deployment.terms = OnchainTermsRegistry(vm.envAddress("REHEARSAL_TERMS_REGISTRY"));
+        deployment.module = CanonicalIndependentChildVerifierV2(vm.envAddress("REHEARSAL_VERIFIER_MODULE"));
+        require(deployment.factory.settlementToken() == address(deployment.token), "rehearsal factory token drift");
+        require(deployment.participants.attester() == attester, "rehearsal attester drift");
+        require(deployment.module.canonicalFactory() == address(deployment.factory), "rehearsal module factory drift");
+        require(
+            address(deployment.module.participantRegistry()) == address(deployment.participants),
+            "rehearsal participant registry drift"
+        );
+        require(
+            address(deployment.module.termsRegistry()) == address(deployment.terms), "rehearsal terms registry drift"
+        );
+        require(
+            deployment.module.taskVerifierSetHash() == keccak256(abi.encode(verifiers)), "rehearsal verifier set drift"
+        );
+        require(deployment.module.taskVerifierThreshold() == 2, "rehearsal verifier threshold drift");
+    }
+
+    function _fundActors(uint256 deployerKey, RehearsalSettlementToken token, address parentSolver, address childSolver)
+        private
+    {
+        vm.startBroadcast(deployerKey);
+        require(token.transfer(parentSolver, 1_100_000), "parent rehearsal funding failed");
+        require(token.transfer(childSolver, 100_000), "child rehearsal funding failed");
+        payable(parentSolver).transfer(15_000_000_000_000);
+        payable(childSolver).transfer(5_000_000_000_000);
+        vm.stopBroadcast();
+    }
+
+    function _register(
+        uint256 deployerKey,
+        uint256 attesterKey,
+        ParticipantEligibilityRegistry registry,
+        address wallet,
+        bytes32 participantId
+    ) private {
+        uint64 validUntil = uint64(block.timestamp + 14 days);
+        bytes32 digest = registry.attestationDigest(wallet, participantId, SOURCE_HASH, validUntil, 0);
+        bytes memory signature = _sign(attesterKey, digest);
+        vm.startBroadcast(deployerKey);
+        registry.register(wallet, participantId, SOURCE_HASH, validUntil, signature);
+        vm.stopBroadcast();
+    }
+
+    function _createParent(uint256 deployerKey, Deployment memory deployment) private returns (AgentBounty parent) {
+        AgentBountyFactory.CreateBountyParams memory params = AgentBountyFactory.CreateBountyParams({
+            solverReward: 900_000,
+            verifierReward: 100_000,
+            termsHash: keccak256("base-sepolia-parent-terms-v2"),
+            policyHash: keccak256("base-sepolia-parent-policy-v2"),
+            acceptanceCriteriaHash: deployment.module.ACCEPTANCE_CRITERIA_HASH(),
+            benchmarkHash: keccak256("base-sepolia-parent-benchmark-v2"),
+            evidenceSchemaHash: keccak256("base-sepolia-parent-evidence-v2"),
+            fundingDeadline: uint64(block.timestamp + 1 days),
+            claimWindowSeconds: 1 hours,
+            verificationWindowSeconds: 1 days,
+            verificationMode: AgentBounty.VerificationMode.DeterministicModule,
+            verifierModule: address(deployment.module),
+            verifierRewardRecipient: vm.addr(deployerKey),
+            threshold: 1
+        });
+        vm.startBroadcast(deployerKey);
+        deployment.token.approve(address(deployment.factory), 1_000_000);
+        (address parentAddress,) =
+            deployment.factory.createBounty(params, new address[](0), 1_000_000, keccak256("base-sepolia-parent-v2"));
+        vm.stopBroadcast();
+        parent = AgentBounty(parentAddress);
+    }
+
+    function _publishParentTerms(uint256 parentKey, Deployment memory deployment, AgentBounty parent) private {
+        address[] memory verifiers = new address[](2);
+        verifiers[0] = vm.envAddress("REGRESSION_VERIFIER_ONE_ADDRESS");
+        verifiers[1] = vm.envAddress("REGRESSION_VERIFIER_TWO_ADDRESS");
+        OnchainTermsRegistry.TermsInput memory input = OnchainTermsRegistry.TermsInput({
+            parentBountyId: parent.bountyId(),
+            parentRound: 1,
+            policyHash: CHILD_POLICY_HASH,
+            acceptanceCriteriaHash: CHILD_CRITERIA_HASH,
+            benchmarkHash: CHILD_BENCHMARK_HASH,
+            evidenceSchemaHash: CHILD_EVIDENCE_SCHEMA_HASH,
+            verifierSetHash: keccak256(abi.encode(verifiers)),
+            verifierThreshold: 2
+        });
+        vm.startBroadcast(parentKey);
+        deployment.terms.publish(CHILD_TERMS, input);
+        vm.stopBroadcast();
+    }
+
+    function _claimParent(uint256 parentKey, Deployment memory deployment, AgentBounty parent) private {
+        vm.startBroadcast(parentKey);
+        deployment.token.approve(address(parent), 100_000);
+        parent.claim();
+        vm.stopBroadcast();
+    }
+
+    function _createAndClaimChild(
+        uint256 parentKey,
+        uint256 childKey,
+        Deployment memory deployment,
+        AgentBounty parent,
+        address[] memory verifiers
+    ) private returns (AgentBounty child) {
+        AgentBountyFactory.CreateBountyParams memory params = AgentBountyFactory.CreateBountyParams({
+            solverReward: 900_000,
+            verifierReward: 100_000,
+            termsHash: keccak256(CHILD_TERMS),
+            policyHash: CHILD_POLICY_HASH,
+            acceptanceCriteriaHash: CHILD_CRITERIA_HASH,
+            benchmarkHash: CHILD_BENCHMARK_HASH,
+            evidenceSchemaHash: CHILD_EVIDENCE_SCHEMA_HASH,
+            fundingDeadline: uint64(block.timestamp + 1 days),
+            claimWindowSeconds: 1 hours,
+            verificationWindowSeconds: 1 days,
+            verificationMode: AgentBounty.VerificationMode.SignedQuorum,
+            verifierModule: address(0),
+            verifierRewardRecipient: address(0),
+            threshold: 2
+        });
+        vm.startBroadcast(parentKey);
+        deployment.token.approve(address(deployment.factory), 1_000_000);
+        (address childAddress,) = deployment.factory
+            .createBounty(params, verifiers, 1_000_000, keccak256(abi.encode("base-sepolia-child-v2", address(parent))));
+        vm.stopBroadcast();
+        child = AgentBounty(childAddress);
+        vm.startBroadcast(childKey);
+        deployment.token.approve(address(child), 100_000);
+        child.claim();
+        vm.stopBroadcast();
+    }
+
+    function _submitAndSettleChild(RehearsalActors memory actors, AgentBounty child) private {
+        vm.startBroadcast(CHILD_SOLVER_KEY);
+        child.submit(keccak256("base-sepolia-child-submission-v2"), keccak256("base-sepolia-child-evidence-v2"));
+        vm.stopBroadcast();
+
+        AgentBounty.Attestation[] memory attestations = new AgentBounty.Attestation[](2);
+        uint256 deadline = block.timestamp + 1 hours;
+        uint256[2] memory keys = [actors.verifierOneKey, actors.verifierTwoKey];
+        for (uint256 i = 0; i < 2; i++) {
+            bytes32 responseHash = keccak256(abi.encode("base-sepolia-sandbox-pass-v2", i));
+            attestations[i] = AgentBounty.Attestation({
+                verifier: actors.verifiers[i],
+                passed: true,
+                responseHash: responseHash,
+                deadline: deadline,
+                signature: _sign(keys[i], child.attestationDigest(actors.verifiers[i], true, responseHash, deadline))
+            });
+        }
+        vm.startBroadcast(actors.deployerKey);
+        child.settleWithAttestations(attestations);
+        vm.stopBroadcast();
+    }
+
+    function _submitAndSettleParent(uint256 parentKey, uint256 deployerKey, AgentBounty parent, AgentBounty child)
+        private
+    {
+        vm.startBroadcast(parentKey);
+        parent.submit(keccak256("base-sepolia-parent-submission-v2"), keccak256("base-sepolia-parent-evidence-v2"));
+        vm.stopBroadcast();
+        vm.startBroadcast(deployerKey);
+        parent.verifyAndSettle(abi.encode(address(child)));
+        vm.stopBroadcast();
+    }
+
+    function _writeEvidence(
+        address deployer,
+        Deployment memory deployment,
+        AgentBounty parent,
+        AgentBounty child,
+        address parentSolver,
+        address childSolver,
+        address[] memory verifiers
+    ) private {
+        string memory objectKey = "base-sepolia-standing-meta-v2-rehearsal";
+        vm.serializeUint(objectKey, "chain_id", block.chainid);
+        vm.serializeAddress(objectKey, "deployer", deployer);
+        vm.serializeAddress(objectKey, "rehearsal_token", address(deployment.token));
+        vm.serializeAddress(objectKey, "canonical_factory", address(deployment.factory));
+        vm.serializeAddress(objectKey, "participant_registry", address(deployment.participants));
+        vm.serializeAddress(objectKey, "terms_registry", address(deployment.terms));
+        vm.serializeAddress(objectKey, "verifier_module", address(deployment.module));
+        vm.serializeAddress(objectKey, "parent_bounty", address(parent));
+        vm.serializeAddress(objectKey, "child_bounty", address(child));
+        vm.serializeAddress(objectKey, "parent_solver", parentSolver);
+        vm.serializeAddress(objectKey, "child_solver", childSolver);
+        vm.serializeAddress(objectKey, "verifier_one", verifiers[0]);
+        vm.serializeAddress(objectKey, "verifier_two", verifiers[1]);
+        vm.serializeBytes32(objectKey, "parent_bounty_id", parent.bountyId());
+        vm.serializeBytes32(objectKey, "child_bounty_id", child.bountyId());
+        vm.serializeBytes32(objectKey, "verifier_set_hash", keccak256(abi.encode(verifiers)));
+        vm.serializeBytes32(objectKey, "acceptance_criteria_hash", deployment.module.ACCEPTANCE_CRITERIA_HASH());
+        vm.serializeUint(objectKey, "parent_status", uint8(parent.bountyStatus()));
+        string memory json = vm.serializeUint(objectKey, "child_status", uint8(child.bountyStatus()));
+        vm.writeJson(json, vm.envString("REHEARSAL_EVIDENCE_PATH"));
+    }
+
+    function _writePreparationEvidence(
+        address deployer,
+        Deployment memory deployment,
+        AgentBounty parent,
+        address parentSolver,
+        address childSolver,
+        address[] memory verifiers
+    ) private {
+        OnchainTermsRegistry.TermsCommitment memory published = deployment.terms.commitment(keccak256(CHILD_TERMS));
+        string memory objectKey = "base-sepolia-standing-meta-v2-preparation";
+        vm.serializeUint(objectKey, "chain_id", block.chainid);
+        vm.serializeAddress(objectKey, "deployer", deployer);
+        vm.serializeAddress(objectKey, "rehearsal_token", address(deployment.token));
+        vm.serializeAddress(objectKey, "canonical_factory", address(deployment.factory));
+        vm.serializeAddress(objectKey, "participant_registry", address(deployment.participants));
+        vm.serializeAddress(objectKey, "terms_registry", address(deployment.terms));
+        vm.serializeAddress(objectKey, "verifier_module", address(deployment.module));
+        vm.serializeAddress(objectKey, "parent_bounty", address(parent));
+        vm.serializeAddress(objectKey, "parent_solver", parentSolver);
+        vm.serializeAddress(objectKey, "child_solver", childSolver);
+        vm.serializeAddress(objectKey, "verifier_one", verifiers[0]);
+        vm.serializeAddress(objectKey, "verifier_two", verifiers[1]);
+        vm.serializeBytes32(objectKey, "parent_bounty_id", parent.bountyId());
+        vm.serializeBytes32(objectKey, "verifier_set_hash", keccak256(abi.encode(verifiers)));
+        vm.serializeUint(objectKey, "terms_published_at", published.publishedAt);
+        string memory json = vm.serializeUint(objectKey, "parent_status", uint8(parent.bountyStatus()));
+        vm.writeJson(json, vm.envString("REHEARSAL_EVIDENCE_PATH"));
+    }
+
+    function _sign(uint256 privateKey, bytes32 digest) private returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+}

--- a/contracts/base-escrow/script/DeployStandingMetaV2.s.sol
+++ b/contracts/base-escrow/script/DeployStandingMetaV2.s.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.26;
 
 import "../src/AgentBountyFactory.sol";
-import "../src/CanonicalIndependentChildVerifierV2.sol";
+import "../src/StandingMetaV2Bundle.sol";
 
 interface StandingMetaDeployVm {
     function addr(uint256 privateKey) external returns (address);
@@ -58,13 +58,14 @@ contract DeployStandingMetaV2 {
         bytes32 verifierSetHash = keccak256(abi.encode(verifiers));
 
         vm.startBroadcast(deployerKey);
-        ParticipantEligibilityRegistry participants = new ParticipantEligibilityRegistry(attester);
-        OnchainTermsRegistry terms = new OnchainTermsRegistry();
-        CanonicalIndependentChildVerifierV2 module = new CanonicalIndependentChildVerifierV2(
-            BASE_MAINNET_FACTORY, address(participants), address(terms), verifierSetHash, 2
-        );
+        StandingMetaV2Bundle bundle = new StandingMetaV2Bundle(BASE_MAINNET_FACTORY, attester, verifierOne, verifierTwo);
         vm.stopBroadcast();
 
+        ParticipantEligibilityRegistry participants = bundle.participantRegistry();
+        OnchainTermsRegistry terms = bundle.termsRegistry();
+        CanonicalIndependentChildVerifierV2 module = bundle.verifierModule();
+
+        require(bundle.canonicalFactory() == BASE_MAINNET_FACTORY, "bundle factory drift");
         require(address(module.canonicalFactory()) == BASE_MAINNET_FACTORY, "module factory drift");
         require(module.settlementToken() == BASE_MAINNET_USDC, "module token drift");
         require(address(module.participantRegistry()) == address(participants), "participant registry drift");
@@ -79,6 +80,7 @@ contract DeployStandingMetaV2 {
         vm.serializeAddress(objectKey, "canonical_factory", BASE_MAINNET_FACTORY);
         vm.serializeAddress(objectKey, "settlement_token", BASE_MAINNET_USDC);
         vm.serializeAddress(objectKey, "participant_attester", attester);
+        vm.serializeAddress(objectKey, "bundle", address(bundle));
         vm.serializeAddress(objectKey, "participant_registry", address(participants));
         vm.serializeAddress(objectKey, "terms_registry", address(terms));
         vm.serializeAddress(objectKey, "verifier_one", verifierOne);

--- a/contracts/base-escrow/script/DeployStandingMetaV2.s.sol
+++ b/contracts/base-escrow/script/DeployStandingMetaV2.s.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../src/AgentBountyFactory.sol";
+import "../src/CanonicalIndependentChildVerifierV2.sol";
+
+interface StandingMetaDeployVm {
+    function addr(uint256 privateKey) external returns (address);
+    function envAddress(string calldata name) external returns (address);
+    function envString(string calldata name) external returns (string memory);
+    function envUint(string calldata name) external returns (uint256);
+    function startBroadcast(uint256 privateKey) external;
+    function stopBroadcast() external;
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address value)
+        external
+        returns (string memory);
+    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32 value)
+        external
+        returns (string memory);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
+        external
+        returns (string memory);
+    function writeJson(string calldata json, string calldata path) external;
+}
+
+/// @notice Deploys only the standing-meta-v2 policy components on Base mainnet.
+/// The canonical factory and native USDC addresses are deliberately immutable here.
+contract DeployStandingMetaV2 {
+    StandingMetaDeployVm private constant vm =
+        StandingMetaDeployVm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    uint256 private constant BASE_MAINNET_CHAIN_ID = 8_453;
+    address private constant BASE_MAINNET_FACTORY = 0x082C52131aaF0C56e76b075f895EAB6fcaB6d2F9;
+    address private constant BASE_MAINNET_USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    uint256 private constant MIN_KEEPER_BALANCE_AFTER_DEPLOYMENT = 100_000_000_000_000;
+
+    function run() external {
+        require(block.chainid == BASE_MAINNET_CHAIN_ID, "Base mainnet only");
+        require(
+            AgentBountyFactory(BASE_MAINNET_FACTORY).settlementToken() == BASE_MAINNET_USDC,
+            "canonical factory token drift"
+        );
+
+        uint256 deployerKey = vm.envUint("BASE_KEEPER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+        require(deployer.balance >= 500_000_000_000_000, "keeper reserve too low to deploy safely");
+
+        address attester = vm.envAddress("PARTICIPANT_ATTESTER_ADDRESS");
+        address verifierOne = vm.envAddress("REGRESSION_VERIFIER_ONE_ADDRESS");
+        address verifierTwo = vm.envAddress("REGRESSION_VERIFIER_TWO_ADDRESS");
+        require(attester != address(0), "attester zero");
+        require(
+            verifierOne != address(0) && verifierTwo != address(0) && verifierOne != verifierTwo, "verifier set invalid"
+        );
+        address[] memory verifiers = new address[](2);
+        verifiers[0] = verifierOne;
+        verifiers[1] = verifierTwo;
+        bytes32 verifierSetHash = keccak256(abi.encode(verifiers));
+
+        vm.startBroadcast(deployerKey);
+        ParticipantEligibilityRegistry participants = new ParticipantEligibilityRegistry(attester);
+        OnchainTermsRegistry terms = new OnchainTermsRegistry();
+        CanonicalIndependentChildVerifierV2 module = new CanonicalIndependentChildVerifierV2(
+            BASE_MAINNET_FACTORY, address(participants), address(terms), verifierSetHash, 2
+        );
+        vm.stopBroadcast();
+
+        require(address(module.canonicalFactory()) == BASE_MAINNET_FACTORY, "module factory drift");
+        require(module.settlementToken() == BASE_MAINNET_USDC, "module token drift");
+        require(address(module.participantRegistry()) == address(participants), "participant registry drift");
+        require(address(module.termsRegistry()) == address(terms), "terms registry drift");
+        require(module.taskVerifierSetHash() == verifierSetHash, "verifier set drift");
+        require(module.taskVerifierThreshold() == 2, "verifier threshold drift");
+        require(deployer.balance >= MIN_KEEPER_BALANCE_AFTER_DEPLOYMENT, "keeper reserve depleted below minimum");
+
+        string memory objectKey = "standing-meta-v2-deployment";
+        vm.serializeUint(objectKey, "chain_id", block.chainid);
+        vm.serializeAddress(objectKey, "deployer", deployer);
+        vm.serializeAddress(objectKey, "canonical_factory", BASE_MAINNET_FACTORY);
+        vm.serializeAddress(objectKey, "settlement_token", BASE_MAINNET_USDC);
+        vm.serializeAddress(objectKey, "participant_attester", attester);
+        vm.serializeAddress(objectKey, "participant_registry", address(participants));
+        vm.serializeAddress(objectKey, "terms_registry", address(terms));
+        vm.serializeAddress(objectKey, "verifier_one", verifierOne);
+        vm.serializeAddress(objectKey, "verifier_two", verifierTwo);
+        vm.serializeBytes32(objectKey, "verifier_set_hash", verifierSetHash);
+        vm.serializeBytes32(objectKey, "acceptance_criteria_hash", module.ACCEPTANCE_CRITERIA_HASH());
+        vm.serializeUint(objectKey, "keeper_balance_after_wei", deployer.balance);
+        string memory json = vm.serializeAddress(objectKey, "verifier_module", address(module));
+        vm.writeJson(json, vm.envString("DEPLOYMENT_EVIDENCE_PATH"));
+    }
+}

--- a/contracts/base-escrow/src/CanonicalIndependentChildVerifierV2.sol
+++ b/contracts/base-escrow/src/CanonicalIndependentChildVerifierV2.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./IAgentBounty.sol";
+import "./OnchainTermsRegistry.sol";
+import "./ParticipantEligibilityRegistry.sol";
+
+interface IIndependentChildFactoryView {
+    function settlementToken() external view returns (address);
+    function isCanonicalBounty(address bounty) external view returns (bool);
+}
+
+interface IIndependentChildBountyView {
+    function bountyId() external view returns (bytes32);
+    function creator() external view returns (address);
+    function factory() external view returns (address);
+    function settlementToken() external view returns (address);
+    function solverReward() external view returns (uint256);
+    function targetAmount() external view returns (uint256);
+    function fundedAmount() external view returns (uint256);
+    function termsHash() external view returns (bytes32);
+    function policyHash() external view returns (bytes32);
+    function acceptanceCriteriaHash() external view returns (bytes32);
+    function benchmarkHash() external view returns (bytes32);
+    function evidenceSchemaHash() external view returns (bytes32);
+    function verifierSetHash() external view returns (bytes32);
+    function verificationMode() external view returns (uint8);
+    function verifierModule() external view returns (address);
+    function threshold() external view returns (uint8);
+    function status() external view returns (uint8);
+    function round() external view returns (uint64);
+    function solver() external view returns (address);
+    function activeClaimBond() external view returns (uint256);
+    function submissionHash() external view returns (bytes32);
+    function evidenceHash() external view returns (bytes32);
+    function claimExpiresAt() external view returns (uint64);
+    function claimWindowSeconds() external view returns (uint64);
+}
+
+/// @notice Settles a standing meta-bounty only after a precommitted, task-verified,
+/// independently completed child pays out. Incomplete or malformed proofs revert,
+/// so an untrusted caller cannot turn missing evidence into a rejected submission.
+contract CanonicalIndependentChildVerifierV2 is IAgentBountyVerifier {
+    struct ParentScope {
+        address parentAddress;
+        bytes32 bountyId;
+        uint64 round;
+        address solver;
+        bytes32 submissionHash;
+        bytes32 evidenceHash;
+        bytes32 policyHash;
+    }
+
+    bytes32 public constant PROTOCOL_TAG = keccak256("agent-bounties/independent-child-v2");
+    uint8 public constant DETERMINISTIC_MODULE_MODE = 0;
+    uint8 public constant SIGNED_QUORUM_MODE = 1;
+    uint8 public constant SUBMITTED_STATUS = 3;
+    uint8 public constant SETTLED_STATUS = 4;
+
+    string public constant ACCEPTANCE_CRITERIA_JSON = '["Publish the exact child terms on Base from the parent solver wallet before claiming this bounty.",'
+        '"Create and fully fund the parent-bound canonical child to at least this bounty solver reward.",'
+        '"Use the committed sandboxed-regression signed verifier quorum and immutable task criteria.",'
+        '"Have a participant registered before the parent claim, with a different participant ID, complete the child.",'
+        '"Receive canonical child settlement before submitting the child address to this verifier."]';
+    bytes32 public constant ACCEPTANCE_CRITERIA_HASH = keccak256(bytes(ACCEPTANCE_CRITERIA_JSON));
+
+    address public immutable canonicalFactory;
+    address public immutable settlementToken;
+    ParticipantEligibilityRegistry public immutable participantRegistry;
+    OnchainTermsRegistry public immutable termsRegistry;
+    bytes32 public immutable taskVerifierSetHash;
+    uint8 public immutable taskVerifierThreshold;
+
+    error InvalidProof();
+    error InvalidParent();
+    error InvalidChild();
+    error TermsUnavailable();
+    error ParticipantIneligible();
+    error SameParticipant();
+
+    constructor(
+        address canonicalFactory_,
+        address participantRegistry_,
+        address termsRegistry_,
+        bytes32 taskVerifierSetHash_,
+        uint8 taskVerifierThreshold_
+    ) {
+        require(canonicalFactory_ != address(0), "factory zero");
+        require(participantRegistry_.code.length > 0, "participant registry missing");
+        require(termsRegistry_.code.length > 0, "terms registry missing");
+        require(taskVerifierSetHash_ != bytes32(0) && taskVerifierThreshold_ >= 2, "verifier policy invalid");
+        address token = IIndependentChildFactoryView(canonicalFactory_).settlementToken();
+        require(token != address(0), "token zero");
+        canonicalFactory = canonicalFactory_;
+        settlementToken = token;
+        participantRegistry = ParticipantEligibilityRegistry(participantRegistry_);
+        termsRegistry = OnchainTermsRegistry(termsRegistry_);
+        taskVerifierSetHash = taskVerifierSetHash_;
+        taskVerifierThreshold = taskVerifierThreshold_;
+    }
+
+    /// @notice The proof is exactly abi.encode(address childBounty).
+    function verify(
+        bytes32 parentBountyId,
+        uint64 parentRound,
+        address parentSolver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        bytes calldata proof
+    ) external view returns (bool passed, bytes32 responseHash) {
+        if (proof.length != 32) revert InvalidProof();
+        uint256 encodedChild;
+        assembly ("memory-safe") {
+            encodedChild := calldataload(proof.offset)
+        }
+        if (encodedChild >> 160 != 0) revert InvalidProof();
+        // The high-bit check above proves this cast cannot truncate.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        address childAddress = address(uint160(encodedChild));
+
+        ParentScope memory scope = ParentScope({
+            parentAddress: msg.sender,
+            bountyId: parentBountyId,
+            round: parentRound,
+            solver: parentSolver,
+            submissionHash: submissionHash,
+            evidenceHash: evidenceHash,
+            policyHash: policyHash
+        });
+        responseHash = _verify(scope, childAddress);
+        return (true, responseHash);
+    }
+
+    function _verify(ParentScope memory scope, address childAddress) private view returns (bytes32 responseHash) {
+        IIndependentChildBountyView parent =
+            _validParent(scope.parentAddress, scope.bountyId, scope.round, scope.solver);
+        uint64 claimedAt = parent.claimExpiresAt() - parent.claimWindowSeconds();
+        IIndependentChildBountyView child = _validChild(parent, childAddress, scope.solver);
+        _validTerms(child, scope.bountyId, scope.round, scope.solver, claimedAt);
+        _validParticipants(scope.solver, child.solver(), claimedAt);
+
+        responseHash = keccak256(
+            abi.encode(
+                PROTOCOL_TAG,
+                scope,
+                childAddress,
+                child.bountyId(),
+                child.solver(),
+                child.submissionHash(),
+                child.evidenceHash(),
+                child.termsHash()
+            )
+        );
+    }
+
+    function _validParent(address parentAddress, bytes32 parentBountyId, uint64 parentRound, address parentSolver)
+        private
+        view
+        returns (IIndependentChildBountyView parent)
+    {
+        if (!IIndependentChildFactoryView(canonicalFactory).isCanonicalBounty(parentAddress)) revert InvalidParent();
+        parent = IIndependentChildBountyView(parentAddress);
+        if (
+            parent.bountyId() != parentBountyId || parent.factory() != canonicalFactory
+                || parent.settlementToken() != settlementToken
+                || parent.acceptanceCriteriaHash() != ACCEPTANCE_CRITERIA_HASH
+                || parent.verificationMode() != DETERMINISTIC_MODULE_MODE || parent.verifierModule() != address(this)
+                || parent.threshold() != 1 || parent.status() != SUBMITTED_STATUS || parent.round() != parentRound
+                || parent.solver() != parentSolver || parent.claimExpiresAt() < parent.claimWindowSeconds()
+        ) revert InvalidParent();
+    }
+
+    function _validChild(IIndependentChildBountyView parent, address childAddress, address parentSolver)
+        private
+        view
+        returns (IIndependentChildBountyView child)
+    {
+        if (
+            childAddress == address(0) || childAddress == address(parent)
+                || !IIndependentChildFactoryView(canonicalFactory).isCanonicalBounty(childAddress)
+        ) revert InvalidChild();
+        child = IIndependentChildBountyView(childAddress);
+        if (
+            child.creator() != parentSolver || child.factory() != canonicalFactory
+                || child.settlementToken() != settlementToken || child.targetAmount() < parent.solverReward()
+                || child.verificationMode() != SIGNED_QUORUM_MODE || child.verifierModule() != address(0)
+                || child.verifierSetHash() != taskVerifierSetHash || child.threshold() != taskVerifierThreshold
+                || child.status() != SETTLED_STATUS || child.fundedAmount() != 0 || child.activeClaimBond() != 0
+                || child.solver() == address(0) || child.solver() == parentSolver
+                || child.submissionHash() == bytes32(0) || child.evidenceHash() == bytes32(0)
+        ) revert InvalidChild();
+    }
+
+    function _validTerms(
+        IIndependentChildBountyView child,
+        bytes32 parentBountyId,
+        uint64 parentRound,
+        address parentSolver,
+        uint64 parentClaimedAt
+    ) private view {
+        OnchainTermsRegistry.TermsCommitment memory record = termsRegistry.commitment(child.termsHash());
+        if (record.publishedAt == 0) revert TermsUnavailable();
+        if (
+            record.publisher != parentSolver || record.publishedAt >= parentClaimedAt
+                || record.parentBountyId != parentBountyId || record.parentRound != parentRound
+                || record.policyHash != child.policyHash()
+                || record.acceptanceCriteriaHash != child.acceptanceCriteriaHash()
+                || record.benchmarkHash != child.benchmarkHash()
+                || record.evidenceSchemaHash != child.evidenceSchemaHash()
+                || record.verifierSetHash != taskVerifierSetHash || record.verifierThreshold != taskVerifierThreshold
+        ) revert TermsUnavailable();
+    }
+
+    function _validParticipants(address parentSolver, address childSolver, uint64 parentClaimedAt) private view {
+        (bytes32 parentParticipant,, bool parentEligible) =
+            participantRegistry.eligibleAt(parentSolver, parentClaimedAt);
+        (bytes32 childParticipant,, bool childEligible) = participantRegistry.eligibleAt(childSolver, parentClaimedAt);
+        if (!parentEligible || !childEligible) revert ParticipantIneligible();
+        if (parentParticipant == childParticipant) revert SameParticipant();
+    }
+}

--- a/contracts/base-escrow/src/OnchainTermsRegistry.sol
+++ b/contracts/base-escrow/src/OnchainTermsRegistry.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+/// @notice Publishes exact task terms and typed commitments before a standing-meta claim.
+/// The full preimage is emitted once so indexers can always reconstruct it from Base.
+contract OnchainTermsRegistry {
+    uint256 public constant MAX_TERMS_BYTES = 32_768;
+
+    struct TermsCommitment {
+        address publisher;
+        uint64 publishedAt;
+        uint64 parentRound;
+        uint8 verifierThreshold;
+        uint32 byteLength;
+        bytes32 parentBountyId;
+        bytes32 policyHash;
+        bytes32 acceptanceCriteriaHash;
+        bytes32 benchmarkHash;
+        bytes32 evidenceSchemaHash;
+        bytes32 verifierSetHash;
+    }
+
+    struct TermsInput {
+        bytes32 parentBountyId;
+        uint64 parentRound;
+        bytes32 policyHash;
+        bytes32 acceptanceCriteriaHash;
+        bytes32 benchmarkHash;
+        bytes32 evidenceSchemaHash;
+        bytes32 verifierSetHash;
+        uint8 verifierThreshold;
+    }
+
+    mapping(bytes32 => TermsCommitment) public commitments;
+
+    event TermsPublished(bytes32 indexed termsHash, address indexed publisher, bytes canonicalTerms);
+
+    function commitment(bytes32 termsHash) external view returns (TermsCommitment memory) {
+        return commitments[termsHash];
+    }
+
+    function publish(bytes calldata canonicalTerms, TermsInput calldata input) external returns (bytes32 termsHash) {
+        require(canonicalTerms.length > 0 && canonicalTerms.length <= MAX_TERMS_BYTES, "terms size out of bounds");
+        require(input.parentBountyId != bytes32(0) && input.parentRound > 0, "parent binding missing");
+        require(
+            input.policyHash != bytes32(0) && input.acceptanceCriteriaHash != bytes32(0)
+                && input.benchmarkHash != bytes32(0) && input.evidenceSchemaHash != bytes32(0),
+            "content commitment missing"
+        );
+        require(input.verifierSetHash != bytes32(0) && input.verifierThreshold >= 2, "verifier commitment invalid");
+
+        termsHash = keccak256(canonicalTerms);
+        require(commitments[termsHash].publishedAt == 0, "terms already published");
+        commitments[termsHash] = TermsCommitment({
+            publisher: msg.sender,
+            publishedAt: uint64(block.timestamp),
+            parentRound: input.parentRound,
+            verifierThreshold: input.verifierThreshold,
+            byteLength: uint32(canonicalTerms.length),
+            parentBountyId: input.parentBountyId,
+            policyHash: input.policyHash,
+            acceptanceCriteriaHash: input.acceptanceCriteriaHash,
+            benchmarkHash: input.benchmarkHash,
+            evidenceSchemaHash: input.evidenceSchemaHash,
+            verifierSetHash: input.verifierSetHash
+        });
+        emit TermsPublished(termsHash, msg.sender, canonicalTerms);
+    }
+}

--- a/contracts/base-escrow/src/ParticipantEligibilityRegistry.sol
+++ b/contracts/base-escrow/src/ParticipantEligibilityRegistry.sol
@@ -80,6 +80,8 @@ contract ParticipantEligibilityRegistry {
         } else {
             require(record.participantId == participantId, "participant immutable");
             require(record.sourceHash == sourceHash, "source immutable");
+            require(block.timestamp <= record.validUntil, "expired record cannot renew");
+            require(validUntil > record.validUntil, "renewal must extend validity");
         }
         record.validUntil = validUntil;
         nonces[wallet] = nonce + 1;
@@ -94,7 +96,7 @@ contract ParticipantEligibilityRegistry {
         ParticipantRecord memory record = participants[wallet];
         participantId = record.participantId;
         sourceHash = record.sourceHash;
-        eligible = participantId != bytes32(0) && record.registeredAt <= cutoff && record.validUntil >= cutoff;
+        eligible = participantId != bytes32(0) && record.registeredAt < cutoff && record.validUntil >= cutoff;
     }
 
     function _recover(bytes32 digest, bytes calldata signature) private pure returns (address recovered) {

--- a/contracts/base-escrow/src/ParticipantEligibilityRegistry.sol
+++ b/contracts/base-escrow/src/ParticipantEligibilityRegistry.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+/// @notice Records source-scoped participant identities authorized by one immutable attester.
+/// Multiple wallets may share one participant ID, but a wallet can never change identities.
+contract ParticipantEligibilityRegistry {
+    struct ParticipantRecord {
+        bytes32 participantId;
+        bytes32 sourceHash;
+        uint64 registeredAt;
+        uint64 validUntil;
+    }
+
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant NAME_HASH = keccak256("Agent Bounties Participant Registry");
+    bytes32 private constant VERSION_HASH = keccak256("1");
+    bytes32 private constant ATTESTATION_TYPEHASH = keccak256(
+        "ParticipantAttestation(address wallet,bytes32 participantId,bytes32 sourceHash,uint64 validUntil,uint256 nonce)"
+    );
+    uint256 private constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
+    address public immutable attester;
+    mapping(address => ParticipantRecord) public participants;
+    mapping(address => uint256) public nonces;
+
+    event ParticipantAttested(
+        address indexed wallet,
+        bytes32 indexed participantId,
+        bytes32 indexed sourceHash,
+        uint64 registeredAt,
+        uint64 validUntil,
+        uint256 nonce
+    );
+
+    constructor(address attester_) {
+        require(attester_ != address(0), "attester zero");
+        attester = attester_;
+    }
+
+    function attestationDigest(
+        address wallet,
+        bytes32 participantId,
+        bytes32 sourceHash,
+        uint64 validUntil,
+        uint256 nonce
+    ) public view returns (bytes32) {
+        bytes32 structHash = keccak256(
+            abi.encode(ATTESTATION_TYPEHASH, wallet, participantId, sourceHash, validUntil, nonce)
+        );
+        bytes32 domainSeparator =
+            keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, address(this)));
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    /// @notice Anyone may relay an attester-authorized identity registration or renewal.
+    function register(
+        address wallet,
+        bytes32 participantId,
+        bytes32 sourceHash,
+        uint64 validUntil,
+        bytes calldata signature
+    ) external {
+        require(wallet != address(0), "wallet zero");
+        require(participantId != bytes32(0), "participant zero");
+        require(sourceHash != bytes32(0), "source zero");
+        require(validUntil > block.timestamp && validUntil <= block.timestamp + 365 days, "validity out of bounds");
+
+        uint256 nonce = nonces[wallet];
+        require(
+            _recover(attestationDigest(wallet, participantId, sourceHash, validUntil, nonce), signature) == attester,
+            "invalid attestation"
+        );
+
+        ParticipantRecord storage record = participants[wallet];
+        if (record.participantId == bytes32(0)) {
+            record.participantId = participantId;
+            record.sourceHash = sourceHash;
+            record.registeredAt = uint64(block.timestamp);
+        } else {
+            require(record.participantId == participantId, "participant immutable");
+            require(record.sourceHash == sourceHash, "source immutable");
+        }
+        record.validUntil = validUntil;
+        nonces[wallet] = nonce + 1;
+        emit ParticipantAttested(wallet, participantId, sourceHash, record.registeredAt, validUntil, nonce);
+    }
+
+    function eligibleAt(address wallet, uint64 cutoff)
+        external
+        view
+        returns (bytes32 participantId, bytes32 sourceHash, bool eligible)
+    {
+        ParticipantRecord memory record = participants[wallet];
+        participantId = record.participantId;
+        sourceHash = record.sourceHash;
+        eligible = participantId != bytes32(0) && record.registeredAt <= cutoff && record.validUntil >= cutoff;
+    }
+
+    function _recover(bytes32 digest, bytes calldata signature) private pure returns (address recovered) {
+        if (signature.length != 65) return address(0);
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly ("memory-safe") {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 0x20))
+            v := byte(0, calldataload(add(signature.offset, 0x40)))
+        }
+        if (uint256(s) > SECP256K1N_DIV_2 || (v != 27 && v != 28)) return address(0);
+        recovered = ecrecover(digest, v, r, s);
+    }
+}

--- a/contracts/base-escrow/src/StandingMetaV2Bundle.sol
+++ b/contracts/base-escrow/src/StandingMetaV2Bundle.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./CanonicalIndependentChildVerifierV2.sol";
+
+/// @notice Atomically deploys the immutable standing-meta-v2 policy components.
+/// A failed child deployment reverts the whole bundle, leaving no partial policy.
+contract StandingMetaV2Bundle {
+    address public immutable canonicalFactory;
+    ParticipantEligibilityRegistry public immutable participantRegistry;
+    OnchainTermsRegistry public immutable termsRegistry;
+    CanonicalIndependentChildVerifierV2 public immutable verifierModule;
+
+    constructor(address canonicalFactory_, address attester, address verifierOne, address verifierTwo) {
+        require(canonicalFactory_.code.length > 0, "factory missing");
+        require(attester != address(0), "attester zero");
+        require(
+            verifierOne != address(0) && verifierTwo != address(0) && verifierOne != verifierTwo, "verifiers invalid"
+        );
+
+        address[] memory verifiers = new address[](2);
+        verifiers[0] = verifierOne;
+        verifiers[1] = verifierTwo;
+
+        canonicalFactory = canonicalFactory_;
+        participantRegistry = new ParticipantEligibilityRegistry(attester);
+        termsRegistry = new OnchainTermsRegistry();
+        verifierModule = new CanonicalIndependentChildVerifierV2(
+            canonicalFactory_, address(participantRegistry), address(termsRegistry), keccak256(abi.encode(verifiers)), 2
+        );
+    }
+}

--- a/contracts/base-escrow/test/CanonicalIndependentChildVerifierV2.t.sol
+++ b/contracts/base-escrow/test/CanonicalIndependentChildVerifierV2.t.sol
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../src/AgentBountyFactory.sol";
+import "../src/CanonicalIndependentChildVerifierV2.sol";
+
+interface IndependentChildVm {
+    function addr(uint256 privateKey) external returns (address);
+    function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+    function warp(uint256 timestamp) external;
+}
+
+contract IndependentChildToken {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+contract IndependentChildActor {
+    function approve(IndependentChildToken token, address spender, uint256 amount) external {
+        token.approve(spender, amount);
+    }
+
+    function create(
+        AgentBountyFactory factory,
+        AgentBountyFactory.CreateBountyParams calldata params,
+        address[] calldata verifiers,
+        uint256 initialFunding,
+        bytes32 creationNonce
+    ) external returns (AgentBounty bounty) {
+        (address bountyAddress,) = factory.createBounty(params, verifiers, initialFunding, creationNonce);
+        bounty = AgentBounty(bountyAddress);
+    }
+
+    function publish(
+        OnchainTermsRegistry registry,
+        bytes calldata terms,
+        OnchainTermsRegistry.TermsInput calldata input
+    ) external returns (bytes32) {
+        return registry.publish(terms, input);
+    }
+
+    function claim(AgentBounty bounty) external {
+        bounty.claim();
+    }
+
+    function submit(AgentBounty bounty, bytes32 submissionHash, bytes32 evidenceHash) external {
+        bounty.submit(submissionHash, evidenceHash);
+    }
+}
+
+contract CanonicalIndependentChildVerifierV2Test {
+    IndependentChildVm private constant vm =
+        IndependentChildVm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    uint256 private constant ELIGIBILITY_ATTESTER_KEY = 0xA11CE;
+    uint256 private constant TASK_VERIFIER_ONE_KEY = 0xBEEF;
+    uint256 private constant TASK_VERIFIER_TWO_KEY = 0xCAFE;
+    uint256 private constant SUBSTITUTE_VERIFIER_KEY = 0xD00D;
+    bytes32 private constant POLICY_HASH = keccak256("sandboxed-regression-policy-v1");
+    bytes32 private constant CHILD_CRITERIA_HASH = keccak256("child-criteria");
+    bytes32 private constant CHILD_BENCHMARK_HASH = keccak256("child-benchmark");
+    bytes32 private constant EVIDENCE_SCHEMA_HASH = keccak256("child-evidence-schema");
+    bytes32 private constant SOURCE_HASH = keccak256("github-source-v1");
+    bytes32 private constant PARENT_PARTICIPANT = keccak256("participant-parent");
+    bytes32 private constant CHILD_PARTICIPANT = keccak256("participant-child");
+    bytes private constant CHILD_TERMS = '{"schema":"agent-bounties/test-child-v2"}';
+
+    IndependentChildToken private token;
+    AgentBountyFactory private factory;
+    ParticipantEligibilityRegistry private participantRegistry;
+    OnchainTermsRegistry private termsRegistry;
+    CanonicalIndependentChildVerifierV2 private module;
+    IndependentChildActor private parentSolver;
+    IndependentChildActor private childSolver;
+    IndependentChildActor private verifierRewardRecipient;
+    address[] private taskVerifiers;
+    uint256 private nonce;
+
+    function setUp() public {
+        token = new IndependentChildToken();
+        factory = new AgentBountyFactory(address(token));
+        participantRegistry = new ParticipantEligibilityRegistry(vm.addr(ELIGIBILITY_ATTESTER_KEY));
+        termsRegistry = new OnchainTermsRegistry();
+        taskVerifiers.push(vm.addr(TASK_VERIFIER_ONE_KEY));
+        taskVerifiers.push(vm.addr(TASK_VERIFIER_TWO_KEY));
+        module = new CanonicalIndependentChildVerifierV2(
+            address(factory),
+            address(participantRegistry),
+            address(termsRegistry),
+            keccak256(abi.encode(taskVerifiers)),
+            2
+        );
+        parentSolver = new IndependentChildActor();
+        childSolver = new IndependentChildActor();
+        verifierRewardRecipient = new IndependentChildActor();
+        token.mint(address(this), 10_000);
+        token.approve(address(factory), type(uint256).max);
+    }
+
+    function testSettledIndependentSandboxChildSettlesParent() public {
+        (AgentBounty parent, AgentBounty child) = _prepareSettledChild(CHILD_PARTICIPANT, true);
+
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+        parent.verifyAndSettle(abi.encode(address(child)));
+
+        require(parent.bountyStatus() == AgentBounty.BountyStatus.Settled, "parent not settled");
+        require(child.bountyStatus() == AgentBounty.BountyStatus.Settled, "child not settled");
+        require(token.balanceOf(address(childSolver)) == 1_000, "child solver payout mismatch");
+        require(token.balanceOf(address(verifierRewardRecipient)) == 100, "parent verifier payout mismatch");
+    }
+
+    function testSameParticipantCannotSettleParent() public {
+        (AgentBounty parent, AgentBounty child) = _prepareSettledChild(PARENT_PARTICIPANT, true);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "same participant settled parent");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testTermsPublishedAfterClaimCannotSettleParent() public {
+        (AgentBounty parent, AgentBounty child) = _prepareSettledChild(CHILD_PARTICIPANT, false);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "late terms settled parent");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testMalformedProofRevertsWithoutRejectingParent() public {
+        (AgentBounty parent,) = _prepareSettledChild(CHILD_PARTICIPANT, true);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (hex"01")));
+
+        require(!ok, "malformed proof accepted");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testParticipantIdentityCannotChange() public {
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        uint64 validUntil = uint64(block.timestamp + 14 days);
+        bytes32 changedId = keccak256("changed-participant");
+        bytes32 digest = participantRegistry.attestationDigest(
+            address(parentSolver), changedId, SOURCE_HASH, validUntil, participantRegistry.nonces(address(parentSolver))
+        );
+        bytes memory signature = _sign(ELIGIBILITY_ATTESTER_KEY, digest);
+
+        (bool ok,) = address(participantRegistry)
+            .call(
+                abi.encodeCall(
+                    participantRegistry.register, (address(parentSolver), changedId, SOURCE_HASH, validUntil, signature)
+                )
+            );
+        require(!ok, "participant identity changed");
+    }
+
+    function testEligibilityIsEvaluatedAtTheClaimCutoff() public {
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        uint64 cutoff = uint64(block.timestamp);
+
+        vm.warp(block.timestamp + 15 days);
+        (bytes32 participantId, bytes32 sourceHash, bool eligible) =
+            participantRegistry.eligibleAt(address(parentSolver), cutoff);
+
+        require(eligible, "historical eligibility was lost");
+        require(participantId == PARENT_PARTICIPANT, "participant mismatch");
+        require(sourceHash == SOURCE_HASH, "source mismatch");
+    }
+
+    function testUnregisteredChildParticipantCannotSettleParent() public {
+        AgentBounty parent = _createParent();
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        _publishChildTerms(parent);
+        vm.warp(block.timestamp + 1);
+
+        token.mint(address(parentSolver), 1_100);
+        parentSolver.approve(token, address(parent), 100);
+        parentSolver.claim(parent);
+        parentSolver.approve(token, address(factory), 1_000);
+        AgentBounty child = parentSolver.create(factory, _childParams(), taskVerifiers, 1_000, _nextNonce());
+
+        token.mint(address(childSolver), 100);
+        childSolver.approve(token, address(child), 100);
+        childSolver.claim(child);
+        childSolver.submit(child, keccak256("child-submission"), keccak256("child-evidence"));
+        _settleChild(child);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "unregistered participant settled parent");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testVerifierSubstitutionCannotSettleParent() public {
+        AgentBounty parent = _createParent();
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        _register(address(childSolver), CHILD_PARTICIPANT);
+        _publishChildTerms(parent);
+        vm.warp(block.timestamp + 1);
+
+        token.mint(address(parentSolver), 1_100);
+        parentSolver.approve(token, address(parent), 100);
+        parentSolver.claim(parent);
+        parentSolver.approve(token, address(factory), 1_000);
+        address[] memory substituted = new address[](2);
+        substituted[0] = taskVerifiers[0];
+        substituted[1] = vm.addr(SUBSTITUTE_VERIFIER_KEY);
+        AgentBounty child = parentSolver.create(factory, _childParams(), substituted, 1_000, _nextNonce());
+
+        token.mint(address(childSolver), 100);
+        childSolver.approve(token, address(child), 100);
+        childSolver.claim(child);
+        childSolver.submit(child, keccak256("child-submission"), keccak256("child-evidence"));
+        _settleChildWith(child, substituted, SUBSTITUTE_VERIFIER_KEY);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "substituted verifier set settled parent");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function _prepareSettledChild(bytes32 childParticipant, bool publishBeforeClaim)
+        private
+        returns (AgentBounty parent, AgentBounty child)
+    {
+        parent = _createParent();
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        _register(address(childSolver), childParticipant);
+        if (publishBeforeClaim) {
+            _publishChildTerms(parent);
+            vm.warp(block.timestamp + 1);
+        }
+
+        token.mint(address(parentSolver), 1_100);
+        parentSolver.approve(token, address(parent), 100);
+        parentSolver.claim(parent);
+
+        if (!publishBeforeClaim) {
+            vm.warp(block.timestamp + 1);
+            _publishChildTerms(parent);
+        }
+        parentSolver.approve(token, address(factory), 1_000);
+        child = parentSolver.create(factory, _childParams(), taskVerifiers, 1_000, _nextNonce());
+
+        token.mint(address(childSolver), 100);
+        childSolver.approve(token, address(child), 100);
+        childSolver.claim(child);
+        childSolver.submit(child, keccak256("child-submission"), keccak256("child-evidence"));
+        _settleChild(child);
+    }
+
+    function _createParent() private returns (AgentBounty parent) {
+        AgentBountyFactory.CreateBountyParams memory params = AgentBountyFactory.CreateBountyParams({
+            solverReward: 900,
+            verifierReward: 100,
+            termsHash: keccak256("parent-terms"),
+            policyHash: keccak256("parent-policy"),
+            acceptanceCriteriaHash: module.ACCEPTANCE_CRITERIA_HASH(),
+            benchmarkHash: keccak256("parent-benchmark"),
+            evidenceSchemaHash: keccak256("parent-evidence-schema"),
+            fundingDeadline: uint64(block.timestamp + 1 days),
+            claimWindowSeconds: 1 hours,
+            verificationWindowSeconds: 1 days,
+            verificationMode: AgentBounty.VerificationMode.DeterministicModule,
+            verifierModule: address(module),
+            verifierRewardRecipient: address(verifierRewardRecipient),
+            threshold: 1
+        });
+        (address parentAddress,) = factory.createBounty(params, new address[](0), 1_000, _nextNonce());
+        parent = AgentBounty(parentAddress);
+    }
+
+    function _publishChildTerms(AgentBounty parent) private {
+        OnchainTermsRegistry.TermsInput memory input = OnchainTermsRegistry.TermsInput({
+            parentBountyId: parent.bountyId(),
+            parentRound: 1,
+            policyHash: POLICY_HASH,
+            acceptanceCriteriaHash: CHILD_CRITERIA_HASH,
+            benchmarkHash: CHILD_BENCHMARK_HASH,
+            evidenceSchemaHash: EVIDENCE_SCHEMA_HASH,
+            verifierSetHash: keccak256(abi.encode(taskVerifiers)),
+            verifierThreshold: 2
+        });
+        parentSolver.publish(termsRegistry, CHILD_TERMS, input);
+    }
+
+    function _childParams() private view returns (AgentBountyFactory.CreateBountyParams memory) {
+        return AgentBountyFactory.CreateBountyParams({
+            solverReward: 900,
+            verifierReward: 100,
+            termsHash: keccak256(CHILD_TERMS),
+            policyHash: POLICY_HASH,
+            acceptanceCriteriaHash: CHILD_CRITERIA_HASH,
+            benchmarkHash: CHILD_BENCHMARK_HASH,
+            evidenceSchemaHash: EVIDENCE_SCHEMA_HASH,
+            fundingDeadline: uint64(block.timestamp + 1 days),
+            claimWindowSeconds: 1 hours,
+            verificationWindowSeconds: 1 days,
+            verificationMode: AgentBounty.VerificationMode.SignedQuorum,
+            verifierModule: address(0),
+            verifierRewardRecipient: address(0),
+            threshold: 2
+        });
+    }
+
+    function _settleChild(AgentBounty child) private {
+        _settleChildWith(child, taskVerifiers, TASK_VERIFIER_TWO_KEY);
+    }
+
+    function _settleChildWith(AgentBounty child, address[] memory verifiers, uint256 secondVerifierKey) private {
+        AgentBounty.Attestation[] memory attestations = new AgentBounty.Attestation[](2);
+        uint256 deadline = block.timestamp + 1 hours;
+        for (uint256 i = 0; i < 2; i++) {
+            bytes32 responseHash = keccak256(abi.encode("sandbox-pass", i));
+            address verifier = verifiers[i];
+            bytes32 digest = child.attestationDigest(verifier, true, responseHash, deadline);
+            uint256 key = i == 0 ? TASK_VERIFIER_ONE_KEY : secondVerifierKey;
+            attestations[i] = AgentBounty.Attestation({
+                verifier: verifier,
+                passed: true,
+                responseHash: responseHash,
+                deadline: deadline,
+                signature: _sign(key, digest)
+            });
+        }
+        child.settleWithAttestations(attestations);
+    }
+
+    function _register(address wallet, bytes32 participantId) private {
+        uint64 validUntil = uint64(block.timestamp + 14 days);
+        uint256 registrationNonce = participantRegistry.nonces(wallet);
+        bytes32 digest =
+            participantRegistry.attestationDigest(wallet, participantId, SOURCE_HASH, validUntil, registrationNonce);
+        participantRegistry.register(
+            wallet, participantId, SOURCE_HASH, validUntil, _sign(ELIGIBILITY_ATTESTER_KEY, digest)
+        );
+    }
+
+    function _sign(uint256 key, bytes32 digest) private returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _assertParentAttemptPreserved(AgentBounty parent) private view {
+        require(parent.bountyStatus() == AgentBounty.BountyStatus.Submitted, "parent state changed");
+        require(parent.fundedAmount() == parent.targetAmount(), "parent funding changed");
+        require(parent.solver() == address(parentSolver), "parent solver cleared");
+        require(parent.activeClaimBond() == 100, "parent bond changed");
+    }
+
+    function _nextNonce() private returns (bytes32) {
+        nonce += 1;
+        return bytes32(nonce);
+    }
+}

--- a/contracts/base-escrow/test/CanonicalIndependentChildVerifierV2.t.sol
+++ b/contracts/base-escrow/test/CanonicalIndependentChildVerifierV2.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import "../src/AgentBountyFactory.sol";
 import "../src/CanonicalIndependentChildVerifierV2.sol";
+import "../src/StandingMetaV2Bundle.sol";
 
 interface IndependentChildVm {
     function addr(uint256 privateKey) external returns (address);
@@ -181,8 +182,62 @@ contract CanonicalIndependentChildVerifierV2Test {
         require(!ok, "participant identity changed");
     }
 
+    function testExpiredParticipantCannotRenewRetroactively() public {
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        vm.warp(block.timestamp + 15 days);
+        uint64 validUntil = uint64(block.timestamp + 14 days);
+        uint256 registrationNonce = participantRegistry.nonces(address(parentSolver));
+        bytes32 digest = participantRegistry.attestationDigest(
+            address(parentSolver), PARENT_PARTICIPANT, SOURCE_HASH, validUntil, registrationNonce
+        );
+
+        (bool ok,) = address(participantRegistry)
+            .call(
+                abi.encodeCall(
+                    participantRegistry.register,
+                    (
+                        address(parentSolver),
+                        PARENT_PARTICIPANT,
+                        SOURCE_HASH,
+                        validUntil,
+                        _sign(ELIGIBILITY_ATTESTER_KEY, digest)
+                    )
+                )
+            );
+
+        require(!ok, "expired participant renewed retroactively");
+    }
+
+    function testActiveParticipantCanExtendValidity() public {
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        (,,, uint64 previousValidUntil) = participantRegistry.participants(address(parentSolver));
+        uint64 nextValidUntil = previousValidUntil + 14 days;
+        uint256 registrationNonce = participantRegistry.nonces(address(parentSolver));
+        bytes32 digest = participantRegistry.attestationDigest(
+            address(parentSolver), PARENT_PARTICIPANT, SOURCE_HASH, nextValidUntil, registrationNonce
+        );
+
+        participantRegistry.register(
+            address(parentSolver),
+            PARENT_PARTICIPANT,
+            SOURCE_HASH,
+            nextValidUntil,
+            _sign(ELIGIBILITY_ATTESTER_KEY, digest)
+        );
+        (,,, uint64 observedValidUntil) = participantRegistry.participants(address(parentSolver));
+
+        require(observedValidUntil == nextValidUntil, "active participant validity did not extend");
+    }
+
+    function testRegistrationAtClaimCutoffIsNotEligible() public {
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        (,, bool eligible) = participantRegistry.eligibleAt(address(parentSolver), uint64(block.timestamp));
+        require(!eligible, "same-timestamp registration was eligible");
+    }
+
     function testEligibilityIsEvaluatedAtTheClaimCutoff() public {
         _register(address(parentSolver), PARENT_PARTICIPANT);
+        vm.warp(block.timestamp + 1);
         uint64 cutoff = uint64(block.timestamp);
 
         vm.warp(block.timestamp + 15 days);
@@ -192,6 +247,26 @@ contract CanonicalIndependentChildVerifierV2Test {
         require(eligible, "historical eligibility was lost");
         require(participantId == PARENT_PARTICIPANT, "participant mismatch");
         require(sourceHash == SOURCE_HASH, "source mismatch");
+    }
+
+    function testBundleDeploysTheExactPolicyAtomically() public {
+        StandingMetaV2Bundle bundle = new StandingMetaV2Bundle(
+            address(factory),
+            vm.addr(ELIGIBILITY_ATTESTER_KEY),
+            vm.addr(TASK_VERIFIER_ONE_KEY),
+            vm.addr(TASK_VERIFIER_TWO_KEY)
+        );
+        CanonicalIndependentChildVerifierV2 bundledModule = bundle.verifierModule();
+
+        require(bundle.canonicalFactory() == address(factory), "bundle factory mismatch");
+        require(bundledModule.canonicalFactory() == address(factory), "module factory mismatch");
+        require(
+            address(bundledModule.participantRegistry()) == address(bundle.participantRegistry()),
+            "bundle participant registry mismatch"
+        );
+        require(address(bundledModule.termsRegistry()) == address(bundle.termsRegistry()), "bundle terms mismatch");
+        require(bundledModule.taskVerifierSetHash() == keccak256(abi.encode(taskVerifiers)), "bundle quorum mismatch");
+        require(bundledModule.taskVerifierThreshold() == 2, "bundle threshold mismatch");
     }
 
     function testUnregisteredChildParticipantCannotSettleParent() public {

--- a/crates/verifier-sdk/src/lib.rs
+++ b/crates/verifier-sdk/src/lib.rs
@@ -494,11 +494,67 @@ pub trait RegressionSandboxExecutor: Send + Sync {
     ) -> Result<RegressionSandboxExecution, RegressionSandboxExecutorError>;
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RegressionVerificationOutcome {
     pub verdict: RegressionVerdict,
     pub receipt: RegressionSandboxReceipt,
     pub response_hash: String,
+}
+
+pub fn validate_regression_outcome(
+    policy: &RegressionSandboxPolicy,
+    task: &RegressionVerificationTask,
+    outcome: &RegressionVerificationOutcome,
+) -> VerifierResultType<()> {
+    policy.validate()?;
+    task.validate()?;
+    outcome.receipt.execution.validate(policy)?;
+    if outcome.receipt.schema_version != REGRESSION_SANDBOX_RECEIPT_VERSION
+        || outcome.receipt.scope != task.scope
+        || outcome.receipt.runner_manifest_hash != policy.runner_manifest_hash()?
+        || outcome.receipt.command_hash != policy.command_hash()?
+        || outcome.receipt.source_digest != task.source_digest
+        || outcome.receipt.benchmark_digest != policy.benchmark_digest
+        || outcome.receipt.image != policy.image
+    {
+        return Err(VerifierError::Failed(
+            "regression receipt differs from the immutable task or runner policy; no attestation is allowed"
+                .to_string(),
+        ));
+    }
+    let expected_verdict = if outcome.receipt.execution.exit_code == 0 {
+        RegressionVerdict::Passed
+    } else {
+        RegressionVerdict::Failed
+    };
+    if outcome.verdict != expected_verdict {
+        return Err(VerifierError::Failed(
+            "regression verdict differs from the completed process exit; no attestation is allowed"
+                .to_string(),
+        ));
+    }
+    #[derive(Serialize)]
+    struct ResponsePreimage<'a> {
+        schema_version: &'static str,
+        verdict: RegressionVerdict,
+        receipt: &'a RegressionSandboxReceipt,
+    }
+    let expected_response_hash = canonical_sha256_bytes32(&ResponsePreimage {
+        schema_version: REGRESSION_SANDBOX_RECEIPT_VERSION,
+        verdict: outcome.verdict,
+        receipt: &outcome.receipt,
+    })?;
+    if !outcome
+        .response_hash
+        .eq_ignore_ascii_case(&expected_response_hash)
+    {
+        return Err(VerifierError::Failed(
+            "regression response hash does not commit the exact receipt; no attestation is allowed"
+                .to_string(),
+        ));
+    }
+    Ok(())
 }
 
 pub struct SandboxedRegressionVerifier<E> {
@@ -522,10 +578,10 @@ impl<E: RegressionSandboxExecutor> SandboxedRegressionVerifier<E> {
         execution.validate(&self.policy)?;
         let receipt = RegressionSandboxReceipt {
             schema_version: REGRESSION_SANDBOX_RECEIPT_VERSION.to_string(),
-            scope: task.scope,
+            scope: task.scope.clone(),
             runner_manifest_hash: self.policy.runner_manifest_hash()?,
             command_hash: self.policy.command_hash()?,
-            source_digest: task.source_digest,
+            source_digest: task.source_digest.clone(),
             benchmark_digest: self.policy.benchmark_digest.clone(),
             image: self.policy.image.clone(),
             execution,
@@ -535,22 +591,24 @@ impl<E: RegressionSandboxExecutor> SandboxedRegressionVerifier<E> {
         } else {
             RegressionVerdict::Failed
         };
+        let mut outcome = RegressionVerificationOutcome {
+            verdict,
+            receipt,
+            response_hash: String::new(),
+        };
         #[derive(Serialize)]
         struct ResponsePreimage<'a> {
             schema_version: &'static str,
             verdict: RegressionVerdict,
             receipt: &'a RegressionSandboxReceipt,
         }
-        let response_hash = canonical_sha256_bytes32(&ResponsePreimage {
+        outcome.response_hash = canonical_sha256_bytes32(&ResponsePreimage {
             schema_version: REGRESSION_SANDBOX_RECEIPT_VERSION,
-            verdict,
-            receipt: &receipt,
+            verdict: outcome.verdict,
+            receipt: &outcome.receipt,
         })?;
-        Ok(RegressionVerificationOutcome {
-            verdict,
-            receipt,
-            response_hash,
-        })
+        validate_regression_outcome(&self.policy, &task, &outcome)?;
+        Ok(outcome)
     }
 }
 
@@ -1714,6 +1772,32 @@ mod tests {
         assert!(first.response_hash.starts_with("0x"));
         assert_eq!(first.response_hash.len(), 66);
         assert_eq!(first.receipt.scope, regression_scope());
+    }
+
+    #[tokio::test]
+    async fn regression_candidate_validation_rejects_scope_verdict_and_hash_mutation() {
+        let policy = regression_policy();
+        let task = regression_task();
+        let outcome = SandboxedRegressionVerifier {
+            executor: StubRegressionExecutor::completed(0),
+            policy: policy.clone(),
+        }
+        .verify(task.clone())
+        .await
+        .unwrap();
+        validate_regression_outcome(&policy, &task, &outcome).unwrap();
+
+        let mut changed_scope = outcome.clone();
+        changed_scope.receipt.scope.round += 1;
+        assert!(validate_regression_outcome(&policy, &task, &changed_scope).is_err());
+
+        let mut changed_verdict = outcome.clone();
+        changed_verdict.verdict = RegressionVerdict::Failed;
+        assert!(validate_regression_outcome(&policy, &task, &changed_verdict).is_err());
+
+        let mut changed_hash = outcome;
+        changed_hash.response_hash = hash("a");
+        assert!(validate_regression_outcome(&policy, &task, &changed_hash).is_err());
     }
 
     #[tokio::test]

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -1,13 +1,17 @@
 use anyhow::Context;
 use db::PostgresStore;
-use std::{env, time::Duration};
+use std::{
+    env,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tokio::time::sleep;
 use worker::{
     indexer_error_is_retryable, poll_autonomous_indexer_once_with_heartbeat,
     redact_operational_error, run_regression_sandbox_request, snapshot_directory,
-    stage_regression_input, AutonomousIndexerConfig, IndexerRecoveryDecision,
-    IndexerRecoveryPolicy, RegressionInputKind, RegressionSandboxRunRequest,
-    REGRESSION_SANDBOX_DOCKER_BINARY_ENV, REGRESSION_SANDBOX_STAGING_ROOT_ENV,
+    stage_regression_input, validate_regression_candidate, AutonomousIndexerConfig,
+    IndexerRecoveryDecision, IndexerRecoveryPolicy, RegressionCandidateValidationRequest,
+    RegressionInputKind, RegressionSandboxRunRequest, REGRESSION_SANDBOX_DOCKER_BINARY_ENV,
+    REGRESSION_SANDBOX_STAGING_ROOT_ENV,
 };
 
 #[tokio::main]
@@ -74,6 +78,25 @@ async fn main() -> anyhow::Result<()> {
             max_files,
         )?;
         println!("{}", serde_json::to_string_pretty(&staged)?);
+        return Ok(());
+    }
+    if arguments
+        .first()
+        .is_some_and(|value| value == "--validate-regression-candidate")
+    {
+        if arguments.len() != 2 {
+            anyhow::bail!("usage: worker --validate-regression-candidate <request.json>");
+        }
+        let request = std::fs::read_to_string(&arguments[1])
+            .context("failed to read regression candidate request")?;
+        let request: RegressionCandidateValidationRequest = serde_json::from_str(&request)
+            .context("failed to parse regression candidate request")?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system clock is before the Unix epoch")?
+            .as_secs();
+        validate_regression_candidate(request, now)?;
+        println!("ok");
         return Ok(());
     }
     let once =

--- a/crates/worker/src/regression_sandbox.rs
+++ b/crates/worker/src/regression_sandbox.rs
@@ -19,9 +19,10 @@ use std::{
 };
 use tokio::{io::AsyncReadExt, process::Command, task, time::Instant};
 use verifier_sdk::{
-    RegressionSandboxExecution, RegressionSandboxExecutor, RegressionSandboxExecutorError,
-    RegressionSandboxIsolation, RegressionSandboxPolicy, RegressionVerificationOutcome,
-    RegressionVerificationScope, RegressionVerificationTask, SandboxedRegressionVerifier,
+    validate_regression_outcome, RegressionSandboxExecution, RegressionSandboxExecutor,
+    RegressionSandboxExecutorError, RegressionSandboxIsolation, RegressionSandboxPolicy,
+    RegressionVerificationOutcome, RegressionVerificationScope, RegressionVerificationTask,
+    SandboxedRegressionVerifier,
 };
 
 pub const REGRESSION_SANDBOX_ENGINE: &str = "sandboxed_regression_v1";
@@ -34,6 +35,14 @@ static RUN_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 #[serde(deny_unknown_fields)]
 pub struct RegressionSandboxRunRequest {
     pub job: AutonomousVerificationJob,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegressionCandidateValidationRequest {
+    pub job: AutonomousVerificationJob,
+    pub current_job: AutonomousVerificationJob,
+    pub outcome: RegressionVerificationOutcome,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -524,6 +533,20 @@ pub fn prepare_regression_run(
         policy,
         task,
     })
+}
+
+pub fn validate_regression_candidate(
+    request: RegressionCandidateValidationRequest,
+    observed_at_unix: u64,
+) -> anyhow::Result<()> {
+    if serde_json::to_value(&request.job)? != serde_json::to_value(&request.current_job)? {
+        return Err(anyhow!(
+            "runner candidate no longer matches the current canonical verification job"
+        ));
+    }
+    let prepared = prepare_regression_run(request.current_job, observed_at_unix, Path::new("."))?;
+    validate_regression_outcome(&prepared.policy, &prepared.task, &request.outcome)
+        .context("regression candidate failed exact receipt validation")
 }
 
 fn validate_terms_hashes(job: &AutonomousVerificationJob) -> anyhow::Result<()> {

--- a/deployments/bounded-agent-wallet-base-mainnet.json
+++ b/deployments/bounded-agent-wallet-base-mainnet.json
@@ -1,6 +1,6 @@
 {
   "schema": "agent-bounties/bounded-agent-wallet-deployment-v1",
-  "contract_source_revision": "7708253cd4914eaa06109523f565751f7d83b6f1",
+  "contract_source_revision": "c09ecad36a9d6d93d1272e81819c7196d0d97214",
   "contract_source_revision_kind": "git-tree",
   "contract_source_dirty": false,
   "network": "base-mainnet",
@@ -45,11 +45,20 @@
     "CanonicalChildBountyVerifier": {
       "source_sha256": "0xc7b58a7ccfe0dc6d6d72934b9b361024e3c04db012ffd0346ae09f7ecd9e0429"
     },
+    "CanonicalIndependentChildVerifierV2": {
+      "source_sha256": "0x229dc4cf79dfd59815a2d2227e0bbbad03992514fdb7d04d9a5b76a1623a47d5"
+    },
     "IAgentBounty": {
       "source_sha256": "0xede2df7af3f07c825a2769da37f7ad1f240fc9e64ae812fe4ce229d89e1785fd"
     },
     "LeadingZeroWorkVerifier": {
       "source_sha256": "0x9ff8543422aa6c203f3934f1f7ce8f02a0331265ef3bda4ae9c41314ae30ef6b"
+    },
+    "OnchainTermsRegistry": {
+      "source_sha256": "0x8c02a7c182b7900806fdc4fa63abbebebec8618b47f20f0e7ba4261d21553739"
+    },
+    "ParticipantEligibilityRegistry": {
+      "source_sha256": "0x97240c200d183296e45422bce310616b61bc03ba4cf71b5913eaa7689a63f72a"
     }
   },
   "evidence_boundary": "This manifest derives exact addresses, bytecode, and unsigned deployment calldata. It is not deployment, delegation, funding, completion, payout, or settlement evidence."

--- a/deployments/bounded-agent-wallet-base-mainnet.json
+++ b/deployments/bounded-agent-wallet-base-mainnet.json
@@ -1,6 +1,6 @@
 {
   "schema": "agent-bounties/bounded-agent-wallet-deployment-v1",
-  "contract_source_revision": "c09ecad36a9d6d93d1272e81819c7196d0d97214",
+  "contract_source_revision": "da731c015a5dbee7053fc57abd50792d0b3b30f6",
   "contract_source_revision_kind": "git-tree",
   "contract_source_dirty": false,
   "network": "base-mainnet",
@@ -58,7 +58,10 @@
       "source_sha256": "0x8c02a7c182b7900806fdc4fa63abbebebec8618b47f20f0e7ba4261d21553739"
     },
     "ParticipantEligibilityRegistry": {
-      "source_sha256": "0x97240c200d183296e45422bce310616b61bc03ba4cf71b5913eaa7689a63f72a"
+      "source_sha256": "0xec345bbd18b749c6991249dee9f67a2331abd5a5f56edf3f785866dc79e64aa6"
+    },
+    "StandingMetaV2Bundle": {
+      "source_sha256": "0x356530a76a3cc34b4ac9cf7d0afc29d664270f3496b527f0592439f05ececf62"
     }
   },
   "evidence_boundary": "This manifest derives exact addresses, bytecode, and unsigned deployment calldata. It is not deployment, delegation, funding, completion, payout, or settlement evidence."

--- a/render.yaml
+++ b/render.yaml
@@ -56,6 +56,8 @@ envVarGroups:
 services:
   - type: web
     name: agent-bounties-api
+    domains:
+      - api.bountyboard.global
     runtime: docker
     plan: starter
     region: oregon
@@ -133,6 +135,8 @@ services:
 
   - type: web
     name: agent-bounties-mcp
+    domains:
+      - mcp.bountyboard.global
     runtime: docker
     plan: starter
     region: oregon

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -263,6 +263,8 @@ def main() -> int:
             fail(f"Render deployment workflow missing contract: {required}")
 
     api = named_block(services, "agent-bounties-api")
+    if "domains:\n      - api.bountyboard.global" not in api:
+        fail("API service must attach api.bountyboard.global")
     require_env_value(api, "APP_PACKAGE", "api")
     require_env_value(api, "APP_BINARY", "api")
     require_env_value(api, "ENABLE_STRIPE_LIVE_EXECUTION", '"false"')
@@ -284,6 +286,8 @@ def main() -> int:
         fail("API service must use /health")
 
     mcp = named_block(services, "agent-bounties-mcp")
+    if "domains:\n      - mcp.bountyboard.global" not in mcp:
+        fail("MCP service must attach mcp.bountyboard.global")
     require_env_value(mcp, "APP_PACKAGE", "mcp-server")
     require_env_value(mcp, "APP_BINARY", "mcp-server")
     require_env_value(mcp, "ENABLE_STRIPE_LIVE_EXECUTION", '"false"')

--- a/scripts/register_participant.py
+++ b/scripts/register_participant.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Register a GitHub participant identity for the standing-meta protocol."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "agent-bounties/participant-registration-v1"
+COMMAND = re.compile(r"^/agent-bounty register (0x[0-9a-fA-F]{40})\s*$")
+ADDRESS = re.compile(r"^0x[0-9a-f]{40}$")
+HASH = re.compile(r"^0x[0-9a-f]{64}$")
+
+
+class RegistrationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RegistrationRequest:
+    repository: str
+    issue_number: int
+    github_login: str
+    github_user_id: int
+    wallet: str
+
+
+def parse_event(value: object, expected_repository: str) -> RegistrationRequest:
+    if not isinstance(value, dict) or value.get("action") not in {"created", "edited"}:
+        raise RegistrationError("only created or edited issue comments can register participants")
+    repository = value.get("repository")
+    comment = value.get("comment")
+    issue = value.get("issue")
+    sender = value.get("sender")
+    if not all(isinstance(item, dict) for item in (repository, comment, issue, sender)):
+        raise RegistrationError("GitHub event is missing registration scope")
+    full_name = str(repository.get("full_name", ""))
+    if full_name.lower() != expected_repository.lower():
+        raise RegistrationError("registration event belongs to a different repository")
+    if issue.get("pull_request") is not None:
+        raise RegistrationError("participant registration must be requested on an issue")
+    match = COMMAND.fullmatch(str(comment.get("body", "")))
+    if match is None:
+        raise RegistrationError("registration command must be `/agent-bounty register 0xWallet`")
+    issue_number = issue.get("number")
+    user_id = sender.get("id")
+    login = str(sender.get("login", ""))
+    if (
+        not isinstance(issue_number, int)
+        or issue_number <= 0
+        or not isinstance(user_id, int)
+        or user_id <= 0
+        or not re.fullmatch(r"[A-Za-z0-9-]{1,39}", login)
+    ):
+        raise RegistrationError("GitHub participant identity is invalid")
+    return RegistrationRequest(
+        repository=full_name,
+        issue_number=issue_number,
+        github_login=login,
+        github_user_id=user_id,
+        wallet=match.group(1).lower(),
+    )
+
+
+def run(command: list[str]) -> str:
+    completed = subprocess.run(command, capture_output=True, text=True, timeout=120, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()[:600]
+        raise RegistrationError(f"participant transaction failed closed: {detail}")
+    return completed.stdout.strip()
+
+
+def register(args: argparse.Namespace, request: RegistrationRequest) -> dict[str, Any]:
+    registry = str(args.registry).lower()
+    if not ADDRESS.fullmatch(registry):
+        raise RegistrationError("participant registry address is unavailable")
+    attester_key = os.environ.get("PARTICIPANT_ATTESTER_PRIVATE_KEY", "").strip()
+    keeper_key = os.environ.get("BASE_KEEPER_PRIVATE_KEY", "").strip()
+    if not attester_key or not keeper_key:
+        raise RegistrationError("participant attester and keeper capabilities are required")
+    cast = str(args.cast)
+    if run([cast, "chain-id", "--rpc-url", args.rpc_url]) != "8453":
+        raise RegistrationError("participant registration is pinned to Base mainnet")
+    attester = run([cast, "wallet", "address", "--private-key", attester_key]).lower()
+    configured = run([cast, "call", "--rpc-url", args.rpc_url, registry, "attester()(address)"]).lower()
+    if attester != configured:
+        raise RegistrationError("attester key does not match the immutable registry")
+    participant_id = run(
+        [cast, "keccak", f"agent-bounties/github-user-v1:{request.github_user_id}"]
+    ).lower()
+    source_hash = run([cast, "keccak", "agent-bounties/github-user-id"]).lower()
+    nonce = run(
+        [cast, "call", "--rpc-url", args.rpc_url, registry, "nonces(address)(uint256)", request.wallet]
+    )
+    valid_until = int(time.time()) + 30 * 24 * 60 * 60
+    digest = run(
+        [
+            cast,
+            "call",
+            "--rpc-url",
+            args.rpc_url,
+            registry,
+            "attestationDigest(address,bytes32,bytes32,uint64,uint256)(bytes32)",
+            request.wallet,
+            participant_id,
+            source_hash,
+            str(valid_until),
+            nonce,
+        ]
+    ).lower()
+    signature = run(
+        [cast, "wallet", "sign", "--no-hash", "--private-key", attester_key, digest]
+    ).lower()
+    receipt = json.loads(
+        run(
+            [
+                cast,
+                "send",
+                "--json",
+                "--rpc-url",
+                args.rpc_url,
+                "--private-key",
+                keeper_key,
+                registry,
+                "register(address,bytes32,bytes32,uint64,bytes)",
+                request.wallet,
+                participant_id,
+                source_hash,
+                str(valid_until),
+                signature,
+            ]
+        )
+    )
+    transaction_hash = str(receipt.get("transactionHash", "")).lower()
+    if not HASH.fullmatch(transaction_hash) or str(receipt.get("status", "")) not in {"1", "0x1"}:
+        raise RegistrationError("participant registration did not return a successful receipt")
+    eligible = run(
+        [
+            cast,
+            "call",
+            "--rpc-url",
+            args.rpc_url,
+            registry,
+            "eligibleAt(address,uint64)(bytes32,bytes32,bool)",
+            request.wallet,
+            str(int(time.time())),
+        ]
+    )
+    if "true" not in eligible.lower():
+        raise RegistrationError("participant registry did not confirm eligibility")
+    return {
+        "schema": SCHEMA,
+        "success": True,
+        "repository": request.repository,
+        "issue_number": request.issue_number,
+        "github_login": request.github_login,
+        "github_user_id": request.github_user_id,
+        "wallet": request.wallet,
+        "participant_id": participant_id,
+        "source_hash": source_hash,
+        "registry": registry,
+        "valid_until": valid_until,
+        "transaction_hash": transaction_hash,
+    }
+
+
+def markdown(evidence: dict[str, Any]) -> str:
+    if evidence.get("success"):
+        return (
+            f"Participant registration confirmed for `@{evidence['github_login']}` and "
+            f"`{evidence['wallet']}`.\n\n"
+            f"Base transaction: `https://basescan.org/tx/{evidence['transaction_hash']}`\n\n"
+            "This source-scoped identity is used only to enforce independent participation in "
+            "standing meta-bounties. It is not payment, claim, completion, or payout evidence."
+        )
+    return (
+        "Participant registration was not completed. The request failed closed: "
+        f"{evidence.get('error', 'unknown error')}\n\n"
+        "Use exactly `/agent-bounty register 0xYourBaseWallet` and retry after correcting the stated issue."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--registry", required=True)
+    parser.add_argument("--rpc-url", default="https://mainnet.base.org")
+    parser.add_argument("--cast", type=Path, default=Path("cast"))
+    parser.add_argument("--json-out", type=Path, required=True)
+    parser.add_argument("--md-out", type=Path, required=True)
+    args = parser.parse_args()
+    evidence: dict[str, Any] = {"schema": SCHEMA, "success": False, "error": None}
+    try:
+        request = parse_event(json.loads(args.event.read_text(encoding="utf-8")), args.repository)
+        evidence = register(args, request)
+    except (RegistrationError, OSError, ValueError, json.JSONDecodeError) as error:
+        evidence["error"] = str(error)[:600]
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.md_out.write_text(markdown(evidence) + "\n", encoding="utf-8")
+    return 0 if evidence.get("success") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regression_verifier_pipeline.py
+++ b/scripts/regression_verifier_pipeline.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""Run, validate, sign, and relay sandboxed-regression verifier jobs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+CANDIDATE_SCHEMA = "agent-bounties/regression-candidate-v1"
+ATTESTATION_SCHEMA = "agent-bounties/regression-attestation-v1"
+MANIFEST_SCHEMA = "agent-bounties/regression-candidate-manifest-v1"
+ADDRESS = re.compile(r"^0x[0-9a-f]{40}$")
+HASH = re.compile(r"^0x[0-9a-f]{64}$")
+SHA = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+DEFAULT_API = "https://agent-bounties-api.onrender.com"
+
+
+class PipelineError(RuntimeError):
+    pass
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def normalize_address(value: object, field: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not ADDRESS.fullmatch(normalized):
+        raise PipelineError(f"{field} must be a lowercase EVM address")
+    return normalized
+
+
+def run(command: list[str], *, env: dict[str, str] | None = None) -> str:
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=900,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()[:800]
+        raise PipelineError(f"command failed closed: {detail}")
+    return completed.stdout.strip()
+
+
+def fetch_json(url: str, timeout: float = 30) -> Any:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "agent-bounties-regression-verifier/1",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        if response.status != 200:
+            raise PipelineError(f"verification feed returned HTTP {response.status}")
+        return json.loads(response.read().decode("utf-8"))
+
+
+def verification_jobs(api_base: str, network: str, verifier: str) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode({"network": network, "verifier": verifier})
+    value = fetch_json(
+        f"{api_base.rstrip('/')}/v1/base/autonomous-bounties/verification-jobs?{query}"
+    )
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise PipelineError("verification feed must be an array of jobs")
+    return value
+
+
+def parse_github_commit_url(value: object) -> tuple[str, str]:
+    try:
+        parsed = urllib.parse.urlparse(str(value))
+    except ValueError as error:
+        raise PipelineError("artifact reference is not a valid URL") from error
+    parts = [part for part in parsed.path.split("/") if part]
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "github.com"
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or len(parts) != 4
+        or parts[2] != "commit"
+    ):
+        raise PipelineError("artifact reference must be an exact public GitHub commit URL")
+    repository = f"{parts[0]}/{parts[1]}"
+    commit = parts[3].lower()
+    if not REPOSITORY.fullmatch(repository) or not SHA.fullmatch(commit):
+        raise PipelineError("artifact reference repository or commit is invalid")
+    return repository, commit
+
+
+def benchmark_source(job: dict[str, Any]) -> tuple[str, str, str]:
+    source = (
+        job.get("terms", {})
+        .get("document", {})
+        .get("benchmark", {})
+        .get("source")
+    )
+    if not isinstance(source, dict) or set(source) != {
+        "kind",
+        "repository",
+        "commit",
+        "subdirectory",
+    }:
+        raise PipelineError("benchmark source must use the exact github_commit schema")
+    repository = str(source.get("repository", ""))
+    commit = str(source.get("commit", "")).lower()
+    subdirectory = str(source.get("subdirectory", ""))
+    if source.get("kind") != "github_commit" or not REPOSITORY.fullmatch(repository):
+        raise PipelineError("benchmark repository is invalid")
+    if not SHA.fullmatch(commit):
+        raise PipelineError("benchmark commit must be a full Git SHA")
+    validate_subdirectory(subdirectory)
+    return repository, commit, subdirectory
+
+
+def validate_subdirectory(value: str) -> None:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or value.startswith("/")
+        or value.endswith("/")
+        or "\\" in value
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise PipelineError("snapshot subdirectory must be a normalized relative path")
+
+
+def download_archive(repository: str, commit: str, compressed_limit: int) -> bytes:
+    url = f"https://codeload.github.com/{repository}/tar.gz/{commit}"
+    request = urllib.request.Request(url, headers={"User-Agent": "agent-bounties-regression-verifier/1"})
+    body = bytearray()
+    with urllib.request.urlopen(request, timeout=60) as response:
+        if response.status != 200:
+            raise PipelineError(f"GitHub archive returned HTTP {response.status}")
+        while True:
+            chunk = response.read(64 * 1024)
+            if not chunk:
+                break
+            body.extend(chunk)
+            if len(body) > compressed_limit:
+                raise PipelineError("GitHub archive exceeds the compressed input limit")
+    return bytes(body)
+
+
+def extract_snapshot(
+    archive: bytes,
+    destination: Path,
+    *,
+    subdirectory: str | None,
+    max_bytes: int,
+    max_files: int,
+) -> None:
+    prefix = None if subdirectory is None else PurePosixPath(subdirectory).parts
+    seen: set[str] = set()
+    total = 0
+    files = 0
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as bundle:
+        members = bundle.getmembers()
+        if len(members) > max_files * 4 + 100:
+            raise PipelineError("GitHub archive has too many entries")
+        for member in members:
+            path = PurePosixPath(member.name)
+            parts = path.parts
+            if not parts or path.is_absolute() or any(part in {"", ".", ".."} for part in parts):
+                raise PipelineError("GitHub archive contains an unsafe path")
+            relative = parts[1:]
+            if prefix is not None:
+                if relative[: len(prefix)] != prefix:
+                    continue
+                relative = relative[len(prefix) :]
+            if not relative:
+                continue
+            relative_name = "/".join(relative)
+            if relative_name in seen:
+                raise PipelineError("GitHub archive contains duplicate paths")
+            seen.add(relative_name)
+            target = destination.joinpath(*relative)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise PipelineError("GitHub archive contains links or special files")
+            files += 1
+            total += member.size
+            if files > max_files or total > max_bytes:
+                raise PipelineError("GitHub snapshot exceeds committed limits")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = bundle.extractfile(member)
+            if source is None:
+                raise PipelineError("GitHub archive file is unreadable")
+            with target.open("wb") as output:
+                shutil.copyfileobj(source, output, 64 * 1024)
+            target.chmod(0o555 if member.mode & 0o111 else 0o444)
+    if files == 0:
+        raise PipelineError("GitHub snapshot contains no regular files")
+
+
+def runner_manifest(job: dict[str, Any]) -> dict[str, Any]:
+    value = (
+        job.get("terms", {})
+        .get("document", {})
+        .get("benchmark", {})
+        .get("runner_manifest")
+    )
+    if not isinstance(value, dict):
+        raise PipelineError("runner manifest is unavailable")
+    for field in (
+        "max_source_bytes",
+        "max_source_files",
+        "max_benchmark_bytes",
+        "max_benchmark_files",
+        "benchmark_digest",
+    ):
+        if field not in value:
+            raise PipelineError(f"runner manifest is missing {field}")
+    return value
+
+
+def stage(
+    worker: Path,
+    kind: str,
+    source: Path,
+    staging: Path,
+    max_bytes: int,
+    max_files: int,
+) -> dict[str, Any]:
+    value = json.loads(
+        run(
+            [
+                str(worker),
+                "--stage-regression-input",
+                kind,
+                str(source),
+                str(staging),
+                str(max_bytes),
+                str(max_files),
+            ]
+        )
+    )
+    if not isinstance(value, dict) or not str(value.get("snapshot", {}).get("digest", "")).startswith(
+        "sha256:"
+    ):
+        raise PipelineError("worker returned invalid staging evidence")
+    return value
+
+
+def run_job(worker: Path, staging: Path, job: dict[str, Any], scratch: Path) -> dict[str, Any]:
+    manifest = runner_manifest(job)
+    source_repo, source_commit = parse_github_commit_url(
+        job.get("submission_evidence", {}).get("artifact_reference")
+    )
+    source_subdir = str(
+        job.get("submission_evidence", {}).get("evidence", {}).get("source_subdirectory", ".")
+    )
+    if source_subdir != ".":
+        validate_subdirectory(source_subdir)
+    benchmark_repo, benchmark_commit, benchmark_subdir = benchmark_source(job)
+
+    source_dir = scratch / "source"
+    benchmark_dir = scratch / "benchmark"
+    source_dir.mkdir()
+    benchmark_dir.mkdir()
+    source_bytes = int(manifest["max_source_bytes"])
+    source_files = int(manifest["max_source_files"])
+    benchmark_bytes = int(manifest["max_benchmark_bytes"])
+    benchmark_files = int(manifest["max_benchmark_files"])
+    source_archive = download_archive(source_repo, source_commit, min(source_bytes, 256 * 1024 * 1024))
+    benchmark_archive = download_archive(
+        benchmark_repo, benchmark_commit, min(benchmark_bytes, 128 * 1024 * 1024)
+    )
+    extract_snapshot(
+        source_archive,
+        source_dir,
+        subdirectory=None if source_subdir == "." else source_subdir,
+        max_bytes=source_bytes,
+        max_files=source_files,
+    )
+    extract_snapshot(
+        benchmark_archive,
+        benchmark_dir,
+        subdirectory=benchmark_subdir,
+        max_bytes=benchmark_bytes,
+        max_files=benchmark_files,
+    )
+    staged_source = stage(worker, "source", source_dir, staging, source_bytes, source_files)
+    staged_benchmark = stage(
+        worker, "benchmark", benchmark_dir, staging, benchmark_bytes, benchmark_files
+    )
+    expected_source = str(
+        job.get("submission_evidence", {}).get("evidence", {}).get("source_snapshot_digest", "")
+    )
+    if staged_source["snapshot"]["digest"] != expected_source:
+        raise PipelineError("downloaded source does not match submission evidence")
+    if staged_benchmark["snapshot"]["digest"] != manifest["benchmark_digest"]:
+        raise PipelineError("downloaded benchmark does not match immutable terms")
+
+    request = scratch / "request.json"
+    write_json(request, {"job": job})
+    environment = dict(os.environ)
+    environment["REGRESSION_SANDBOX_STAGING_ROOT"] = str(staging)
+    environment.setdefault("REGRESSION_SANDBOX_DOCKER_BINARY", "docker")
+    outcome = json.loads(run([str(worker), "--run-regression", str(request)], env=environment))
+    return {
+        "schema": CANDIDATE_SCHEMA,
+        "job": job,
+        "outcome": outcome,
+        "runner_revision": os.environ.get("GITHUB_SHA", "local"),
+    }
+
+
+def command_run(args: argparse.Namespace) -> None:
+    verifiers = [normalize_address(value, "verifier") for value in args.verifier]
+    if len(set(verifiers)) != 2:
+        raise PipelineError("runner requires exactly two distinct verifier addresses")
+    jobs = verification_jobs(args.api_base, args.network, verifiers[0])
+    selected = [
+        job
+        for job in jobs
+        if [str(value).lower() for value in job.get("eligible_verifiers", [])] == verifiers
+        and job.get("threshold") == 2
+        and job.get("verification_mode") == "signed_quorum"
+    ][: args.max_jobs]
+    args.output.mkdir(parents=True, exist_ok=True)
+    candidates = []
+    for job in selected:
+        job_id = str(job.get("job_id", ""))
+        if not re.fullmatch(r"[A-Za-z0-9_.:-]{1,200}", job_id):
+            raise PipelineError("verification job id is invalid")
+        with tempfile.TemporaryDirectory(prefix="agent-bounties-regression-") as temporary:
+            candidate = run_job(
+                args.worker.resolve(), args.staging.resolve(), job, Path(temporary)
+            )
+        name = f"candidate-{hashlib.sha256(job_id.encode()).hexdigest()}.json"
+        write_json(args.output / name, candidate)
+        candidates.append({"job_id": job_id, "file": name})
+    write_json(
+        args.output / "manifest.json",
+        {"schema": MANIFEST_SCHEMA, "network": args.network, "candidates": candidates},
+    )
+
+
+def current_job(api_base: str, network: str, verifier: str, job_id: str) -> dict[str, Any]:
+    matches = [
+        job
+        for job in verification_jobs(api_base, network, verifier)
+        if job.get("job_id") == job_id
+    ]
+    if len(matches) != 1:
+        raise PipelineError("candidate does not have exactly one current canonical job")
+    return matches[0]
+
+
+def validate_candidate(
+    worker: Path,
+    candidate: dict[str, Any],
+    current: dict[str, Any],
+    scratch: Path,
+) -> None:
+    if candidate.get("schema") != CANDIDATE_SCHEMA:
+        raise PipelineError("candidate schema is invalid")
+    request = scratch / "validate.json"
+    write_json(
+        request,
+        {"job": candidate.get("job"), "current_job": current, "outcome": candidate.get("outcome")},
+    )
+    if run([str(worker.resolve()), "--validate-regression-candidate", str(request)]) != "ok":
+        raise PipelineError("worker did not validate the regression candidate")
+
+
+def command_sign(args: argparse.Namespace) -> None:
+    key = os.environ.get(args.private_key_env, "").strip()
+    if not key:
+        raise PipelineError(f"{args.private_key_env} is required")
+    signer = normalize_address(
+        run([str(args.cast), "wallet", "address", "--private-key", key]), "signer"
+    )
+    expected = normalize_address(args.expected_signer, "expected signer")
+    if signer != expected:
+        raise PipelineError("signer private key does not match the expected public address")
+    manifest = read_json(args.candidates / "manifest.json")
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        raise PipelineError("candidate manifest schema is invalid")
+    args.output.mkdir(parents=True, exist_ok=True)
+    signed = []
+    for entry in manifest.get("candidates", []):
+        candidate = read_json(args.candidates / entry["file"])
+        job = candidate.get("job", {})
+        job_id = str(job.get("job_id", ""))
+        current = current_job(args.api_base, args.network, signer, job_id)
+        with tempfile.TemporaryDirectory(prefix="agent-bounties-sign-") as temporary:
+            validate_candidate(args.worker, candidate, current, Path(temporary))
+        expiry = int(current["verification_expires_at"])
+        now = int(time.time())
+        deadline = min(now + 900, expiry)
+        if deadline <= now + 120:
+            raise PipelineError("verification deadline is too close to sign safely")
+        outcome = candidate["outcome"]
+        response_hash = str(outcome.get("response_hash", "")).lower()
+        if not HASH.fullmatch(response_hash):
+            raise PipelineError("candidate response hash is invalid")
+        passed = outcome.get("verdict") == "passed"
+        bounty = normalize_address(current.get("bounty_contract"), "bounty contract")
+        digest = run(
+            [
+                str(args.cast),
+                "call",
+                "--rpc-url",
+                args.rpc_url,
+                bounty,
+                "attestationDigest(address,bool,bytes32,uint256)(bytes32)",
+                signer,
+                str(passed).lower(),
+                response_hash,
+                str(deadline),
+            ]
+        ).lower()
+        if not HASH.fullmatch(digest):
+            raise PipelineError("contract returned an invalid attestation digest")
+        signature = run(
+            [
+                str(args.cast),
+                "wallet",
+                "sign",
+                "--no-hash",
+                "--private-key",
+                key,
+                digest,
+            ]
+        ).lower()
+        if not re.fullmatch(r"0x[0-9a-f]{130}", signature):
+            raise PipelineError("signer returned an invalid signature")
+        name = f"attestation-{hashlib.sha256(job_id.encode()).hexdigest()}.json"
+        write_json(
+            args.output / name,
+            {
+                "schema": ATTESTATION_SCHEMA,
+                "job_id": job_id,
+                "bounty_contract": bounty,
+                "verifier": signer,
+                "passed": passed,
+                "response_hash": response_hash,
+                "deadline": deadline,
+                "signature": signature,
+                "candidate_file": entry["file"],
+            },
+        )
+        signed.append({"job_id": job_id, "file": name})
+    write_json(
+        args.output / "manifest.json",
+        {"schema": ATTESTATION_SCHEMA, "signer": signer, "attestations": signed},
+    )
+
+
+def command_relay(args: argparse.Namespace) -> None:
+    keeper = os.environ.get(args.keeper_key_env, "").strip()
+    if not keeper:
+        raise PipelineError(f"{args.keeper_key_env} is required")
+    expected = {
+        normalize_address(args.verifier[0], "verifier"),
+        normalize_address(args.verifier[1], "verifier"),
+    }
+    candidate_manifest = read_json(args.candidates / "manifest.json")
+    manifests = [read_json(path / "manifest.json") for path in args.attestations]
+    by_signer: dict[str, dict[str, str]] = {}
+    for path, manifest in zip(args.attestations, manifests, strict=True):
+        signer = normalize_address(manifest.get("signer"), "attestation signer")
+        if signer in by_signer:
+            raise PipelineError("duplicate attestation signer")
+        by_signer[signer] = {entry["job_id"]: str(path / entry["file"]) for entry in manifest["attestations"]}
+    if set(by_signer) != expected:
+        raise PipelineError("attestation artifacts do not contain the exact verifier set")
+
+    for entry in candidate_manifest.get("candidates", []):
+        job_id = entry["job_id"]
+        candidate = read_json(args.candidates / entry["file"])
+        current = current_job(args.api_base, args.network, sorted(expected)[0], job_id)
+        with tempfile.TemporaryDirectory(prefix="agent-bounties-relay-") as temporary:
+            validate_candidate(args.worker, candidate, current, Path(temporary))
+        attestations = [read_json(Path(by_signer[signer][job_id])) for signer in sorted(expected)]
+        first = attestations[0]
+        for attestation in attestations:
+            if (
+                attestation.get("schema") != ATTESTATION_SCHEMA
+                or attestation.get("job_id") != job_id
+                or attestation.get("bounty_contract") != current.get("bounty_contract").lower()
+                or attestation.get("passed") != first.get("passed")
+                or attestation.get("response_hash") != first.get("response_hash")
+            ):
+                raise PipelineError("attestation artifacts disagree on canonical scope or verdict")
+        tuple_values = ",".join(
+            f"({item['verifier']},{str(item['passed']).lower()},{item['response_hash']},{item['deadline']},{item['signature']})"
+            for item in attestations
+        )
+        transaction = run(
+            [
+                str(args.cast),
+                "send",
+                "--json",
+                "--rpc-url",
+                args.rpc_url,
+                "--private-key",
+                keeper,
+                current["bounty_contract"],
+                "settleWithAttestations((address,bool,bytes32,uint256,bytes)[])",
+                f"[{tuple_values}]",
+            ]
+        )
+        receipt = json.loads(transaction)
+        transaction_hash = str(receipt.get("transactionHash", "")).lower()
+        if not HASH.fullmatch(transaction_hash) or str(receipt.get("status", "")) not in {"0x1", "1"}:
+            raise PipelineError("attestation relay did not return a successful receipt")
+        print(f"relayed {job_id}: {transaction_hash}")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    subcommands = root.add_subparsers(dest="command", required=True)
+
+    run_parser = subcommands.add_parser("run")
+    run_parser.add_argument("--api-base", default=DEFAULT_API)
+    run_parser.add_argument("--network", default="base-mainnet")
+    run_parser.add_argument("--verifier", action="append", required=True)
+    run_parser.add_argument("--worker", type=Path, required=True)
+    run_parser.add_argument("--staging", type=Path, required=True)
+    run_parser.add_argument("--output", type=Path, required=True)
+    run_parser.add_argument("--max-jobs", type=int, default=5)
+    run_parser.set_defaults(handler=command_run)
+
+    sign_parser = subcommands.add_parser("sign")
+    sign_parser.add_argument("--api-base", default=DEFAULT_API)
+    sign_parser.add_argument("--network", default="base-mainnet")
+    sign_parser.add_argument("--rpc-url", required=True)
+    sign_parser.add_argument("--candidates", type=Path, required=True)
+    sign_parser.add_argument("--output", type=Path, required=True)
+    sign_parser.add_argument("--worker", type=Path, required=True)
+    sign_parser.add_argument("--cast", type=Path, default=Path("cast"))
+    sign_parser.add_argument("--private-key-env", required=True)
+    sign_parser.add_argument("--expected-signer", required=True)
+    sign_parser.set_defaults(handler=command_sign)
+
+    relay_parser = subcommands.add_parser("relay")
+    relay_parser.add_argument("--api-base", default=DEFAULT_API)
+    relay_parser.add_argument("--network", default="base-mainnet")
+    relay_parser.add_argument("--rpc-url", required=True)
+    relay_parser.add_argument("--candidates", type=Path, required=True)
+    relay_parser.add_argument("--attestations", type=Path, action="append", required=True)
+    relay_parser.add_argument("--verifier", action="append", required=True)
+    relay_parser.add_argument("--worker", type=Path, required=True)
+    relay_parser.add_argument("--cast", type=Path, default=Path("cast"))
+    relay_parser.add_argument("--keeper-key-env", default="BASE_KEEPER_PRIVATE_KEY")
+    relay_parser.set_defaults(handler=command_relay)
+    return root
+
+
+def main() -> int:
+    try:
+        args = parser().parse_args()
+        args.handler(args)
+    except (PipelineError, OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"regression verifier pipeline failed: {error}", file=os.sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -34,6 +34,10 @@ FAILED_STATUSES = {
     "deactivated",
 }
 TRANSIENT_HTTP_STATUSES = {429, 500, 503}
+CUSTOM_DOMAINS = {
+    "agent-bounties-api": "api.bountyboard.global",
+    "agent-bounties-mcp": "mcp.bountyboard.global",
+}
 
 
 class RecoveryError(RuntimeError):
@@ -141,6 +145,19 @@ def unwrap_deploy(payload: object) -> dict[str, Any]:
     if not isinstance(deploy, dict):
         raise RecoveryError("Render deploy response is missing deploy metadata")
     return deploy
+
+
+def unwrap_custom_domains(payload: object) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise RecoveryError("Render custom-domain response must be an array")
+    domains: list[dict[str, Any]] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        domain = entry.get("customDomain", entry)
+        if isinstance(domain, dict):
+            domains.append(domain)
+    return domains
 
 
 def deploy_commit(deploy: dict[str, Any]) -> str | None:
@@ -266,6 +283,27 @@ class RenderClient:
 
     def list_deploys(self, service_id: str) -> Any:
         return self._read_with_retry(f"/services/{service_id}/deploys?limit=20")
+
+    def ensure_custom_domain(self, service: dict[str, Any], domain: str) -> dict[str, Any]:
+        service_id = service["id"]
+        existing = [
+            item
+            for item in unwrap_custom_domains(
+                self._read_with_retry(f"/services/{service_id}/custom-domains?limit=100")
+            )
+            if str(item.get("name", "")).lower() == domain.lower()
+        ]
+        if len(existing) > 1:
+            raise RecoveryError(f"{service['name']} has duplicate Render custom domains for {domain}")
+        if existing:
+            return existing[0]
+        created = self._request_json(
+            "POST", f"/services/{service_id}/custom-domains", {"name": domain}
+        )
+        custom_domain = created.get("customDomain", created) if isinstance(created, dict) else None
+        if not isinstance(custom_domain, dict) or str(custom_domain.get("name", "")).lower() != domain.lower():
+            raise RecoveryError(f"Render did not attach {domain} to {service['name']}")
+        return custom_domain
 
     def get_deploy(self, service_id: str, deploy_id: str) -> dict[str, Any]:
         return unwrap_deploy(
@@ -452,6 +490,20 @@ def deploy(
     for spec, service in services:
         client.disable_native_auto_deploy(service)
 
+    custom_domains = []
+    for spec, service in services:
+        domain = CUSTOM_DOMAINS.get(spec.name)
+        if domain is None:
+            continue
+        record = client.ensure_custom_domain(service, domain)
+        custom_domains.append(
+            {
+                "service": spec.name,
+                "name": domain,
+                "status": record.get("verificationStatus", record.get("status", "attached")),
+            }
+        )
+
     for spec, service in services:
         created = client.ensure_deploy(service, revision)
         deploy_id, status = validate_deploy(created, revision, spec.name)
@@ -505,7 +557,7 @@ def deploy(
                 "native_auto_deploy": "disabled",
             }
         )
-    return {"services": service_evidence, "health": health}
+    return {"services": service_evidence, "health": health, "custom_domains": custom_domains}
 
 
 def parse_args() -> argparse.Namespace:
@@ -542,6 +594,7 @@ def main() -> int:
         "success": False,
         "services": [],
         "health": [],
+        "custom_domains": [],
         "error": None,
     }
     try:

--- a/scripts/standing_meta_v2_deploy.py
+++ b/scripts/standing_meta_v2_deploy.py
@@ -340,25 +340,31 @@ def deploy_sepolia(foundry: Foundry, output: Path) -> dict[str, Any]:
         private_key,
         [deployments["token"]["contract"]],
     )
-    deployments["participant_registry"] = foundry.create(
-        "src/ParticipantEligibilityRegistry.sol:ParticipantEligibilityRegistry",
-        private_key,
-        [public["PARTICIPANT_ATTESTER_ADDRESS"]],
-    )
-    deployments["terms_registry"] = foundry.create(
-        "src/OnchainTermsRegistry.sol:OnchainTermsRegistry", private_key
-    )
-    deployments["verifier_module"] = foundry.create(
-        "src/CanonicalIndependentChildVerifierV2.sol:CanonicalIndependentChildVerifierV2",
+    deployments["bundle"] = foundry.create(
+        "src/StandingMetaV2Bundle.sol:StandingMetaV2Bundle",
         private_key,
         [
             deployments["factory"]["contract"],
-            deployments["participant_registry"]["contract"],
-            deployments["terms_registry"]["contract"],
-            set_hash,
-            "2",
+            public["PARTICIPANT_ATTESTER_ADDRESS"],
+            public["REGRESSION_VERIFIER_ONE_ADDRESS"],
+            public["REGRESSION_VERIFIER_TWO_ADDRESS"],
         ],
     )
+    bundle_address = deployments["bundle"]["contract"]
+    linked_components = {
+        "participant_registry": "participantRegistry()(address)",
+        "terms_registry": "termsRegistry()(address)",
+        "verifier_module": "verifierModule()(address)",
+    }
+    for name, signature in linked_components.items():
+        component = normalize_address(foundry.call(bundle_address, signature), f"bundle {name}")
+        if foundry.code(component) in {"0x", "0x0"}:
+            raise DeploymentError(f"bundle {name} has no runtime code")
+        deployments[name] = {
+            "contract": component,
+            "transaction_hash": deployments["bundle"]["transaction_hash"],
+            "source": f"StandingMetaV2Bundle.{signature.split('(')[0]}",
+        }
 
     target = foundry.repo / "target"
     target.mkdir(parents=True, exist_ok=True)
@@ -449,6 +455,8 @@ def deploy_mainnet(foundry: Foundry, output: Path) -> dict[str, Any]:
     transactions = read_broadcast(
         broadcast_path(foundry, "DeployStandingMetaV2", BASE_MAINNET_CHAIN_ID)
     )
+    if len(transactions) != 1 or transactions[0]["to"] is not None:
+        raise DeploymentError("mainnet policy components were not deployed atomically in one creation")
     expected = {
         "canonical_factory": BASE_MAINNET_FACTORY,
         "settlement_token": BASE_MAINNET_USDC,
@@ -462,9 +470,11 @@ def deploy_mainnet(foundry: Foundry, output: Path) -> dict[str, Any]:
         if observed != wanted:
             raise DeploymentError(f"mainnet {field} mismatch: expected {wanted}, got {observed}")
     module = normalize_address(raw.get("verifier_module"), "mainnet verifier module")
+    bundle = normalize_address(raw.get("bundle"), "mainnet deployment bundle")
     participant_registry = normalize_address(raw.get("participant_registry"), "mainnet participant registry")
     terms_registry = normalize_address(raw.get("terms_registry"), "mainnet terms registry")
     for label, address in {
+        "deployment bundle": bundle,
         "verifier module": module,
         "participant registry": participant_registry,
         "terms registry": terms_registry,
@@ -472,6 +482,18 @@ def deploy_mainnet(foundry: Foundry, output: Path) -> dict[str, Any]:
         if foundry.code(address) in {"0x", "0x0"}:
             raise DeploymentError(f"{label} has no runtime code")
     onchain = {
+        "bundle_factory": normalize_address(
+            foundry.call(bundle, "canonicalFactory()(address)"), "bundle factory"
+        ),
+        "bundle_participant_registry": normalize_address(
+            foundry.call(bundle, "participantRegistry()(address)"), "bundle participant registry"
+        ),
+        "bundle_terms_registry": normalize_address(
+            foundry.call(bundle, "termsRegistry()(address)"), "bundle terms registry"
+        ),
+        "bundle_verifier_module": normalize_address(
+            foundry.call(bundle, "verifierModule()(address)"), "bundle verifier module"
+        ),
         "factory": normalize_address(foundry.call(module, "canonicalFactory()(address)"), "module factory"),
         "token": normalize_address(foundry.call(module, "settlementToken()(address)"), "module token"),
         "participant_registry": normalize_address(
@@ -484,6 +506,10 @@ def deploy_mainnet(foundry: Foundry, output: Path) -> dict[str, Any]:
         "verifier_threshold": int(foundry.call(module, "taskVerifierThreshold()(uint8)")),
     }
     expected_onchain: dict[str, object] = {
+        "bundle_factory": BASE_MAINNET_FACTORY,
+        "bundle_participant_registry": participant_registry,
+        "bundle_terms_registry": terms_registry,
+        "bundle_verifier_module": module,
         "factory": BASE_MAINNET_FACTORY,
         "token": BASE_MAINNET_USDC,
         "participant_registry": participant_registry,

--- a/scripts/standing_meta_v2_deploy.py
+++ b/scripts/standing_meta_v2_deploy.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""Deploy and prove the standing-meta-v2 components without exposing signer keys."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import time
+from typing import Any, Mapping, Sequence
+
+
+BASE_MAINNET_CHAIN_ID = 8453
+BASE_SEPOLIA_CHAIN_ID = 84532
+BASE_MAINNET_FACTORY = "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9"
+BASE_MAINNET_USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+BASE_SEPOLIA_USDC = "0x036cbd53842c5426634e7929541ec2318f3dcf7e"
+MIN_MAINNET_KEEPER_WEI = 100_000_000_000_000
+MIN_MAINNET_DEPLOY_WEI = 500_000_000_000_000
+MIN_SEPOLIA_DEPLOY_WEI = 90_000_000_000_000
+ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+BYTES32_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
+CREATE_JSON_RE = re.compile(r"\{\s*\"deployer\".*?\}\s*$", re.DOTALL)
+
+
+class DeploymentError(RuntimeError):
+    pass
+
+
+def normalize_address(value: object, label: str) -> str:
+    text = str(value).strip()
+    if not ADDRESS_RE.fullmatch(text):
+        raise DeploymentError(f"{label} is not an EVM address")
+    return text.lower()
+
+
+def require_bytes32(value: object, label: str) -> str:
+    text = str(value).strip().lower()
+    if not BYTES32_RE.fullmatch(text):
+        raise DeploymentError(f"{label} is not bytes32")
+    return text
+
+
+def run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str] | None = None,
+    timeout: int = 300,
+) -> str:
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        tail = completed.stdout[-6_000:].strip()
+        raise DeploymentError(f"command failed with exit {completed.returncode}: {tail}")
+    return completed.stdout.strip()
+
+
+class Foundry:
+    def __init__(self, repo: Path, rpc_url: str, forge: str, cast: str) -> None:
+        self.repo = repo
+        self.contracts = repo / "contracts" / "base-escrow"
+        self.rpc_url = rpc_url
+        self.forge = forge
+        self.cast = cast
+
+    def cast_run(self, *args: str) -> str:
+        return run([self.cast, *args, "--rpc-url", self.rpc_url], cwd=self.repo)
+
+    def chain_id(self) -> int:
+        return int(self.cast_run("chain-id"))
+
+    def address_for_key(self, private_key: str) -> str:
+        return normalize_address(
+            run(
+                [self.cast, "wallet", "address", "--private-key", private_key],
+                cwd=self.repo,
+            ),
+            "private-key address",
+        )
+
+    def balance(self, address: str) -> int:
+        return int(self.cast_run("balance", address))
+
+    def call(self, address: str, signature: str, *args: str) -> str:
+        return self.cast_run("call", address, signature, *args).strip()
+
+    def code(self, address: str) -> str:
+        return self.cast_run("code", address).strip().lower()
+
+    def receipt(self, transaction_hash: str) -> dict[str, Any]:
+        value = json.loads(self.cast_run("receipt", transaction_hash, "--json"))
+        if not isinstance(value, dict) or value.get("status") not in {"0x1", "0x01", 1}:
+            raise DeploymentError(f"transaction was not successful: {transaction_hash}")
+        return value
+
+    def create(
+        self,
+        source: str,
+        private_key: str,
+        constructor_args: Sequence[str] = (),
+    ) -> dict[str, str]:
+        command = [
+            self.forge,
+            "create",
+            "--broadcast",
+            "--json",
+            "--rpc-url",
+            self.rpc_url,
+            "--private-key",
+            private_key,
+            source,
+        ]
+        if constructor_args:
+            command.extend(["--constructor-args", *constructor_args])
+        output = run(command, cwd=self.contracts)
+        match = CREATE_JSON_RE.search(output)
+        if not match:
+            raise DeploymentError("forge create did not return its canonical JSON receipt")
+        value = json.loads(match.group(0))
+        result = {
+            "deployer": normalize_address(value.get("deployer"), "forge deployer"),
+            "contract": normalize_address(value.get("deployedTo"), "deployed contract"),
+            "transaction_hash": require_bytes32(value.get("transactionHash"), "deployment transaction"),
+            "source": source,
+        }
+        self.receipt(result["transaction_hash"])
+        if self.code(result["contract"]) in {"0x", "0x0"}:
+            raise DeploymentError(f"deployed contract has no runtime code: {result['contract']}")
+        return result
+
+    def script(self, source: str, env: Mapping[str, str]) -> None:
+        run(
+            [
+                self.forge,
+                "script",
+                source,
+                "--rpc-url",
+                self.rpc_url,
+                "--broadcast",
+                "--slow",
+                "-v",
+            ],
+            cwd=self.contracts,
+            env=env,
+            timeout=600,
+        )
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise DeploymentError(f"{name} is required")
+    return value
+
+
+def verifier_set_hash(foundry: Foundry, one: str, two: str) -> str:
+    encoded = run(
+        [foundry.cast, "abi-encode", "f(address[])", f"[{one},{two}]"],
+        cwd=foundry.repo,
+    )
+    return require_bytes32(
+        run([foundry.cast, "keccak", encoded.strip()], cwd=foundry.repo),
+        "verifier set hash",
+    )
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise DeploymentError(f"expected a JSON object in {path}")
+    return value
+
+
+def read_broadcast(path: Path) -> list[dict[str, Any]]:
+    value = load_json(path)
+    transactions = value.get("transactions")
+    receipts = value.get("receipts")
+    if not isinstance(transactions, list) or not isinstance(receipts, list) or len(transactions) != len(receipts):
+        raise DeploymentError("Foundry broadcast transactions and receipts do not align")
+    result: list[dict[str, Any]] = []
+    for transaction, receipt in zip(transactions, receipts, strict=True):
+        if not isinstance(transaction, dict) or not isinstance(receipt, dict) or receipt.get("status") != "0x1":
+            raise DeploymentError("Foundry broadcast contains an unsuccessful transaction")
+        transaction_hash = require_bytes32(transaction.get("hash"), "broadcast transaction")
+        if receipt.get("transactionHash", "").lower() != transaction_hash:
+            raise DeploymentError("Foundry broadcast receipt hash mismatch")
+        result.append(
+            {
+                "transaction_hash": transaction_hash,
+                "from": normalize_address(receipt.get("from"), "broadcast sender"),
+                "to": normalize_address(receipt.get("to"), "broadcast recipient")
+                if receipt.get("to")
+                else None,
+                "function": transaction.get("function"),
+                "block_number": int(str(receipt.get("blockNumber")), 16),
+                "logs": receipt.get("logs", []),
+            }
+        )
+    return result
+
+
+def wait_for_later_timestamp(foundry: Foundry, published_at: int, timeout_seconds: int = 90) -> int:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        observed = int(foundry.cast_run("block", "latest", "--field", "timestamp"))
+        if observed > published_at:
+            return observed
+        time.sleep(2)
+    raise DeploymentError("Base did not produce a timestamp later than the terms publication")
+
+
+def broadcast_path(foundry: Foundry, script_name: str, chain_id: int) -> Path:
+    return foundry.contracts / "broadcast" / f"{script_name}.s.sol" / str(chain_id) / "run-latest.json"
+
+
+def settlement_topic(foundry: Foundry) -> str:
+    return require_bytes32(
+        run(
+            [
+                foundry.cast,
+                "keccak",
+                "BountySettled(bytes32,uint64,address,uint256,uint256,uint256,uint256,bytes32,bytes32,bytes32,bytes32)",
+            ],
+            cwd=foundry.repo,
+        ),
+        "BountySettled topic",
+    )
+
+
+def verify_rehearsal(
+    foundry: Foundry,
+    deployments: Mapping[str, Mapping[str, Any]],
+    final: Mapping[str, Any],
+    complete_transactions: Sequence[Mapping[str, Any]],
+    expected_verifier_set_hash: str,
+) -> dict[str, Any]:
+    parent = normalize_address(final.get("parent_bounty"), "parent bounty")
+    child = normalize_address(final.get("child_bounty"), "child bounty")
+    factory = normalize_address(deployments["factory"]["contract"], "rehearsal factory")
+    module = normalize_address(deployments["verifier_module"]["contract"], "rehearsal module")
+    token = normalize_address(deployments["token"]["contract"], "rehearsal token")
+    exact_calls = {
+        "factory_token": (
+            normalize_address(foundry.call(factory, "settlementToken()(address)"), "factory token"),
+            token,
+        ),
+        "module_factory": (
+            normalize_address(foundry.call(module, "canonicalFactory()(address)"), "module factory"),
+            factory,
+        ),
+        "module_verifier_set": (
+            require_bytes32(foundry.call(module, "taskVerifierSetHash()(bytes32)"), "module verifier set"),
+            expected_verifier_set_hash,
+        ),
+        "parent_status": (int(foundry.call(parent, "status()(uint8)")), 4),
+        "child_status": (int(foundry.call(child, "status()(uint8)")), 4),
+        "parent_canonical": (foundry.call(factory, "isCanonicalBounty(address)(bool)", parent).lower(), "true"),
+        "child_canonical": (foundry.call(factory, "isCanonicalBounty(address)(bool)", child).lower(), "true"),
+    }
+    for label, (observed, expected) in exact_calls.items():
+        if observed != expected:
+            raise DeploymentError(f"rehearsal {label} mismatch: expected {expected}, got {observed}")
+
+    topic = settlement_topic(foundry)
+    settled_addresses: set[str] = set()
+    for transaction in complete_transactions:
+        for log in transaction.get("logs", []):
+            if not isinstance(log, dict):
+                continue
+            topics = log.get("topics")
+            if isinstance(topics, list) and topics and str(topics[0]).lower() == topic:
+                settled_addresses.add(normalize_address(log.get("address"), "settlement log address"))
+    if settled_addresses != {parent, child}:
+        raise DeploymentError("rehearsal did not emit exactly one canonical settlement for parent and child")
+    return {
+        "parent_status": 4,
+        "child_status": 4,
+        "settlement_event_contracts": sorted(settled_addresses),
+        "evidence_boundary": "Confirmed Base receipts and canonical BountySettled events prove this rehearsal.",
+    }
+
+
+def common_public_env() -> dict[str, str]:
+    return {
+        "PARTICIPANT_ATTESTER_ADDRESS": normalize_address(
+            require_env("PARTICIPANT_ATTESTER_ADDRESS"), "participant attester"
+        ),
+        "REGRESSION_VERIFIER_ONE_ADDRESS": normalize_address(
+            require_env("REGRESSION_VERIFIER_ONE_ADDRESS"), "verifier one"
+        ),
+        "REGRESSION_VERIFIER_TWO_ADDRESS": normalize_address(
+            require_env("REGRESSION_VERIFIER_TWO_ADDRESS"), "verifier two"
+        ),
+    }
+
+
+def deploy_sepolia(foundry: Foundry, output: Path) -> dict[str, Any]:
+    if foundry.chain_id() != BASE_SEPOLIA_CHAIN_ID:
+        raise DeploymentError("Sepolia deployment is pinned to Base chain 84532")
+    private_key = require_env("BASE_KEEPER_PRIVATE_KEY")
+    deployer = foundry.address_for_key(private_key)
+    balance_before = foundry.balance(deployer)
+    if balance_before < MIN_SEPOLIA_DEPLOY_WEI:
+        raise DeploymentError(
+            f"Base Sepolia keeper {deployer} needs at least {MIN_SEPOLIA_DEPLOY_WEI} wei; has {balance_before}"
+        )
+    public = common_public_env()
+    set_hash = verifier_set_hash(
+        foundry,
+        public["REGRESSION_VERIFIER_ONE_ADDRESS"],
+        public["REGRESSION_VERIFIER_TWO_ADDRESS"],
+    )
+    if foundry.code(BASE_SEPOLIA_USDC) in {"0x", "0x0"}:
+        raise DeploymentError("canonical Base Sepolia USDC has no runtime code")
+    if int(foundry.call(BASE_SEPOLIA_USDC, "balanceOf(address)(uint256)", deployer)) < 2_200_000:
+        raise DeploymentError(f"Base Sepolia keeper {deployer} needs at least 2.2 canonical test USDC")
+    deployments: dict[str, dict[str, Any]] = {
+        "token": {
+            "contract": BASE_SEPOLIA_USDC,
+            "transaction_hash": None,
+            "source": "canonical-base-sepolia-usdc",
+        }
+    }
+    deployments["factory"] = foundry.create(
+        "src/AgentBountyFactory.sol:AgentBountyFactory",
+        private_key,
+        [deployments["token"]["contract"]],
+    )
+    deployments["participant_registry"] = foundry.create(
+        "src/ParticipantEligibilityRegistry.sol:ParticipantEligibilityRegistry",
+        private_key,
+        [public["PARTICIPANT_ATTESTER_ADDRESS"]],
+    )
+    deployments["terms_registry"] = foundry.create(
+        "src/OnchainTermsRegistry.sol:OnchainTermsRegistry", private_key
+    )
+    deployments["verifier_module"] = foundry.create(
+        "src/CanonicalIndependentChildVerifierV2.sol:CanonicalIndependentChildVerifierV2",
+        private_key,
+        [
+            deployments["factory"]["contract"],
+            deployments["participant_registry"]["contract"],
+            deployments["terms_registry"]["contract"],
+            set_hash,
+            "2",
+        ],
+    )
+
+    target = foundry.repo / "target"
+    target.mkdir(parents=True, exist_ok=True)
+    prepare_path = target / "base-sepolia-standing-meta-v2-prepare.json"
+    complete_path = target / "base-sepolia-standing-meta-v2-complete.json"
+    script_env = dict(os.environ)
+    script_env.update(public)
+    script_env.update(
+        {
+            "REHEARSAL_TOKEN": deployments["token"]["contract"],
+            "REHEARSAL_FACTORY": deployments["factory"]["contract"],
+            "REHEARSAL_PARTICIPANT_REGISTRY": deployments["participant_registry"]["contract"],
+            "REHEARSAL_TERMS_REGISTRY": deployments["terms_registry"]["contract"],
+            "REHEARSAL_VERIFIER_MODULE": deployments["verifier_module"]["contract"],
+            "REHEARSAL_PHASE": "prepare",
+            "REHEARSAL_EVIDENCE_PATH": "../../target/base-sepolia-standing-meta-v2-prepare.json",
+        }
+    )
+    script_source = (
+        "script/BaseSepoliaStandingMetaV2Rehearsal.s.sol:BaseSepoliaStandingMetaV2Rehearsal"
+    )
+    foundry.script(script_source, script_env)
+    prepare = load_json(prepare_path)
+    prepare_transactions = read_broadcast(
+        broadcast_path(foundry, "BaseSepoliaStandingMetaV2Rehearsal", BASE_SEPOLIA_CHAIN_ID)
+    )
+    observed_timestamp = wait_for_later_timestamp(foundry, int(prepare["terms_published_at"]))
+    script_env.update(
+        {
+            "REHEARSAL_PHASE": "complete",
+            "REHEARSAL_PARENT_BOUNTY": normalize_address(prepare["parent_bounty"], "prepared parent"),
+            "REHEARSAL_EVIDENCE_PATH": "../../target/base-sepolia-standing-meta-v2-complete.json",
+        }
+    )
+    foundry.script(script_source, script_env)
+    final = load_json(complete_path)
+    complete_transactions = read_broadcast(
+        broadcast_path(foundry, "BaseSepoliaStandingMetaV2Rehearsal", BASE_SEPOLIA_CHAIN_ID)
+    )
+    verification = verify_rehearsal(foundry, deployments, final, complete_transactions, set_hash)
+    report = {
+        "schema": "agent-bounties/standing-meta-v2-rehearsal-v1",
+        "network": "base-sepolia",
+        "chain_id": BASE_SEPOLIA_CHAIN_ID,
+        "deployer": deployer,
+        "keeper_balance_before_wei": balance_before,
+        "keeper_balance_after_wei": foundry.balance(deployer),
+        "verifier_set_hash": set_hash,
+        "deployments": deployments,
+        "preparation": prepare,
+        "completion": final,
+        "preparation_transactions": prepare_transactions,
+        "completion_transactions": complete_transactions,
+        "timestamp_after_preparation": observed_timestamp,
+        "verification": verification,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def deploy_mainnet(foundry: Foundry, output: Path) -> dict[str, Any]:
+    if foundry.chain_id() != BASE_MAINNET_CHAIN_ID:
+        raise DeploymentError("mainnet deployment is pinned to Base chain 8453")
+    private_key = require_env("BASE_KEEPER_PRIVATE_KEY")
+    deployer = foundry.address_for_key(private_key)
+    balance_before = foundry.balance(deployer)
+    if balance_before < MIN_MAINNET_DEPLOY_WEI:
+        raise DeploymentError(
+            f"Base keeper {deployer} needs at least {MIN_MAINNET_DEPLOY_WEI} wei; has {balance_before}"
+        )
+    public = common_public_env()
+    set_hash = verifier_set_hash(
+        foundry,
+        public["REGRESSION_VERIFIER_ONE_ADDRESS"],
+        public["REGRESSION_VERIFIER_TWO_ADDRESS"],
+    )
+    target = foundry.repo / "target"
+    target.mkdir(parents=True, exist_ok=True)
+    raw_path = target / "base-mainnet-standing-meta-v2-deployment-raw.json"
+    script_env = dict(os.environ)
+    script_env.update(public)
+    script_env["DEPLOYMENT_EVIDENCE_PATH"] = (
+        "../../target/base-mainnet-standing-meta-v2-deployment-raw.json"
+    )
+    foundry.script("script/DeployStandingMetaV2.s.sol:DeployStandingMetaV2", script_env)
+    raw = load_json(raw_path)
+    transactions = read_broadcast(
+        broadcast_path(foundry, "DeployStandingMetaV2", BASE_MAINNET_CHAIN_ID)
+    )
+    expected = {
+        "canonical_factory": BASE_MAINNET_FACTORY,
+        "settlement_token": BASE_MAINNET_USDC,
+        "participant_attester": public["PARTICIPANT_ATTESTER_ADDRESS"],
+        "verifier_one": public["REGRESSION_VERIFIER_ONE_ADDRESS"],
+        "verifier_two": public["REGRESSION_VERIFIER_TWO_ADDRESS"],
+        "verifier_set_hash": set_hash,
+    }
+    for field, wanted in expected.items():
+        observed = str(raw.get(field, "")).lower()
+        if observed != wanted:
+            raise DeploymentError(f"mainnet {field} mismatch: expected {wanted}, got {observed}")
+    module = normalize_address(raw.get("verifier_module"), "mainnet verifier module")
+    participant_registry = normalize_address(raw.get("participant_registry"), "mainnet participant registry")
+    terms_registry = normalize_address(raw.get("terms_registry"), "mainnet terms registry")
+    for label, address in {
+        "verifier module": module,
+        "participant registry": participant_registry,
+        "terms registry": terms_registry,
+    }.items():
+        if foundry.code(address) in {"0x", "0x0"}:
+            raise DeploymentError(f"{label} has no runtime code")
+    onchain = {
+        "factory": normalize_address(foundry.call(module, "canonicalFactory()(address)"), "module factory"),
+        "token": normalize_address(foundry.call(module, "settlementToken()(address)"), "module token"),
+        "participant_registry": normalize_address(
+            foundry.call(module, "participantRegistry()(address)"), "module participant registry"
+        ),
+        "terms_registry": normalize_address(foundry.call(module, "termsRegistry()(address)"), "module terms registry"),
+        "verifier_set_hash": require_bytes32(
+            foundry.call(module, "taskVerifierSetHash()(bytes32)"), "module verifier set"
+        ),
+        "verifier_threshold": int(foundry.call(module, "taskVerifierThreshold()(uint8)")),
+    }
+    expected_onchain: dict[str, object] = {
+        "factory": BASE_MAINNET_FACTORY,
+        "token": BASE_MAINNET_USDC,
+        "participant_registry": participant_registry,
+        "terms_registry": terms_registry,
+        "verifier_set_hash": set_hash,
+        "verifier_threshold": 2,
+    }
+    if onchain != expected_onchain:
+        raise DeploymentError(f"mainnet module immutable mismatch: expected {expected_onchain}, got {onchain}")
+    balance_after = foundry.balance(deployer)
+    if balance_after < MIN_MAINNET_KEEPER_WEI:
+        raise DeploymentError("mainnet deployment depleted the keeper below its operational reserve")
+    report = {
+        "schema": "agent-bounties/standing-meta-v2-deployment-v1",
+        "network": "base-mainnet",
+        "chain_id": BASE_MAINNET_CHAIN_ID,
+        "deployer": deployer,
+        "keeper_balance_before_wei": balance_before,
+        "keeper_balance_after_wei": balance_after,
+        "components": raw,
+        "transactions": transactions,
+        "onchain": onchain,
+        "evidence_boundary": "Confirmed Base deployment receipts and exact immutable getter checks.",
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("network", choices=("sepolia", "mainnet"))
+    parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--forge", default=os.environ.get("FORGE_BIN", "forge"))
+    parser.add_argument("--cast", default=os.environ.get("CAST_BIN", "cast"))
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo = Path(__file__).resolve().parents[1]
+    output = args.output if args.output.is_absolute() else repo / args.output
+    foundry = Foundry(repo, args.rpc_url, args.forge, args.cast)
+    try:
+        report = deploy_sepolia(foundry, output) if args.network == "sepolia" else deploy_mainnet(foundry, output)
+    except (DeploymentError, OSError, ValueError, KeyError, json.JSONDecodeError, subprocess.SubprocessError) as error:
+        print(f"standing_meta_v2_deployment=failed network={args.network} error={error}")
+        return 1
+    print(
+        f"standing_meta_v2_deployment=passed network={report['network']} "
+        f"output={output}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_register_participant.py
+++ b/scripts/test_register_participant.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("register_participant.py")
+SPEC = importlib.util.spec_from_file_location("register_participant", SCRIPT)
+assert SPEC and SPEC.loader
+registration = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = registration
+SPEC.loader.exec_module(registration)
+
+
+def event(body: str = "/agent-bounty register 0x" + "a" * 40):
+    return {
+        "action": "created",
+        "repository": {"full_name": "NSPG13/agent-bounties"},
+        "comment": {"body": body},
+        "issue": {"number": 321},
+        "sender": {"id": 12345, "login": "solver-agent"},
+    }
+
+
+class RegisterParticipantTests(unittest.TestCase):
+    def test_exact_command_binds_numeric_github_identity(self) -> None:
+        request = registration.parse_event(event(), "NSPG13/agent-bounties")
+        self.assertEqual(request.github_user_id, 12345)
+        self.assertEqual(request.wallet, "0x" + "a" * 40)
+
+    def test_repository_pr_and_command_confusion_fail_closed(self) -> None:
+        wrong_repo = event()
+        wrong_repo["repository"]["full_name"] = "attacker/fork"
+        pull_request = event()
+        pull_request["issue"]["pull_request"] = {"url": "https://example.test"}
+        malformed = event("/agent-bounty register 0x" + "a" * 40 + " --extra")
+        for value in (wrong_repo, pull_request, malformed):
+            with self.subTest(value=value), self.assertRaises(registration.RegistrationError):
+                registration.parse_event(value, "NSPG13/agent-bounties")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_regression_verifier_pipeline.py
+++ b/scripts/test_regression_verifier_pipeline.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("regression_verifier_pipeline.py")
+SPEC = importlib.util.spec_from_file_location("regression_verifier_pipeline", SCRIPT)
+assert SPEC and SPEC.loader
+pipeline = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = pipeline
+SPEC.loader.exec_module(pipeline)
+
+
+def archive(entries: list[tuple[str, bytes | None, str]]) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as bundle:
+        for name, body, kind in entries:
+            info = tarfile.TarInfo(name)
+            if kind == "dir":
+                info.type = tarfile.DIRTYPE
+                bundle.addfile(info)
+            elif kind == "symlink":
+                info.type = tarfile.SYMTYPE
+                info.linkname = "target"
+                bundle.addfile(info)
+            else:
+                assert body is not None
+                info.size = len(body)
+                bundle.addfile(info, io.BytesIO(body))
+    return output.getvalue()
+
+
+class RegressionVerifierPipelineTests(unittest.TestCase):
+    def test_artifact_reference_requires_an_exact_public_commit(self) -> None:
+        expected = ("owner/repo", "a" * 40)
+        self.assertEqual(
+            pipeline.parse_github_commit_url(
+                f"https://github.com/owner/repo/commit/{'a' * 40}"
+            ),
+            expected,
+        )
+        invalid = [
+            f"http://github.com/owner/repo/commit/{'a' * 40}",
+            f"https://user@github.com/owner/repo/commit/{'a' * 40}",
+            f"https://github.com/owner/repo/commit/{'a' * 39}",
+            f"https://github.com/owner/repo/commit/{'a' * 40}?download=1",
+            f"https://evil.example/owner/repo/commit/{'a' * 40}",
+        ]
+        for value in invalid:
+            with self.subTest(value=value), self.assertRaises(pipeline.PipelineError):
+                pipeline.parse_github_commit_url(value)
+
+    def test_safe_archive_strips_root_and_selects_committed_subdirectory(self) -> None:
+        value = archive(
+            [
+                ("repo-root/bench", None, "dir"),
+                ("repo-root/bench/test.txt", b"expected", "file"),
+                ("repo-root/source.txt", b"ignored", "file"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            pipeline.extract_snapshot(
+                value,
+                root,
+                subdirectory="bench",
+                max_bytes=100,
+                max_files=2,
+            )
+            self.assertEqual((root / "test.txt").read_bytes(), b"expected")
+            self.assertFalse((root / "source.txt").exists())
+
+    def test_archive_links_traversal_and_size_overrun_fail_closed(self) -> None:
+        cases = [
+            archive([("root/link", None, "symlink")]),
+            archive([("root/../escape", b"bad", "file")]),
+        ]
+        for value in cases:
+            with self.subTest(size=len(value)), tempfile.TemporaryDirectory() as temporary:
+                with self.assertRaises(pipeline.PipelineError):
+                    pipeline.extract_snapshot(
+                        value,
+                        Path(temporary),
+                        subdirectory=None,
+                        max_bytes=100,
+                        max_files=2,
+                    )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            with self.assertRaises(pipeline.PipelineError):
+                pipeline.extract_snapshot(
+                    archive([("root/large", b"0123456789", "file")]),
+                    Path(temporary),
+                    subdirectory=None,
+                    max_bytes=5,
+                    max_files=2,
+                )
+
+    def test_benchmark_source_is_exact_and_commit_pinned(self) -> None:
+        job = {
+            "terms": {
+                "document": {
+                    "benchmark": {
+                        "source": {
+                            "kind": "github_commit",
+                            "repository": "owner/repo",
+                            "commit": "b" * 40,
+                            "subdirectory": "benchmarks/task",
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(
+            pipeline.benchmark_source(job),
+            ("owner/repo", "b" * 40, "benchmarks/task"),
+        )
+        job["terms"]["document"]["benchmark"]["source"]["branch"] = "main"
+        with self.assertRaises(pipeline.PipelineError):
+            pipeline.benchmark_source(job)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -81,6 +81,9 @@ class ResolutionFailureClient:
     def ensure_deploy(self, service, revision):
         self.mutations.append(("deploy", service["name"]))
 
+    def ensure_custom_domain(self, service, domain):
+        self.mutations.append(("domain", service["name"], domain))
+
 
 class RenderDeployRecoveryTests(unittest.TestCase):
     def test_revision_requires_full_sha(self) -> None:
@@ -143,6 +146,44 @@ class RenderDeployRecoveryTests(unittest.TestCase):
                 )
             ],
         )
+
+    def test_custom_domain_is_reused_or_attached_exactly_once(self) -> None:
+        existing = RecordingClient()
+        existing._read_with_retry = lambda _path: [
+            {"customDomain": {"name": "api.bountyboard.global", "verificationStatus": "verified"}}
+        ]
+        reused = existing.ensure_custom_domain(
+            {"id": "srv-api", "name": "agent-bounties-api"},
+            "api.bountyboard.global",
+        )
+        self.assertEqual(reused["verificationStatus"], "verified")
+        self.assertEqual(existing.requests, [])
+
+        created = RecordingClient(
+            response={"customDomain": {"name": "api.bountyboard.global", "verificationStatus": "pending"}}
+        )
+        created._read_with_retry = lambda _path: []
+        attached = created.ensure_custom_domain(
+            {"id": "srv-api", "name": "agent-bounties-api"},
+            "api.bountyboard.global",
+        )
+        self.assertEqual(attached["verificationStatus"], "pending")
+        self.assertEqual(
+            created.requests,
+            [("POST", "/services/srv-api/custom-domains", {"name": "api.bountyboard.global"})],
+        )
+
+    def test_duplicate_custom_domains_fail_closed(self) -> None:
+        client = RecordingClient()
+        client._read_with_retry = lambda _path: [
+            {"name": "api.bountyboard.global"},
+            {"customDomain": {"name": "API.BOUNTYBOARD.GLOBAL"}},
+        ]
+        with self.assertRaisesRegex(recovery.RecoveryError, "duplicate"):
+            client.ensure_custom_domain(
+                {"id": "srv-api", "name": "agent-bounties-api"},
+                "api.bountyboard.global",
+            )
 
     def test_rejected_trigger_fails_without_unbounded_retry(self) -> None:
         client = RecordingClient(error=recovery.RenderHttpError(401, "unauthorized"))

--- a/scripts/test_standing_meta_v2_deploy.py
+++ b/scripts/test_standing_meta_v2_deploy.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from scripts.standing_meta_v2_deploy import (
+    BASE_SEPOLIA_USDC,
+    DeploymentError,
+    normalize_address,
+    read_broadcast,
+    require_bytes32,
+)
+
+
+class StandingMetaV2DeployTests(unittest.TestCase):
+    def test_rehearsal_uses_canonical_base_sepolia_usdc(self) -> None:
+        self.assertEqual(BASE_SEPOLIA_USDC, "0x036cbd53842c5426634e7929541ec2318f3dcf7e")
+
+    def test_exact_address_and_bytes32_shapes(self) -> None:
+        self.assertEqual(
+            normalize_address("0x" + "Aa" * 20, "address"),
+            "0x" + "aa" * 20,
+        )
+        self.assertEqual(require_bytes32("0x" + "BB" * 32, "hash"), "0x" + "bb" * 32)
+        with self.assertRaises(DeploymentError):
+            normalize_address("0x1234", "address")
+        with self.assertRaises(DeploymentError):
+            require_bytes32("0x" + "00" * 31, "hash")
+
+    def test_broadcast_requires_aligned_successful_receipts(self) -> None:
+        transaction_hash = "0x" + "11" * 32
+        payload = {
+            "transactions": [
+                {
+                    "hash": transaction_hash,
+                    "function": "claim()",
+                }
+            ],
+            "receipts": [
+                {
+                    "status": "0x1",
+                    "transactionHash": transaction_hash,
+                    "from": "0x" + "22" * 20,
+                    "to": "0x" + "33" * 20,
+                    "blockNumber": "0x2a",
+                    "logs": [],
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "run.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            parsed = read_broadcast(path)
+            self.assertEqual(parsed[0]["transaction_hash"], transaction_hash)
+            self.assertEqual(parsed[0]["block_number"], 42)
+            payload["receipts"][0]["status"] = "0x0"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaises(DeploymentError):
+                read_broadcast(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+bountyboard.global

--- a/site/agent-budget.js
+++ b/site/agent-budget.js
@@ -16,7 +16,7 @@
   const CHAIN_ID = "0x2105";
   const ZERO_HASH = `0x${"00".repeat(32)}`;
   const EXPECTED = Object.freeze({
-    sourceRevision: "c09ecad36a9d6d93d1272e81819c7196d0d97214",
+    sourceRevision: "da731c015a5dbee7053fc57abd50792d0b3b30f6",
     bountyFactory: "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     settlementToken: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
     deterministicVerifier: "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",

--- a/site/agent-budget.js
+++ b/site/agent-budget.js
@@ -16,7 +16,7 @@
   const CHAIN_ID = "0x2105";
   const ZERO_HASH = `0x${"00".repeat(32)}`;
   const EXPECTED = Object.freeze({
-    sourceRevision: "7708253cd4914eaa06109523f565751f7d83b6f1",
+    sourceRevision: "c09ecad36a9d6d93d1272e81819c7196d0d97214",
     bountyFactory: "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     settlementToken: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
     deterministicVerifier: "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",


### PR DESCRIPTION
## Summary
- add standing-meta v2 with independent participant identities, precommitted child terms, and exact two-signer sandboxed regression verification
- add a funded canonical Base Sepolia rehearsal and gated Base-mainnet deployment workflow
- add participant registration and split-secret regression verifier pipelines
- attach `bountyboard.global` to GitHub Pages and `api`/`mcp` subdomains to Render
- refresh bounded-wallet source provenance without changing its deployed bytecode bindings

## Safety boundaries
- Base mainnet deployment cannot run unless the same dispatch completes the funded Base Sepolia parent/child settlement rehearsal
- separate signer jobs each receive one verifier secret; the runner and relay receive neither verifier key
- advisory AI output cannot authorize settlement
- Render domain attachment and deployment fail closed on ambiguous service/domain state

## Verified locally
- `python -m unittest scripts.test_standing_meta_v2_deploy scripts.test_register_participant scripts.test_regression_verifier_pipeline scripts.test_render_deploy_recovery -v`
- `cargo fmt --all -- --check`
- `cargo test -p verifier-sdk -p worker`
- `forge test --root contracts/base-escrow --match-contract CanonicalIndependentChildVerifierV2Test -vv`
- `forge build --root contracts/base-escrow --sizes`
- `python scripts/check-site.py`
- `python scripts/check-render-blueprint.py`
- `scripts/preflight.ps1 -Mode core`

A calibrated local rehearsal at Base's observed 0.006 gwei gas price started with exactly 0.0001 ETH, completed four deployments plus both settlement loops, and retained 0.000041231821265747 ETH.

Public maintainer notices: #321 and #324.