### PR TITLE
ops: automate leaderboard reward activation

### DIFF
--- a/.github/workflows/leaderboard-reward-deploy.yml
+++ b/.github/workflows/leaderboard-reward-deploy.yml
@@ -1,0 +1,121 @@
+name: Leaderboard reward deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_mainnet:
+        description: Deploy after the Base Sepolia deployment and fork payout rehearsal pass
+        required: true
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - ".github/workflows/leaderboard-reward-deploy.yml"
+      - "contracts/base-escrow/script/DeploySolverLeaderboardRewards.s.sol"
+      - "contracts/base-escrow/src/SolverLeaderboardRewards.sol"
+      - "contracts/base-escrow/test/SolverLeaderboardRewards*.t.sol"
+      - "scripts/verify_leaderboard_reward_deployment.py"
+      - "scripts/test_verify_leaderboard_reward_deployment.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: leaderboard-reward-deploy
+  cancel-in-progress: false
+
+jobs:
+  deterministic-gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - run: |
+          python scripts/test_verify_leaderboard_reward_deployment.py -v
+          python -m py_compile scripts/verify_leaderboard_reward_deployment.py
+          forge test --root contracts/base-escrow --match-contract SolverLeaderboardRewardsTest
+          forge build --root contracts/base-escrow --sizes
+
+  base-sepolia-rehearsal:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs: deterministic-gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      BASE_SEPOLIA_RPC_URL: https://sepolia.base.org
+      LEADERBOARD_SIGNER_A: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
+      LEADERBOARD_SIGNER_B: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}
+      REGRESSION_VERIFIER_ONE_PRIVATE_KEY: ${{ secrets.REGRESSION_VERIFIER_ONE_PRIVATE_KEY }}
+      REGRESSION_VERIFIER_TWO_PRIVATE_KEY: ${{ secrets.REGRESSION_VERIFIER_TWO_PRIVATE_KEY }}
+      RUN_LEADERBOARD_SEPOLIA_FORK: "true"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - name: Deploy and attest Base Sepolia contract
+        run: |
+          mkdir -p target
+          export LEADERBOARD_DEPLOYMENT_OUTPUT="$GITHUB_WORKSPACE/target/base-sepolia-leaderboard-raw.json"
+          forge script --root contracts/base-escrow \
+            script/DeploySolverLeaderboardRewards.s.sol:DeploySolverLeaderboardRewards \
+            --rpc-url "$BASE_SEPOLIA_RPC_URL" --broadcast --slow
+          python scripts/verify_leaderboard_reward_deployment.py \
+            --network base-sepolia \
+            --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+            --manifest target/base-sepolia-leaderboard-raw.json \
+            --broadcast contracts/base-escrow/broadcast/DeploySolverLeaderboardRewards.s.sol/84532/run-latest.json \
+            --output target/base-sepolia-leaderboard-deployment.json
+          python -c "import json; print('LEADERBOARD_SEPOLIA_REWARD_CONTRACT=' + json.load(open('target/base-sepolia-leaderboard-deployment.json'))['reward_contract'])" >> "$GITHUB_ENV"
+      - name: Rehearse both exact payouts on a Base Sepolia fork
+        run: >-
+          forge test --root contracts/base-escrow
+          --match-contract SolverLeaderboardRewardsSepoliaForkTest -vv
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: base-sepolia-leaderboard-rehearsal
+          path: target/base-sepolia-leaderboard-*.json
+          if-no-files-found: error
+          retention-days: 30
+
+  base-mainnet-deploy:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.deploy_mainnet
+    needs: base-sepolia-rehearsal
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      LEADERBOARD_SIGNER_A: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
+      LEADERBOARD_SIGNER_B: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - name: Deploy and attest Base mainnet contract
+        run: |
+          mkdir -p target
+          export LEADERBOARD_DEPLOYMENT_OUTPUT="$GITHUB_WORKSPACE/target/base-mainnet-leaderboard-raw.json"
+          forge script --root contracts/base-escrow \
+            script/DeploySolverLeaderboardRewards.s.sol:DeploySolverLeaderboardRewards \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --broadcast --slow
+          python scripts/verify_leaderboard_reward_deployment.py \
+            --network base-mainnet \
+            --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --manifest target/base-mainnet-leaderboard-raw.json \
+            --broadcast contracts/base-escrow/broadcast/DeploySolverLeaderboardRewards.s.sol/8453/run-latest.json \
+            --output target/base-mainnet-leaderboard-deployment.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: base-mainnet-leaderboard-deployment
+          path: target/base-mainnet-leaderboard-*.json
+          if-no-files-found: error
+          retention-days: 90

