### PR TITLE
fix: use natural botanical art and historical community counts

### DIFF
--- a/site/guild-home.js
+++ b/site/guild-home.js
@@ -111,10 +111,10 @@
 
   /*
    * Historical community metrics replace the rolling 30-day paid-solver number.
-   * The platform registry is preferred for participants. Public GitHub history
-   * supplies a live contributor/interactor count and a non-inflating fallback.
+   * The sources are independently deduplicated and are never added together,
+   * because doing so could count the same person or agent twice.
    */
-  const COMMUNITY_CACHE_KEY = "agent-bounties-community-metrics-v2";
+  const COMMUNITY_CACHE_KEY = "agent-bounties-community-metrics-v3";
   const COMMUNITY_CACHE_MS = 60 * 60 * 1_000;
   const COMMUNITY_REFRESH_MS = 30 * 60 * 1_000;
   const GITHUB_PAGE_SIZE = 100;
@@ -274,26 +274,28 @@
   }
 
   function renderCommunityMetrics(metrics) {
-    const contributorTitle = metrics.githubComplete
-      ? "Distinct historical public contributors found across repository commits, issues, pull requests, and comments."
-      : "Distinct historical public contributors found in the available repository history; unavailable sources were not estimated.";
-    const participantTitle = metrics.platformParticipants !== null
+    const contributorTitle = metrics.contributorSource === "github-public-history"
+      ? metrics.githubComplete
+        ? "Distinct historical public contributors found across repository commits, issues, pull requests, and comments."
+        : "Distinct historical public contributors found in the available repository history; unavailable sources were not estimated."
+      : "Historical public participants recorded by the platform audience registry; repository contributor history was temporarily unavailable.";
+    const participantTitle = metrics.participantSource === "platform-audience-registry"
       ? "Historical public participants recorded by the Agent Bounties audience registry."
       : metrics.githubComplete
-        ? "Historical public repository participants, including contributors and stargazers; the platform aggregate is temporarily unavailable."
+        ? "Historical public repository participants, including contributors and stargazers."
         : "Historical public participants found in the available repository records; unavailable sources were not estimated.";
 
     displayHistoricalCount(
       "[data-community-contributors]",
       metrics.contributors,
       contributorTitle,
-      "github-public-history",
+      metrics.contributorSource,
     );
     displayHistoricalCount(
       "[data-community-participants]",
       metrics.participants,
       participantTitle,
-      metrics.platformParticipants !== null ? "platform-audience-registry" : "github-public-history",
+      metrics.participantSource,
     );
 
     const crests = document.querySelector(".adventurer-crests");
@@ -340,16 +342,45 @@
     const github = githubResult.status === "fulfilled"
       ? githubResult.value
       : { contributors: null, participants: null, complete: false };
-    const contributors = Number.isSafeInteger(github.contributors)
+    const githubContributors = Number.isSafeInteger(github.contributors)
       ? github.contributors
+      : null;
+    const githubParticipants = Number.isSafeInteger(github.participants)
+      ? github.participants
+      : null;
+
+    const contributors = githubContributors !== null
+      ? githubContributors
       : platformParticipants;
-    const participants = Number.isSafeInteger(platformParticipants)
-      ? platformParticipants
-      : github.participants;
+    const contributorSource = githubContributors !== null
+      ? "github-public-history"
+      : platformParticipants !== null
+        ? "platform-audience-registry"
+        : "unavailable";
+
+    let participants = null;
+    let participantSource = "unavailable";
+    if (platformParticipants !== null && githubParticipants !== null) {
+      if (platformParticipants >= githubParticipants) {
+        participants = platformParticipants;
+        participantSource = "platform-audience-registry";
+      } else {
+        participants = githubParticipants;
+        participantSource = "github-public-history";
+      }
+    } else if (platformParticipants !== null) {
+      participants = platformParticipants;
+      participantSource = "platform-audience-registry";
+    } else if (githubParticipants !== null) {
+      participants = githubParticipants;
+      participantSource = "github-public-history";
+    }
+
     const metrics = {
       contributors,
       participants,
-      platformParticipants,
+      contributorSource,
+      participantSource,
       githubComplete: github.complete,
     };
     if (Number.isSafeInteger(contributors) && Number.isSafeInteger(participants)) {

--- a/site/guild-home.js
+++ b/site/guild-home.js
@@ -109,5 +109,262 @@
     window.addEventListener("scroll", scheduleDepth, { passive: true });
   }
 
+  /*
+   * Historical community metrics replace the rolling 30-day paid-solver number.
+   * The platform registry is preferred for participants. Public GitHub history
+   * supplies a live contributor/interactor count and a non-inflating fallback.
+   */
+  const COMMUNITY_CACHE_KEY = "agent-bounties-community-metrics-v2";
+  const COMMUNITY_CACHE_MS = 60 * 60 * 1_000;
+  const COMMUNITY_REFRESH_MS = 30 * 60 * 1_000;
+  const GITHUB_PAGE_SIZE = 100;
+  const GITHUB_MAX_PAGES = 10;
+  const GITHUB_API = "https://api.github.com/repos/NSPG13/agent-bounties";
+
+  function prepareCommunityPresentation() {
+    const participantOutput = document.querySelector(".participant-count");
+    const oldPaidOutputs = Array.from(document.querySelectorAll("[data-adoption-paid]"));
+    oldPaidOutputs.forEach((output) => output.removeAttribute("data-adoption-paid"));
+
+    if (participantOutput) {
+      participantOutput.dataset.communityParticipants = "";
+      participantOutput.textContent = "--";
+      participantOutput.title = "Loading the historical public participant count.";
+      const crests = participantOutput.closest(".adventurer-crests");
+      if (crests) {
+        crests.setAttribute("aria-label", "Historical public participants recorded by Agent Bounties");
+      }
+    }
+
+    oldPaidOutputs
+      .filter((output) => output !== participantOutput)
+      .forEach((output) => {
+        output.dataset.communityContributors = "";
+        output.textContent = "--";
+        output.title = "Loading the historical contributor count.";
+      });
+
+    const worldContributorRow = document.querySelector(".world-ledger dl > div:last-child");
+    if (worldContributorRow) {
+      const label = worldContributorRow.querySelector("dt");
+      const detail = worldContributorRow.querySelector("dd span");
+      if (label) label.textContent = "Contributors";
+      if (detail) detail.textContent = "historical public project contributors";
+    }
+
+    const impactContributorLabel = document.querySelector(".impact-ledger li:last-child small");
+    if (impactContributorLabel) impactContributorLabel.textContent = "Contributors";
+
+    const communityStylesheet = document.querySelector('link[href^="home-community.css"]');
+    if (communityStylesheet) communityStylesheet.href = "home-community.css?v=489";
+
+    const missionSprig = document.querySelector(".mission-sprig");
+    const charter = missionSprig && missionSprig.closest(".charter-copy");
+    if (missionSprig) {
+      missionSprig.title = "Quercus alba botanical plate, 1819, public domain";
+    }
+    if (charter && !charter.querySelector(".botanical-credit")) {
+      const credit = document.createElement("a");
+      credit.className = "botanical-credit";
+      credit.href = "https://commons.wikimedia.org/wiki/File:NAS-001_Quercus_alba.png";
+      credit.target = "_blank";
+      credit.rel = "noopener noreferrer";
+      credit.textContent = "Quercus alba, 1819 · public domain";
+      credit.setAttribute("aria-label", "Botanical artwork source: Quercus alba, 1819, public domain on Wikimedia Commons");
+      charter.append(credit);
+    }
+  }
+
+  function publicActorKey(actor) {
+    if (!actor || typeof actor !== "object") return null;
+    if (actor.id !== undefined && actor.id !== null) return `id:${actor.id}`;
+    if (actor.login) return `login:${String(actor.login).toLowerCase()}`;
+    if (actor.name || actor.email) {
+      return `anonymous:${String(actor.name || "").toLowerCase()}:${String(actor.email || "").toLowerCase()}`;
+    }
+    return null;
+  }
+
+  async function collectGithubPages(path, onItem) {
+    let completed = false;
+    for (let page = 1; page <= GITHUB_MAX_PAGES; page += 1) {
+      const joiner = path.includes("?") ? "&" : "?";
+      const response = await fetch(
+        `${GITHUB_API}${path}${joiner}per_page=${GITHUB_PAGE_SIZE}&page=${page}`,
+        {
+          cache: "no-store",
+          headers: { Accept: "application/vnd.github+json" },
+        },
+      );
+      if (!response.ok) throw new Error(`GitHub community request failed (${response.status}).`);
+      const items = await response.json();
+      if (!Array.isArray(items)) throw new Error("GitHub community response is malformed.");
+      items.forEach(onItem);
+      if (items.length < GITHUB_PAGE_SIZE) {
+        completed = true;
+        break;
+      }
+    }
+    return completed;
+  }
+
+  async function loadGithubCommunityMetrics() {
+    const contributors = new Set();
+    const participants = new Set();
+    const addContributor = (actor) => {
+      const key = publicActorKey(actor);
+      if (!key) return;
+      contributors.add(key);
+      participants.add(key);
+    };
+    const addParticipant = (actor) => {
+      const key = publicActorKey(actor);
+      if (key) participants.add(key);
+    };
+
+    const requests = await Promise.allSettled([
+      collectGithubPages("/contributors?anon=true", addContributor),
+      collectGithubPages("/issues?state=all", (item) => addContributor(item.user)),
+      collectGithubPages("/issues/comments", (item) => addContributor(item.user)),
+      collectGithubPages("/pulls/comments", (item) => addContributor(item.user)),
+      collectGithubPages("/stargazers", addParticipant),
+    ]);
+    const successfulSources = requests.filter((request) => request.status === "fulfilled").length;
+    if (!successfulSources || !participants.size) {
+      throw new Error("No public GitHub community source was available.");
+    }
+    return {
+      contributors: contributors.size || null,
+      participants: participants.size,
+      complete: requests.every(
+        (request) => request.status === "fulfilled" && request.value === true,
+      ),
+    };
+  }
+
+  async function loadPlatformParticipantCount() {
+    const protocolResponse = await fetch("protocol.json", { cache: "no-store" });
+    if (!protocolResponse.ok) throw new Error("Protocol configuration is unavailable.");
+    const protocol = await protocolResponse.json();
+    const api = String(protocol.api_base_url || "").replace(/\/$/, "");
+    if (!api) throw new Error("Hosted API URL is unavailable.");
+    const response = await fetch(`${api}/v1/audience/report`, { cache: "no-store" });
+    if (!response.ok) throw new Error(`Historical participant registry is unavailable (${response.status}).`);
+    const report = await response.json();
+    const total = Number(report.total_members);
+    if (!Number.isSafeInteger(total) || total < 0) {
+      throw new Error("Historical participant registry returned an invalid count.");
+    }
+    return total;
+  }
+
+  function displayHistoricalCount(selector, count, title, source) {
+    document.querySelectorAll(selector).forEach((output) => {
+      if (!Number.isSafeInteger(count) || count < 0) {
+        output.textContent = "--";
+        output.removeAttribute("data-loaded");
+        output.title = "Historical count is temporarily unavailable; no estimate is shown.";
+        return;
+      }
+      output.textContent = count.toLocaleString();
+      output.dataset.loaded = "true";
+      output.dataset.metricSource = source;
+      output.title = title;
+    });
+  }
+
+  function renderCommunityMetrics(metrics) {
+    const contributorTitle = metrics.githubComplete
+      ? "Distinct historical public contributors found across repository commits, issues, pull requests, and comments."
+      : "Distinct historical public contributors found in the available repository history; unavailable sources were not estimated.";
+    const participantTitle = metrics.platformParticipants !== null
+      ? "Historical public participants recorded by the Agent Bounties audience registry."
+      : metrics.githubComplete
+        ? "Historical public repository participants, including contributors and stargazers; the platform aggregate is temporarily unavailable."
+        : "Historical public participants found in the available repository records; unavailable sources were not estimated.";
+
+    displayHistoricalCount(
+      "[data-community-contributors]",
+      metrics.contributors,
+      contributorTitle,
+      "github-public-history",
+    );
+    displayHistoricalCount(
+      "[data-community-participants]",
+      metrics.participants,
+      participantTitle,
+      metrics.platformParticipants !== null ? "platform-audience-registry" : "github-public-history",
+    );
+
+    const crests = document.querySelector(".adventurer-crests");
+    if (crests && Number.isSafeInteger(metrics.participants)) {
+      crests.setAttribute(
+        "aria-label",
+        `${metrics.participants.toLocaleString()} historical public participants`,
+      );
+    }
+  }
+
+  function readCachedCommunityMetrics() {
+    try {
+      const cached = JSON.parse(window.localStorage.getItem(COMMUNITY_CACHE_KEY) || "null");
+      if (!cached || Date.now() - Number(cached.cachedAt) > COMMUNITY_CACHE_MS) return null;
+      if (!Number.isSafeInteger(cached.contributors) || !Number.isSafeInteger(cached.participants)) {
+        return null;
+      }
+      return cached;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function cacheCommunityMetrics(metrics) {
+    try {
+      window.localStorage.setItem(
+        COMMUNITY_CACHE_KEY,
+        JSON.stringify({ ...metrics, cachedAt: Date.now() }),
+      );
+    } catch (_error) {
+      // Metrics remain functional when storage is disabled.
+    }
+  }
+
+  async function refreshCommunityMetrics() {
+    const [platformResult, githubResult] = await Promise.allSettled([
+      loadPlatformParticipantCount(),
+      loadGithubCommunityMetrics(),
+    ]);
+    const platformParticipants = platformResult.status === "fulfilled"
+      ? platformResult.value
+      : null;
+    const github = githubResult.status === "fulfilled"
+      ? githubResult.value
+      : { contributors: null, participants: null, complete: false };
+    const contributors = Number.isSafeInteger(github.contributors)
+      ? github.contributors
+      : platformParticipants;
+    const participants = Number.isSafeInteger(platformParticipants)
+      ? platformParticipants
+      : github.participants;
+    const metrics = {
+      contributors,
+      participants,
+      platformParticipants,
+      githubComplete: github.complete,
+    };
+    if (Number.isSafeInteger(contributors) && Number.isSafeInteger(participants)) {
+      cacheCommunityMetrics(metrics);
+    }
+    renderCommunityMetrics(metrics);
+  }
+
+  prepareCommunityPresentation();
+  const cachedCommunityMetrics = readCachedCommunityMetrics();
+  if (cachedCommunityMetrics) renderCommunityMetrics(cachedCommunityMetrics);
+  refreshCommunityMetrics();
+  window.setInterval(() => {
+    if (!document.hidden) refreshCommunityMetrics();
+  }, COMMUNITY_REFRESH_MS);
+
   root.classList.add("guild-home-ready");
 }());

--- a/site/home-community.css
+++ b/site/home-community.css
@@ -1,6 +1,6 @@
-/* Focused homepage community corrections for issue #485. */
+/* Focused homepage community corrections for issues #485 and #489. */
 
-/* The original raster sprig includes stray text. Replace it with clean inline SVG art. */
+/* Remove the old raster sprig and render a real public-domain botanical plate. */
 .community-shell::after {
   content: none;
   background: none;
@@ -13,7 +13,7 @@
 
 .charter-copy > :not(.mission-sprig) {
   position: relative;
-  z-index: 1;
+  z-index: 2;
 }
 
 .mission-sprig {
@@ -23,16 +23,61 @@
   bottom: -7px;
   width: 126px;
   height: 218px;
-  opacity: 0.82;
-  filter: drop-shadow(0 0 18px rgba(171, 232, 65, 0.12));
+  overflow: hidden;
+  border-radius: 0 0 15px 0;
+  opacity: 0.86;
+  filter: drop-shadow(0 0 20px rgba(171, 232, 65, 0.1));
+  pointer-events: none;
+}
+
+/*
+ * Quercus alba botanical plate, 1819, Pierre-Joseph Redouté.
+ * Public domain source: Wikimedia Commons, File:NAS-001 Quercus alba.png.
+ * Inversion plus screen blending removes the paper field while retaining the
+ * natural engraved leaf and branch detail against the dark solarpunk panel.
+ */
+.mission-sprig::before {
+  content: "";
+  position: absolute;
+  inset: -7% -22% -6% -30%;
+  background: url("https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/NAS-001_Quercus_alba.png/500px-NAS-001_Quercus_alba.png") 55% 38% / cover no-repeat;
+  filter: invert(1) sepia(1) saturate(2.2) hue-rotate(34deg) brightness(0.8) contrast(1.22);
+  mix-blend-mode: screen;
+  opacity: 0.78;
+  transform: rotate(-1.5deg) scale(1.02);
+  transform-origin: 55% 100%;
+}
+
+.mission-sprig::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(5, 14, 10, 0.96), transparent 34%),
+    linear-gradient(180deg, rgba(5, 14, 10, 0.12), transparent 42%, rgba(5, 14, 10, 0.22));
   pointer-events: none;
 }
 
 .mission-sprig svg {
-  display: block;
-  width: 100%;
-  height: 100%;
-  overflow: visible;
+  display: none;
+}
+
+.botanical-credit {
+  position: absolute !important;
+  z-index: 3 !important;
+  right: 10px;
+  bottom: 8px;
+  max-width: 115px;
+  color: rgba(222, 231, 218, 0.54) !important;
+  font-size: 6px;
+  line-height: 1.25;
+  text-align: right;
+  text-decoration: none;
+}
+
+.botanical-credit:hover,
+.botanical-credit:focus-visible {
+  color: var(--guild-lime-bright) !important;
 }
 
 /* Crop the obsolete +1.2k badge out of the face asset and replace it with live data. */
