### PR TITLE
fix: serve canonical website URLs in legal policy

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -80,6 +80,7 @@ jobs:
       RUNTIME_REVISION: ${{ inputs.runtime_revision }}
       PRODUCTION_API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://api.bountyboard.global' }}
       PRODUCTION_MCP_BASE_URL: ${{ vars.PRODUCTION_MCP_BASE_URL || 'https://mcp.bountyboard.global' }}
+      PRODUCTION_WEBSITE_BASE_URL: ${{ vars.PRODUCTION_WEBSITE_BASE_URL || 'https://bountyboard.global' }}
       RENDER_DEPLOY_PAUSE_REASON: ${{ vars.RENDER_DEPLOY_PAUSE_REASON }}
     steps:
       - uses: actions/checkout@v4
@@ -182,6 +183,7 @@ jobs:
             --mcp-url "${PRODUCTION_MCP_BASE_URL%/}/health" \
             --public-base-url "${PRODUCTION_API_BASE_URL%/}" \
             --mcp-base-url "${PRODUCTION_MCP_BASE_URL%/}" \
+            --website-base-url "${PRODUCTION_WEBSITE_BASE_URL%/}" \
             --base-mainnet-leaderboard-reward-contract "$BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT" \
             --base-sepolia-leaderboard-reward-contract "$BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT" \
             --output target/operations/render-deploy.json

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1748,16 +1748,23 @@ fn build_legal_policy(public_base_url: &str) -> LegalPolicyResponse {
     }
 }
 
+fn legal_website_base_url(configured: Option<String>, public_base_url: &str) -> String {
+    configured.and_then(non_empty_secret).unwrap_or_else(|| {
+        match public_base_url.trim_end_matches('/') {
+            "https://api.bountyboard.global" => "https://bountyboard.global".to_string(),
+            value => value.to_string(),
+        }
+    })
+}
+
 #[utoipa::path(
     get,
     path = "/v1/legal/policy",
     responses((status = 200, body = LegalPolicyResponse))
 )]
 async fn legal_policy(State(state): State<SharedState>) -> Json<LegalPolicyResponse> {
-    let website_base_url = env::var("WEBSITE_BASE_URL")
-        .ok()
-        .and_then(non_empty_secret)
-        .unwrap_or_else(|| state.public_base_url.clone());
+    let website_base_url =
+        legal_website_base_url(env::var("WEBSITE_BASE_URL").ok(), &state.public_base_url);
     Json(build_legal_policy(&website_base_url))
 }
 
@@ -10600,6 +10607,17 @@ mod tests {
             .supported_actions
             .iter()
             .any(|action| action == "post_bounty"));
+        assert_eq!(
+            legal_website_base_url(None, "https://api.bountyboard.global/"),
+            "https://bountyboard.global"
+        );
+        assert_eq!(
+            legal_website_base_url(
+                Some(" https://preview.example ".to_string()),
+                "https://api.bountyboard.global"
+            ),
+            "https://preview.example"
+        );
 
         let now = Utc.with_ymd_and_hms(2026, 7, 18, 18, 0, 0).unwrap();
         let mut request = RecordLegalAcceptanceRequest {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,7 +54,8 @@ succeeds on a push to `main`, the workflow:
 3. resolves all three Render services by exact name and verifies repository,
    branch, and service type;
 4. disables any drifted native auto-deploy setting;
-5. reconciles `PUBLIC_BASE_URL` and `MCP_BASE_URL` on both public services;
+5. reconciles `PUBLIC_BASE_URL`, `MCP_BASE_URL`, and `WEBSITE_BASE_URL` on
+   both public services;
 6. reconciles all nonsecret cloud-agent settings on API and copies the optional
    GitHub-held model key without including its value in evidence;
 7. calls Render's deploy API with the exact commit for API, MCP, and worker;

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -285,6 +285,7 @@ def main() -> int:
         "scripts/render_deploy_recovery.py",
         '--public-base-url "${PRODUCTION_API_BASE_URL%/}"',
         '--mcp-base-url "${PRODUCTION_MCP_BASE_URL%/}"',
+        '--website-base-url "${PRODUCTION_WEBSITE_BASE_URL%/}"',
     ]
     for required in workflow_contract:
         if required not in deploy_workflow:

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -287,6 +287,22 @@ def normalize_public_base_url(name: str, value: str) -> str:
     return candidate
 
 
+def public_environment_values(
+    public_base_url: str,
+    mcp_base_url: str,
+    website_base_url: str,
+) -> dict[str, str]:
+    return {
+        "PUBLIC_BASE_URL": normalize_public_base_url(
+            "PUBLIC_BASE_URL", public_base_url
+        ),
+        "MCP_BASE_URL": normalize_public_base_url("MCP_BASE_URL", mcp_base_url),
+        "WEBSITE_BASE_URL": normalize_public_base_url(
+            "WEBSITE_BASE_URL", website_base_url
+        ),
+    }
+
+
 def normalize_evm_address(name: str, value: str) -> str:
     normalized = value.strip().lower()
     if not re.fullmatch(r"0x[0-9a-f]{40}", normalized):
