### PR TITLE
test: add direct agent earning benchmarks

### DIFF
--- a/benchmarks/direct-v1/agent-loop/README.md
+++ b/benchmarks/direct-v1/agent-loop/README.md
@@ -1,0 +1,97 @@
+# Direct Agent Loop Benchmarks
+
+This directory defines three independent, deterministic coding bounties. Each
+bounty adds one dependency-free Node.js CLI. The benchmark is committed before
+funding, runs without network access, and never authorizes payment by itself.
+
+## Common Contract
+
+- Use only Node.js built-ins.
+- Write exactly one compact JSON line to stdout and nothing to stderr.
+- Exit `0` for a valid result, `1` for a valid input that cannot safely produce
+  the requested result, and `2` for malformed CLI or JSON input.
+- Treat EVM addresses case-insensitively and emit them in lowercase.
+- Do not read environment secrets, make network requests, or invoke a shell.
+
+Run one task with:
+
+```sh
+node benchmarks/direct-v1/agent-loop/test.mjs TASK_ID WORKSPACE
+```
+
+## Task: `claim-next-action`
+
+Add `scripts/next-agent-claim-action.mjs`. It accepts one path containing an
+Agent Bounties claim response and converts it into a safe machine action.
+
+Supported states and exact actions:
+
+| Input | Action | May sign | May start work |
+|---|---|---:|---:|
+| `waitlisted` | `poll_same_idempotency_key` | false | false |
+| `authorization_ready` | `sign_wallet_request_and_replay` | true | false |
+| `relaying` | `replay_same_signed_request` | false | false |
+| `claimed` | `start_work` | false | true |
+| `agent-bounties/claim-problem-v1` | `follow_error_next_action` | false | false |
+
+The authorization-ready path must require an exact `eth_signTypedData_v4`
+wallet request bound to the candidate solver and a replay request. The claimed
+path must require matching top-level and candidate canonical event IDs. Unknown
+states or unsafe/missing fields fail closed. Exact error codes and output field
+order are enforced by `test.mjs`.
+
+## Task: `select-funded-bounty`
+
+Add `scripts/select-funded-bounty.mjs`. It accepts a feed JSON path and the
+agent's public Base wallet. It rejects malformed feed items, then considers
+only entries that are:
+
+- canonically `claimable`;
+- fully funded;
+- backed by valid terms;
+- verification-ready with no validation errors;
+- positive-reward and positive-bond; and
+- created by a different wallet.
+
+Rank eligible entries by solver reward descending, claim bond ascending, then
+bounty ID ascending. Emit the selected canonical identifiers and the
+`agent_native_claim` next action. A well-formed feed with no safe opportunity
+exits `1`.
+
+## Task: `verify-settlement-evidence`
+
+Add `scripts/verify-settlement-evidence.mjs`. It accepts a feed-item JSON path,
+an expected bounty contract, and an expected solver wallet. It must require
+exactly one matching canonical `bounty_settled` event and validate:
+
+- bounty ID, contract, transaction hash, and non-negative log index;
+- expected solver and positive round;
+- solver reward, returned bond, verifier reward, and timeout bonus;
+- `solver_payout = solver_reward + claim_bond_returned + timeout_bond_bonus`;
+- all four committed bytes32 hashes.
+
+Only a valid event returns `paid: true`. A transaction hash, item status, or
+amount without the exact event must fail closed.
+
+## Immutable Runner
+
+- image: `docker.io/library/node@sha256:b74031e546d7f4faf561d797ac1b76beccac856a042815ca77db4fd047581605`
+- platform: `linux/amd64`
+- command: `node /benchmark/test.mjs TASK_ID /workspace`
+- network: disabled
+- workdir: `/workspace`
+- timeout: 30 seconds
+- CPU: 500 millicores
+- memory: 134217728 bytes
+- processes: 32
+- output: 262144 bytes
+- tmpfs: 67108864 bytes
+- test seed: 1
+
+The runner manifest stores the digest of the exact GitHub commit snapshot of
+this directory. Run the benchmark contract self-test with:
+
+```sh
+node benchmarks/direct-v1/agent-loop/self-test.mjs
+```
+

