### PR TITLE
feat: activate standing-meta-v2 verifier

### DIFF
--- a/deployments/bounded-agent-wallet-base-mainnet.json
+++ b/deployments/bounded-agent-wallet-base-mainnet.json
@@ -9,7 +9,7 @@
   "canonical": {
     "bounty_factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-    "deterministic_verifier": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e"
+    "deterministic_verifier": "0xe573cb4f471d38b5bf10ce82237251ac902c9867"
   },
   "deterministic_deployer": {
     "address": "0x4e59b44847b379578588920ca78fbf26c0b4956c",

--- a/deployments/standing-meta-v2-base-mainnet.json
+++ b/deployments/standing-meta-v2-base-mainnet.json
@@ -1,0 +1,45 @@
+{
+  "schema": "agent-bounties/standing-meta-v2-deployment-v1",
+  "network": "base-mainnet",
+  "chain_id": 8453,
+  "source_revision": "3224cc7fdec4087cfb2cb522019c0954a2d965da",
+  "workflow_run": "https://github.com/NSPG13/agent-bounties/actions/runs/29547580559",
+  "deployment": {
+    "transaction_hash": "0x6a75ecbd630e3f31513cfb9e967120f670d176d7e2e903d977d8b087b32e9190",
+    "block_number": 48731293,
+    "receipt_status": 1,
+    "deployer": "0xc26a630e85134ed30968735c8e7de4576cfa5dbc"
+  },
+  "components": {
+    "bundle": "0x8dc3819dcbbf87015b4312808c1d1080956d3def",
+    "canonical_factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
+    "participant_registry": "0x9875dcaf570bde8ff1aa62275d3c8985f4fd1294",
+    "terms_registry": "0x35e5d49c12b75c119d33951c2c4f054c5732208c",
+    "verifier_module": "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
+    "verifier_runtime_code_hash": "0xe3b6e82880edee69b1f30560506ac80a46b4ebcc6c083cfa8207e3673eede26c",
+    "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "participant_attester": "0x5563ca06363eedb3d39ae1733bb8aa6eca3d5728",
+    "verifier_set_hash": "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
+    "verifier_threshold": 2,
+    "acceptance_criteria_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54"
+  },
+  "keeper_reserve": {
+    "keeper": "0xc26a630e85134ed30968735c8e7de4576cfa5dbc",
+    "floor_wei": 100000000000000,
+    "confirmed_balance_wei": 970365530562740,
+    "functional_relay_transaction": "0x65ad6d2faa353b5fb424e5dfe82c2ee769a901e1a647faf9df20f3f9034441e1",
+    "functional_relay_block": 48710634,
+    "functional_relay_receipt_status": 1,
+    "functional_relay_workflow": "https://github.com/NSPG13/agent-bounties/actions/runs/29538881444"
+  },
+  "base_sepolia_rehearsal": {
+    "parent_bounty": "0xf089b7f92543adcce8de4035d1252d4505d20d70",
+    "child_bounty": "0xb4239b41c85e5564d174634756b7b0e5892e49db",
+    "parent_solver": "0x155586f20e44a8c967bd06779433d01c87a3d01d",
+    "child_solver": "0xdd0389565aa1e5f114747e5a58dbda370b6212e8",
+    "parent_status": 4,
+    "child_status": 4,
+    "evidence": "Both contracts emitted canonical settlement events in the protected rehearsal. This is testnet evidence, not a mainnet payout."
+  },
+  "evidence_boundary": "The deployment receipt, exact immutable getters, runtime code hash, keeper balance, and relay receipt are confirmed Base-mainnet evidence. Only a canonical BountySettled event proves a future bounty payout."
+}

--- a/docs/autonomous-protocol.md
+++ b/docs/autonomous-protocol.md
@@ -252,6 +252,17 @@ criteria. The complete content-addressed child terms must be published and
 retrievable before creation; direct factory calls do not repair missing or
 invalid terms.
 
+#### Independent Child Distribution Module V2
+
+`agent-bounties/independent-child-v2` is the current standing-meta policy. Its
+proof remains exactly `abi.encode(address childBounty)`, but the module also
+requires pre-claim terms publication in `OnchainTermsRegistry`, pre-claim
+eligibility in `ParticipantEligibilityRegistry`, different immutable
+participant IDs, and a child committed to the exact sandboxed-regression signed
+verifier set at threshold two. The child must be canonically settled before the
+parent submission. This closes the late-terms, same-operator multi-wallet, and
+unverifiable-child gaps in canonical-child-v1.
+
 ### Signed Quorum
 
 The bounty commits one to eight verifier wallets and a threshold. Each verifier

--- a/docs/bounded-agent-wallet.md
+++ b/docs/bounded-agent-wallet.md
@@ -25,7 +25,11 @@ The proposed first mainnet policy is:
 | Actions | create, fund, claim, submit |
 | Verification | exact approved deterministic module only |
 
-Signed-quorum and AI-judge bounties are disabled in the initial policy. Returned
+The first live policy allowed the permissionless proof-of-work module. Policy
+version two replaces that module with the standing-meta-v2 verifier while
+preserving every financial cap, action permission, expiry, wallet balance, and
+prior spend counter. Signed-quorum and AI-judge actions remain disabled at the
+bounded-wallet layer. Returned
 claim bonds and bounty earnings increase the wallet balance but do not restore
 the gross lifetime budget. The owner must explicitly replace the policy to
 extend authority.
@@ -111,6 +115,14 @@ The plan includes exact calldata for `revokePolicy()`. Revocation stops new
 delegate actions immediately. The owner may then call
 `withdrawToken(nativeUsdc, owner, balance)` or install a reviewed replacement
 policy. Ownership transfer is two-step.
+
+An existing wallet may move from the obsolete verifier to the reviewed
+standing-meta-v2 verifier with one zero-value `configurePolicy` transaction.
+Use a fresh delegate at the same time because local bindings are intentionally
+immutable. The activation page reads the complete live policy, accepts only the
+known obsolete verifier or current reviewed verifier, changes only the delegate
+and verifier words, simulates the call, and then verifies the exact receipt,
+version increment, unchanged caps, unchanged balance, and unchanged prior spend.
 
 ## Activation State
 

--- a/docs/local-delegate-wallet.md
+++ b/docs/local-delegate-wallet.md
@@ -49,6 +49,19 @@ python scripts/local_delegate_wallet.py bind `
 Binding is intentionally immutable. Rotate by creating a new delegate directory
 and installing a new owner-approved policy.
 
+For a verifier upgrade, keep the old signer recoverable until confirmation by
+using a separate state directory:
+
+```powershell
+$state = Join-Path $env:LOCALAPPDATA "AgentBounties\delegate-v2"
+python scripts/local_delegate_wallet.py --state-dir $state init
+python scripts/local_delegate_wallet.py --state-dir $state status
+```
+
+Enter only the printed public address on `agent-budget.html`. After the exact
+zero-value update is confirmed and independently inspected, bind that directory
+to the new on-chain policy hash with `--state-dir $state`.
+
 ## Sign One Gas-Sponsored Creation
 
 First publish terms and request the canonical creation plan from the hosted API.

--- a/docs/standing-meta-bounty-invariant.md
+++ b/docs/standing-meta-bounty-invariant.md
@@ -1,79 +1,68 @@
 # Standing Meta-Bounty Invariant
 
-Agent Bounties maintains a funded incentive for participants to create useful
+Agent Bounties maintains funded incentives for participants to post useful
 bounties that a different participant completes.
 
 ## Inventory Rule
 
-- Hard floor: at least one canonical, fully funded, claimable standing
-  meta-bounty on Base mainnet.
-- Replenishment target: at least two qualifying meta-bounties. The second
-  bounty preserves claimable supply while the first is being claimed.
-- A GitHub issue, unsigned transaction plan, wallet signature, broadcast hash,
-  or indexed bounty without canonical funding evidence does not count.
-- An ordinary funded bounty does not count toward the standing meta-bounty
-  floor.
+- A qualifying bounty is canonical, fully funded, claimable, and verified by
+  the exact standing-meta-v2 module on Base mainnet.
+- The current migration floor is one and the replenishment target is two. The
+  floor moves to five only after five v2 contracts are canonically funded and
+  independently reconciled; changing a CI number does not create inventory.
+- An issue, unsigned plan, signature, broadcast hash, or unconfirmed index row
+  does not count.
+- Ordinary funded bounties do not count toward the standing-meta floor.
 
-The inventory guard runs every 15 minutes. Zero qualifying meta-bounties fails
-the workflow. One satisfies the hard floor but raises a replenishment warning.
-Two or more satisfies the current operating target.
+The inventory guard runs every 15 minutes and fails closed when canonical
+evidence is stale, malformed, or below the configured floor.
 
 ## Qualifying Outcome
 
-A qualifying standing meta-bounty uses the exact deployed
-`CanonicalChildBountyVerifier` runtime and locked acceptance criteria. Its
-solver is paid only after all of these conditions are true:
+A qualifying parent uses the deployed `CanonicalIndependentChildVerifierV2`
+runtime and its exact acceptance criteria. The parent solver is paid only after:
 
-1. The solver creates a canonical autonomous-v1 child bounty.
-2. The child is fully funded to at least the parent solver reward. Pooled
-   funding is allowed.
-3. The child benchmark is bound to the parent bounty and round, and the child
-   uses its own explicit deterministic verifier.
-4. A different wallet completes the child and receives canonical settlement
-   before the parent verification deadline.
+1. The solver publishes exact parent-bound child terms on Base before claiming
+   the parent.
+2. The solver creates and fully funds that canonical child to at least the
+   parent solver reward.
+3. The child uses the committed sandboxed-regression signed verifier quorum,
+   immutable task criteria, and threshold two.
+4. Parent and child solvers were registered before the parent claim and have
+   different immutable participant IDs.
+5. The different participant completes the child and receives canonical
+   settlement before the parent solver submits the child address.
 
-This makes posting new funded work and attracting another participant the
-measurable work product. A solver cannot complete the required child loop with
-the same wallet. This address-level separation does not prove unrelated
-beneficial ownership, so standing rewards remain deliberately small and public
-analytics should flag repeated wallet clusters rather than claiming Sybil
-resistance.
+This makes posting funded work and attracting another participant the
+measurable product. Participant IDs are stronger than wallet separation, but
+they are not universal proof of unrelated beneficial ownership; analytics must
+not claim complete Sybil resistance.
 
 ## Evidence Boundary
 
-The portable inventory verifier marks a bounty as `standing_meta_bounty` only
-after it verifies:
+The portable inventory verifier marks `standing_meta_bounty` only after it
+verifies canonical claimability and funding, content-addressed terms, the exact
+verifier address and runtime hash at a Base safe block, and the locked
+acceptance-criteria hash. The immutable module then enforces on-chain terms,
+participant eligibility, different participants, the signed-quorum child
+policy, and canonical child settlement.
 
-- canonical claimability and complete funding;
-- content-addressed terms matching the on-chain commitments;
-- the canonical child verifier address and acceptance criteria;
-- the verifier's exact runtime code hash at a Base `safe` block; and
-- the explicit different-wallet and settled-child requirements.
+The child terms bind the parent ID and round, child policy, benchmark, evidence
+schema, acceptance criteria, verifier set, and threshold. Late, missing, or
+mismatched terms cannot settle the parent. Only a confirmed canonical
+`BountySettled` event proves eventual payout.
 
-The child must independently publish retrievable terms and use a task-specific
-deterministic verifier whose payout condition matches those terms. The parent
-canonical-child verifier and the leading-zero proof-of-work canary are not
-valid child task verifiers. A direct on-chain child with missing or invalid
-terms does not count as healthy inventory even if its immutable contract can be
-claimed.
-
-The guard rejects malformed or spoofed standing-meta descriptors. Only a
-confirmed canonical `BountySettled` event proves eventual payout.
-
-The initial Base mainnet verifier deployment, four-bounty activation receipt,
-canonical event counts, and exact safe-block state are recorded in
-[`docs/evidence/standing-meta-bounties-base-mainnet-2026-07-13.json`](evidence/standing-meta-bounties-base-mainnet-2026-07-13.json).
+The v2 Base-mainnet deployment, runtime hash, Base Sepolia end-to-end rehearsal,
+and keeper reserve proof are recorded in
+[`deployments/standing-meta-v2-base-mainnet.json`](../deployments/standing-meta-v2-base-mainnet.json).
 
 ## Replenishment
 
-When inventory falls below two, replenishment is the highest-priority liquidity
-operation. Create and fully fund another canonical child-loop bounty, publish
-its terms, and wait for canonical indexing before counting it.
+When inventory falls below the configured target, replenishment is the
+highest-priority liquidity operation. Create and fully fund another canonical
+standing-meta-v2 bounty and wait for canonical indexing before counting it.
 
-The current autonomous-v1 contracts do not atomically reserve a replacement
-when the final claimable meta-bounty is claimed. The two-bounty target and
-15-minute fail-closed monitor reduce that gap but cannot eliminate simultaneous
-claim risk. An absolute always-claimable guarantee requires a future on-chain
-inventory coordinator or preauthorized replenishment reserve. Until then,
-public status must distinguish the hard monitored floor from an atomic
-guarantee.
+The contracts do not atomically reserve a replacement when inventory is
+claimed. Monitoring and a preauthorized bounded reserve reduce this gap but do
+not eliminate simultaneous claims. An absolute always-claimable guarantee
+requires a future on-chain inventory coordinator.

--- a/scripts/bounty_inventory_guard.py
+++ b/scripts/bounty_inventory_guard.py
@@ -38,15 +38,15 @@ ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
 BYTES32 = re.compile(r"^0x[0-9a-fA-F]{64}$")
 CLAIMABLE_EVIDENCE = "confirmed_canonical_autonomous_bounty"
 MAX_REPORT_AGE_SECONDS = 900
-STANDING_META_SCHEMA = "agent-bounties/standing-meta-bounty-v1"
+STANDING_META_SCHEMA = "agent-bounties/standing-meta-bounty-v2"
 STANDING_META_CLASS = "post_bounty_third_party_completion"
-STANDING_META_PROTOCOL = "agent-bounties/canonical-child-v1"
-STANDING_META_VERIFIER = "0x40adac5a1d00a725f77682f8940b893eaed31ecf"
+STANDING_META_PROTOCOL = "agent-bounties/independent-child-v2"
+STANDING_META_VERIFIER = "0xe573cb4f471d38b5bf10ce82237251ac902c9867"
 STANDING_META_VERIFIER_CODE_HASH = (
-    "0xbb6d6df11b85f59b5010aa61f4caf499fb27b94a0f5978aff85fa97ed2bbd2c3"
+    "0xe3b6e82880edee69b1f30560506ac80a46b4ebcc6c083cfa8207e3673eede26c"
 )
 STANDING_META_ACCEPTANCE_HASH = (
-    "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de"
+    "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54"
 )
 
 

--- a/scripts/build_bounded_agent_wallet_bundle.py
+++ b/scripts/build_bounded_agent_wallet_bundle.py
@@ -17,7 +17,7 @@ CREATE2_DEPLOYER = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
 CREATE2_DEPLOYER_CODE_HASH = "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989"
 BOUNTY_FACTORY = "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9"
 USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
-VERIFIER = "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e"
+VERIFIER = "0xe573cb4f471d38b5bf10ce82237251ac902c9867"
 SALT_LABEL = "agent-bounties/base-mainnet/bounded-agent-wallet-factory/v1"
 SOURCE_INPUTS = ("contracts/base-escrow",)
 

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -146,6 +146,9 @@ def main() -> int:
     bounded_deployment = json.loads(
         (repo_root / "deployments" / "bounded-agent-wallet-base-mainnet.json").read_text(encoding="utf-8")
     )
+    standing_meta_deployment = json.loads(
+        (repo_root / "deployments" / "standing-meta-v2-base-mainnet.json").read_text(encoding="utf-8")
+    )
     bounded_page = (site_dir / "agent-budget.html").read_text(encoding="utf-8")
     bounded_javascript = (site_dir / "agent-budget.js").read_text(encoding="utf-8")
     pages_workflow = (repo_root / ".github" / "workflows" / "pages.yml").read_text(encoding="utf-8")
@@ -516,8 +519,8 @@ def main() -> int:
             "Lifetime gross spend, USDC",
             "exact approved deterministic verifier only",
             "Owner escape hatch",
-            "Review delegate rotation",
-            "Rotate delegate",
+            "Review policy update",
+            "Update policy",
             "not independently audited",
             "Post your own bounty",
             "agent-budget.js",
@@ -540,7 +543,8 @@ def main() -> int:
             'predictWallet: "0x240fa116"',
             'revokePolicy: "0x9eba3667"',
             'configurePolicy: "0x27d3543c"',
-            "Only the delegate changes",
+            "Only the delegate and deterministic verifier change",
+            "OBSOLETE_DETERMINISTIC_VERIFIER",
             "manifest.contract_source_dirty !== false",
             "contract_source_revision",
             "contract_source_revision_kind",
@@ -603,6 +607,24 @@ def main() -> int:
     for name, value in pinned_values.items():
         if f'{name}: "{value.lower()}"' not in bounded_javascript:
             fail(f"agent budget activation does not pin manifest field: {name}")
+    if standing_meta_deployment.get("schema") != "agent-bounties/standing-meta-v2-deployment-v1":
+        fail("standing-meta-v2 deployment manifest has the wrong schema")
+    if standing_meta_deployment.get("chain_id") != 8453 or standing_meta_deployment.get("network") != "base-mainnet":
+        fail("standing-meta-v2 deployment manifest must target Base mainnet")
+    if standing_meta_deployment.get("deployment", {}).get("receipt_status") != 1:
+        fail("standing-meta-v2 deployment manifest requires a successful receipt")
+    standing_components = standing_meta_deployment.get("components", {})
+    if standing_components.get("verifier_module") != bounded_deployment["canonical"]["deterministic_verifier"]:
+        fail("bounded wallet and standing-meta-v2 manifests disagree on the verifier")
+    if standing_components.get("verifier_runtime_code_hash") != (
+        "0xe3b6e82880edee69b1f30560506ac80a46b4ebcc6c083cfa8207e3673eede26c"
+    ):
+        fail("standing-meta-v2 deployment manifest has the wrong verifier runtime hash")
+    reserve = standing_meta_deployment.get("keeper_reserve", {})
+    if reserve.get("functional_relay_receipt_status") != 1:
+        fail("keeper reserve evidence requires a successful relay receipt")
+    if reserve.get("confirmed_balance_wei", 0) < reserve.get("floor_wei", 1):
+        fail("keeper reserve evidence is below its configured floor")
     require_phrases(
         "pages.yml bounded wallet",
         pages_workflow,

--- a/scripts/plan_bounded_agent_budget.py
+++ b/scripts/plan_bounded_agent_budget.py
@@ -27,7 +27,7 @@ EXPECTED_CHAIN_ID = 8453
 EXPECTED_CANONICAL = {
     "bounty_factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-    "deterministic_verifier": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
+    "deterministic_verifier": "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
 }
 EXPECTED_CREATE2_DEPLOYER = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
 EXPECTED_CREATE2_DEPLOYER_HASH = "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989"

--- a/scripts/test_bounty_inventory_guard.py
+++ b/scripts/test_bounty_inventory_guard.py
@@ -53,19 +53,19 @@ def standing_meta_report(*, corrupt_code_hash: bool = False) -> Path:
     item.update(
         {
             "verification_mode": "deterministic_module",
-            "verifier_module": "0x40adac5a1d00a725f77682f8940b893eaed31ecf",
+            "verifier_module": "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
             "verification_ready": True,
             "standing_meta_bounty": {
-                "schema_version": "agent-bounties/standing-meta-bounty-v1",
+                "schema_version": "agent-bounties/standing-meta-bounty-v2",
                 "inventory_class": "post_bounty_third_party_completion",
-                "verifier_protocol": "agent-bounties/canonical-child-v1",
-                "verifier_module": "0x40adac5a1d00a725f77682f8940b893eaed31ecf",
+                "verifier_protocol": "agent-bounties/independent-child-v2",
+                "verifier_module": "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
                 "verifier_runtime_code_hash": (
                     "0x" + "66" * 32
                     if corrupt_code_hash
-                    else "0xbb6d6df11b85f59b5010aa61f4caf499fb27b94a0f5978aff85fa97ed2bbd2c3"
+                    else "0xe3b6e82880edee69b1f30560506ac80a46b4ebcc6c083cfa8207e3673eede26c"
                 ),
-                "acceptance_criteria_hash": "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de",
+                "acceptance_criteria_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
                 "requires_funded_canonical_child": True,
                 "requires_different_solver_wallet": True,
                 "required_child_status": "settled",

--- a/site/agent-budget.html
+++ b/site/agent-budget.html
@@ -109,14 +109,14 @@
             </label>
             <label class="check-line">
               <input name="rotationReviewed" type="checkbox">
-              <span>I reviewed the delegate-only policy change. All limits, allowed actions, verifier restrictions, expiry, balance, and prior spend remain unchanged.</span>
+              <span>I reviewed the exact delegate and verifier change. All limits, allowed actions, verification modes, expiry, balance, and prior spend remain unchanged.</span>
             </label>
             <div class="actions">
-              <button id="review-delegate-rotation" class="button secondary" type="button" disabled>Review delegate rotation</button>
-              <button id="rotate-agent-delegate" class="button secondary" type="button" disabled>Rotate delegate</button>
+              <button id="review-delegate-rotation" class="button secondary" type="button" disabled>Review policy update</button>
+              <button id="rotate-agent-delegate" class="button secondary" type="button" disabled>Update policy</button>
               <button id="revoke-agent-budget" class="button secondary" type="button" disabled>Revoke agent authority</button>
             </div>
-            <p class="fine">Rotation replaces only the signer and invalidates queued signatures. Revocation blocks all new delegate actions. Neither action moves the wallet's USDC.</p>
+            <p class="fine">The update replaces the signer and, only when required, the obsolete verifier with the reviewed standing-meta-v2 verifier. Revocation blocks all new delegate actions. Neither action moves the wallet's USDC.</p>
           </div>
         </form>
       </section>

--- a/site/agent-budget.js
+++ b/site/agent-budget.js
@@ -19,7 +19,7 @@
     sourceRevision: "dc05b4e01474f09f02bb1bbb69651e4ce4deb338",
     bountyFactory: "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     settlementToken: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-    deterministicVerifier: "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
+    deterministicVerifier: "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
     deterministicDeployer: "0x4e59b44847b379578588920ca78fbf26c0b4956c",
     deterministicDeployerHash: "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989",
     walletFactory: "0x3840936351049aed639780a16845e6094c1f17f6",
@@ -28,6 +28,7 @@
     implementationRuntimeHash: "0x7fb59d5add3ac348ac3d7e6a5aa6b22ad542a6e6093a1ceb8d535f747ed536df",
     cloneRuntimeHash: "0xc663bed9b4097e22e5a18c0ecb662561bf45df1829e6412cdd0d8568d05ca1b6",
   });
+  const OBSOLETE_DETERMINISTIC_VERIFIER = "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e";
   const SELECTORS = Object.freeze({
     predictWallet: "0x240fa116",
     createAndFund: "0x86f357d0",
@@ -740,15 +741,20 @@
     if (delegate === state.account) throw new Error("Use a dedicated delegate address, not the owner wallet.");
     const observed = await inspectExistingWallet(wallet);
     const currentDelegate = wordAddress(observed.policy[0], "Current delegate");
-    if (delegate === currentDelegate) throw new Error("Replacement delegate is already active.");
-    if (wordAddress(observed.policy[10], "Deterministic verifier")
-      !== state.manifest.canonical.deterministic_verifier) {
-      throw new Error("Existing policy does not use the reviewed deterministic verifier.");
+    const currentVerifier = wordAddress(observed.policy[10], "Deterministic verifier");
+    const nextVerifier = state.manifest.canonical.deterministic_verifier;
+    if (currentVerifier !== nextVerifier && currentVerifier !== OBSOLETE_DETERMINISTIC_VERIFIER) {
+      throw new Error("Existing policy uses an unknown verifier; this page will not replace it.");
+    }
+    const verifierChanged = currentVerifier !== nextVerifier;
+    if (delegate === currentDelegate && !verifierChanged) {
+      throw new Error("The replacement delegate and reviewed verifier are already active.");
     }
     const now = BigInt(await latestTimestamp());
     if (wordUint(observed.policy[2]) <= now) throw new Error("Existing policy is expired; create a new reviewed policy instead.");
     const nextPolicy = [...observed.policy];
     nextPolicy[0] = addressWord(delegate);
+    nextPolicy[10] = addressWord(nextVerifier);
     const nextEncoded = `0x${nextPolicy.join("")}`;
     const currentHash = await hash(observed.policyEncoded);
     const nextHash = await hash(nextEncoded);
@@ -757,6 +763,9 @@
       wallet,
       delegate,
       currentDelegate,
+      currentVerifier,
+      nextVerifier,
+      verifierChanged,
       currentPolicy: observed.policyEncoded,
       currentHash,
       nextPolicy: nextEncoded,
@@ -771,10 +780,14 @@
       `Bounded wallet: ${wallet}`,
       `Current delegate: ${currentDelegate}`,
       `Replacement delegate: ${delegate}`,
+      `Current verifier: ${currentVerifier}`,
+      `Reviewed verifier: ${nextVerifier}`,
       `Current / next policy version: ${observed.version} / ${observed.version + 1n}`,
       `Current / next policy hash: ${currentHash} / ${nextHash}`,
       `Wallet balance remains ${Number(observed.balance) / 1_000_000} USDC.`,
-      "Only the delegate changes; all spending caps, actions, verifier restrictions, and expiry remain byte-for-byte identical.",
+      verifierChanged
+        ? "Only the delegate and deterministic verifier change; all caps, actions, modes, expiry, balance, and prior spend remain byte-for-byte identical."
+        : "Only the delegate changes; all caps, actions, verifier restrictions, expiry, balance, and prior spend remain byte-for-byte identical.",
       "The transaction transfers no USDC or ETH.",
     ], "pending");
     updateButtons();
@@ -782,7 +795,7 @@
 
   async function rotateDelegate() {
     if (!state.rotationPlan) throw new Error("Review the exact delegate rotation first.");
-    if (!form().elements.rotationReviewed.checked) throw new Error("Confirm the exact delegate-only change first.");
+    if (!form().elements.rotationReviewed.checked) throw new Error("Confirm the exact reviewed policy change first.");
     if (rotationSnapshot() !== state.rotationPlan.snapshot) {
       state.rotationPlan = null;
       throw new Error("Wallet or delegate changed. Review the rotation again.");
@@ -808,6 +821,7 @@
         "Confirm one zero-value owner transaction.",
         `Wallet: ${state.rotationPlan.wallet}`,
         `Replacement delegate: ${state.rotationPlan.delegate}`,
+        `Reviewed verifier: ${state.rotationPlan.nextVerifier}`,
         `Next policy hash: ${state.rotationPlan.nextHash}`,
         "No token or native-ETH transfer is requested.",
       ], "pending");
@@ -820,10 +834,11 @@
         || after.balance !== state.rotationPlan.balance) {
         throw new Error("Confirmed rotation did not produce the exact reviewed wallet state.");
       }
-      status("Agent delegate rotated", "success");
+      status(state.rotationPlan.verifierChanged ? "Agent policy upgraded" : "Agent delegate rotated", "success");
       output([
-        `Rotation confirmed: ${transactionHash}`,
+        `Policy update confirmed: ${transactionHash}`,
         `Active delegate: ${state.rotationPlan.delegate}`,
+        `Active verifier: ${state.rotationPlan.nextVerifier}`,
         `Policy hash: ${state.rotationPlan.nextHash}`,
         `Wallet balance: ${Number(after.balance) / 1_000_000} USDC`,
         "The agent can now sign capped actions for a separate gas sponsor; the wallet needs no ETH.",

--- a/skills/agent-bounties/scripts/check-in.mjs
+++ b/skills/agent-bounties/scripts/check-in.mjs
@@ -32,17 +32,18 @@ const KECCAK_ROUND_CONSTANTS = Object.freeze([
 ]);
 const TERMS_SOURCE_COMMIT = "907f8741f8127a9610aa796cbce15c91a0bc690a";
 export const STANDING_META_BOUNTY = Object.freeze({
-  schemaVersion: "agent-bounties/standing-meta-bounty-v1",
+  schemaVersion: "agent-bounties/standing-meta-bounty-v2",
   inventoryClass: "post_bounty_third_party_completion",
-  verifierProtocol: "agent-bounties/canonical-child-v1",
-  verifierModule: "0x40adac5a1d00a725f77682f8940b893eaed31ecf",
-  verifierRuntimeCodeHash: "0xbb6d6df11b85f59b5010aa61f4caf499fb27b94a0f5978aff85fa97ed2bbd2c3",
-  acceptanceCriteriaHash: "0xa103c2c907f96e03a2f2b0e6b2209e0a3ca53686f7e9f79d89d7bfa1f8e314de",
+  verifierProtocol: "agent-bounties/independent-child-v2",
+  verifierModule: "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
+  verifierRuntimeCodeHash: "0xe3b6e82880edee69b1f30560506ac80a46b4ebcc6c083cfa8207e3673eede26c",
+  acceptanceCriteriaHash: "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
   acceptanceCriteria: Object.freeze([
-    "Post a canonical autonomous-v1 child bounty whose creator is the active solver.",
-    "Fully fund the child to at least the parent solver reward; pooled contributors are allowed.",
-    "Bind the child benchmark to the parent bounty ID and round and use an explicit deterministic verifier.",
-    "Have a different wallet complete the child and receive canonical settlement before the parent verification deadline.",
+    "Publish the exact child terms on Base from the parent solver wallet before claiming this bounty.",
+    "Create and fully fund the parent-bound canonical child to at least this bounty solver reward.",
+    "Use the committed sandboxed-regression signed verifier quorum and immutable task criteria.",
+    "Have a participant registered before the parent claim, with a different participant ID, complete the child.",
+    "Receive canonical child settlement before submitting the child address to this verifier.",
   ]),
 });
 


### PR DESCRIPTION
## Summary
- publish the confirmed Base-mainnet standing-meta-v2 deployment, Sepolia rehearsal, and keeper reserve/relay evidence
- pin the bounded wallet to the v2 verifier and add a fail-closed one-confirmation delegate/verifier policy upgrade
- update canonical inventory recognition and agent discovery to the exact v2 address, runtime hash, and acceptance criteria
- document the participant, terms, signed-quorum child, and settlement requirements

## Safety boundary
The owner transaction is zero value. The upgrade path changes only policy words 0 (delegate) and 10 (deterministic verifier), simulates first, and rejects any change to caps, actions, modes, expiry, balance, lifetime spend, or unknown current verifier.

## Verification
- full scripts/check.ps1 passed (203s)
- Python inventory, wallet, and relay tests passed
- OpenClaw discovery tests passed
- site and docs contract checks passed
- Base deployment receipt and exact runtime hash independently rechecked