### PR TITLE
fix: pause all Render deploys at quota

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -105,13 +105,13 @@ jobs:
             echo "deploy_only is manual recovery only" >&2
             exit 1
           fi
-          if [[ -n "${RENDER_DEPLOY_PAUSE_REASON}" && "${REQUESTED_DEPLOY_MODE}" != "deploy_only" ]]; then
+          if [[ -n "${RENDER_DEPLOY_PAUSE_REASON}" ]]; then
             if [[ ! "${RENDER_DEPLOY_PAUSE_REASON}" =~ ^[a-z0-9_-]{1,80}$ ]]; then
               echo "RENDER_DEPLOY_PAUSE_REASON has an invalid format" >&2
               exit 1
             fi
             echo "deploy=false" >> "$GITHUB_OUTPUT"
-            echo "Render deployment paused: ${RENDER_DEPLOY_PAUSE_REASON}. Clear the repository variable, then dispatch this workflow." >> "$GITHUB_STEP_SUMMARY"
+            echo "Render deployment paused: ${RENDER_DEPLOY_PAUSE_REASON}. Render quota-gates build_and_deploy and deploy_only. Restore capacity, clear the repository variable, then dispatch this workflow." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           if [[ ! "${TARGET_REVISION}" =~ ^[0-9a-fA-F]{40}$ ]]; then

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -90,9 +90,12 @@ the Render key. If current `main` is newer and failing, pass the latest
 successful 40-character SHA in the manual `revision` input.
 
 If Render exhausts pipeline minutes, set the repository variable
-`RENDER_DEPLOY_PAUSE_REASON=build_pipeline_minutes_exhausted`. Normal builds
-then stop before touching Render. Apply runtime-only configuration in this
-order:
+`RENDER_DEPLOY_PAUSE_REASON=build_pipeline_minutes_exhausted`. Every deployment
+mode then stops before touching Render. Restore bounded pipeline capacity or
+wait for the billing reset, delete the variable, and dispatch the latest
+successful `main` SHA.
+
+Use `deploy_only` for runtime-only configuration after capacity is available:
 
 1. Read the exact SHA from the production `/health` revision header.
 2. Dispatch `Render Deploy Recovery` from current successful `main`.
@@ -103,8 +106,9 @@ order:
 supplied SHA. It reuses that artifact, applies saved environment values, and
 does not build new code. It restarts only API, then requires the supplied SHA
 from `/health` and the exact leaderboard contracts from the live API. Render's
-branch label is recorded but is not artifact evidence. Delete the pause
-variable only after pipeline capacity returns.
+branch label is recorded but is not artifact evidence. Render currently applies
+the workspace pipeline quota before both deployment modes, so `deploy_only` is
+not a quota bypass.
 
 The API and MCP services need the same `DATABASE_URL`, public URLs, factory,
 implementation, and Base RPC configuration. Canonical planners fail closed


### PR DESCRIPTION
## Why
Render canceled both documented deploy modes after this workspace exhausted build pipeline minutes. Runs 29656366394 and 29657085129 prove that deploy-only is not a usable quota bypass here.

## Change
- block both build-and-deploy and deploy-only while RENDER_DEPLOY_PAUSE_REASON is set
- report the exact recovery action: restore pipeline capacity or wait for the billing reset
- correct the deployment runbook so operators do not trigger doomed recovery runs

## Verification
- 44 render deployment recovery tests pass
- render Blueprint check passes
- core preflight passes
- git diff check passes