--- a/benchmarks/direct-v1/agent-loop/self-test.mjs
+++ b/benchmarks/direct-v1/agent-loop/self-test.mjs
@@ -1,0 +1,165 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const runner = join(benchmarkRoot, "test.mjs");
+const temporary = mkdtempSync(join(tmpdir(), "agent-bounties-direct-benchmark-"));
+const sourceRoot = join(temporary, "source");
+const scriptsRoot = join(sourceRoot, "scripts");
+mkdirSync(scriptsRoot, { recursive: true });
+
+const claimImplementation = `
+import { readFileSync } from "node:fs";
+const emit = (value, status = 0) => { console.log(JSON.stringify(value)); process.exit(status); };
+if (process.argv.length !== 3) emit({ok:false,errors:["claim_response_path_required"]}, 2);
+let text;
+try { text = readFileSync(process.argv[2], "utf8"); } catch { emit({ok:false,errors:["claim_response_unreadable"]}, 2); }
+let value;
+try { value = JSON.parse(text); } catch { emit({ok:false,errors:["claim_response_invalid_json"]}, 2); }
+if (!value || Array.isArray(value) || typeof value !== "object") emit({ok:false,errors:["claim_response_object_required"]}, 2);
+if (value.schema_version === "agent-bounties/claim-problem-v1") {
+  if (value.state !== "failed" || typeof value.error !== "string" || !value.error || typeof value.failed_transition !== "string" || !value.failed_transition || typeof value.next_action !== "string" || !value.next_action) emit({ok:false,errors:["claim_problem_invalid"]}, 1);
+  emit({ok:true,state:"failed",action:"follow_error_next_action",may_sign:false,may_start_work:false,error:value.error,failed_transition:value.failed_transition});
+}
+if (value.schema_version !== "agent-bounties/agent-native-claim-v1") emit({ok:false,errors:["claim_response_schema_unsupported"]}, 1);
+const candidate = value.candidate;
+if (!candidate || Array.isArray(candidate) || typeof candidate !== "object" || typeof candidate.status !== "string") emit({ok:false,errors:["claim_candidate_invalid"]}, 1);
+const state = candidate.status;
+if (state === "waitlisted") emit({ok:true,state,action:"poll_same_idempotency_key",may_sign:false,may_start_work:false});
+if (state === "authorization_ready") {
+  const request = value.wallet_request;
+  const next = value.next_request;
+  const params = request?.params;
+  const solver = String(candidate.solver_wallet ?? "").toLowerCase();
+  const valid = request?.method === "eth_signTypedData_v4" && Array.isArray(params) && params.length === 2 && String(params[0]).toLowerCase() === solver && /^0x[0-9a-f]{40}$/.test(solver) && typeof params[1] === "string" && params[1].length > 0 && next && !Array.isArray(next) && typeof next === "object" && typeof next.url === "string" && next.method === "POST" && next.body && typeof next.body.idempotency_key === "string";
+  if (!valid) emit({ok:false,errors:["authorization_request_invalid"]}, 1);
+  emit({ok:true,state,action:"sign_wallet_request_and_replay",may_sign:true,may_start_work:false});
+}
+if (state === "relaying") emit({ok:true,state,action:"replay_same_signed_request",may_sign:false,may_start_work:false});
+if (state === "claimed") {
+  const event = value.canonical_event_id;
+  if (typeof event !== "string" || !event || candidate.canonical_event_id !== event) emit({ok:false,errors:["canonical_claim_evidence_invalid"]}, 1);
+  emit({ok:true,state,action:"start_work",may_sign:false,may_start_work:true,canonical_event_id:event});
+}
+emit({ok:false,errors:["claim_state_unsupported:" + state]}, 1);
+`;
+
+const selectionImplementation = `
+import { readFileSync } from "node:fs";
+const emit = (value, status = 0) => { console.log(JSON.stringify(value)); process.exit(status); };
+const address = /^0x[0-9a-f]{40}$/;
+const hash = /^0x[0-9a-f]{64}$/;
+const uint = /^(0|[1-9][0-9]*)$/;
+if (process.argv.length !== 4) emit({ok:false,errors:["feed_path_and_solver_required"]}, 2);
+const solver = process.argv[3].toLowerCase();
+if (!address.test(solver)) emit({ok:false,errors:["solver_wallet_invalid"]}, 2);
+let text;
+try { text = readFileSync(process.argv[2], "utf8"); } catch { emit({ok:false,errors:["feed_unreadable"]}, 2); }
+let feed;
+try { feed = JSON.parse(text); } catch { emit({ok:false,errors:["feed_invalid_json"]}, 2); }
+if (!Array.isArray(feed)) emit({ok:false,errors:["feed_array_required"]}, 2);
+const normalized = [];
+for (let index = 0; index < feed.length; index += 1) {
+  const item = feed[index];
+  const values = ["solver_reward","verifier_reward","claim_bond","target_amount","funded_amount"];
+  const valid = item && !Array.isArray(item) && typeof item === "object" && hash.test(String(item.bounty_id ?? "").toLowerCase()) && address.test(String(item.bounty_contract ?? "").toLowerCase()) && address.test(String(item.creator ?? "").toLowerCase()) && hash.test(String(item.terms_hash ?? "").toLowerCase()) && typeof item.status === "string" && values.every((key) => typeof item[key] === "string" && uint.test(item[key])) && typeof item.terms_valid === "boolean" && typeof item.verification_ready === "boolean" && Array.isArray(item.validation_errors);
+  if (!valid) emit({ok:false,errors:["feed_item_invalid:" + index]}, 2);
+  normalized.push({...item,bounty_id:item.bounty_id.toLowerCase(),bounty_contract:item.bounty_contract.toLowerCase(),creator:item.creator.toLowerCase(),terms_hash:item.terms_hash.toLowerCase()});
+}
+const eligible = normalized.filter((item) => item.status === "claimable" && item.terms_valid && item.verification_ready && item.validation_errors.length === 0 && BigInt(item.solver_reward) > 0n && BigInt(item.claim_bond) > 0n && BigInt(item.funded_amount) >= BigInt(item.target_amount) && item.creator !== solver);
+eligible.sort((left, right) => {
+  const reward = BigInt(right.solver_reward) - BigInt(left.solver_reward);
+  if (reward !== 0n) return reward > 0n ? 1 : -1;
+  const bond = BigInt(left.claim_bond) - BigInt(right.claim_bond);
+  if (bond !== 0n) return bond > 0n ? 1 : -1;
+  return left.bounty_id.localeCompare(right.bounty_id);
+});
+if (eligible.length === 0) emit({ok:false,errors:["no_safe_claimable_bounty"]}, 1);
+const item = eligible[0];
+emit({ok:true,bounty_contract:item.bounty_contract,bounty_id:item.bounty_id,solver_reward:item.solver_reward,claim_bond:item.claim_bond,terms_hash:item.terms_hash,next_action:"agent_native_claim",request_bond_sponsorship:true});
+`;
+
+const settlementImplementation = `
+import { readFileSync } from "node:fs";
+const emit = (value, status = 0) => { console.log(JSON.stringify(value)); process.exit(status); };
+const address = /^0x[0-9a-f]{40}$/;
+const hash = /^0x[0-9a-f]{64}$/;
+const amount = (value) => {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) return BigInt(value);
+  if (typeof value === "string" && /^(0|[1-9][0-9]*)$/.test(value)) return BigInt(value);
+  return null;
+};
+if (process.argv.length !== 5) emit({ok:false,errors:["item_path_contract_and_solver_required"]}, 2);
+const expectedContract = process.argv[3].toLowerCase();
+const expectedSolver = process.argv[4].toLowerCase();
+if (!address.test(expectedContract) || !address.test(expectedSolver)) emit({ok:false,errors:["expected_address_invalid"]}, 2);
+let text;
+try { text = readFileSync(process.argv[2], "utf8"); } catch { emit({ok:false,errors:["settlement_item_unreadable"]}, 2); }
+let item;
+try { item = JSON.parse(text); } catch { emit({ok:false,errors:["settlement_item_invalid_json"]}, 2); }
+if (!item || Array.isArray(item) || typeof item !== "object") emit({ok:false,errors:["settlement_item_object_required"]}, 2);
+const contract = String(item.bounty_contract ?? "").toLowerCase();
+const bountyId = String(item.bounty_id ?? "").toLowerCase();
+if (contract !== expectedContract || !address.test(contract) || !hash.test(bountyId) || !Array.isArray(item.events)) emit({ok:false,errors:["settlement_identity_invalid"]}, 1);
+const matches = item.events.filter((event) => event && event.kind === "bounty_settled" && String(event.contract_address ?? "").toLowerCase() === contract);
+if (matches.length !== 1) emit({ok:false,errors:["exact_settlement_event_required"]}, 1);
+const event = matches[0];
+const tx = String(event.tx_hash ?? "").toLowerCase();
+if (!hash.test(tx) || event.bounty_id?.toLowerCase() !== bountyId || !Number.isInteger(event.log_index) || event.log_index < 0 || !event.data || Array.isArray(event.data)) emit({ok:false,errors:["settlement_event_identity_invalid"]}, 1);
+const data = event.data;
+if (String(data.solver ?? "").toLowerCase() !== expectedSolver || !address.test(expectedSolver)) emit({ok:false,errors:["settlement_solver_mismatch"]}, 1);
+const round = amount(data.round);
+const solverReward = amount(data.solver_reward);
+const returnedBond = amount(data.claim_bond_returned);
+const timeoutBonus = amount(data.timeout_bond_bonus);
+const solverPayout = amount(data.solver_payout);
+const verifierReward = amount(data.verifier_reward);
+const itemReward = amount(item.solver_reward);
+const itemBond = amount(item.claim_bond);
+const itemVerifier = amount(item.verifier_reward);
+if ([round,solverReward,returnedBond,timeoutBonus,solverPayout,verifierReward,itemReward,itemBond,itemVerifier].some((value) => value === null) || round <= 0n || solverReward !== itemReward || returnedBond !== itemBond || verifierReward !== itemVerifier || solverPayout !== solverReward + returnedBond + timeoutBonus) emit({ok:false,errors:["settlement_amount_mismatch"]}, 1);
+for (const key of ["submission_hash","evidence_hash","policy_hash","verification_hash"]) if (!hash.test(String(data[key] ?? "").toLowerCase())) emit({ok:false,errors:["settlement_commitment_invalid"]}, 1);
+emit({ok:true,paid:true,bounty_contract:contract,bounty_id:bountyId,solver:expectedSolver,solver_payout:solverPayout.toString(),verifier_reward:verifierReward.toString(),transaction_hash:tx,log_index:event.log_index});
+`;
+
+const files = {
+  "claim-next-action": ["next-agent-claim-action.mjs", claimImplementation],
+  "select-funded-bounty": ["select-funded-bounty.mjs", selectionImplementation],
+  "verify-settlement-evidence": ["verify-settlement-evidence.mjs", settlementImplementation],
+};
+
+function run(task, root) {
+  return spawnSync(process.execPath, [runner, task, root], {
+    encoding: "utf8",
+    timeout: 15_000,
+    windowsHide: true,
+  });
+}
+
+try {
+  for (const [, [name, implementation]] of Object.entries(files)) {
+    writeFileSync(join(scriptsRoot, name), implementation);
+  }
+  for (const task of Object.keys(files)) {
+    const good = run(task, sourceRoot);
+    if (good.status !== 0) {
+      throw new Error(`${task} known-good failed: ${good.stdout}${good.stderr}`);
+    }
+  }
+
+  for (const [task, [name, implementation]] of Object.entries(files)) {
+    writeFileSync(join(scriptsRoot, name), 'console.log(JSON.stringify({ok:true}));\n');
+    const bad = run(task, sourceRoot);
+    if (bad.status === 0) throw new Error(`${task} always-success implementation passed`);
+    writeFileSync(join(scriptsRoot, name), implementation);
+
+    const missing = run(task, join(temporary, "missing"));
+    if (missing.status === 0) throw new Error(`${task} missing implementation passed`);
+  }
+  console.log("direct_agent_loop_benchmark_self_test=passed tasks=3");
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/benchmarks/direct-v1/agent-loop/test.mjs
+++ b/benchmarks/direct-v1/agent-loop/test.mjs
@@ -1,0 +1,304 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const task = process.argv[2];
+const sourceRoot = resolve(process.argv[3] ?? "/workspace");
+const scripts = {
+  "claim-next-action": "next-agent-claim-action.mjs",
+  "select-funded-bounty": "select-funded-bounty.mjs",
+  "verify-settlement-evidence": "verify-settlement-evidence.mjs",
+};
+
+if (!Object.hasOwn(scripts, task)) {
+  console.error(`unknown task: ${task ?? "missing"}`);
+  process.exit(1);
+}
+
+const implementation = join(sourceRoot, "scripts", scripts[task]);
+if (!existsSync(implementation)) {
+  console.error(`missing implementation: ${implementation}`);
+  process.exit(1);
+}
+
+const temporary = mkdtempSync(join(tmpdir(), `agent-bounties-${task}-`));
+const address = (digit) => `0x${digit.repeat(40)}`;
+const hash = (digit) => `0x${digit.repeat(64)}`;
+
+function fixture(name, value, raw = false) {
+  const path = join(temporary, name);
+  writeFileSync(path, raw ? value : `${JSON.stringify(value)}\n`);
+  return path;
+}
+
+function invoke(args) {
+  return spawnSync(process.execPath, [implementation, ...args], {
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+  });
+}
+
+function expectRun(name, args, status, output) {
+  const result = invoke(args);
+  if (result.error) throw new Error(`${name}: ${result.error.message}`);
+  if (result.status !== status) {
+    throw new Error(
+      `${name}: expected exit ${status}, received ${result.status}; stdout=${JSON.stringify(result.stdout)} stderr=${JSON.stringify(result.stderr)}`,
+    );
+  }
+  if (result.stderr !== "") {
+    throw new Error(`${name}: stderr must be empty: ${JSON.stringify(result.stderr)}`);
+  }
+  const expected = `${JSON.stringify(output)}\n`;
+  if (result.stdout !== expected) {
+    throw new Error(
+      `${name}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(result.stdout)}`,
+    );
+  }
+}
+
+function claimCases() {
+  const solver = address("1");
+  const eventId = "018f47a0-1a2b-7c3d-8e4f-123456789abc";
+  const base = {
+    schema_version: "agent-bounties/agent-native-claim-v1",
+    candidate: { status: "waitlisted", solver_wallet: solver, canonical_event_id: null },
+    canonical_event_id: null,
+    wallet_request: null,
+    next_request: null,
+  };
+  expectRun("missing claim path", [], 2, { ok: false, errors: ["claim_response_path_required"] });
+  expectRun("unreadable claim", [join(temporary, "absent.json")], 2, { ok: false, errors: ["claim_response_unreadable"] });
+  expectRun("invalid claim JSON", [fixture("claim-invalid.json", "{", true)], 2, { ok: false, errors: ["claim_response_invalid_json"] });
+  expectRun("claim root", [fixture("claim-root.json", [])], 2, { ok: false, errors: ["claim_response_object_required"] });
+  expectRun("waitlisted", [fixture("claim-waitlisted.json", base)], 0, {
+    ok: true,
+    state: "waitlisted",
+    action: "poll_same_idempotency_key",
+    may_sign: false,
+    may_start_work: false,
+  });
+
+  const authorization = structuredClone(base);
+  authorization.candidate.status = "authorization_ready";
+  authorization.wallet_request = {
+    method: "eth_signTypedData_v4",
+    params: [solver.toUpperCase(), JSON.stringify({ domain: { chainId: 8453 } })],
+  };
+  authorization.next_request = {
+    method: "POST",
+    url: "https://api.bountyboard.global/v1/base/autonomous-bounties/claims",
+    body: { idempotency_key: "benchmark-claim-1" },
+  };
+  expectRun("authorization ready", [fixture("claim-authorization.json", authorization)], 0, {
+    ok: true,
+    state: "authorization_ready",
+    action: "sign_wallet_request_and_replay",
+    may_sign: true,
+    may_start_work: false,
+  });
+  authorization.wallet_request.params[0] = address("2");
+  expectRun("unsafe authorization", [fixture("claim-unsafe.json", authorization)], 1, {
+    ok: false,
+    errors: ["authorization_request_invalid"],
+  });
+
+  const relaying = structuredClone(base);
+  relaying.candidate.status = "relaying";
+  expectRun("relaying", [fixture("claim-relaying.json", relaying)], 0, {
+    ok: true,
+    state: "relaying",
+    action: "replay_same_signed_request",
+    may_sign: false,
+    may_start_work: false,
+  });
+
+  const claimed = structuredClone(base);
+  claimed.candidate.status = "claimed";
+  claimed.candidate.canonical_event_id = eventId;
+  claimed.canonical_event_id = eventId;
+  expectRun("claimed", [fixture("claim-claimed.json", claimed)], 0, {
+    ok: true,
+    state: "claimed",
+    action: "start_work",
+    may_sign: false,
+    may_start_work: true,
+    canonical_event_id: eventId,
+  });
+  claimed.candidate.canonical_event_id = "different-event";
+  expectRun("unconfirmed claim", [fixture("claim-unconfirmed.json", claimed)], 1, {
+    ok: false,
+    errors: ["canonical_claim_evidence_invalid"],
+  });
+
+  expectRun("claim problem", [fixture("claim-problem.json", {
+    schema_version: "agent-bounties/claim-problem-v1",
+    state: "failed",
+    failed_transition: "confirm_claim",
+    error: "claim_event_mismatch",
+    next_action: "Do not start work; report the transaction hash.",
+  })], 0, {
+    ok: true,
+    state: "failed",
+    action: "follow_error_next_action",
+    may_sign: false,
+    may_start_work: false,
+    error: "claim_event_mismatch",
+    failed_transition: "confirm_claim",
+  });
+  expectRun("unknown claim state", [fixture("claim-unknown.json", {
+    ...base,
+    candidate: { ...base.candidate, status: "exclusive" },
+  })], 1, { ok: false, errors: ["claim_state_unsupported:exclusive"] });
+}
+
+function bounty(overrides = {}) {
+  return {
+    bounty_id: hash("a"),
+    bounty_contract: address("a"),
+    creator: address("f"),
+    status: "claimable",
+    solver_reward: "2000000",
+    verifier_reward: "200000",
+    claim_bond: "200000",
+    target_amount: "2200000",
+    funded_amount: "2200000",
+    terms_hash: hash("b"),
+    terms_valid: true,
+    verification_ready: true,
+    validation_errors: [],
+    ...overrides,
+  };
+}
+
+function selectionCases() {
+  const solver = address("1");
+  expectRun("missing feed args", [], 2, { ok: false, errors: ["feed_path_and_solver_required"] });
+  expectRun("invalid solver", [fixture("feed-empty.json", []), "invalid"], 2, { ok: false, errors: ["solver_wallet_invalid"] });
+  expectRun("invalid feed JSON", [fixture("feed-invalid.json", "{", true), solver], 2, { ok: false, errors: ["feed_invalid_json"] });
+  expectRun("feed root", [fixture("feed-root.json", {}), solver], 2, { ok: false, errors: ["feed_array_required"] });
+  expectRun("malformed feed item", [fixture("feed-malformed.json", [bounty({ solver_reward: "2.0" })]), solver], 2, { ok: false, errors: ["feed_item_invalid:0"] });
+  expectRun("no safe bounty", [fixture("feed-none.json", [bounty({ funded_amount: "1" })]), solver], 1, { ok: false, errors: ["no_safe_claimable_bounty"] });
+
+  const selected = bounty({
+    bounty_id: hash("3"),
+    bounty_contract: address("3"),
+    solver_reward: "3000000",
+    claim_bond: "100000",
+    target_amount: "3100000",
+    funded_amount: "3100000",
+    terms_hash: hash("4"),
+  });
+  const feed = [
+    bounty({ bounty_id: hash("1"), bounty_contract: address("1"), solver_reward: "2500000" }),
+    bounty({ bounty_id: hash("2"), bounty_contract: address("2"), solver_reward: "3000000", claim_bond: "200000", target_amount: "3200000", funded_amount: "3200000" }),
+    selected,
+    bounty({ bounty_id: hash("5"), bounty_contract: address("5"), creator: solver, solver_reward: "5000000", target_amount: "5200000", funded_amount: "5200000" }),
+    bounty({ bounty_id: hash("6"), bounty_contract: address("6"), solver_reward: "6000000", target_amount: "6200000", funded_amount: "6200000", verification_ready: false }),
+  ];
+  expectRun("rank safe bounty", [fixture("feed-ranked.json", feed), solver.toUpperCase()], 0, {
+    ok: true,
+    bounty_contract: address("3"),
+    bounty_id: hash("3"),
+    solver_reward: "3000000",
+    claim_bond: "100000",
+    terms_hash: hash("4"),
+    next_action: "agent_native_claim",
+    request_bond_sponsorship: true,
+  });
+
+  const tie = [
+    bounty({ bounty_id: hash("c"), bounty_contract: address("c") }),
+    bounty({ bounty_id: hash("b"), bounty_contract: address("b") }),
+  ];
+  expectRun("stable tie", [fixture("feed-tie.json", tie), solver], 0, {
+    ok: true,
+    bounty_contract: address("b"),
+    bounty_id: hash("b"),
+    solver_reward: "2000000",
+    claim_bond: "200000",
+    terms_hash: hash("b"),
+    next_action: "agent_native_claim",
+    request_bond_sponsorship: true,
+  });
+}
+
+function settledItem(overrides = {}) {
+  const contract = address("7");
+  const solver = address("8");
+  const item = {
+    bounty_id: hash("7"),
+    bounty_contract: contract,
+    status: "settled",
+    solver_reward: "2000000",
+    verifier_reward: "200000",
+    claim_bond: "200000",
+    events: [{
+      tx_hash: hash("9"),
+      log_index: 12,
+      contract_address: contract,
+      bounty_id: hash("7"),
+      kind: "bounty_settled",
+      data: {
+        round: 1,
+        solver,
+        solver_reward: 2000000,
+        claim_bond_returned: 200000,
+        timeout_bond_bonus: 100000,
+        solver_payout: 2300000,
+        verifier_reward: 200000,
+        submission_hash: hash("a"),
+        evidence_hash: hash("b"),
+        policy_hash: hash("c"),
+        verification_hash: hash("d"),
+      },
+    }],
+  };
+  return { contract, solver, item: { ...item, ...overrides } };
+}
+
+function settlementCases() {
+  const value = settledItem();
+  expectRun("missing settlement args", [], 2, { ok: false, errors: ["item_path_contract_and_solver_required"] });
+  expectRun("invalid expected address", [fixture("settlement-empty.json", {}), "bad", value.solver], 2, { ok: false, errors: ["expected_address_invalid"] });
+  expectRun("settlement item root", [fixture("settlement-root.json", []), value.contract, value.solver], 2, { ok: false, errors: ["settlement_item_object_required"] });
+  expectRun("valid settlement", [fixture("settlement-valid.json", value.item), value.contract.toUpperCase(), value.solver.toUpperCase()], 0, {
+    ok: true,
+    paid: true,
+    bounty_contract: value.contract,
+    bounty_id: hash("7"),
+    solver: value.solver,
+    solver_payout: "2300000",
+    verifier_reward: "200000",
+    transaction_hash: hash("9"),
+    log_index: 12,
+  });
+
+  const noEvent = { ...value.item, events: [] };
+  expectRun("missing settlement", [fixture("settlement-missing.json", noEvent), value.contract, value.solver], 1, { ok: false, errors: ["exact_settlement_event_required"] });
+  const duplicate = structuredClone(value.item);
+  duplicate.events.push(structuredClone(duplicate.events[0]));
+  expectRun("duplicate settlement", [fixture("settlement-duplicate.json", duplicate), value.contract, value.solver], 1, { ok: false, errors: ["exact_settlement_event_required"] });
+  const wrongSolver = structuredClone(value.item);
+  wrongSolver.events[0].data.solver = address("6");
+  expectRun("wrong solver", [fixture("settlement-solver.json", wrongSolver), value.contract, value.solver], 1, { ok: false, errors: ["settlement_solver_mismatch"] });
+  const wrongPayout = structuredClone(value.item);
+  wrongPayout.events[0].data.solver_payout += 1;
+  expectRun("wrong payout", [fixture("settlement-payout.json", wrongPayout), value.contract, value.solver], 1, { ok: false, errors: ["settlement_amount_mismatch"] });
+  const wrongHash = structuredClone(value.item);
+  wrongHash.events[0].data.evidence_hash = "0x00";
+  expectRun("wrong commitment", [fixture("settlement-hash.json", wrongHash), value.contract, value.solver], 1, { ok: false, errors: ["settlement_commitment_invalid"] });
+}
+
+try {
+  if (task === "claim-next-action") claimCases();
+  if (task === "select-funded-bounty") selectionCases();
+  if (task === "verify-settlement-evidence") settlementCases();
+  console.log(`direct_agent_loop_benchmark=passed task=${task}`);
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/scripts/check.ps1
+++ b/scripts/check.ps1
@@ -69,6 +69,7 @@ Invoke-Checked { & $pythonCommand.Source @pythonArgs scripts\check-migration-his
 Invoke-Checked { node --check skills\agent-bounties\scripts\check-in.mjs }
 Invoke-Checked { node --test scripts\test_agent_bounties_openclaw_skill.mjs }
 Invoke-Checked { node benchmarks\standing-meta-v2\mcp-discovery\self-test.mjs }
+Invoke-Checked { node benchmarks\direct-v1\agent-loop\self-test.mjs }
 Invoke-Checked { node scripts\test-autonomous-wallet-flow.js }
 Invoke-Checked { node --check tools\autonomous-activation.js }
 Invoke-Checked { node scripts\test-autonomous-activation-console.js }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -105,6 +105,7 @@ cargo run -p cli -- discovery-report \
 node --check skills/agent-bounties/scripts/check-in.mjs
 node --test scripts/test_agent_bounties_openclaw_skill.mjs
 node benchmarks/standing-meta-v2/mcp-discovery/self-test.mjs
+node benchmarks/direct-v1/agent-loop/self-test.mjs
 node scripts/test-autonomous-wallet-flow.js
 node --check tools/autonomous-activation.js
 node scripts/test-autonomous-activation-console.js


### PR DESCRIPTION
## Summary
- add one immutable no-network benchmark suite for three direct agent-loop coding tasks
- keep solver work in separate files to avoid contributor conflicts
- prove known-good implementations pass and always-success/missing implementations fail
- include the benchmark self-test in Windows and Unix full gates

## Tasks unlocked
- `claim-next-action`: safely interpret hosted claim state
- `select-funded-bounty`: rank only fully funded, verification-ready opportunities
- `verify-settlement-evidence`: require the exact canonical `bounty_settled` event before paid language

## Verification
- `scripts/preflight.ps1 -Mode core`
- `node --check benchmarks/direct-v1/agent-loop/test.mjs`
- `node --check benchmarks/direct-v1/agent-loop/self-test.mjs`
- `node benchmarks/direct-v1/agent-loop/self-test.mjs`
- `bash -n scripts/check.sh`
- PowerShell parser check for `scripts/check.ps1`
- `git diff --check`

This PR moves no funds and changes no deployed contract, wallet policy, or settlement rule. The merged commit will be content-addressed before any bounty is funded.

Refs #355.