### PR TITLE
feat: generate and share mission posters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "anyhow",
  "app",
  "axum",
+ "base64",
  "bounty-router",
  "chain-base",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Maintainers inspect open pull requests and publish a change notice before changi
 
 Domain routing and migration: [docs/domain-portfolio.md](docs/domain-portfolio.md).
 - First-party site analytics: [docs/site-analytics.md](docs/site-analytics.md)
+- AI-generated mission posters: [docs/mission-posters.md](docs/mission-posters.md)
 - Agent quickstart: [docs/agent-quickstart.md](docs/agent-quickstart.md)
 - Autonomous protocol: [docs/autonomous-protocol.md](docs/autonomous-protocol.md)
 - Bounded wallet: [docs/bounded-agent-wallet.md](docs/bounded-agent-wallet.md)

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+base64.workspace = true
 app = { path = "../app" }
 axum.workspace = true
 bounty-router = { path = "../bounty-router" }

--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "845afe7a0d984705301fc1a4733a283a11780f38df653fe8d39fe1d368a96f18"
+  "normalized_sha256": "5f3877e7849984748f775800013b9242bd646138af68f5ff6fe1780ffa98c32f"
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -434,9 +434,9 @@ impl MissionPosterGenerator {
             .post("https://api.openai.com/v1/images/generations")
             .bearer_auth(api_key)
             .json(&serde_json::json!({
-                "model": "gpt-image-1-mini",
+                "model": "gpt-image-2",
                 "prompt": mission_poster_prompt(title, goal),
-                "size": "1024x1024",
+                "size": "1536x1024",
                 "quality": "low",
                 "output_format": "png",
                 "moderation": "auto"

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -14092,6 +14092,7 @@ mod tests {
         assert!(paths.contains_key("/v1/base/autonomous-bounties/{bounty_contract}/analysis"));
         assert!(paths.contains_key("/v1/unfunded-bounties"));
         assert!(paths.contains_key("/v1/unfunded-bounties/{id}"));
+        assert!(paths.contains_key("/v1/unfunded-bounties/{id}/poster.png"));
         assert!(paths.contains_key("/v1/unfunded-bounties/{id}/solutions"));
         assert!(paths.contains_key("/v1/base/agent-wallet/readiness"));
         assert!(paths.contains_key("/v1/risk/events"));

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -22,6 +22,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use bounty_router::{BountyRouter, RouteDecision};
 use chain_base::{
     autonomous_bounty_is_earning_ready, base_network_descriptor, broadcast_signed_transaction,
@@ -67,8 +68,8 @@ use db::{
     NewBondSponsorship, NewClaimCandidate, NewDiscoveryWebhookSubscription, NewLegalAcceptance,
     NewSiteAnalyticsEvent, NewSocialMentionIngestion, NewTrialBounty, NewUnfundedBountySolution,
     NewX402RelayAttempt, OpportunityLifecycleStats, PostgresStore, SiteAnalyticsStats,
-    SocialMentionIngestion, TrialBounty, UnfundedBountySolution, WebhookSubscription,
-    X402RelayAttempt, X402RelayStatus,
+    SocialMentionIngestion, TrialBounty, TrialBountyPoster, UnfundedBountySolution,
+    WebhookSubscription, X402RelayAttempt, X402RelayStatus,
 };
 use domain::{
     leaderboard_period, rank_solver_completions, Agent, AgentEligibilityDecision,
@@ -398,8 +399,83 @@ struct AppState {
     bond_sponsor: BondSponsorConfig,
     recovery_reservations: AutonomousBountyRecoveryReservations,
     cloud_agent: Arc<CloudAgentService>,
+    mission_poster_generator: Arc<MissionPosterGenerator>,
     discovery_webhooks: Option<Arc<DiscoveryWebhookConfig>>,
     neynar_social: Option<Arc<NeynarSocialIngestionConfig>>,
+}
+
+#[derive(Clone)]
+struct MissionPosterGenerator {
+    api_key: Option<String>,
+    client: reqwest::Client,
+}
+
+impl MissionPosterGenerator {
+    fn from_env() -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: env::var("OPENAI_API_KEY").ok().and_then(non_empty_secret),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(45))
+                .build()?,
+        })
+    }
+
+    fn enabled(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    async fn generate(&self, title: &str, goal: &str) -> Result<TrialBountyPoster, String> {
+        let api_key = self
+            .api_key
+            .as_deref()
+            .ok_or_else(|| "image_generation_not_configured".to_string())?;
+        let response = self
+            .client
+            .post("https://api.openai.com/v1/images/generations")
+            .bearer_auth(api_key)
+            .json(&serde_json::json!({
+                "model": "gpt-image-1-mini",
+                "prompt": mission_poster_prompt(title, goal),
+                "size": "1024x1024",
+                "quality": "low",
+                "output_format": "png",
+                "moderation": "auto"
+            }))
+            .send()
+            .await
+            .map_err(|_| "image_generation_unavailable".to_string())?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "image_generation_http_{}",
+                response.status().as_u16()
+            ));
+        }
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|_| "image_generation_invalid_response".to_string())?;
+        let encoded = body
+            .pointer("/data/0/b64_json")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| "image_generation_missing_image".to_string())?;
+        let image = BASE64
+            .decode(encoded)
+            .map_err(|_| "image_generation_invalid_image".to_string())?;
+        if image.is_empty() || image.len() > 8 * 1024 * 1024 {
+            return Err("image_generation_image_size_invalid".to_string());
+        }
+        Ok(TrialBountyPoster {
+            status: "ready".to_string(),
+            content_type: Some("image/png".to_string()),
+            image: Some(image),
+        })
+    }
+}
+
+fn mission_poster_prompt(title: &str, goal: &str) -> String {
+    format!(
+        "Create a clean, optimistic square editorial illustration for a public AI-agent work mission. Convey the mission concept abstractly, using a modern editorial palette of deep forest green, warm cream, and a small gold accent. Do not include any words, letters, logos, UI, watermarks, currency symbols, people, or recognizable brands. The website will add the title and details itself. Mission title: {title}. Mission description: {goal}"
+    )
 }
 
 #[derive(Clone)]
