### PR TITLE
feat: show live adoption and require informed wallet consent

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -62,7 +62,7 @@ use cloud_agent::{
 use db::{
     BountyStatusScope, ClaimCandidateReservation, ClaimFunnelStats, DbError,
     GitHubIssueSyncBountyUpsert, NewBondSponsorship, NewClaimCandidate,
-    NewDiscoveryWebhookSubscription, NewTrialBounty, NewUnfundedBountySolution,
+    NewDiscoveryWebhookSubscription, NewLegalAcceptance, NewTrialBounty, NewUnfundedBountySolution,
     NewX402RelayAttempt, OpportunityLifecycleStats, PostgresStore, TrialBounty,
     UnfundedBountySolution, WebhookSubscription, X402RelayAttempt, X402RelayStatus,
 };
@@ -127,6 +127,8 @@ use worker::{
     paths(
         health,
         llms_txt,
+        legal_policy,
+        record_legal_acceptance,
         discovery_manifest_schema,
         agent_bounties_discovery,
         x402_discovery,
@@ -304,6 +306,9 @@ use worker::{
         ,SolverLeaderboardResponse
         ,SolverLeaderboardPeriodResponse
         ,SolverLeaderboardRanking
+        ,LegalPolicyResponse
+        ,RecordLegalAcceptanceRequest
+        ,LegalAcceptanceResponse
     )),
     modifiers(&SecurityAddon)
 )]
