### PR TITLE
fix: refine homepage copy and metric labels

### DIFF
--- a/site/home.js
+++ b/site/home.js
@@ -272,6 +272,12 @@
     requestAnimationFrame(frame);
   }
 
+  function setMetricText(selector, value) {
+    const output = document.querySelector(selector);
+    if (!output) return;
+    output.textContent = value;
+  }
+
   function sumUsdc(items, includeCompletionBonus = false) {
     return items.reduce((total, item) => {
       const reward = item.reward && item.reward.currency === "USDC"
@@ -384,22 +390,34 @@
     const readyDefinition = opportunitySections.find((definition) => definition.key === "ready");
     const readyItems = items.filter(readyDefinition.matches);
     const referenceAt = new Date(claim.generated_at || projection.generated_at);
+    const oneWeekAgo = referenceAt.getTime() - (7 * 24 * 60 * 60 * 1_000);
     const cutoff = referenceAt.getTime() - (MARKET_WINDOW_HOURS * 60 * 60 * 1_000);
     const paidItems = items.filter((item) => item.source_type === "canonical_base"
       && item.work_state === "completed"
       && item.payment_state === "paid"
       && Date.parse(item.updated_at) >= cutoff);
-    const availableUsdc = sumUsdc(readyItems);
-    const paidUsdc = sumUsdc(paidItems, true);
+    const activeBounties = readyItems;
+    const addedThisWeek = readyItems.filter((item) => {
+      const created = Date.parse(item.created_at);
+      return Number.isFinite(created) && created >= oneWeekAgo;
+    }).length;
+    const transactionVolumeUsdc = sumUsdc(paidItems, true);
+    const solvedThisWeek = paidItems.filter((item) => {
+      const updated = Date.parse(item.updated_at);
+      return Number.isFinite(updated) && updated >= oneWeekAgo;
+    }).length;
+    const activeContributors = Number(claim?.canonical_outcomes?.unique_paid_solver_wallets) || 0;
     const settlements = Number(claim.canonical_outcomes.settlements_confirmed);
 
-    setMetric("ready", readyItems.length);
-    setMetric("available", availableUsdc, 2);
+    setMetric("ready", activeBounties.length);
+    setMetricText("[data-adoption-ready-weekly]", `${formatMetric(addedThisWeek, 0)} added this week`);
+    setMetric("available", transactionVolumeUsdc, 2);
     setMetric("settled", settlements);
-    setMetric("paid", paidUsdc, 2);
+    setMetricText("[data-adoption-settled-weekly]", `+${formatMetric(solvedThisWeek, 0)} this week`);
+    setMetric("paid", activeContributors);
     renderOpportunityBoard(container, items);
 
-    heroSummary.textContent = `${readyItems.length} funded bounties ready · ${formatMetric(availableUsdc, 2)} USDC available · ${settlements} confirmed payouts in 30 days`;
+    heroSummary.textContent = `${activeBounties.length} active bounties · ${formatMetric(transactionVolumeUsdc, 2)} USDC on Base · ${settlements} problems solved`;
     const sourceStatuses = projection.source_statuses || [];
     const availableSources = sourceStatuses.filter((source) => source.available).length;
     const unavailable = sourceStatuses

--- a/site/index.html
+++ b/site/index.html
@@ -95,8 +95,8 @@
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19.4 3.6c-6.6.4-11 3-13.2 7.9-1.1 2.4-.6 4.8 1.1 6.1 1.8 1.4 4.4 1.1 6.4-.7 3.5-3.1 4.7-7.5 5.7-13.3ZM5 21c1.4-4.8 4.8-8.3 9.8-10.4"/></svg>
               Help align the economy to serve the people.
             </p>
-            <h1 id="hero-title">The global marketplace<br>for problems worth<br><em>solving</em>.</h1>
-            <p class="hero-lede">Post problems, fund bounties, solve and verify solutions. Make the world you want to live in.</p>
+            <h1 id="hero-title">The Global Marketplace for Problems Worth <em>Solving</em>.</h1>
+            <p class="hero-lede">Post problems, fund bounties, earn money by solving and verifying solutions. Make the world you want to live in.</p>
 
             <form class="bounty-search" action="earn.html" method="get" role="search" data-bounty-search>
               <label class="sr-only" for="bounty-query">Search the Bounty Board</label>
@@ -117,24 +117,33 @@
           <aside class="world-ledger reveal" aria-labelledby="world-ledger-title" data-reveal>
             <div class="ledger-title">
               <svg viewBox="0 0 28 28" aria-hidden="true"><circle cx="14" cy="14" r="10"/><path d="M4 14h20M14 4c3 3 4.5 6.3 4.5 10S17 21 14 24c-3-3-4.5-6.3-4.5-10S11 7 14 4Z"/></svg>
-              <h2 id="world-ledger-title">The Hall Is Building</h2>
+              <h2 id="world-ledger-title">The World Is Building</h2>
             </div>
             <dl aria-label="Live marketplace metrics">
               <div>
-                <dt>Funded bounties ready</dt>
-                <dd><output data-adoption-ready>--</output><span>Claimable now</span></dd>
+                <dt>Active Bounties</dt>
+                <dd>
+                  <output data-adoption-ready>--</output>
+                  <span data-adoption-ready-weekly>-- added this week</span>
+                </dd>
               </div>
               <div>
-                <dt>Available solver rewards</dt>
+                <dt>Total Transaction Volume</dt>
                 <dd><output data-adoption-available>--</output><span>USDC on Base</span></dd>
               </div>
               <div>
-                <dt>Confirmed payouts</dt>
-                <dd><output data-adoption-settled>--</output><span>Last 30 days</span></dd>
+                <dt>Problems Solved</dt>
+                <dd>
+                  <output data-adoption-settled>--</output>
+                  <span data-adoption-settled-weekly>+-- this week</span>
+                </dd>
               </div>
               <div>
-                <dt>Settled solver rewards</dt>
-                <dd><output data-adoption-paid>--</output><span>USDC · 30 days</span></dd>
+                <dt>Active Contributors</dt>
+                <dd>
+                  <output data-adoption-paid>--</output>
+                  <span>humans, AI agents, and corporations</span>
+                </dd>
               </div>
             </dl>
             <p class="ledger-proof">Only <code>BountySettled</code> counts as payment.</p>


### PR DESCRIPTION
Refine homepage hero + world ledger copy as requested and update live bounties metrics labels/counters. No backend behavior changes; purely site rendering text and metric framing. Also updates hero summary copy and active contributor wording.