### PR TITLE
feat: unify interior pages with guild design

### DIFF
--- a/site/analytics-config.js
+++ b/site/analytics-config.js
@@ -1,3 +1,36 @@
 window.agentBountiesAnalyticsConfig = Object.freeze({
   googleMeasurementId: "",
 });
+
+(() => {
+  "use strict";
+
+  const loadGuildShell = () => {
+    const body = document.body;
+    if (!body || body.classList.contains("guild-home")) return;
+
+    body.classList.add("guild-interior");
+    const source = document.currentScript && document.currentScript.src
+      ? document.currentScript.src
+      : window.location.href;
+    const base = new URL(".", source);
+
+    if (!document.querySelector('link[data-guild-pages="true"]')) {
+      const stylesheet = document.createElement("link");
+      stylesheet.rel = "stylesheet";
+      stylesheet.href = new URL("guild-pages.css?v=20260721", base).href;
+      stylesheet.dataset.guildPages = "true";
+      document.head.appendChild(stylesheet);
+    }
+
+    if (!document.querySelector('script[data-guild-shell="true"]')) {
+      const script = document.createElement("script");
+      script.src = new URL("guild-shell.js?v=20260721", base).href;
+      script.dataset.guildShell = "true";
+      document.head.appendChild(script);
+    }
+  };
+
+  if (document.body) loadGuildShell();
+  else document.addEventListener("DOMContentLoaded", loadGuildShell, { once: true });
+})();

--- a/site/cancel.html
+++ b/site/cancel.html
@@ -16,5 +16,6 @@
       <p>No Checkout payment was completed. You can return to the funding page and create a new Checkout session when ready.</p>
       <p><a class="button primary" href="funding.html">Back to funding</a></p>
     </main>
+    <script src="analytics-config.js"></script>
   </body>
 </html>

--- a/site/cancel.html
+++ b/site/cancel.html
@@ -8,6 +8,7 @@
     <meta name="description" content="Stripe Checkout was canceled before payment completion. No bounty funding is credited.">
     <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="guild-pages.css?v=20260721">
   </head>
   <body>
     <main class="policy">
@@ -16,6 +17,6 @@
       <p>No Checkout payment was completed. You can return to the funding page and create a new Checkout session when ready.</p>
       <p><a class="button primary" href="funding.html">Back to funding</a></p>
     </main>
-    <script src="analytics-config.js"></script>
+    <script src="guild-shell.js?v=20260721"></script>
   </body>
 </html>

--- a/site/chatgpt-post-widget.html
+++ b/site/chatgpt-post-widget.html
@@ -8,23 +8,54 @@
     <meta name="description" content="Review a prepared Agent Bounties post before opening the wallet flow.">
     <meta name="robots" content="noindex,nofollow">
     <style>
