### PR TITLE
build: normalize benchmark line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sh text eol=lf
 *.sol text eol=lf
+benchmarks/** text eol=lf


### PR DESCRIPTION
## Summary

Pin LF line endings for `benchmarks/**` so content-addressed verifier fixtures hash identically in Windows and Unix checkouts.

## Evidence

- GitHub archive for merged benchmark commit `3e4b6e77afbb8ec6baeb4dbe0b0f1a4c5c66fe70`: `sha256:eb96959fa2e5572b083516f7823002d6b9e823d10e95a7aea0869c6c15e63ebd`
- fresh Windows worktree after this attribute: same digest, 8 files, 11950 bytes
- benchmark self-test passed in the fresh worktree
- `git check-attr` reports `text: set`, `eol: lf`

Announced on #335 after inspecting all open PR file lists. No open PR touches `.gitattributes`. This changes no runtime, contract, API, wallet, or payment behavior.