### PR TITLE
fix: wait for confirmed block indexing

### DIFF
--- a/scripts/standing_meta_v2_deploy.py
+++ b/scripts/standing_meta_v2_deploy.py
@@ -261,6 +261,30 @@ def wait_for_later_timestamp(
     )
 
 
+def wait_for_block_timestamp(
+    foundry: Foundry,
+    block_number: int,
+    *,
+    timeout_seconds: float = 90,
+    poll_interval_seconds: float = 2,
+) -> int:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: DeploymentError | None = None
+    while True:
+        try:
+            return parse_cast_uint(
+                foundry.cast_run("block", str(block_number), "--field", "timestamp"),
+                "terms publication block timestamp",
+            )
+        except DeploymentError as error:
+            last_error = error
+        if time.monotonic() >= deadline:
+            raise DeploymentError(
+                f"confirmed block {block_number} was unavailable before the RPC deadline: {last_error}"
+            ) from last_error
+        time.sleep(poll_interval_seconds)
+
+
 def confirmed_terms_publication(
     foundry: Foundry,
     terms_registry: str,
@@ -277,10 +301,7 @@ def confirmed_terms_publication(
     if len(matches) != 1:
         raise DeploymentError("preparation must contain exactly one decoded terms publication")
     block_number = int(matches[0]["block_number"])
-    block_timestamp = parse_cast_uint(
-        foundry.cast_run("block", str(block_number), "--field", "timestamp"),
-        "terms publication block timestamp",
-    )
+    block_timestamp = wait_for_block_timestamp(foundry, block_number)
     if block_timestamp < simulated_timestamp:
         raise DeploymentError("confirmed terms publication predates its simulation evidence")
     return {"block_number": block_number, "timestamp": block_timestamp}

--- a/scripts/test_standing_meta_v2_deploy.py
+++ b/scripts/test_standing_meta_v2_deploy.py
@@ -11,6 +11,7 @@ from scripts.standing_meta_v2_deploy import (
     parse_cast_uint,
     read_broadcast,
     require_bytes32,
+    wait_for_block_timestamp,
     wait_for_runtime_code,
     wait_for_later_timestamp,
 )
@@ -27,16 +28,38 @@ class CodeSequence:
 
 
 class CastSequence:
-    def __init__(self, values: list[str]) -> None:
+    def __init__(self, values: list[object]) -> None:
         self.values = values
 
     def cast_run(self, *_args: str) -> str:
         if len(self.values) > 1:
-            return self.values.pop(0)
-        return self.values[0]
+            value = self.values.pop(0)
+        else:
+            value = self.values[0]
+        if isinstance(value, Exception):
+            raise value
+        return str(value)
 
 
 class StandingMetaV2DeployTests(unittest.TestCase):
+    def test_block_timestamp_waits_for_rpc_indexing(self) -> None:
+        foundry = CastSequence([DeploymentError("block not found"), "112 [1.12e2]"])
+        self.assertEqual(
+            wait_for_block_timestamp(
+                foundry, 42, timeout_seconds=1, poll_interval_seconds=0  # type: ignore[arg-type]
+            ),
+            112,
+        )
+
+    def test_block_timestamp_timeout_fails_closed(self) -> None:
+        with self.assertRaises(DeploymentError):
+            wait_for_block_timestamp(
+                CastSequence([DeploymentError("block not found")]),  # type: ignore[arg-type]
+                42,
+                timeout_seconds=0,
+                poll_interval_seconds=0,
+            )
+
     def test_terms_wait_uses_confirmed_publication_block(self) -> None:
         registry = "0x" + "33" * 20
         transactions = [


### PR DESCRIPTION
## Summary
- poll the exact confirmed publication block until the RPC can return its timestamp
- keep the lookup pinned to the receipt block rather than `latest`
- fail closed after 90 seconds
- cover delayed indexing and timeout behavior

## Live evidence
The previous run selected the correct publication receipt block, but the public Base RPC immediately returned `block not found`. No mainnet deployment occurred.

## Verification
- `python -m unittest scripts.test_standing_meta_v2_deploy -v`
- `git diff --check`