### PR TITLE
fix: wait for deployed runtime code

### DIFF
--- a/scripts/standing_meta_v2_deploy.py
+++ b/scripts/standing_meta_v2_deploy.py
@@ -147,8 +147,7 @@ class Foundry:
             "source": source,
         }
         self.receipt(result["transaction_hash"])
-        if self.code(result["contract"]) in {"0x", "0x0"}:
-            raise DeploymentError(f"deployed contract has no runtime code: {result['contract']}")
+        wait_for_runtime_code(self, result["contract"], "deployed contract")
         return result
 
     def script(self, source: str, env: Mapping[str, str]) -> None:
@@ -167,6 +166,24 @@ class Foundry:
             env=env,
             timeout=600,
         )
+
+
+def wait_for_runtime_code(
+    foundry: Foundry,
+    address: str,
+    label: str,
+    *,
+    timeout_seconds: float = 90,
+    poll_interval_seconds: float = 2,
+) -> str:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        code = foundry.code(address)
+        if code not in {"0x", "0x0"}:
+            return code
+        if time.monotonic() >= deadline:
+            raise DeploymentError(f"{label} has no runtime code after a confirmed receipt: {address}")
+        time.sleep(poll_interval_seconds)
 
 
 def require_env(name: str) -> str:
@@ -373,8 +390,7 @@ def deploy_sepolia(foundry: Foundry, output: Path) -> dict[str, Any]:
     }
     for name, signature in linked_components.items():
         component = normalize_address(foundry.call(bundle_address, signature), f"bundle {name}")
-        if foundry.code(component) in {"0x", "0x0"}:
-            raise DeploymentError(f"bundle {name} has no runtime code")
+        wait_for_runtime_code(foundry, component, f"bundle {name}")
         deployments[name] = {
             "contract": component,
             "transaction_hash": deployments["bundle"]["transaction_hash"],
@@ -494,8 +510,7 @@ def deploy_mainnet(foundry: Foundry, output: Path) -> dict[str, Any]:
         "participant registry": participant_registry,
         "terms registry": terms_registry,
     }.items():
-        if foundry.code(address) in {"0x", "0x0"}:
-            raise DeploymentError(f"{label} has no runtime code")
+        wait_for_runtime_code(foundry, address, label)
     onchain = {
         "bundle_factory": normalize_address(
             foundry.call(bundle, "canonicalFactory()(address)"), "bundle factory"

--- a/scripts/test_standing_meta_v2_deploy.py
+++ b/scripts/test_standing_meta_v2_deploy.py
@@ -10,10 +10,44 @@ from scripts.standing_meta_v2_deploy import (
     parse_cast_uint,
     read_broadcast,
     require_bytes32,
+    wait_for_runtime_code,
 )
 
 
+class CodeSequence:
+    def __init__(self, values: list[str]) -> None:
+        self.values = values
+
+    def code(self, _address: str) -> str:
+        if len(self.values) > 1:
+            return self.values.pop(0)
+        return self.values[0]
+
+
 class StandingMetaV2DeployTests(unittest.TestCase):
+    def test_runtime_code_waits_for_rpc_propagation(self) -> None:
+        foundry = CodeSequence(["0x", "0x6000"])
+        self.assertEqual(
+            wait_for_runtime_code(
+                foundry,  # type: ignore[arg-type]
+                "0x" + "11" * 20,
+                "test contract",
+                timeout_seconds=1,
+                poll_interval_seconds=0,
+            ),
+            "0x6000",
+        )
+
+    def test_runtime_code_timeout_fails_closed(self) -> None:
+        with self.assertRaises(DeploymentError):
+            wait_for_runtime_code(
+                CodeSequence(["0x"]),  # type: ignore[arg-type]
+                "0x" + "11" * 20,
+                "test contract",
+                timeout_seconds=0,
+                poll_interval_seconds=0,
+            )
+
     def test_cast_uint_accepts_foundry_annotations(self) -> None:
         self.assertEqual(parse_cast_uint("3000000 [3e6]"), 3_000_000)
         self.assertEqual(parse_cast_uint("0x2a [42]"), 42)


### PR DESCRIPTION
## Summary
- poll post-receipt runtime bytecode to tolerate bounded Base RPC propagation
- keep a 90-second fail-closed deadline
- apply the same check to atomic bundle components and mainnet verification
- cover both delayed success and timeout failure

## Live evidence
The first queried address returned empty code immediately after a successful creation receipt and now returns 6,765 bytes. Mainnet was not reached.

## Verification
- `python -m unittest scripts.test_standing_meta_v2_deploy -v`
- `git diff --check`