### PR TITLE
chore: reconcile leaderboard production config

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -126,6 +126,8 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           CLOUD_AGENT_API_KEY: ${{ secrets.CLOUD_AGENT_API_KEY }}
+          BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT: ${{ vars.BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT }}
+          BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT: ${{ vars.BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT }}
         run: |
           python scripts/render_deploy_recovery.py \
             --revision "${TARGET_REVISION}" \
@@ -133,6 +135,8 @@ jobs:
             --mcp-url "${PRODUCTION_MCP_BASE_URL%/}/health" \
             --public-base-url "${PRODUCTION_API_BASE_URL%/}" \
             --mcp-base-url "${PRODUCTION_MCP_BASE_URL%/}" \
+            --base-mainnet-leaderboard-reward-contract "$BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT" \
+            --base-sepolia-leaderboard-reward-contract "$BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT" \
             --output target/operations/render-deploy.json
 
       - name: Publish deployment evidence summary
@@ -160,7 +164,7 @@ jobs:
               f"- Verified: `{str(evidence['success']).lower()}`",
               f"- Services live: `{sum(item['status'] == 'live' for item in evidence['services'])}/3`",
               f"- Exact health attestations: `{len(evidence['health'])}/2`",
-              f"- Public endpoint variables: `{len(evidence.get('public_environment', []))}/4`",
+              f"- Public runtime variables reconciled: `{len(evidence.get('public_environment', []))}`",
               f"- Cloud runtime variables: `{len(evidence.get('cloud_environment', []))}/10`",
               f"- Cloud model credential supplied: `{bool(evidence.get('secret_environment'))}`",
               f"- Cloud drafting ready: `{bool(evidence.get('cloud_readiness', {}).get('available'))}`",

--- a/docs/solver-leaderboard.md
+++ b/docs/solver-leaderboard.md
@@ -2,6 +2,9 @@
 
 The leaderboard rewards canonical bounty completion.
 
+Base mainnet: `0xb2637dd1dcf4ac9e22b42e9612e907ac44c52c69`.
+Base Sepolia: `0x2e84ef6708d5fff0e9909e80481a00b7ac47293e`.
+
 ## Rules
 
 - Daily prize: 3 USDC. Period: 00:00 to 24:00 UTC.
@@ -19,7 +22,7 @@ The leaderboard rewards canonical bounty completion.
 3. Deploy on Base Sepolia.
 4. Rehearse both exact payouts against the deployment on a Base Sepolia fork.
 5. Deploy on Base mainnet.
-6. Set `BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT` on the API.
+6. Set both repository contract variables. The Render controller configures the API.
 7. Fund at least 29 USDC. Fund 47 USDC for each full week of runway.
 8. Confirm `reward_pool.funding_status=funded` at a Base safe block. This proves balance coverage, not period reservation or payment.
 
@@ -50,12 +53,11 @@ The hourly `Leaderboard Reward Runner` creates a no-secret candidate after the o
 
 Activate it after deployment:
 
-1. Set repository variable `BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT`.
-2. Set the same Render environment value.
-3. Confirm the contract signers equal `REGRESSION_VERIFIER_ONE_ADDRESS` and `REGRESSION_VERIFIER_TWO_ADDRESS`.
-4. Run `Leaderboard Reward Runner` on `main`.
-5. Confirm both signer jobs and the relay.
-6. Confirm `reward_payout_status=paid` and the ranked wallet at a safe block.
-7. Confirm `LeaderboardRewardPaid` and the USDC transfer before reporting payment.
+1. Confirm both repository contract variables.
+2. Confirm the contract signers match both regression verifier addresses.
+3. Run `Leaderboard Reward Runner` on `main`.
+4. Confirm both signer jobs and the relay.
+5. Confirm `reward_payout_status=paid` at a safe block.
+6. Confirm `LeaderboardRewardPaid` and the USDC transfer before reporting payment.
 
 Ranking never moves funds directly. A configured address, pool balance, signature, or transaction hash is not payment. The contract records the paid winner atomically with the transfer.

