### PR TITLE
fix: pause Render deploys on pipeline quota

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -66,6 +66,7 @@ jobs:
       TARGET_REVISION: ${{ github.event.workflow_run.head_sha || inputs.revision || github.sha }}
       PRODUCTION_API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://api.bountyboard.global' }}
       PRODUCTION_MCP_BASE_URL: ${{ vars.PRODUCTION_MCP_BASE_URL || 'https://mcp.bountyboard.global' }}
+      RENDER_DEPLOY_PAUSE_REASON: ${{ vars.RENDER_DEPLOY_PAUSE_REASON }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,6 +83,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [[ -n "${RENDER_DEPLOY_PAUSE_REASON}" ]]; then
+            if [[ ! "${RENDER_DEPLOY_PAUSE_REASON}" =~ ^[a-z0-9_-]{1,80}$ ]]; then
+              echo "RENDER_DEPLOY_PAUSE_REASON has an invalid format" >&2
+              exit 1
+            fi
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Render deployment paused: ${RENDER_DEPLOY_PAUSE_REASON}. Clear the repository variable, then dispatch this workflow." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           if [[ ! "${TARGET_REVISION}" =~ ^[0-9a-fA-F]{40}$ ]]; then
             echo "TARGET_REVISION must be an exact 40-character Git SHA" >&2
             exit 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,6 +89,12 @@ read-only and continues to fail closed on revision skew; it does not possess
 the Render key. If current `main` is newer and failing, pass the latest
 successful 40-character SHA in the manual `revision` input.
 
+If Render exhausts pipeline minutes, set the repository variable
+`RENDER_DEPLOY_PAUSE_REASON=build_pipeline_minutes_exhausted`. Deployment then
+skips before touching Render. Set a bounded pipeline spend limit in Render,
+delete the variable, and dispatch `Render Deploy Recovery` for the latest
+successful `main` SHA.
+
 The API and MCP services need the same `DATABASE_URL`, public URLs, factory,
 implementation, and Base RPC configuration. Canonical planners fail closed
 without Postgres and the active protocol addresses.

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -268,6 +268,8 @@ def main() -> int:
         "github.event.workflow_run.event == 'push'",
         "github.event.workflow_run.head_branch == 'main'",
         "github.event.workflow_run.head_repository.full_name == github.repository",
+        "RENDER_DEPLOY_PAUSE_REASON",
+        "Render deployment paused:",
         "cancel-in-progress: false",
         "actions: read",
         "Select latest successful main revision",

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -119,6 +119,7 @@ BUILD_FAILURE_PATTERNS = {
     "docker": ("failed to solve", "did not complete successfully"),
     "missing_file": ("does not exist", "is missing", "no such file or directory", "not found"),
     "network": ("connection reset", "connection timed out", "temporary failure"),
+    "pipeline_quota": ("build pipeline minutes", "build spend limit"),
     "resource_limit": ("no space left", "out of memory", "signal: 9", "killed"),
     "rust_toolchain": ("requires rustc", "rustc version", "rust version"),
 }

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -465,6 +465,18 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         self.assertEqual(query["startTime"], ["2026-07-18T07:31:00Z"])
         self.assertIn("docker", result["classifications"])
 
+    def test_build_pipeline_quota_is_classified(self) -> None:
+        result = recovery.summarize_build_logs(
+            {
+                "logs": [
+                    {
+                        "message": "Build canceled: your workspace has run out of build pipeline minutes."
+                    }
+                ]
+            }
+        )
+        self.assertEqual(result["classifications"], ["pipeline_quota"])
+
     def test_all_service_bindings_validate_before_any_mutation(self) -> None:
         client = ResolutionFailureClient()
         with self.assertRaisesRegex(recovery.RecoveryError, "unexpected repository"):


### PR DESCRIPTION
## What changed
- honor a validated RENDER_DEPLOY_PAUSE_REASON repository variable before any Render mutation
- classify exhausted pipeline minutes explicitly
- pin the pause contract in the Blueprint drift gate
- document one ordered resume path

## Confirmed incident
Render deploy dep-d9dpevtaeets739oo9sg was canceled because the workspace exhausted pipeline minutes and reached its spend limit. The live API remains healthy at leaderboard revision 8f03c8b5.

## Verification
- controller tests: 35 passed
- Blueprint contract: passed
- core preflight: passed
- diff check: passed

The repository variable is already set to build_pipeline_minutes_exhausted. After this merges, unrelated main changes skip deployment cleanly. Clear it only after setting a bounded Render pipeline spend limit, then dispatch the workflow.