### PR TITLE
fix: verify rehearsal balance deltas

### DIFF
--- a/.github/workflows/standing-meta-v2-deploy.yml
+++ b/.github/workflows/standing-meta-v2-deploy.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           python -m unittest scripts.test_standing_meta_v2_deploy -v
           forge test --root contracts/base-escrow --match-contract CanonicalIndependentChildVerifierV2Test -vv
+          forge test --root contracts/base-escrow --match-contract BaseSepoliaStandingMetaV2RehearsalBalanceTest -vv
           forge build --root contracts/base-escrow --sizes
 
   base-sepolia-rehearsal:

--- a/contracts/base-escrow/script/BaseSepoliaStandingMetaV2Rehearsal.s.sol
+++ b/contracts/base-escrow/script/BaseSepoliaStandingMetaV2Rehearsal.s.sol
@@ -96,6 +96,8 @@ contract BaseSepoliaStandingMetaV2Rehearsal {
 
     function _complete(RehearsalActors memory actors, Deployment memory deployment) private {
         AgentBounty parent = AgentBounty(vm.envAddress("REHEARSAL_PARENT_BOUNTY"));
+        uint256 parentBalanceBefore = deployment.token.balanceOf(actors.parentSolver);
+        uint256 childBalanceBefore = deployment.token.balanceOf(actors.childSolver);
         require(deployment.factory.isCanonicalBounty(address(parent)), "prepared parent is not canonical");
         require(parent.verifierModule() == address(deployment.module), "prepared parent module drift");
         OnchainTermsRegistry.TermsCommitment memory published = deployment.terms.commitment(keccak256(CHILD_TERMS));
@@ -109,11 +111,26 @@ contract BaseSepoliaStandingMetaV2Rehearsal {
 
         require(parent.bountyStatus() == AgentBounty.BountyStatus.Settled, "parent not settled");
         require(child.bountyStatus() == AgentBounty.BountyStatus.Settled, "child not settled");
-        require(deployment.token.balanceOf(actors.parentSolver) == 1_000_000, "parent net payout mismatch");
-        require(deployment.token.balanceOf(actors.childSolver) == 1_000_000, "child net payout mismatch");
+        _assertCompletionBalanceDeltas(
+            parentBalanceBefore,
+            childBalanceBefore,
+            deployment.token.balanceOf(actors.parentSolver),
+            deployment.token.balanceOf(actors.childSolver)
+        );
         _writeEvidence(
             actors.deployer, deployment, parent, child, actors.parentSolver, actors.childSolver, actors.verifiers
         );
+    }
+
+    function _assertCompletionBalanceDeltas(
+        uint256 parentBalanceBefore,
+        uint256 childBalanceBefore,
+        uint256 parentBalanceAfter,
+        uint256 childBalanceAfter
+    ) internal pure {
+        require(parentBalanceBefore >= 100_000, "parent rehearsal balance underflow");
+        require(parentBalanceAfter == parentBalanceBefore - 100_000, "parent net payout mismatch");
+        require(childBalanceAfter == childBalanceBefore + 900_000, "child net payout mismatch");
     }
 
     function _loadActors() private returns (RehearsalActors memory actors) {

--- a/contracts/base-escrow/test/BaseSepoliaStandingMetaV2Rehearsal.t.sol
+++ b/contracts/base-escrow/test/BaseSepoliaStandingMetaV2Rehearsal.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../script/BaseSepoliaStandingMetaV2Rehearsal.s.sol";
+
+contract BaseSepoliaStandingMetaV2RehearsalHarness is BaseSepoliaStandingMetaV2Rehearsal {
+    function assertCompletionBalanceDeltas(
+        uint256 parentBalanceBefore,
+        uint256 childBalanceBefore,
+        uint256 parentBalanceAfter,
+        uint256 childBalanceAfter
+    ) external pure {
+        _assertCompletionBalanceDeltas(
+            parentBalanceBefore, childBalanceBefore, parentBalanceAfter, childBalanceAfter
+        );
+    }
+}
+
+contract BaseSepoliaStandingMetaV2RehearsalBalanceTest {
+    BaseSepoliaStandingMetaV2RehearsalHarness private harness;
+
+    function setUp() public {
+        harness = new BaseSepoliaStandingMetaV2RehearsalHarness();
+    }
+
+    function testBalanceDeltasAllowPriorRehearsalPayouts() public view {
+        harness.assertCompletionBalanceDeltas(3_400_000, 300_000, 3_300_000, 1_200_000);
+    }
+
+    function testAbsoluteBalanceAssumptionIsRejected() public {
+        (bool ok,) = address(harness).call(
+            abi.encodeCall(harness.assertCompletionBalanceDeltas, (3_400_000, 300_000, 1_000_000, 1_000_000))
+        );
+        require(!ok, "absolute-balance regression must revert");
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1350,9 +1350,9 @@ fn artifact_runtime_with_immutables(
     }
     let mut declarations = BTreeMap::new();
     collect_immutable_address_declarations(
-        artifact
-            .get("ast")
-            .context("contract artifact is missing its source AST")?,
+        artifact.get("ast").context(
+            "contract artifact is missing its source AST; rebuild with forge build --ast",
+        )?,
         &mut declarations,
     )?;
     let mut patched = BTreeSet::new();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -46,11 +46,6 @@ use std::{
 };
 use uuid::Uuid;
 
-// Solc 0.8.26 keys immutable references by declaration id. Pinning both ids
-// makes compiler/source drift fail closed instead of swapping constructor values.
-const FACTORY_SETTLEMENT_TOKEN_IMMUTABLE_ID: &str = "2738";
-const FACTORY_IMPLEMENTATION_IMMUTABLE_ID: &str = "2740";
-
 #[derive(Parser)]
 #[command(name = "agent-bounties")]
 #[command(about = "Open-source agent bounty network CLI")]
@@ -896,16 +891,8 @@ fn autonomous_activation_bundle(
     let factory_runtime = artifact_runtime_with_immutables(
         &factory_artifact,
         &[
-            (
-                FACTORY_SETTLEMENT_TOKEN_IMMUTABLE_ID,
-                "settlementToken",
-                BASE_MAINNET_USDC_TOKEN_ADDRESS,
-            ),
-            (
-                FACTORY_IMPLEMENTATION_IMMUTABLE_ID,
-                "implementation",
-                &expected_implementation,
-            ),
+            ("settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS),
+            ("implementation", &expected_implementation),
         ],
     )?;
     let implementation_runtime =
@@ -1347,7 +1334,7 @@ fn artifact_hex<'a>(artifact: &'a serde_json::Value, pointer: &str) -> Result<&'
 
 fn artifact_runtime_with_immutables(
     artifact: &serde_json::Value,
-    immutable_addresses: &[(&str, &str, &str)],
+    immutable_addresses: &[(&str, &str)],
 ) -> Result<Vec<u8>> {
     let mut runtime = hex::decode(artifact_hex(artifact, "/deployedBytecode/object")?)?;
     let references = artifact
@@ -1361,11 +1348,21 @@ fn artifact_runtime_with_immutables(
             references.len()
         );
     }
+    let mut declarations = BTreeMap::new();
+    collect_immutable_address_declarations(
+        artifact
+            .get("ast")
+            .context("contract artifact is missing its source AST")?,
+        &mut declarations,
+    )?;
     let mut patched = BTreeSet::new();
-    for (declaration_id, name, address) in immutable_addresses {
-        let locations = references.get(*declaration_id).ok_or_else(|| {
-            anyhow!("contract artifact has no immutable declaration {declaration_id} for {name}")
-        })?;
+    for (name, address) in immutable_addresses {
+        let declaration_id = declarations
+            .get(*name)
+            .ok_or_else(|| anyhow!("contract artifact has no immutable address named {name}"))?;
+        let locations = references
+            .get(declaration_id)
+            .ok_or_else(|| anyhow!("contract artifact has no immutable references for {name}"))?;
         let normalized = normalize_cli_address(address)?;
         let mut word = [0u8; 32];
         word[12..].copy_from_slice(&hex::decode(&normalized[2..])?);
@@ -1396,12 +1393,66 @@ fn artifact_runtime_with_immutables(
         }
         patched.insert(name.to_string());
     }
-    for (_, name, _) in immutable_addresses {
+    for (name, _) in immutable_addresses {
         if !patched.contains(*name) {
             bail!("contract artifact has no immutable references for {name}");
         }
     }
     Ok(runtime)
+}
+
+fn collect_immutable_address_declarations(
+    node: &serde_json::Value,
+    declarations: &mut BTreeMap<String, String>,
+) -> Result<()> {
+    match node {
+        serde_json::Value::Object(object) => {
+            let is_immutable = object.get("nodeType").and_then(serde_json::Value::as_str)
+                == Some("VariableDeclaration")
+                && object.get("mutability").and_then(serde_json::Value::as_str)
+                    == Some("immutable")
+                && object
+                    .get("stateVariable")
+                    .and_then(serde_json::Value::as_bool)
+                    == Some(true);
+            if is_immutable {
+                let name = object
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .context("immutable declaration is missing its name")?;
+                let declaration_id = object
+                    .get("id")
+                    .and_then(serde_json::Value::as_u64)
+                    .context("immutable declaration is missing its numeric id")?
+                    .to_string();
+                let type_string = object
+                    .get("typeDescriptions")
+                    .and_then(serde_json::Value::as_object)
+                    .and_then(|types| types.get("typeString"))
+                    .and_then(serde_json::Value::as_str)
+                    .context("immutable declaration is missing its type")?;
+                if type_string != "address" {
+                    bail!("immutable {name} is not an address");
+                }
+                if declarations
+                    .insert(name.to_string(), declaration_id)
+                    .is_some()
+                {
+                    bail!("contract artifact has duplicate immutable address {name}");
+                }
+            }
+            for child in object.values() {
+                collect_immutable_address_declarations(child, declarations)?;
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                collect_immutable_address_declarations(child, declarations)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn normalize_cli_address(value: &str) -> Result<String> {
@@ -5553,23 +5604,46 @@ mod tests {
     #[test]
     fn factory_runtime_hash_patches_constructor_immutables_without_generated_files() {
         let artifact = serde_json::json!({
+            "ast": {
+                "nodeType": "SourceUnit",
+                "nodes": [{
+                    "nodeType": "ContractDefinition",
+                    "nodes": [
+                        {
+                            "id": 5271,
+                            "mutability": "immutable",
+                            "name": "settlementToken",
+                            "nodeType": "VariableDeclaration",
+                            "stateVariable": true,
+                            "typeDescriptions": { "typeString": "address" }
+                        },
+                        {
+                            "id": 5273,
+                            "mutability": "immutable",
+                            "name": "implementation",
+                            "nodeType": "VariableDeclaration",
+                            "stateVariable": true,
+                            "typeDescriptions": { "typeString": "address" }
+                        }
+                    ]
+                }]
+            },
             "deployedBytecode": {
                 "object": format!("0x{}", "00".repeat(96)),
                 "immutableReferences": {
-                    "1": [
+                    "5271": [
                         { "start": 0, "length": 32 },
                         { "start": 64, "length": 32 }
                     ],
-                    "2": [{ "start": 32, "length": 32 }]
+                    "5273": [{ "start": 32, "length": 32 }]
                 }
             }
         });
         let runtime = artifact_runtime_with_immutables(
             &artifact,
             &[
-                ("1", "settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS),
+                ("settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS),
                 (
-                    "2",
                     "implementation",
                     "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9",
                 ),
@@ -5582,6 +5656,42 @@ mod tests {
         assert_eq!(&runtime[12..32], settlement);
         assert_eq!(&runtime[44..64], implementation);
         assert_eq!(&runtime[76..96], settlement);
+    }
+
+    #[test]
+    fn factory_runtime_hash_resolves_immutable_ids_from_the_current_ast() {
+        let artifact = serde_json::json!({
+            "ast": {
+                "nodeType": "SourceUnit",
+                "nodes": [{
+                    "id": 991_337,
+                    "mutability": "immutable",
+                    "name": "settlementToken",
+                    "nodeType": "VariableDeclaration",
+                    "stateVariable": true,
+                    "typeDescriptions": { "typeString": "address" }
+                }]
+            },
+            "deployedBytecode": {
+                "object": format!("0x{}", "00".repeat(32)),
+                "immutableReferences": {
+                    "991337": [{ "start": 0, "length": 32 }]
+                }
+            }
+        });
+
+        let runtime = artifact_runtime_with_immutables(
+            &artifact,
+            &[("settlementToken", BASE_MAINNET_USDC_TOKEN_ADDRESS)],
+        )
+        .unwrap();
+
+        assert_eq!(
+            &runtime[12..32],
+            hex::decode(&BASE_MAINNET_USDC_TOKEN_ADDRESS[2..])
+                .unwrap()
+                .as_slice()
+        );
     }
 
     fn active_deployment_fixture() -> serde_json::Value {

--- a/deployments/bounded-agent-wallet-base-mainnet.json
+++ b/deployments/bounded-agent-wallet-base-mainnet.json
@@ -1,6 +1,6 @@
 {
   "schema": "agent-bounties/bounded-agent-wallet-deployment-v1",
-  "contract_source_revision": "da731c015a5dbee7053fc57abd50792d0b3b30f6",
+  "contract_source_revision": "dc05b4e01474f09f02bb1bbb69651e4ce4deb338",
   "contract_source_revision_kind": "git-tree",
   "contract_source_dirty": false,
   "network": "base-mainnet",

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -94,6 +94,7 @@ Pop-Location
 
 Push-Location (Join-Path $repoRoot "contracts\base-escrow")
 Invoke-Checked { forge test --fuzz-runs 1000 }
+Invoke-Checked { forge build --force --ast }
 Pop-Location
 
 $sepoliaBundlePath = Join-Path $repoRoot "deployments\base-sepolia-sponsor-activation.json"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -159,6 +159,7 @@ npm run check:examples
 
 cd "$repo_root/contracts/base-escrow"
 forge test --fuzz-runs 1000
+forge build --force --ast
 
 cd "$repo_root"
 sepolia_bundle="deployments/base-sepolia-sponsor-activation.json"

--- a/site/agent-budget.js
+++ b/site/agent-budget.js
@@ -16,7 +16,7 @@
   const CHAIN_ID = "0x2105";
   const ZERO_HASH = `0x${"00".repeat(32)}`;
   const EXPECTED = Object.freeze({
-    sourceRevision: "da731c015a5dbee7053fc57abd50792d0b3b30f6",
+    sourceRevision: "dc05b4e01474f09f02bb1bbb69651e4ce4deb338",
     bountyFactory: "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     settlementToken: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
     deterministicVerifier: "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",


### PR DESCRIPTION
## Summary
- verify exact completion balance deltas instead of absolute deterministic-actor balances
- preserve the 0.1 USDC parent outflow and 0.9 USDC child net gain invariants
- add a Solidity harness with accumulated prior balances
- run the new regression in the live deployment workflow gate

## Live evidence
The previous full completion simulation emitted both settlements, then the obsolete absolute-balance assertion reverted before broadcast. No mainnet deployment occurred.

## Verification
- `forge test --root contracts/base-escrow --match-contract BaseSepoliaStandingMetaV2RehearsalBalanceTest -vv`
- `python -m unittest scripts.test_standing_meta_v2_deploy -v`
- `git diff --check`