### PR TITLE
fix: attest deploy-only runtime via health

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -101,8 +101,10 @@ order:
 
 `deploy_only` rejects a service whose current live artifact does not match the
 supplied SHA. It reuses that artifact, applies saved environment values, and
-does not build new code. Delete the pause variable only after pipeline capacity
-returns.
+does not build new code. It restarts only API, then requires the supplied SHA
+from `/health` and the exact leaderboard contracts from the live API. Render's
+branch label is recorded but is not artifact evidence. Delete the pause
+variable only after pipeline capacity returns.
 
 The API and MCP services need the same `DATABASE_URL`, public URLs, factory,
 implementation, and Base RPC configuration. Canonical planners fail closed

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -337,7 +337,28 @@ def existing_deploy(payload: object, revision: str) -> dict[str, Any] | None:
     return None
 
 
-def current_live_deploy(payload: object, revision: str) -> dict[str, Any]:
+def new_active_deploy(
+    payload: object,
+    baseline_ids: set[str],
+) -> dict[str, Any] | None:
+    if not isinstance(payload, list):
+        raise RecoveryError("Render deploy-list response must be an array")
+    for entry in payload:
+        try:
+            deploy = unwrap_deploy(entry)
+        except RecoveryError:
+            continue
+        deploy_id = deploy.get("id")
+        if (
+            isinstance(deploy_id, str)
+            and deploy_id not in baseline_ids
+            and deploy.get("status") in ACTIVE_STATUSES | {"live"}
+        ):
+            return deploy
+    return None
+
+
+def current_live_deploy_record(payload: object) -> dict[str, Any]:
     if not isinstance(payload, list):
         raise RecoveryError("Render deploy-list response must be an array")
     for entry in payload:
@@ -347,12 +368,17 @@ def current_live_deploy(payload: object, revision: str) -> dict[str, Any]:
             continue
         if deploy.get("status") != "live":
             continue
-        if deploy_commit(deploy) != revision:
-            raise RecoveryError(
-                "deploy_only requires the current live artifact to match the requested revision"
-            )
         return deploy
     raise RecoveryError("deploy_only requires a current live Render artifact")
+
+
+def current_live_deploy(payload: object, revision: str) -> dict[str, Any]:
+    deploy = current_live_deploy_record(payload)
+    if deploy_commit(deploy) != revision:
+        raise RecoveryError(
+            "deploy_only requires the current live artifact to match the requested revision"
+        )
+    return deploy
 
 
 class RenderClient:
@@ -551,7 +577,15 @@ class RenderClient:
     ) -> dict[str, Any]:
         deploy_mode = validate_deploy_mode(deploy_mode)
         service_id = service["id"]
