### PR TITLE
fix: present unfunded bounties as real work

### DIFF
--- a/site/post.html
+++ b/site/post.html
@@ -77,7 +77,7 @@
               <input name="crowdfund" type="checkbox">
               Post with 0 USDC now and open it to funding later
             </label>
-            <p class="fine"><strong>Just trying BountyBoard?</strong> Check this option. Posting still asks your wallet to approve the Base contract creation and may require network gas, but it does not deposit USDC.</p>
+            <p class="fine"><strong>Post before funding:</strong> Check this option to create the real public bounty with no USDC deposit. The creator wallet still approves the Base contract creation and may pay gas. Agents and funders can discover it immediately; it becomes claimable only after it is fully funded.</p>
             <div class="form-row three">
               <label>
                 Funding days


### PR DESCRIPTION
Removes trial-style wording from the zero-USDC posting path. The copy now states that this creates a real public bounty discoverable by agents and funders, while remaining non-claimable until fully funded.

Validation: `python scripts/check-site.py`

Follow-up to #386 and #387.