### PR TITLE
Enable social mention drafts after canonical GitHub proof

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -89,7 +89,7 @@ use github_app::{
     GitHubClaimCommentPlan, GitHubCreateCommentInput, GitHubCreateCommentPlan,
     GitHubFundingCommentInput, GitHubFundingCommentPlan, GitHubIssueApiSyncInput,
     GitHubIssueApiSyncPlan, GitHubIssueFormBounty, GitHubProofComment, GitHubProofCommentPlan,
-    SocialMentionDraftInput, SocialMentionDraftPlan, GITHUB_CREATE_DISCOVERY_SOURCE,
+    SocialMentionDraftInput, SocialMentionDraftPlan,
 };
 use ledger::Ledger;
 use opportunities::{
@@ -10051,7 +10051,7 @@ async fn plan_social_mention_draft(
     let operator_enabled = env_flag("AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED");
     let github_conversion = if operator_enabled {
         match load_autonomous_bounty_feed(&state, "base-mainnet", false).await {
-            Ok(feed) => github_create_conversion_evidence(&feed),
+            Ok(feed) => github_issue_conversion_evidence(&feed),
             Err(_) => unavailable_github_conversion_evidence(),
         }
     } else {
@@ -10078,15 +10078,14 @@ fn unavailable_github_conversion_evidence() -> GitHubCanonicalConversionEvidence
     }
 }
 
-fn github_create_conversion_evidence(
+fn github_issue_conversion_evidence(
     feed: &[AutonomousBountyFeedItem],
 ) -> GitHubCanonicalConversionEvidence {
     let github_items = feed.iter().filter(|item| {
         item.terms.as_ref().is_some_and(|terms| {
-            terms.document.discovery_source.as_deref() == Some(GITHUB_CREATE_DISCOVERY_SOURCE)
-                && terms.document.source_url.as_deref().is_some_and(|url| {
-                    url.starts_with("https://github.com/") && url.contains("/issues/")
-                })
+            terms.document.source_url.as_deref().is_some_and(|url| {
+                url.starts_with("https://github.com/") && url.contains("/issues/")
+            })
         })
     });
     let mut funded = 0_u32;
@@ -12792,13 +12791,13 @@ mod tests {
     }
 
     #[test]
-    fn social_rollout_counts_only_canonical_events_with_exact_github_attribution() {
+    fn social_rollout_counts_canonical_events_with_github_issue_provenance() {
         let now = Utc::now();
         let mut document: AutonomousBountyTermsDocument =
             serde_json::from_str(include_str!("../../../bounties/autonomous-v1/244.json")).unwrap();
         document.source_url =
             Some("https://github.com/agent-bounties/agent-bounties/issues/501".to_string());
-        document.discovery_source = Some(GITHUB_CREATE_DISCOVERY_SOURCE.to_string());
+        document.discovery_source = Some("GitHub /agent-bounty create".to_string());
         let terms = AutonomousBountyTermsRecord {
             terms_hash: format!("0x{}", "44".repeat(32)),
             policy_hash: format!("0x{}", "45".repeat(32)),
@@ -12846,13 +12845,27 @@ mod tests {
             ],
         };
 
-        let mut ignored = item.clone();
-        ignored.terms.as_mut().unwrap().document.discovery_source =
-            Some("manual GitHub link".to_string());
-        let evidence = github_create_conversion_evidence(&[item, ignored]);
+        let mut legacy_github_item = item.clone();
+        legacy_github_item
+            .terms
+            .as_mut()
+            .unwrap()
+            .document
+            .discovery_source = Some("manual GitHub link".to_string());
+
+        let mut ignored_non_github_item = item.clone();
+        ignored_non_github_item
+            .terms
+            .as_mut()
+            .unwrap()
+            .document
+            .source_url = Some("https://example.com/tasks/501".to_string());
+
+        let evidence =
+            github_issue_conversion_evidence(&[item, legacy_github_item, ignored_non_github_item]);
         assert!(evidence.evidence_available);
-        assert_eq!(evidence.github_originated_canonical_funded, 1);
-        assert_eq!(evidence.github_originated_canonical_settled, 1);
+        assert_eq!(evidence.github_originated_canonical_funded, 2);
+        assert_eq!(evidence.github_originated_canonical_settled, 2);
     }
 
     #[tokio::test]

--- a/docs/github-issue-create-comments.md
+++ b/docs/github-issue-create-comments.md
@@ -49,14 +49,15 @@ Social drafting remains disabled unless both conditions hold:
 1. an operator explicitly sets
    `AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED=true`; and
 2. the hosted API's indexed Base feed contains at least three distinct
-   GitHub-command-attributed bounties with confirmed
+   GitHub-issue-attributed bounties with confirmed
    `BountyBecameClaimable` and at least two with confirmed `BountySettled`.
 
 Counts come from canonical events joined to public terms whose `source_url` is
-a GitHub issue and whose `discovery_source` is exactly
-`GitHub /agent-bounty create`. Caller-supplied counts, social replies, likes,
-AI classifications, wallet prompts, signatures, and transaction hashes cannot
-open the gate.
+a GitHub issue. This recognizes qualifying GitHub-originated bounty history
+that predates the create-comment command while preserving its original
+`discovery_source`. Caller-supplied counts, social replies, likes, AI
+classifications, wallet prompts, signatures, and transaction hashes cannot open
+the gate.
 
 After the gate passes, a social mention containing the same exact
 `/agent-bounty create <amount> USDC` command can produce only a reviewable

--- a/render.yaml
+++ b/render.yaml
@@ -90,6 +90,8 @@ services:
         value: https://bountyboard.global
       - key: MCP_BASE_URL
         value: https://mcp.bountyboard.global
+      - key: AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED
+        value: "true"
       - key: DATABASE_URL
         fromDatabase:
           name: agent-bounties-postgres

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -294,6 +294,7 @@ def main() -> int:
     controller_path = repo_root / "scripts" / "render_deploy_recovery.py"
     controller = controller_path.read_text(encoding="utf-8")
     for required in [
+        "API_RUNTIME_ENVIRONMENT",
         "CLOUD_AGENT_RUNTIME_ENVIRONMENT",
         "reconcile_cloud_agent_environment",
         "validate_cloud_agent_readiness",
@@ -308,6 +309,7 @@ def main() -> int:
         fail("API service must attach api.bountyboard.global")
     require_env_value(api, "APP_PACKAGE", "api")
     require_env_value(api, "APP_BINARY", "api")
+    require_env_value(api, "AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED", '"true"')
     require_env_value(api, "ENABLE_STRIPE_LIVE_EXECUTION", '"false"')
     require_env_value(api, "ENABLE_STRIPE_PUBLIC_CHECKOUT", '"false"')
     require_env_value(api, "ENABLE_BASE_TX_BROADCAST", '"false"')

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -45,6 +45,9 @@ PUBLIC_ENV_SERVICE_NAMES = {
     "agent-bounties-mcp",
 }
 CLOUD_AGENT_API_SERVICE_NAME = "agent-bounties-api"
+API_RUNTIME_ENVIRONMENT = {
+    "AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED": "true",
+}
 CLOUD_AGENT_RUNTIME_ENVIRONMENT = {
     "CLOUD_AGENT_ENABLED": "true",
     "CLOUD_AGENT_PUBLIC_DRAFTS": "true",
@@ -1024,6 +1027,17 @@ def deploy(
                 }
             )
         if spec.name == CLOUD_AGENT_API_SERVICE_NAME:
+            for key, value in API_RUNTIME_ENVIRONMENT.items():
+                record = client.ensure_env_var(service, key, value)
+                public_environment_changed[spec.name] |= record["changed"]
+                reconciled_public_environment.append(
+                    {
+                        "service": spec.name,
+                        "key": key,
+                        "value": value,
+                        "changed": record["changed"],
+                    }
+                )
             for key, value in leaderboard_environment.items():
                 record = client.ensure_env_var(service, key, value)
                 public_environment_changed[spec.name] |= record["changed"]

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -360,6 +360,12 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             },
         )
 
+    def test_api_runtime_environment_enables_social_mention_drafts(self) -> None:
+        self.assertEqual(
+            recovery.API_RUNTIME_ENVIRONMENT,
+            {"AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED": "true"},
+        )
+
     def test_leaderboard_environment_requires_exact_addresses(self) -> None:
         values = recovery.leaderboard_environment_values(
             "0x" + "AA" * 20,


### PR DESCRIPTION
## Summary
- count canonical GitHub issue provenance for the social rollout gate, including pre-command bounty history
- enable the review-only social mention planner on the API service
- reconcile the production flag through the exact-revision Render deployment controller

## Production evidence
- 21 GitHub-issue-attributed bounties have `BountyBecameClaimable`
- 10 have `BountySettled`
- rollout threshold is 3 funded / 2 settled

## Safety
- social input still creates only a reviewable draft
- no social webhook, automatic bounty creation, funding, verification, or settlement authority
- public maintainer notice: https://github.com/NSPG13/agent-bounties/issues/416#issuecomment-5017457738

## Checks
- `cargo test -p api` (98 passed, 3 database-only ignored)
- `python scripts/test_render_deploy_recovery.py -v` (46 passed)
- `python scripts/check-render-blueprint.py`
- `cargo fmt --all -- --check`
- `git diff --check`