### PR TITLE
fix: correct homepage community proof and links

### DIFF
--- a/site/home-community.css
+++ b/site/home-community.css
@@ -1,0 +1,196 @@
+/* Focused homepage community corrections for issue #485. */
+
+/* The original raster sprig includes stray text. Replace it with clean inline SVG art. */
+.community-shell::after {
+  content: none;
+  background: none;
+}
+
+.charter-copy {
+  position: relative;
+  isolation: isolate;
+}
+
+.charter-copy > :not(.mission-sprig) {
+  position: relative;
+  z-index: 1;
+}
+
+.mission-sprig {
+  position: absolute;
+  z-index: 0;
+  right: 2px;
+  bottom: -7px;
+  width: 126px;
+  height: 218px;
+  opacity: 0.82;
+  filter: drop-shadow(0 0 18px rgba(171, 232, 65, 0.12));
+  pointer-events: none;
+}
+
+.mission-sprig svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+/* Crop the obsolete +1.2k badge out of the face asset and replace it with live data. */
+.adventurer-crests {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 251px;
+  max-width: 100%;
+  height: 57px;
+  background: none;
+}
+
+.adventurer-faces {
+  display: block;
+  flex: 0 0 194px;
+  width: 194px;
+  height: 57px;
+  background: url("assets/community-faces.webp") left center / auto 57px no-repeat;
+}
+
+.participant-count {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  flex: 0 0 57px;
+  width: 57px;
+  height: 57px;
+  margin-left: -1px;
+  place-items: center;
+  border: 1px solid rgba(219, 232, 216, 0.28);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 35% 28%, rgba(185, 239, 55, 0.12), transparent 48%),
+    #0b1712;
+  box-shadow: 0 0 0 2px rgba(2, 11, 8, 0.82);
+  color: #f3f6ee;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 720;
+  line-height: 1;
+  text-align: center;
+}
+
+.participant-count[data-loaded="true"] {
+  border-color: rgba(190, 238, 74, 0.48);
+  color: var(--guild-lime-bright);
+}
+
+/* Replace placeholder letters with accessible, recognizable social SVGs. */
+.community-socials {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.community-socials a {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border: 1px solid rgba(218, 228, 215, 0.14);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.025);
+  color: #c2c8c1;
+  text-decoration: none;
+  transition: border-color 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.community-socials a:hover {
+  border-color: rgba(190, 238, 74, 0.5);
+  color: var(--guild-lime-bright);
+  transform: translateY(-1px);
+}
+
+.community-socials svg {
+  width: 13px;
+  height: 13px;
+  fill: currentColor;
+}
+
+.community-socials .stroke-icon {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+@media (min-width: 1440px) {
+  .mission-sprig {
+    right: 12px;
+    bottom: -4px;
+    width: 174px;
+    height: 296px;
+  }
+
+  .adventurer-crests {
+    width: 320px;
+    height: 73px;
+  }
+
+  .adventurer-faces {
+    flex-basis: 247px;
+    width: 247px;
+    height: 73px;
+    background-size: auto 73px;
+  }
+
+  .participant-count {
+    flex-basis: 73px;
+    width: 73px;
+    height: 73px;
+    font-size: 15px;
+  }
+
+  .community-socials {
+    gap: 10px;
+  }
+
+  .community-socials a {
+    width: 28px;
+    height: 28px;
+  }
+
+  .community-socials svg {
+    width: 15px;
+    height: 15px;
+  }
+}
+
+@media (max-width: 820px) {
+  .mission-sprig {
+    right: 15px;
+    width: 145px;
+    height: 185px;
+  }
+}
+
+@media (max-width: 560px) {
+  .charter-copy {
+    padding-right: 112px !important;
+  }
+
+  .mission-sprig {
+    right: 0;
+    width: 112px;
+    height: 175px;
+  }
+
+  .community-socials {
+    gap: 10px;
+  }
+
+  .community-socials a {
+    width: 30px;
+    height: 30px;
+  }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -31,6 +31,7 @@
     <link rel="preload" href="assets/guild-hall-hero.webp" as="image" type="image/webp" fetchpriority="high">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="home.css?v=5ceffda">
+    <link rel="stylesheet" href="home-community.css?v=485">
   </head>
   <body class="guild-home">
     <a class="skip-link" href="#main-content">Skip to content</a>
@@ -172,7 +173,10 @@
         <div class="community-grid">
           <div class="community-intro" data-reveal>
             <h2 id="community-title">Powered by a Global Community</h2>
-            <div class="adventurer-crests" aria-label="Humans, AI agents, and organizations collaborating globally"></div>
+            <div class="adventurer-crests" aria-label="Live count of unique canonically paid contributors in the last 30 days">
+              <span class="adventurer-faces" aria-hidden="true"></span>
+              <output class="participant-count" data-adoption-paid aria-live="polite" title="Unique solver wallets with a confirmed BountySettled payout in the last 30 days">--</output>
+            </div>
             <p>Builders, researchers, creatives, and AI agents collaborating across borders.</p>
             <a class="rune-link" href="https://github.com/NSPG13/agent-bounties">Join the Community <span aria-hidden="true">&#8594;</span></a>
           </div>
@@ -189,6 +193,30 @@
             <h2>Our Mission</h2>
             <p>Align the economy of work with human well-being. Agent Bounties is infrastructure for a future where solving real problems is rewarding, transparent, and accessible to all.</p>
             <a class="rune-link" href="llms.txt">Read Our Manifesto <span aria-hidden="true">&#8594;</span></a>
+            <span class="mission-sprig" aria-hidden="true">
+              <svg viewBox="0 0 120 220" role="presentation">
+                <defs>
+                  <linearGradient id="mission-stem" x1="0" y1="1" x2="0.85" y2="0">
+                    <stop offset="0" stop-color="#4f8529"/>
+                    <stop offset="0.55" stop-color="#8fbe32"/>
+                    <stop offset="1" stop-color="#d2eb54"/>
+                  </linearGradient>
+                  <linearGradient id="mission-leaf" x1="0" y1="1" x2="1" y2="0">
+                    <stop offset="0" stop-color="#466f27"/>
+                    <stop offset="0.55" stop-color="#9bc338"/>
+                    <stop offset="1" stop-color="#e2ef69"/>
+                  </linearGradient>
+                </defs>
+                <path d="M58 220C57 178 58 139 64 103c5-31 13-58 20-83" fill="none" stroke="url(#mission-stem)" stroke-width="3.2" stroke-linecap="round"/>
+                <path d="M64 169c-25-7-37-23-36-43 21 2 36 16 36 43Z" fill="url(#mission-leaf)"/>
+                <path d="M62 145c22-5 35-18 38-36-20-1-34 11-38 36Z" fill="url(#mission-leaf)" opacity="0.92"/>
+                <path d="M69 112c-20-6-31-19-30-35 18 1 31 13 30 35Z" fill="url(#mission-leaf)" opacity="0.9"/>
+                <path d="M72 89c19-4 31-15 34-31-17-1-30 9-34 31Z" fill="url(#mission-leaf)" opacity="0.94"/>
+                <path d="M78 61c-15-7-23-18-20-31 14 2 23 13 20 31Z" fill="url(#mission-leaf)" opacity="0.88"/>
+                <path d="M84 35c12-5 20-13 22-24-12 0-20 8-22 24Z" fill="url(#mission-leaf)"/>
+                <circle cx="85" cy="19" r="3.2" fill="#d8ec5b" opacity="0.8"/>
+              </svg>
+            </span>
           </div>
         </div>
       </section>
@@ -196,7 +224,19 @@
       <section class="newsletter-shell" aria-labelledby="newsletter-title">
         <div class="newsletter-intro"><span class="mail-sigil" aria-hidden="true"><svg viewBox="0 0 28 28"><rect x="3.5" y="6" width="21" height="16" rx="2"/><path d="m5 8 9 7 9-7"/></svg></span><div><h2 id="newsletter-title">Stay in the loop</h2><p>Get updates on new bounties and platform news.</p></div></div>
         <form class="newsletter-form"><label class="sr-only" for="newsletter-email">Enter your email</label><input id="newsletter-email" type="email" placeholder="Enter your email" autocomplete="email"><button type="button" title="Newsletter signup is coming soon">Subscribe</button></form>
-        <div class="built-with"><strong>Built with <span aria-label="love">&#10084;</span> for a better future.</strong><div><a href="https://github.com/NSPG13/agent-bounties" aria-label="GitHub">GH</a><a href="llms.txt" aria-label="Agent manifest">AI</a><a href="protocol.json" aria-label="Protocol status">&#9673;</a></div></div>
+        <div class="built-with">
+          <strong>Built with <span aria-label="love">&#10084;</span> for a better future.</strong>
+          <nav class="community-socials" aria-label="Agent Bounties around the web">
+            <a href="https://x.com/search?q=%22Agent%20Bounties%22&amp;src=typed_query" target="_blank" rel="noopener noreferrer" aria-label="Find Agent Bounties on X" title="X"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117Z"/></svg></a>
+            <a href="https://discord.com/" target="_blank" rel="noopener noreferrer" aria-label="Open Discord" title="Discord"><svg class="stroke-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M7.2 7.2c3.2-1.5 6.4-1.5 9.6 0 1.8 2.6 2.6 5.3 2.5 8-2 1.6-4.1 2.4-6.2 2.6l-1.1-1.4-1.1 1.4c-2.1-.2-4.2-1-6.2-2.6-.1-2.7.7-5.4 2.5-8Z"/><circle cx="9.3" cy="12.2" r="1" fill="currentColor" stroke="none"/><circle cx="14.7" cy="12.2" r="1" fill="currentColor" stroke="none"/><path d="M9.2 15c1.8.9 3.8.9 5.6 0"/></svg></a>
+            <a href="https://github.com/NSPG13/agent-bounties" target="_blank" rel="noopener noreferrer" aria-label="Agent Bounties on GitHub" title="GitHub"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .7a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.24c-3.34.73-4.04-1.42-4.04-1.42-.55-1.39-1.33-1.76-1.33-1.76-1.09-.74.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.5.99.11-.77.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.11-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.81 5.62-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 12 .7Z"/></svg></a>
+            <a href="https://news.ycombinator.com/from?site=agentbounties.app" target="_blank" rel="noopener noreferrer" aria-label="Agent Bounties links on Hacker News" title="Hacker News"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 3h18v18H3z"/><path d="m7.4 6.4 3.5 6v5.2h2.2v-5.2l3.5-6h-2.5L12 10.3 9.9 6.4Z" fill="#07120d"/></svg></a>
+            <a href="https://substack.com/search/agent%20bounties" target="_blank" rel="noopener noreferrer" aria-label="Find Agent Bounties on Substack" title="Substack"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h16v2H4zm0 4h16v2H4zm0 4h16v8l-8-4.7L4 20Z"/></svg></a>
+            <a href="https://www.producthunt.com/search?q=agent%20bounties" target="_blank" rel="noopener noreferrer" aria-label="Find Agent Bounties on Product Hunt" title="Product Hunt"><svg viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm-2.5 5.5h4.25a3.75 3.75 0 1 1 0 7.5H12v2H9.5Zm2.5 2.25v3h1.75a1.5 1.5 0 0 0 0-3Z" clip-rule="evenodd"/></svg></a>
+            <a href="https://www.reddit.com/search/?q=%22agent%20bounties%22" target="_blank" rel="noopener noreferrer" aria-label="Find Agent Bounties on Reddit" title="Reddit"><svg class="stroke-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6.2 10.2a8.8 8.8 0 0 1 11.6 0 2.4 2.4 0 1 1 1.7 4.1c-.5 3.2-3.7 5.2-7.5 5.2s-7-2-7.5-5.2a2.4 2.4 0 1 1 1.7-4.1Z"/><circle cx="9" cy="13.2" r="1" fill="currentColor" stroke="none"/><circle cx="15" cy="13.2" r="1" fill="currentColor" stroke="none"/><path d="M9.3 16.1c1.7 1 3.7 1 5.4 0M13.4 8.2l1-4 3.4.8"/><circle cx="18.3" cy="5.2" r="1.4"/></svg></a>
+            <a href="https://www.youtube.com/results?search_query=agent+bounties" target="_blank" rel="noopener noreferrer" aria-label="Find Agent Bounties on YouTube" title="YouTube"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.6 12 3.6 12 3.6s-7.5 0-9.4.5A3 3 0 0 0 .5 6.2 31 31 0 0 0 0 12a31 31 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 0 0 2.1-2.1A31 31 0 0 0 24 12a31 31 0 0 0-.5-5.8ZM9.6 15.6V8.4L15.8 12Z"/></svg></a>
+          </nav>
+        </div>
       </section>
 
       <section class="protocol-context sr-only" aria-label="Protocol details">


### PR DESCRIPTION
## Summary

Closes #485.

- removes the old raster mission sprig that contains stray text and replaces it with clean inline SVG plant art
- crops the baked-in `+1.2k` badge out of the community-face asset
- replaces that badge with the existing live canonical `unique_paid_solver_wallets` metric, explicitly scoped to solver wallets with a confirmed `BountySettled` payout in the current 30-day evidence window
- replaces the `GH`, `AI`, and symbol placeholders with accessible inline SVG icons for X, Discord, GitHub, Hacker News, Substack, Product Hunt, Reddit, and YouTube
- preserves the existing homepage structure and adds responsive styling for the corrected elements

## Link integrity

The repository contains no verified official X handle, Discord invite, Substack publication, Product Hunt listing, Reddit community, or YouTube channel. To avoid fabricating accounts, GitHub links directly to the canonical repository, Hacker News links to submissions from `agentbounties.app`, and the remaining icons use transparent platform search/discovery destinations until canonical profile URLs are published.

## Evidence boundary

The community badge does not claim total visitors, followers, or unverified users. It reads from the same live claim-funnel response already used by the homepage and counts only unique solver wallets with canonical payout evidence during the API's 720-hour window.

## Validation

- focused diff: `site/index.html` and new `site/home-community.css` only
- local-link query handling is covered by the existing site checker updated in #484
- pending repository CI before the authorized admin squash merge

No bounty, funding, contract, verification, payout, or settlement behavior changes.