### PR TITLE
fix: recover canonical domains within Render cap

### DIFF
--- a/docs/domain-portfolio.md
+++ b/docs/domain-portfolio.md
@@ -3,7 +3,9 @@
 `agentbounties.app` is the only canonical website. Official links, canonical
 tags, sitemaps, social profiles, and partner backlinks must use it. The API and
 MCP services remain at `api.agentbounties.app` and `mcp.agentbounties.app`.
-`status.agentbounties.app` redirects to the canonical API health endpoint.
+The public status link is `https://agentbounties.app/status/` and redirects to
+the canonical API health endpoint. A dedicated status subdomain is deferred
+until it can be hosted independently from the two production runtime domains.
 
 ## Routing contract
 
@@ -22,11 +24,9 @@ MCP services remain at `api.agentbounties.app` and `mcp.agentbounties.app`.
 | `agentbounties.xyz` | `/` | Defensive alias until Labs exists |
 | `bountyboard.global` | `/` | Legacy compatibility redirect |
 
-The API service owns the alternate hosts and returns `308 Permanent Redirect`.
-For `/`, it uses the role-specific destination above. For any deeper path, it
-preserves the path and query string exactly. `api.bountyboard.global` and
-`mcp.bountyboard.global` remain direct service aliases during migration so
-existing state-changing agent calls never depend on redirects.
+The registrar redirect edge owns alternate hosts and returns a permanent,
+unmasked redirect. Runtime traffic uses only the canonical API and MCP hosts;
+agents must not send state-changing requests through a vanity-domain redirect.
 
 ## DNS records
 
@@ -41,16 +41,11 @@ Create these records on `agentbounties.app`:
 | `CNAME` | `www` | `nspg13.github.io` |
 | `CNAME` | `api` | `agent-bounties-api.onrender.com` |
 | `CNAME` | `mcp` | `agent-bounties-mcp.onrender.com` |
-| `CNAME` | `status` | `agent-bounties-api.onrender.com` |
 
-For every alternate apex domain, point `@` to
-`agent-bounties-api.onrender.com` with the provider's `ALIAS`/flattened CNAME
-feature, and point `www` there with `CNAME`. Do not use masked forwarding.
-Render provisions TLS after each domain is attached and DNS resolves.
-
-Keep the old API and MCP DNS records on their current Render services. Move the
-legacy `bountyboard.global` website apex and `www` to the API service only after
-`agentbounties.app` serves the complete site over HTTPS.
+Configure each alternate apex and `www` host as a permanent, unmasked redirect
+to its routing-contract destination. Keep API and MCP clients on the canonical
+`.app` hosts. Render's two custom-domain slots are reserved for those runtime
+origins, and GitHub Pages owns the canonical website certificate.
 
 ## Migration order
 

--- a/render.yaml
+++ b/render.yaml
@@ -67,19 +67,6 @@ services:
     name: agent-bounties-api
     domains:
       - api.agentbounties.app
-      - status.agentbounties.app
-      - api.bountyboard.global
-      - bountyboard.global
-      - agentbounties.io
-      - agentbounties.dev
-      - agentbounties.work
-      - agentbounties.global
-      - agentbounties.network
-      - agentbounties.bid
-      - agentbounties.org
-      - agentbounties.co
-      - agentbounties.net
-      - agentbounties.xyz
     runtime: docker
     plan: starter
     region: oregon
@@ -198,7 +185,6 @@ services:
     name: agent-bounties-mcp
     domains:
       - mcp.agentbounties.app
-      - mcp.bountyboard.global
     runtime: docker
     plan: starter
     region: oregon

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -47,6 +47,13 @@ def named_block(text: str, name: str) -> str:
     fail(f"render.yaml missing service block for {name}")
 
 
