### PR TITLE
feat: add claim-next-action, select-funded-bounty, verify-settlement-evidence CLIs

### DIFF
--- a/scripts/next-agent-claim-action.mjs
+++ b/scripts/next-agent-claim-action.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+function err(code, errors) {
+  out({ ok: false, errors });
+  process.exit(code);
+}
+
+const arg = process.argv[2];
+if (!arg) {
+  err(2, ["claim_response_path_required"]);
+}
+
+let raw;
+try {
+  raw = readFileSync(arg, "utf8");
+} catch {
+  err(2, ["claim_response_unreadable"]);
+}
+
+let doc;
+try {
+  doc = JSON.parse(raw);
+} catch {
+  err(2, ["claim_response_invalid_json"]);
+}
+
+if (!doc || typeof doc !== "object" || Array.isArray(doc)) {
+  err(2, ["claim_response_object_required"]);
+}
+
+const schemaVersion = doc.schema_version;
+
+if (schemaVersion === "agent-bounties/claim-problem-v1") {
+  const state = doc.state ?? "failed";
+  const failedTransition = doc.failed_transition;
+  const error = doc.error;
+  out({ ok: true, state, action: "follow_error_next_action", may_sign: false, may_start_work: false, error, failed_transition: failedTransition });
+  process.exit(0);
+}
+
+// State can be at doc.state or doc.candidate.status
+const state = doc.state ?? doc.candidate?.status;
+if (!state) {
+  err(2, ["claim_response_missing_state"]);
+}
+
+switch (state) {
+  case "waitlisted":
+    out({ ok: true, state, action: "poll_same_idempotency_key", may_sign: false, may_start_work: false });
+    break;
+
+  case "authorization_ready": {
+    const walletRequest = doc.wallet_request;
+    if (!walletRequest || typeof walletRequest !== "object") {
+      err(1, ["authorization_request_invalid"]);
+      break;
+    }
+    if (walletRequest.method !== "eth_signTypedData_v4") {
+      err(1, ["authorization_request_invalid"]);
+      break;
+    }
+    const params = walletRequest.params;
+    if (!Array.isArray(params) || params.length < 1) {
+      err(1, ["authorization_request_invalid"]);
+      break;
+    }
+    const solverWallet = doc.candidate?.solver_wallet;
+    if (!solverWallet) {
+      err(1, ["authorization_request_invalid"]);
+      break;
+    }
+    const providedAddress = params[0];
+    if (typeof providedAddress !== "string" || providedAddress.toLowerCase() !== solverWallet.toLowerCase()) {
+      err(1, ["authorization_request_invalid"]);
+      break;
+    }
+    if (!doc.next_request || typeof doc.next_request !== "object") {
+      err(1, ["authorization_request_invalid"]);
+      break;
+    }
+    out({ ok: true, state, action: "sign_wallet_request_and_replay", may_sign: true, may_start_work: false });
+    break;
+  }
+
+  case "relaying":
+    out({ ok: true, state, action: "replay_same_signed_request", may_sign: false, may_start_work: false });
+    break;
+
+  case "claimed": {
+    const candidateEventId = doc.candidate?.canonical_event_id;
+    const topLevelEventId = doc.canonical_event_id;
+    if (!candidateEventId || !topLevelEventId || candidateEventId !== topLevelEventId) {
+      err(1, ["canonical_claim_evidence_invalid"]);
+      break;
+    }
+    out({ ok: true, state, action: "start_work", may_sign: false, may_start_work: true, canonical_event_id: topLevelEventId });
+    break;
+  }
+
+  default:
+    err(1, [`claim_state_unsupported:${state}`]);
+}

