### PR TITLE
fix: set chain-specific deployment reserves

### DIFF
--- a/contracts/base-escrow/script/DeploySolverLeaderboardRewards.s.sol
+++ b/contracts/base-escrow/script/DeploySolverLeaderboardRewards.s.sol
@@ -35,7 +35,8 @@ contract DeploySolverLeaderboardRewards {
 
         uint256 deployerKey = vm.envUint("BASE_KEEPER_PRIVATE_KEY");
         address deployer = vm.addr(deployerKey);
-        require(deployer.balance >= 100_000_000_000_000, "deployment gas reserve too low");
+        uint256 minimumReserve = block.chainid == 8_453 ? 100_000_000_000_000 : 50_000_000_000_000;
+        require(deployer.balance >= minimumReserve, "deployment gas reserve too low");
 
         vm.startBroadcast(deployerKey);
         SolverLeaderboardRewards rewards = new SolverLeaderboardRewards(token, signerA, signerB);


### PR DESCRIPTION
## Why
The keeper has 0.000094585976216679 ETH on Base Sepolia. The prior successful deployment measured a requirement of 0.000015945578 ETH, but the script used a fixed 0.0001 ETH floor and blocked the next rehearsal before broadcast.

## Change
- retain the 0.0001 ETH Base mainnet deployment floor
- set the Base Sepolia floor to 0.00005 ETH, over three times the measured requirement

## Verification
- compiled the deployment script
- deployed successfully on an isolated Base Sepolia fork with the deployer balance set to exactly 0.00005 ETH
- orge test --match-contract SolverLeaderboardRewardsTest --fuzz-runs 1000: 7 passed
- core preflight passed
- git diff --check passed

No payment is authorized by this PR. Mainnet remains locked behind the successful live Sepolia deployment and isolated daily/weekly payout rehearsal.