### PR TITLE
Enforce five funded standing meta bounties

### DIFF
--- a/.github/workflows/bounty-inventory-guard.yml
+++ b/.github/workflows/bounty-inventory-guard.yml
@@ -81,8 +81,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           BOUNTY_INVENTORY_THRESHOLD: "5"
-          META_BOUNTY_INVENTORY_THRESHOLD: "1"
-          META_BOUNTY_REPLENISHMENT_TARGET: "2"
+          META_BOUNTY_INVENTORY_THRESHOLD: "5"
+          META_BOUNTY_REPLENISHMENT_TARGET: "5"
         run: |
           python scripts/bounty_inventory_guard.py \
             --claimable-report claimable-inventory.json \

--- a/docs/standing-meta-bounty-invariant.md
+++ b/docs/standing-meta-bounty-invariant.md
@@ -7,9 +7,9 @@ bounties that a different participant completes.
 
 - A qualifying bounty is canonical, fully funded, claimable, and verified by
   the exact standing-meta-v2 module on Base mainnet.
-- The current migration floor is one and the replenishment target is two. The
-  floor moves to five only after five v2 contracts are canonically funded and
-  independently reconciled; changing a CI number does not create inventory.
+- The hard floor and replenishment target are both five. This became enforceable
+  only after five v2 contracts were canonically funded and independently
+  reconciled; changing a CI number does not create inventory.
 - An issue, unsigned plan, signature, broadcast hash, or unconfirmed index row
   does not count.
 - Ordinary funded bounties do not count toward the standing-meta floor.
@@ -58,9 +58,9 @@ and keeper reserve proof are recorded in
 
 ## Replenishment
 
-When inventory falls below the configured target, replenishment is the
-highest-priority liquidity operation. Create and fully fund another canonical
-standing-meta-v2 bounty and wait for canonical indexing before counting it.
+When inventory falls below five, replenishment is the highest-priority
+liquidity operation. Create and fully fund another canonical standing-meta-v2
+bounty and wait for canonical indexing before counting it.
 
 The contracts do not atomically reserve a replacement when inventory is
 claimed. Monitoring and a preauthorized bounded reserve reduce this gap but do