--- a/scripts/select-funded-bounty.mjs
+++ b/scripts/select-funded-bounty.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const VALID_ADDRESS_RE = /^0x[0-9a-f]{40}$/i;
+const VALID_BOUNTY_ID_RE = /^0x[0-9a-f]{64}$/i;
+
+function err(code, errors) {
+  process.stdout.write(JSON.stringify({ ok: false, errors }) + "\n");
+  process.exit(code);
+}
+
+function ok(entry) {
+  const out = {
+    ok: true,
+    bounty_contract: entry.bounty_contract.toLowerCase(),
+    bounty_id: entry.bounty_id.toLowerCase(),
+    solver_reward: entry.solver_reward,
+    claim_bond: entry.claim_bond,
+    terms_hash: entry.terms_hash,
+    next_action: "agent_native_claim",
+    request_bond_sponsorship: true,
+  };
+  process.stdout.write(JSON.stringify(out) + "\n");
+  process.exit(0);
+}
+
+function isValidInt(v) {
+  if (typeof v !== "string") return false;
+  if (!/^-?\d+$/.test(v)) return false;
+  if (/^-?0\d/.test(v) && v.length > 2) return false;
+  return true;
+}
+
+function isMalformed(item) {
+  if (typeof item !== "object" || item === null || Array.isArray(item)) return true;
+  if (typeof item.status !== "string") return true;
+  if (!isValidInt(item.solver_reward)) return true;
+  if (!isValidInt(item.claim_bond)) return true;
+  if (!isValidInt(item.target_amount)) return true;
+  if (!isValidInt(item.funded_amount)) return true;
+  if (!VALID_BOUNTY_ID_RE.test(item.bounty_id)) return true;
+  if (!VALID_ADDRESS_RE.test(item.bounty_contract)) return true;
+  if (!VALID_ADDRESS_RE.test(item.creator)) return true;
+  return false;
+}
+
+function isEligible(item, solver) {
+  if (item.status !== "claimable") return false;
+  if (BigInt(item.funded_amount) < BigInt(item.target_amount)) return false;
+  if (item.terms_valid !== true) return false;
+  if (item.verification_ready !== true) return false;
+  if (item.validation_errors && item.validation_errors.length > 0) return false;
+  if (BigInt(item.solver_reward) <= 0n) return false;
+  if (BigInt(item.claim_bond) <= 0n) return false;
+  if (item.creator.toLowerCase() === solver.toLowerCase()) return false;
+  return true;
+}
+
+const args = process.argv.slice(2);
+if (args.length !== 2) {
+  err(2, ["feed_path_and_solver_required"]);
+}
+
+const [feedPath, solver] = args;
+
+if (!VALID_ADDRESS_RE.test(solver)) {
+  err(2, ["solver_wallet_invalid"]);
+}
+
+let raw;
+try {
+  raw = readFileSync(feedPath, "utf8");
+} catch {
+  err(2, ["feed_invalid_json"]);
+}
+
+let feed;
+try {
+  feed = JSON.parse(raw);
+} catch {
+  err(2, ["feed_invalid_json"]);
+}
+
+if (!Array.isArray(feed)) {
+  err(2, ["feed_array_required"]);
+}
+
+const malformed = [];
+for (let i = 0; i < feed.length; i++) {
+  if (isMalformed(feed[i])) {
+    malformed.push(`feed_item_invalid:${i}`);
+  }
+}
+if (malformed.length > 0) {
+  err(2, malformed);
+}
+
+const eligible = feed.filter((item) => isEligible(item, solver));
+
+if (eligible.length === 0) {
+  err(1, ["no_safe_claimable_bounty"]);
+}
+
+eligible.sort((a, b) => {
+  const rA = BigInt(a.solver_reward);
+  const rB = BigInt(b.solver_reward);
+  if (rA > rB) return -1;
+  if (rA < rB) return 1;
+  const bA = BigInt(a.claim_bond);
+  const bB = BigInt(b.claim_bond);
+  if (bA < bB) return -1;
+  if (bA > bB) return 1;
+  return a.bounty_id < b.bounty_id ? -1 : a.bounty_id > b.bounty_id ? 1 : 0;
+});
+
+ok(eligible[0]);

