### PR TITLE
fix: attest code hash without eth_getProof

### DIFF
--- a/scripts/test_verify_leaderboard_reward_deployment.py
+++ b/scripts/test_verify_leaderboard_reward_deployment.py
@@ -76,22 +76,29 @@ class DeploymentVerificationTest(unittest.TestCase):
                     "blockNumber": "0x123",
                 }
             ),
-            ("codehash", CONTRACT.lower()): "0x" + "55" * 32,
         }
         if key not in values:
             raise AssertionError(f"unexpected cast call: {key}")
         return values[key]
 
+    @staticmethod
+    def local_cast_result(_cast, *arguments):
+        if arguments != ("keccak", "0x6001"):
+            raise AssertionError(f"unexpected local cast call: {arguments}")
+        return "0x" + "55" * 32
+
+    @patch.object(verifier, "run_local_cast", side_effect=local_cast_result.__func__)
     @patch.object(verifier, "run_cast", side_effect=cast_result.__func__)
-    def test_accepts_exact_deployment(self, _run):
+    def test_accepts_exact_deployment(self, _run, _local_run):
         report = verifier.verify(self.args)
         self.assertEqual(report["reward_contract"], CONTRACT)
         self.assertEqual(report["daily_reward_usdc_base_units"], 3_000_000)
         self.assertEqual(report["weekly_reward_usdc_base_units"], 26_000_000)
         self.assertEqual(report["deployment_transaction"], TX)
 
+    @patch.object(verifier, "run_local_cast", side_effect=local_cast_result.__func__)
     @patch.object(verifier, "run_cast", side_effect=cast_result.__func__)
-    def test_rejects_signer_drift(self, run):
+    def test_rejects_signer_drift(self, run, _local_run):
         original = run.side_effect
 
         def drift(cast, rpc, *arguments):

--- a/scripts/verify_leaderboard_reward_deployment.py
+++ b/scripts/verify_leaderboard_reward_deployment.py
@@ -63,6 +63,20 @@ def run_cast(cast: str, rpc_url: str, *arguments: str) -> str:
     return result.stdout.strip()
 
 
+def run_local_cast(cast: str, *arguments: str) -> str:
+    result = subprocess.run(
+        [cast, *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "cast failed"
+        raise VerificationError(message)
+    return result.stdout.strip()
+
+
 def transaction_hash(broadcast: dict[str, Any], contract: str) -> str:
     for transaction in broadcast.get("transactions", []):
         if not isinstance(transaction, dict):
@@ -98,7 +112,8 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     chain_id = chain_int(run_cast(args.cast, args.rpc_url, "chain-id"), "chain id")
     if chain_id != expected_chain or chain_int(manifest.get("chain_id"), "manifest chain id") != chain_id:
         raise VerificationError("deployment chain does not match the requested network")
-    if run_cast(args.cast, args.rpc_url, "code", contract) == "0x":
+    runtime_code = run_cast(args.cast, args.rpc_url, "code", contract)
+    if runtime_code == "0x":
         raise VerificationError("deployed contract has no code")
 
     def call(signature: str) -> str:
@@ -129,7 +144,9 @@ def verify(args: argparse.Namespace) -> dict[str, Any]:
     if normalize_address(receipt.get("contractAddress"), "receipt contract") != contract:
         raise VerificationError("receipt contract does not match the manifest")
     block_number = chain_int(receipt.get("blockNumber"), "deployment block")
-    code_hash = run_cast(args.cast, args.rpc_url, "codehash", contract).lower()
+    # `cast codehash` uses eth_getProof, which public Base RPCs do not expose.
+    # Hashing standard eth_getCode output locally produces the same Keccak hash.
+    code_hash = run_local_cast(args.cast, "keccak", runtime_code).lower()
     if not HASH.fullmatch(code_hash):
         raise VerificationError("runtime code hash is invalid")
 


### PR DESCRIPTION
## Why
Base's public Sepolia RPC rejects eth_getProof, which cast codehash uses. Activation run 29632902309 deployed the Sepolia contract but failed post-deployment attestation, so mainnet stayed locked.

## Change
- fetch runtime bytecode with standard eth_getCode
- compute its Keccak-256 hash locally with Foundry
- keep exact receipt, bytecode, immutable getter, token, signer, reward, and calendar checks
- add a regression test that rejects any return to the unsupported RPC path

## Verification
- python scripts/test_verify_leaderboard_reward_deployment.py -v
- live Base Sepolia eth_getCode plus local Keccak probe
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Mode core
- git diff --check

No payment is authorized by this PR. Base mainnet remains gated behind a successful Sepolia deployment and fork-isolated daily and weekly payout rehearsal.