### PR TITLE
fix: restore homepage wallet connection

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,7 @@ on:
       - "site/**"
       - "scripts/check-site.py"
       - "scripts/test-homepage-wallet-wiring.py"
+      - "scripts/test-homepage-wallet-flow.js"
   push:
     branches: [main]
     paths:
@@ -16,6 +17,7 @@ on:
       - "site/**"
       - "scripts/check-site.py"
       - "scripts/test-homepage-wallet-wiring.py"
+      - "scripts/test-homepage-wallet-flow.js"
   workflow_dispatch:
 
 permissions:
@@ -35,8 +37,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
       - run: python scripts/check-site.py
       - run: python scripts/test-homepage-wallet-wiring.py
+      - run: node scripts/test-homepage-wallet-flow.js
 
   deploy:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
       - "deployments/bounded-agent-wallet-base-mainnet.json"
       - "site/**"
       - "scripts/check-site.py"
+      - "scripts/test-homepage-wallet-wiring.py"
   push:
     branches: [main]
     paths:
@@ -14,6 +15,7 @@ on:
       - "deployments/bounded-agent-wallet-base-mainnet.json"
       - "site/**"
       - "scripts/check-site.py"
+      - "scripts/test-homepage-wallet-wiring.py"
   workflow_dispatch:
 
 permissions:
@@ -34,6 +36,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: python scripts/check-site.py
+      - run: python scripts/test-homepage-wallet-wiring.py
 
   deploy:
     if: github.event_name != 'pull_request'

