### PR TITLE
fix: verify Render domain attachment by readback

### DIFF
--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -563,13 +563,28 @@ class RenderClient:
             raise RecoveryError(f"{service['name']} has duplicate Render custom domains for {domain}")
         if existing:
             return existing[0]
-        created = self._request_json(
+        self._request_json(
             "POST", f"/services/{service_id}/custom-domains", {"name": domain}
         )
-        custom_domain = created.get("customDomain", created) if isinstance(created, dict) else None
-        if not isinstance(custom_domain, dict) or str(custom_domain.get("name", "")).lower() != domain.lower():
-            raise RecoveryError(f"Render did not attach {domain} to {service['name']}")
-        return custom_domain
+        for attempt in range(1, 6):
+            attached = [
+                item
+                for item in unwrap_custom_domains(
+                    self._read_with_retry(
+                        f"/services/{service_id}/custom-domains?limit=100"
+                    )
+                )
+                if str(item.get("name", "")).lower() == domain.lower()
+            ]
+            if len(attached) > 1:
+                raise RecoveryError(
+                    f"{service['name']} has duplicate Render custom domains for {domain}"
+                )
+            if attached:
+                return attached[0]
+            if attempt < 5:
+                self._sleep(float(attempt * 2))
+        raise RecoveryError(f"Render did not attach {domain} to {service['name']}")
 
     def reconcile_custom_domains(
         self, service: dict[str, Any], domains: tuple[str, ...]

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -304,9 +304,23 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         self.assertEqual(existing.requests, [])
 
         created = RecordingClient(
-            response={"customDomain": {"name": "api.agentbounties.app", "verificationStatus": "pending"}}
+            response={"id": "cd-opaque-provider-response"}
         )
-        created._read_with_retry = lambda _path: []
+        reads = iter(
+            [
+                [],
+                [],
+                [
+                    {
+                        "customDomain": {
+                            "name": "api.agentbounties.app",
+                            "verificationStatus": "pending",
+                        }
+                    }
+                ],
+            ]
+        )
+        created._read_with_retry = lambda _path: next(reads)
         attached = created.ensure_custom_domain(
             {"id": "srv-api", "name": "agent-bounties-api"},
             "api.agentbounties.app",
@@ -342,6 +356,7 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             [
                 [{"name": "api.bountyboard.global"}],
                 [],
+                [{"name": "api.agentbounties.app", "verificationStatus": "pending"}],
             ]
         )
         client._read_with_retry = lambda _path: next(reads)


### PR DESCRIPTION
Render accepted the domain attach request but returned an asynchronous POST shape. This polls authoritative custom-domain inventory, fails closed on missing or duplicate evidence, and has 54 passing recovery tests plus the Blueprint gate.