### PR TITLE
fix: wait from confirmed terms block

### DIFF
--- a/scripts/standing_meta_v2_deploy.py
+++ b/scripts/standing_meta_v2_deploy.py
@@ -261,6 +261,31 @@ def wait_for_later_timestamp(
     )
 
 
+def confirmed_terms_publication(
+    foundry: Foundry,
+    terms_registry: str,
+    transactions: Sequence[Mapping[str, Any]],
+    simulated_timestamp: int,
+) -> dict[str, int]:
+    registry = normalize_address(terms_registry, "terms registry")
+    matches = [
+        transaction
+        for transaction in transactions
+        if transaction.get("to") == registry
+        and str(transaction.get("function") or "").startswith("publish(")
+    ]
+    if len(matches) != 1:
+        raise DeploymentError("preparation must contain exactly one decoded terms publication")
+    block_number = int(matches[0]["block_number"])
+    block_timestamp = parse_cast_uint(
+        foundry.cast_run("block", str(block_number), "--field", "timestamp"),
+        "terms publication block timestamp",
+    )
+    if block_timestamp < simulated_timestamp:
+        raise DeploymentError("confirmed terms publication predates its simulation evidence")
+    return {"block_number": block_number, "timestamp": block_timestamp}
+
+
 def broadcast_path(foundry: Foundry, script_name: str, chain_id: int) -> Path:
     return foundry.contracts / "broadcast" / f"{script_name}.s.sol" / str(chain_id) / "run-latest.json"
 
@@ -431,7 +456,13 @@ def deploy_sepolia(foundry: Foundry, output: Path) -> dict[str, Any]:
     prepare_transactions = read_broadcast(
         broadcast_path(foundry, "BaseSepoliaStandingMetaV2Rehearsal", BASE_SEPOLIA_CHAIN_ID)
     )
-    observed_timestamp = wait_for_later_timestamp(foundry, int(prepare["terms_published_at"]))
+    terms_publication = confirmed_terms_publication(
+        foundry,
+        deployments["terms_registry"]["contract"],
+        prepare_transactions,
+        int(prepare["terms_published_at"]),
+    )
+    observed_timestamp = wait_for_later_timestamp(foundry, terms_publication["timestamp"])
     script_env.update(
         {
             "REHEARSAL_PHASE": "complete",
@@ -458,6 +489,7 @@ def deploy_sepolia(foundry: Foundry, output: Path) -> dict[str, Any]:
         "completion": final,
         "preparation_transactions": prepare_transactions,
         "completion_transactions": complete_transactions,
+        "terms_publication": terms_publication,
         "timestamp_after_preparation": observed_timestamp,
         "verification": verification,
     }

--- a/scripts/test_standing_meta_v2_deploy.py
+++ b/scripts/test_standing_meta_v2_deploy.py
@@ -6,6 +6,7 @@ import unittest
 from scripts.standing_meta_v2_deploy import (
     BASE_SEPOLIA_USDC,
     DeploymentError,
+    confirmed_terms_publication,
     normalize_address,
     parse_cast_uint,
     read_broadcast,
@@ -36,6 +37,39 @@ class CastSequence:
 
 
 class StandingMetaV2DeployTests(unittest.TestCase):
+    def test_terms_wait_uses_confirmed_publication_block(self) -> None:
+        registry = "0x" + "33" * 20
+        transactions = [
+            {
+                "to": "0x" + "22" * 20,
+                "function": "transfer(address,uint256)",
+                "block_number": 40,
+            },
+            {
+                "to": registry,
+                "function": "publish(bytes,(bytes32,uint64))",
+                "block_number": 42,
+            },
+        ]
+        self.assertEqual(
+            confirmed_terms_publication(
+                CastSequence(["112 [1.12e2]"]),  # type: ignore[arg-type]
+                registry,
+                transactions,
+                110,
+            ),
+            {"block_number": 42, "timestamp": 112},
+        )
+
+    def test_terms_publication_rejects_ambiguous_evidence(self) -> None:
+        with self.assertRaises(DeploymentError):
+            confirmed_terms_publication(
+                CastSequence(["112"]),  # type: ignore[arg-type]
+                "0x" + "33" * 20,
+                [],
+                110,
+            )
+
     def test_completion_waits_for_four_base_block_margin(self) -> None:
         foundry = CastSequence(["107 [1.07e2]", "108 [1.08e2]"])
         self.assertEqual(


### PR DESCRIPTION
## Summary
- identify the exact decoded `publish(...)` broadcast to the exact terms registry
- derive the wait baseline from that transaction's confirmed Base block
- reject missing, duplicate, or simulation-inconsistent publication evidence
- preserve the eight-second completion margin and include canonical timing in evidence

## Live evidence
The prior run proved Forge simulation time can precede the eventual registry `publishedAt`. No mainnet deployment occurred.

## Verification
- `python -m unittest scripts.test_standing_meta_v2_deploy -v`
- `git diff --check`