### PR TITLE
fix: use the full desktop viewport

### DIFF
--- a/site/home.css
+++ b/site/home.css
@@ -1330,8 +1330,8 @@
 /* Responsive */
 @media (min-width: 1180px) {
   :root {
-    --page-max: 1480px;
-    --desktop-inset: clamp(112px, 12vw, 240px);
+    --page-max: 2400px;
+    --desktop-inset: clamp(32px, 3vw, 56px);
   }
 
   .guild-actions-shell,


### PR DESCRIPTION
## Summary
- removes the conservative 1480 px desktop canvas ceiling
- reduces wide-screen total side inset from 12vw to a small 32–56 px safety gutter
- lets ordinary laptop and desktop viewports use approximately 97% of their available width
- preserves readable text measures plus all existing tablet/mobile geometry

Maintainer notice: #479

## Open PR impact
#482, #480, #272, #246, #151, and #139 do not modify `site/home.css`; no contributor work is superseded or overlapped.

## Validation
- `scripts/preflight.ps1 -Mode core`
- `python scripts/check-site.py`
- `git diff --check`
- 1024 × 1536: original 930 px content canvas preserved
- 1440 × 900: 1382 px canvas, 22 px rendered left gutter, four 331.9 px action columns
- 1920 × 1080: 1849 px canvas, 28 px rendered left gutter, four 444.2 px action columns
- no horizontal overflow
- no browser warnings or errors

CSS-only layout correction. No payment, contract, API, bounty, verification, or settlement behavior changes.