### PR TITLE
fix: reconcile cloud agent Render configuration

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -125,6 +125,7 @@ jobs:
         shell: bash
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          CLOUD_AGENT_API_KEY: ${{ secrets.CLOUD_AGENT_API_KEY }}
         run: |
           python scripts/render_deploy_recovery.py \
             --revision "${TARGET_REVISION}" \
@@ -160,6 +161,9 @@ jobs:
               f"- Services live: `{sum(item['status'] == 'live' for item in evidence['services'])}/3`",
               f"- Exact health attestations: `{len(evidence['health'])}/2`",
               f"- Public endpoint variables: `{len(evidence.get('public_environment', []))}/4`",
+              f"- Cloud runtime variables: `{len(evidence.get('cloud_environment', []))}/10`",
+              f"- Cloud model credential supplied: `{bool(evidence.get('secret_environment'))}`",
+              f"- Cloud drafting ready: `{bool(evidence.get('cloud_readiness', {}).get('available'))}`",
               "",
               "The controller can deploy application services only. It cannot deploy contracts, sign wallet transactions, or authorize settlement.",
           ]

--- a/docs/cloud-agent-operations.md
+++ b/docs/cloud-agent-operations.md
@@ -21,9 +21,12 @@ executable verifier, and publish and fund through the canonical protocol.
 ## Provider Configuration
 
 The adapter supports OpenAI-compatible chat completions and Anthropic Messages.
-Render keeps `CLOUD_AGENT_API_KEY` in the isolated
-`agent-bounties-cloud-agent` environment group. Only `agent-bounties-api`
-receives that group.
+Only `agent-bounties-api` receives `CLOUD_AGENT_API_KEY`. The Blueprint declares
+it directly on that service with `sync: false`; Render does not support
+`sync: false` inside environment groups. The exact-SHA deployment controller
+reconciles all nonsecret settings and, when the repository Actions secret is
+present, copies the model credential directly to the API service without
+including its value in deployment evidence.
 
 Required production settings:
 
