### PR TITLE
ci: pause stale revision monitors with deploys

### DIFF
--- a/.github/workflows/operational-control-loop.yml
+++ b/.github/workflows/operational-control-loop.yml
@@ -26,7 +26,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  deployment-paused:
+    if: github.event_name != 'workflow_dispatch' && vars.RENDER_DEPLOY_PAUSE_REASON != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report declared deployment pause
+        run: echo "Operational control loop paused - ${{ vars.RENDER_DEPLOY_PAUSE_REASON }}" >> "$GITHUB_STEP_SUMMARY"
+
   observe-plan-verify:
+    if: github.event_name == 'workflow_dispatch' || vars.RENDER_DEPLOY_PAUSE_REASON == ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -31,7 +31,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  deployment-paused:
+    if: github.event_name != 'workflow_dispatch' && vars.RENDER_DEPLOY_PAUSE_REASON != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report declared deployment pause
+        run: echo "Production smoke paused - ${{ vars.RENDER_DEPLOY_PAUSE_REASON }}" >> "$GITHUB_STEP_SUMMARY"
+
   production-smoke:
+    if: github.event_name == 'workflow_dispatch' || vars.RENDER_DEPLOY_PAUSE_REASON == ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:


### PR DESCRIPTION
## Summary
- skip scheduled production smoke while the declared Render deployment pause is active
- skip scheduled operational recovery probes under the same declared pause
- preserve unconditional manual dispatch for both monitors
- emit a concise successful pause summary instead of false failure alerts

Deleting RENDER_DEPLOY_PAUSE_REASON restores scheduled enforcement.

## Validation
- actionlint on both workflows
- powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Mode core
- git diff --check