### PR TITLE
fix: wait for Base timestamp finality

### DIFF
--- a/scripts/standing_meta_v2_deploy.py
+++ b/scripts/standing_meta_v2_deploy.py
@@ -21,6 +21,7 @@ BASE_SEPOLIA_USDC = "0x036cbd53842c5426634e7929541ec2318f3dcf7e"
 MIN_MAINNET_KEEPER_WEI = 100_000_000_000_000
 MIN_MAINNET_DEPLOY_WEI = 500_000_000_000_000
 MIN_SEPOLIA_DEPLOY_WEI = 90_000_000_000_000
+MIN_COMPLETION_TIMESTAMP_DELTA = 8
 ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 BYTES32_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
 CREATE_JSON_RE = re.compile(r"\{\s*\"deployer\".*?\}\s*$", re.DOTALL)
@@ -239,17 +240,25 @@ def read_broadcast(path: Path) -> list[dict[str, Any]]:
     return result
 
 
-def wait_for_later_timestamp(foundry: Foundry, published_at: int, timeout_seconds: int = 90) -> int:
+def wait_for_later_timestamp(
+    foundry: Foundry,
+    published_at: int,
+    timeout_seconds: float = 90,
+    poll_interval_seconds: float = 2,
+) -> int:
     deadline = time.monotonic() + timeout_seconds
+    required_timestamp = published_at + MIN_COMPLETION_TIMESTAMP_DELTA
     while time.monotonic() < deadline:
         observed = parse_cast_uint(
             foundry.cast_run("block", "latest", "--field", "timestamp"),
             "block timestamp",
         )
-        if observed > published_at:
+        if observed >= required_timestamp:
             return observed
-        time.sleep(2)
-    raise DeploymentError("Base did not produce a timestamp later than the terms publication")
+        time.sleep(poll_interval_seconds)
+    raise DeploymentError(
+        f"Base did not reach the completion timestamp margin: required {required_timestamp}"
+    )
 
 
 def broadcast_path(foundry: Foundry, script_name: str, chain_id: int) -> Path:

--- a/scripts/test_standing_meta_v2_deploy.py
+++ b/scripts/test_standing_meta_v2_deploy.py
@@ -11,6 +11,7 @@ from scripts.standing_meta_v2_deploy import (
     read_broadcast,
     require_bytes32,
     wait_for_runtime_code,
+    wait_for_later_timestamp,
 )
 
 
@@ -24,7 +25,29 @@ class CodeSequence:
         return self.values[0]
 
 
+class CastSequence:
+    def __init__(self, values: list[str]) -> None:
+        self.values = values
+
+    def cast_run(self, *_args: str) -> str:
+        if len(self.values) > 1:
+            return self.values.pop(0)
+        return self.values[0]
+
+
 class StandingMetaV2DeployTests(unittest.TestCase):
+    def test_completion_waits_for_four_base_block_margin(self) -> None:
+        foundry = CastSequence(["107 [1.07e2]", "108 [1.08e2]"])
+        self.assertEqual(
+            wait_for_later_timestamp(
+                foundry,  # type: ignore[arg-type]
+                100,
+                timeout_seconds=1,
+                poll_interval_seconds=0,
+            ),
+            108,
+        )
+
     def test_runtime_code_waits_for_rpc_propagation(self) -> None:
         foundry = CodeSequence(["0x", "0x6000"])
         self.assertEqual(


### PR DESCRIPTION
## Summary
- require an eight-second Base timestamp margin before the completion phase
- retain the bounded 90-second fail-closed deadline
- cover the exact seven-versus-eight-second boundary

## Live evidence
The signed Sepolia preparation succeeded, but Forge's completion simulation reached a lagging RPC backend at the terms-publication timestamp. No mainnet deployment occurred.

## Verification
- `python -m unittest scripts.test_standing_meta_v2_deploy -v`
- `git diff --check`