--- a/render.yaml
+++ b/render.yaml
@@ -37,9 +37,9 @@ envVarGroups:
       - key: BASE_MAINNET_BOUNTY_IMPLEMENTATION
         value: 0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9
       - key: BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT
-        sync: false
+        value: 0xb2637dd1dcf4ac9e22b42e9612e907ac44c52c69
       - key: BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT
-        sync: false
+        value: 0x2e84ef6708d5fff0e9909e80481a00b7ac47293e
       - key: BASE_RECOVERY_RESERVED_BOUNTY_CONTRACTS
         value: "0x680030abf3ffffbc8d0a550b6355a8713c54d3c8,0x3137e6c0f44b940580ea7efc5f8cc6c6c0bda3f1,0xb35b94e1225b66e50644a331feccdab0439e63d7"
 

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -16,6 +16,8 @@ RECOVERY_RESERVED_BOUNTY_CONTRACTS = (
     "0x3137e6c0f44b940580ea7efc5f8cc6c6c0bda3f1,"
     "0xb35b94e1225b66e50644a331feccdab0439e63d7"
 )
+MAINNET_LEADERBOARD_REWARD_CONTRACT = "0xb2637dd1dcf4ac9e22b42e9612e907ac44c52c69"
+SEPOLIA_LEADERBOARD_REWARD_CONTRACT = "0x2e84ef6708d5fff0e9909e80481a00b7ac47293e"
 
 
 def fail(message: str) -> None:
@@ -203,6 +205,8 @@ def main() -> int:
             "BASE_SEPOLIA_BOUNTY_IMPLEMENTATION",
             "BASE_MAINNET_BOUNTY_FACTORY",
             "BASE_MAINNET_BOUNTY_IMPLEMENTATION",
+            "BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT",
+            "BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT",
             "BASE_RECOVERY_RESERVED_BOUNTY_CONTRACTS",
         ],
     )
@@ -211,6 +215,16 @@ def main() -> int:
     require_env_sync_false(base_group, "BASE_SEPOLIA_BOUNTY_IMPLEMENTATION")
     require_env_value(base_group, "BASE_MAINNET_RPC_URL", rpc_url)
     require_env_value(base_group, "BASE_MAINNET_USDC_TOKEN", str(deployment["native_usdc"]))
+    require_env_value(
+        base_group,
+        "BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT",
+        MAINNET_LEADERBOARD_REWARD_CONTRACT,
+    )
+    require_env_value(
+        base_group,
+        "BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT",
+        SEPOLIA_LEADERBOARD_REWARD_CONTRACT,
+    )
     require_env_value(
         base_group,
         "BASE_RECOVERY_RESERVED_BOUNTY_CONTRACTS",

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -211,6 +211,27 @@ def normalize_public_base_url(name: str, value: str) -> str:
     return candidate
 
 
+def normalize_evm_address(name: str, value: str) -> str:
+    normalized = value.strip().lower()
+    if not re.fullmatch(r"0x[0-9a-f]{40}", normalized):
+        raise RecoveryError(f"{name} must be an exact EVM address")
+    return normalized
+
+
+def leaderboard_environment_values(
+    mainnet_contract: str | None,
+    sepolia_contract: str | None,
+) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for key, value in (
+        ("BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT", mainnet_contract),
+        ("BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT", sepolia_contract),
+    ):
+        if value is not None:
+            values[key] = normalize_evm_address(key, value)
+    return values
+
+
 def deploy_commit(deploy: dict[str, Any]) -> str | None:
     commit = deploy.get("commit")
     if not isinstance(commit, dict):
@@ -675,6 +696,8 @@ def deploy(
     public_base_url: str = "https://api.bountyboard.global",
     mcp_base_url: str = "https://mcp.bountyboard.global",
     cloud_agent_api_key: str | None = None,
+    base_mainnet_leaderboard_reward_contract: str | None = None,
+    base_sepolia_leaderboard_reward_contract: str | None = None,
 ) -> dict[str, Any]:
     services: list[tuple[ServiceSpec, dict[str, Any]]] = []
     pending: dict[str, tuple[str, str]] = {}
@@ -692,6 +715,10 @@ def deploy(
         ),
         "MCP_BASE_URL": normalize_public_base_url("MCP_BASE_URL", mcp_base_url),
     }