--- a/scripts/test-homepage-wallet-flow.js
+++ b/scripts/test-homepage-wallet-flow.js
@@ -1,0 +1,136 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const listeners = new Map();
+const walletCalls = [];
+
+function addListener(target, type, listener) {
+  const key = `${target}:${type}`;
+  const existing = listeners.get(key) || [];
+  existing.push(listener);
+  listeners.set(key, existing);
+}
+
+const provider = {
+  request: async ({ method }) => {
+    walletCalls.push(method);
+    if (method === "eth_requestAccounts") return ["0x1111111111111111111111111111111111111111"];
+    if (method === "eth_chainId") return "0x2105";
+    throw new Error(`Unexpected wallet method: ${method}`);
+  },
+  isMetaMask: true,
+};
+
+const output = { textContent: "", dataset: {} };
+const selector = {
+  value: "0",
+  disabled: false,
+  options: [],
+  addEventListener(type, listener) {
+    addListener("selector", type, listener);
+  },
+  append(option) {
+    this.options.push(option);
+  },
+  replaceChildren(...options) {
+    this.options = options;
+    const selectedIndex = Math.max(0, options.findIndex((option) => option.selected));
+    this.value = options[selectedIndex] ? options[selectedIndex].value : "0";
+  },
+  closest() {
+    return null;
+  },
+};
+
+const button = {
+  dataset: { output: "wallet-status" },
+  addEventListener(type, listener) {
+    addListener("button", type, listener);
+  },
+  closest() {
+    return null;
+  },
+};
+
+const documentListeners = new Map();
+const document = {
+  id: undefined,
+  addEventListener(type, listener) {
+    documentListeners.set(type, listener);
+  },
+  createElement(tag) {
+    if (tag !== "option") throw new Error(`Unexpected element creation: ${tag}`);
+    return { value: "", textContent: "", selected: false };
+  },
+  getElementById(id) {
+    return id === "wallet-status" ? output : null;
+  },
+  querySelector(selectorText) {
+    if (selectorText === "[data-wallet-provider]") return selector;
+    return null;
+  },
+  querySelectorAll(selectorText) {
+    if (selectorText === "[data-connect-wallet]") return [button];
+    if (selectorText === "[data-wallet-provider]") return [selector];
+    return [];
+  },
+};
+
+global.document = document;
+global.window = {
+  ethereum: provider,
+  addEventListener(type, listener) {
+    addListener("window", type, listener);
+  },
+  dispatchEvent(event) {
+    for (const listener of listeners.get(`window:${event.type}`) || []) listener(event);
+    return true;
+  },
+};
+global.fetch = async (url) => {
+  if (url !== "protocol.json") throw new Error(`Unexpected fetch: ${url}`);
+  return {
+    ok: true,
+    async json() {
+      return {
+        status: "active",
+        chain_id_hex: "0x2105",
+        api_base_url: "https://api.agentbounties.app",
+      };
+    },
+  };
+};
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "site", "autonomous.js"),
+  "utf8",
+);
+vm.runInThisContext(source, { filename: "site/autonomous.js" });
+
+(async () => {
+  const initialize = documentListeners.get("DOMContentLoaded");
+  if (!initialize) throw new Error("wallet controller did not register DOMContentLoaded initialization");
+  await initialize();
+
+  const click = (listeners.get("button:click") || [])[0];
+  if (!click) throw new Error("homepage Connect Wallet button did not receive a click handler");
+  await click();
+
+  if (!walletCalls.includes("eth_requestAccounts")) {
+    throw new Error("homepage click never requested wallet accounts");
+  }
+  if (!walletCalls.includes("eth_chainId")) {
+    throw new Error("homepage click never verified the Base chain");
+  }
+  if (!output.textContent.startsWith("Connected: 0x1111")) {
+    throw new Error(`homepage did not report a connected account: ${output.textContent}`);
+  }
+
+  console.log("homepage Connect Wallet click reaches the injected provider");
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/test-homepage-wallet-wiring.py
+++ b/scripts/test-homepage-wallet-wiring.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+repo_root = Path(__file__).resolve().parents[1]
+index_html = (repo_root / "site" / "index.html").read_text(encoding="utf-8")
+autonomous_js = (repo_root / "site" / "autonomous.js").read_text(encoding="utf-8")
+
+if index_html.count("data-connect-wallet") != 1:
+    raise SystemExit("homepage must expose exactly one Connect Wallet control")
+
+if index_html.count("data-wallet-provider") != 1:
+    raise SystemExit(
+        "homepage Connect Wallet requires exactly one provider selector for the shared wallet controller"
+    )
+
+provider_markup = index_html[index_html.index("data-wallet-provider") - 80 : index_html.index("data-wallet-provider") + 160]
+if "hidden" not in provider_markup:
+    raise SystemExit("homepage provider selector must remain hidden from the streamlined navigation")
+
+for required in ("discoverProviders()", "selectProvider(context)", 'walletRequest("eth_requestAccounts")'):
+    if required not in autonomous_js:
+        raise SystemExit(f"shared wallet controller missing required wiring: {required}")
+
+print("homepage wallet wiring is valid")

--- a/site/index.html
+++ b/site/index.html
@@ -73,6 +73,7 @@
         <a class="network-chip" href="protocol.json" aria-label="View Base protocol status">
           <span class="base-rune" aria-hidden="true"></span><span>Base</span><span aria-hidden="true">&#8964;</span>
         </a>
+        <select data-wallet-provider hidden aria-label="Wallet provider"><option>Detecting browser wallets</option></select>
         <button class="wallet-button" type="button" data-connect-wallet data-output="wallet-status">Connect Wallet</button>
         <output id="wallet-status" class="wallet-status" aria-live="polite"></output>
         <a class="round-menu" href="llms.txt" aria-label="Open agent resources"><span></span><span></span><span></span></a>


### PR DESCRIPTION
Closes #491.

## What changed
- Added the hidden provider selector required by the shared EIP-6963/EIP-1193 wallet controller on the streamlined homepage.
- Added a focused structural regression for the homepage wallet wiring.
- Added an offline click-path regression that executes the real wallet controller against a mocked injected wallet and verifies account access plus the Base chain check.
- Added both regressions to the Pages validation workflow and its path filters.

## Root cause
The homepage exposed `data-connect-wallet` but omitted `data-wallet-provider`. The shared `selectProvider(context)` therefore parsed no provider index and threw before calling `eth_requestAccounts`, even when an injected wallet had been discovered.

## Validation
- Production change is limited to one hidden homepage provider selector.
- The structural regression requires the provider selector and shared controller wiring.
- The click-path regression requires the homepage button to reach `eth_requestAccounts`, verify `eth_chainId`, and render the connected account.
- Pages validation must pass before deployment.
- After merge, the Pages workflow deploys the exact `main` revision and the live homepage is checked for the deployed wiring.