-        matched = existing_deploy(self.list_deploys(service_id), revision)
+        listed_deploys = self.list_deploys(service_id)
+        matched = existing_deploy(listed_deploys, revision)
+        baseline_ids = {
+            deploy["id"]
+            for entry in listed_deploys
+            if isinstance(entry, dict)
+            for deploy in [entry.get("deploy", entry)]
+            if isinstance(deploy, dict) and isinstance(deploy.get("id"), str)
+        }
         if matched is not None and not (force and matched.get("status") == "live"):
             return matched
         replaced_live_id = (
@@ -582,18 +616,29 @@ class RenderClient:
                 if attempt == 3:
                     raise
             self._sleep(float(attempt * 2))
-            matched = existing_deploy(self.list_deploys(service_id), revision)
+            latest_deploys = self.list_deploys(service_id)
+            matched = (
+                new_active_deploy(latest_deploys, baseline_ids)
+                if deploy_mode == "deploy_only"
+                else existing_deploy(latest_deploys, revision)
+            )
             if matched is not None and matched.get("id") != replaced_live_id:
                 return matched
         raise AssertionError("unreachable")
 
 
-def validate_deploy(deploy: dict[str, Any], revision: str, service_name: str) -> tuple[str, str]:
+def validate_deploy(
+    deploy: dict[str, Any],
+    revision: str,
+    service_name: str,
+    *,
+    require_revision: bool = True,
+) -> tuple[str, str]:
     deploy_id = deploy.get("id")
     status = deploy.get("status")
     if not isinstance(deploy_id, str) or not deploy_id.startswith("dep-"):
         raise RecoveryError(f"{service_name} deploy is missing an id")
-    if deploy_commit(deploy) != revision:
+    if require_revision and deploy_commit(deploy) != revision:
         raise RecoveryError(f"{service_name} deploy does not attest the requested revision")
     if not isinstance(status, str):
         raise RecoveryError(f"{service_name} deploy is missing status")
@@ -636,6 +681,7 @@ def poll_deploys(
     *,
     timeout_seconds: float,
     poll_seconds: float,
+    metadata_revision_exempt: frozenset[str] = frozenset(),
     clock: Callable[[], float] = time.monotonic,
     sleeper: Callable[[float], None] = time.sleep,
 ) -> dict[str, dict[str, Any]]:
@@ -645,7 +691,12 @@ def poll_deploys(
         for service_name, (service, deploy_id) in list(pending.items()):
             service_id = service["id"]
             deploy = client.get_deploy(service_id, deploy_id)
-            _, status = validate_deploy(deploy, revision, service_name)
+            _, status = validate_deploy(
+                deploy,
+                revision,
+                service_name,
+                require_revision=service_name not in metadata_revision_exempt,
+            )
             if status == "live":
                 completed[service_name] = deploy
                 pending.pop(service_name)
@@ -900,13 +951,24 @@ def deploy(
     services: list[tuple[ServiceSpec, dict[str, Any]]] = []
     pending: dict[str, tuple[dict[str, Any], str]] = {}
     initial: dict[str, dict[str, Any]] = {}
+    preexisting_live: dict[str, dict[str, Any]] = {}
 
     for spec in specs:
         services.append((spec, client.resolve_service(spec)))
 
     if deploy_mode == "deploy_only":
-        for _, service in services:
-            current_live_deploy(client.list_deploys(service["id"]), revision)
+        for spec, service in services:
+            deploys = client.list_deploys(service["id"])
+            if spec.health_url is None:
+                current = current_live_deploy(deploys, revision)
+            else:
+                current = current_live_deploy_record(deploys)
+                validate_health(
+                    spec.name,
+                    revision,
+                    fetch_health(spec.health_url, 10),
+                )
+            preexisting_live[spec.name] = current
 
     for spec, service in services:
         client.disable_native_auto_deploy(service)
@@ -973,17 +1035,31 @@ def deploy(
             }
         )
 
+    metadata_revision_exempt = (
+        frozenset(spec.name for spec in specs if spec.health_url is not None)
+        if deploy_mode == "deploy_only"
+        else frozenset()
+    )
     for spec, service in services:
-        created = client.ensure_deploy(
-            service,
+        if deploy_mode == "deploy_only" and spec.name != CLOUD_AGENT_API_SERVICE_NAME:
+            created = preexisting_live[spec.name]
+        else:
+            created = client.ensure_deploy(
+                service,
+                revision,
+                force=(
+                    True
+                    if deploy_mode == "deploy_only"
+                    else public_environment_changed.get(spec.name, False)
+                ),
+                deploy_mode=deploy_mode,
+            )
+        deploy_id, status = validate_deploy(
+            created,
             revision,
-            force=(
-                deploy_mode == "deploy_only"
-                or public_environment_changed.get(spec.name, False)
-            ),
-            deploy_mode=deploy_mode,
+            spec.name,
+            require_revision=spec.name not in metadata_revision_exempt,
         )
-        deploy_id, status = validate_deploy(created, revision, spec.name)
         initial[spec.name] = created
         if status == "live":
             continue
@@ -1005,6 +1081,7 @@ def deploy(
             revision,
             timeout_seconds=deploy_timeout_seconds,
             poll_seconds=poll_seconds,
+            metadata_revision_exempt=metadata_revision_exempt,
         )
     )
 
@@ -1048,7 +1125,12 @@ def deploy(
     service_evidence = []
     for spec, service in services:
         deployed = completed[spec.name]
-        deploy_id, status = validate_deploy(deployed, revision, spec.name)
+        deploy_id, status = validate_deploy(
+            deployed,
+            revision,
+            spec.name,
+            require_revision=spec.name not in metadata_revision_exempt,
+        )
         service_evidence.append(
             {
                 "name": spec.name,
@@ -1057,6 +1139,13 @@ def deploy(
                 "deploy_id": deploy_id,
                 "status": status,
                 "commit": revision,
+                "metadata_commit": deploy_commit(deployed),
+                "runtime_revision": revision,
+                "runtime_revision_evidence": (
+                    "health_and_readiness"
+                    if spec.name in metadata_revision_exempt
+                    else "render_deploy_metadata"
+                ),
                 "trigger": deployed.get("trigger"),
                 "native_auto_deploy": "disabled",
             }

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -104,6 +104,32 @@ class ResolutionFailureClient:
         self.mutations.append(("domain", service["name"], domain))
 
 
+class DeployOnlyPreflightClient:
+    def __init__(self) -> None:
+        self.mutations = []
+
+    def resolve_service(self, spec):
+        return {
+            "id": f"srv-{spec.name}",
+            "name": spec.name,
+            "autoDeploy": False,
+        }
+
+    def list_deploys(self, service_id):
+        return [
+            {
+                "deploy": {
+                    "id": f"dep-{service_id}",
+                    "status": "live",
+                    "commit": {"id": "a" * 40},
+                }
+            }
+        ]
+
+    def disable_native_auto_deploy(self, service):
+        self.mutations.append(("disable", service["name"]))
+
+
 class RenderDeployRecoveryTests(unittest.TestCase):
     def test_revision_requires_full_sha(self) -> None:
         self.assertEqual(recovery.validate_revision("A" * 40), "a" * 40)
@@ -160,8 +186,35 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             {"deploy": {"id": "dep-live", "status": "live", "commit": {"id": revision}}},
         ]
         self.assertEqual(recovery.current_live_deploy(payload, revision)["id"], "dep-live")
+        self.assertEqual(recovery.current_live_deploy_record(payload)["id"], "dep-live")
         with self.assertRaisesRegex(recovery.RecoveryError, "current live artifact"):
             recovery.current_live_deploy(payload, "c" * 40)
+
+        health = (
+            200,
+            "ok\n",
+            {
+                "x-agent-bounties-revision": "c" * 40,
+                "x-agent-bounties-protocol": recovery.PROTOCOL,
+            },
+        )
+        self.assertEqual(
+            recovery.validate_health("agent-bounties-api", "c" * 40, health)[
+                "revision"
+            ],
+            "c" * 40,
+        )
+
+    def test_new_active_deploy_excludes_preexisting_ids(self) -> None:
+        payload = [
+            {"deploy": {"id": "dep-new", "status": "update_in_progress"}},
+            {"deploy": {"id": "dep-old", "status": "live"}},
+        ]
+        self.assertEqual(
+            recovery.new_active_deploy(payload, {"dep-old"})["id"],
+            "dep-new",
+        )
+        self.assertIsNone(recovery.new_active_deploy(payload[1:], {"dep-old"}))
 
     def test_trigger_binds_exact_commit_and_does_not_clear_cache(self) -> None:
         revision = "a" * 40
@@ -562,6 +615,28 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         self.assertEqual(len(client.resolved), 3)
         self.assertEqual(client.mutations, [])
 
+    def test_deploy_only_health_preflight_fails_before_mutation(self) -> None:
+        client = DeployOnlyPreflightClient()
+        wrong_health = (
+            200,
+            "ok\n",
+            {
+                "x-agent-bounties-revision": "b" * 40,
+                "x-agent-bounties-protocol": recovery.PROTOCOL,
+            },
+        )
+        with mock.patch.object(recovery, "fetch_health", return_value=wrong_health):
+            with self.assertRaisesRegex(recovery.RecoveryError, "different revision"):
+                recovery.deploy(
+                    client,
+                    "a" * 40,
+                    deploy_mode="deploy_only",
+                    deploy_timeout_seconds=1,
+                    health_timeout_seconds=1,
+                    poll_seconds=0,
+                )
+        self.assertEqual(client.mutations, [])
+
     def test_poll_succeeds_only_after_exact_deploy_is_live(self) -> None:
         client = FakeClient(["build_in_progress", "live"])
         clock = FakeClock()
@@ -575,6 +650,39 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             sleeper=clock.sleep,
         )
         self.assertEqual(result["agent-bounties-api"]["status"], "live")
+
+    def test_deploy_only_poll_uses_health_for_runtime_revision(self) -> None:
+        client = FakeClient(["update_in_progress", "live"])
+        clock = FakeClock()
+        result = recovery.poll_deploys(
+            client,
+            {"agent-bounties-api": ({"id": "srv-api"}, "dep-api")},
+            "b" * 40,
+            timeout_seconds=20,
+            poll_seconds=2,
+            metadata_revision_exempt=frozenset({"agent-bounties-api"}),
+            clock=clock,
+            sleeper=clock.sleep,
+        )
+        self.assertEqual(result["agent-bounties-api"]["status"], "live")
+
+    def test_revision_metadata_mismatch_requires_explicit_exemption(self) -> None:
+        deploy = {
+            "id": "dep-api",
+            "status": "created",
+            "commit": {"id": "a" * 40},
+        }
+        with self.assertRaisesRegex(recovery.RecoveryError, "does not attest"):
+            recovery.validate_deploy(deploy, "b" * 40, "agent-bounties-api")
+        self.assertEqual(
+            recovery.validate_deploy(
+                deploy,
+                "b" * 40,
+                "agent-bounties-api",
+                require_revision=False,
+            ),
+            ("dep-api", "created"),
+        )
 
     def test_poll_fails_closed_on_build_failure(self) -> None:
         client = FakeClient(["build_failed"])


### PR DESCRIPTION
## Failure addressed
Render recovery run 29656366394 failed closed because deploy_only labels the new deploy with branch metadata, not the reused artifact SHA. Production remained unchanged.

## Correction
- preflight API and MCP artifacts through cache-bypassed exact /health headers
- keep exact Render revision evidence for the background worker
- restart only API, the sole leaderboard-contract consumer
- treat the new Render deploy ID as operation evidence, not artifact evidence
- require stable exact API health plus exact mainnet and Sepolia leaderboard contracts
- prevent transient retries from accepting or duplicating an old deploy

## Verification
- python scripts/test_render_deploy_recovery.py -v (44 passed)
- python -m py_compile scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py
- scripts/preflight.ps1 -Mode core

No bounty, verifier, settlement, payment, API, or MCP contract changes.