--- a/scripts/bounty_inventory_guard.py
+++ b/scripts/bounty_inventory_guard.py
@@ -141,14 +141,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument(
         "--meta-threshold",
         type=int,
-        default=int(os.environ.get("META_BOUNTY_INVENTORY_THRESHOLD", "1")),
-        help="Hard floor for funded, claimable standing meta-bounties (default 1)",
+        default=int(os.environ.get("META_BOUNTY_INVENTORY_THRESHOLD", "5")),
+        help="Hard floor for funded, claimable standing meta-bounties (default 5)",
     )
     p.add_argument(
         "--meta-replenishment-target",
         type=int,
-        default=int(os.environ.get("META_BOUNTY_REPLENISHMENT_TARGET", "2")),
-        help="Target that creates a buffer above the standing meta-bounty floor (default 2)",
+        default=int(os.environ.get("META_BOUNTY_REPLENISHMENT_TARGET", "5")),
+        help="Target for funded, claimable standing meta-bounties (default 5)",
     )
     p.add_argument(
         "--claimable-report",

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -216,20 +216,27 @@ function standingMetaTransport(runtimeCodeHash = STANDING_META_BOUNTY.verifierRu
 
 function makeHostedStandingMetaCandidate(item) {
   item.verifier_module = STANDING_META_BOUNTY.verifierModule;
+  item.terms.acceptance_criteria_hash = STANDING_META_BOUNTY.acceptanceCriteriaHash;
   item.terms.document.acceptance_criteria = [...STANDING_META_BOUNTY.acceptanceCriteria];
   item.terms.document.benchmark = {
-    engine: "canonical_child_loop_v1",
+    engine: "standing_meta_v2_parent",
+    lane: "cli",
+    required_child_engine: STANDING_META_BOUNTY.childEngine,
     required_child_status: "settled",
-    verifier_module: STANDING_META_BOUNTY.verifierModule,
+    required_child_verifier_set_hash: STANDING_META_BOUNTY.childVerifierSetHash,
+    required_child_verifier_threshold: STANDING_META_BOUNTY.childVerifierThreshold,
+    participant_registry: STANDING_META_BOUNTY.participantRegistry,
+    terms_registry: STANDING_META_BOUNTY.termsRegistry,
   };
   item.terms.document.evidence_schema = {
     type: "object",
-    required: ["child_bounty_contract"],
+    required: [...STANDING_META_BOUNTY.requiredEvidence],
   };
   item.terms.document.verification_policy = {
     mechanism: "deterministic_module",
     verifier_module: STANDING_META_BOUNTY.verifierModule,
     threshold: 1,
+    self_verification_forbidden: true,
   };
   return item;
 }
@@ -760,6 +767,21 @@ test("hosted meta-looking terms do not count when verifier bytecode differs", as
   assert.equal(report.verified_claimable_bounties.length, 1);
   assert.equal(report.verified_claimable_bounties[0].standing_meta_bounty, undefined);
   assert.ok(report.warnings.includes("standing_meta_verifier_code_mismatch"));
+});
+
+test("hosted meta-looking terms do not count when the child quorum drifts", async () => {
+  const input = await fixture("verified-claimable.json");
+  const item = makeHostedStandingMetaCandidate(input.autonomous_feed.body[0]);
+  item.terms.document.benchmark.required_child_verifier_set_hash = `0x${"66".repeat(32)}`;
+  const report = await collectInventory({
+    apiBaseUrl: "https://api.example.test",
+    fixture: input,
+    baseRpcUrl: "https://rpc.example.test",
+    rpcTransport: standingMetaTransport(),
+  });
+
+  assert.equal(report.verified_claimable_bounties.length, 1);
+  assert.equal(report.verified_claimable_bounties[0].standing_meta_bounty, undefined);
 });
 
 test("hosted quorum bounty is excluded without a service availability attestation", async () => {

--- a/scripts/test_bounty_inventory_guard.py
+++ b/scripts/test_bounty_inventory_guard.py
@@ -15,11 +15,13 @@ SCRIPT = Path(__file__).resolve().parent / "bounty_inventory_guard.py"
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 
-def run_guard(*args: str) -> subprocess.CompletedProcess[str]:
+def run_guard(
+    *args: str, use_meta_defaults: bool = False
+) -> subprocess.CompletedProcess[str]:
     resolved = list(args)
-    if "--meta-threshold" not in resolved:
+    if not use_meta_defaults and "--meta-threshold" not in resolved:
         resolved.extend(["--meta-threshold", "0"])
-    if "--meta-replenishment-target" not in resolved:
+    if not use_meta_defaults and "--meta-replenishment-target" not in resolved:
         resolved.extend(["--meta-replenishment-target", "0"])
     return subprocess.run(
         [sys.executable, str(SCRIPT), *resolved],
@@ -42,40 +44,47 @@ def current_claimable_report(name: str, *, bom: bool = False) -> Path:
     return target
 
 
-def standing_meta_report(*, corrupt_code_hash: bool = False) -> Path:
+def standing_meta_report(
+    *, count: int = 1, corrupt_code_hash: bool = False
+) -> Path:
     data = json.loads(
         (FIXTURES / "bounty_inventory_claimable_above.json").read_text(
             encoding="utf-8"
         )
     )
     data["observed_at"] = datetime.now(timezone.utc).isoformat()
-    item = data["verified_claimable_bounties"][0]
-    item.update(
-        {
-            "verification_mode": "deterministic_module",
-            "verifier_module": "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
-            "verification_ready": True,
-            "standing_meta_bounty": {
-                "schema_version": "agent-bounties/standing-meta-bounty-v2",
-                "inventory_class": "post_bounty_third_party_completion",
-                "verifier_protocol": "agent-bounties/independent-child-v2",
+    items = data["verified_claimable_bounties"]
+    if count < 0 or count > len(items):
+        raise ValueError("standing meta fixture count is out of range")
+    for index, item in enumerate(items[:count]):
+        item.update(
+            {
+                "verification_mode": "deterministic_module",
                 "verifier_module": "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
-                "verifier_runtime_code_hash": (
-                    "0x" + "66" * 32
-                    if corrupt_code_hash
-                    else "0xe3b6e82880edee69b1f30560506ac80a46b4ebcc6c083cfa8207e3673eede26c"
-                ),
-                "acceptance_criteria_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
-                "requires_funded_canonical_child": True,
-                "requires_different_solver_wallet": True,
-                "required_child_status": "settled",
-                "observed_block_number": 74565,
-                "observed_block_hash": "0x" + "dd" * 32,
-            },
-        }
-    )
+                "verification_ready": True,
+                "standing_meta_bounty": {
+                    "schema_version": "agent-bounties/standing-meta-bounty-v2",
+                    "inventory_class": "post_bounty_third_party_completion",
+                    "verifier_protocol": "agent-bounties/independent-child-v2",
+                    "verifier_module": "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
+                    "verifier_runtime_code_hash": (
+                        "0x" + "66" * 32
+                        if corrupt_code_hash and index == 0
+                        else "0xe3b6e82880edee69b1f30560506ac80a46b4ebcc6c083cfa8207e3673eede26c"
+                    ),
+                    "acceptance_criteria_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
+                    "requires_funded_canonical_child": True,
+                    "requires_different_solver_wallet": True,
+                    "required_child_status": "settled",
+                    "observed_block_number": 74565 + index,
+                    "observed_block_hash": "0x" + f"{221 + index:02x}" * 32,
+                },
+            }
+        )
     target = ROOT / "target" / "tmp" / (
-        "standing-meta-corrupt.json" if corrupt_code_hash else "standing-meta.json"
+        "standing-meta-corrupt.json"
+        if corrupt_code_hash
+        else f"standing-meta-{count}.json"
     )
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(json.dumps(data), encoding="utf-8")
@@ -83,6 +92,38 @@ def standing_meta_report(*, corrupt_code_hash: bool = False) -> Path:
 
 
 class BountyInventoryGuardTests(unittest.TestCase):
+    def test_default_standing_meta_floor_requires_five(self) -> None:
+        passing = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "5",
+            "--claimable-report",
+            str(standing_meta_report(count=5)),
+            "--fail-below",
+            use_meta_defaults=True,
+        )
+        self.assertEqual(passing.returncode, 0, passing.stderr + passing.stdout)
+        payload = json.loads(passing.stdout.split("--- JSON ---", 1)[1])
+        self.assertEqual(payload["meta_threshold"], 5)
+        self.assertEqual(payload["meta_replenishment_target"], 5)
+        self.assertEqual(payload["verified_meta_claimable_count"], 5)
+
+        below = run_guard(
+            "--fixture",
+            str(FIXTURES / "bounty_inventory_above.json"),
+            "--threshold",
+            "5",
+            "--claimable-report",
+            str(standing_meta_report(count=4)),
+            "--fail-below",
+            use_meta_defaults=True,
+        )
+        self.assertEqual(below.returncode, 2, below.stderr + below.stdout)
+        payload = json.loads(below.stdout.split("--- JSON ---", 1)[1])
+        self.assertEqual(payload["verified_meta_claimable_count"], 4)
+        self.assertTrue(payload["meta_below_threshold"])
+
     def test_claimable_report_accepts_utf8_bom(self) -> None:
         bom_report = current_claimable_report(
             "bounty_inventory_claimable_above.json", bom=True

--- a/skills/agent-bounties/scripts/check-in.mjs
+++ b/skills/agent-bounties/scripts/check-in.mjs
@@ -38,6 +38,17 @@ export const STANDING_META_BOUNTY = Object.freeze({
   verifierModule: "0xe573cb4f471d38b5bf10ce82237251ac902c9867",
   verifierRuntimeCodeHash: "0xe3b6e82880edee69b1f30560506ac80a46b4ebcc6c083cfa8207e3673eede26c",
   acceptanceCriteriaHash: "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
+  childEngine: "sandboxed_regression_v1",
+  childVerifierSetHash: "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
+  childVerifierThreshold: 2,
+  participantRegistry: "0x9875dcaf570bde8ff1aa62275d3c8985f4fd1294",
+  termsRegistry: "0x35e5d49c12b75c119d33951c2c4f054c5732208c",
+  requiredEvidence: Object.freeze([
+    "child_bounty_contract",
+    "discovery_source",
+    "participation_reason",
+    "improvement_feedback",
+  ]),
   acceptanceCriteria: Object.freeze([
     "Publish the exact child terms on Base from the parent solver wallet before claiming this bounty.",
     "Create and fully fund the parent-bound canonical child to at least this bounty solver reward.",
@@ -913,15 +924,27 @@ function hostedStandingMetaCandidate(item) {
   return Boolean(
     item?.verification_mode === "deterministic_module"
       && String(item?.verifier_module || "").toLowerCase() === STANDING_META_BOUNTY.verifierModule
+      && String(item?.terms?.acceptance_criteria_hash || "").toLowerCase()
+        === STANDING_META_BOUNTY.acceptanceCriteriaHash
       && exactStrings(document?.acceptance_criteria, STANDING_META_BOUNTY.acceptanceCriteria)
       && policy?.mechanism === "deterministic_module"
       && String(policy?.verifier_module || "").toLowerCase() === STANDING_META_BOUNTY.verifierModule
       && policy?.threshold === 1
-      && benchmark?.engine === "canonical_child_loop_v1"
+      && policy?.self_verification_forbidden === true
+      && benchmark?.engine === "standing_meta_v2_parent"
+      && typeof benchmark?.lane === "string"
+      && benchmark.lane.trim().length > 0
+      && benchmark?.required_child_engine === STANDING_META_BOUNTY.childEngine
       && benchmark?.required_child_status === "settled"
-      && String(benchmark?.verifier_module || "").toLowerCase() === STANDING_META_BOUNTY.verifierModule
-      && Array.isArray(requiredEvidence)
-      && requiredEvidence.includes("child_bounty_contract"),
+      && String(benchmark?.required_child_verifier_set_hash || "").toLowerCase()
+        === STANDING_META_BOUNTY.childVerifierSetHash
+      && benchmark?.required_child_verifier_threshold
+        === STANDING_META_BOUNTY.childVerifierThreshold
+      && String(benchmark?.participant_registry || "").toLowerCase()
+        === STANDING_META_BOUNTY.participantRegistry
+      && String(benchmark?.terms_registry || "").toLowerCase()
+        === STANDING_META_BOUNTY.termsRegistry
+      && exactStrings(requiredEvidence, STANDING_META_BOUNTY.requiredEvidence),
   );
 }
 


### PR DESCRIPTION
## Summary
- raise the standing-meta hard floor and replenishment target to five
- update the portable collector to recognize only the exact deployed standing-meta-v2 terms shape
- require safe-block verifier bytecode attestation before emitting the meta marker
- add deterministic five-pass, four-fail, wrong-quorum, and bytecode-drift coverage
- update the invariant documentation

## Live evidence
The pre-merge live collector and guard reported:

- verified canonical claimable: `5/5`
- verified standing meta: `5/5`
- protocol: `active`
- evidence valid: `true`
- missing: `0`

The first live run failed closed because the collector still recognized the historical benchmark shape. This PR corrects that handoff; it does not infer status from GitHub labels or titles.

## Verification
- `node --test scripts/test_agent_bounties_openclaw_skill.mjs` (23 passed)
- `python -m unittest scripts.test_bounty_inventory_guard` (15 passed)
- live `check-in.mjs` + `bounty_inventory_guard.py --fail-below` (5/5)
- `scripts/check.ps1` (full gate, 269.7s)

Public maintainer notice: #341.

No contract, bounty terms, claim, verification, or settlement rule changes.