@@ -950,6 +966,7 @@ def deploy(
     poll_seconds: float,
     public_base_url: str = "https://api.bountyboard.global",
     mcp_base_url: str = "https://mcp.bountyboard.global",
+    website_base_url: str = "https://bountyboard.global",
     cloud_agent_api_key: str | None = None,
     base_mainnet_leaderboard_reward_contract: str | None = None,
     base_sepolia_leaderboard_reward_contract: str | None = None,
@@ -980,26 +997,25 @@ def deploy(
     for spec, service in services:
         client.disable_native_auto_deploy(service)
 
-    public_environment_values = {
-        "PUBLIC_BASE_URL": normalize_public_base_url(
-            "PUBLIC_BASE_URL", public_base_url
-        ),
-        "MCP_BASE_URL": normalize_public_base_url("MCP_BASE_URL", mcp_base_url),
-    }
+    desired_public_environment = public_environment_values(
+        public_base_url,
+        mcp_base_url,
+        website_base_url,
+    )
     leaderboard_environment = leaderboard_environment_values(
         base_mainnet_leaderboard_reward_contract,
         base_sepolia_leaderboard_reward_contract,
     )
-    public_environment = []
+    reconciled_public_environment = []
     public_environment_changed: dict[str, bool] = {}
     for spec, service in services:
         if spec.name not in PUBLIC_ENV_SERVICE_NAMES:
             continue
         public_environment_changed[spec.name] = False
-        for key, value in public_environment_values.items():
+        for key, value in desired_public_environment.items():
             record = client.ensure_env_var(service, key, value)
             public_environment_changed[spec.name] |= record["changed"]
-            public_environment.append(
+            reconciled_public_environment.append(
                 {
                     "service": spec.name,
                     "key": key,
@@ -1011,7 +1027,7 @@ def deploy(
             for key, value in leaderboard_environment.items():
                 record = client.ensure_env_var(service, key, value)
                 public_environment_changed[spec.name] |= record["changed"]
-                public_environment.append(
+                reconciled_public_environment.append(
                     {
                         "service": spec.name,
                         "key": key,
@@ -1162,7 +1178,7 @@ def deploy(
         "services": service_evidence,
         "health": health,
         "custom_domains": custom_domains,
-        "public_environment": public_environment,
+        "public_environment": reconciled_public_environment,
         "cloud_environment": cloud_environment,
         "secret_environment": secret_environment,
         "cloud_readiness": cloud_readiness,
@@ -1195,6 +1211,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--mcp-base-url",
         default="https://mcp.bountyboard.global",
+    )
+    parser.add_argument(
+        "--website-base-url",
+        default="https://bountyboard.global",
     )
     parser.add_argument("--base-mainnet-leaderboard-reward-contract")
     parser.add_argument("--base-sepolia-leaderboard-reward-contract")
@@ -1245,6 +1265,7 @@ def main() -> int:
             poll_seconds=args.poll_seconds,
             public_base_url=args.public_base_url,
             mcp_base_url=args.mcp_base_url,
+            website_base_url=args.website_base_url,
             cloud_agent_api_key=os.environ.get("CLOUD_AGENT_API_KEY"),
             base_mainnet_leaderboard_reward_contract=(
                 args.base_mainnet_leaderboard_reward_contract

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -346,6 +346,20 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             with self.subTest(value=value), self.assertRaises(recovery.RecoveryError):
                 recovery.normalize_public_base_url("PUBLIC_BASE_URL", value)
 
+    def test_public_environment_includes_website_origin(self) -> None:
+        self.assertEqual(
+            recovery.public_environment_values(
+                "https://api.bountyboard.global/",
+                "https://mcp.bountyboard.global/",
+                "https://bountyboard.global/",
+            ),
+            {
+                "PUBLIC_BASE_URL": "https://api.bountyboard.global",
+                "MCP_BASE_URL": "https://mcp.bountyboard.global",
+                "WEBSITE_BASE_URL": "https://bountyboard.global",
+            },
+        )
+
     def test_leaderboard_environment_requires_exact_addresses(self) -> None:
         values = recovery.leaderboard_environment_values(
             "0x" + "AA" * 20,


### PR DESCRIPTION
## Problem
Production verification after #413 found that `/v1/legal/policy` returned Terms and Privacy URLs on `api.bountyboard.global`. Browser-relative links worked, but machine clients received the wrong public origin.

## Fix
- reconcile `WEBSITE_BASE_URL` through the exact-revision Render controller
- add a production-safe API fallback from the canonical API origin to `https://bountyboard.global`
- add controller and API tests, deployment docs, and Blueprint drift enforcement

## Verification
- 45 Render controller tests pass
- Render Blueprint contract passes
- focused API legal-policy test passes
- site check and core preflight pass
- `cargo fmt --all -- --check`

Follow-up to #412 and #413.