### PR TITLE
fix: skip stale verifier artifacts cleanly

### DIFF
--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -38,6 +38,7 @@ jobs:
     needs: contract
     runs-on: ubuntu-latest
     outputs:
+      authorized: ${{ steps.main.outputs.authorized }}
       revision: ${{ steps.main.outputs.revision }}
       run_id: ${{ steps.main.outputs.run_id }}
     steps:
@@ -52,13 +53,23 @@ jobs:
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           current_main="$(git rev-parse refs/remotes/origin/main)"
           if [[ "$CANDIDATE_REVISION" != "$current_main" ]]; then
-            echo "Refusing to sign a candidate from stale main" >&2
-            exit 1
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Stale regression candidate skipped::Runner revision $CANDIDATE_REVISION is not current main $current_main; no signer or relay job will run."
+            {
+              echo "## Stale regression candidate skipped"
+              echo
+              echo "- candidate: \`$CANDIDATE_REVISION\`"
+              echo "- current main: \`$current_main\`"
+              echo "- effect: both signers and the relay are skipped"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
+          echo "authorized=true" >> "$GITHUB_OUTPUT"
           echo "revision=$CANDIDATE_REVISION" >> "$GITHUB_OUTPUT"
           echo "run_id=$CANDIDATE_RUN_ID" >> "$GITHUB_OUTPUT"
 
   sign-one:
+    if: needs.authorize-run.outputs.authorized == 'true'
     needs: authorize-run
     uses: ./.github/workflows/regression-verifier-signing-reusable.yml
     with:
@@ -70,6 +81,7 @@ jobs:
       verifier_private_key: ${{ secrets.REGRESSION_VERIFIER_ONE_PRIVATE_KEY }}
 
   sign-two:
+    if: needs.authorize-run.outputs.authorized == 'true'
     needs: authorize-run
     uses: ./.github/workflows/regression-verifier-signing-reusable.yml
     with:
@@ -81,6 +93,7 @@ jobs:
       verifier_private_key: ${{ secrets.REGRESSION_VERIFIER_TWO_PRIVATE_KEY }}
 
   relay:
+    if: needs.authorize-run.outputs.authorized == 'true'
     needs: [authorize-run, sign-one, sign-two]
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/scripts/test_regression_verifier_pipeline.py
+++ b/scripts/test_regression_verifier_pipeline.py
@@ -37,6 +37,18 @@ def archive(entries: list[tuple[str, bytes | None, str]]) -> bytes:
 
 
 class RegressionVerifierPipelineTests(unittest.TestCase):
+    def test_stale_runner_revision_skips_every_signing_job(self) -> None:
+        workflow = (
+            SCRIPT.parent.parent / ".github" / "workflows" / "regression-verifier-signer.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn('echo "authorized=false" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn('echo "authorized=true" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertEqual(
+            workflow.count("if: needs.authorize-run.outputs.authorized == 'true'"),
+            3,
+        )
+        self.assertNotIn("Refusing to sign a candidate from stale main", workflow)
+
     def test_artifact_reference_requires_an_exact_public_commit(self) -> None:
         expected = ("owner/repo", "a" * 40)
         self.assertEqual(


### PR DESCRIPTION
## Summary
- convert a stale-main regression candidate into an explicit warning/no-op
- gate both signing slots and relay on the exact current-main authorization output
- add a deterministic workflow contract test

## Why
Run 29565375255 correctly rejected a runner artifact from `51c4947` after `main` advanced to `fdd1364`, but emitted a failure notification. This preserves fail-closed behavior without reporting a safe race as an incident.

## Verification
- `python scripts/test_regression_verifier_pipeline.py -v`
- workflow YAML parse
- `python -m py_compile scripts/test_regression_verifier_pipeline.py`
- `git diff --check`

No contract, policy, signer secret, funding, or settlement change.

Closes #355.