+def domain_lines(block: str) -> list[str]:
+    match = re.search(r"(?ms)^    domains:\n(?P<body>.*?)(?=^    \S)", block)
+    if not match:
+        fail("Render web service missing domains block")
+    return [line.strip() for line in match.group("body").splitlines() if line.strip()]
+
+
 def env_entry(block: str, key: str) -> str:
     match = re.search(
         rf"(?ms)^      - key: {re.escape(key)}\n(?P<body>(?:        .+\n?)+)",
@@ -313,24 +320,10 @@ def main() -> int:
             fail(f"Render deployment controller missing cloud contract: {required}")
 
     api = named_block(services, "agent-bounties-api")
-    for domain in [
-        "api.agentbounties.app",
-        "status.agentbounties.app",
-        "api.bountyboard.global",
-        "bountyboard.global",
-        "agentbounties.io",
-        "agentbounties.dev",
-        "agentbounties.work",
-        "agentbounties.global",
-        "agentbounties.network",
-        "agentbounties.bid",
-        "agentbounties.org",
-        "agentbounties.co",
-        "agentbounties.net",
-        "agentbounties.xyz",
-    ]:
-        if f"      - {domain}" not in api:
-            fail(f"API service must attach {domain}")
+    if "      - api.agentbounties.app" not in api:
+        fail("API service must attach api.agentbounties.app")
+    if domain_lines(api) != ["- api.agentbounties.app"]:
+        fail("API service must reserve exactly one Render custom-domain slot")
     require_env_value(api, "APP_PACKAGE", "api")
     require_env_value(api, "APP_BINARY", "api")
     require_env_value(api, "AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED", '"true"')
@@ -377,9 +370,10 @@ def main() -> int:
         fail("API service must use /health")
 
     mcp = named_block(services, "agent-bounties-mcp")
-    for domain in ["mcp.agentbounties.app", "mcp.bountyboard.global"]:
-        if f"      - {domain}" not in mcp:
-            fail(f"MCP service must attach {domain}")
+    if "      - mcp.agentbounties.app" not in mcp:
+        fail("MCP service must attach mcp.agentbounties.app")
+    if domain_lines(mcp) != ["- mcp.agentbounties.app"]:
+        fail("MCP service must reserve exactly one Render custom-domain slot")
     require_env_value(mcp, "APP_PACKAGE", "mcp-server")
     require_env_value(mcp, "APP_BINARY", "mcp-server")
     require_env_value(mcp, "ENABLE_STRIPE_LIVE_EXECUTION", '"false"')

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -37,26 +37,10 @@ FAILED_STATUSES = {
 }
 TRANSIENT_HTTP_STATUSES = {429, 500, 503}
 CUSTOM_DOMAINS = {
-    "agent-bounties-api": (
-        "api.agentbounties.app",
-        "status.agentbounties.app",
-        "api.bountyboard.global",
-        "bountyboard.global",
-        "agentbounties.io",
-        "agentbounties.dev",
-        "agentbounties.work",
-        "agentbounties.global",
-        "agentbounties.network",
-        "agentbounties.bid",
-        "agentbounties.org",
-        "agentbounties.co",
-        "agentbounties.net",
-        "agentbounties.xyz",
-    ),
-    "agent-bounties-mcp": (
-        "mcp.agentbounties.app",
-        "mcp.bountyboard.global",
-    ),
+    # Render Hobby permits two custom domains per workspace. Keep runtime
+    # domains here; marketing and legacy hosts redirect at the DNS edge.
+    "agent-bounties-api": ("api.agentbounties.app",),
+    "agent-bounties-mcp": ("mcp.agentbounties.app",),
 }
 PUBLIC_ENV_SERVICE_NAMES = {
     "agent-bounties-api",
@@ -586,6 +570,31 @@ class RenderClient:
         if not isinstance(custom_domain, dict) or str(custom_domain.get("name", "")).lower() != domain.lower():
             raise RecoveryError(f"Render did not attach {domain} to {service['name']}")
         return custom_domain
+
+    def reconcile_custom_domains(
+        self, service: dict[str, Any], domains: tuple[str, ...]
+    ) -> list[dict[str, Any]]:
+        service_id = service["id"]
+        desired = {domain.lower() for domain in domains}
+        existing = unwrap_custom_domains(
+            self._read_with_retry(f"/services/{service_id}/custom-domains?limit=100")
+        )
+        names = [str(item.get("name", "")) for item in existing]
+        if len({name.lower() for name in names}) != len(names):
+            raise RecoveryError(f"{service['name']} has duplicate Render custom domains")
+
+        # Delete obsolete aliases first so a plan-level domain cap cannot block
+        # attaching the canonical replacement. The onrender.com origin remains
+        # available throughout this control-plane migration.
+        for name in names:
+            if name.lower() not in desired:
+                encoded_name = urllib.parse.quote(name, safe="")
+                self._request_json(
+                    "DELETE",
+                    f"/services/{service_id}/custom-domains/{encoded_name}",
+                )
+
+        return [self.ensure_custom_domain(service, domain) for domain in domains]
 
     def ensure_env_var(
         self,
@@ -1392,8 +1401,10 @@ def deploy(
 
     custom_domains = []
     for spec, service in services:
-        for domain in CUSTOM_DOMAINS.get(spec.name, ()):
-            record = client.ensure_custom_domain(service, domain)
+        domains = CUSTOM_DOMAINS.get(spec.name, ())
+        for domain, record in zip(
+            domains, client.reconcile_custom_domains(service, domains), strict=True
+        ):
             custom_domains.append(
                 {
                     "service": spec.name,

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -329,18 +329,52 @@ class RenderDeployRecoveryTests(unittest.TestCase):
                 "api.agentbounties.app",
             )
 
-    def test_custom_domain_inventory_preserves_clients_and_routes_vanity_domains(self) -> None:
+    def test_custom_domain_reconciliation_removes_alias_before_attaching_canonical(self) -> None:
+        client = RecordingClient(
+            response={
+                "customDomain": {
+                    "name": "api.agentbounties.app",
+                    "verificationStatus": "pending",
+                }
+            }
+        )
+        reads = iter(
+            [
+                [{"name": "api.bountyboard.global"}],
+                [],
+            ]
+        )
+        client._read_with_retry = lambda _path: next(reads)
+        reconciled = client.reconcile_custom_domains(
+            {"id": "srv-api", "name": "agent-bounties-api"},
+            ("api.agentbounties.app",),
+        )
+        self.assertEqual(reconciled[0]["name"], "api.agentbounties.app")
+        self.assertEqual(
+            client.requests,
+            [
+                (
+                    "DELETE",
+                    "/services/srv-api/custom-domains/api.bountyboard.global",
+                    None,
+                ),
+                (
+                    "POST",
+                    "/services/srv-api/custom-domains",
+                    {"name": "api.agentbounties.app"},
+                ),
+            ],
+        )
+
+    def test_custom_domain_inventory_reserves_two_runtime_slots(self) -> None:
         self.assertEqual(
             recovery.CUSTOM_DOMAINS["agent-bounties-mcp"],
-            ("mcp.agentbounties.app", "mcp.bountyboard.global"),
+            ("mcp.agentbounties.app",),
         )
-        api_domains = recovery.CUSTOM_DOMAINS["agent-bounties-api"]
-        self.assertEqual(api_domains[0], "api.agentbounties.app")
-        self.assertIn("api.bountyboard.global", api_domains)
-        self.assertIn("status.agentbounties.app", api_domains)
-        self.assertIn("bountyboard.global", api_domains)
-        self.assertIn("agentbounties.work", api_domains)
-        self.assertEqual(len(api_domains), len(set(api_domains)))
+        self.assertEqual(
+            recovery.CUSTOM_DOMAINS["agent-bounties-api"],
+            ("api.agentbounties.app",),
+        )
 
     def test_public_base_urls_require_bare_https_origins(self) -> None:
         self.assertEqual(

--- a/site/status/index.html
+++ b/site/status/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-destination="https://api.agentbounties.app/health">
+  <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <meta http-equiv="refresh" content="0;url=https://api.agentbounties.app/health">
+    <link rel="canonical" href="https://api.agentbounties.app/health">
+    <title>Agent Bounties status</title>
+    <script src="../route-alias.js" defer></script>
+  </head>
+  <body><p><a href="https://api.agentbounties.app/health">Open service status</a></p></body>
+</html>


### PR DESCRIPTION
## Summary
- reserve Render's two Hobby custom-domain slots for the canonical API and MCP origins
- reconcile obsolete aliases before attaching replacements so the domain cap cannot deadlock deployment
- move status to a canonical static route and document registrar-edge vanity redirects

## Incident
The post-#460 Render recovery run failed with HTTP 400: Hobby Tier is limited to 2 custom domains.

## Verification
- python scripts/check-render-blueprint.py
- python scripts/test_render_deploy_recovery.py -v (54 passed)
- python scripts/check-site.py
- git diff --check

Open contributor PRs are not affected; runtime contracts remain pi.agentbounties.app and mcp.agentbounties.app.