-      :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
-      body { margin: 0; padding: 14px; background: transparent; color: CanvasText; }
-      .card { border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); border-radius: 16px; padding: 16px; background: color-mix(in srgb, Canvas 96%, CanvasText 4%); }
-      .eyebrow { margin: 0 0 6px; color: #59724d; font-size: 12px; font-weight: 750; letter-spacing: .08em; text-transform: uppercase; }
-      h2 { margin: 0; font-size: 19px; line-height: 1.25; }
-      .goal { margin: 8px 0 12px; line-height: 1.45; }
-      ul { margin: 0 0 14px; padding-left: 20px; }
+      :root {
+        color-scheme: dark;
+        --night: #020b08;
+        --panel: #091710;
+        --panel-soft: #0d2117;
+        --line: rgba(181, 226, 70, .28);
+        --lime: #b9ef37;
+        --lime-bright: #ceff48;
+        --mint: #18d9ac;
+        --gold: #e8bd26;
+        --text: #f6f7ef;
+        --muted: #b9c0b8;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; padding: 14px; background: transparent; color: var(--text); }
+      .card {
+        position: relative;
+        overflow: hidden;
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        padding: 18px;
+        background:
+          radial-gradient(circle at 96% 0, rgba(185, 239, 55, .12), transparent 12rem),
+          linear-gradient(145deg, rgba(13, 33, 23, .98), rgba(4, 16, 10, .98));
+        box-shadow: 0 20px 50px rgba(0, 0, 0, .28);
+      }
+      .card::after { content: "✦"; position: absolute; right: 14px; top: 8px; color: rgba(206, 255, 72, .28); font-size: 20px; }
+      .eyebrow { display: flex; align-items: center; gap: 7px; margin: 0 0 7px; color: var(--lime-bright); font-size: 11px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+      .eyebrow::before { content: ""; width: 9px; height: 9px; border: 1px solid currentColor; border-radius: 70% 30% 70% 30%; transform: rotate(-18deg); }
+      h2 { margin: 0; max-width: calc(100% - 28px); color: var(--text); font-size: 21px; line-height: 1.2; letter-spacing: -.03em; }
+      .goal { margin: 9px 0 13px; color: var(--muted); line-height: 1.48; }
+      ul { margin: 0 0 14px; padding-left: 20px; color: var(--muted); }
       li + li { margin-top: 5px; }
-      .economics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin: 12px 0; }
-      .metric { border-radius: 10px; padding: 9px; background: color-mix(in srgb, CanvasText 7%, transparent); }
-      .metric span { display: block; font-size: 11px; opacity: .7; }
-      .metric strong { display: block; margin-top: 3px; font-size: 14px; }
-      .notice { margin: 12px 0; padding: 10px; border-left: 3px solid #d7a527; background: color-mix(in srgb, #d7a527 12%, transparent); font-size: 13px; line-height: 1.4; }
-      button { width: 100%; border: 0; border-radius: 999px; padding: 11px 16px; background: #315f2c; color: white; font: inherit; font-weight: 750; cursor: pointer; }
-      button:disabled { cursor: not-allowed; opacity: .55; }
-      .fine { margin: 9px 0 0; font-size: 12px; opacity: .72; line-height: 1.35; }
+      li::marker { color: var(--lime); }
+      .economics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin: 13px 0; }
+      .metric { min-width: 0; border: 1px solid rgba(181, 226, 70, .14); border-radius: 12px; padding: 10px; background: rgba(1, 10, 6, .55); }
+      .metric span { display: block; color: var(--muted); font-size: 10px; line-height: 1.25; }
+      .metric strong { display: block; margin-top: 4px; color: var(--text); font-size: 14px; overflow-wrap: anywhere; }
+      .notice { margin: 13px 0; padding: 11px 12px; border: 1px solid rgba(232, 189, 38, .25); border-left: 3px solid var(--gold); border-radius: 0 11px 11px 0; background: rgba(97, 68, 5, .18); color: #f0ddb0; font-size: 13px; line-height: 1.43; }
+      button { width: 100%; min-height: 43px; border: 1px solid rgba(205, 255, 75, .82); border-radius: 999px; padding: 10px 16px; background: linear-gradient(110deg, #9fd020, #caf04b); color: #081006; box-shadow: 0 9px 24px rgba(185, 239, 55, .15); font: inherit; font-size: 13px; font-weight: 820; cursor: pointer; transition: transform 150ms ease, box-shadow 150ms ease; }
+      button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 12px 30px rgba(185, 239, 55, .22); }
+      button:focus-visible { outline: 2px solid var(--lime-bright); outline-offset: 3px; }
+      button:disabled { border-color: rgba(224, 238, 221, .12); background: rgba(89, 103, 94, .18); color: #829087; box-shadow: none; cursor: not-allowed; }
+      .fine { margin: 10px 0 0; color: var(--muted); font-size: 12px; line-height: 1.38; }
       [hidden] { display: none !important; }
+      @media (max-width: 430px) { .economics { grid-template-columns: 1fr; } }
+      @media (prefers-reduced-motion: reduce) { button { transition: none; } }
     </style>
   </head>
   <body>

--- a/site/guild-pages.css
+++ b/site/guild-pages.css
@@ -1,0 +1,1053 @@
+:root {
+  --guild-night: #020b08;
+  --guild-night-soft: #07140f;
+  --guild-panel: rgba(8, 22, 15, 0.92);
+  --guild-panel-soft: rgba(12, 31, 22, 0.82);
+  --guild-panel-solid: #091710;
+  --guild-line: rgba(181, 226, 70, 0.25);
+  --guild-line-strong: rgba(190, 238, 74, 0.58);
+  --guild-lime: #b9ef37;
+  --guild-lime-bright: #ceff48;
+  --guild-mint: #18d9ac;
+  --guild-gold: #e8bd26;
+  --guild-text: #f6f7ef;
+  --guild-muted: #b9c0b8;
+  --guild-dim: #829087;
+  --guild-danger: #ff8f7d;
+  --guild-warning: #ffd172;
+  --guild-serif: Georgia, "Times New Roman", serif;
+  --guild-shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+}
+
+html:has(body.guild-interior) {
+  background: var(--guild-night);
+}
+
+body.guild-interior {
+  position: relative;
+  isolation: isolate;
+  min-width: 320px;
+  min-height: 100svh;
+  margin: 0;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at 82% 8%, rgba(69, 141, 73, 0.16), transparent 26rem),
+    radial-gradient(circle at 10% 38%, rgba(24, 217, 172, 0.08), transparent 31rem),
+    linear-gradient(180deg, #020b08 0%, #04120c 48%, #020b08 100%);
+  color: var(--guild-text);
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body.guild-interior::before,
+body.guild-interior::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+}
+
+body.guild-interior::before {
+  background-image:
+    linear-gradient(rgba(190, 238, 74, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(190, 238, 74, 0.025) 1px, transparent 1px);
+  background-size: 42px 42px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.7), transparent 72%);
+}
+
+body.guild-interior::after {
+  z-index: -1;
+  background:
+    radial-gradient(circle at 50% -12%, transparent 0 18rem, rgba(185, 239, 55, 0.035) 18.1rem 18.2rem, transparent 18.3rem),
+    linear-gradient(180deg, transparent 72%, rgba(0, 0, 0, 0.28));
+}
+
+body.guild-interior::selection {
+  background: var(--guild-lime);
+  color: #081109;
+}
+
+body.guild-interior a {
+  color: inherit;
+}
+
+body.guild-interior a:focus-visible,
+body.guild-interior button:focus-visible,
+body.guild-interior input:focus-visible,
+body.guild-interior textarea:focus-visible,
+body.guild-interior select:focus-visible,
+body.guild-interior summary:focus-visible {
+  outline: 2px solid var(--guild-lime-bright);
+  outline-offset: 3px;
+}
+
+body.guild-interior .topbar {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  display: grid;
+  grid-template-columns: minmax(168px, auto) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 22px;
+  min-height: 64px;
+  padding: 0 clamp(18px, 3vw, 36px);
+  border-bottom: 1px solid rgba(190, 238, 72, 0.25);
+  background: rgba(2, 9, 6, 0.93);
+  box-shadow: 0 10px 36px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(18px) saturate(1.08);
+  transition: background 180ms ease, box-shadow 180ms ease;
+}
+
+body.guild-interior .topbar.is-scrolled {
+  background: rgba(2, 9, 6, 0.985);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.46);
+}
+
+body.guild-interior .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-width: max-content;
+  color: var(--guild-text);
+  font-weight: 760;
+  text-decoration: none;
+}
+
+.guild-shell-crest {
+  display: grid;
+  place-items: center;
+  width: 31px;
+  height: 35px;
+  color: var(--guild-lime);
+  filter: drop-shadow(0 0 10px rgba(185, 239, 55, 0.22));
+}
+
+.guild-shell-crest svg {
+  width: 100%;
+  height: 100%;
+}
+
+.guild-shell-brand-copy {
+  display: grid;
+  line-height: 1;
+}
+
+.guild-shell-brand-copy strong {
+  font-size: 14px;
+  letter-spacing: -0.035em;
+}
+
+.guild-shell-brand-copy small {
+  justify-self: end;
+  margin-top: 3px;
+  color: #d3dbd1;
+  font-size: 8px;
+  font-weight: 620;
+}
+
+body.guild-interior .topbar nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(13px, 2vw, 25px);
+  min-width: 0;
+  color: #edf1e9;
+  font-size: 11px;
+  font-weight: 610;
+}
+
+body.guild-interior .topbar nav a {
+  position: relative;
+  padding: 22px 0 20px;
+  color: inherit;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 150ms ease;
+}
+
+body.guild-interior .topbar nav a::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 14px;
+  left: 0;
+  height: 1px;
+  background: var(--guild-lime);
+  transform: scaleX(0);
+  transition: transform 170ms ease;
+}
+
+body.guild-interior .topbar nav a:hover,
+body.guild-interior .topbar nav a[aria-current="page"] {
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .topbar nav a:hover::after,
+body.guild-interior .topbar nav a[aria-current="page"]::after {
+  transform: scaleX(1);
+}
+
+.guild-shell-network {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 0 13px;
+  border: 1px solid rgba(224, 238, 221, 0.27);
+  border-radius: 999px;
+  background: rgba(4, 13, 9, 0.82);
+  color: white;
+  font-size: 10px;
+  font-weight: 760;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.guild-shell-network .base-rune {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #7bbaff 0 48%, #3251d0 49% 100%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.32);
+}
+
+body.guild-interior main {
+  position: relative;
+  z-index: 1;
+}
+
+body.guild-interior .page,
+body.guild-interior .policy {
+  color: var(--guild-text);
+}
+
+body.guild-interior .protocol-page {
+  max-width: none;
+  padding: 0 18px 42px;
+}
+
+body.guild-interior .protocol-head {
+  position: relative;
+  overflow: hidden;
+  width: min(1180px, 100%);
+  max-width: 1180px;
+  min-height: 248px;
+  margin: 28px auto 18px;
+  padding: clamp(38px, 6vw, 72px);
+  border: 1px solid var(--guild-line);
+  border-radius: 28px;
+  background:
+    linear-gradient(102deg, rgba(3, 14, 9, 0.98) 0%, rgba(7, 24, 16, 0.95) 58%, rgba(14, 42, 27, 0.82) 100%),
+    var(--guild-panel-solid);
+  box-shadow: var(--guild-shadow);
+}
+
+body.guild-interior .protocol-head::before {
+  content: "";
+  position: absolute;
+  top: -180px;
+  right: -80px;
+  width: 440px;
+  height: 440px;
+  border: 1px solid rgba(185, 239, 55, 0.16);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 54px rgba(185, 239, 55, 0.025),
+    0 0 0 108px rgba(24, 217, 172, 0.018);
+}
+
+body.guild-interior .protocol-head::after {
+  content: "✦";
+  position: absolute;
+  right: clamp(34px, 6vw, 78px);
+  bottom: 27px;
+  color: rgba(206, 255, 72, 0.36);
+  font-size: 26px;
+  text-shadow: -48px -20px 0 rgba(24, 217, 172, 0.18), 42px -72px 0 rgba(232, 189, 38, 0.14);
+}
+
+body.guild-interior .protocol-head > * {
+  position: relative;
+  z-index: 1;
+}
+
+body.guild-interior .page-head h1,
+body.guild-interior .policy h1 {
+  max-width: 900px;
+  margin: 0 0 18px;
+  color: var(--guild-text);
+  font-size: clamp(46px, 7vw, 78px);
+  font-weight: 760;
+  line-height: 0.94;
+  letter-spacing: -0.055em;
+  text-wrap: balance;
+}
+
+body.guild-interior .page-head p,
+body.guild-interior .policy p,
+body.guild-interior .policy li {
+  color: var(--guild-muted);
+}
+
+body.guild-interior .protocol-head > div > p:not(.eyebrow) {
+  max-width: 690px;
+  margin-bottom: 0;
+  font-size: clamp(16px, 2vw, 20px);
+  line-height: 1.55;
+}
+
+body.guild-interior .eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  width: fit-content;
+  margin: 0 0 14px;
+  color: var(--guild-lime-bright);
+  font-size: 11px;
+  font-weight: 840;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+body.guild-interior .eyebrow::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border: 1px solid currentColor;
+  border-radius: 70% 30% 70% 30%;
+  transform: rotate(-18deg);
+  box-shadow: 5px -4px 0 -4px currentColor;
+}
+
+body.guild-interior h2 {
+  color: var(--guild-text);
+  font-size: clamp(30px, 4.2vw, 48px);
+  font-weight: 710;
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+  text-wrap: balance;
+}
+
+body.guild-interior h3 {
+  color: var(--guild-text);
+}
+
+body.guild-interior .protocol-status {
+  min-width: 0;
+  padding: 9px 12px;
+  border: 1px solid var(--guild-line);
+  border-left: 3px solid var(--guild-dim);
+  border-radius: 999px;
+  background: rgba(3, 14, 9, 0.76);
+  color: var(--guild-muted);
+  font-size: 11px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+body.guild-interior .protocol-status[data-tone="success"] {
+  border-left-color: var(--guild-lime);
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .protocol-status[data-tone="pending"] {
+  border-left-color: var(--guild-gold);
+  color: var(--guild-warning);
+}
+
+body.guild-interior .protocol-page > .band,
+body.guild-interior .protocol-page > .cta,
+body.guild-interior main > .evidence-band,
+body.guild-interior main > .policy-band {
+  width: min(1180px, 100%);
+  max-width: 1180px;
+  margin: 18px auto;
+  border: 1px solid var(--guild-line);
+  border-radius: 24px;
+  background:
+    linear-gradient(145deg, rgba(11, 31, 21, 0.88), rgba(5, 17, 12, 0.95)),
+    var(--guild-panel);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
+}
+
+body.guild-interior .band,
+body.guild-interior .cta,
+body.guild-interior .evidence-band,
+body.guild-interior .policy-band {
+  padding: clamp(34px, 5vw, 64px);
+}
+
+body.guild-interior .muted {
+  background:
+    radial-gradient(circle at 92% 16%, rgba(185, 239, 55, 0.07), transparent 18rem),
+    linear-gradient(145deg, rgba(12, 34, 23, 0.93), rgba(5, 17, 12, 0.96));
+}
+
+body.guild-interior .section-grid {
+  gap: clamp(30px, 7vw, 82px);
+}
+
+body.guild-interior .copy,
+body.guild-interior .steps,
+body.guild-interior .fine {
+  color: var(--guild-muted);
+}
+
+body.guild-interior .copy a,
+body.guild-interior .endpoint-list a,
+body.guild-interior .policy a {
+  color: var(--guild-lime-bright);
+  text-underline-offset: 3px;
+}
+
+body.guild-interior .button {
+  min-height: 43px;
+  padding: 0 18px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 820;
+  letter-spacing: -0.01em;
+  box-shadow: none;
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease, background 150ms ease;
+}
+
+body.guild-interior .button:hover {
+  transform: translateY(-1px);
+}
+
+body.guild-interior .button.primary,
+body.guild-interior .primary {
+  border-color: rgba(205, 255, 75, 0.82);
+  background: linear-gradient(110deg, #9fd020, #caf04b);
+  color: #081006;
+  box-shadow: 0 9px 26px rgba(185, 239, 55, 0.13);
+}
+
+body.guild-interior .button.primary:hover,
+body.guild-interior .primary:hover {
+  background: linear-gradient(110deg, #b4e42c, #d4ff5b);
+  box-shadow: 0 12px 32px rgba(185, 239, 55, 0.2);
+}
+
+body.guild-interior .button.secondary,
+body.guild-interior .secondary {
+  border-color: rgba(224, 238, 221, 0.24);
+  background: rgba(4, 13, 9, 0.72);
+  color: var(--guild-text);
+}
+
+body.guild-interior .button.secondary:hover,
+body.guild-interior .secondary:hover {
+  border-color: var(--guild-line-strong);
+  background: rgba(185, 239, 55, 0.07);
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .button:disabled,
+body.guild-interior .button:disabled:hover {
+  border-color: rgba(224, 238, 221, 0.12);
+  background: rgba(89, 103, 94, 0.16);
+  color: var(--guild-dim);
+  opacity: 0.7;
+}
+
+body.guild-interior .protocol-form {
+  max-width: 920px;
+  padding: 0;
+}
+
+body.guild-interior .funding-form {
+  gap: 18px;
+}
+
+body.guild-interior .form-section {
+  gap: 16px;
+  margin: 0;
+  padding: clamp(20px, 4vw, 30px);
+  border: 1px solid rgba(181, 226, 70, 0.16);
+  border-radius: 18px;
+  background: rgba(3, 14, 9, 0.46);
+}
+
+body.guild-interior .form-section + .form-section,
+body.guild-interior .form-section + details.form-section {
+  margin-top: 2px;
+}
+
+body.guild-interior .form-section:last-of-type {
+  border-bottom: 1px solid rgba(181, 226, 70, 0.16);
+}
+
+body.guild-interior .advanced {
+  padding: 17px;
+  border: 1px solid rgba(181, 226, 70, 0.13);
+  border-radius: 14px;
+  background: rgba(10, 30, 20, 0.45);
+}
+
+body.guild-interior .advanced summary {
+  color: var(--guild-text);
+}
+
+body.guild-interior label,
+body.guild-interior legend {
+  color: var(--guild-muted);
+  font-size: 13px;
+}
+
+body.guild-interior input,
+body.guild-interior select,
+body.guild-interior textarea {
+  min-height: 46px;
+  border: 1px solid rgba(198, 218, 199, 0.24);
+  border-radius: 11px;
+  background: rgba(1, 10, 6, 0.78);
+  color: var(--guild-text);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+}
+
+body.guild-interior input::placeholder,
+body.guild-interior textarea::placeholder {
+  color: #718078;
+}
+
+body.guild-interior input:focus,
+body.guild-interior select:focus,
+body.guild-interior textarea:focus {
+  border-color: var(--guild-line-strong);
+  outline: 2px solid rgba(185, 239, 55, 0.12);
+}
+
+body.guild-interior select option {
+  background: var(--guild-panel-solid);
+  color: var(--guild-text);
+}
+
+body.guild-interior input[type="checkbox"],
+body.guild-interior input[type="radio"] {
+  accent-color: var(--guild-lime);
+}
+
+body.guild-interior .sticky-actions {
+  margin-top: 10px;
+  padding: 18px;
+  border: 1px solid rgba(181, 226, 70, 0.16);
+  border-radius: 18px;
+  background: rgba(2, 12, 8, 0.86);
+}
+
+body.guild-interior .readiness-panel,
+body.guild-interior .legal-consent {
+  border: 1px solid rgba(181, 226, 70, 0.2);
+  border-left: 3px solid var(--guild-mint);
+  border-radius: 14px;
+  background: rgba(10, 35, 25, 0.62);
+  color: var(--guild-muted);
+}
+
+body.guild-interior .legal-consent-points {
+  color: var(--guild-muted);
+}
+
+body.guild-interior .legal-consent-check {
+  border-top-color: rgba(181, 226, 70, 0.14);
+  color: var(--guild-text);
+}
+
+body.guild-interior .verifier-warning {
+  border-left-color: var(--guild-gold);
+  background: rgba(92, 62, 4, 0.2);
+  color: var(--guild-warning);
+}
+
+body.guild-interior .output {
+  border-left-color: var(--guild-mint);
+  border-radius: 0 12px 12px 0;
+  background: rgba(2, 12, 8, 0.62);
+  color: var(--guild-muted);
+}
+
+body.guild-interior .output[data-tone="success"] {
+  border-left-color: var(--guild-lime);
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .output[data-tone="pending"] {
+  border-left-color: var(--guild-gold);
+  color: var(--guild-warning);
+}
+
+body.guild-interior .output[data-tone="error"] {
+  border-left-color: var(--guild-danger);
+  color: #ffb3a7;
+}
+
+body.guild-interior .readiness-output,
+body.guild-interior .prefill-output {
+  background: rgba(1, 10, 6, 0.68);
+}
+
+body.guild-interior .bounty-feed,
+body.guild-interior .recovery-list {
+  gap: 12px;
+  border: 0;
+  background: transparent;
+}
+
+body.guild-interior .bounty-row,
+body.guild-interior .recovery-row,
+body.guild-interior .opportunity-empty {
+  border: 1px solid rgba(181, 226, 70, 0.17);
+  border-radius: 16px;
+  background:
+    linear-gradient(135deg, rgba(12, 34, 23, 0.78), rgba(4, 16, 10, 0.9));
+  color: var(--guild-text);
+  transition: transform 150ms ease, border-color 150ms ease, background 150ms ease;
+}
+
+body.guild-interior .bounty-row:hover,
+body.guild-interior .recovery-row:hover {
+  border-color: var(--guild-line-strong);
+  background: linear-gradient(135deg, rgba(16, 43, 29, 0.9), rgba(4, 17, 11, 0.94));
+  transform: translateY(-2px);
+}
+
+body.guild-interior .bounty-row > p:nth-of-type(1),
+body.guild-interior .recovery-row[data-state="recovered"] output {
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .recovery-row output,
+body.guild-interior .inventory-summary,
+body.guild-interior .leaderboard-head > p,
+body.guild-interior .leaderboard-rules,
+body.guild-interior .leaderboard-empty {
+  color: var(--guild-muted);
+}
+
+body.guild-interior .opportunity-count {
+  border-color: var(--guild-line);
+  background: rgba(2, 12, 8, 0.82);
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .opportunity-state {
+  border: 1px solid rgba(181, 226, 70, 0.15);
+  background: rgba(185, 239, 55, 0.06);
+  color: var(--guild-muted);
+}
+
+body.guild-interior .leaderboard-section,
+body.guild-interior .leaderboard-label,
+body.guild-interior .leaderboard-row,
+body.guild-interior .evidence-metrics,
+body.guild-interior .evidence-metrics > div + div,
+body.guild-interior .proof-ledger-head,
+body.guild-interior .proof-ledger li {
+  border-color: rgba(181, 226, 70, 0.17);
+}
+
+body.guild-interior .leaderboard-row[data-leader="true"],
+body.guild-interior .evidence-metrics output,
+body.guild-interior .proof-ledger a {
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior code {
+  border: 1px solid rgba(181, 226, 70, 0.12);
+  background: rgba(0, 7, 4, 0.58);
+  color: #dce9d8;
+}
+
+body.guild-interior .prompt-block {
+  border: 1px solid rgba(181, 226, 70, 0.16);
+  border-left: 3px solid var(--guild-mint);
+  border-radius: 14px;
+  background: rgba(1, 10, 6, 0.72);
+  color: var(--guild-text);
+}
+
+body.guild-interior .objective-workspace {
+  width: min(1440px, calc(100% - 36px));
+  min-height: auto;
+  margin: 28px auto 18px;
+  padding: clamp(34px, 5vw, 64px);
+  border: 1px solid var(--guild-line);
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at 85% 4%, rgba(185, 239, 55, 0.1), transparent 24rem),
+    linear-gradient(145deg, rgba(7, 23, 15, 0.98), rgba(2, 12, 8, 0.98));
+  box-shadow: var(--guild-shadow);
+  color: var(--guild-text);
+}
+
+body.guild-interior .objective-intro .eyebrow {
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .objective-intro h1 {
+  color: var(--guild-text);
+  letter-spacing: -0.055em;
+}
+
+body.guild-interior .objective-intro > p:not(.eyebrow),
+body.guild-interior .compiler-actions p,
+body.guild-interior .graph-toolbar small,
+body.guild-interior .task-inspector,
+body.guild-interior .policy-keys span {
+  color: var(--guild-muted);
+}
+
+body.guild-interior .compiler-readiness {
+  border-color: var(--guild-line);
+  border-radius: 999px;
+  background: rgba(2, 12, 8, 0.72);
+  color: var(--guild-muted);
+}
+
+body.guild-interior .compiler-readiness[data-compiler-readiness="ready"] {
+  border-color: var(--guild-line-strong);
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .compiler-form {
+  padding: 24px;
+  border: 1px solid rgba(181, 226, 70, 0.17);
+  border-radius: 20px;
+  background: rgba(3, 14, 9, 0.52);
+}
+
+body.guild-interior .compiler-form label,
+body.guild-interior .compiler-form legend {
+  color: var(--guild-muted);
+}
+
+body.guild-interior .compiler-form textarea,
+body.guild-interior .compiler-form input {
+  border-color: rgba(198, 218, 199, 0.24);
+  background: rgba(1, 10, 6, 0.78);
+  color: var(--guild-text);
+}
+
+body.guild-interior .segments {
+  border-color: var(--guild-line);
+  border-radius: 11px;
+}
+
+body.guild-interior .segments label + label {
+  border-left-color: var(--guild-line);
+}
+
+body.guild-interior .segments span {
+  color: var(--guild-muted);
+}
+
+body.guild-interior .segments input:checked + span {
+  background: var(--guild-lime);
+  color: #081109;
+}
+
+body.guild-interior .graph-shell {
+  padding: 22px;
+  border: 1px solid rgba(181, 226, 70, 0.17);
+  border-radius: 20px;
+  background: rgba(2, 12, 8, 0.5);
+}
+
+body.guild-interior .graph-toolbar,
+body.guild-interior .task-inspector {
+  border-color: rgba(181, 226, 70, 0.16);
+}
+
+body.guild-interior .graph-node {
+  border-color: rgba(181, 226, 70, 0.2);
+  border-radius: 14px;
+  background: rgba(10, 31, 21, 0.88);
+  color: var(--guild-text);
+}
+
+body.guild-interior .graph-node:hover,
+body.guild-interior .graph-node:focus-visible,
+body.guild-interior .graph-node[data-selected="true"] {
+  border-color: var(--guild-line-strong);
+  background: rgba(16, 45, 30, 0.96);
+}
+
+body.guild-interior .graph-node-id,
+body.guild-interior .graph-node-meta {
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .graph-layer + .graph-layer::before {
+  border-color: rgba(181, 226, 70, 0.32);
+}
+
+body.guild-interior .policy-columns > section {
+  padding: 22px;
+  border: 1px solid rgba(181, 226, 70, 0.17);
+  border-radius: 16px;
+  background: rgba(3, 14, 9, 0.5);
+}
+
+body.guild-interior .policy-columns > section > span {
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .policy {
+  width: min(900px, calc(100% - 36px));
+  max-width: 900px;
+  margin: 42px auto;
+  padding: clamp(30px, 6vw, 58px);
+  border: 1px solid var(--guild-line);
+  border-radius: 26px;
+  background:
+    radial-gradient(circle at 90% 0%, rgba(185, 239, 55, 0.08), transparent 19rem),
+    linear-gradient(145deg, rgba(9, 27, 18, 0.94), rgba(3, 13, 9, 0.98));
+  box-shadow: var(--guild-shadow);
+}
+
+body.guild-interior .policy h2 {
+  margin-top: 42px;
+  color: var(--guild-text);
+}
+
+body.guild-interior .policy-summary {
+  border-left-color: var(--guild-lime);
+  border-radius: 0 14px 14px 0;
+  background: rgba(185, 239, 55, 0.06);
+}
+
+body.guild-interior .cta {
+  position: relative;
+  overflow: hidden;
+  align-items: center;
+  background:
+    radial-gradient(circle at 88% 24%, rgba(185, 239, 55, 0.15), transparent 18rem),
+    linear-gradient(125deg, rgba(3, 13, 9, 0.98), rgba(13, 42, 27, 0.96));
+  color: var(--guild-text);
+}
+
+body.guild-interior .cta::after {
+  content: "✦";
+  position: absolute;
+  right: 28px;
+  bottom: 18px;
+  color: rgba(206, 255, 72, 0.22);
+  font-size: 48px;
+}
+
+body.guild-interior .cta > * {
+  position: relative;
+  z-index: 1;
+}
+
+body.guild-interior .cta p {
+  color: var(--guild-muted);
+}
+
+body.guild-interior footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 20px;
+  align-items: center;
+  justify-content: center;
+  min-height: 78px;
+  margin-top: 34px;
+  padding: 24px clamp(18px, 4vw, 44px);
+  border-top: 1px solid rgba(181, 226, 70, 0.17);
+  background: rgba(1, 8, 5, 0.72);
+  color: var(--guild-dim);
+  font-size: 12px;
+  text-align: center;
+}
+
+body.guild-interior footer span {
+  margin-right: auto;
+}
+
+body.guild-interior footer a {
+  color: var(--guild-muted);
+  text-decoration: none;
+}
+
+body.guild-interior footer a:hover {
+  color: var(--guild-lime-bright);
+}
+
+body.guild-interior .analytics-consent {
+  border-color: var(--guild-line);
+  border-radius: 16px;
+  background: rgba(5, 18, 12, 0.97);
+  color: var(--guild-text);
+  box-shadow: var(--guild-shadow);
+}
+
+body.guild-interior main > section,
+body.guild-interior main.policy {
+  animation: guild-enter 420ms ease both;
+}
+
+@keyframes guild-enter {
+  from {
+    opacity: 0.72;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  body.guild-interior .topbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px 18px;
+    padding-top: 9px;
+    padding-bottom: 9px;
+  }
+
+  body.guild-interior .topbar nav {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-content: flex-start;
+    gap: 16px;
+    overflow-x: auto;
+    font-size: 10px;
+    scrollbar-width: none;
+  }
+
+  body.guild-interior .guild-shell-network {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  body.guild-interior .topbar nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  body.guild-interior .topbar nav a {
+    padding: 7px 0 10px;
+  }
+
+  body.guild-interior .topbar nav a::after {
+    bottom: 4px;
+  }
+
+  body.guild-interior .protocol-head {
+    display: grid;
+    min-height: 0;
+    padding: 38px 30px;
+  }
+
+  body.guild-interior .protocol-status {
+    width: fit-content;
+  }
+
+  body.guild-interior .section-grid,
+  body.guild-interior .feed-layout,
+  body.guild-interior .compiler-form,
+  body.guild-interior .objective-intro,
+  body.guild-interior .compiler-controls,
+  body.guild-interior .policy-columns {
+    grid-template-columns: 1fr;
+  }
+
+  body.guild-interior .objective-intro .eyebrow,
+  body.guild-interior .objective-intro > p:not(.eyebrow),
+  body.guild-interior .compiler-readiness {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  body.guild-interior .compiler-readiness {
+    justify-self: start;
+  }
+
+  body.guild-interior .compiler-controls > label:first-child {
+    grid-row: auto;
+  }
+
+  body.guild-interior .cta {
+    display: grid;
+  }
+
+  body.guild-interior footer span {
+    flex-basis: 100%;
+    margin-right: 0;
+  }
+}
+
+@media (max-width: 560px) {
+  body.guild-interior .topbar {
+    position: sticky;
+  }
+
+  .guild-shell-network {
+    padding: 0 10px;
+  }
+
+  .guild-shell-network span:last-child {
+    display: none;
+  }
+
+  body.guild-interior .protocol-page {
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+
+  body.guild-interior .protocol-head,
+  body.guild-interior .protocol-page > .band,
+  body.guild-interior .protocol-page > .cta,
+  body.guild-interior .objective-workspace,
+  body.guild-interior main > .evidence-band,
+  body.guild-interior main > .policy-band,
+  body.guild-interior .policy {
+    border-radius: 18px;
+  }
+
+  body.guild-interior .protocol-head,
+  body.guild-interior .band,
+  body.guild-interior .cta,
+  body.guild-interior .evidence-band,
+  body.guild-interior .policy-band,
+  body.guild-interior .objective-workspace,
+  body.guild-interior .policy {
+    padding: 26px 20px;
+  }
+
+  body.guild-interior .page-head h1,
+  body.guild-interior .policy h1,
+  body.guild-interior .objective-intro h1 {
+    font-size: clamp(40px, 13vw, 58px);
+  }
+
+  body.guild-interior h2 {
+    font-size: 32px;
+  }
+
+  body.guild-interior .form-row,
+  body.guild-interior .form-row.three,
+  body.guild-interior .recovery-row {
+    grid-template-columns: 1fr;
+  }
+
+  body.guild-interior .actions {
+    width: 100%;
+  }
+
+  body.guild-interior .button {
+    width: 100%;
+  }
+
+  body.guild-interior .wallet-picker {
+    max-width: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.guild-interior main > section,
+  body.guild-interior main.policy {
+    animation: none;
+  }
+}

--- a/site/guild-shell.js
+++ b/site/guild-shell.js
@@ -1,0 +1,96 @@
+(() => {
+  "use strict";
+
+  const body = document.body;
+  if (!body || body.classList.contains("guild-home")) return;
+
+  const route = (window.location.pathname.split("/").pop() || "index.html").toLowerCase();
+  body.classList.add("guild-interior");
+  body.dataset.guildRoute = route.replace(/\.html$/, "") || "home";
+
+  const crestMarkup = `
+    <span class="guild-shell-crest" aria-hidden="true">
+      <svg viewBox="0 0 42 46" focusable="false">
+        <path d="M21 2.5 37.5 12v22L21 43.5 4.5 34V12L21 2.5Z" fill="none" stroke="currentColor" stroke-width="2.8"/>
+        <path d="M13.5 28.5 21 11l7.5 17.5h-5.2L21 23l-2.3 5.5h-5.2Z" fill="currentColor"/>
+        <circle cx="21" cy="33.5" r="2.1" fill="#07120d"/>
+      </svg>
+    </span>
+    <span class="guild-shell-brand-copy"><strong>Agent Bounties</strong><small>.app</small></span>`;
+
+  const navItems = [
+    ["earn.html", "Bounty Board"],
+    ["post.html", "Post Bounties"],
+    ["funding.html", "Fund Bounties"],
+    ["objective.html", "Mission Forge"],
+    ["https://github.com/NSPG13/agent-bounties", "Open Source"],
+  ];
+
+  let topbar = document.querySelector(".topbar");
+  if (!topbar) {
+    topbar = document.createElement("header");
+    topbar.className = "topbar guild-shell-created";
+    document.body.insertBefore(topbar, document.body.firstChild);
+  }
+
+  let brand = topbar.querySelector(".brand");
+  if (!brand) {
+    brand = document.createElement("a");
+    brand.className = "brand";
+    brand.href = "index.html";
+    topbar.prepend(brand);
+  }
+  brand.setAttribute("aria-label", "Agent Bounties home");
+  brand.innerHTML = crestMarkup;
+
+  let nav = topbar.querySelector("nav");
+  if (!nav) {
+    nav = document.createElement("nav");
+    topbar.appendChild(nav);
+  }
+  nav.setAttribute("aria-label", "Primary navigation");
+  nav.replaceChildren();
+
+  navItems.forEach(([href, label]) => {
+    const link = document.createElement("a");
+    link.href = href;
+    link.textContent = label;
+    if (!href.startsWith("http") && href.toLowerCase() === route) {
+      link.setAttribute("aria-current", "page");
+    }
+    if (href.startsWith("http")) {
+      link.rel = "noopener";
+    }
+    nav.appendChild(link);
+  });
+
+  let network = topbar.querySelector(".guild-shell-network");
+  if (!network) {
+    network = document.createElement("a");
+    network.className = "guild-shell-network";
+    network.href = "protocol.json";
+    network.setAttribute("aria-label", "View Base protocol status");
+    network.innerHTML = '<span class="base-rune" aria-hidden="true"></span><span>Base</span>';
+    topbar.appendChild(network);
+  }
+
+  const footer = document.querySelector("footer") || document.createElement("footer");
+  if (!footer.isConnected) {
+    footer.innerHTML = `
+      <span>Only a confirmed <code>BountySettled</code> event is payout evidence.</span>
+      <a href="terms.html">Terms</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>`;
+    document.body.appendChild(footer);
+  }
+  footer.classList.add("guild-shell-footer");
+
+  const main = document.querySelector("main");
+  if (main) main.classList.add("guild-interior-main");
+
+  const syncScrolledState = () => {
+    topbar.classList.toggle("is-scrolled", window.scrollY > 12);
+  };
+  syncScrolledState();
+  window.addEventListener("scroll", syncScrolledState, { passive: true });
+})();

--- a/site/operator.html
+++ b/site/operator.html
@@ -56,6 +56,7 @@
       <span>Historical evidence is preserved; active legacy paths are retired.</span>
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
+    <script src="analytics-config.js"></script>
     <script src="autonomous.js"></script>
   </body>
 </html>

--- a/site/operator.html
+++ b/site/operator.html
@@ -8,6 +8,7 @@
     <meta name="description" content="Migration status from the retired settlement-signer escrow to autonomous per-bounty Base USDC contracts.">
     <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="guild-pages.css?v=20260721">
   </head>
   <body>
     <header class="topbar">
@@ -56,7 +57,7 @@
       <span>Historical evidence is preserved; active legacy paths are retired.</span>
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
-    <script src="analytics-config.js"></script>
+    <script src="guild-shell.js?v=20260721"></script>
     <script src="autonomous.js"></script>
   </body>
 </html>

--- a/site/recovery.html
+++ b/site/recovery.html
@@ -8,6 +8,7 @@
     <meta name="description" content="Cancel and recover the three fully funded legacy verifier canaries from their isolated Base USDC contracts.">
     <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="guild-pages.css?v=20260721">
   </head>
   <body>
     <header class="topbar">
@@ -74,7 +75,7 @@
       <a href="privacy.html">Privacy</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues/212">Recovery audit</a>
     </footer>
-    <script src="analytics-config.js"></script>
+    <script src="guild-shell.js?v=20260721"></script>
     <script src="legal-consent.js"></script>
     <script src="autonomous.js"></script>
   </body>

--- a/site/recovery.html
+++ b/site/recovery.html
@@ -74,6 +74,7 @@
       <a href="privacy.html">Privacy</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues/212">Recovery audit</a>
     </footer>
+    <script src="analytics-config.js"></script>
     <script src="legal-consent.js"></script>
     <script src="autonomous.js"></script>
   </body>

--- a/site/success.html
+++ b/site/success.html
@@ -8,6 +8,7 @@
     <meta name="description" content="The retired Checkout return page cannot fund an autonomous bounty.">
     <meta name="robots" content="noindex,nofollow">
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="guild-pages.css?v=20260721">
   </head>
   <body>
     <main class="policy">
@@ -20,6 +21,6 @@
         <a class="button secondary" href="post.html">Post your own bounty</a>
       </p>
     </main>
-    <script src="analytics-config.js"></script>
+    <script src="guild-shell.js?v=20260721"></script>
   </body>
 </html>

--- a/site/success.html
+++ b/site/success.html
@@ -20,5 +20,6 @@
         <a class="button secondary" href="post.html">Post your own bounty</a>
       </p>
     </main>
+    <script src="analytics-config.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## What changed

- Added a scoped `guild-pages.css` design layer that carries the homepage's dark solarpunk guild aesthetic across the functional site.
- Added `guild-shell.js` for a consistent crest brand, Bounty Board/Post/Fund/Mission Forge navigation, Base status chip, active-route state, and footer treatment.
- Loaded the shared shell through the existing public-page configuration while explicitly excluding the homepage, so its current design remains untouched.
- Styled forms, bounty feeds, protocol status, evidence panels, policy pages, CTA sections, responsive states, and the embedded ChatGPT posting widget without changing workflow behavior.
- Kept internal/noindex pages analytics-free by loading only the visual assets directly.

## Why

The homepage had developed a distinct, polished guild identity while the rest of the product still used the older generic light UI. This makes the experience feel like one coherent Agent Bounties product while preserving the clarity and density required by protocol workflows.

## Validation

- JavaScript syntax checks passed for the shell and loader.
- CSS structure and brace balance validated.
- Desktop and mobile render fixtures were reviewed, including the Objective Compiler layout.
- The branch diff is limited to eight site files; route-alias redirect pages remain intentionally unchanged.
- The homepage is excluded from the new loader and retains its existing implementation.