--- a/scripts/verify-settlement-evidence.mjs
+++ b/scripts/verify-settlement-evidence.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const HEX_ADDR_RE = /^0x[0-9a-f]{40}$/i;
+const HEX_HASH_RE = /^0x[0-9a-f]{64}$/i;
+
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+function fail(code, errors) {
+  out({ ok: false, errors });
+  process.exit(code);
+}
+
+const [itemPath, expectedContract, expectedSolver] = process.argv.slice(2);
+
+if (!itemPath || !expectedContract || !expectedSolver) {
+  fail(2, ["item_path_contract_and_solver_required"]);
+}
+
+if (!HEX_ADDR_RE.test(expectedContract) || !HEX_ADDR_RE.test(expectedSolver)) {
+  fail(2, ["expected_address_invalid"]);
+}
+
+let item;
+try {
+  item = JSON.parse(readFileSync(itemPath, "utf8"));
+} catch {
+  fail(2, ["settlement_item_object_required"]);
+}
+
+if (Array.isArray(item) || item === null || typeof item !== "object") {
+  fail(2, ["settlement_item_object_required"]);
+}
+
+const events = Array.isArray(item.events) ? item.events : [];
+const ecLower = expectedContract.toLowerCase();
+const esLower = expectedSolver.toLowerCase();
+
+const candidates = events.filter((e) => {
+  if (e.kind !== "bounty_settled") return false;
+  if (typeof e.contract_address !== "string" || e.contract_address.toLowerCase() !== ecLower) return false;
+  if (e.bounty_id !== item.bounty_id) return false;
+  if (typeof e.log_index !== "number" || e.log_index < 0) return false;
+  if (!e.data || typeof e.data.round !== "number" || e.data.round <= 0) return false;
+  return true;
+});
+
+if (candidates.length === 0) {
+  fail(1, ["exact_settlement_event_required"]);
+}
+
+const solverMatches = candidates.filter(
+  (e) => typeof e.data.solver === "string" && e.data.solver.toLowerCase() === esLower
+);
+
+if (solverMatches.length === 0) {
+  fail(1, ["settlement_solver_mismatch"]);
+}
+
+if (solverMatches.length !== 1) {
+  fail(1, ["exact_settlement_event_required"]);
+}
+
+const m = solverMatches[0];
+const d = m.data;
+
+const solverReward = d.solver_reward;
+const claimBondReturned = d.claim_bond_returned;
+const verifierReward = d.verifier_reward;
+const timeoutBondBonus = d.timeout_bond_bonus;
+
+if (
+  typeof solverReward !== "number" || solverReward < 0 ||
+  typeof claimBondReturned !== "number" || claimBondReturned < 0 ||
+  typeof verifierReward !== "number" || verifierReward < 0 ||
+  typeof timeoutBondBonus !== "number" || timeoutBondBonus < 0
+) {
+  fail(1, ["settlement_amount_mismatch"]);
+}
+
+const solverPayout = solverReward + claimBondReturned + timeoutBondBonus;
+
+// Validate against the solver_payout in the event data
+if (typeof d.solver_payout === "number" && solverPayout !== d.solver_payout) {
+  fail(1, ["settlement_amount_mismatch"]);
+}
+
+// Also validate against item.amount if present
+if (typeof item.amount === "number" && solverPayout !== item.amount) {
+  fail(1, ["settlement_amount_mismatch"]);
+}
+
+if (
+  !HEX_HASH_RE.test(d.submission_hash) ||
+  !HEX_HASH_RE.test(d.evidence_hash) ||
+  !HEX_HASH_RE.test(d.policy_hash) ||
+  !HEX_HASH_RE.test(d.verification_hash)
+) {
+  fail(1, ["settlement_commitment_invalid"]);
+}
+
+out({
+  ok: true,
+  paid: true,
+  bounty_contract: m.contract_address,
+  bounty_id: item.bounty_id,
+  solver: d.solver,
+  solver_payout: String(solverPayout),
+  verifier_reward: String(verifierReward),
+  transaction_hash: m.tx_hash,
+  log_index: m.log_index,
+});
+process.exit(0);


### PR DESCRIPTION
## Summary

Adds three dependency-free Node.js CLI scripts that pass all deterministic regression benchmarks:

1. **** - Converts Agent Bounties claim responses into safe next actions
2. **** - Selects the best funded bounty from a canonical feed
3. **** - Verifies canonical settlement evidence for payment

## Implementation

All scripts:
- Use only Node.js built-ins (no network, no secrets, no shell)
- Write exactly one compact JSON line to stdout, nothing to stderr
- Follow fail-closed principles for security
- Handle all edge cases as specified in the benchmark README

## Verification

All three scripts pass the deterministic regression benchmarks:


## Claims

-  (claim-next-action)
-  (select-funded-bounty) 
-  (verify-settlement-evidence)

Resolves #358, resolves #359, resolves #360