@@ -36,6 +39,14 @@ CLOUD_AGENT_ENDPOINT=https://api.openai.com/v1/chat/completions
 CLOUD_AGENT_MODEL=gpt-4.1-mini
 CLOUD_AGENT_API_KEY=<Render secret>
 ```
+
+Store the same credential as the repository Actions secret
+`CLOUD_AGENT_API_KEY`, then dispatch **Render Deploy Recovery**. Existing Render
+Blueprints ignore newly added `sync: false` placeholders, so the deployment
+controller is the repeatable configuration path. Rotating the Actions secret
+and dispatching again rotates the API-service value and forces a redeploy. The
+controller then fails closed unless readiness reports hosted execution,
+draft-only authority, no local fallback, and `available: true`.
 
 The default public quota is 25 fresh drafts per UTC day per API process.
 Idempotent retries return the cached draft and do not consume another model

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,9 +24,11 @@ The root `render.yaml` creates:
 - `agent-bounties-mcp`,
 - `agent-bounties-base-indexer`.
 
-The `agent-bounties-cloud-agent` environment group contains only the hosted
-model API key and is attached only to `agent-bounties-api`. MCP proxies the API
-and must not receive this secret. Set the key in Render and verify
+`CLOUD_AGENT_API_KEY` is a direct `sync: false` secret on
+`agent-bounties-api`; Render ignores `sync: false` inside environment groups.
+MCP proxies the API and must not receive this secret. The exact-SHA controller
+reconciles nonsecret model settings and copies the optional repository Actions
+secret `CLOUD_AGENT_API_KEY` into the API service without logging it. Verify
 `GET /v1/cloud-agent/readiness`; see
 [`cloud-agent-operations.md`](cloud-agent-operations.md).
 
@@ -47,12 +49,16 @@ succeeds on a push to `main`, the workflow:
    branch, and service type;
 4. disables any drifted native auto-deploy setting;
 5. reconciles `PUBLIC_BASE_URL` and `MCP_BASE_URL` on both public services;
-6. calls Render's deploy API with the exact commit for API, MCP, and worker;
-7. waits for all three deploys to reach `live` and fails on terminal errors;
-8. verifies exact revision and protocol headers from API and MCP `/health`;
-9. stores a redacted 30-day deployment evidence artifact.
+6. reconciles all nonsecret cloud-agent settings on API and copies the optional
+   GitHub-held model key without including its value in evidence;
+7. calls Render's deploy API with the exact commit for API, MCP, and worker;
+8. waits for all three deploys to reach `live` and fails on terminal errors;
+9. verifies exact revision and protocol headers from API and MCP `/health`;
+10. attests cloud readiness and fails if a supplied model credential did not
+    become usable;
+11. stores a redacted 30-day deployment evidence artifact.
 
-Configure one GitHub Actions secret named `RENDER_API_KEY`. Create it in the
+Configure the GitHub Actions secret `RENDER_API_KEY`. Create it in the
 Render Dashboard for the workspace that owns these three services, then store
 it only under repository **Settings > Secrets and variables > Actions**. Never
 put the key in Render variables, workflow inputs, logs, issues, or Git. A
@@ -61,6 +67,12 @@ The key can deploy application services, so rotate it after suspected exposure.
 Creating, rotating, or revoking the credential is an explicit R3 access change;
 using the already-provisioned credential for the bounded exact-SHA application
 deploy is R2.
+
+To enable hosted bounty drafting, also configure the repository Actions secret
+`CLOUD_AGENT_API_KEY`. It is passed only to the bounded deployment job, written
+only to `agent-bounties-api`, and redacted from evidence. If it is absent, the
+deployment still succeeds but `/v1/cloud-agent/readiness` remains unavailable
+and reports the missing credential explicitly; no local-model fallback runs.
 
 The controller can be rehearsed without credentials:
 
@@ -108,12 +120,15 @@ control. Every address must have a public incident record. Malformed values stop
 API and MCP startup; configured contracts remain visible in the full canonical
 feed but cannot appear as earning-ready work or verifier jobs.
 
-Secrets belong in Render environment groups, never in Git:
+Shared secrets belong in Render environment groups, never in Git:
 
 - `DATABASE_URL`,
 - managed RPC credentials,
 - optional `OPERATOR_API_TOKEN` for non-protocol administrative surfaces,
 - future Stripe secrets and verified webhook secret.
+
+The hosted model credential is a direct API-service secret, not a shared
+environment-group value. This prevents MCP and the indexer from receiving it.
 
 The separate `RENDER_API_KEY` belongs only in GitHub Actions and is never
 injected into an application container.

--- a/render.yaml
+++ b/render.yaml
@@ -53,11 +53,6 @@ envVarGroups:
       - key: BOND_SPONSOR_BASE_SEPOLIA_CONTRACT
         sync: false
 
-  - name: agent-bounties-cloud-agent
-    envVars:
-      - key: CLOUD_AGENT_API_KEY
-        sync: false
-
 services:
   - type: web
     name: agent-bounties-api
@@ -132,6 +127,8 @@ services:
         value: "false"
       - key: ALLOW_UNSIGNED_STRIPE_WEBHOOKS
         value: "false"
+      - key: CLOUD_AGENT_API_KEY
+        sync: false
       - key: CLOUD_AGENT_ENABLED
         value: "true"
       - key: CLOUD_AGENT_PUBLIC_DRAFTS
@@ -157,7 +154,6 @@ services:
       - fromGroup: agent-bounties-base
       - fromGroup: agent-bounties-x402-relayer
       - fromGroup: agent-bounties-bond-sponsor
-      - fromGroup: agent-bounties-cloud-agent
 
   - type: web
     name: agent-bounties-mcp

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -222,12 +222,8 @@ def main() -> int:
         ["X402_RELAYER_PRIVATE_KEY"],
     )
     require_env_sync_false(relayer_group, "X402_RELAYER_PRIVATE_KEY")
-    cloud_agent_group = require_group(
-        text,
-        "agent-bounties-cloud-agent",
-        ["CLOUD_AGENT_API_KEY"],
-    )
-    require_env_sync_false(cloud_agent_group, "CLOUD_AGENT_API_KEY")
+    if "agent-bounties-cloud-agent" in section(text, "envVarGroups"):
+        fail("CLOUD_AGENT_API_KEY cannot use sync: false inside an environment group")
     if active:
         require_env_value(base_group, "BASE_MAINNET_BOUNTY_FACTORY", str(factory["contract"]))
         require_env_value(base_group, "BASE_MAINNET_BOUNTY_IMPLEMENTATION", str(factory["implementation"]))
@@ -262,6 +258,7 @@ def main() -> int:
         "actions: read",
         "Select latest successful main revision",
         "RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}",
+        "CLOUD_AGENT_API_KEY: ${{ secrets.CLOUD_AGENT_API_KEY }}",
         "scripts/render_deploy_recovery.py",
         '--public-base-url "${PRODUCTION_API_BASE_URL%/}"',
         '--mcp-base-url "${PRODUCTION_MCP_BASE_URL%/}"',
@@ -269,6 +266,18 @@ def main() -> int:
     for required in workflow_contract:
         if required not in deploy_workflow:
             fail(f"Render deployment workflow missing contract: {required}")
+
+    controller_path = repo_root / "scripts" / "render_deploy_recovery.py"
+    controller = controller_path.read_text(encoding="utf-8")
+    for required in [
+        "CLOUD_AGENT_RUNTIME_ENVIRONMENT",
+        "reconcile_cloud_agent_environment",
+        "validate_cloud_agent_readiness",
+        'cloud_agent_api_key=os.environ.get("CLOUD_AGENT_API_KEY")',
+        '"secret_environment": secret_environment',
+    ]:
+        if required not in controller:
+            fail(f"Render deployment controller missing cloud contract: {required}")
 
     api = named_block(services, "agent-bounties-api")
     if "domains:\n      - api.bountyboard.global" not in api:
@@ -279,11 +288,17 @@ def main() -> int:
     require_env_value(api, "ENABLE_STRIPE_PUBLIC_CHECKOUT", '"false"')
     require_env_value(api, "ENABLE_BASE_TX_BROADCAST", '"false"')
     require_env_value(api, "ENABLE_X402_HOSTED_RELAY", '"true"')
+    require_env_sync_false(api, "CLOUD_AGENT_API_KEY")
     require_env_value(api, "CLOUD_AGENT_ENABLED", '"true"')
     require_env_value(api, "CLOUD_AGENT_PUBLIC_DRAFTS", '"true"')
+    require_env_value(api, "CLOUD_AGENT_PROVIDER", "openai-compatible")
     require_env_value(api, "CLOUD_AGENT_PROTOCOL", "openai_chat_completions")
     require_env_value(api, "CLOUD_AGENT_ENDPOINT", "https://api.openai.com/v1/chat/completions")
+    require_env_value(api, "CLOUD_AGENT_MODEL", "gpt-4.1-mini")
+    require_env_value(api, "CLOUD_AGENT_MAX_INPUT_CHARS", '"12000"')
+    require_env_value(api, "CLOUD_AGENT_MAX_OUTPUT_TOKENS", '"2500"')
     require_env_value(api, "CLOUD_AGENT_MAX_DAILY_DRAFTS", '"25"')
+    require_env_value(api, "CLOUD_AGENT_TIMEOUT_SECONDS", '"45"')
     require_env_value(api, "X402_RELAYER_MIN_USDC_BASE_UNITS", '"100000"')
     require_env_value(api, "X402_RELAYER_MAX_USDC_BASE_UNITS", '"5000000"')
     require_env_value(api, "X402_RELAYER_MAX_GAS", '"300000"')
@@ -295,8 +310,8 @@ def main() -> int:
     )
     if "fromGroup: agent-bounties-x402-relayer" not in api:
         fail("API service must receive the isolated x402 relayer secret group")
-    if "fromGroup: agent-bounties-cloud-agent" not in api:
-        fail("API service must receive the isolated cloud-agent secret group")
+    if "fromGroup: agent-bounties-cloud-agent" in api:
+        fail("API service must keep the cloud credential as a direct sync:false secret")
     if "healthCheckPath: /health" not in api:
         fail("API service must use /health")
 
@@ -312,6 +327,8 @@ def main() -> int:
         fail("MCP service must not receive the x402 relayer private key")
     if "fromGroup: agent-bounties-cloud-agent" in mcp:
         fail("MCP service must proxy cloud drafts without receiving the model API key")
+    if "key: CLOUD_AGENT_API_KEY" in mcp:
+        fail("MCP service must not receive the model API key")
     if "healthCheckPath: /health" not in mcp:
         fail("MCP service must use /health")
 

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -42,6 +42,19 @@ PUBLIC_ENV_SERVICE_NAMES = {
     "agent-bounties-api",
     "agent-bounties-mcp",
 }
+CLOUD_AGENT_API_SERVICE_NAME = "agent-bounties-api"
+CLOUD_AGENT_RUNTIME_ENVIRONMENT = {
+    "CLOUD_AGENT_ENABLED": "true",
+    "CLOUD_AGENT_PUBLIC_DRAFTS": "true",
+    "CLOUD_AGENT_PROVIDER": "openai-compatible",
+    "CLOUD_AGENT_PROTOCOL": "openai_chat_completions",
+    "CLOUD_AGENT_ENDPOINT": "https://api.openai.com/v1/chat/completions",
+    "CLOUD_AGENT_MODEL": "gpt-4.1-mini",
+    "CLOUD_AGENT_MAX_INPUT_CHARS": "12000",
+    "CLOUD_AGENT_MAX_OUTPUT_TOKENS": "2500",
+    "CLOUD_AGENT_MAX_DAILY_DRAFTS": "25",
+    "CLOUD_AGENT_TIMEOUT_SECONDS": "45",
+}
 
 
 class RecoveryError(RuntimeError):
@@ -487,6 +500,73 @@ def fetch_health(url: str, timeout_seconds: float) -> tuple[int, str, dict[str, 
         raise RecoveryError(f"health probe transport failed: {redact(str(error))}") from None
 
 
+def fetch_json(url: str, timeout_seconds: float) -> dict[str, Any]:
+    separator = "&" if "?" in url else "?"
+    request = urllib.request.Request(
+        f"{url}{separator}_agent_bounties_probe={time.time_ns()}",
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "Cache-Control": "no-cache, no-store",
+            "Connection": "close",
+            "Pragma": "no-cache",
+            "User-Agent": "agent-bounties-render-recovery/1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            status = response.status
+            body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as error:
+        raise RecoveryError(
+            f"JSON readiness probe returned HTTP {error.code}"
+        ) from None
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise RecoveryError(
+            f"JSON readiness probe transport failed: {redact(str(error))}"
+        ) from None
+    if status != 200:
+        raise RecoveryError(f"JSON readiness probe returned HTTP {status}")
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as error:
+        raise RecoveryError(f"JSON readiness probe returned invalid JSON: {error}") from None
+    if not isinstance(payload, dict):
+        raise RecoveryError("JSON readiness probe must return an object")
+    return payload
+
+
+def validate_cloud_agent_readiness(
+    payload: dict[str, Any],
+    *,
+    credential_supplied: bool,
+) -> dict[str, Any]:
+    if payload.get("schema_version") != "agent-bounties/cloud-agent-readiness-v1":
+        raise RecoveryError("cloud-agent readiness schema is invalid")
+    if payload.get("execution") != "hosted_cloud_api":
+        raise RecoveryError("cloud-agent readiness does not attest hosted execution")
+    if payload.get("local_fallback") is not False:
+        raise RecoveryError("cloud-agent readiness must prohibit a local fallback")
+    if payload.get("authority") != "draft_only":
+        raise RecoveryError("cloud-agent readiness exceeds draft-only authority")
+    available = payload.get("available")
+    missing = payload.get("missing_configuration")
+    if not isinstance(available, bool) or not isinstance(missing, list):
+        raise RecoveryError("cloud-agent readiness is incomplete")
+    if credential_supplied and (not available or missing):
+        raise RecoveryError("supplied cloud-agent credential did not become ready")
+    return {
+        "available": available,
+        "credential_supplied": credential_supplied,
+        "provider": payload.get("provider"),
+        "model": payload.get("model"),
+        "public_drafts": payload.get("public_drafts"),
+        "local_fallback": False,
+        "authority": "draft_only",
+        "missing_configuration": missing,
+    }
+
+
 def validate_health(
     service_name: str,
     revision: str,
@@ -549,6 +629,41 @@ def write_evidence(path: Path, evidence: dict[str, Any]) -> None:
     path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def reconcile_cloud_agent_environment(
+    client: RenderClient,
+    service: dict[str, Any],
+    api_key: str | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], bool]:
+    runtime_environment = []
+    changed = False
+    for key, value in CLOUD_AGENT_RUNTIME_ENVIRONMENT.items():
+        record = client.ensure_env_var(service, key, value)
+        changed |= record["changed"]
+        runtime_environment.append(
+            {
+                "service": service["name"],
+                "key": key,
+                "value": value,
+                "changed": record["changed"],
+            }
+        )
+
+    secret_environment = []
+    normalized_key = api_key.strip() if isinstance(api_key, str) else ""
+    if normalized_key:
+        record = client.ensure_env_var(service, "CLOUD_AGENT_API_KEY", normalized_key)
+        changed |= record["changed"]
+        secret_environment.append(
+            {
+                "service": service["name"],
+                "key": "CLOUD_AGENT_API_KEY",
+                "configured": True,
+                "changed": record["changed"],
+            }
+        )
+    return runtime_environment, secret_environment, changed
+
+
 def deploy(
     client: RenderClient,
     revision: str,
@@ -559,6 +674,7 @@ def deploy(
     poll_seconds: float,
     public_base_url: str = "https://api.bountyboard.global",
     mcp_base_url: str = "https://mcp.bountyboard.global",
+    cloud_agent_api_key: str | None = None,
 ) -> dict[str, Any]:
     services: list[tuple[ServiceSpec, dict[str, Any]]] = []
     pending: dict[str, tuple[str, str]] = {}
@@ -593,6 +709,14 @@ def deploy(
                     "changed": record["changed"],
                 }
             )
+
+    api_service = next(
+        service for spec, service in services if spec.name == CLOUD_AGENT_API_SERVICE_NAME
+    )
+    cloud_environment, secret_environment, cloud_environment_changed = (
+        reconcile_cloud_agent_environment(client, api_service, cloud_agent_api_key)
+    )
+    public_environment_changed[CLOUD_AGENT_API_SERVICE_NAME] |= cloud_environment_changed
 
     custom_domains = []
     for spec, service in services:
@@ -649,6 +773,15 @@ def deploy(
         for spec, _ in services
         if spec.health_url is not None
     ]
+    cloud_readiness = validate_cloud_agent_readiness(
+        fetch_json(
+            f"{public_base_url.rstrip('/')}/v1/cloud-agent/readiness",
+            20,
+        ),
+        credential_supplied=bool(
+            cloud_agent_api_key and cloud_agent_api_key.strip()
+        ),
+    )
     service_evidence = []
     for spec, service in services:
         deployed = completed[spec.name]
@@ -670,6 +803,9 @@ def deploy(
         "health": health,
         "custom_domains": custom_domains,
         "public_environment": public_environment,
+        "cloud_environment": cloud_environment,
+        "secret_environment": secret_environment,
+        "cloud_readiness": cloud_readiness,
     }
 
 
@@ -717,6 +853,9 @@ def main() -> int:
         "health": [],
         "custom_domains": [],
         "public_environment": [],
+        "cloud_environment": [],
+        "secret_environment": [],
+        "cloud_readiness": {},
         "error": None,
     }
     try:
@@ -734,6 +873,7 @@ def main() -> int:
             poll_seconds=args.poll_seconds,
             public_base_url=args.public_base_url,
             mcp_base_url=args.mcp_base_url,
+            cloud_agent_api_key=os.environ.get("CLOUD_AGENT_API_KEY"),
         )
         evidence.update(result)
         evidence["revision"] = revision

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -60,6 +60,16 @@ class RecordingClient(recovery.RenderClient):
         return self.response
 
 
+class EnvironmentClient:
+    def __init__(self, changed=True) -> None:
+        self.changed = changed
+        self.calls = []
+
+    def ensure_env_var(self, service, key, value):
+        self.calls.append((service["name"], key, value))
+        return {"key": key, "value": value, "changed": self.changed}
+
+
 class ResolutionFailureClient:
     def __init__(self) -> None:
         self.resolved = []
@@ -280,6 +290,49 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             ],
         )
 
+    def test_cloud_environment_reconciliation_never_returns_secret_value(self) -> None:
+        client = EnvironmentClient()
+        service = {"id": "srv-api", "name": "agent-bounties-api"}
+        runtime, secrets, changed = recovery.reconcile_cloud_agent_environment(
+            client,
+            service,
+            "  model-secret-value  ",
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(len(runtime), len(recovery.CLOUD_AGENT_RUNTIME_ENVIRONMENT))
+        self.assertEqual(
+            secrets,
+            [
+                {
+                    "service": "agent-bounties-api",
+                    "key": "CLOUD_AGENT_API_KEY",
+                    "configured": True,
+                    "changed": True,
+                }
+            ],
+        )
+        self.assertEqual(client.calls[-1], (
+            "agent-bounties-api",
+            "CLOUD_AGENT_API_KEY",
+            "model-secret-value",
+        ))
+        self.assertNotIn("model-secret-value", recovery.json.dumps([runtime, secrets]))
+
+    def test_missing_cloud_secret_is_never_written_or_invented(self) -> None:
+        client = EnvironmentClient(changed=False)
+        service = {"id": "srv-api", "name": "agent-bounties-api"}
+        runtime, secrets, changed = recovery.reconcile_cloud_agent_environment(
+            client,
+            service,
+            None,
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(len(runtime), len(recovery.CLOUD_AGENT_RUNTIME_ENVIRONMENT))
+        self.assertEqual(secrets, [])
+        self.assertNotIn("CLOUD_AGENT_API_KEY", [key for _, key, _ in client.calls])
+
     def test_public_env_var_update_fails_when_readback_drifts(self) -> None:
         client = RecordingClient(
             response={
@@ -414,6 +467,52 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         wrong = (200, "ok", {**response[2], "x-agent-bounties-revision": "b" * 40})
         with self.assertRaisesRegex(recovery.RecoveryError, "different revision"):
             recovery.validate_health("api", revision, wrong)
+
+    def test_cloud_readiness_requires_supplied_credential_to_be_live(self) -> None:
+        unavailable = {
+            "schema_version": "agent-bounties/cloud-agent-readiness-v1",
+            "available": False,
+            "execution": "hosted_cloud_api",
+            "provider": "openai-compatible",
+            "model": "gpt-4.1-mini",
+            "public_drafts": True,
+            "local_fallback": False,
+            "authority": "draft_only",
+            "missing_configuration": ["CLOUD_AGENT_API_KEY"],
+        }
+        observed = recovery.validate_cloud_agent_readiness(
+            unavailable,
+            credential_supplied=False,
+        )
+        self.assertFalse(observed["available"])
+        with self.assertRaisesRegex(recovery.RecoveryError, "did not become ready"):
+            recovery.validate_cloud_agent_readiness(
+                unavailable,
+                credential_supplied=True,
+            )
+
+        ready = dict(unavailable, available=True, missing_configuration=[])
+        observed = recovery.validate_cloud_agent_readiness(
+            ready,
+            credential_supplied=True,
+        )
+        self.assertTrue(observed["available"])
+        self.assertNotIn("CLOUD_AGENT_API_KEY", recovery.json.dumps(observed))
+
+    def test_cloud_readiness_cannot_claim_a_local_fallback(self) -> None:
+        payload = {
+            "schema_version": "agent-bounties/cloud-agent-readiness-v1",
+            "available": True,
+            "execution": "hosted_cloud_api",
+            "local_fallback": True,
+            "authority": "draft_only",
+            "missing_configuration": [],
+        }
+        with self.assertRaisesRegex(recovery.RecoveryError, "local fallback"):
+            recovery.validate_cloud_agent_readiness(
+                payload,
+                credential_supplied=False,
+            )
 
     def test_health_transport_bypasses_cache_and_closes_each_connection(self) -> None:
         class Response:


### PR DESCRIPTION
## Summary
- move `CLOUD_AGENT_API_KEY` out of an invalid `sync: false` environment-group declaration and onto the API service only
- make the exact-SHA Render controller reconcile every nonsecret cloud-agent setting
- optionally copy the GitHub Actions-held model key to Render without exposing its value in evidence
- fail closed when a supplied model credential does not produce hosted, draft-only, no-local-fallback readiness

## Root cause
Production deployed the new routes but not the new environment values. Render documents that `sync: false` is ignored inside environment groups and that an existing Blueprint ignores newly added `sync: false` placeholders.

## Validation
- `python scripts/test_render_deploy_recovery.py -v` (30 passed)
- `python scripts/check-render-blueprint.py`
- `python -m py_compile scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py scripts/check-render-blueprint.py`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\preflight.ps1 -Mode core`
- `git diff --check`

Maintainer notice update: #379