+    leaderboard_environment = leaderboard_environment_values(
+        base_mainnet_leaderboard_reward_contract,
+        base_sepolia_leaderboard_reward_contract,
+    )
     public_environment = []
     public_environment_changed: dict[str, bool] = {}
     for spec, service in services:
@@ -709,6 +736,18 @@ def deploy(
                     "changed": record["changed"],
                 }
             )
+        if spec.name == CLOUD_AGENT_API_SERVICE_NAME:
+            for key, value in leaderboard_environment.items():
+                record = client.ensure_env_var(service, key, value)
+                public_environment_changed[spec.name] |= record["changed"]
+                public_environment.append(
+                    {
+                        "service": spec.name,
+                        "key": key,
+                        "value": value,
+                        "changed": record["changed"],
+                    }
+                )
 
     api_service = next(
         service for spec, service in services if spec.name == CLOUD_AGENT_API_SERVICE_NAME
@@ -830,6 +869,8 @@ def parse_args() -> argparse.Namespace:
         "--mcp-base-url",
         default="https://mcp.bountyboard.global",
     )
+    parser.add_argument("--base-mainnet-leaderboard-reward-contract")
+    parser.add_argument("--base-sepolia-leaderboard-reward-contract")
     parser.add_argument("--deploy-timeout-seconds", type=float, default=2400)
     parser.add_argument("--health-timeout-seconds", type=float, default=300)
     parser.add_argument("--poll-seconds", type=float, default=10)
@@ -874,6 +915,12 @@ def main() -> int:
             public_base_url=args.public_base_url,
             mcp_base_url=args.mcp_base_url,
             cloud_agent_api_key=os.environ.get("CLOUD_AGENT_API_KEY"),
+            base_mainnet_leaderboard_reward_contract=(
+                args.base_mainnet_leaderboard_reward_contract
+            ),
+            base_sepolia_leaderboard_reward_contract=(
+                args.base_sepolia_leaderboard_reward_contract
+            ),
         )
         evidence.update(result)
         evidence["revision"] = revision

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -212,6 +212,25 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             with self.subTest(value=value), self.assertRaises(recovery.RecoveryError):
                 recovery.normalize_public_base_url("PUBLIC_BASE_URL", value)
 
+    def test_leaderboard_environment_requires_exact_addresses(self) -> None:
+        values = recovery.leaderboard_environment_values(
+            "0x" + "AA" * 20,
+            "0x" + "bb" * 20,
+        )
+        self.assertEqual(
+            values,
+            {
+                "BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT": "0x" + "aa" * 20,
+                "BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT": "0x" + "bb" * 20,
+            },
+        )
+        for value in ("", "0x1234", "0x" + "zz" * 20):
+            with self.subTest(value=value), self.assertRaises(recovery.RecoveryError):
+                recovery.leaderboard_environment_values(value, None)
+
+    def test_omitted_leaderboard_environment_stays_omitted(self) -> None:
+        self.assertEqual(recovery.leaderboard_environment_values(None, None), {})
+
     def test_matching_public_env_var_is_verified_without_mutation(self) -> None:
         expected = {
             "key": "PUBLIC_BASE_URL",


### PR DESCRIPTION
## Why
The leaderboard contracts are deployed and attested, but production must not depend on a local browser to learn their addresses.

## Change
- pin the verified Base mainnet and Sepolia addresses in ender.yaml
- validate both addresses in the Blueprint drift gate
- pass both repository variables into the cloud-only exact-main deploy workflow
- reconcile both values into the API through Render's authenticated API
- force an exact-revision redeploy when either value changes
- publish the addresses and shorter activation steps

## Verification
- 32 Render controller tests passed
- Render Blueprint drift check passed
- actionlint passed
- Python compilation passed
- core preflight passed
- git diff --check passed

Deployment evidence: run 29634230192. Mainnet contract: 