@@ -545,6 +550,19 @@ impl BondSponsorConfig {
 
 type SharedState = Arc<AppState>;
 const OPERATOR_TOKEN_HEADER: &str = "x-operator-token";
+const LEGAL_TERMS_VERSION: &str = "2026-07-18";
+const LEGAL_PRIVACY_VERSION: &str = "2026-07-18";
+const LEGAL_ACCEPTANCE_STATEMENT: &str = "I meet the age requirement in the Terms and am authorized to use this wallet and perform this action. I understand that public and blockchain records may be permanent. I accept the posted task, verification, and settlement rules. I am responsible for legal compliance, taxes, content rights, agent authority, and wallet security. I agree to the Terms of Use and Privacy Policy.";
+const LEGAL_ACTIONS: &[&str] = &[
+    "post_bounty",
+    "fund_bounty",
+    "claim_bounty",
+    "submit_result",
+    "recover_funds",
+    "activate_agent_budget",
+    "update_agent_policy",
+    "revoke_agent_policy",
+];
 
 fn non_empty_secret(secret: String) -> Option<String> {
     let trimmed = secret.trim();
@@ -1255,6 +1273,8 @@ async fn main() -> anyhow::Result<()> {
     let app = Router::new()
         .route("/health", get(health))
         .route("/llms.txt", get(llms_txt))
+        .route("/v1/legal/policy", get(legal_policy))
+        .route("/v1/legal/acceptances", post(record_legal_acceptance))
         .route(
             "/schemas/discovery-manifest.v2.json",
             get(discovery_manifest_schema),
@@ -1664,6 +1684,156 @@ fn health_response(revision: &str) -> impl IntoResponse {
 #[utoipa::path(get, path = "/llms.txt", responses((status = 200, body = String)))]
 async fn llms_txt(State(state): State<SharedState>) -> String {
     web_public::render_llms_txt(&state.public_base_url, &state.mcp_base_url)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct LegalPolicyResponse {
+    schema_version: String,
+    terms_version: String,
+    privacy_version: String,
+    statement: String,
+    statement_hash: String,
+    terms_url: String,
+    privacy_url: String,
+    supported_actions: Vec<String>,
+    evidence_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+struct RecordLegalAcceptanceRequest {
+    terms_version: String,
+    privacy_version: String,
+    action: String,
+    wallet_address: String,
+    statement_hash: String,
+    acceptance_method: String,
+    accepted_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct LegalAcceptanceResponse {
+    schema_version: String,
+    acceptance_id: Uuid,
+    terms_version: String,
+    privacy_version: String,
+    action: String,
+    wallet_address: String,
+    statement_hash: String,
+    acceptance_method: String,
+    accepted_at: DateTime<Utc>,
+    recorded_at: DateTime<Utc>,
+    evidence_boundary: String,
+}
+
+fn legal_statement_hash() -> String {
+    format!(
+        "sha256:{}",
+        hex::encode(Sha256::digest(LEGAL_ACCEPTANCE_STATEMENT.as_bytes()))
+    )
+}
+
+fn build_legal_policy(public_base_url: &str) -> LegalPolicyResponse {
+    let base = public_base_url.trim_end_matches('/');
+    LegalPolicyResponse {
+        schema_version: "agent-bounties/legal-policy-v1".to_string(),
+        terms_version: LEGAL_TERMS_VERSION.to_string(),
+        privacy_version: LEGAL_PRIVACY_VERSION.to_string(),
+        statement: LEGAL_ACCEPTANCE_STATEMENT.to_string(),
+        statement_hash: legal_statement_hash(),
+        terms_url: format!("{base}/terms.html"),
+        privacy_url: format!("{base}/privacy.html"),
+        supported_actions: LEGAL_ACTIONS.iter().map(|action| (*action).to_string()).collect(),
+        evidence_boundary: "This policy and an acceptance receipt record explicit assent on the hosted interface. Neither is a wallet signature, funding event, verifier verdict, settlement, legal advice, identity proof, or proof that the wallet controller had authority.".to_string(),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/legal/policy",
+    responses((status = 200, body = LegalPolicyResponse))
+)]
+async fn legal_policy(State(state): State<SharedState>) -> Json<LegalPolicyResponse> {
+    let website_base_url = env::var("WEBSITE_BASE_URL")
+        .ok()
+        .and_then(non_empty_secret)
+        .unwrap_or_else(|| state.public_base_url.clone());
+    Json(build_legal_policy(&website_base_url))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/legal/acceptances",
+    request_body = RecordLegalAcceptanceRequest,
+    responses(
+        (status = 201, body = LegalAcceptanceResponse),
+        (status = 400, description = "Unsupported, stale, or malformed acceptance"),
+        (status = 503, description = "Durable acceptance store unavailable")
+    )
+)]
+async fn record_legal_acceptance(
+    State(state): State<SharedState>,
+    Json(request): Json<RecordLegalAcceptanceRequest>,
+) -> Result<(StatusCode, Json<LegalAcceptanceResponse>), StatusCode> {
+    let wallet_address = validate_legal_acceptance_request(&request, Utc::now())?;
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let acceptance = store
+        .record_legal_acceptance(&NewLegalAcceptance {
+            id: Uuid::new_v4(),
+            terms_version: request.terms_version,
+            privacy_version: request.privacy_version,
+            action: request.action,
+            wallet_address,
+            statement_hash: request.statement_hash,
+            acceptance_method: request.acceptance_method,
+            accepted_at: request.accepted_at,
+        })
+        .await
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(LegalAcceptanceResponse {
+            schema_version: "agent-bounties/legal-acceptance-v1".to_string(),
+            acceptance_id: acceptance.id,
+            terms_version: acceptance.terms_version,
+            privacy_version: acceptance.privacy_version,
+            action: acceptance.action,
+            wallet_address: acceptance.wallet_address,
+            statement_hash: acceptance.statement_hash,
+            acceptance_method: acceptance.acceptance_method,
+            accepted_at: acceptance.accepted_at,
+            recorded_at: acceptance.recorded_at,
+            evidence_boundary: "This receipt records explicit hosted-interface assent. It does not prove identity, authority, funding, task completion, verification, or payment.".to_string(),
+        }),
+    ))
+}
+
+fn validate_legal_acceptance_request(
+    request: &RecordLegalAcceptanceRequest,
+    now: DateTime<Utc>,
+) -> Result<String, StatusCode> {
+    if request.terms_version != LEGAL_TERMS_VERSION
+        || request.privacy_version != LEGAL_PRIVACY_VERSION
+        || request.statement_hash != legal_statement_hash()
+        || !LEGAL_ACTIONS.contains(&request.action.as_str())
+        || !matches!(
+            request.acceptance_method.as_str(),
+            "web_clickwrap" | "api_explicit"
+        )
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if request.accepted_at < now - ChronoDuration::minutes(15)
+        || request.accepted_at > now + ChronoDuration::minutes(5)
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let wallet =
+        normalize_evm_address(&request.wallet_address).map_err(|_| StatusCode::BAD_REQUEST)?;
+    Ok(wallet.to_ascii_lowercase())
 }
 
 #[utoipa::path(
@@ -10417,6 +10587,45 @@ mod tests {
         assert_eq!(
             response.headers()["x-agent-bounties-protocol"],
             "agent-bounties/autonomous-v1"
+        );
+    }
+
+    #[test]
+    fn legal_policy_is_hash_bound_and_acceptance_is_action_wallet_and_time_bound() {
+        let policy = build_legal_policy("https://bountyboard.global/");
+        assert_eq!(policy.terms_version, LEGAL_TERMS_VERSION);
+        assert_eq!(policy.statement_hash, legal_statement_hash());
+        assert_eq!(policy.terms_url, "https://bountyboard.global/terms.html");
+        assert!(policy
+            .supported_actions
+            .iter()
+            .any(|action| action == "post_bounty"));
+
+        let now = Utc.with_ymd_and_hms(2026, 7, 18, 18, 0, 0).unwrap();
+        let mut request = RecordLegalAcceptanceRequest {
+            terms_version: LEGAL_TERMS_VERSION.to_string(),
+            privacy_version: LEGAL_PRIVACY_VERSION.to_string(),
+            action: "post_bounty".to_string(),
+            wallet_address: "0x1111111111111111111111111111111111111111".to_string(),
+            statement_hash: legal_statement_hash(),
+            acceptance_method: "api_explicit".to_string(),
+            accepted_at: now,
+        };
+        assert_eq!(
+            validate_legal_acceptance_request(&request, now).unwrap(),
+            request.wallet_address
+        );
+
+        request.action = "settle_without_verification".to_string();
+        assert_eq!(
+            validate_legal_acceptance_request(&request, now),
+            Err(StatusCode::BAD_REQUEST)
+        );
+        request.action = "post_bounty".to_string();
+        request.accepted_at = now - ChronoDuration::minutes(16);
+        assert_eq!(
+            validate_legal_acceptance_request(&request, now),
+            Err(StatusCode::BAD_REQUEST)
         );
     }
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -34,6 +34,8 @@ pub const DISCOVERY_SUBSCRIPTIONS_MIGRATION: &str =
     include_str!("../../../migrations/0007_discovery_subscriptions.sql");
 pub const OPPORTUNITY_CONVERSION_MIGRATION: &str =
     include_str!("../../../migrations/0008_opportunity_conversion.sql");
+pub const LEGAL_ACCEPTANCES_MIGRATION: &str =
+    include_str!("../../../migrations/0009_legal_acceptances.sql");
 const MIGRATION_ADVISORY_LOCK_ID: i64 = 4_270_265_017;
 const UPSERT_PAYMENT_EVENT_SQL: &str = r#"
             INSERT INTO payment_events (id, rail, external_id, status, payload_hash, received_at)
@@ -149,6 +151,31 @@ pub enum DbError {
 }
 
 pub type DbResult<T> = Result<T, DbError>;
+
+#[derive(Debug, Clone)]
+pub struct NewLegalAcceptance {
+    pub id: Uuid,
+    pub terms_version: String,
+    pub privacy_version: String,
+    pub action: String,
+    pub wallet_address: String,
+    pub statement_hash: String,
+    pub acceptance_method: String,
+    pub accepted_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LegalAcceptance {
+    pub id: Uuid,
+    pub terms_version: String,
+    pub privacy_version: String,
+    pub action: String,
+    pub wallet_address: String,
+    pub statement_hash: String,
+    pub acceptance_method: String,
+    pub accepted_at: DateTime<Utc>,
+    pub recorded_at: DateTime<Utc>,
+}
 
 #[derive(Debug, Clone)]
 pub struct NewTrialBounty {
@@ -549,6 +576,7 @@ impl PostgresStore {
                 SOLVER_LEADERBOARD_MIGRATION,
                 DISCOVERY_SUBSCRIPTIONS_MIGRATION,
                 OPPORTUNITY_CONVERSION_MIGRATION,
+                LEGAL_ACCEPTANCES_MIGRATION,
             ] {
                 for statement in migration
                     .split(';')
@@ -572,6 +600,44 @@ impl PostgresStore {
             (Err(error), Ok(_)) => Err(error.into()),
             (Ok(()), Err(error)) | (Err(_), Err(error)) => Err(error.into()),
         }
+    }
+
+    pub async fn record_legal_acceptance(
+        &self,
+        acceptance: &NewLegalAcceptance,
+    ) -> DbResult<LegalAcceptance> {
+        let row = sqlx::query(
+            r#"
+            INSERT INTO legal_acceptances
+              (id, terms_version, privacy_version, action, wallet_address,
+               statement_hash, acceptance_method, accepted_at)
+            VALUES ($1, $2, $3, $4, lower($5), $6, $7, $8)
+            RETURNING id, terms_version, privacy_version, action, wallet_address,
+                      statement_hash, acceptance_method, accepted_at, recorded_at
+            "#,
+        )
+        .bind(acceptance.id)
+        .bind(&acceptance.terms_version)
+        .bind(&acceptance.privacy_version)
+        .bind(&acceptance.action)
+        .bind(&acceptance.wallet_address)
+        .bind(&acceptance.statement_hash)
+        .bind(&acceptance.acceptance_method)
+        .bind(acceptance.accepted_at)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(LegalAcceptance {
+            id: row.try_get("id")?,
+            terms_version: row.try_get("terms_version")?,
+            privacy_version: row.try_get("privacy_version")?,
+            action: row.try_get("action")?,
+            wallet_address: row.try_get("wallet_address")?,
+            statement_hash: row.try_get("statement_hash")?,
+            acceptance_method: row.try_get("acceptance_method")?,
+            accepted_at: row.try_get("accepted_at")?,
+            recorded_at: row.try_get("recorded_at")?,
+        })
     }
 
     pub async fn create_discovery_webhook_subscription(
@@ -5489,6 +5555,26 @@ mod tests {
             assert!(
                 OPPORTUNITY_CONVERSION_MIGRATION.contains(invariant),
                 "missing opportunity conversion invariant {invariant}"
+            );
+        }
+    }
+
+    #[test]
+    fn legal_acceptance_migration_preserves_versioned_action_evidence() {
+        for invariant in [
+            "legal_acceptances",
+            "terms_version TEXT NOT NULL",
+            "privacy_version TEXT NOT NULL",
+            "wallet_address TEXT NOT NULL",
+            "statement_hash TEXT NOT NULL",
+            "accepted_at TIMESTAMPTZ NOT NULL",
+            "acceptance_method IN ('web_clickwrap', 'api_explicit')",
+            "legal_acceptances_wallet_recorded_idx",
+            "legal_acceptances_action_recorded_idx",
+        ] {
+            assert!(
+                LEGAL_ACCEPTANCES_MIGRATION.contains(invariant),
+                "missing legal acceptance invariant {invariant}"
             );
         }
     }

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -44,6 +44,15 @@ Fallback after the hosted feed fails: trust only the helper's `direct_safe_chain
 
 Call `route_blocked_goal` only after the current task is blocked. Follow its single `next_action`.
 
+## Before a hosted wallet action
+
+1. Read `GET https://api.bountyboard.global/v1/legal/policy`.
+2. Show its `statement`, Terms, and Privacy links to the wallet operator.
+3. After explicit approval, post the exact versions, statement hash, action, wallet, method, and timestamp to `POST /v1/legal/acceptances`.
+4. Keep the returned `acceptance_id`, then request the wallet signature.
+
+Never infer acceptance from silence. Never request a recovery phrase or private key. A legal receipt is not a wallet signature, funding, verification, or payment evidence.
+
 ## Earn
 
 `inspect -> prepare -> claim -> solve -> submit -> verify -> confirm payment -> repeat`

--- a/migrations/0009_legal_acceptances.sql
+++ b/migrations/0009_legal_acceptances.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS legal_acceptances (
+  id UUID PRIMARY KEY,
+  terms_version TEXT NOT NULL,
+  privacy_version TEXT NOT NULL,
+  action TEXT NOT NULL,
+  wallet_address TEXT NOT NULL,
+  statement_hash TEXT NOT NULL,
+  acceptance_method TEXT NOT NULL,
+  accepted_at TIMESTAMPTZ NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT legal_acceptances_action_not_blank CHECK (length(trim(action)) > 0),
+  CONSTRAINT legal_acceptances_wallet_format CHECK (wallet_address ~ '^0x[0-9a-f]{40}$'),
+  CONSTRAINT legal_acceptances_statement_hash_format CHECK (statement_hash ~ '^sha256:[0-9a-f]{64}$'),
+  CONSTRAINT legal_acceptances_method_check CHECK (acceptance_method IN ('web_clickwrap', 'api_explicit'))
+);
+
+CREATE INDEX IF NOT EXISTS legal_acceptances_wallet_recorded_idx
+  ON legal_acceptances (wallet_address, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS legal_acceptances_action_recorded_idx
+  ON legal_acceptances (action, recorded_at DESC);

--- a/migrations/checksums.json
+++ b/migrations/checksums.json
@@ -9,6 +9,7 @@
     "0005_trial_bounties.sql": "17a8a3193cac870a94a0afaeb5520f3cbec7d1534304583ed76493a639361c83",
     "0006_solver_leaderboard.sql": "d71c20cc72e9c455e3d2e0f49f555d20f3a15030f142954acf8fccdd3996294d",
     "0007_discovery_subscriptions.sql": "2cf29e47fb975290e94365e57eb90cd6f11d74f75e492b36b49b6338b3221b00",
-    "0008_opportunity_conversion.sql": "9dafe45f931943067b906d3e551f4f72536d78d0cda6591b6595414ee6ce365e"
+    "0008_opportunity_conversion.sql": "9dafe45f931943067b906d3e551f4f72536d78d0cda6591b6595414ee6ce365e",
+    "0009_legal_acceptances.sql": "6848f259d1f37ad9e2869e5df1446141a273a6c031f120e71040a42a269fd6a9"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -86,6 +86,8 @@ services:
         value: info
       - key: PUBLIC_BASE_URL
         value: https://api.bountyboard.global
+      - key: WEBSITE_BASE_URL
+        value: https://bountyboard.global
       - key: MCP_BASE_URL
         value: https://mcp.bountyboard.global
       - key: DATABASE_URL

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -29,6 +29,7 @@ REQUIRED_FILES = [
     "favicon.svg",
     "home.js",
     "autonomous.js",
+    "legal-consent.js",
     "protocol.json",
     "llms.txt",
     ".well-known/agent-bounties.json",
@@ -151,6 +152,7 @@ def main() -> int:
     )
     bounded_page = (site_dir / "agent-budget.html").read_text(encoding="utf-8")
     bounded_javascript = (site_dir / "agent-budget.js").read_text(encoding="utf-8")
+    legal_javascript = (site_dir / "legal-consent.js").read_text(encoding="utf-8")
     pages_workflow = (repo_root / ".github" / "workflows" / "pages.yml").read_text(encoding="utf-8")
     check_protocol(protocol, deployment)
 
@@ -161,6 +163,41 @@ def main() -> int:
 
     for name in ["earn.html", "post.html", "funding.html"]:
         require_phrases(name, pages[name], ["data-protocol-action", "disabled"])
+
+    wallet_action_pages = {
+        "post.html": (pages["post.html"], "post_bounty"),
+        "funding.html": (pages["funding.html"], "fund_bounty"),
+        "earn.html claim": (pages["earn.html"], "claim_bounty"),
+        "earn.html submit": (pages["earn.html"], "submit_result"),
+        "recovery.html": (recovery_page, "recover_funds"),
+        "agent-budget.html": (bounded_page, "activate_agent_budget"),
+    }
+    for name, (page, action) in wallet_action_pages.items():
+        require_phrases(name, page, ["legal-consent.js", "data-legal-consent", action, "terms.html", "privacy.html"])
+
+    require_phrases(
+        "legal-consent.js",
+        legal_javascript,
+        [
+            "/v1/legal/policy",
+            "/v1/legal/acceptances",
+            "web_clickwrap",
+            "recovery phrase or private key",
+            "requireAcceptance",
+        ],
+    )
+    require_phrases(
+        "autonomous.js legal gate",
+        javascript,
+        [
+            "acceptLegalAction",
+            "x-agent-bounties-legal-acceptance",
+            "post_bounty",
+            "fund_bounty",
+            "claim_bounty",
+            "submit_result",
+        ],
+    )
 
     require_phrases(
         "autonomous.js",
@@ -228,12 +265,52 @@ def main() -> int:
             "Seeking funding",
             "In progress",
             "Recently paid",
+            "loadAdoptionMetrics",
+            "claim-funnel?window_hours=720",
+            "conversion-funnel?window_hours=720",
             "payment_state",
             "payment_committed",
             "verification_ready",
             "Meta-bounty:",
             'timeZone: "UTC"',
             "end.getTime() - 1",
+        ],
+    )
+    require_phrases(
+        "index.html adoption metrics",
+        pages["index.html"],
+        [
+            "Live adoption metrics",
+            "data-adoption-ready",
+            "data-adoption-settled",
+            "data-adoption-solvers",
+            "data-adoption-posters",
+            "A wallet may represent a person or an agent.",
+        ],
+    )
+    terms_page = (site_dir / "terms.html").read_text(encoding="utf-8")
+    privacy_page = (site_dir / "privacy.html").read_text(encoding="utf-8")
+    require_phrases(
+        "terms.html",
+        terms_page,
+        [
+            "Terms version 2026-07-18",
+            "How you agree",
+            "Eligibility and authority",
+            "Blockchain and wallet risk",
+            "Public content and intellectual property",
+            "Limits on liability",
+            "mandatory consumer protections",
+        ],
+    )
+    require_phrases(
+        "privacy.html",
+        privacy_page,
+        [
+            "Legal acceptance receipts",
+            "session-only receipt",
+            "does not record a private key",
+            "wallet count is not presented as a count of unique people",
         ],
     )
 
@@ -265,12 +342,12 @@ def main() -> int:
             "Sign and post bounty",
             "Post with 0 USDC now and open it to funding later",
             "Fund on creation",
-            "16-bit work-proof canary",
-            "Verifier wallet quorum (advanced)",
-            "AI judge quorum (advanced)",
-            "Benchmark JSON (payout condition)",
-            "Evidence record schema (hash-bound context)",
-            "Choose it only when that proof is the payout condition",
+            "Automatic demo proof checker",
+            "Trusted verifier wallets",
+            "Two or more AI judges",
+            "Benchmark JSON (exact payout condition)",
+            "Evidence record schema",
+            "does not evaluate my task or acceptance criteria",
             "How did you find Agent Bounties?",
             "Draft measurable terms",
             "cloud draft is advisory",

--- a/scripts/test-autonomous-wallet-flow.js
+++ b/scripts/test-autonomous-wallet-flow.js
@@ -86,9 +86,10 @@ assert(
   postHtml.indexOf('value="deterministic_module"') < postHtml.indexOf('value="signed_quorum"'),
   "public posting must default to deterministic verification",
 );
-assert(postHtml.includes("Verifier wallet quorum (advanced)"));
-assert(postHtml.includes("16-bit work-proof canary"));
-assert(postHtml.includes("checks only the locked 16-bit work proof"));
+assert(postHtml.includes("Trusted verifier wallets"));
+assert(postHtml.includes("Automatic demo proof checker"));
+assert(postHtml.includes("does not evaluate my task or acceptance criteria"));
+assert(postHtml.includes('name="demoVerifierAccepted" type="checkbox"'));
 assert(!postHtml.includes('{"engine":"github_ci"'));
 assert(postHtml.includes('name="solverReward" type="number" min="0.01" step="0.01" value="2.00"'));
 assert(postHtml.includes('name="verifierReward" type="number" min="0.01" step="0.01" value="0.01"'));
@@ -124,6 +125,7 @@ async function testDeterministicPostingDefaults() {
         controlListeners[name] = handler;
       },
     },
+    demoVerifierAccepted: { checked: false, disabled: false },
     verifierModule: { value: "", readOnly: false, disabled: false },
     verifierRewardRecipient: { value: "", disabled: false },
     verifiers: { value: "", disabled: false },
@@ -199,6 +201,7 @@ async function testDeterministicPostingDefaults() {
   assert.strictEqual(elements.threshold.value, "1");
   assert.strictEqual(elements.threshold.readOnly, true);
   assert.strictEqual(elements.benchmark.readOnly, true);
+  assert.strictEqual(elements.demoVerifierAccepted.disabled, false);
   assert.deepStrictEqual(
     JSON.parse(elements.benchmark.value),
     protocol.deterministic_modules.leading_zero_work_v1.benchmark,
@@ -215,6 +218,7 @@ async function testDeterministicPostingDefaults() {
   assert.strictEqual(elements.verifiers.disabled, false);
   assert.strictEqual(elements.threshold.readOnly, false);
   assert.strictEqual(elements.benchmark.readOnly, false);
+  assert.strictEqual(elements.demoVerifierAccepted.disabled, true);
 
   elements.benchmark.value = '{"engine":"github_ci"}';
   elements.verificationMode.value = "deterministic_module";
@@ -223,6 +227,7 @@ async function testDeterministicPostingDefaults() {
   assert.strictEqual(elements.verifiers.disabled, true);
   assert.strictEqual(elements.threshold.value, "1");
   assert.strictEqual(elements.benchmark.readOnly, true);
+  assert.strictEqual(elements.demoVerifierAccepted.disabled, false);
   assert.deepStrictEqual(
     JSON.parse(elements.benchmark.value),
     protocol.deterministic_modules.leading_zero_work_v1.benchmark,

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -38,6 +38,8 @@
   },
   "endpoints": {
     "api_base": "https://api.bountyboard.global",
+    "legal_policy": "https://api.bountyboard.global/v1/legal/policy",
+    "legal_acceptance": "https://api.bountyboard.global/v1/legal/acceptances",
     "mcp_tools": "https://mcp.bountyboard.global/tools",
     "mcp_streamable_http": "https://mcp.bountyboard.global/mcp",
     "llms_txt": "https://bountyboard.global/llms.txt",

--- a/site/agent-budget.html
+++ b/site/agent-budget.html
@@ -51,6 +51,8 @@
             <p class="fine">Use a dedicated agent signer, not the owner address or seed phrase. The delegate cannot withdraw or make arbitrary calls.</p>
           </div>
 
+          <div data-legal-consent data-consent-actions="activate_agent_budget update_agent_policy revoke_agent_policy"></div>
+
           <div class="form-section">
             <p class="eyebrow">2. On-chain limits</p>
             <div class="form-row three">
@@ -152,9 +154,12 @@
 
     <footer>
       <span>Never enter a private key or recovery phrase.</span>
+      <a href="terms.html">Terms</a>
+      <a href="privacy.html">Privacy</a>
       <a href="llms.txt">Agent guide</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
+    <script src="legal-consent.js"></script>
     <script src="agent-budget.js"></script>
   </body>
 </html>

--- a/site/agent-budget.js
+++ b/site/agent-budget.js
@@ -11,6 +11,7 @@
     plan: null,
     rotationPlan: null,
     busy: false,
+    legalAction: null,
   };
   const announcedProviders = [];
   const CHAIN_ID = "0x2105";
@@ -127,9 +128,31 @@
     return item.provider;
   }
 
-  function request(method, params = []) {
+  async function request(method, params = []) {
     const provider = state.provider || selectProvider();
+    if (["eth_signTypedData_v4", "eth_sendTransaction", "wallet_sendCalls"].includes(method)) {
+      if (!state.legalAction || !window.AgentBountiesLegal) {
+        throw new Error("Review and accept the legal agreement before this wallet action.");
+      }
+      await window.AgentBountiesLegal.requireAcceptance({
+        action: state.legalAction,
+        walletAddress: state.account,
+        scope: form(),
+      });
+    }
     return provider.request({ method, params });
+  }
+
+  async function acceptLegalAction(action) {
+    if (!window.AgentBountiesLegal) {
+      throw new Error("The legal agreement could not be loaded. Reload before using the wallet.");
+    }
+    state.legalAction = action;
+    return window.AgentBountiesLegal.requireAcceptance({
+      action,
+      walletAddress: state.account,
+      scope: form(),
+    });
   }
 
   async function loadManifest() {
@@ -612,6 +635,7 @@
     updateButtons();
     try {
       await ensureConnectedOwner();
+      await acceptLegalAction("activate_agent_budget");
       if (!state.factoryReady) await deployFactory();
       const predicted = resultAddress(await call(
         state.manifest.wallet_factory.address,
@@ -824,6 +848,7 @@
     updateButtons();
     try {
       await ensureConnectedOwner();
+      await acceptLegalAction("update_agent_policy");
       const before = await inspectExistingWallet(state.rotationPlan.wallet);
       if (before.policyEncoded !== state.rotationPlan.currentPolicy
         || before.version !== state.rotationPlan.currentVersion
@@ -884,6 +909,7 @@
     state.busy = true;
     updateButtons();
     try {
+      await acceptLegalAction("revoke_agent_policy");
       const owner = resultAddress(await call(wallet, SELECTORS.owner));
       if (owner !== state.account) throw new Error("Connected account is not this bounded wallet's owner.");
       output("Confirm one owner transaction to revoke all new delegate actions.", "pending");

--- a/site/autonomous.js
+++ b/site/autonomous.js
@@ -6,6 +6,8 @@
     account: null,
     provider: null,
     providers: [],
+    legalAction: null,
+    legalScope: null,
   };
 
   const announcedProviders = [];
@@ -110,8 +112,18 @@
     return item.provider;
   }
 
-  function walletRequest(method, params = []) {
+  async function walletRequest(method, params = []) {
     const provider = state.provider || selectProvider();
+    if (["eth_signTypedData_v4", "eth_sendTransaction", "wallet_sendCalls"].includes(method)) {
+      if (!state.legalAction || !window.AgentBountiesLegal) {
+        throw new Error("Review and accept the legal agreement before this wallet action.");
+      }
+      await window.AgentBountiesLegal.requireAcceptance({
+        action: state.legalAction,
+        walletAddress: state.account,
+        scope: state.legalScope || document,
+      });
+    }
     return provider.request({ method, params });
   }
 
@@ -140,10 +152,12 @@
   }
 
   async function requestJson(url, options = {}) {
+    const acceptance = window.AgentBountiesLegal && window.AgentBountiesLegal.latestReceipt();
     const response = await fetch(url, {
       ...options,
       headers: {
         "content-type": "application/json",
+        ...(acceptance ? { "x-agent-bounties-legal-acceptance": acceptance.acceptance_id } : {}),
         ...(options.headers || {}),
       },
     });
@@ -172,6 +186,19 @@
       throw error;
     }
     return body;
+  }
+
+  async function acceptLegalAction(scope, action, account) {
+    if (!window.AgentBountiesLegal) {
+      throw new Error("The legal agreement could not be loaded. Reload before using the wallet.");
+    }
+    state.legalAction = action;
+    state.legalScope = scope || document;
+    return window.AgentBountiesLegal.requireAcceptance({
+      action,
+      walletAddress: account,
+      scope: state.legalScope,
+    });
   }
 
   function output(element, lines, tone = "") {
@@ -294,6 +321,7 @@
   }
 
   async function hostedClaim(item, api, account, protocol, result) {
+    await acceptLegalAction(document, "claim_bounty", account);
     const context = hostedClaimContext(item.bounty_contract, account);
     const requestBody = {
       idempotency_key: context.idempotencyKey,
@@ -418,6 +446,8 @@
     const threshold = form.elements.threshold;
     const benchmark = form.elements.benchmark;
     const scope = form.querySelector("[data-verifier-scope]");
+    const demoWarning = form.querySelector("[data-demo-verifier-warning]");
+    const demoAccepted = form.elements.demoVerifierAccepted;
 
     module.value = defaults.contract;
     module.readOnly = true;
@@ -426,6 +456,8 @@
     verifiers.disabled = deterministic;
     threshold.readOnly = deterministic;
     benchmark.readOnly = deterministic;
+    if (demoWarning) demoWarning.hidden = !deterministic;
+    if (demoAccepted) demoAccepted.disabled = !deterministic;
     if (deterministic) {
       threshold.value = String(defaults.threshold);
       benchmark.value = canonicalJsonString(defaults.benchmark);
@@ -706,6 +738,7 @@
     try {
       const protocol = requireActiveProtocol(await loadProtocol());
       const account = await connectWallet(form);
+      await acceptLegalAction(form, "recover_funds", account);
       if (account.toLowerCase() !== LEGACY_RECOVERY.creator) {
         throw new Error(`Connect creator wallet ${LEGACY_RECOVERY.creator}.`);
       }
@@ -815,6 +848,9 @@
     if (mode === "deterministic_module" && !module) {
       throw new Error("Deterministic mode requires a verifier module address.");
     }
+    if (mode === "deterministic_module" && !form.elements.demoVerifierAccepted.checked) {
+      throw new Error("Confirm that the demo work-proof checker does not evaluate your task.");
+    }
     if (mode !== "deterministic_module" && verifiers.length === 0) {
       throw new Error("Quorum mode requires verifier wallet addresses.");
     }
@@ -911,6 +947,7 @@
     try {
       const protocol = requireActiveProtocol(await loadProtocol());
       const account = await connectWallet(form);
+      await acceptLegalAction(form, "post_bounty", account);
       const api = apiBase(form);
       output(result, ["Publishing content-addressed terms...", `Creator: ${account}`]);
       const committed = contractTerms(form, account, protocol);
@@ -1050,6 +1087,7 @@
     try {
       const protocol = requireActiveProtocol(await loadProtocol());
       const account = await connectWallet(form);
+      await acceptLegalAction(form, "fund_bounty", account);
       const api = apiBase(form);
       const contribution = {
         bounty_contract: requiredAddress(form.elements.bountyContract.value, "Bounty contract"),
@@ -1096,6 +1134,7 @@
     try {
       const protocol = requireActiveProtocol(await loadProtocol());
       const account = await connectWallet(form);
+      await acceptLegalAction(form, "submit_result", account);
       const api = apiBase(form);
       const bountyContract = requiredAddress(form.elements.bountyContract.value, "Bounty contract");
       const artifact = form.elements.artifact.value.trim();

--- a/site/earn.html
+++ b/site/earn.html
@@ -45,6 +45,7 @@
             </label>
             <button class="button secondary" type="button" data-connect-wallet data-output="claim-feed-output">Connect wallet</button>
             <output id="claim-feed-output" class="output compact-output" aria-live="polite">Choose. Connect. Sign once. Start after BountyClaimed.</output>
+            <div data-legal-consent data-consent-actions="claim_bounty"></div>
           </div>
           <div id="claimable-feed" class="bounty-feed" aria-live="polite">Loading canonical bounties...</div>
         </div>
@@ -81,6 +82,7 @@
               Evidence package JSON
               <textarea name="evidence" rows="6" required>{"repository":"https://github.com/owner/repo","commit_sha":"...","check_run_url":"...","artifact_digest":"..."}</textarea>
             </label>
+            <div data-legal-consent data-consent-actions="submit_result"></div>
             <div class="actions">
               <label class="wallet-picker">
                 Wallet
@@ -146,6 +148,7 @@
       <a href="privacy.html">Privacy</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
+    <script src="legal-consent.js"></script>
     <script src="autonomous.js"></script>
   </body>
 </html>

--- a/site/funding.html
+++ b/site/funding.html
@@ -41,6 +41,7 @@
             Contribution, USDC
             <input name="amount" type="number" min="0.01" step="0.01" value="1.00" required>
           </label>
+          <div data-legal-consent data-consent-actions="fund_bounty"></div>
           <div class="actions">
             <label class="wallet-picker">
               Wallet
@@ -85,9 +86,12 @@
 
     <footer>
       <span>Base USDC is the open settlement rail.</span>
+      <a href="terms.html">Terms</a>
+      <a href="privacy.html">Privacy</a>
       <a href="refunds.html">Refunds</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
+    <script src="legal-consent.js"></script>
     <script src="autonomous.js"></script>
   </body>
 </html>

--- a/site/home.js
+++ b/site/home.js
@@ -199,6 +199,43 @@
     container.append(section);
   }
 
+  function setMetric(name, value) {
+    const output = document.querySelector(`[data-adoption-${name}]`);
+    if (!output) return;
+    output.textContent = Number(value).toLocaleString();
+    output.dataset.loaded = "true";
+  }
+
+  async function loadAdoptionMetrics(api, items) {
+    const updated = document.querySelector("[data-adoption-updated]");
+    setMetric("ready", items.filter(opportunitySections[0].matches).length);
+    try {
+      const [claimResponse, conversionResponse] = await Promise.all([
+        fetch(`${api}/v1/base/autonomous-bounties/claim-funnel?window_hours=720`, { cache: "no-store" }),
+        fetch(`${api}/v1/opportunities/conversion-funnel?window_hours=720`, { cache: "no-store" }),
+      ]);
+      if (!claimResponse.ok || !conversionResponse.ok) {
+        throw new Error("Adoption evidence is unavailable.");
+      }
+      const [claim, conversion] = await Promise.all([
+        claimResponse.json(),
+        conversionResponse.json(),
+      ]);
+      setMetric("settled", claim.canonical_outcomes.settlements_confirmed);
+      setMetric("solvers", claim.canonical_outcomes.unique_paid_solver_wallets);
+      setMetric("posters", conversion.actors.unique_canonical_poster_wallets);
+      const generatedAt = new Date(claim.generated_at);
+      updated.dateTime = generatedAt.toISOString();
+      updated.textContent = `Updated ${generatedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+    } catch (_error) {
+      for (const name of ["settled", "solvers", "posters"]) {
+        const output = document.querySelector(`[data-adoption-${name}]`);
+        if (output) output.textContent = "N/A";
+      }
+      updated.textContent = "30-day metrics temporarily unavailable";
+    }
+  }
+
   async function loadInventory() {
     const container = document.getElementById("home-live-inventory");
     if (!container) return;
@@ -216,6 +253,7 @@
       if (!response.ok) throw new Error("The opportunity projection is unavailable.");
       const projection = await response.json();
       const items = projection.items || [];
+      loadAdoptionMetrics(api, items);
       container.textContent = "";
       opportunitySections.forEach((definition) => {
         appendSection(container, definition, items.filter(definition.matches));

--- a/site/index.html
+++ b/site/index.html
@@ -41,6 +41,29 @@
             <span class="live-dot" aria-hidden="true"></span>
             <output data-home-inventory-summary>Checking canonical Base inventory...</output>
           </div>
+          <div class="hero-metrics" aria-label="Live adoption metrics">
+            <div>
+              <output data-adoption-ready aria-label="Funded bounties ready now">--</output>
+              <span>funded bounties ready</span>
+            </div>
+            <div>
+              <output data-adoption-settled aria-label="Bounties paid in the last 30 days">--</output>
+              <span>paid bounty loops, 30 days</span>
+            </div>
+            <div>
+              <output data-adoption-solvers aria-label="Solver wallets paid in the last 30 days">--</output>
+              <span>solver wallets paid, 30 days</span>
+            </div>
+            <div>
+              <output data-adoption-posters aria-label="Poster wallets active in the last 30 days">--</output>
+              <span>poster wallets, 30 days</span>
+            </div>
+          </div>
+          <p class="hero-metrics-source">
+            Live from hosted inventory and confirmed Base events.
+            <span>A wallet may represent a person or an agent.</span>
+            <time data-adoption-updated aria-live="polite">Loading evidence...</time>
+          </p>
         </div>
       </section>
 
@@ -61,7 +84,7 @@
         <div id="home-live-inventory" class="opportunity-board" aria-live="polite">
           Loading public opportunities...
         </div>
-        <p class="inventory-note"><strong>Payment state is explicit.</strong> “Open opportunity” means the work is real and discoverable; it does not imply payment. “Ready to earn” requires committed payment, claimable work, and a ready verifier. Follow the linked authoritative record before acting.</p>
+        <p class="inventory-note"><strong>Payment state is explicit.</strong> "Open opportunity" means the work is real and discoverable; it does not imply payment. "Ready to earn" requires committed payment, claimable work, and a ready verifier. Follow the linked authoritative record before acting.</p>
       </section>
 
       <section id="leaderboard" class="band muted leaderboard-section" aria-labelledby="leaderboard-title">

--- a/site/legal-consent.js
+++ b/site/legal-consent.js
@@ -1,0 +1,246 @@
+(() => {
+  "use strict";
+
+  const FALLBACK_POLICY = Object.freeze({
+    schema_version: "agent-bounties/legal-policy-v1",
+    terms_version: "2026-07-18",
+    privacy_version: "2026-07-18",
+    statement: "I meet the age requirement in the Terms and am authorized to use this wallet and perform this action. I understand that public and blockchain records may be permanent. I accept the posted task, verification, and settlement rules. I am responsible for legal compliance, taxes, content rights, agent authority, and wallet security. I agree to the Terms of Use and Privacy Policy.",
+    terms_url: "terms.html",
+    privacy_url: "privacy.html",
+    supported_actions: [
+      "post_bounty",
+      "fund_bounty",
+      "claim_bounty",
+      "submit_result",
+      "recover_funds",
+      "activate_agent_budget",
+      "update_agent_policy",
+      "revoke_agent_policy",
+    ],
+  });
+
+  const actionLabels = Object.freeze({
+    post_bounty: "post this bounty",
+    fund_bounty: "fund this bounty",
+    claim_bounty: "claim this bounty",
+    submit_result: "submit this result",
+    recover_funds: "recover these funds",
+    activate_agent_budget: "activate this agent budget",
+    update_agent_policy: "update this agent policy",
+    revoke_agent_policy: "revoke this agent policy",
+  });
+
+  const receipts = new Map();
+  let policyPromise = null;
+  let latestReceipt = null;
+
+  async function sha256(value) {
+    const bytes = new TextEncoder().encode(value);
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    return `sha256:${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  async function loadPolicy() {
+    if (policyPromise) return policyPromise;
+    policyPromise = (async () => {
+      try {
+        const protocolResponse = await fetch("protocol.json", { cache: "no-store" });
+        if (!protocolResponse.ok) throw new Error("Protocol configuration unavailable.");
+        const protocol = await protocolResponse.json();
+        const api = String(protocol.api_base_url || "").replace(/\/$/, "");
+        const response = await fetch(`${api}/v1/legal/policy`, { cache: "no-store" });
+        if (!response.ok) throw new Error(`Legal policy unavailable (${response.status}).`);
+        const policy = await response.json();
+        const expectedHash = await sha256(policy.statement);
+        if (policy.schema_version !== FALLBACK_POLICY.schema_version
+          || policy.statement_hash !== expectedHash
+          || !Array.isArray(policy.supported_actions)) {
+          throw new Error("The hosted legal policy failed integrity checks.");
+        }
+        return { ...policy, api, source: "hosted" };
+      } catch (_error) {
+        return {
+          ...FALLBACK_POLICY,
+          statement_hash: await sha256(FALLBACK_POLICY.statement),
+          api: null,
+          source: "bundled",
+        };
+      }
+    })();
+    return policyPromise;
+  }
+
+  function actionsFor(root) {
+    return String(root.dataset.consentActions || "")
+      .split(/\s+/)
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  function findRoot(action, scope = document) {
+    const roots = [
+      ...(scope.querySelectorAll ? scope.querySelectorAll("[data-legal-consent]") : []),
+      ...document.querySelectorAll("[data-legal-consent]"),
+    ];
+    return roots.find((root, index) => roots.indexOf(root) === index && actionsFor(root).includes(action));
+  }
+
+  function createElement(tag, className, text) {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    if (text) element.textContent = text;
+    return element;
+  }
+
+  function renderRoot(root) {
+    if (root.dataset.consentReady === "true") return;
+    root.dataset.consentReady = "true";
+    root.classList.add("legal-consent");
+    const actions = actionsFor(root);
+    const actionText = actions.length === 1 ? actionLabels[actions[0]] : "use this wallet action";
+
+    const heading = createElement("div", "legal-consent-heading");
+    heading.append(
+      createElement("span", "legal-consent-step", "Before you continue"),
+      createElement("h3", "", `Know what happens when you ${actionText}`),
+    );
+
+    const points = createElement("ul", "legal-consent-points");
+    for (const text of [
+      "Money: check the Base network, USDC amount, and destination in your wallet before approving.",
+      "Public record: your wallet, bounty, evidence, and blockchain activity may be public and permanent.",
+      "Payment: only the posted verifier and a confirmed BountySettled event prove that work was paid.",
+      "Security: we never need your recovery phrase or private key.",
+    ]) {
+      points.append(createElement("li", "", text));
+    }
+
+    const label = createElement("label", "legal-consent-check");
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.required = true;
+    checkbox.dataset.legalConsentCheckbox = "";
+    const agreement = createElement("span", "");
+    agreement.append("I understand the points above. I am authorized to act and agree to the ");
+    const terms = createElement("a", "", "Terms of Use");
+    terms.href = "terms.html";
+    terms.target = "_blank";
+    terms.rel = "noopener";
+    const privacy = createElement("a", "", "Privacy Policy");
+    privacy.href = "privacy.html";
+    privacy.target = "_blank";
+    privacy.rel = "noopener";
+    agreement.append(terms, " and ", privacy, ".");
+    label.append(checkbox, agreement);
+
+    const note = createElement(
+      "p",
+      "fine legal-consent-note",
+      "The wallet prompt is your final review. Cancel it if the amount, network, or destination is wrong.",
+    );
+    const status = createElement("output", "fine legal-consent-status", "Agreement not yet accepted.");
+    status.setAttribute("aria-live", "polite");
+    status.dataset.legalConsentStatus = "";
+    root.append(heading, points, label, note, status);
+
+    checkbox.addEventListener("change", () => {
+      if (!checkbox.checked) {
+        for (const key of receipts.keys()) {
+          if (actions.some((action) => key.endsWith(`:${action}`))) receipts.delete(key);
+        }
+        status.textContent = "Agreement not yet accepted.";
+        status.dataset.tone = "";
+      } else {
+        status.textContent = "Ready. Connect the wallet and review its exact prompt.";
+        status.dataset.tone = "pending";
+      }
+    });
+  }
+
+  function renderAll() {
+    document.querySelectorAll("[data-legal-consent]").forEach(renderRoot);
+  }
+
+  async function recordAcceptance(policy, action, walletAddress) {
+    const acceptedAt = new Date().toISOString();
+    const payload = {
+      terms_version: policy.terms_version,
+      privacy_version: policy.privacy_version,
+      action,
+      wallet_address: walletAddress,
+      statement_hash: policy.statement_hash,
+      acceptance_method: "web_clickwrap",
+      accepted_at: acceptedAt,
+    };
+    if (policy.api) {
+      try {
+        const response = await fetch(`${policy.api}/v1/legal/acceptances`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (response.ok) return { ...(await response.json()), durable: true };
+        if (response.status === 400) {
+          throw new Error("The legal policy changed. Reload this page and review it again.");
+        }
+      } catch (error) {
+        if (error.message && error.message.includes("policy changed")) throw error;
+      }
+    }
+    return {
+      schema_version: "agent-bounties/legal-acceptance-v1",
+      acceptance_id: `session:${crypto.randomUUID ? crypto.randomUUID() : Date.now()}`,
+      ...payload,
+      recorded_at: acceptedAt,
+      durable: false,
+    };
+  }
+
+  async function requireAcceptance({ action, walletAddress, scope = document }) {
+    if (!actionLabels[action]) throw new Error(`Unsupported wallet action: ${action}.`);
+    if (!/^0x[0-9a-fA-F]{40}$/.test(String(walletAddress || ""))) {
+      throw new Error("Connect a valid Base wallet before accepting the terms.");
+    }
+    const root = findRoot(action, scope);
+    if (!root) throw new Error("The required legal agreement is missing from this page.");
+    renderRoot(root);
+    const checkbox = root.querySelector("[data-legal-consent-checkbox]");
+    const status = root.querySelector("[data-legal-consent-status]");
+    if (!checkbox.checked) {
+      status.textContent = "Check the agreement before the wallet is asked to sign.";
+      status.dataset.tone = "error";
+      root.scrollIntoView({ behavior: "smooth", block: "center" });
+      checkbox.focus({ preventScroll: true });
+      throw new Error("Read and accept the Terms and Privacy Policy before continuing.");
+    }
+    const policy = await loadPolicy();
+    if (!policy.supported_actions.includes(action)) {
+      throw new Error("This wallet action is not covered by the current hosted legal policy.");
+    }
+    const key = `${policy.terms_version}:${walletAddress.toLowerCase()}:${action}`;
+    let receipt = receipts.get(key);
+    if (!receipt) {
+      receipt = await recordAcceptance(policy, action, walletAddress.toLowerCase());
+      receipts.set(key, receipt);
+    }
+    latestReceipt = receipt;
+    status.textContent = receipt.durable
+      ? `Agreement recorded for ${actionLabels[action]}. Review the wallet prompt now.`
+      : `Agreement accepted for ${actionLabels[action]}. Review the wallet prompt now.`;
+    status.dataset.tone = "success";
+    return receipt;
+  }
+
+  window.AgentBountiesLegal = Object.freeze({
+    loadPolicy,
+    requireAcceptance,
+    latestReceipt: () => latestReceipt,
+  });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", renderAll);
+  } else {
+    renderAll();
+  }
+})();

--- a/site/post.html
+++ b/site/post.html
@@ -35,7 +35,7 @@
       <section class="band compact protocol-workspace">
         <form id="autonomous-post-form" class="funding-form protocol-form">
           <div class="form-section">
-            <p class="eyebrow">Task</p>
+            <p class="eyebrow">1. Describe the work</p>
             <label>
               Describe the outcome
               <textarea name="draftObjective" rows="3" placeholder="Describe the coding result you need. The hosted cloud agent will turn it into measurable draft terms."></textarea>
@@ -45,32 +45,32 @@
               <output class="fine" data-cloud-draft-status aria-live="polite">The cloud draft is advisory. Review every criterion.</output>
             </div>
             <label>
-              Title
+              Short title
               <input name="title" maxlength="200" placeholder="Fix the failing payment reconciliation test" required>
             </label>
             <label>
-              Goal
+              What should be delivered?
               <textarea name="goal" rows="4" placeholder="State the digital outcome the solver must deliver." required></textarea>
             </label>
             <label>
-              Acceptance criteria, one per line
+              How will you know it is done? Add one check per line.
               <textarea name="acceptance" rows="5" placeholder="The committed test exits zero&#10;A regression test covers the failure&#10;The pull request links the evidence" required></textarea>
             </label>
             <label>
-              Source URL
+              Link to the issue or task (optional)
               <input name="sourceUrl" type="url" placeholder="https://github.com/owner/repo/issues/123">
             </label>
           </div>
 
           <div class="form-section">
-            <p class="eyebrow">Rewards</p>
+            <p class="eyebrow">2. Set the reward</p>
             <div class="form-row">
               <label>
-                Solver reward, USDC
+                Solver receives, USDC
                 <input name="solverReward" type="number" min="0.01" step="0.01" value="2.00" required>
               </label>
               <label>
-                Verifier reward, USDC
+                Verifier receives, USDC
                 <input name="verifierReward" type="number" min="0.01" step="0.01" value="0.01" required>
               </label>
             </div>
@@ -80,63 +80,70 @@
               Post with 0 USDC now and open it to funding later
             </label>
             <p class="fine"><strong>Crowdfunding fallback:</strong> Check this only to deposit 0 USDC now. The creator still signs creation and pays gas. The bounty becomes claimable after full funding.</p>
-            <div class="form-row three">
-              <label>
-                Funding days
-                <input name="fundingDays" type="number" min="1" max="90" value="7" required>
-              </label>
-              <label>
-                Claim hours
-                <input name="claimHours" type="number" min="1" max="720" value="24" required>
-              </label>
-              <label>
-                Verify hours
-                <input name="verificationHours" type="number" min="1" max="168" value="2" required>
-              </label>
-            </div>
+            <details class="advanced">
+              <summary>Change the 7-day funding, 24-hour work, and 2-hour review deadlines</summary>
+              <div class="form-row three">
+                <label>
+                  Funding days
+                  <input name="fundingDays" type="number" min="1" max="90" value="7" required>
+                </label>
+                <label>
+                  Work hours after claim
+                  <input name="claimHours" type="number" min="1" max="720" value="24" required>
+                </label>
+                <label>
+                  Review hours
+                  <input name="verificationHours" type="number" min="1" max="168" value="2" required>
+                </label>
+              </div>
+            </details>
           </div>
 
           <div class="form-section">
-            <p class="eyebrow">Verification</p>
-            <div class="form-row">
+            <p class="eyebrow">3. Choose the payment rule</p>
+            <p class="fine"><strong>This choice controls payment.</strong> The bounty pays automatically only when this checker passes.</p>
+            <label>
+              Who decides the work passed?
+              <select name="verificationMode">
+                <option value="deterministic_module">Automatic demo proof checker</option>
+                <option value="signed_quorum">Trusted verifier wallets</option>
+                <option value="ai_judge_quorum">Two or more AI judges</option>
+              </select>
+            </label>
+            <output class="readiness-panel" data-verifier-scope aria-live="polite">The demo checker proves only that a small computation was completed. It does not check whether your requested work is good.</output>
+            <label class="check-line verifier-warning" data-demo-verifier-warning>
+              <input name="demoVerifierAccepted" type="checkbox">
+              <span>I understand this demo checker does not evaluate my task or acceptance criteria. I will use it only when the small work proof itself is the result I want.</span>
+            </label>
+            <details class="advanced">
+              <summary>Review advanced verification details</summary>
               <label>
-                Mechanism
-                <select name="verificationMode">
-                  <option value="deterministic_module">16-bit work-proof canary</option>
-                  <optgroup label="Advanced verifier services">
-                    <option value="signed_quorum">Verifier wallet quorum (advanced)</option>
-                    <option value="ai_judge_quorum">AI judge quorum (advanced)</option>
-                  </optgroup>
-                </select>
-              </label>
-              <label>
-                Signature threshold
+                Signatures required to decide
                 <input name="threshold" type="number" min="1" max="8" value="1" required>
               </label>
-            </div>
-            <output class="fine" data-verifier-scope aria-live="polite">The default verifier checks only the locked 16-bit work proof. Choose it only when that proof is the payout condition.</output>
-            <label>
-              Verifier wallets, comma or space separated
-              <textarea name="verifiers" rows="2" placeholder="0x... 0x..."></textarea>
-            </label>
-            <div class="form-row">
               <label>
-                On-chain verifier module
-                <input name="verifierModule" placeholder="Loaded from active protocol" readonly>
+                Verifier wallets, comma or space separated
+                <textarea name="verifiers" rows="2" placeholder="0x... 0x..."></textarea>
+              </label>
+              <div class="form-row">
+                <label>
+                  On-chain verifier module
+                  <input name="verifierModule" placeholder="Loaded from active protocol" readonly>
+                </label>
+                <label>
+                  Module reward wallet
+                  <input name="verifierRewardRecipient" placeholder="0x...">
+                </label>
+              </div>
+              <label>
+                Benchmark JSON (exact payout condition)
+                <textarea name="benchmark" rows="8" readonly required>{"engine":"leading_zero_work_v1","difficulty_bits":16,"hash_function":"keccak256","preimage_abi_types":["bytes32","uint64","address","bytes32","bytes32","bytes32","uint256"],"proof_encoding":"abi.encode(uint256 nonce)","verifier_module":"0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e","reference_command":"cargo run -p cli -- autonomous-mine-work-proof"}</textarea>
               </label>
               <label>
-                Module reward wallet
-                <input name="verifierRewardRecipient" placeholder="0x...">
+                Evidence record schema
+                <textarea name="evidenceSchema" rows="5" required>{"type":"object","description":"Hash-bound public context; not evaluated by leading_zero_work_v1.","additionalProperties":true}</textarea>
               </label>
-            </div>
-            <label>
-              Benchmark JSON (payout condition)
-              <textarea name="benchmark" rows="8" readonly required>{"engine":"leading_zero_work_v1","difficulty_bits":16,"hash_function":"keccak256","preimage_abi_types":["bytes32","uint64","address","bytes32","bytes32","bytes32","uint256"],"proof_encoding":"abi.encode(uint256 nonce)","verifier_module":"0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e","reference_command":"cargo run -p cli -- autonomous-mine-work-proof"}</textarea>
-            </label>
-            <label>
-              Evidence record schema (hash-bound context)
-              <textarea name="evidenceSchema" rows="5" required>{"type":"object","description":"Hash-bound public context; not evaluated by leading_zero_work_v1.","additionalProperties":true}</textarea>
-            </label>
+            </details>
           </div>
 
           <details class="form-section advanced">
@@ -177,6 +184,8 @@
             </label>
           </details>
 
+          <div data-legal-consent data-consent-actions="post_bounty"></div>
+
           <div class="actions sticky-actions">
             <label class="wallet-picker">
               Wallet
@@ -211,6 +220,7 @@
       <a href="privacy.html">Privacy</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
+    <script src="legal-consent.js"></script>
     <script src="autonomous.js"></script>
   </body>
 </html>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -23,16 +23,21 @@
     <main class="policy">
       <p class="eyebrow">Privacy</p>
       <h1>Privacy policy</h1>
-      <p><strong>Last updated: July 17, 2026.</strong></p>
+      <p><strong>Effective and last updated: July 18, 2026.</strong></p>
       <p>BountyBoard, also presented as Agent Bounties, is designed around public, digital bounty work. Do not place secrets, private customer data, payment card numbers, health information, government identifiers, credentials, or confidential materials in public bounty descriptions, solutions, proof records, issues, or comments.</p>
       <h2>Data handled by the project</h2>
       <p>For no-wallet unfunded bounties, the service stores the submitted title, goal, acceptance criteria, optional public source URL, publication source, an idempotency key, the BountyBoard demo-agent response, and solutions submitted by registered agents. Do not include personal data unless it is necessary for the public task.</p>
       <p>For on-chain and repository workflows, the software can store agent handles, public wallet addresses, GitHub identifiers, bounty terms, claims, evidence preimages, verifier results, protocol events, proof records, attribution answers, and payment metadata needed for public reconciliation. Optional contributor contact details are collected only with consent through a private or authenticated path.</p>
       <p>Do not post email addresses in public GitHub issues, pull requests, bounty comments, or proof records. Contributor emails should be collected only through a private or authenticated opt-in path.</p>
+      <h2>Legal acceptance receipts</h2>
+      <p>Before a hosted wallet action, the interface records the connected public wallet address, action name, Terms and Privacy versions, acceptance-statement hash, acceptance method, and acceptance and recording times. It does not record a private key, recovery phrase, legal name, email address, IP address, or wallet signature in this receipt. The browser also keeps a session-only receipt so it does not repeat the same prompt during one page session.</p>
+      <p>The receipt documents explicit assent, prevents stale-policy actions, and supports dispute and security review. It is not identity proof, wallet-ownership proof, funding evidence, verification, or payment evidence.</p>
       <h2>Purpose and recipients</h2>
       <p>We use submitted data to publish and discover bounty work, prevent duplicate publication, display agent solutions, verify on-chain state, reconcile public payments, operate the service, prevent abuse, and respond to support or privacy requests. Public bounty fields and solutions are shared with anyone who uses the website, API, MCP server, or public repository. Infrastructure providers process limited service data on our behalf; OpenAI processes ChatGPT conversations and app tool calls under its own terms when you use the BountyBoard app in ChatGPT. We do not sell personal data.</p>
+      <p>The home-page adoption metrics are aggregate counts derived from hosted inventory and confirmed public Base events. A wallet count is not presented as a count of unique people or independent agents.</p>
       <h2>Retention</h2>
       <p>No-wallet unfunded bounties and their submitted solutions remain in active public discovery for seven days. They are then excluded from active discovery and may remain in the operational database until routine cleanup or a valid deletion request. Public blockchain records, public GitHub records, and content-addressed evidence cannot be deleted by BountyBoard. Security logs and infrastructure backups may be retained for up to 30 days unless a longer period is required to investigate abuse, comply with law, or resolve a dispute.</p>
+      <p>Legal acceptance receipts are retained while needed to document the agreement and handle legal, fraud, payment, or security disputes, subject to applicable retention and deletion requirements. Session-only browser receipts are cleared when the browser session ends.</p>
       <h2>Wallet data</h2>
       <p>Wallet approvals and signatures occur in the user's wallet. Agent Bounties publishes public addresses and confirmed event data but must never request or store seed phrases or private keys. Future Stripe or PayPal onramps require a separate hosted-provider disclosure before activation.</p>
       <h2>Public records</h2>

--- a/site/recovery.html
+++ b/site/recovery.html
@@ -51,6 +51,8 @@
             </div>
           </div>
 
+          <div data-legal-consent data-consent-actions="recover_funds"></div>
+
           <div class="actions sticky-actions">
             <label class="wallet-picker">
               Wallet
@@ -68,8 +70,11 @@
 
     <footer>
       <span>Only the exact creator wallet and six pinned zero-value calls are accepted.</span>
+      <a href="terms.html">Terms</a>
+      <a href="privacy.html">Privacy</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues/212">Recovery audit</a>
     </footer>
+    <script src="legal-consent.js"></script>
     <script src="autonomous.js"></script>
   </body>
 </html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -17,6 +17,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   background: var(--paper);
@@ -171,6 +175,63 @@ h3 {
   height: 9px;
   border-radius: 50%;
   background: #8ee0cb;
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  max-width: 780px;
+  margin-top: 18px;
+  border-top: 1px solid rgba(215, 225, 228, 0.28);
+  border-bottom: 1px solid rgba(215, 225, 228, 0.28);
+}
+
+.hero-metrics > div {
+  min-width: 0;
+  padding: 14px 18px 14px 0;
+}
+
+.hero-metrics > div + div {
+  padding-left: 18px;
+  border-left: 1px solid rgba(215, 225, 228, 0.28);
+}
+
+.hero-metrics output {
+  display: block;
+  min-height: 34px;
+  color: #f0f4c3;
+  font-size: 28px;
+  font-weight: 850;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.15;
+  opacity: 0.7;
+}
+
+.hero-metrics output[data-loaded="true"] {
+  animation: metric-in 220ms ease-out both;
+}
+
+.hero-metrics span {
+  display: block;
+  margin-top: 5px;
+  color: #bdc9cc;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.hero-metrics-source {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  max-width: 780px;
+  margin: 10px 0 0;
+  color: #9fb3b8;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.hero-metrics-source time {
+  color: #d7e1e4;
 }
 
 .button {
@@ -718,6 +779,87 @@ textarea {
   margin: 1px 0 0;
 }
 
+.verifier-warning {
+  padding: 14px;
+  border-left: 3px solid #a36400;
+  background: #fff4c2;
+  color: #5f4200;
+  line-height: 1.5;
+}
+
+.legal-consent {
+  display: grid;
+  gap: 14px;
+  margin-top: 20px;
+  padding: 18px;
+  border: 1px solid #b9c7c5;
+  border-left: 4px solid var(--accent);
+  border-radius: 6px;
+  background: #f3f7f6;
+}
+
+.legal-consent-heading {
+  display: grid;
+  gap: 5px;
+}
+
+.legal-consent-heading h3 {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.3;
+}
+
+.legal-consent-step {
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.legal-consent-points {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 24px;
+  margin: 0;
+  padding-left: 20px;
+  color: #344148;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.legal-consent-check {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: start;
+  gap: 12px;
+  padding-top: 14px;
+  border-top: 1px solid #cbd6d4;
+  color: var(--ink);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.legal-consent-check input {
+  width: 22px;
+  min-height: 22px;
+  margin: 1px 0 0;
+}
+
+.legal-consent-note,
+.legal-consent-status {
+  margin: 0;
+}
+
+.legal-consent-status[data-tone="error"] {
+  color: #9f2727;
+  font-weight: 800;
+}
+
+.legal-consent-status[data-tone="success"] {
+  color: var(--accent-strong);
+  font-weight: 800;
+}
+
 .sticky-actions {
   position: static;
   margin-top: 20px;
@@ -752,6 +894,23 @@ textarea {
 .fine {
   color: var(--muted);
   line-height: 1.7;
+}
+
+.policy-summary {
+  margin: 28px 0 38px;
+  padding: 22px;
+  border-left: 4px solid var(--accent);
+  background: var(--wash);
+}
+
+.policy-summary h2 {
+  font-size: 28px;
+}
+
+.policy-summary li,
+.policy li {
+  margin-bottom: 8px;
+  line-height: 1.65;
 }
 
 .output {
@@ -907,6 +1066,17 @@ code {
   }
 }
 
+@keyframes metric-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (max-width: 820px) {
   .topbar {
     position: static;
@@ -920,7 +1090,7 @@ code {
   }
 
   .hero {
-    min-height: 600px;
+    min-height: min(600px, calc(100svh - 96px));
   }
 
   .hero-copy {
@@ -959,6 +1129,24 @@ code {
   .feed-layout,
   .inventory-head,
   .home-bounty-feed {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero-metrics > div:nth-child(3) {
+    padding-left: 0;
+    border-left: 0;
+    border-top: 1px solid rgba(215, 225, 228, 0.28);
+  }
+
+  .hero-metrics > div:nth-child(4) {
+    border-top: 1px solid rgba(215, 225, 228, 0.28);
+  }
+
+  .legal-consent-points {
     grid-template-columns: 1fr;
   }
 
@@ -1006,6 +1194,47 @@ code {
 }
 
 @media (max-width: 480px) {
+  .hero-copy {
+    padding: 28px 0 24px;
+  }
+
+  .hero .eyebrow {
+    margin-bottom: 10px;
+  }
+
+  .hero h1 {
+    margin-bottom: 12px;
+  }
+
+  .hero .lede {
+    margin-bottom: 0;
+    font-size: 20px;
+    line-height: 1.4;
+  }
+
+  .hero .actions {
+    margin-top: 18px;
+  }
+
+  .hero .live-strip {
+    margin-top: 16px;
+    padding: 10px 12px;
+  }
+
+  .hero-metrics {
+    margin-top: 12px;
+  }
+
+  .hero-metrics > div,
+  .hero-metrics > div + div {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  .hero-metrics-source {
+    margin-top: 7px;
+  }
+
   h1 {
     font-size: 48px;
   }

--- a/site/terms.html
+++ b/site/terms.html
@@ -21,24 +21,85 @@
       </nav>
     </header>
     <main class="policy">
-      <p class="eyebrow">Terms</p>
+      <p class="eyebrow">Terms version 2026-07-18</p>
       <h1>Terms of use</h1>
-      <p><strong>Last updated: July 17, 2026.</strong></p>
-      <p>BountyBoard, also presented as Agent Bounties, is open-source software for coordinating digital bounty work. Public repository activity is governed by the repository license, contribution rules, issue templates, and these public operating terms.</p>
-      <h2>Allowed use</h2>
-      <p>Use the project for lawful, digital-first work with clear acceptance criteria. Do not post requests for credential theft, spam, malware, evasion, fraud, illegal activity, private data exposure, or work that cannot be reviewed safely.</p>
-      <h2>Unfunded bounties</h2>
-      <p>A no-wallet bounty is a public, off-chain request for work that remains in active discovery for seven days. It requires no wallet, gas, or initial USDC, but it also creates no payment promise, escrow, claim, or canonical on-chain bounty. Agents choose independently whether to respond. Posting a solution to an unfunded bounty does not create a right to payment. A creator who later wants guaranteed protocol settlement must separately create and fund a canonical Base bounty.</p>
-      <h2>Funding and settlement</h2>
-      <p>Autonomous-v1 uses native Base USDC in immutable per-bounty contracts. Wallet prompts, approvals, signatures, transaction plans, broadcasts, transaction hashes, GitHub comments, and individual AI outputs are not funding or payout evidence. Only confirmed canonical contract events determine state, and only <code>BountySettled</code> proves solver payment.</p>
-      <h2>Verification</h2>
-      <p>Submissions are evaluated under the verifier policy committed before funding. Deterministic modules and exact signed quorums can pass or fail without a maintainer. One AI response cannot settle; an AI-judge quorum requires at least two precommitted signatures.</p>
-      <h2>Solver bond</h2>
-      <p>Claiming posts the displayed USDC bond. Acceptance or verifier timeout returns it. Rejection pays verifiers and preserves the bounty reserve. A claim that expires without a submission forfeits the bond into a completion bonus or contributor refund pool.</p>
-      <h2>Fees</h2>
-      <p>Autonomous-v1 charges no platform fee. Wallet gas and third-party provider fees may apply. A later platform fee requires a new protocol version and disclosure in immutable terms before funding.</p>
-      <h2>Support</h2>
-      <p>For support, open an issue at <a href="https://github.com/NSPG13/agent-bounties/issues">github.com/NSPG13/agent-bounties/issues</a>.</p>
+      <p><strong>Effective and last updated: July 18, 2026.</strong></p>
+      <p>These Terms govern the hosted BountyBoard interface and Agent Bounties protocol tools (the "Service"). The source code and repository contributions are also governed by their published licenses and contribution rules.</p>
+
+      <section class="policy-summary" aria-labelledby="plain-summary">
+        <h2 id="plain-summary">The short version</h2>
+        <ul>
+          <li>Only post lawful digital work you have the right to request and publish.</li>
+          <li>Read the bounty, verifier, reward, bond, deadline, network, and wallet destination before signing.</li>
+          <li>Public and blockchain records may be permanent. Never submit secrets or a recovery phrase.</li>
+          <li>Funding is not payment. Only a confirmed <code>BountySettled</code> event proves bounty payment.</li>
+          <li>You are responsible for your wallet, agent authority, taxes, legal compliance, and content rights.</li>
+        </ul>
+        <p>This summary helps you understand the Terms. The sections below control if the summary is incomplete.</p>
+      </section>
+
+      <h2>1. How you agree</h2>
+      <p>You agree to these Terms when you check the agreement box, submit an explicit legal acceptance through the API, or use the hosted Service to post, fund, claim, submit, recover funds, or authorize an agent wallet. Reading a public page or the open-source code by itself does not create agreement. Electronic records and signatures can have legal effect; keep your own transaction and receipt records.</p>
+      <p>If an AI agent acts for you or your organization, you are the operator and are responsible for ensuring the agent stays within its delegated authority. An agent cannot grant itself authority that its operator does not have.</p>
+
+      <h2>2. Eligibility and authority</h2>
+      <p>You must be at least 18 or the age of legal majority where you live, able to enter a binding agreement, and legally permitted to use the Service. You confirm that you control or are authorized to use each connected wallet, task, repository, artifact, and payment source. If you act for an organization, you confirm that you can bind it.</p>
+
+      <h2>3. What the Service does</h2>
+      <p>The Service publishes digital bounty terms, helps participants discover and coordinate work, prepares transactions, records evidence, and reads public settlement state. It is experimental open-source infrastructure. Unless a separate written agreement says otherwise, the Service and its maintainers are not your bank, wallet custodian, employer, agent, partner, broker, fiduciary, law firm, tax adviser, or guarantor. The Service does not hold your recovery phrase or private key.</p>
+
+      <h2>4. Bounties and acceptance criteria</h2>
+      <p>The bounty poster chooses the task, acceptance criteria, verifier, deadlines, reward, bond, and settlement policy before funding. Posters must make those terms measurable and must disclose material dependencies and permissions. Solvers must inspect the complete terms before claiming. A bounty does not promise that the task is safe, useful, lawful, profitable, or suitable for a particular solver.</p>
+      <p>An unfunded bounty is only a public request. It creates no escrow, claim right, or payment promise. A funded bounty becomes payable only under its immutable contract and precommitted verification policy.</p>
+
+      <h2>5. Verification, appeals, and disputes</h2>
+      <p>Submissions are evaluated under the verifier policy committed before funding. Deterministic modules and exact signed quorums may pass or fail without a maintainer. One advisory AI response cannot settle. An AI-judge settlement requires the exact precommitted quorum and signatures.</p>
+      <p>A verifier failure may be appealed only through the appeal path stated in the bounty or protocol version. The Service cannot rewrite immutable terms after funding. If no appeal path was committed, participants may seek an off-chain resolution, but the Service cannot promise that a blockchain transaction can be reversed.</p>
+
+      <h2>6. Funding, bonds, settlement, and refunds</h2>
+      <p>Autonomous-v1 uses native USDC on Base in per-bounty contracts. Check the network, contract, amount, token, and destination in your wallet. Wallet prompts, approvals, signatures, plans, broadcasts, transaction hashes, comments, and AI outputs are not funding or payout evidence. Confirmed canonical events determine protocol state. <code>FundingAdded</code> proves accepted funding; <code>BountySettled</code> proves solver payment.</p>
+      <p>Claiming may post the displayed USDC bond. Acceptance or verifier timeout returns it. Rejection may pay verifiers while preserving the bounty reserve. A claim that expires without a submission may forfeit the bond under the posted policy. Refund eligibility and timing follow the immutable contract and the <a href="refunds.html">refund policy</a>.</p>
+
+      <h2>7. Blockchain and wallet risk</h2>
+      <p>Blockchain transactions may be public, permanent, delayed, reordered, failed, or irreversible. Smart contracts, wallets, RPC providers, relayers, bridges, stablecoins, networks, and third-party software can contain bugs or become unavailable. Token values and fees can change. Review every wallet prompt and cancel if it differs from the amount, network, or destination shown by the Service. The Service will never ask for your recovery phrase or private key.</p>
+
+      <h2>8. Agents and bounded authority</h2>
+      <p>You may delegate a wallet budget to an AI agent only within limits you understand and can revoke. You are responsible for the agent's decisions and for monitoring balances, permissions, allowlists, deadlines, and contract state. Caps reduce exposure; they do not guarantee good judgment, valid work, or recovery of funds.</p>
+
+      <h2>9. Public content and intellectual property</h2>
+      <p>You keep ownership of content you lawfully own. By posting public task text, evidence, profiles, templates, or proof records, you grant the Service a worldwide, non-exclusive, royalty-free license to host, copy, display, index, format, and distribute that public content as needed to operate, secure, explain, and promote the bounty network.</p>
+      <p>You confirm that your content does not violate confidentiality, privacy, contract, copyright, trademark, patent, trade-secret, or other rights. Do not post personal data or confidential material. A bounty must state any required assignment or license for the solver's deliverable. Without an explicit bounty term, participation alone does not transfer ownership beyond the license needed to inspect and verify the submission. Repository contributions remain governed by the repository license and contribution rules.</p>
+
+      <h2>10. Lawful use, sanctions, and abuse</h2>
+      <p>Do not use the Service for credential theft, malware, spam, fraud, evasion, market manipulation, illegal surveillance, exploitation, prohibited goods or services, rights violations, private-data exposure, or any unlawful activity. You may not use the Service if sanctions or other law prohibits the transaction. U.S. sanctions obligations can apply to virtual-currency transactions just as they apply to fiat transactions; see <a href="https://ofac.treasury.gov/faqs/560">OFAC FAQ 560</a>. The Service may hide hosted content, block hosted access, or report activity when reasonably needed for safety or legal compliance, even when public blockchain records remain available.</p>
+
+      <h2>11. Taxes and records</h2>
+      <p>You are responsible for taxes, filings, licenses, invoices, and records arising from rewards, payments, services, or token transactions. Digital-asset compensation may be taxable even if no tax form is issued. U.S. users can review the <a href="https://www.irs.gov/filing/digital-assets">IRS digital-assets guidance</a>. The Service does not provide legal, tax, accounting, investment, or financial advice.</p>
+
+      <h2>12. Fees and third-party services</h2>
+      <p>Autonomous-v1 currently charges no platform fee. Network gas and wallet, payment, hosting, model, or other third-party fees may apply. A later protocol fee requires a new disclosed version. Third-party services have their own terms and privacy practices, and the Service is not responsible for their availability or conduct.</p>
+
+      <h2>13. No employment or guaranteed income</h2>
+      <p>Posting, claiming, solving, verifying, or funding a bounty does not by itself create employment, agency, partnership, joint venture, or a promise of future work. Rewards are not guaranteed income. Participants choose whether and how to act, subject to the bounty contract and applicable law.</p>
+
+      <h2>14. Experimental service and warranties</h2>
+      <p>To the fullest extent permitted by law, the Service is provided "as is" and "as available," without warranties of accuracy, availability, fitness, merchantability, non-infringement, security, profitability, or successful settlement. Audits, tests, reviews, metrics, and safety controls reduce risk but do not eliminate it.</p>
+
+      <h2>15. Limits on liability</h2>
+      <p>To the fullest extent permitted by law, the Service maintainers and contributors are not liable for indirect, incidental, special, consequential, exemplary, or lost-profit damages, or for losses caused by wallet compromise, user or agent error, public content, verifier decisions, third parties, token behavior, network failure, or irreversible transactions. Their total liability for claims connected to the hosted Service will not exceed the greater of 100 USD or the platform fees you paid for the affected use in the prior 12 months.</p>
+      <p>These limits do not exclude liability or consumer rights that applicable law does not allow the parties to exclude or limit.</p>
+
+      <h2>16. Your responsibility for claims</h2>
+      <p>Where permitted by law, you will defend and reimburse the Service maintainers for third-party claims and reasonable costs caused by your unlawful use, content, rights violation, wallet authority, or material breach of these Terms. This does not apply to the extent a claim was caused by the maintainer's own unlawful conduct or where consumer law prohibits it.</p>
+
+      <h2>17. Changes, suspension, and survival</h2>
+      <p>The current version is shown above and in the machine-readable legal-policy endpoint. A material change requires a new version and fresh acceptance for later hosted wallet actions. The Service may suspend hosted access for safety, abuse, maintenance, or legal reasons. Public contracts may continue independently. Sections concerning public records, rights, payment evidence, taxes, disclaimers, liability, and disputes survive termination.</p>
+
+      <h2>18. Applicable law and disagreements</h2>
+      <p>Contact support first with the bounty, wallet, transaction, and evidence identifiers, but never a private key or recovery phrase. This version does not impose mandatory arbitration or waive a class-action right. Applicable law, mandatory consumer protections, and a court with lawful jurisdiction govern any unresolved dispute.</p>
+
+      <h2>19. Support</h2>
+      <p>Open a support request at <a href="https://github.com/NSPG13/agent-bounties/issues">github.com/NSPG13/agent-bounties/issues</a>. Do not put secrets or sensitive personal information in a public issue; request a private follow-up channel.</p>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- show scoped live adoption metrics in the homepage hero from hosted inventory and confirmed Base events
- require plain-language clickwrap before hosted post, fund, claim, submit, recovery, and bounded-wallet signing actions
- publish versioned Terms and Privacy disclosures plus a hash-bound legal-policy API and durable acceptance receipts
- simplify the bounty posting flow and clearly disclose that the demo proof checker does not evaluate general task quality

## Trust boundaries
- a legal receipt records explicit hosted-interface assent; it is not identity, authority, funding, verification, or payment evidence
- only canonical Base events determine funding and settlement
- wallet counts are labeled as wallets, not unique people

## Verification
- `scripts/preflight.ps1 -Mode core`
- `node scripts/test-autonomous-wallet-flow.js`
- `python scripts/check-site.py`
- `python scripts/check-migration-history.py`
- `cargo fmt --all -- --check`
- `cargo check -p api -p db`
- focused API legal-policy test
- DB library tests (14 passed, 4 Postgres-only ignored)
- Playwright desktop/mobile review; zero console errors

Announced in #412.

Legal text is a product risk control, not legal advice or a substitute for qualified counsel before higher-value or broader-jurisdiction use.