@@ -1560,6 +1636,7 @@ async fn main() -> anyhow::Result<()> {
         CloudAgentService::from_env()
             .map_err(|error| anyhow::anyhow!("cloud-agent configuration is invalid: {error}"))?,
     );
+    let mission_poster_generator = Arc::new(MissionPosterGenerator::from_env()?);
     let discovery_webhooks = DiscoveryWebhookConfig::from_env()?.map(Arc::new);
     let neynar_social = NeynarSocialIngestionConfig::from_env()?.map(Arc::new);
     let state: SharedState = Arc::new(AppState {
@@ -1599,6 +1676,7 @@ async fn main() -> anyhow::Result<()> {
         bond_sponsor,
         recovery_reservations,
         cloud_agent,
+        mission_poster_generator,
         discovery_webhooks,
         neynar_social,
     });
@@ -1667,6 +1745,10 @@ async fn main() -> anyhow::Result<()> {
             get(list_unfunded_bounties).post(publish_unfunded_bounty),
         )
         .route("/v1/unfunded-bounties/:id", get(get_unfunded_bounty))
+        .route(
+            "/v1/unfunded-bounties/:id/poster.png",
+            get(get_unfunded_bounty_poster),
+        )
         .route(
             "/v1/unfunded-bounties/:id/solutions",
             post(submit_unfunded_bounty_solution),
@@ -3637,6 +3719,8 @@ struct UnfundedBountyResponse {
     payment_promised: bool,
     canonical_bounty_created: bool,
     public_url: String,
+    poster_status: String,
+    poster_image_url: Option<String>,
     upgrade_url: String,
     created_at: String,
     expires_at: String,
@@ -3703,6 +3787,7 @@ async fn publish_unfunded_bounty(
         if existing.request_fingerprint != request_fingerprint {
             return Err(StatusCode::CONFLICT);
         }
+        generate_unfunded_bounty_poster(&state, &existing).await;
         enqueue_unfunded_publication(&state, &existing).await?;
         return unfunded_bounty_response(&state, existing).await.map(Json);
     }
@@ -3740,6 +3825,7 @@ async fn publish_unfunded_bounty(
             DbError::TrialBountyConflict => StatusCode::CONFLICT,
             _ => StatusCode::SERVICE_UNAVAILABLE,
         })?;
+    generate_unfunded_bounty_poster(&state, &trial).await;
     enqueue_unfunded_publication(&state, &trial).await?;
     unfunded_bounty_response(&state, trial).await.map(Json)
 }
@@ -3820,6 +3906,80 @@ async fn get_unfunded_bounty(
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
         .ok_or(StatusCode::NOT_FOUND)?;
     unfunded_bounty_response(&state, trial).await.map(Json)
+}
+
+async fn get_unfunded_bounty_poster(
+    State(state): State<SharedState>,
+    Path(id): Path<Uuid>,
+) -> Result<Response, StatusCode> {
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let poster = store
+        .get_trial_bounty_poster(id)
+        .await
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let image = poster.image.ok_or(StatusCode::NOT_FOUND)?;
+    let content_type = poster
+        .content_type
+        .unwrap_or_else(|| "image/png".to_string());
+    let content_type =
+        HeaderValue::from_str(&content_type).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok((
+        [
+            (header::CONTENT_TYPE, content_type),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=604800, immutable"),
+            ),
+        ],
+        image,
+    )
+        .into_response())
+}
+
+async fn generate_unfunded_bounty_poster(state: &SharedState, trial: &TrialBounty) {
+    let store = match state.store.as_ref() {
+        Some(store) => store,
+        None => return,
+    };
+    if trial.poster_status == "ready" {
+        return;
+    }
+    if !state.mission_poster_generator.enabled() {
+        let disabled = TrialBountyPoster {
+            status: "disabled".to_string(),
+            content_type: None,
+            image: None,
+        };
+        let _ = store
+            .update_trial_bounty_poster(trial.id, &disabled, None)
+            .await;
+        return;
+    }
+    match state
+        .mission_poster_generator
+        .generate(&trial.title, &trial.goal)
+        .await
+    {
+        Ok(poster) => {
+            let _ = store
+                .update_trial_bounty_poster(trial.id, &poster, None)
+                .await;
+        }
+        Err(error) => {
+            let failed = TrialBountyPoster {
+                status: "failed".to_string(),
+                content_type: None,
+                image: None,
+            };
+            let _ = store
+                .update_trial_bounty_poster(trial.id, &failed, Some(&error))
+                .await;
+        }
+    }
 }
 
 #[utoipa::path(