@@ -132,6 +177,13 @@
     height: 296px;
   }
 
+  .botanical-credit {
+    right: 17px;
+    bottom: 11px;
+    max-width: 150px;
+    font-size: 7px;
+  }
+
   .adventurer-crests {
     width: 320px;
     height: 73px;
@@ -183,6 +235,13 @@
     right: 0;
     width: 112px;
     height: 175px;
+  }
+
+  .botanical-credit {
+    right: 5px;
+    bottom: 6px;
+    max-width: 94px;
+    font-size: 5.5px;
   }
 
   .community-socials {


### PR DESCRIPTION
## Summary

Closes #489.

- replaces the synthetic mission sprig with a natural 1819 *Quercus alba* botanical plate by Pierre-Joseph Redouté
- uses the public-domain Wikimedia Commons scan as the source and adds an on-page attribution link
- removes the homepage community counters from the rolling 30-day `unique_paid_solver_wallets` metric
- renames **Active Contributors** to **Contributors**
- reads the platform's all-time audience registry and independently deduplicated public repository history
- derives repository contributors from commits, issues, pull requests, and comments
- includes stargazers only in the broader public-participant source, never in the contributor count
- selects the larger independently deduplicated participant source without adding sources together, preventing both the previous undercount and cross-source double-counting
- shows `--` instead of inventing a count when no historical source is available
- refreshes the community metrics and cache-busts the corrected community stylesheet at runtime

## Metric boundaries

The participant sources are never added together because the same person or agent may exist in both. The displayed participant count is the larger independently deduplicated historical source: the platform audience registry or the public repository community record. The contributor count uses public repository contribution and interaction history, with the platform registry only as an honest fallback if GitHub is unavailable.

GitHub pagination is bounded to 1,000 records per source. When a source cannot be completely read, the UI labels the number as derived from the available records and does not estimate missing participants.

The old count of five represented only distinct solver wallets with a confirmed `BountySettled` event in a rolling 720-hour window. It was valid for that narrow payment cohort, but incorrect as a historical project-community count.

## Botanical source

- Artwork: *Quercus alba*, 1819
- Artist: Pierre-Joseph Redouté
- Source: Wikimedia Commons, `File:NAS-001 Quercus alba.png`
- Rights: public domain

## Scope

Only `site/guild-home.js` and `site/home-community.css` change. No bounty, funding, contract, verification, payout, or settlement behavior changes.

## Validation

- Pages validation: pass
- dependency review: pass
- code-size report: pass
- recovery contract: pass
- ruleset drift: pass
- Postgres sync: pass
- repository-wide full check: still running

After validation, this PR will use the explicitly authorized admin squash merge path.