### PR TITLE
chore: force corrected guild Pages deployment

### DIFF
--- a/site/live-guild-build.txt
+++ b/site/live-guild-build.txt
@@ -1,2 +1,2 @@
-20260722-1
-The interior guild shell is loaded directly from page HTML. This file is a deployment canary for verifying that the live origin serves the current build.
+20260722-2
+The interior guild shell is loaded directly from page HTML. This canary forces and identifies the first production deployment using the corrected Pages workflow that preserves the guild bootstrap.


### PR DESCRIPTION
This one-line canary change forces a new production Pages deployment after #497 corrected the deploy workflow. The live site is accepted only when `live-guild-build.txt` returns `20260722-2` and `earn.html` serves the static guild navigation and body build marker from #496.