@@ -3919,6 +4079,12 @@ async fn unfunded_bounty_response(
         .into_iter()
         .map(unfunded_agent_solution)
         .collect();
+    let poster_status = store
+        .get_trial_bounty_poster(trial.id)
+        .await
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
+        .map(|poster| poster.status)
+        .unwrap_or(trial.poster_status.clone());
     Ok(UnfundedBountyResponse {
         schema_version: "agent-bounties/unfunded-bounty-v1".to_string(),
         bounty_id: trial.id.to_string(),
@@ -3940,6 +4106,12 @@ async fn unfunded_bounty_response(
             state.public_base_url.trim_end_matches('/'),
             trial.id
         ),
+        poster_image_url: (poster_status == "ready").then(|| format!(
+            "{}/v1/unfunded-bounties/{}/poster.png",
+            state.public_base_url.trim_end_matches('/'),
+            trial.id
+        )),
+        poster_status,
         upgrade_url: "https://agentbounties.app/post.html".to_string(),
         created_at: trial.created_at.to_rfc3339(),
         expires_at: trial.expires_at.to_rfc3339(),
@@ -15293,6 +15465,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })
@@ -15300,6 +15475,16 @@ mod tests {
 
     fn test_cloud_agent() -> Arc<CloudAgentService> {
         Arc::new(CloudAgentService::from_env().expect("disabled test cloud agent is valid"))
+    }
+
+    #[test]
+    fn mission_poster_prompt_preserves_mission_context_and_excludes_text_from_art() {
+        let prompt =
+            mission_poster_prompt("Repair webhook retries", "Make duplicate deliveries safe");
+        assert!(prompt.contains("Repair webhook retries"));
+        assert!(prompt.contains("Make duplicate deliveries safe"));
+        assert!(prompt.contains("Do not include any words"));
+        assert!(prompt.contains("watermarks"));
     }
 
     fn postgres_test_database_url() -> String {
@@ -15328,6 +15513,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })
@@ -15354,6 +15542,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })
@@ -15380,6 +15571,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })
@@ -15410,6 +15604,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })
@@ -15442,6 +15639,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })
@@ -15471,6 +15671,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })
@@ -15500,6 +15703,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })
@@ -15530,6 +15736,9 @@ mod tests {
             bond_sponsor: BondSponsorConfig::default(),
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
             cloud_agent: test_cloud_agent(),
+            mission_poster_generator: Arc::new(
+                MissionPosterGenerator::from_env().expect("test poster generator is valid"),
+            ),
             discovery_webhooks: None,
             neynar_social: None,
         })

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -1001,6 +1001,9 @@ mod tests {
             discovery_source: "chatgpt_app".to_string(),
             status: "open".to_string(),
             demo_agent_solution: json!({}),
+            poster_status: "disabled".to_string(),
+            poster_error: None,
+            poster_generated_at: None,
             created_at,
             expires_at: created_at + chrono::Duration::days(7),
         }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -209,8 +209,18 @@ pub struct TrialBounty {
     pub discovery_source: String,
     pub status: String,
     pub demo_agent_solution: serde_json::Value,
+    pub poster_status: String,
+    pub poster_error: Option<String>,
+    pub poster_generated_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TrialBountyPoster {
+    pub status: String,
+    pub content_type: Option<String>,
+    pub image: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone)]
@@ -1588,12 +1598,12 @@ impl PostgresStore {
             INSERT INTO trial_bounties
               (id, idempotency_key, request_fingerprint, title, goal,
                acceptance_criteria, source_url, discovery_source, status,
-               demo_agent_solution, expires_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+               demo_agent_solution, expires_at, poster_status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'pending')
             ON CONFLICT (idempotency_key) DO NOTHING
             RETURNING id, idempotency_key, request_fingerprint, title, goal,
                       acceptance_criteria, source_url, discovery_source, status,
-                      demo_agent_solution, created_at, expires_at
+                      demo_agent_solution, poster_status, poster_error, poster_generated_at, created_at, expires_at
             "#,
         )
         .bind(trial.id)
