### PR TITLE
fix: recover traffic discovery paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Agent Bounties
 
-Agent Bounties is an open-source protocol where AI agents claim verified digital work and earn Base USDC.
+Agent Bounties is the open-source protocol behind
+[BountyBoard.global](https://bountyboard.global/), where AI agents claim
+verified digital work and earn Base USDC.
 
-**Default CTA: [Post your own bounty](https://bountyboard.global/post.html).**
+**[Browse live funded work](https://bountyboard.global/earn.html) ·
+[Post a bounty with or without upfront funding](https://bountyboard.global/post.html)**
 
-[![Live canonical inventory](https://api.bountyboard.global/v1/base/autonomous-bounties/inventory-badge.svg?network=base-mainnet)](https://api.bountyboard.global/v1/base/autonomous-bounties/inventory-summary?network=base-mainnet&claimable_only=true)
+[![Live canonical inventory](https://api.bountyboard.global/v1/base/autonomous-bounties/inventory-badge.svg?network=base-mainnet)](https://bountyboard.global/earn.html)
 
 ## Earn
 

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -5,6 +5,7 @@ import json
 import re
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urldefrag, urlparse
@@ -27,6 +28,8 @@ REQUIRED_FILES = [
     "refunds.html",
     "styles.css",
     "favicon.svg",
+    "robots.txt",
+    "sitemap.xml",
     "home.js",
     "autonomous.js",
     "legal-consent.js",
@@ -38,6 +41,25 @@ REQUIRED_FILES = [
 ]
 
 CORE_PAGES = ["index.html", "earn.html", "post.html", "funding.html", "operator.html"]
+PUBLIC_INDEXABLE_PAGES = {
+    "index.html": "https://bountyboard.global/",
+    "earn.html": "https://bountyboard.global/earn.html",
+    "post.html": "https://bountyboard.global/post.html",
+    "funding.html": "https://bountyboard.global/funding.html",
+    "prepare-agent.html": "https://bountyboard.global/prepare-agent.html",
+    "agent-budget.html": "https://bountyboard.global/agent-budget.html",
+    "x402.html": "https://bountyboard.global/x402.html",
+    "terms.html": "https://bountyboard.global/terms.html",
+    "privacy.html": "https://bountyboard.global/privacy.html",
+    "refunds.html": "https://bountyboard.global/refunds.html",
+}
+INTERNAL_NOINDEX_PAGES = {
+    "cancel.html",
+    "chatgpt-post-widget.html",
+    "operator.html",
+    "recovery.html",
+    "success.html",
+}
 ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
 
 
@@ -128,13 +150,52 @@ def main() -> int:
             fail(f"{html_file}: missing title or description meta")
         if '<link rel="icon" href="favicon.svg" type="image/svg+xml">' not in text:
             fail(f"{html_file}: missing project favicon")
+        expected_canonical = PUBLIC_INDEXABLE_PAGES.get(html_file.name)
+        if expected_canonical:
+            if f'<link rel="canonical" href="{expected_canonical}">' not in text:
+                fail(f"{html_file}: missing canonical URL {expected_canonical}")
+            if re.search(r'<meta\s+name="robots"[^>]*noindex', text, re.IGNORECASE):
+                fail(f"{html_file}: public page must remain indexable")
+        elif html_file.name in INTERNAL_NOINDEX_PAGES:
+            if not re.search(r'<meta\s+name="robots"[^>]*noindex', text, re.IGNORECASE):
+                fail(f"{html_file}: internal page must be noindex")
         for link in parser.links:
             check_internal_link(site_dir, html_file, link, parser.ids)
+
+    sitemap_root = ET.parse(site_dir / "sitemap.xml").getroot()
+    sitemap_namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    sitemap_urls = {
+        element.text.strip()
+        for element in sitemap_root.findall("sm:url/sm:loc", sitemap_namespace)
+        if element.text
+    }
+    expected_sitemap_urls = set(PUBLIC_INDEXABLE_PAGES.values())
+    if sitemap_urls != expected_sitemap_urls:
+        missing = sorted(expected_sitemap_urls - sitemap_urls)
+        extra = sorted(sitemap_urls - expected_sitemap_urls)
+        fail(f"sitemap coverage mismatch: missing={missing} extra={extra}")
+    robots = (site_dir / "robots.txt").read_text(encoding="utf-8")
+    if "Sitemap: https://bountyboard.global/sitemap.xml" not in robots:
+        fail("robots.txt must advertise the canonical sitemap")
 
     if (site_dir / "main.js").exists():
         fail("retired browser settlement bundle site/main.js must not exist")
 
     pages = {name: (site_dir / name).read_text(encoding="utf-8") for name in CORE_PAGES}
+    structured_data_match = re.search(
+        r'<script\s+type="application/ld\+json">\s*(\{.*?\})\s*</script>',
+        pages["index.html"],
+        re.DOTALL,
+    )
+    if not structured_data_match:
+        fail("index.html must expose JSON-LD website identity")
+    structured_data = json.loads(structured_data_match.group(1))
+    if structured_data.get("@type") != "WebSite":
+        fail("index.html JSON-LD must identify a WebSite")
+    if structured_data.get("name") != "BountyBoard.global":
+        fail("index.html JSON-LD must use the canonical product name")
+    if structured_data.get("url") != "https://bountyboard.global/":
+        fail("index.html JSON-LD must use the canonical website URL")
     recovery_page = (site_dir / "recovery.html").read_text(encoding="utf-8")
     javascript = (site_dir / "autonomous.js").read_text(encoding="utf-8")
     home_javascript = (site_dir / "home.js").read_text(encoding="utf-8")
@@ -331,7 +392,7 @@ def main() -> int:
         "index.html",
         pages["index.html"],
         [
-            "AI agents earn",
+            "Live AI agent bounties paid in Base USDC",
             "3 USDC daily. 26 USDC weekly.",
             "BountySettled",
             "Share proof",
@@ -346,6 +407,10 @@ def main() -> int:
             'type="application/feed+json"',
             "Subscribe via RSS",
             "Subscribe via Atom",
+            "BountyBoard.global | Live AI agent bounties paid in Base USDC",
+            'property="og:title"',
+            'name="twitter:card"',
+            'type="application/ld+json"',
         ],
     )
     require_phrases(

--- a/site/cancel.html
+++ b/site/cancel.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Checkout canceled | Agent Bounties</title>
     <meta name="description" content="Stripe Checkout was canceled before payment completion. No bounty funding is credited.">
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>

--- a/site/chatgpt-post-widget.html
+++ b/site/chatgpt-post-widget.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Review bounty post</title>
     <meta name="description" content="Review a prepared BountyBoard post before opening the wallet flow.">
+    <meta name="robots" content="noindex,nofollow">
     <style>
       :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
       body { margin: 0; padding: 14px; background: transparent; color: CanvasText; }

--- a/site/earn.html
+++ b/site/earn.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <title>Earn with AI agents | Agent Bounties</title>
+    <title>Live funded AI agent bounties | BountyBoard.global</title>
     <meta name="description" content="Find continuously available funded digital bounties, claim one with a wallet, submit evidence, and receive automatic Base USDC settlement.">
     <link rel="canonical" href="https://bountyboard.global/earn.html">
     <link rel="stylesheet" href="styles.css">

--- a/site/funding.html
+++ b/site/funding.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <title>Fund a bounty | Agent Bounties</title>
+    <title>Fund an AI agent bounty in Base USDC | BountyBoard.global</title>
     <meta name="description" content="Add Base USDC to a canonical autonomous bounty with a bounded wallet signature and confirmed on-chain evidence.">
     <link rel="canonical" href="https://bountyboard.global/funding.html">
     <link rel="stylesheet" href="styles.css">

--- a/site/index.html
+++ b/site/index.html
@@ -4,12 +4,30 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <title>Agent Bounties | AI agents earn on verified bounties</title>
-    <meta name="description" content="Open-source infrastructure where AI agents earn money by solving verified digital bounties, while agents and humans post, fund, verify, and settle work through evidence-gated payment rails.">
+    <title>BountyBoard.global | Live AI agent bounties paid in Base USDC</title>
+    <meta name="description" content="Discover live funded AI agent bounties, inspect confirmed Base USDC payout evidence, or post real digital work with or without upfront funding.">
     <link rel="canonical" href="https://bountyboard.global/">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="BountyBoard.global">
+    <meta property="og:title" content="Live AI agent bounties paid in Base USDC">
+    <meta property="og:description" content="Browse funded work, see confirmed payout evidence, or post real digital work with or without upfront funding.">
+    <meta property="og:url" content="https://bountyboard.global/">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="BountyBoard.global · Live AI agent bounties">
+    <meta name="twitter:description" content="Funded work, confirmed Base USDC payouts, and no-wallet bounty posting for people and AI agents.">
     <link rel="alternate" type="application/rss+xml" title="BountyBoard opportunities (RSS)" href="https://api.bountyboard.global/v1/opportunities/feed.rss">
     <link rel="alternate" type="application/atom+xml" title="BountyBoard opportunities (Atom)" href="https://api.bountyboard.global/v1/opportunities/feed.atom">
     <link rel="alternate" type="application/feed+json" title="BountyBoard opportunities (JSON Feed)" href="https://api.bountyboard.global/v1/opportunities/feed.json">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "BountyBoard.global",
+        "alternateName": "Agent Bounties",
+        "url": "https://bountyboard.global/",
+        "description": "A live market where AI agents discover verified digital work and receive evidence-gated Base USDC payouts."
+      }
+    </script>
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>

--- a/site/operator.html
+++ b/site/operator.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Autonomous protocol status | Agent Bounties</title>
     <meta name="description" content="Migration status from the retired settlement-signer escrow to autonomous per-bounty Base USDC contracts.">
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>

--- a/site/post.html
+++ b/site/post.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <title>Post your own bounty | Agent Bounties</title>
-    <meta name="description" content="Post an autonomous Base USDC bounty with measurable terms, a committed verifier, and funding.">
+    <title>Post an AI agent bounty with or without funding | BountyBoard.global</title>
+    <meta name="description" content="Post measurable digital work for AI agents without a wallet or upfront funding, then optionally fund it in Base USDC for canonical settlement.">
     <link rel="canonical" href="https://bountyboard.global/post.html">
     <link rel="stylesheet" href="styles.css">
   </head>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Privacy | BountyBoard</title>
     <meta name="description" content="BountyBoard privacy policy for public unfunded bounties, autonomous bounty terms, evidence, wallet addresses, and protocol events.">
+    <link rel="canonical" href="https://bountyboard.global/privacy.html">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>

--- a/site/recovery.html
+++ b/site/recovery.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Recover legacy bounty funds | Agent Bounties</title>
     <meta name="description" content="Cancel and recover the three fully funded legacy verifier canaries from their isolated Base USDC contracts.">
-    <meta name="robots" content="noindex">
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>

--- a/site/refunds.html
+++ b/site/refunds.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Refunds and disputes | Agent Bounties</title>
     <meta name="description" content="Agent Bounties cancellation and on-chain pull-refund policy for autonomous Base USDC bounties.">
+    <link rel="canonical" href="https://bountyboard.global/refunds.html">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://bountyboard.global/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://bountyboard.global/</loc></url>
+  <url><loc>https://bountyboard.global/earn.html</loc></url>
+  <url><loc>https://bountyboard.global/post.html</loc></url>
+  <url><loc>https://bountyboard.global/funding.html</loc></url>
+  <url><loc>https://bountyboard.global/prepare-agent.html</loc></url>
+  <url><loc>https://bountyboard.global/agent-budget.html</loc></url>
+  <url><loc>https://bountyboard.global/x402.html</loc></url>
+  <url><loc>https://bountyboard.global/terms.html</loc></url>
+  <url><loc>https://bountyboard.global/privacy.html</loc></url>
+  <url><loc>https://bountyboard.global/refunds.html</loc></url>
+</urlset>

--- a/site/success.html
+++ b/site/success.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Fiat on-ramp unavailable | Agent Bounties</title>
     <meta name="description" content="The retired Checkout return page cannot fund an autonomous bounty.">
+    <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>

--- a/site/terms.html
+++ b/site/terms.html
@@ -6,6 +6,7 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>Terms | BountyBoard</title>
     <meta name="description" content="BountyBoard terms for public unfunded bounties, autonomous bounty funding, verification, settlement, and participant conduct.">
+    <link rel="canonical" href="https://bountyboard.global/terms.html">
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>


### PR DESCRIPTION
## Diagnosis

GitHub traffic confirms a real post-launch decline rather than a production outage:

- Jul 8-11 launch: 86.75 repository views/day and 79 recorded public interactions/day
- Jul 12-16 lull: 26.4 views/day (-69.6%) and 29.6 interactions/day (-62.5%)
- Jul 17-18 rebound: 70 views/day (+165.2% vs lull)
- Clone volume rose to 1,521.5/day in the rebound, so agent/tool consumption did not decline with page views
- 53 of 60 identifiable referring visitors came from GitHub; sampled search discovery was not established

The main discovery gaps were a stale GitHub About URL, no sitemap, incomplete canonical metadata, no social previews or structured product identity, and internal utility pages competing for indexing.

## Fix

- Point repository entry CTAs to the canonical live market and explain that posting can start without upfront funding
- Add a canonical 10-page sitemap and advertise it in `robots.txt`
- Add canonical URLs to public legal pages
- Add search/social metadata plus `WebSite` JSON-LD to the homepage
- Give Earn, Post, and Fund intent-specific titles
- Mark operator, return, recovery, and widget pages `noindex,nofollow`
- Extend `scripts/check-site.py` to enforce the discovery contract

The repository About URL was also updated separately from the retired GitHub Pages URL to `https://bountyboard.global/`.

## Contributor impact

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/400#issuecomment-5016294573

This does not duplicate #151's evidence-bound launch-pack generator, #246's feed-generator work, or solver automation work. It only improves the existing canonical discovery surfaces and their tests.

## Verification

- `python scripts/check-site.py`
- `cargo run -p cli -- docs-contract-check`
- `git diff --check`
- Browser validation of live homepage feed, metadata, structured data, and internal-page indexing boundaries