### PR TITLE
fix: use contract-root leaderboard deployment paths

### DIFF
--- a/.github/workflows/leaderboard-reward-deploy.yml
+++ b/.github/workflows/leaderboard-reward-deploy.yml
@@ -62,10 +62,12 @@ jobs:
       - name: Deploy and attest Base Sepolia contract
         run: |
           mkdir -p target
-          export LEADERBOARD_DEPLOYMENT_OUTPUT="$GITHUB_WORKSPACE/target/base-sepolia-leaderboard-raw.json"
-          forge script --root contracts/base-escrow \
+          export LEADERBOARD_DEPLOYMENT_OUTPUT="../../target/base-sepolia-leaderboard-raw.json"
+          pushd contracts/base-escrow
+          forge script \
             script/DeploySolverLeaderboardRewards.s.sol:DeploySolverLeaderboardRewards \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" --broadcast --slow
+          popd
           python scripts/verify_leaderboard_reward_deployment.py \
             --network base-sepolia \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" \
@@ -103,10 +105,12 @@ jobs:
       - name: Deploy and attest Base mainnet contract
         run: |
           mkdir -p target
-          export LEADERBOARD_DEPLOYMENT_OUTPUT="$GITHUB_WORKSPACE/target/base-mainnet-leaderboard-raw.json"
-          forge script --root contracts/base-escrow \
+          export LEADERBOARD_DEPLOYMENT_OUTPUT="../../target/base-mainnet-leaderboard-raw.json"
+          pushd contracts/base-escrow
+          forge script \
             script/DeploySolverLeaderboardRewards.s.sol:DeploySolverLeaderboardRewards \
             --rpc-url "$BASE_MAINNET_RPC_URL" --broadcast --slow
+          popd
           python scripts/verify_leaderboard_reward_deployment.py \
             --network base-mainnet \
             --rpc-url "$BASE_MAINNET_RPC_URL" \


### PR DESCRIPTION
## Cause
Run 29632660313 failed closed before mainnet because Foundry could not write the absolute deployment-output path while using --root.

## Fix
Run each Forge deployment from contracts/base-escrow and write through the repository-approved ../../target path. This exact form passed the local Base Sepolia fork deployment and attestation.

## Scope
Workflow path handling only. No contract, signer, reward, funding, or settlement behavior changes. No mainnet contract or USDC movement occurred in the failed run.

## Verification
- actionlint: pass
- git diff check: pass
- exact relative-path deployment and attestation: previously passed locally against a Base Sepolia fork