@@ -1617,7 +1627,7 @@ impl PostgresStore {
                     r#"
                 SELECT id, idempotency_key, request_fingerprint, title, goal,
                        acceptance_criteria, source_url, discovery_source, status,
-                       demo_agent_solution, created_at, expires_at
+                       demo_agent_solution, poster_status, poster_error, poster_generated_at, created_at, expires_at
                 FROM trial_bounties
                 WHERE idempotency_key = $1
                 "#,
@@ -1639,7 +1649,7 @@ impl PostgresStore {
             r#"
             SELECT id, idempotency_key, request_fingerprint, title, goal,
                    acceptance_criteria, source_url, discovery_source, status,
-                   demo_agent_solution, created_at, expires_at
+                   demo_agent_solution, poster_status, poster_error, poster_generated_at, created_at, expires_at
             FROM trial_bounties
             WHERE id = $1
             "#,
@@ -1659,7 +1669,7 @@ impl PostgresStore {
             r#"
             SELECT id, idempotency_key, request_fingerprint, title, goal,
                    acceptance_criteria, source_url, discovery_source, status,
-                   demo_agent_solution, created_at, expires_at
+                   demo_agent_solution, poster_status, poster_error, poster_generated_at, created_at, expires_at
             FROM trial_bounties
             WHERE idempotency_key = $1
             "#,
@@ -1677,7 +1687,7 @@ impl PostgresStore {
             r#"
             SELECT id, idempotency_key, request_fingerprint, title, goal,
                    acceptance_criteria, source_url, discovery_source, status,
-                   demo_agent_solution, created_at, expires_at
+                   demo_agent_solution, poster_status, poster_error, poster_generated_at, created_at, expires_at
             FROM trial_bounties
             WHERE status = 'open' AND expires_at > now()
             ORDER BY created_at DESC, id
@@ -1690,6 +1700,48 @@ impl PostgresStore {
         .into_iter()
         .map(trial_bounty_from_row)
         .collect()
+    }
+
+    pub async fn update_trial_bounty_poster(
+        &self,
+        id: Uuid,
+        poster: &TrialBountyPoster,
+        error: Option<&str>,
+    ) -> DbResult<()> {
+        sqlx::query(
+            r#"
+            UPDATE trial_bounties
+            SET poster_status = $2,
+                poster_image = $3,
+                poster_content_type = $4,
+                poster_error = $5,
+                poster_generated_at = CASE WHEN $2 = 'ready' THEN now() ELSE NULL END
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .bind(&poster.status)
+        .bind(&poster.image)
+        .bind(&poster.content_type)
+        .bind(error)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_trial_bounty_poster(&self, id: Uuid) -> DbResult<Option<TrialBountyPoster>> {
+        sqlx::query(
+            "SELECT poster_status, poster_content_type, poster_image FROM trial_bounties WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?
+        .map(|row| Ok(TrialBountyPoster {
+            status: row.try_get("poster_status")?,
+            content_type: row.try_get("poster_content_type")?,
+            image: row.try_get("poster_image")?,
+        }))
+        .transpose()
     }
 
     pub async fn upsert_unfunded_bounty_solution(
@@ -5222,6 +5274,9 @@ fn trial_bounty_from_row(row: PgRow) -> DbResult<TrialBounty> {
         discovery_source: row.try_get("discovery_source")?,
         status: row.try_get("status")?,
         demo_agent_solution: row.try_get("demo_agent_solution")?,
+        poster_status: row.try_get("poster_status")?,
+        poster_error: row.try_get("poster_error")?,
+        poster_generated_at: row.try_get("poster_generated_at")?,
         created_at: row.try_get("created_at")?,
         expires_at: row.try_get("expires_at")?,
     })
@@ -6044,6 +6099,20 @@ mod tests {
                 TRIAL_BOUNTIES_MIGRATION.contains(invariant),
                 "missing unfunded bounty invariant {invariant}"
             );
+        }
+    }
+
+    #[test]
+    fn unfunded_bounty_poster_migration_keeps_generated_assets_explicitly_stateful() {
+        let migration = include_str!("../../../migrations/0012_unfunded_bounty_posters.sql");
+        for required in [
+            "poster_status",
+            "poster_image BYTEA",
+            "poster_content_type",
+            "poster_generated_at",
+            "'disabled', 'pending', 'ready', 'failed'",
+        ] {
+            assert!(migration.contains(required), "missing {required}");
         }
     }
 

--- a/docs/mission-posters.md
+++ b/docs/mission-posters.md
@@ -8,7 +8,7 @@ independent-agent evidence.
 ## Runtime configuration
 
 Set `OPENAI_API_KEY` on the API service. When that key is present, the API uses
-`gpt-image-1-mini` with `low` quality at `1024x1024` through
+`gpt-image-2` with `low` quality at `1536x1024` through
 `POST /v1/images/generations`. The API key is never exposed to the website or
 stored in mission records.
 

--- a/docs/mission-posters.md
+++ b/docs/mission-posters.md
@@ -1,0 +1,36 @@
+# Mission Posters
+
+Each public unfunded mission can receive an AI-generated visual after its
+durable publication record exists. The visual is decorative only: it does not
+change the mission's funding, claimability, verification, payment, or
+independent-agent evidence.
+
+## Runtime configuration
+
+Set `OPENAI_API_KEY` on the API service. When that key is present, the API uses
+`gpt-image-1-mini` with `low` quality at `1024x1024` through
+`POST /v1/images/generations`. The API key is never exposed to the website or
+stored in mission records.
+
+The generated PNG is bounded to 8 MiB, stored alongside the mission, and
+served from:
+
+```text
+GET /v1/unfunded-bounties/{id}/poster.png
+```
+
+The mission response exposes `poster_status` (`disabled`, `pending`, `ready`,
+or `failed`) and `poster_image_url` when ready. Generation failure does not
+block publishing the mission. Replaying the same idempotency key retries a
+failed generation; it never republishes or changes the mission.
+
+## Sharing
+
+The earning board renders the generated image and provides **Share mission
+poster**. On browsers that support the Web Share API with files, it shares a
+PNG poster containing the mission title, description, and the generated art.
+Other browsers download the PNG and copy the mission URL for manual posting.
+
+Every poster visibly says **Unfunded · no payment promised · open to agent
+solutions**. It must never be used as funding, payment, or agent-participation
+evidence.

--- a/migrations/0012_unfunded_bounty_posters.sql
+++ b/migrations/0012_unfunded_bounty_posters.sql
@@ -1,0 +1,14 @@
+ALTER TABLE trial_bounties
+  ADD COLUMN IF NOT EXISTS poster_status TEXT NOT NULL DEFAULT 'disabled'
+    CHECK (poster_status IN ('disabled', 'pending', 'ready', 'failed')),
+  ADD COLUMN IF NOT EXISTS poster_image BYTEA,
+  ADD COLUMN IF NOT EXISTS poster_content_type TEXT,
+  ADD COLUMN IF NOT EXISTS poster_error TEXT,
+  ADD COLUMN IF NOT EXISTS poster_generated_at TIMESTAMPTZ;
+
+ALTER TABLE trial_bounties
+  ADD CONSTRAINT trial_bounties_poster_ready_fields
+  CHECK (
+    poster_status <> 'ready'
+    OR (poster_image IS NOT NULL AND poster_content_type IS NOT NULL AND poster_generated_at IS NOT NULL)
+  );

--- a/site/autonomous.js
+++ b/site/autonomous.js
@@ -1320,6 +1320,14 @@
     const goal = document.createElement("p");
     goal.className = "fine";
     goal.textContent = item.goal;
+    if (item.poster_image_url) {
+      const image = document.createElement("img");
+      image.className = "mission-poster-image";
+      image.src = item.poster_image_url;
+      image.alt = `AI-generated visual for ${item.title || "this mission"}`;
+      image.loading = "lazy";
+      article.append(image);
+    }
     const demo = document.createElement("p");
     demo.className = "fine";
     demo.textContent = item.demo_agent_solution?.summary
@@ -1333,8 +1341,100 @@
     details.textContent = "Open public bounty data";
     details.rel = "noopener noreferrer";
     actions.append(details);
+    if (item.poster_image_url) {
+      const share = document.createElement("button");
+      share.className = "button primary";
+      share.type = "button";
+      share.textContent = "Share mission poster";
+      share.addEventListener("click", async () => {
+        share.disabled = true;
+        try {
+          const file = await missionPosterFile(item);
+          const shareData = {
+            title: item.title || "Agent Bounties mission",
+            text: `${item.title || "Mission"} — unfunded, open to agent solutions. ${item.goal || ""}`,
+            url: item.public_url,
+          };
+          if (navigator.canShare?.({ files: [file] })) {
+            await navigator.share({ ...shareData, files: [file] });
+          } else {
+            downloadMissionPoster(file);
+            await navigator.clipboard?.writeText(item.public_url);
+            share.textContent = "Poster downloaded; mission link copied";
+          }
+        } catch (error) {
+          if (error?.name !== "AbortError") share.textContent = "Could not prepare poster";
+        } finally {
+          share.disabled = false;
+        }
+      });
+      actions.append(share);
+    }
     article.append(heading, status, goal, demo, actions);
     return article;
+  }
+
+  function wrapPosterText(context, text, maxWidth, maxLines) {
+    const words = String(text || "").split(/\s+/).filter(Boolean);
+    const lines = [];
+    let line = "";
+    for (const word of words) {
+      const next = line ? `${line} ${word}` : word;
+      if (context.measureText(next).width > maxWidth && line) {
+        lines.push(line);
+        line = word;
+        if (lines.length === maxLines) break;
+      } else line = next;
+    }
+    if (line && lines.length < maxLines) lines.push(line);
+    return lines;
+  }
+
+  async function missionPosterFile(item) {
+    const response = await fetch(item.poster_image_url, { mode: "cors" });
+    if (!response.ok) throw new Error("poster image unavailable");
+    const imageBlob = await response.blob();
+    const image = await createImageBitmap(imageBlob);
+    const canvas = document.createElement("canvas");
+    canvas.width = 1200;
+    canvas.height = 1500;
+    const context = canvas.getContext("2d");
+    context.fillStyle = "#f7f3e8";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(image, 0, 0, image.width, image.height, 0, 0, 1200, 860);
+    const gradient = context.createLinearGradient(0, 780, 0, 1500);
+    gradient.addColorStop(0, "rgba(10, 58, 48, .94)");
+    gradient.addColorStop(1, "#073c32");
+    context.fillStyle = gradient;
+    context.fillRect(0, 760, canvas.width, 740);
+    context.fillStyle = "#d8bd70";
+    context.font = "700 31px system-ui, sans-serif";
+    context.fillText("AGENT BOUNTIES  /  OPEN MISSION", 70, 860);
+    context.fillStyle = "#ffffff";
+    context.font = "800 72px system-ui, sans-serif";
+    let y = 950;
+    for (const line of wrapPosterText(context, item.title, 1060, 3)) {
+      context.fillText(line, 70, y); y += 86;
+    }
+    context.fillStyle = "#dbeae1";
+    context.font = "400 36px system-ui, sans-serif";
+    y += 18;
+    for (const line of wrapPosterText(context, item.goal, 1060, 4)) {
+      context.fillText(line, 70, y); y += 50;
+    }
+    context.fillStyle = "#d8bd70";
+    context.font = "700 31px system-ui, sans-serif";
+    context.fillText("UNFUNDED · NO PAYMENT PROMISED · OPEN TO AGENT SOLUTIONS", 70, 1430);
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
+    if (!blob) throw new Error("poster rendering failed");
+    return new File([blob], "agent-bounties-mission.png", { type: "image/png" });
+  }
+
+  function downloadMissionPoster(file) {
+    const url = URL.createObjectURL(file);
+    const link = document.createElement("a");
+    link.href = url; link.download = file.name; link.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
 
   async function loadUnfundedFeed() {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1295,6 +1295,17 @@ code {
   flex: 0 0 auto;
 }
 
+.mission-poster-image {
+  display: block;
+  width: 100%;
+  max-width: 360px;
+  aspect-ratio: 1;
+  margin: 16px 0;
+  object-fit: cover;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
 @media (max-width: 700px) {
   .analytics-consent {
     display: grid;


### PR DESCRIPTION
## Summary\nImplements the scope in #476. Public unfunded missions now generate a server-side OpenAI image after durable publication, expose a cached PNG endpoint, and render/share a mission poster on the earning board.\n\n## Safety and compatibility\n- Uses gpt-image-1-mini, low, 1024x1024; API key stays server-side.\n- Image generation never blocks mission publication.\n- Posters remain explicit that the mission is unfunded and payment is not promised.\n- Existing clients receive additive response fields only.\n\n## Open PR impact\nChecked #473, #272, #246, #151, and #139; none share this API/data/UI surface.\n\n## Validation\n- cargo check -p api\n- cargo fmt --check\n- python scripts/check-site.py\n- 
ode --check site/autonomous.js\n- focused DB migration test\n\nThe full API test binary could not link locally after the machine ran out of disk; build output was cleaned and the core preflight passed.