### PR TITLE
fix: reuse verified Render builds for runtime config

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -19,7 +19,19 @@ on:
   workflow_dispatch:
     inputs:
       revision:
-        description: "Exact current main SHA; defaults to the dispatch revision"
+        description: "Controller SHA; defaults to the dispatch revision"
+        required: false
+        type: string
+      deploy_mode:
+        description: "Build the controller SHA or redeploy the verified current artifact"
+        required: false
+        default: build_and_deploy
+        type: choice
+        options:
+          - build_and_deploy
+          - deploy_only
+      runtime_revision:
+        description: "Exact current production SHA; required for deploy_only"
         required: false
         type: string
 
@@ -64,6 +76,8 @@ jobs:
       cancel-in-progress: false
     env:
       TARGET_REVISION: ${{ github.event.workflow_run.head_sha || inputs.revision || github.sha }}
+      REQUESTED_DEPLOY_MODE: ${{ inputs.deploy_mode || 'build_and_deploy' }}
+      RUNTIME_REVISION: ${{ inputs.runtime_revision }}
       PRODUCTION_API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://api.bountyboard.global' }}
       PRODUCTION_MCP_BASE_URL: ${{ vars.PRODUCTION_MCP_BASE_URL || 'https://mcp.bountyboard.global' }}
       RENDER_DEPLOY_PAUSE_REASON: ${{ vars.RENDER_DEPLOY_PAUSE_REASON }}
