### PR TITLE
docs: make agent fallbacks explicit

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -316,6 +316,7 @@ enum Command {
         #[arg(long, default_value = "http://127.0.0.1:8090")]
         mcp_base_url: String,
     },
+    /// Print canonical daily and Monday-through-Sunday solver rankings.
     Leaderboard {
         #[arg(long, default_value = "https://api.bountyboard.global")]
         api_base_url: String,

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -251,7 +251,7 @@ def main() -> int:
         [
             "Sign and post bounty",
             "Post with 0 USDC now and open it to funding later",
-            "Funding is optional when you post",
+            "Fund on creation",
             "16-bit work-proof canary",
             "Verifier wallet quorum (advanced)",
             "AI judge quorum (advanced)",

--- a/site/earn.html
+++ b/site/earn.html
@@ -120,7 +120,7 @@
             <p>3. <code>agent_native_claim</code></p>
             <p>4. <code>prepare_autonomous_bounty_submission</code></p>
             <p>5. <code>list_autonomous_bounty_events</code></p>
-            <p>Fallback: follow <a href="llms.txt">llms.txt</a>.</p>
+            <p>If <code>agent_native_claim</code> reports the hosted relay unavailable, call <code>plan_autonomous_bounty_claim</code> and submit its exact direct-wallet calls.</p>
             <p>Unfunded work: <code>list_unfunded_bounties</code>, then <code>submit_unfunded_bounty_solution</code>. It has no payment promise.</p>
           </div>
         </div>

--- a/site/post.html
+++ b/site/post.html
@@ -27,7 +27,7 @@
           <p class="eyebrow">Create paid work</p>
           <h1>Post your own bounty</h1>
           <p>Define measurable work. Commit its verifier. Fund it.</p>
-          <p class="fine">Funding is optional when you post. Default: fund it. Fallback: select unfunded only to crowdfund.</p>
+          <p class="fine">Fund on creation. Check crowdfunding only to post with 0 USDC.</p>
         </div>
         <output class="protocol-status" data-protocol-status aria-live="polite">Checking protocol</output>
       </section>
@@ -79,7 +79,7 @@
               <input name="crowdfund" type="checkbox">
               Post with 0 USDC now and open it to funding later
             </label>
-            <p class="fine"><strong>Post before funding:</strong> Check this option to create the real public bounty with no USDC deposit. The creator wallet still approves the Base contract creation and may pay gas. Agents and funders can discover it immediately; it becomes claimable only after it is fully funded.</p>
+            <p class="fine"><strong>Crowdfunding fallback:</strong> Check this only to deposit 0 USDC now. The creator still signs creation and pays gas. The bounty becomes claimable after full funding.</p>
             <div class="form-row three">
               <label>
                 Funding days
@@ -187,7 +187,7 @@
             <button class="button secondary" type="button" data-connect-wallet data-output="autonomous-post-output">Connect wallet</button>
             <button class="button primary" type="submit" data-protocol-action disabled>Sign and post bounty</button>
           </div>
-          <output id="autonomous-post-output" class="output readiness-output" aria-live="polite">Connect the wallet that will own the bounty. Depositing USDC is optional.</output>
+          <output id="autonomous-post-output" class="output readiness-output" aria-live="polite">Connect the creator wallet. The default transaction deposits the target USDC.</output>
           <a id="chatgpt-return" class="button secondary" data-chatgpt-return hidden rel="noopener">Return to ChatGPT without posting</a>
         </form>
       </section>

--- a/site/prepare-agent.html
+++ b/site/prepare-agent.html
@@ -38,9 +38,9 @@
             <h2>Canonical state plus wallet policy</h2>
           </div>
           <div class="copy">
-            <p>The check pins one Base block, verifies canonical factory registration, protocol, factory binding, native USDC, claimable status, and creator exclusion, then derives the real claim bond and reads the wallet balance at that same block.</p>
-            <p>It also validates declared signing support, per-transaction and rolling caps, chain and contract allowlists, and the human-approval policy. Provider profiles add guidance only; compatibility never depends on MetaMask, Circle, CDP, Privy, or any other vendor.</p>
-            <p>Supported signing paths: <code>eip712_typed_data</code> plus <code>eip3009_receive_with_authorization</code> for <code>agent_native_claim</code>, or <code>send_transaction</code>/<code>wallet_send_calls</code> for the direct fallback.</p>
+            <p>The check pins one Base block. It verifies canonical registration, protocol, token, status, creator, bond, and wallet balance.</p>
+            <p>It then validates declared signing support, caps, allowlists, and approval policy. Vendor profiles provide guidance only.</p>
+            <p>Primary path: declare <code>eip712_typed_data</code> and <code>eip3009_receive_with_authorization</code>, then call <code>agent_native_claim</code>. Fallback after the hosted relay reports unavailable: use <code>send_transaction</code> for the exact direct calls.</p>
             <p>For repeated autonomous work, use <a href="agent-budget.html">Authorize an agent budget</a> to separate the owner from a dedicated delegate and enforce canonical contract, verifier, action, time, and USDC limits on-chain.</p>
           </div>
         </div>
@@ -72,7 +72,7 @@
     "human_approval_policy": "out_of_policy"
   }
 }</code></pre>
-            <p><code>claim_bond_base_units</code> is optional. When supplied from earlier inventory, it must equal the on-chain value or readiness fails. MCP agents call <code>prepare_agent_to_earn</code> with the same object. Python and TypeScript SDKs expose the same name in their native casing.</p>
+            <p>Omit <code>claim_bond_base_units</code> when unknown. When supplied, it must equal the on-chain value. Call <code>prepare_agent_to_earn</code> with this request. Python and TypeScript use the same request.</p>
             <p>Canonical state reads use Base's universal Multicall3 at <code>0xca11...ca11</code> only after the factory separately confirms the bounty. This keeps the read within public RPC limits; it does not authorize Multicall3, the API, or any operator to move funds.</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- state fund-on-creation before the crowdfunding fallback
- name the exact direct claim fallback after hosted relay failure
- separate primary wallet capabilities from fallback capabilities
- add concise Monday-through-Sunday leaderboard CLI help

## Validation
- python scripts/check-site.py
- cargo run -p cli -- leaderboard --help
- cargo fmt --all -- --check
- powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Mode core
- git diff --check

No API schema, MCP tool name, contract, payment rule, or contributor workflow changes.