--- a/contracts/base-escrow/test/SolverLeaderboardRewardsSepoliaFork.t.sol
+++ b/contracts/base-escrow/test/SolverLeaderboardRewardsSepoliaFork.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../src/SolverLeaderboardRewards.sol";
+
+interface VmLeaderboardFork {
+    function addr(uint256 privateKey) external returns (address keyAddr);
+    function createSelectFork(string calldata urlOrAlias) external returns (uint256 forkId);
+    function envAddress(string calldata name) external returns (address value);
+    function envOr(string calldata name, bool defaultValue) external returns (bool value);
+    function envString(string calldata name) external returns (string memory value);
+    function envUint(string calldata name) external returns (uint256 value);
+    function load(address target, bytes32 slot) external view returns (bytes32 data);
+    function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+    function skip(bool skipTest) external;
+    function store(address target, bytes32 slot, bytes32 value) external;
+    function warp(uint256 timestamp) external;
+}
+
+interface SepoliaUsdc {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+/// @notice Replays both prize amounts against the exact deployed Base Sepolia contract.
+/// Token balance setup changes fork storage only. No transaction is broadcast.
+contract SolverLeaderboardRewardsSepoliaForkTest {
+    VmLeaderboardFork private constant vm = VmLeaderboardFork(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    address private constant USDC = 0x036CbD53842c5426634e7929541eC2318f3dCF7e;
+    address private constant WINNER = 0x000000000000000000000000000000000000bEEF;
+    uint256 private constant FUNDING = 29_000_000;
+
+    function testDeployedContractPaysDailyAndWeeklyRewards() public {
+        if (!vm.envOr("RUN_LEADERBOARD_SEPOLIA_FORK", false)) {
+            vm.skip(true);
+            return;
+        }
+        vm.createSelectFork(vm.envString("BASE_SEPOLIA_RPC_URL"));
+        require(block.chainid == 84_532, "wrong chain");
+
+        SolverLeaderboardRewards rewards =
+            SolverLeaderboardRewards(vm.envAddress("LEADERBOARD_SEPOLIA_REWARD_CONTRACT"));
+        require(address(rewards).code.length > 0, "reward contract missing");
+        require(rewards.settlementToken() == USDC, "token drift");
+
+        uint256 signerAKey = vm.envUint("REGRESSION_VERIFIER_ONE_PRIVATE_KEY");
+        uint256 signerBKey = vm.envUint("REGRESSION_VERIFIER_TWO_PRIVATE_KEY");
+        require(rewards.signerA() == vm.addr(signerAKey), "signer A drift");
+        require(rewards.signerB() == vm.addr(signerBKey), "signer B drift");
+
+        SepoliaUsdc usdc = SepoliaUsdc(USDC);
+        uint256 winnerBefore = usdc.balanceOf(WINNER);
+        _setForkBalance(usdc, FUNDING);
+        require(usdc.approve(address(rewards), FUNDING), "approval failed");
+        rewards.fund(FUNDING);
+
+        uint64 dailyStart = rewards.firstDailyStart();
+        uint64 weeklyStart = rewards.firstWeeklyStart();
+        uint256 dailyFinal = uint256(dailyStart) + 1 days + rewards.FINALIZATION_DELAY();
+        uint256 weeklyFinal = uint256(weeklyStart) + 7 days + rewards.FINALIZATION_DELAY();
+        vm.warp(dailyFinal > weeklyFinal ? dailyFinal : weeklyFinal);
+
+        _pay(rewards, SolverLeaderboardRewards.PeriodKind.Daily, dailyStart, 3, signerAKey, signerBKey);
+        _pay(rewards, SolverLeaderboardRewards.PeriodKind.Weekly, weeklyStart, 8, signerAKey, signerBKey);
+
+        require(usdc.balanceOf(WINNER) == winnerBefore + FUNDING, "winner did not receive 29 USDC");
+        require(usdc.balanceOf(address(rewards)) == 0, "reward pool did not settle exactly");
+        require(
+            rewards.paidAwardWinner(rewards.awardId(SolverLeaderboardRewards.PeriodKind.Daily, dailyStart)) == WINNER,
+            "daily winner missing"
+        );
+        require(
+            rewards.paidAwardWinner(rewards.awardId(SolverLeaderboardRewards.PeriodKind.Weekly, weeklyStart)) == WINNER,
+            "weekly winner missing"
+        );
+    }
+
+    function _pay(
+        SolverLeaderboardRewards rewards,
+        SolverLeaderboardRewards.PeriodKind kind,
+        uint64 startsAt,
+        uint32 completions,
+        uint256 signerAKey,
+        uint256 signerBKey
+    ) private {
+        bytes32 evidenceHash = keccak256(abi.encode("base-sepolia-rehearsal", kind, startsAt));
+        bytes32 digest = rewards.awardDigest(kind, startsAt, WINNER, completions, evidenceHash);
+        (uint8 vA, bytes32 rA, bytes32 sA) = vm.sign(signerAKey, digest);
+        (uint8 vB, bytes32 rB, bytes32 sB) = vm.sign(signerBKey, digest);
+        require(ecrecover(digest, vA, rA, sA) == rewards.signerA(), "signature A mismatch");
+        require(ecrecover(digest, vB, rB, sB) == rewards.signerB(), "signature B mismatch");
+        rewards.pay(
+            kind,
+            startsAt,
+            WINNER,
+            completions,
+            evidenceHash,
+            abi.encodePacked(rA, sA, vA),
+            abi.encodePacked(rB, sB, vB)
+        );
+    }
+
+    function _setForkBalance(SepoliaUsdc usdc, uint256 amount) private {
+        for (uint256 slot; slot < 128; slot++) {
+            bytes32 location = keccak256(abi.encode(address(this), slot));
+            bytes32 previous = vm.load(USDC, location);
+            vm.store(USDC, location, bytes32(amount));
+            if (usdc.balanceOf(address(this)) == amount) return;
+            vm.store(USDC, location, previous);
+        }
+        revert("USDC balance slot not found");
+    }
+}

--- a/docs/solver-leaderboard.md
+++ b/docs/solver-leaderboard.md
@@ -17,12 +17,11 @@ The leaderboard rewards canonical bounty completion.
 1. Assign two distinct leaderboard signer addresses.
 2. Run the contract tests.
 3. Deploy on Base Sepolia.
-4. Fund 29 test USDC.
-5. Rehearse one daily and one weekly award.
-6. Deploy on Base mainnet.
-7. Set `BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT` on the API.
-8. Fund at least 29 USDC. Fund 47 USDC for each full week of runway.
-9. Confirm `reward_pool.funding_status=funded` at a Base safe block. This proves balance coverage, not period reservation or payment.
+4. Rehearse both exact payouts against the deployment on a Base Sepolia fork.
+5. Deploy on Base mainnet.
+6. Set `BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT` on the API.
+7. Fund at least 29 USDC. Fund 47 USDC for each full week of runway.
+8. Confirm `reward_pool.funding_status=funded` at a Base safe block. This proves balance coverage, not period reservation or payment.
 
 Deployment starts the daily program at that UTC day's midnight and the weekly program at that week's Monday midnight. The contract rejects every earlier period.
 
@@ -31,6 +30,10 @@ cd contracts/base-escrow
 forge test --match-contract SolverLeaderboardRewardsTest
 forge script script/DeploySolverLeaderboardRewards.s.sol:DeploySolverLeaderboardRewards --rpc-url $env:BASE_RPC_URL --broadcast
 ```
+
+Use `Leaderboard reward deploy`. It deploys Sepolia first, attests the receipt
+and immutable getters, then pays exactly 3 and 26 test USDC on a fork. Mainnet
+deployment cannot start unless that rehearsal passes.
 
 Required deployment variables:
 

--- a/scripts/test_verify_leaderboard_reward_deployment.py
+++ b/scripts/test_verify_leaderboard_reward_deployment.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import verify_leaderboard_reward_deployment as verifier
+
+
+CONTRACT = "0x1111111111111111111111111111111111111111"
+SIGNER_A = "0x2222222222222222222222222222222222222222"
+SIGNER_B = "0x3333333333333333333333333333333333333333"
+TOKEN = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+TX = "0x" + "44" * 32
+
+
+class DeploymentVerificationTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        root = Path(self.temp.name)
+        self.manifest = root / "manifest.json"
+        self.broadcast = root / "broadcast.json"
+        self.manifest.write_text(
+            json.dumps(
+                {
+                    "chain_id": 84532,
+                    "reward_contract": CONTRACT,
+                    "signer_a": SIGNER_A,
+                    "signer_b": SIGNER_B,
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.broadcast.write_text(
+            json.dumps(
+                {
+                    "transactions": [
+                        {"contractAddress": CONTRACT, "hash": TX}
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.args = argparse.Namespace(
+            network="base-sepolia",
+            rpc_url="https://example.invalid",
+            manifest=self.manifest,
+            broadcast=self.broadcast,
+            cast="cast",
+        )
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    @staticmethod
+    def cast_result(_cast, _rpc, *arguments):
+        key = tuple(arguments)
+        values = {
+            ("chain-id",): "84532",
+            ("code", CONTRACT.lower()): "0x6001",
+            ("call", CONTRACT.lower(), "settlementToken()(address)"): TOKEN,
+            ("call", CONTRACT.lower(), "signerA()(address)"): SIGNER_A,
+            ("call", CONTRACT.lower(), "signerB()(address)"): SIGNER_B,
+            ("call", CONTRACT.lower(), "DAILY_REWARD()(uint256)"): "3000000 [3e6]",
+            ("call", CONTRACT.lower(), "WEEKLY_REWARD()(uint256)"): "26000000 [2.6e7]",
+            ("call", CONTRACT.lower(), "FINALIZATION_DELAY()(uint64)"): "3600",
+            ("call", CONTRACT.lower(), "firstDailyStart()(uint64)"): "1728000000",
+            ("call", CONTRACT.lower(), "firstWeeklyStart()(uint64)"): "1727654400",
+            ("receipt", TX, "--json"): json.dumps(
+                {
+                    "status": "0x1",
+                    "contractAddress": CONTRACT,
+                    "blockNumber": "0x123",
+                }
+            ),
+            ("codehash", CONTRACT.lower()): "0x" + "55" * 32,
+        }
+        if key not in values:
+            raise AssertionError(f"unexpected cast call: {key}")
+        return values[key]
+
+    @patch.object(verifier, "run_cast", side_effect=cast_result.__func__)
+    def test_accepts_exact_deployment(self, _run):
+        report = verifier.verify(self.args)
+        self.assertEqual(report["reward_contract"], CONTRACT)
+        self.assertEqual(report["daily_reward_usdc_base_units"], 3_000_000)
+        self.assertEqual(report["weekly_reward_usdc_base_units"], 26_000_000)
+        self.assertEqual(report["deployment_transaction"], TX)
+
+    @patch.object(verifier, "run_cast", side_effect=cast_result.__func__)
+    def test_rejects_signer_drift(self, run):
+        original = run.side_effect
+
+        def drift(cast, rpc, *arguments):
+            if arguments[-1] == "signerA()(address)":
+                return "0x9999999999999999999999999999999999999999"
+            return original(cast, rpc, *arguments)
+
+        run.side_effect = drift
+        with self.assertRaisesRegex(verifier.VerificationError, "signer A"):
+            verifier.verify(self.args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_leaderboard_reward_deployment.py
+++ b/scripts/verify_leaderboard_reward_deployment.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Attest one SolverLeaderboardRewards deployment from receipt and live getters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
+HASH = re.compile(r"^0x[0-9a-fA-F]{64}$")
+NETWORKS = {
+    "base-mainnet": (8453, "0x833589fCD6eDb6E08f4C7C32D4f71b54bdA02913"),
+    "base-sepolia": (84532, "0x036CbD53842c5426634e7929541eC2318f3dCF7e"),
+}
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise VerificationError(f"{path} must contain an object")
+    return value
+
+
+def normalize_address(value: Any, field: str) -> str:
+    text = str(value or "")
+    if not ADDRESS.fullmatch(text):
+        raise VerificationError(f"{field} is not an EVM address")
+    return text.lower()
+
+
+def chain_int(value: Any, field: str) -> int:
+    text = str(value).strip().split()[0]
+    try:
+        parsed = int(text, 0)
+    except ValueError as error:
+        raise VerificationError(f"{field} is not an integer") from error
+    if parsed < 0:
+        raise VerificationError(f"{field} cannot be negative")
+    return parsed
+
+
+def run_cast(cast: str, rpc_url: str, *arguments: str) -> str:
+    result = subprocess.run(
+        [cast, *arguments, "--rpc-url", rpc_url],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "cast failed"
+        raise VerificationError(message)
+    return result.stdout.strip()
+
+
+def transaction_hash(broadcast: dict[str, Any], contract: str) -> str:
+    for transaction in broadcast.get("transactions", []):
+        if not isinstance(transaction, dict):
+            continue
+        deployed = str(transaction.get("contractAddress", "")).lower()
+        if deployed != contract:
+            continue
+        value = str(transaction.get("hash", ""))
+        if HASH.fullmatch(value):
+            return value.lower()
+    for receipt in broadcast.get("receipts", []):
+        if not isinstance(receipt, dict):
+            continue
+        deployed = str(receipt.get("contractAddress", "")).lower()
+        value = str(receipt.get("transactionHash", ""))
+        if deployed == contract and HASH.fullmatch(value):
+            return value.lower()
+    raise VerificationError("broadcast does not identify the deployed contract transaction")
+
+
+def verify(args: argparse.Namespace) -> dict[str, Any]:
+    if args.network not in NETWORKS:
+        raise VerificationError("unsupported network")
+    expected_chain, expected_token = NETWORKS[args.network]
+    manifest = load_json(args.manifest)
+    broadcast = load_json(args.broadcast)
+    contract = normalize_address(manifest.get("reward_contract"), "reward contract")
+    signer_a = normalize_address(manifest.get("signer_a"), "signer A")
+    signer_b = normalize_address(manifest.get("signer_b"), "signer B")
+    if signer_a == signer_b:
+        raise VerificationError("deployment signers are not distinct")
+
+    chain_id = chain_int(run_cast(args.cast, args.rpc_url, "chain-id"), "chain id")
+    if chain_id != expected_chain or chain_int(manifest.get("chain_id"), "manifest chain id") != chain_id:
+        raise VerificationError("deployment chain does not match the requested network")
+    if run_cast(args.cast, args.rpc_url, "code", contract) == "0x":
+        raise VerificationError("deployed contract has no code")
+
+    def call(signature: str) -> str:
+        return run_cast(args.cast, args.rpc_url, "call", contract, signature)
+
+    token = normalize_address(call("settlementToken()(address)"), "settlement token")
+    if token != expected_token.lower():
+        raise VerificationError("deployment is not pinned to native USDC")
+    if normalize_address(call("signerA()(address)"), "live signer A") != signer_a:
+        raise VerificationError("signer A getter drifted")
+    if normalize_address(call("signerB()(address)"), "live signer B") != signer_b:
+        raise VerificationError("signer B getter drifted")
+    if chain_int(call("DAILY_REWARD()(uint256)"), "daily reward") != 3_000_000:
+        raise VerificationError("daily reward drifted")
+    if chain_int(call("WEEKLY_REWARD()(uint256)"), "weekly reward") != 26_000_000:
+        raise VerificationError("weekly reward drifted")
+    if chain_int(call("FINALIZATION_DELAY()(uint64)"), "finalization delay") != 3600:
+        raise VerificationError("finalization delay drifted")
+    daily_start = chain_int(call("firstDailyStart()(uint64)"), "first daily start")
+    weekly_start = chain_int(call("firstWeeklyStart()(uint64)"), "first weekly start")
+    if daily_start % 86_400 != 0 or weekly_start < 345_600 or (weekly_start - 345_600) % 604_800 != 0:
+        raise VerificationError("program calendar alignment drifted")
+
+    tx_hash = transaction_hash(broadcast, contract)
+    receipt = json.loads(run_cast(args.cast, args.rpc_url, "receipt", tx_hash, "--json"))
+    if chain_int(receipt.get("status"), "receipt status") != 1:
+        raise VerificationError("deployment receipt failed")
+    if normalize_address(receipt.get("contractAddress"), "receipt contract") != contract:
+        raise VerificationError("receipt contract does not match the manifest")
+    block_number = chain_int(receipt.get("blockNumber"), "deployment block")
+    code_hash = run_cast(args.cast, args.rpc_url, "codehash", contract).lower()
+    if not HASH.fullmatch(code_hash):
+        raise VerificationError("runtime code hash is invalid")
+
+    return {
+        "schema": "agent-bounties/leaderboard-reward-deployment-v1",
+        "network": args.network,
+        "chain_id": chain_id,
+        "reward_contract": contract,
+        "settlement_token": token,
+        "signer_a": signer_a,
+        "signer_b": signer_b,
+        "daily_reward_usdc_base_units": 3_000_000,
+        "weekly_reward_usdc_base_units": 26_000_000,
+        "first_daily_start": daily_start,
+        "first_weekly_start": weekly_start,
+        "deployment_transaction": tx_hash,
+        "deployment_block": block_number,
+        "runtime_code_hash": code_hash,
+        "verified_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "evidence_boundary": "Confirmed deployment receipt and exact live immutable getter checks. This is not reward funding or payment evidence.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--network", required=True, choices=sorted(NETWORKS))
+    parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--broadcast", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--cast", default="cast")
+    args = parser.parse_args()
+    try:
+        report = verify(args)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    except (OSError, json.JSONDecodeError, VerificationError) as error:
+        print(f"leaderboard_reward_deployment=failed error={error}")
+        return 1
+    print(
+        "leaderboard_reward_deployment=passed "
+        f"network={report['network']} contract={report['reward_contract']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a guarded Base Sepolia-first deployment workflow for SolverLeaderboardRewards
- attest receipts, bytecode, native-USDC binding, signers, constants, and calendar starts
- rehearse exact 3 USDC daily and 26 USDC weekly payouts against the deployed Sepolia contract on an isolated fork
- permit mainnet deployment only after every rehearsal gate passes

## Verification
- preflight core: pass
- deployment verifier tests: 2 passed
- local deployment and receipt attestation against Base Sepolia fork: pass
- exact daily + weekly payout rehearsal: pass
- full Foundry suite with 1,000 fuzz runs: 99 passed, 8 opt-in fork tests skipped
- actionlint: pass
- contract size gate: pass

## Evidence boundary
Deployment evidence is not reward funding or payment evidence. The production API must remain 
ot_configured until a verified mainnet contract is configured, and unfunded until its native Base USDC balance covers the rewards.