### PR TITLE
fix: stabilize leaderboard reward runner

### DIFF
--- a/.github/workflows/leaderboard-reward-runner.yml
+++ b/.github/workflows/leaderboard-reward-runner.yml
@@ -39,6 +39,7 @@ jobs:
     if: >-
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       github.ref == 'refs/heads/main' &&
+      vars.LEADERBOARD_REWARD_RUNNER_ENABLED == 'true' &&
       vars.BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT != ''
     needs: contract
     runs-on: ubuntu-latest

--- a/.github/workflows/leaderboard-reward-signer.yml
+++ b/.github/workflows/leaderboard-reward-signer.yml
@@ -38,6 +38,7 @@ jobs:
        github.event.workflow_run.event == 'workflow_dispatch') &&
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
+      vars.LEADERBOARD_REWARD_RUNNER_ENABLED == 'true' &&
       vars.BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT != ''
     needs: contract
     runs-on: ubuntu-latest

--- a/docs/solver-leaderboard.md
+++ b/docs/solver-leaderboard.md
@@ -55,9 +55,10 @@ Activate it after deployment:
 
 1. Confirm both repository contract variables.
 2. Confirm the contract signers match both regression verifier addresses.
-3. Run `Leaderboard Reward Runner` on `main`.
-4. Confirm both signer jobs and the relay.
-5. Confirm `reward_payout_status=paid` at a safe block.
-6. Confirm `LeaderboardRewardPaid` and the USDC transfer before reporting payment.
+3. Set repository variable `LEADERBOARD_REWARD_RUNNER_ENABLED=true`.
+4. Run `Leaderboard Reward Runner` on `main`.
+5. Confirm both signer jobs and the relay.
+6. Confirm `reward_payout_status=paid` at a safe block.
+7. Confirm `LeaderboardRewardPaid` and the USDC transfer before reporting payment.
 
 Ranking never moves funds directly. A configured address, pool balance, signature, or transaction hash is not payment. The contract records the paid winner atomically with the transfer.

--- a/scripts/leaderboard_reward_pipeline.py
+++ b/scripts/leaderboard_reward_pipeline.py
@@ -296,17 +296,30 @@ def assert_candidate_unchanged(
 
 
 def contract_call(args: argparse.Namespace, signature: str, *values: str) -> str:
-    return run(
+    output = run(
         [
             str(args.cast),
             "call",
+            "--json",
             "--rpc-url",
             args.rpc_url,
             args.contract,
             signature,
             *values,
         ]
-    ).strip().lower()
+    )
+    try:
+        decoded = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise PipelineError("cast call did not return JSON") from error
+    if not isinstance(decoded, list) or len(decoded) != 1:
+        raise PipelineError("cast call must return one value")
+    value = decoded[0]
+    if isinstance(value, bool):
+        return str(value).lower()
+    if not isinstance(value, (int, str)):
+        raise PipelineError("cast call returned an unsupported value")
+    return str(value).strip().lower()
 
 
 def chain_int(value: str, field: str) -> int:

--- a/scripts/test_leaderboard_reward_pipeline.py
+++ b/scripts/test_leaderboard_reward_pipeline.py
@@ -94,6 +94,36 @@ class LeaderboardRewardPipelineTests(unittest.TestCase):
         self.assertEqual(references["daily"].isoformat(), "2026-07-20T23:59:59+00:00")
         self.assertEqual(references["weekly"], self.reference)
 
+    def test_contract_call_uses_machine_readable_single_value(self) -> None:
+        args = Namespace(
+            cast=Path("cast"),
+            rpc_url="https://rpc.example.test",
+            contract=CONTRACT,
+        )
+        with patch.object(pipeline, "run", return_value="[1784332800]") as run:
+            value = pipeline.contract_call(args, "firstDailyStart()(uint64)")
+        self.assertEqual(value, "1784332800")
+        self.assertEqual(run.call_args.args[0][0:3], ["cast", "call", "--json"])
+        self.assertEqual(pipeline.chain_int(value, "first daily start"), 1784332800)
+
+    def test_contract_call_rejects_human_or_ambiguous_output(self) -> None:
+        args = Namespace(
+            cast=Path("cast"),
+            rpc_url="https://rpc.example.test",
+            contract=CONTRACT,
+        )
+        for output, error in (
+            ("1784332800 [1.784e9]", "did not return JSON"),
+            ('["0x1", "0x2"]', "must return one value"),
+            ("[null]", "unsupported value"),
+        ):
+            with (
+                self.subTest(output=output),
+                patch.object(pipeline, "run", return_value=output),
+                self.assertRaisesRegex(pipeline.PipelineError, error),
+            ):
+                pipeline.contract_call(args, "firstDailyStart()(uint64)")
+
     def test_candidate_commits_to_exact_ranked_evidence(self) -> None:
         candidate = pipeline.build_candidate(
             response_fixture(), "daily", CONTRACT, self.reference, self.now


### PR DESCRIPTION
## What changed
- consume machine-readable Cast JSON for all leaderboard contract reads
- reject malformed or multi-value contract output
- keep runner and signer dormant behind an explicit activation variable until production is configured and funded
- document the activation order

## Why
The hourly runner failed on valid Foundry output such as 1784332800 [1.784e9]. After parsing that value, the next expected production state is an unconfigured API while Render deployment is quota-paused. A dormant activation gate prevents noisy scheduled failures without weakening payout validation.

## Validation
- 9 focused pipeline tests passed
- live Base mainnet parser check read both exact signers and program start timestamps
- actionlint passed for both workflows
- core preflight passed
- Python compile and diff checks passed

Operationally, LEADERBOARD_REWARD_RUNNER_ENABLED=false is already set. It will become 	rue only after hosted contract configuration, pool funding, and safe-block reconciliation.