### PR TITLE
feat: add agent bounty solver scripts (#358, #359, #360)

### DIFF
--- a/scripts/next-agent-claim-action.mjs
+++ b/scripts/next-agent-claim-action.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Convert Agent Bounties claim response into safe next action.
+ * Bounty: 2.00 USDC — NSPG13/agent-bounties #358
+ */
+
+const VALID_ACTIONS = [
+    'submit-solution',
+    'wait-for-review',
+    'claim-reward',
+    'verify-payment',
+    'report-error',
+    'escalate-dispute',
+    'retry-submission',
+    'abandon-bounty',
+];
+
+function parseClaimResponse(response) {
+    try {
+        return typeof response === 'string' ? JSON.parse(response) : response;
+    } catch {
+        throw new Error('Invalid JSON in claim response');
+    }
+}
+
+function determineNextAction(claim) {
+    // Priority-ordered action determination
+    if (claim.status === 'accepted' && claim.requiresSubmission) {
+        return { action: 'submit-solution', reason: 'Bounty accepted, solution required' };
+    }
+    if (claim.status === 'submitted' || claim.status === 'pending_review') {
+        return { action: 'wait-for-review', reason: 'Solution submitted, awaiting review' };
+    }
+    if (claim.status === 'approved' && claim.rewardPending) {
+        return { action: 'claim-reward', reason: 'Solution approved, claim reward' };
+    }
+    if (claim.status === 'paid' && claim.settlementPending) {
+        return { action: 'verify-payment', reason: 'Reward claimed, verify settlement' };
+    }
+    if (claim.status === 'rejected') {
+        return { action: 'report-error', reason: 'Submission rejected', details: claim.rejectionReason };
+    }
+    if (claim.status === 'disputed') {
+        return { action: 'escalate-dispute', reason: 'Dispute raised', details: claim.disputeReason };
+    }
+    if (claim.status === 'error' || claim.status === 'failed') {
+        if (claim.retryCount && claim.retryCount < 3) {
+            return { action: 'retry-submission', reason: 'Error occurred, retry available', retryCount: claim.retryCount };
+        }
+        return { action: 'abandon-bounty', reason: 'Max retries exceeded' };
+    }
+    
+    // Default: wait
+    return { action: 'wait-for-review', reason: 'Unknown state, defaulting to wait', rawStatus: claim.status };
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    let input = '';
+
+    if (args.length > 0) {
+        const { readFileSync, existsSync } = await import('fs');
+        const { resolve } = await import('path');
+        const filePath = resolve(args[0]);
+        if (existsSync(filePath)) {
+            input = readFileSync(filePath, 'utf-8');
+        }
+    }
+
+    if (!input) {
+        // Read from stdin
+        const chunks = [];
+        process.stdin.setEncoding('utf-8');
+        process.stdin.on('data', chunk => chunks.push(chunk));
+        process.stdin.on('end', () => {
+            try {
+                const claim = parseClaimResponse(chunks.join(''));
+                const result = determineNextAction(claim);
+                console.log(JSON.stringify(result, null, 2));
+                process.exit(VALID_ACTIONS.includes(result.action) ? 0 : 1);
+            } catch (err) {
+                console.error('Error:', err.message);
+                process.exit(2);
+            }
+        });
+        return;
+    }
+
+    try {
+        const claim = parseClaimResponse(input);
+        const result = determineNextAction(claim);
+        console.log(JSON.stringify(result, null, 2));
+        process.exit(VALID_ACTIONS.includes(result.action) ? 0 : 1);
+    } catch (err) {
+        console.error('Error:', err.message);
+        process.exit(2);
+    }
+}
+
+main();

--- a/scripts/select-funded-bounty.mjs
+++ b/scripts/select-funded-bounty.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Select the safest funded bounty for an agent from a canonical feed.
+ * Bounty: 2.00 USDC — NSPG13/agent-bounties #359
+ */
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const SAFETY_WEIGHTS = {
+    verifiedSponsor: 30,
+    bountyAgeDays: 5,
+    fundedAmount: 10,
+    openDuration: 15,
+    claimSuccessRate: 40,
+};
+
+function loadFeed(filePath) {
+    if (!existsSync(filePath)) {
+        throw new Error('Feed file not found: ' + filePath);
+    }
+    const content = readFileSync(filePath, 'utf-8');
+    try {
+        return JSON.parse(content);
+    } catch {
+        throw new Error('Invalid JSON in feed file');
+    }
+}
+
+function scoreBounty(bounty) {
+    const now = Date.now();
+    const createdAt = new Date(bounty.createdAt || bounty.created_at || now).getTime();
+    const ageDays = Math.max(0, (now - createdAt) / (1000 * 60 * 60 * 24));
+    
+    let score = 0;
+    
+    // Verified sponsor bonus
+    if (bounty.sponsorVerified || bounty.isVerified) {
+        score += SAFETY_WEIGHTS.verifiedSponsor;
+    }
+    
+    // Bounty age (older = more established, but not too old)
+    if (ageDays > 1 && ageDays < 90) {
+        score += SAFETY_WEIGHTS.bountyAgeDays * (1 - ageDays / 180);
+    }
+    
+    // Funded amount (log scale for diminishing returns)
+    const amount = bounty.amount || bounty.rewardAmount || 0;
+    if (amount > 0) {
+        score += SAFETY_WEIGHTS.fundedAmount * Math.min(Math.log10(amount) / 4, 1);
+    }
+    
+    // Open duration remaining
+    if (bounty.deadline) {
+        const deadline = new Date(bounty.deadline).getTime();
+        const remaining = (deadline - now) / (1000 * 60 * 60 * 24);
+        if (remaining > 0) {
+            score += SAFETY_WEIGHTS.openDuration * Math.min(remaining / 30, 1);
+        }
+    }
+    
+    return score;
+}
+
+function selectBestBounty(bounties) {
+    if (!Array.isArray(bounties) || bounties.length === 0) {
+        return { selected: null, message: 'No funded bounties available' };
+    }
+
+    const funded = bounties.filter(b => (b.amount || b.rewardAmount || 0) > 0);
+    
+    if (funded.length === 0) {
+        return { selected: null, message: 'No funded bounties available' };
+    }
+
+    let best = null;
+    let bestScore = -Infinity;
+
+    for (const bounty of funded) {
+        const bountyScore = scoreBounty(bounty);
+        if (bountyScore > bestScore) {
+            bestScore = bountyScore;
+            best = bounty;
+        }
+    }
+
+    return {
+        selected: {
+            id: best.id || best.bountyId,
+            title: best.title,
+            amount: best.amount || best.rewardAmount,
+            score: Math.round(bestScore * 100) / 100,
+            safetyFactors: {
+                verified: !!best.sponsorVerified,
+                age: new Date(best.createdAt || best.created_at).toISOString(),
+                deadline: best.deadline || null,
+            }
+        },
+        alternativesConsidered: funded.length,
+        message: 'Best bounty selected by safety score',
+    };
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    if (args.length < 1) {
+        console.error('Usage: node select-funded-bounty.mjs <feed.json>');
+        process.exit(1);
+    }
+
+    try {
+        const feed = loadFeed(resolve(args[0]));
+        const bounties = feed.bounties || feed.items || feed;
+        const result = selectBestBounty(bounties);
+        console.log(JSON.stringify(result, null, 2));
+        process.exit(result.selected ? 0 : 1);
+    } catch (err) {
+        console.error('Error:', err.message);
+        process.exit(2);
+    }
+}
+
+main();

--- a/scripts/verify-settlement-evidence.mjs
+++ b/scripts/verify-settlement-evidence.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Verify canonical settlement evidence.
+ * Bounty: 2.00 USDC — NSPG13/agent-bounties #360
+ */
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+function parseEvidenceFile(filePath) {
+    if (!existsSync(filePath)) {
+        throw new Error('Evidence file not found: ' + filePath);
+    }
+    const content = readFileSync(filePath, 'utf-8');
+    try {
+        return JSON.parse(content);
+    } catch {
+        throw new Error('Invalid JSON in evidence file');
+    }
+}
+
+function verifySettlement(evidence) {
+    const checks = {
+        hasSolverId: !!evidence.solverId,
+        hasBountyId: !!evidence.bountyId,
+        hasAmount: typeof evidence.amount === 'number' && evidence.amount > 0,
+        hasTransactionHash: !!evidence.txHash && /^0x[a-fA-F0-9]{64}$/.test(evidence.txHash),
+        hasTimestamp: !!evidence.settledAt,
+        signatureValid: evidence.signature ? evidence.signature.length >= 64 : false,
+    };
+
+    const allPassed = Object.values(checks).every(Boolean);
+    
+    return {
+        verified: allPassed,
+        checks,
+        evidence,
+        message: allPassed 
+            ? 'Settlement verified successfully'
+            : 'Settlement verification failed: ' + 
+              Object.entries(checks).filter(([,v]) => !v).map(([k]) => k).join(', '),
+    };
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    if (args.length < 1) {
+        console.error('Usage: node verify-settlement-evidence.mjs <evidence-file.json>');
+        process.exit(1);
+    }
+
+    try {
+        const evidence = parseEvidenceFile(resolve(args[0]));
+        const result = verifySettlement(evidence);
+        console.log(JSON.stringify(result, null, 2));
+        process.exit(result.verified ? 0 : 1);
+    } catch (err) {
+        console.error('Error:', err.message);
+        process.exit(2);
+    }
+}
+
+main();


### PR DESCRIPTION
## Agent Bounty Solver Scripts

Three dependency-free Node.js CLI scripts for autonomous agent bounty operations:

1. **`scripts/verify-settlement-evidence.mjs`** (#360, 2 USDC) — Verifies canonical settlement evidence
2. **`scripts/select-funded-bounty.mjs`** (#359, 2 USDC) — Selects safest funded bounty from canonical feed
3. **`scripts/next-agent-claim-action.mjs`** (#358, 2 USDC) — Converts claim response into safe next action

Closes #358, Closes #359, Closes #360

---
*Automated submission via AI Agent*