### PR TITLE
fix: refresh deployed homepage styles

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -117,7 +117,7 @@ def check_internal_link(site_dir: Path, source: Path, link: str, ids: set[str]) 
         return
     if target.startswith("/"):
         fail(f"{source}: root-relative link is not portable on GitHub Pages: {link}")
-    target_path = (source.parent / (target or source.name)).resolve()
+    target_path = (source.parent / (parsed.path or source.name)).resolve()
     try:
         target_path.relative_to(site_dir.resolve())
     except ValueError:

--- a/site/index.html
+++ b/site/index.html
@@ -30,7 +30,7 @@
     </script>
     <link rel="preload" href="assets/guild-hall-hero.webp" as="image" type="image/webp" fetchpriority="high">
     <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="home.css">
+    <link rel="stylesheet" href="home.css?v=5ceffda">
   </head>
   <body class="guild-home">
     <a class="skip-link" href="#main-content">Skip to content</a>


### PR DESCRIPTION
## Summary
- versions the homepage stylesheet URL so existing browser sessions fetch the full-width CSS deployed in #483
- teaches the static site checker to validate the parsed URL path rather than treating query parameters as part of a local filename

Maintainer notice: #479
Depends on the already merged full-width correction #483.

## Validation
- `scripts/preflight.ps1 -Mode core`
- `python scripts/check-site.py`
- `git diff --check`
- browser confirms stylesheet `home.css?v=5ceffda`
- browser confirms 1382 px canvas with a 22 px gutter at 1440 px
- no horizontal overflow

No payment, bounty, API, contract, verification, or settlement changes.