@@ -83,7 +97,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ -n "${RENDER_DEPLOY_PAUSE_REASON}" ]]; then
+          if [[ "${REQUESTED_DEPLOY_MODE}" != "build_and_deploy" && "${REQUESTED_DEPLOY_MODE}" != "deploy_only" ]]; then
+            echo "Unsupported deploy mode" >&2
+            exit 1
+          fi
+          if [[ "${REQUESTED_DEPLOY_MODE}" == "deploy_only" && "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
+            echo "deploy_only is manual recovery only" >&2
+            exit 1
+          fi
+          if [[ -n "${RENDER_DEPLOY_PAUSE_REASON}" && "${REQUESTED_DEPLOY_MODE}" != "deploy_only" ]]; then
             if [[ ! "${RENDER_DEPLOY_PAUSE_REASON}" =~ ^[a-z0-9_-]{1,80}$ ]]; then
               echo "RENDER_DEPLOY_PAUSE_REASON has an invalid format" >&2
               exit 1
@@ -128,7 +150,21 @@ jobs:
             echo "Latest successful main CI is ${latest_successful}; that revision owns deployment." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          deployment_revision="${TARGET_REVISION,,}"
+          if [[ "${REQUESTED_DEPLOY_MODE}" == "deploy_only" ]]; then
+            if [[ ! "${RUNTIME_REVISION}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "RUNTIME_REVISION must be an exact 40-character Git SHA for deploy_only" >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "${RUNTIME_REVISION}" "${current_main}"; then
+              echo "RUNTIME_REVISION is not reachable from current main" >&2
+              exit 1
+            fi
+            deployment_revision="${RUNTIME_REVISION,,}"
+          fi
           echo "deploy=true" >> "$GITHUB_OUTPUT"
+          echo "deploy_mode=${REQUESTED_DEPLOY_MODE}" >> "$GITHUB_OUTPUT"
+          echo "deployment_revision=${deployment_revision}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy and attest exact revision
         if: steps.target.outputs.deploy == 'true'
@@ -140,7 +176,8 @@ jobs:
           BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT: ${{ vars.BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT }}
         run: |
           python scripts/render_deploy_recovery.py \
-            --revision "${TARGET_REVISION}" \
+            --revision "${{ steps.target.outputs.deployment_revision }}" \
+            --deploy-mode "${{ steps.target.outputs.deploy_mode }}" \
             --api-url "${PRODUCTION_API_BASE_URL%/}/health" \
             --mcp-url "${PRODUCTION_MCP_BASE_URL%/}/health" \
             --public-base-url "${PRODUCTION_API_BASE_URL%/}" \
@@ -171,6 +208,7 @@ jobs:
               "# Render deployment",
               "",
               f"- Revision: `{evidence['revision']}`",
+              f"- Deploy mode: `{evidence['deploy_mode']}`",
               f"- Verified: `{str(evidence['success']).lower()}`",
               f"- Services live: `{sum(item['status'] == 'live' for item in evidence['services'])}/3`",
               f"- Exact health attestations: `{len(evidence['health'])}/2`",
@@ -178,6 +216,7 @@ jobs:
               f"- Cloud runtime variables: `{len(evidence.get('cloud_environment', []))}/10`",
               f"- Cloud model credential supplied: `{bool(evidence.get('secret_environment'))}`",
               f"- Cloud drafting ready: `{bool(evidence.get('cloud_readiness', {}).get('available'))}`",
+              f"- Leaderboard contracts ready: `{len(evidence.get('leaderboard_readiness', []))}`",
               "",
               "The controller can deploy application services only. It cannot deploy contracts, sign wallet transactions, or authorize settlement.",
           ]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -90,10 +90,19 @@ the Render key. If current `main` is newer and failing, pass the latest
 successful 40-character SHA in the manual `revision` input.
 
 If Render exhausts pipeline minutes, set the repository variable
-`RENDER_DEPLOY_PAUSE_REASON=build_pipeline_minutes_exhausted`. Deployment then
-skips before touching Render. Set a bounded pipeline spend limit in Render,
-delete the variable, and dispatch `Render Deploy Recovery` for the latest
-successful `main` SHA.
+`RENDER_DEPLOY_PAUSE_REASON=build_pipeline_minutes_exhausted`. Normal builds
+then stop before touching Render. Apply runtime-only configuration in this
+order:
+
+1. Read the exact SHA from the production `/health` revision header.
+2. Dispatch `Render Deploy Recovery` from current successful `main`.
+3. Select `deploy_only` and enter that production SHA as `runtime_revision`.
+4. Verify the workflow's exact health and readiness evidence.
+
+`deploy_only` rejects a service whose current live artifact does not match the
+supplied SHA. It reuses that artifact, applies saved environment values, and
+does not build new code. Delete the pause variable only after pipeline capacity
+returns.
 
 The API and MCP services need the same `DATABASE_URL`, public URLs, factory,
 implementation, and Base RPC configuration. Canonical planners fail closed

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -20,6 +20,7 @@ SCHEMA = "agent-bounties/render-deploy-evidence-v1"
 REPOSITORY = "github.com/nspg13/agent-bounties"
 PROTOCOL = "agent-bounties/autonomous-v1"
 HEALTH_STABILITY_PROBES = 8
+DEPLOY_MODES = {"build_and_deploy", "deploy_only"}
 ACTIVE_STATUSES = {
     "created",
     "queued",
@@ -179,6 +180,13 @@ def validate_revision(revision: str) -> str:
     return normalized
 
 
+def validate_deploy_mode(value: str) -> str:
+    mode = value.strip().lower()
+    if mode not in DEPLOY_MODES:
+        raise RecoveryError("deploy mode must be build_and_deploy or deploy_only")
+    return mode
+
+
 def normalize_repo(value: object) -> str:
     if not isinstance(value, str):
         return ""
@@ -327,6 +335,24 @@ def existing_deploy(payload: object, revision: str) -> dict[str, Any] | None:
     if deploys and deploy_commit(deploys[0]) == revision and deploys[0].get("status") == "live":
         return deploys[0]
     return None
+
+
+def current_live_deploy(payload: object, revision: str) -> dict[str, Any]:
+    if not isinstance(payload, list):
+        raise RecoveryError("Render deploy-list response must be an array")
+    for entry in payload:
+        try:
+            deploy = unwrap_deploy(entry)
+        except RecoveryError:
+            continue
+        if deploy.get("status") != "live":
+            continue
+        if deploy_commit(deploy) != revision:
+            raise RecoveryError(
+                "deploy_only requires the current live artifact to match the requested revision"
+            )
+        return deploy
+    raise RecoveryError("deploy_only requires a current live Render artifact")
 
 
 class RenderClient:
@@ -521,11 +547,24 @@ class RenderClient:
         revision: str,
         *,
         force: bool = False,
+        deploy_mode: str = "build_and_deploy",
     ) -> dict[str, Any]:
+        deploy_mode = validate_deploy_mode(deploy_mode)
         service_id = service["id"]
         matched = existing_deploy(self.list_deploys(service_id), revision)
         if matched is not None and not (force and matched.get("status") == "live"):
             return matched
+        replaced_live_id = (
+            matched.get("id")
+            if force and matched is not None and matched.get("status") == "live"
+            else None
+        )
+
+        payload = (
+            {"deployMode": "deploy_only"}
+            if deploy_mode == "deploy_only"
+            else {"clearCache": "do_not_clear", "commitId": revision}
+        )
 
         for attempt in range(1, 4):
             try:
@@ -533,7 +572,7 @@ class RenderClient:
                     self._request_json(
                         "POST",
                         f"/services/{service_id}/deploys",
-                        {"clearCache": "do_not_clear", "commitId": revision},
+                        payload,
                     )
                 )
             except RenderHttpError as error:
@@ -544,7 +583,7 @@ class RenderClient:
                     raise
             self._sleep(float(attempt * 2))
             matched = existing_deploy(self.list_deploys(service_id), revision)
-            if matched is not None:
+            if matched is not None and matched.get("id") != replaced_live_id:
                 return matched
         raise AssertionError("unreachable")
 
@@ -717,6 +756,34 @@ def validate_cloud_agent_readiness(
     }
 
 
+def validate_leaderboard_readiness(
+    payload: dict[str, Any],
+    *,
+    network: str,
+    expected_contract: str,
+) -> dict[str, Any]:
+    if payload.get("schema_version") != "agent-bounties/solver-leaderboard-v1":
+        raise RecoveryError("leaderboard readiness schema is invalid")
+    if payload.get("network") != network:
+        raise RecoveryError("leaderboard readiness reports a different network")
+    reward_pool = payload.get("reward_pool")
+    if not isinstance(reward_pool, dict):
+        raise RecoveryError("leaderboard readiness is missing its reward pool")
+    observed_contract = reward_pool.get("contract")
+    if (
+        not isinstance(observed_contract, str)
+        or observed_contract.lower() != expected_contract
+    ):
+        raise RecoveryError("leaderboard readiness reports a different reward contract")
+    return {
+        "network": network,
+        "contract": observed_contract.lower(),
+        "funding_status": reward_pool.get("funding_status"),
+        "balance_usdc": reward_pool.get("balance_usdc"),
+        "observed_safe_block": reward_pool.get("observed_safe_block"),
+    }
+
+
 def validate_health(
     service_name: str,
     revision: str,
@@ -818,6 +885,7 @@ def deploy(
     client: RenderClient,
     revision: str,
     *,
+    deploy_mode: str = "build_and_deploy",
     specs: tuple[ServiceSpec, ...] = SERVICE_SPECS,
     deploy_timeout_seconds: float,
     health_timeout_seconds: float,
@@ -828,12 +896,17 @@ def deploy(
     base_mainnet_leaderboard_reward_contract: str | None = None,
     base_sepolia_leaderboard_reward_contract: str | None = None,
 ) -> dict[str, Any]:
+    deploy_mode = validate_deploy_mode(deploy_mode)
     services: list[tuple[ServiceSpec, dict[str, Any]]] = []
     pending: dict[str, tuple[dict[str, Any], str]] = {}
     initial: dict[str, dict[str, Any]] = {}
 
     for spec in specs:
         services.append((spec, client.resolve_service(spec)))
+
+    if deploy_mode == "deploy_only":
+        for _, service in services:
+            current_live_deploy(client.list_deploys(service["id"]), revision)
 
     for spec, service in services:
         client.disable_native_auto_deploy(service)
@@ -904,7 +977,11 @@ def deploy(
         created = client.ensure_deploy(
             service,
             revision,
-            force=public_environment_changed.get(spec.name, False),
+            force=(
+                deploy_mode == "deploy_only"
+                or public_environment_changed.get(spec.name, False)
+            ),
+            deploy_mode=deploy_mode,
         )
         deploy_id, status = validate_deploy(created, revision, spec.name)
         initial[spec.name] = created
@@ -950,6 +1027,24 @@ def deploy(
             cloud_agent_api_key and cloud_agent_api_key.strip()
         ),
     )
+    leaderboard_readiness = []
+    for network, key in (
+        ("base-mainnet", "BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT"),
+        ("base-sepolia", "BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT"),
+    ):
+        expected_contract = leaderboard_environment.get(key)
+        if expected_contract is None:
+            continue
+        leaderboard_readiness.append(
+            validate_leaderboard_readiness(
+                fetch_json(
+                    f"{public_base_url.rstrip('/')}/v1/base/autonomous-bounties/leaderboard?network={network}",
+                    20,
+                ),
+                network=network,
+                expected_contract=expected_contract,
+            )
+        )
     service_evidence = []
     for spec, service in services:
         deployed = completed[spec.name]
@@ -967,6 +1062,7 @@ def deploy(
             }
         )
     return {
+        "deploy_mode": deploy_mode,
         "services": service_evidence,
         "health": health,
         "custom_domains": custom_domains,
@@ -974,6 +1070,7 @@ def deploy(
         "cloud_environment": cloud_environment,
         "secret_environment": secret_environment,
         "cloud_readiness": cloud_readiness,
+        "leaderboard_readiness": leaderboard_readiness,
     }
 
 
@@ -982,6 +1079,11 @@ def parse_args() -> argparse.Namespace:
         description="Deploy and attest an exact reviewed main revision on Render."
     )
     parser.add_argument("--revision", required=True)
+    parser.add_argument(
+        "--deploy-mode",
+        choices=sorted(DEPLOY_MODES),
+        default="build_and_deploy",
+    )
     parser.add_argument(
         "--api-url",
         default="https://agent-bounties-api.onrender.com/health",
@@ -1018,6 +1120,7 @@ def main() -> int:
         "started_at": utc_now(),
         "completed_at": None,
         "revision": args.revision,
+        "deploy_mode": args.deploy_mode,
         "success": False,
         "services": [],
         "health": [],
@@ -1026,6 +1129,7 @@ def main() -> int:
         "cloud_environment": [],
         "secret_environment": [],
         "cloud_readiness": {},
+        "leaderboard_readiness": [],
         "failure": None,
         "error": None,
     }
@@ -1038,6 +1142,7 @@ def main() -> int:
         result = deploy(
             client,
             revision,
+            deploy_mode=args.deploy_mode,
             specs=tuple(specs),
             deploy_timeout_seconds=args.deploy_timeout_seconds,
             health_timeout_seconds=args.health_timeout_seconds,

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -111,6 +111,15 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             with self.subTest(value=value), self.assertRaises(recovery.RecoveryError):
                 recovery.validate_revision(value)
 
+    def test_deploy_mode_is_explicit(self) -> None:
+        self.assertEqual(recovery.validate_deploy_mode("deploy_only"), "deploy_only")
+        self.assertEqual(
+            recovery.validate_deploy_mode("build_and_deploy"),
+            "build_and_deploy",
+        )
+        with self.assertRaisesRegex(recovery.RecoveryError, "deploy mode"):
+            recovery.validate_deploy_mode("latest")
+
     def test_service_resolution_is_exact_and_repository_bound(self) -> None:
         spec = recovery.SERVICE_SPECS[0]
         service = {
@@ -144,6 +153,16 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         ]
         self.assertIsNone(recovery.existing_deploy(payload, revision))
 
+    def test_deploy_only_requires_exact_current_live_artifact(self) -> None:
+        revision = "a" * 40
+        payload = [
+            {"deploy": {"id": "dep-failed", "status": "build_failed", "commit": {"id": "b" * 40}}},
+            {"deploy": {"id": "dep-live", "status": "live", "commit": {"id": revision}}},
+        ]
+        self.assertEqual(recovery.current_live_deploy(payload, revision)["id"], "dep-live")
+        with self.assertRaisesRegex(recovery.RecoveryError, "current live artifact"):
+            recovery.current_live_deploy(payload, "c" * 40)
+
     def test_trigger_binds_exact_commit_and_does_not_clear_cache(self) -> None:
         revision = "a" * 40
         client = RecordingClient(
@@ -165,6 +184,59 @@ class RenderDeployRecoveryTests(unittest.TestCase):
                 )
             ],
         )
+
+    def test_deploy_only_reuses_artifact_without_commit_or_cache_fields(self) -> None:
+        revision = "a" * 40
+        client = RecordingClient(
+            deploys=[
+                {
+                    "deploy": {
+                        "id": "dep-live",
+                        "status": "live",
+                        "commit": {"id": revision},
+                    }
+                }
+            ],
+            response={
+                "id": "dep-new",
+                "status": "created",
+                "commit": {"id": revision},
+            },
+        )
+        result = client.ensure_deploy(
+            {"id": "srv-api"},
+            revision,
+            force=True,
+            deploy_mode="deploy_only",
+        )
+        self.assertEqual(result["id"], "dep-new")
+        self.assertEqual(
+            client.requests,
+            [("POST", "/services/srv-api/deploys", {"deployMode": "deploy_only"})],
+        )
+
+    def test_forced_retry_never_mistakes_old_live_deploy_for_new_work(self) -> None:
+        revision = "a" * 40
+        client = RecordingClient(
+            deploys=[
+                {
+                    "deploy": {
+                        "id": "dep-old-live",
+                        "status": "live",
+                        "commit": {"id": revision},
+                    }
+                }
+            ],
+            error=recovery.RenderHttpError(503, "temporarily unavailable"),
+        )
+        with self.assertRaises(recovery.RenderHttpError):
+            client.ensure_deploy(
+                {"id": "srv-api"},
+                revision,
+                force=True,
+                deploy_mode="deploy_only",
+            )
+        self.assertEqual(len(client.requests), 3)
 
     def test_custom_domain_is_reused_or_attached_exactly_once(self) -> None:
         existing = RecordingClient()
@@ -580,6 +652,37 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         )
         self.assertTrue(observed["available"])
         self.assertNotIn("CLOUD_AGENT_API_KEY", recovery.json.dumps(observed))
+
+    def test_leaderboard_readiness_requires_exact_contract_and_network(self) -> None:
+        contract = "0x" + "a" * 40
+        payload = {
+            "schema_version": "agent-bounties/solver-leaderboard-v1",
+            "network": "base-mainnet",
+            "reward_pool": {
+                "contract": contract.upper().replace("0X", "0x"),
+                "funding_status": "underfunded",
+                "balance_usdc": "0.00",
+                "observed_safe_block": 123,
+            },
+        }
+        result = recovery.validate_leaderboard_readiness(
+            payload,
+            network="base-mainnet",
+            expected_contract=contract,
+        )
+        self.assertEqual(result["contract"], contract)
+        with self.assertRaisesRegex(recovery.RecoveryError, "different network"):
+            recovery.validate_leaderboard_readiness(
+                payload,
+                network="base-sepolia",
+                expected_contract=contract,
+            )
+        with self.assertRaisesRegex(recovery.RecoveryError, "different reward contract"):
+            recovery.validate_leaderboard_readiness(
+                payload,
+                network="base-mainnet",
+                expected_contract="0x" + "b" * 40,
+            )
 
     def test_cloud_readiness_cannot_claim_a_local_fallback(self) -> None:
         payload = {


### PR DESCRIPTION
## What changed
- add manual deploy_only recovery using Render's existing build artifact
- require the exact current live revision across API, MCP, and indexer before mutation
- reject stale-live evidence after transient deploy errors
- verify exact health, cloud readiness, and leaderboard contract configuration
- document the ordered build-minute recovery path

## Verification
- python scripts/test_render_deploy_recovery.py -v (40 passed)
- python scripts/check-render-blueprint.py
- python -m py_compile scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py
- scripts/preflight.ps1 -Mode core

No bounty, verifier, settlement, payment, API, or MCP contract changes.