### PR TITLE
Fix hosted claim signature handoff

### DIFF
--- a/crates/github-app/src/lib.rs
+++ b/crates/github-app/src/lib.rs
@@ -835,9 +835,9 @@ fn parse_claim_comment_signal(
         let bounty_contract = bounty.bounty_contract.clone();
         let solver_wallet = claim_wallet_address(&input.comment_body);
         let reservation_id = claim_reservation_id(input, command);
-        let claim_handoff_url = bounty_contract
-            .as_deref()
-            .map(|address| claim_handoff_url(input, address));
+        let claim_handoff_url = bounty_contract.as_deref().map(|address| {
+            claim_handoff_url(input, address, &reservation_id, solver_wallet.as_deref())
+        });
         let claim_plan_request = bounty_contract.as_deref().map(|address| {
             json!({
                 "method": "POST",
@@ -933,10 +933,19 @@ fn parse_claim_comment_signal(
     })
 }
 
-fn claim_handoff_url(input: &GitHubClaimCommentInput, bounty_contract: &str) -> String {
+fn claim_handoff_url(
+    input: &GitHubClaimCommentInput,
+    bounty_contract: &str,
+    reservation_id: &str,
+    solver_wallet: Option<&str>,
+) -> String {
+    let solver = solver_wallet
+        .map(|wallet| format!("&solver={}", url_query_encode(wallet)))
+        .unwrap_or_default();
     format!(
-        "{STATIC_EARN_PAGE_URL}?bountyContract={}&source=github-claim&issue={}",
+        "{STATIC_EARN_PAGE_URL}?bountyContract={}&claimKey={}&source=github-claim{solver}&issue={}",
         url_query_encode(bounty_contract),
+        url_query_encode(reservation_id),
         url_query_encode(&input.issue_url)
     )
 }
@@ -2131,6 +2140,8 @@ extract-data-to-schema
         let handoff = signal.claim_handoff_url.expect("claim handoff");
         assert!(handoff.starts_with(STATIC_EARN_PAGE_URL));
         assert!(handoff.contains("bountyContract=0x1111111111111111111111111111111111111111"));
+        assert!(handoff.contains("claimKey="));
+        assert!(handoff.contains("comment%3A1874"));
         assert!(handoff.contains("source=github-claim"));
         assert!(plan.check.text.contains("Copy-paste claim command"));
         assert!(plan.check.text.contains("curl -sS -X POST"));
@@ -2166,6 +2177,11 @@ extract-data-to-schema
         });
 
         let signal = plan.signal.expect("claim signal");
+        assert!(signal
+            .claim_handoff_url
+            .as_deref()
+            .expect("claim handoff")
+            .contains(&format!("solver={}", wallet.to_ascii_lowercase())));
         let request = signal.claim_plan_request.expect("machine request");
         assert_eq!(
             request["body"]["solver_wallet"],

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -288,8 +288,10 @@ def main() -> int:
             "/v1/base/autonomous-bounties/terms",
             "/v1/base/autonomous-bounties/creation-plan",
             "/v1/base/autonomous-bounties/contribution-plan",
-            "/v1/base/autonomous-bounties/claim-plan",
-            "/v1/base/autonomous-bounties/authorized-claim-plan",
+            "/v1/base/autonomous-bounties/claims",
+            "request_bond_sponsorship",
+            "wallet_signature",
+            "canonical_event_id",
             "/v1/base/autonomous-bounties/submission-plan",
             "contract_terms",
             "canonical_bounty_created",
@@ -310,6 +312,8 @@ def main() -> int:
     ]:
         if retired in active_surface:
             fail(f"active site still advertises retired escrow behavior: {retired}")
+    if "/v1/base/autonomous-bounties/authorized-claim-plan" in javascript:
+        fail("browser earning flow must use the hosted one-signature claim path")
     if "sk_live" in active_surface or "private_key" in active_surface.lower():
         fail("active site must not contain secret-looking payment material")
 

--- a/scripts/github_claim_comment.py
+++ b/scripts/github_claim_comment.py
@@ -497,11 +497,21 @@ def apply_canonical_claim_state(
             claim_recovery=claim_recovery,
         )
 
+    request = native_claim_request(signal, api_base_url, contract)
+    request_body = request.get("body") if isinstance(request.get("body"), dict) else {}
+    solver_wallet = str(request_body.get("solver_wallet") or "")
+    solver_query = (
+        f"&solver={urllib.parse.quote(solver_wallet, safe='')}"
+        if EVM_ADDRESS_RE.fullmatch(solver_wallet)
+        else ""
+    )
+    claim_key = str(signal.get("reservation_id") or "github-claim-comment")
     handoff = (
         f"{STATIC_EARN_PAGE_URL}?bountyContract={urllib.parse.quote(contract, safe='')}"
-        f"&source=github-claim&issue={urllib.parse.quote(issue_url, safe='')}"
+        f"&claimKey={urllib.parse.quote(claim_key, safe='')}"
+        f"&source=github-claim{solver_query}"
+        f"&issue={urllib.parse.quote(issue_url, safe='')}"
     )
-    request = native_claim_request(signal, api_base_url, contract)
     signal.update(
         {
             "bounty_contract": contract,
@@ -1221,6 +1231,8 @@ def run_self_test() -> int:
     for required_text in [
         "Exact wallet signature requested",
         "Hosted claim handoff",
+        "claimKey=",
+        f"solver={solver_wallet}",
         "eth_signTypedData_v4",
         "wallet_signature",
         "10000",

--- a/scripts/test-autonomous-wallet-flow.js
+++ b/scripts/test-autonomous-wallet-flow.js
@@ -23,8 +23,10 @@ for (const required of [
   "/v1/base/autonomous-bounties/authorized-creation-plan",
   "/v1/base/autonomous-bounties/contribution-plan",
   "/v1/base/autonomous-bounties/authorized-contribution-plan",
-  "/v1/base/autonomous-bounties/claim-plan",
-  "/v1/base/autonomous-bounties/authorized-claim-plan",
+  "/v1/base/autonomous-bounties/claims",
+  "request_bond_sponsorship",
+  "wallet_signature",
+  "canonical_event_id",
   "/v1/base/autonomous-bounties/submission-plan",
   "FundingAdded",
   "BountyClaimed",
@@ -92,10 +94,11 @@ assert(postHtml.includes('name="solverReward" type="number" min="0.01" step="0.0
 assert(postHtml.includes('name="verifierReward" type="number" min="0.01" step="0.01" value="0.01"'));
 
 const earnHtml = fs.readFileSync(path.join(repoRoot, "site", "earn.html"), "utf8");
-assert(earnHtml.includes("exact indexed bond before the wallet is asked to sign"));
+assert(earnHtml.includes("exact indexed bond before one bounded wallet signature"));
 assert(source.includes('params.get("bountyContract")'));
-assert(source.includes("Connect wallet and sign claim"));
-assert(source.includes("Exact refundable solver bond"));
+assert(source.includes("Sign once to claim"));
+assert(source.includes("Sponsored refundable bond"));
+assert(!source.includes("/v1/base/autonomous-bounties/authorized-claim-plan"));
 
 for (const page of ["index.html", "post.html", "funding.html", "earn.html", "operator.html", "recovery.html"]) {
   const html = fs.readFileSync(path.join(repoRoot, "site", page), "utf8");
@@ -181,7 +184,7 @@ async function testDeterministicPostingDefaults() {
   });
   const instrumentedSource = source.replace(
     /\}\)\(\);\s*$/,
-    "globalThis.__agentBountiesTest = { termsDocument }; })();",
+    "globalThis.__agentBountiesTest = { termsDocument, validateHostedClaimHandoff }; })();",
   );
   new vm.Script(instrumentedSource, { filename: "site/autonomous.js" }).runInContext(context);
   await documentListeners.DOMContentLoaded();
@@ -238,6 +241,93 @@ async function testDeterministicPostingDefaults() {
   );
   assert.strictEqual(terms.verification_policy.module_id, "leading_zero_work_v1");
   assert.strictEqual(terms.verification_policy.settlement_scope, "protocol_canary_only");
+
+  const account = "0x2222222222222222222222222222222222222222";
+  const bountyContract = "0x1111111111111111111111111111111111111111";
+  const requestBody = {
+    idempotency_key: "github-claim-comment:test",
+    network: "base-mainnet",
+    bounty_contract: bountyContract,
+    solver_wallet: account,
+    request_bond_sponsorship: true,
+    source: "github-claim",
+  };
+  const typedData = {
+    types: {
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "version", type: "string" },
+        { name: "chainId", type: "uint256" },
+        { name: "verifyingContract", type: "address" },
+      ],
+      TransferWithAuthorization: [
+        { name: "from", type: "address" },
+        { name: "to", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "validAfter", type: "uint256" },
+        { name: "validBefore", type: "uint256" },
+        { name: "nonce", type: "bytes32" },
+      ],
+    },
+    domain: {
+      name: "USD Coin",
+      version: "2",
+      chainId: 8453,
+      verifyingContract: protocol.native_usdc,
+    },
+    primaryType: "TransferWithAuthorization",
+    message: {
+      from: account,
+      to: bountyContract,
+      value: "10000",
+      validAfter: "0",
+      validBefore: "1800000000",
+      nonce: `0x${"33".repeat(32)}`,
+    },
+  };
+  const handoff = {
+    schema_version: "agent-bounties/agent-native-claim-v1",
+    candidate: {
+      status: "authorization_ready",
+      bounty_contract: bountyContract,
+      solver_wallet: account,
+    },
+    wallet_request: {
+      method: "eth_signTypedData_v4",
+      params: [account, JSON.stringify(typedData)],
+    },
+    next_request: {
+      method: "POST",
+      url: "https://api.bountyboard.global/v1/base/autonomous-bounties/claims",
+      body: requestBody,
+    },
+  };
+  const selected = { bounty_contract: bountyContract, claim_bond: "10000" };
+  const walletRequest = context.__agentBountiesTest.validateHostedClaimHandoff(
+    handoff,
+    requestBody,
+    selected,
+    account,
+    protocol,
+    "https://api.bountyboard.global",
+  );
+  assert.strictEqual(walletRequest.method, "eth_signTypedData_v4");
+
+  const tampered = JSON.parse(JSON.stringify(handoff));
+  const tamperedTypedData = JSON.parse(tampered.wallet_request.params[1]);
+  tamperedTypedData.message.to = "0x3333333333333333333333333333333333333333";
+  tampered.wallet_request.params[1] = JSON.stringify(tamperedTypedData);
+  assert.throws(
+    () => context.__agentBountiesTest.validateHostedClaimHandoff(
+      tampered,
+      requestBody,
+      selected,
+      account,
+      protocol,
+      "https://api.bountyboard.global",
+    ),
+    /differs from the selected Base USDC bond/,
+  );
 }
 
 testDeterministicPostingDefaults()

--- a/site/autonomous.js
+++ b/site/autonomous.js
@@ -157,12 +157,19 @@
       }
     }
     if (!response.ok) {
-      if (response.status === 503) {
-        throw new Error("The autonomous protocol is not deployed on this network yet.");
-      }
-      throw new Error(
-        typeof body === "string" ? body : body && body.error ? body.error : `Request failed (${response.status}).`,
-      );
+      const details = body && typeof body === "object" ? body : null;
+      const message = typeof body === "string"
+        ? body
+        : details && (details.message || details.error)
+          ? details.message || details.error
+          : `Request failed (${response.status}).`;
+      const transition = details && details.failed_transition
+        ? `Failed transition: ${details.failed_transition}.`
+        : "";
+      const next = details && details.next_action ? details.next_action : "";
+      const error = new Error([message, transition, next].filter(Boolean).join("\n"));
+      error.details = details;
+      throw error;
     }
     return body;
   }
@@ -177,6 +184,189 @@
     const bytes = new Uint8Array(32);
     crypto.getRandomValues(bytes);
     return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  function hostedClaimContext(bountyContract, solverWallet) {
+    const params = new URLSearchParams(location.search);
+    const expectedSolver = params.get("solver");
+    if (expectedSolver && requiredAddress(expectedSolver, "Claim-link solver").toLowerCase()
+      !== solverWallet.toLowerCase()) {
+      throw new Error("Connect the payout wallet named by this claim link.");
+    }
+    const suppliedKey = params.get("claimKey");
+    if (suppliedKey) {
+      if (suppliedKey.length > 128 || /[\u0000-\u001f\u007f]/.test(suppliedKey)) {
+        throw new Error("The claim link contains an invalid idempotency key.");
+      }
+      return { idempotencyKey: suppliedKey, source: claimSource(params) };
+    }
+    const storageKey = `agent-bounties:claim:${bountyContract.toLowerCase()}:${solverWallet.toLowerCase()}`;
+    let idempotencyKey = null;
+    if (typeof sessionStorage !== "undefined") idempotencyKey = sessionStorage.getItem(storageKey);
+    if (!idempotencyKey) {
+      idempotencyKey = `web-claim:${randomBytes32().slice(2)}`;
+      if (typeof sessionStorage !== "undefined") sessionStorage.setItem(storageKey, idempotencyKey);
+    }
+    return { idempotencyKey, source: claimSource(params) };
+  }
+
+  function claimSource(params) {
+    const source = String(params.get("source") || "web").trim();
+    return /^[a-zA-Z0-9._:-]{1,64}$/.test(source) ? source : "web";
+  }
+
+  function validateHostedClaimHandoff(handoff, requestBody, item, account, protocol, api) {
+    if (!handoff || handoff.schema_version !== "agent-bounties/agent-native-claim-v1") {
+      throw new Error("The hosted claim response has an unsupported schema.");
+    }
+    const candidate = handoff.candidate;
+    if (!candidate
+      || String(candidate.bounty_contract).toLowerCase() !== item.bounty_contract.toLowerCase()
+      || String(candidate.solver_wallet).toLowerCase() !== account.toLowerCase()) {
+      throw new Error("The hosted claim candidate does not match this bounty and payout wallet.");
+    }
+    if (!handoff.wallet_request) return null;
+    if (candidate.status !== "authorization_ready") {
+      throw new Error(`The hosted claim requested a signature in unexpected state ${candidate.status}.`);
+    }
+    const walletRequest = handoff.wallet_request;
+    if (walletRequest.method !== "eth_signTypedData_v4"
+      || !Array.isArray(walletRequest.params)
+      || walletRequest.params.length !== 2
+      || String(walletRequest.params[0]).toLowerCase() !== account.toLowerCase()) {
+      throw new Error("The hosted claim returned an invalid wallet request.");
+    }
+    let typedData;
+    try {
+      typedData = JSON.parse(walletRequest.params[1]);
+    } catch (_error) {
+      throw new Error("The hosted claim returned unreadable typed data.");
+    }
+    const domain = typedData.domain || {};
+    const message = typedData.message || {};
+    const expectedTypes = {
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "version", type: "string" },
+        { name: "chainId", type: "uint256" },
+        { name: "verifyingContract", type: "address" },
+      ],
+      TransferWithAuthorization: [
+        { name: "from", type: "address" },
+        { name: "to", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "validAfter", type: "uint256" },
+        { name: "validBefore", type: "uint256" },
+        { name: "nonce", type: "bytes32" },
+      ],
+    };
+    const validAfter = Number(message.validAfter);
+    const validBefore = Number(message.validBefore);
+    if (typedData.primaryType !== "TransferWithAuthorization"
+      || JSON.stringify(typedData.types) !== JSON.stringify(expectedTypes)
+      || domain.name !== "USD Coin"
+      || domain.version !== "2"
+      || Number(domain.chainId) !== Number(protocol.chain_id)
+      || String(domain.verifyingContract).toLowerCase() !== protocol.native_usdc.toLowerCase()
+      || String(message.from).toLowerCase() !== account.toLowerCase()
+      || String(message.to).toLowerCase() !== item.bounty_contract.toLowerCase()
+      || String(message.value) !== String(item.claim_bond)
+      || !Number.isSafeInteger(validAfter)
+      || !Number.isSafeInteger(validBefore)
+      || validAfter !== 0
+      || validBefore <= Math.floor(Date.now() / 1_000)
+      || !/^0x[0-9a-fA-F]{64}$/.test(String(message.nonce))) {
+      throw new Error("The hosted claim typed data differs from the selected Base USDC bond.");
+    }
+    const nextRequest = handoff.next_request;
+    const expectedUrl = `${api}/v1/base/autonomous-bounties/claims`;
+    if (!nextRequest || nextRequest.method !== "POST" || nextRequest.url !== expectedUrl
+      || !nextRequest.body
+      || nextRequest.body.idempotency_key !== requestBody.idempotency_key
+      || nextRequest.body.network !== requestBody.network
+      || String(nextRequest.body.bounty_contract).toLowerCase() !== item.bounty_contract.toLowerCase()
+      || String(nextRequest.body.solver_wallet).toLowerCase() !== account.toLowerCase()
+      || nextRequest.body.request_bond_sponsorship !== true
+      || nextRequest.body.source !== requestBody.source) {
+      throw new Error("The hosted claim replay request differs from the prepared candidate.");
+    }
+    return walletRequest;
+  }
+
+  async function hostedClaim(item, api, account, protocol, result) {
+    const context = hostedClaimContext(item.bounty_contract, account);
+    const requestBody = {
+      idempotency_key: context.idempotencyKey,
+      network: "base-mainnet",
+      bounty_contract: item.bounty_contract,
+      solver_wallet: account,
+      request_bond_sponsorship: true,
+      source: context.source,
+    };
+    const endpoint = `${api}/v1/base/autonomous-bounties/claims`;
+    let handoff = await requestJson(endpoint, {
+      method: "POST",
+      body: JSON.stringify(requestBody),
+    });
+    validateHostedClaimHandoff(handoff, requestBody, item, account, protocol, api);
+    if (handoff.candidate.status === "waitlisted") {
+      output(result, [
+        `Waitlisted at position ${handoff.waitlist_position}.`,
+        "No signature or bond was requested. Reopen this exact link to poll.",
+      ], "pending");
+      return;
+    }
+    if (handoff.candidate.status === "claimed" && handoff.canonical_event_id) {
+      output(result, [
+        "Canonical BountyClaimed is confirmed. Start the task.",
+        `Event: ${handoff.canonical_event_id}`,
+      ], "success");
+      return;
+    }
+    const exactWalletRequest = validateHostedClaimHandoff(
+      handoff, requestBody, item, account, protocol, api,
+    );
+    if (!exactWalletRequest) {
+      throw new Error(handoff.next_action || `Claim is ${handoff.candidate.status}.`);
+    }
+    output(result, [
+      "One bounded wallet signature required. No gas transaction is requested.",
+      `Sponsored refundable bond: ${Number(handoff.claim_bond) / 1_000_000} USDC`,
+      `Bounty: ${item.bounty_contract}`,
+    ], "pending");
+    const walletSignature = await walletRequest(
+      exactWalletRequest.method, exactWalletRequest.params,
+    );
+    if (!/^0x[0-9a-fA-F]{130}$/.test(String(walletSignature))) {
+      throw new Error("The wallet did not return one 65-byte claim signature.");
+    }
+    handoff = await requestJson(endpoint, {
+      method: "POST",
+      body: JSON.stringify({ ...requestBody, wallet_signature: walletSignature }),
+    });
+    for (let attempt = 0; attempt < 36; attempt += 1) {
+      if (handoff.candidate.status === "claimed" && handoff.canonical_event_id) {
+        output(result, [
+          "Canonical BountyClaimed is confirmed. Start the task.",
+          `Event: ${handoff.canonical_event_id}`,
+          handoff.claim_transaction_hash ? `Transaction: ${protocol.explorer_url}/tx/${handoff.claim_transaction_hash}` : "",
+        ].filter(Boolean), "success");
+        return;
+      }
+      if (!["relaying", "authorization_ready", "exclusive", "sponsoring"].includes(handoff.candidate.status)) {
+        throw new Error(handoff.next_action || `Claim stopped in state ${handoff.candidate.status}.`);
+      }
+      output(result, [
+        `Claim state: ${handoff.candidate.status}.`,
+        "The sponsor is paying gas. Waiting for canonical BountyClaimed; do not sign again.",
+      ], "pending");
+      await sleep(2_500);
+      handoff = await requestJson(endpoint, {
+        method: "POST",
+        body: JSON.stringify(requestBody),
+      });
+    }
+    throw new Error("The sponsored claim is still pending. Reopen this exact link to reconcile it; do not post another bond.");
   }
 
   function usdcMinor(value) {
@@ -925,7 +1115,7 @@
     const claim = document.createElement("button");
     claim.className = "button primary";
     claim.type = "button";
-    claim.textContent = targeted ? "Connect wallet and sign claim" : "Claim bounty";
+    claim.textContent = targeted ? "Sign once to claim" : "Claim bounty";
     claim.disabled =
       state.protocol.status !== "active" || item.status !== "claimable" || !item.terms || !item.terms_valid;
     claim.addEventListener("click", async () => {
@@ -933,51 +1123,7 @@
       try {
         const protocol = requireActiveProtocol(await loadProtocol());
         const account = await connectWallet(document);
-        const authorizationNonce = randomBytes32();
-        const authorizationValidBefore = Math.floor(Date.now() / 1000) + 3_600;
-        const plan = await requestJson(`${api}/v1/base/autonomous-bounties/claim-plan`, {
-          method: "POST",
-          body: JSON.stringify({
-            network: "base-mainnet",
-            bounty_contract: item.bounty_contract,
-            solver: account,
-            authorization_nonce: authorizationNonce,
-            authorization_valid_before: authorizationValidBefore,
-          }),
-        });
-        output(result, [
-          "Wallet confirmation required.",
-          `Refundable solver bond: ${Number(plan.claim_bond) / 1_000_000} USDC`,
-          "Acceptance or verifier timeout returns the bond. Rejection pays verifiers; no-submission timeout forfeits it into the completion bonus.",
-        ]);
-        let hash = null;
-        if (!(await isContractAccount(account)) && plan.eip3009_authorization) {
-          const signature = await signTypedData(account, plan.eip3009_authorization);
-          const authorized = await requestJson(
-            `${api}/v1/base/autonomous-bounties/authorized-claim-plan`,
-            {
-              method: "POST",
-              body: JSON.stringify({
-                network: "base-mainnet",
-                bounty_contract: item.bounty_contract,
-                solver: account,
-                authorization_nonce: authorizationNonce,
-                authorization_valid_before: authorizationValidBefore,
-                signature,
-                relayer: account,
-              }),
-            },
-          );
-          hash = await sendTransaction(authorized.relay_transaction, account);
-          await waitReceipt(hash);
-        } else {
-          const sent = await sendWalletCalls(plan.wallet_calls, account, protocol);
-          if (sent.kind === "transactions") hash = sent.hashes[sent.hashes.length - 1];
-        }
-        output(result, [
-          "Claim transaction confirmed; waiting for BountyClaimed evidence.",
-          hash ? `${protocol.explorer_url}/tx/${hash}` : "Wallet batch submitted.",
-        ], "pending");
+        await hostedClaim(item, api, account, protocol, result);
       } catch (error) {
         output(result, error.message || String(error), "error");
       }

--- a/site/earn.html
+++ b/site/earn.html
@@ -35,7 +35,7 @@
           <div>
             <p class="eyebrow">Available now</p>
             <h2>Claimable bounties</h2>
-            <p class="fine">Each claim posts the displayed USDC solver bond. A contract-specific claim link shows the canonical bounty and exact indexed bond before the wallet is asked to sign. Submit before the claim deadline; otherwise the bond becomes the next solver's completion bonus.</p>
+            <p class="fine">A contract-specific claim link validates the canonical bounty and exact indexed bond before one bounded wallet signature. When sponsorship is available, the platform supplies the refundable bond and pays Base gas atomically. Submit before the claim deadline; otherwise the bond becomes the next solver's completion bonus.</p>
             <label class="wallet-picker">
               Wallet
               <select data-wallet-provider aria-label="Wallet provider">
@@ -43,7 +43,7 @@
               </select>
             </label>
             <button class="button secondary" type="button" data-connect-wallet data-output="claim-feed-output">Connect wallet</button>
-            <output id="claim-feed-output" class="output compact-output" aria-live="polite">Choose a bounty, then connect the payout wallet and sign its bounded claim request.</output>
+            <output id="claim-feed-output" class="output compact-output" aria-live="polite">Choose a bounty, connect the payout wallet, and sign once. Wait for canonical BountyClaimed before starting work.</output>
           </div>
           <div id="claimable-feed" class="bounty-feed" aria-live="polite">Loading canonical bounties...</div>
         </div>
@@ -105,7 +105,7 @@
           <div class="copy endpoint-list">
             <p><a href="prepare-agent.html"><code>prepare_agent_to_earn</code></a> validates the public wallet, live bond balance, signing capabilities, and bounded policy before claiming.</p>
             <p><code>list_autonomous_bounties</code> finds funded work.</p>
-            <p><code>plan_autonomous_bounty_claim</code> returns the exact USDC bond authorization and claim calls.</p>
+            <p><code>agent_native_claim</code> reserves a candidate, returns one exact USDC authorization, sponsors eligible bonds, relays gas, and confirms canonical ownership.</p>
             <p><code>plan_autonomous_bounty_submission</code> commits artifact and evidence hashes.</p>
             <p><code>list_autonomous_bounty_events</code> exposes verification and payout truth.</p>
             <p><a href="llms.txt">Read llms.txt</a> or connect to the hosted MCP endpoint from the discovery manifest.</p>


### PR DESCRIPTION
## Summary\n- preserve the GitHub claim reservation key and solver wallet in the browser handoff\n- replace the separate direct-wallet fallback with the exact hosted gent_native_claim signature/replay flow\n- validate chain, native USDC, canonical bounty, solver, bond, EIP-712 schema, nonce, expiry, and replay request before signing\n- wait for canonical BountyClaimed before telling a solver to start\n\n## Funnel problem\nThe live 168-hour funnel showed 8 prepared authorizations and 0 transaction broadcasts. The old browser fallback created a second claim plan instead of completing the hosted candidate already prepared by the GitHub bot.\n\n## Safety boundary\nThis does not change contracts, rewards, verifier policy, settlement, or existing candidates. A wallet signature and relay hash remain coordination evidence only.\n\n## Tests\n- scripts/check.ps1\n- cargo test -p github-app\n- python scripts/github_claim_comment.py --self-test\n- 
ode scripts/test-autonomous-wallet-flow.js\n- python scripts/check-site.py\n\nPublic maintainer notice: https://github.com/NSPG13/agent-bounties/issues/333#issuecomment-4998973320