### PR TITLE
feat: replace posting form with a mission-aware AI bounty card

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,12 +47,21 @@ jobs:
       - name: Check simplified public scripts
         run: |
           node --check site/bounty-board.js
-          node --check site/objective.js
+          node --check site/bounty-composer-v2.js
           node --check site/simple-home.js
           node --check site/guild-shell.js
           grep -q 'data-board-search' site/earn.html
           grep -q 'id="fund-bounty-panel"' site/earn.html
-          grep -q 'id="autonomous-post-form"' site/objective.html
+          grep -q 'id="bounty-composer-form"' site/objective.html
+          grep -q 'data-mission-context' site/objective.html
+          grep -q 'data-image-status' site/objective.html
+          grep -q 'data-approve-card' site/objective.html
+          grep -q 'data-open-funding' site/objective.html
+          grep -q 'data-payment-method="crypto"' site/objective.html
+          grep -q 'bounty-composer-v2.js?v=1' site/objective.html
+          grep -q 'x-agent-bounties-draft-visual' site/bounty-composer-v2.js
+          grep -q 'MAX_TASK_DAYS = 30' site/bounty-composer-v2.js
+          grep -q 'Ongoing' site/bounty-composer-v2.js
           grep -q 'You ask. Someone helps. They show proof. They get paid.' site/how-it-works.html
       - name: Verify production analytics substitution preserves the public shell
         env:
@@ -148,6 +157,7 @@ jobs:
             if curl "${common_curl[@]}" "https://agentbounties.app/live-guild-build.txt?verify=${nonce}" -o /tmp/live-canary.txt \
               && curl "${common_curl[@]}" "https://agentbounties.app/earn.html?verify=${nonce}" -o /tmp/live-earn.html \
               && curl "${common_curl[@]}" "https://agentbounties.app/objective.html?verify=${nonce}" -o /tmp/live-objective.html \
+              && curl "${common_curl[@]}" "https://agentbounties.app/bounty-composer-v2.js?verify=${nonce}" -o /tmp/live-composer.js \
               && curl "${common_curl[@]}" "https://agentbounties.app/how-it-works.html?verify=${nonce}" -o /tmp/live-how.html \
               && curl "${common_curl[@]}" "https://agentbounties.app/analytics-config.js?verify=${nonce}" -o /tmp/live-analytics.js \
               && curl "${common_curl[@]}" "https://agentbounties.app/simple-home.js?verify=${nonce}" -o /tmp/live-simple-home.js; then
@@ -158,8 +168,15 @@ jobs:
                 && grep -q 'id="fund-bounty-panel"' /tmp/live-earn.html \
                 && grep -q 'Post something you want done' /tmp/live-earn.html \
                 && grep -q 'bounty-board.js?v=1' /tmp/live-earn.html \
-                && grep -q 'id="autonomous-post-form"' /tmp/live-objective.html \
-                && grep -q 'data-use-selected-task' /tmp/live-objective.html \
+                && grep -q 'id="bounty-composer-form"' /tmp/live-objective.html \
+                && grep -q 'data-mission-context' /tmp/live-objective.html \
+                && grep -q 'data-image-status' /tmp/live-objective.html \
+                && grep -q 'data-approve-card' /tmp/live-objective.html \
+                && grep -q 'data-open-funding' /tmp/live-objective.html \
+                && grep -q 'data-payment-method="crypto"' /tmp/live-objective.html \
+                && grep -q 'bounty-composer-v2.js?v=1' /tmp/live-objective.html \
+                && grep -q 'x-agent-bounties-draft-visual' /tmp/live-composer.js \
+                && grep -q 'MAX_TASK_DAYS = 30' /tmp/live-composer.js \
                 && grep -q 'You ask. Someone helps. They show proof. They get paid.' /tmp/live-how.html \
                 && grep -q 'simple-home.js' /tmp/live-analytics.js \
                 && grep -q '\["earn.html", "Bounty Board"\]' /tmp/live-simple-home.js \
@@ -169,7 +186,7 @@ jobs:
                 failure_detail=""
                 break
               fi
-              failure_detail="expected build ${expected_build}, received ${actual_build:-empty}, or simplified public-workflow markers were missing"
+              failure_detail="expected build ${expected_build}, received ${actual_build:-empty}, or mission-aware public-workflow markers were missing"
             else
               failure_detail="one or more live URLs returned a non-success response"
             fi
@@ -180,7 +197,7 @@ jobs:
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           if [[ "${success}" == "true" ]]; then
             cat > /tmp/live-proof.md <<EOF
-          ✅ **Simplified production workflow canary passed**
+          ✅ **Mission-aware production workflow canary passed**
 
           - Commit: \`${GITHUB_SHA}\`
           - Expected and live build: \`${expected_build}\`
@@ -188,13 +205,13 @@ jobs:
           - Verified at: ${verified_at}
           - Live primary navigation assets contain only **Bounty Board** and **How It Works**.
           - Live Bounty Board contains search filters, visual open-task cards, inline funding, and the posting entry point.
-          - Live Goal Planner contains the integrated posting form.
+          - Live AI composer supports one conversational input, long or ongoing missions, definite funded tasks, bounded pre-publication visuals, explicit card approval, and the wallet funding chooser.
           - Live How It Works page contains the plain-language explanation.
           - Workflow: ${run_url}
           EOF
           else
             cat > /tmp/live-proof.md <<EOF
-          ❌ **Simplified production workflow canary failed**
+          ❌ **Mission-aware production workflow canary failed**
 
           - Commit: \`${GITHUB_SHA}\`
           - Expected build: \`${expected_build}\`

--- a/site/bounty-composer-v2.css
+++ b/site/bounty-composer-v2.css
@@ -1,0 +1,113 @@
+.mission-context {
+  margin: 0 0 22px;
+  border: 1px solid rgba(124, 239, 209, 0.2);
+  border-radius: 17px;
+  padding: 16px;
+  background: rgba(124, 239, 209, 0.045);
+}
+
+.mission-context[hidden] { display: none; }
+
+.mission-context-kicker {
+  margin: 0 0 5px;
+  color: var(--composer-mint);
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.mission-context h3 {
+  margin: 0;
+  color: var(--composer-text);
+  font-size: 1.15rem;
+}
+
+.mission-context > p {
+  margin: 7px 0 0;
+  color: var(--composer-muted);
+  line-height: 1.48;
+}
+
+.mission-horizon {
+  display: inline-flex;
+  margin-top: 10px;
+  border: 1px solid rgba(201, 245, 72, 0.22);
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: var(--composer-lime);
+  font-size: 0.72rem;
+  font-weight: 780;
+}
+
+.mission-task-options {
+  display: grid;
+  gap: 8px;
+  margin-top: 15px;
+}
+
+.mission-task-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: start;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 13px;
+  padding: 12px;
+  color: var(--composer-text);
+  background: rgba(0, 8, 4, 0.35);
+  cursor: pointer;
+}
+
+.mission-task-option:has(input:checked) {
+  border-color: rgba(201, 245, 72, 0.65);
+  background: rgba(201, 245, 72, 0.075);
+}
+
+.mission-task-option input {
+  margin-top: 3px;
+  accent-color: var(--composer-lime);
+}
+
+.mission-task-option strong,
+.mission-task-option small {
+  display: block;
+}
+
+.mission-task-option small {
+  margin-top: 4px;
+  color: var(--composer-muted);
+  line-height: 1.4;
+}
+
+.image-generation-status {
+  position: absolute;
+  right: 16px;
+  bottom: 14px;
+  border: 1px solid rgba(255,255,255,.2);
+  border-radius: 999px;
+  padding: 6px 9px;
+  color: rgba(255,255,255,.78);
+  background: rgba(1, 10, 6, .68);
+  backdrop-filter: blur(9px);
+  font-size: .65rem;
+  font-weight: 760;
+}
+
+.image-generation-status[data-tone="ai"] {
+  color: var(--composer-mint);
+  border-color: rgba(124, 239, 209, .35);
+}
+
+.composer-scope-note {
+  max-width: 720px;
+  margin: 12px auto 0;
+  color: #849088;
+  font-size: .78rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 700px) {
+  .mission-task-option { padding: 11px; }
+  .image-generation-status { right: 10px; bottom: 10px; }
+}

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -1,0 +1,1101 @@
+(() => {
+  "use strict";
+
+  const API = "https://api.agentbounties.app";
+  const MAX_AI_ROUNDS = 3;
+  const MAX_PLAN_TASKS = 6;
+  const MAX_TASK_DAYS = 30;
+  const MIN_TOTAL_USDC = 0.02;
+  const MAX_TOTAL_USDC = 9_000_000_000;
+  const VISUAL_EXTENSION = "x-agent-bounties-draft-visual";
+  const ALLOWED_SCENES = new Set([
+    "infrastructure", "digital", "nature", "health", "research", "education", "coordination", "general",
+  ]);
+  const ALLOWED_ELEMENTS = new Set([
+    "sun", "road", "lamp", "building", "tree", "water", "screen", "document", "network", "tool", "person", "check", "bridge", "book", "chart",
+  ]);
+
+  const ui = {
+    form: document.getElementById("bounty-composer-form"),
+    input: document.getElementById("bounty-composer-input"),
+    label: document.querySelector("[data-composer-label]"),
+    prompt: document.querySelector("[data-assistant-prompt]"),
+    submit: document.querySelector("[data-composer-submit]"),
+    mic: document.querySelector("[data-dictate]"),
+    hint: document.querySelector("[data-composer-hint]"),
+    status: document.querySelector("[data-composer-status]"),
+    progress: Array.from(document.querySelectorAll("[data-progress-step]")),
+    preview: document.getElementById("bounty-preview"),
+    art: document.getElementById("bounty-card-art"),
+    imageStatus: document.querySelector("[data-image-status]"),
+    badge: document.querySelector("[data-card-badge]"),
+    title: document.querySelector("[data-card-title]"),
+    goal: document.querySelector("[data-card-goal]"),
+    criteria: document.querySelector("[data-card-criteria]"),
+    reward: document.querySelector("[data-card-reward]"),
+    deadline: document.querySelector("[data-card-deadline]"),
+    checks: document.querySelector("[data-card-checks]"),
+    confidence: document.querySelector("[data-card-confidence]"),
+    risks: document.querySelector("[data-card-risks]"),
+    missionContext: document.querySelector("[data-mission-context]"),
+    missionTitle: document.querySelector("[data-mission-title]"),
+    missionSummary: document.querySelector("[data-mission-summary]"),
+    missionHorizon: document.querySelector("[data-mission-horizon]"),
+    missionTasks: document.querySelector("[data-mission-tasks]"),
+    approve: document.querySelector("[data-approve-card]"),
+    revise: document.querySelector("[data-revise-card]"),
+    share: document.querySelector("[data-share-card]"),
+    fund: document.querySelector("[data-open-funding]"),
+    dialog: document.getElementById("funding-dialog"),
+    closeDialog: document.querySelector("[data-close-funding]"),
+    cryptoMethod: document.querySelector("[data-payment-method='crypto']"),
+    walletPanel: document.querySelector("[data-wallet-panel]"),
+    walletOptions: document.querySelector("[data-wallet-options]"),
+    walletMessage: document.querySelector("[data-wallet-message]"),
+    readiness: document.querySelector("[data-wallet-readiness]"),
+    account: document.querySelector("[data-wallet-account]"),
+    usdcBalance: document.querySelector("[data-wallet-usdc]"),
+    ethBalance: document.querySelector("[data-wallet-eth]"),
+    requiredUsdc: document.querySelector("[data-wallet-required]"),
+    fundingHelp: document.querySelector("[data-funding-help]"),
+    missingUsdc: document.querySelector("[data-missing-usdc]"),
+    watchUsdc: document.querySelector("[data-watch-usdc]"),
+    copyUsdc: document.querySelector("[data-copy-usdc]"),
+    recheck: document.querySelector("[data-recheck-balance]"),
+    fundNow: document.querySelector("[data-fund-now]"),
+    paymentStatus: document.querySelector("[data-payment-status]"),
+  };
+
+  if (!ui.form || !ui.input || !ui.preview || !ui.dialog || !ui.art) return;
+
+  const state = {
+    phase: "describe",
+    originalRequest: "",
+    context: [],
+    initialDraft: null,
+    draft: null,
+    aiRounds: 0,
+    questions: [],
+    currentQuestion: null,
+    askedQuestions: new Set(),
+    scope: null,
+    horizon: null,
+    missionPlan: null,
+    selectedTaskId: null,
+    taskWindowDays: null,
+    fundingUsdc: null,
+    visualSpec: null,
+    visualSource: "fallback",
+    visualCache: new Map(),
+    imageReady: false,
+    approved: false,
+    protocol: null,
+    providers: [],
+    provider: null,
+    account: null,
+    balances: null,
+    bountyContract: null,
+    bountyId: null,
+    speech: null,
+  };
+
+  const announcedProviders = [];
+  window.addEventListener("eip6963:announceProvider", (event) => {
+    const detail = event && event.detail;
+    if (!detail || !detail.provider || typeof detail.provider.request !== "function") return;
+    if (!announcedProviders.some((item) => item.provider === detail.provider)) announcedProviders.push(detail);
+  });
+
+  function setStatus(message, tone = "") {
+    ui.status.textContent = message || "";
+    ui.status.dataset.tone = tone;
+  }
+
+  function setPaymentStatus(message, tone = "") {
+    ui.paymentStatus.textContent = message || "";
+    ui.paymentStatus.dataset.tone = tone;
+  }
+
+  function setProgress(active) {
+    const order = ["describe", "clarify", "review", "fund"];
+    const activeIndex = order.indexOf(active);
+    ui.progress.forEach((item) => {
+      const index = order.indexOf(item.dataset.progressStep);
+      item.dataset.active = String(index === activeIndex);
+      item.dataset.complete = String(index >= 0 && index < activeIndex);
+    });
+  }
+
+  function setComposer({ phase, prompt, label, placeholder, button, hint = "" }) {
+    state.phase = phase;
+    ui.prompt.textContent = prompt;
+    ui.label.textContent = label;
+    ui.input.placeholder = placeholder;
+    ui.submit.textContent = button;
+    ui.hint.textContent = hint;
+    ui.input.value = "";
+    ui.input.disabled = false;
+    ui.submit.disabled = false;
+    setProgress(phase === "describe" ? "describe" : "clarify");
+    requestAnimationFrame(() => ui.input.focus({ preventScroll: true }));
+  }
+
+  function normalizeQuestion(value) {
+    return String(value || "").trim().toLowerCase().replace(/\s+/g, " ");
+  }
+
+  function safeTextList(values, maximum = 12) {
+    return (Array.isArray(values) ? values : [])
+      .map((value) => String(value || "").trim())
+      .filter(Boolean)
+      .slice(0, maximum);
+  }
+
+  function randomBytes32() {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  function formatUsdc(value, maximum = 6) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "0";
+    return number.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: maximum });
+  }
+
+  function usdcBaseUnits(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number) || number < 0 || number > MAX_TOTAL_USDC) {
+      throw new Error("Enter a valid USDC amount.");
+    }
+    return BigInt(Math.round(number * 1_000_000));
+  }
+
+  function splitReward(total) {
+    const totalUnits = usdcBaseUnits(total);
+    if (totalUnits < 20_000n) throw new Error("The current protocol requires at least 0.02 USDC in total.");
+    const proportional = totalUnits / 50n;
+    const verifier = proportional < 10_000n ? 10_000n : proportional;
+    const cappedVerifier = verifier > totalUnits / 5n ? totalUnits / 5n : verifier;
+    const solver = totalUnits - cappedVerifier;
+    if (solver < 10_000n) throw new Error("The solver reward must remain at least 0.01 USDC.");
+    return { total: totalUnits, solver, verifier: cappedVerifier };
+  }
+
+  function parseFunding(value) {
+    const cleaned = String(value || "").replace(/,/g, "");
+    const match = cleaned.match(/(?:^|[^0-9])(\d+(?:\.\d{1,6})?)(?:\s*(?:base\s*)?usdc|\s*dollars?|\s*usd)?(?:$|[^0-9])/i);
+    if (!match) return null;
+    const amount = Number(match[1]);
+    return Number.isFinite(amount) && amount >= MIN_TOTAL_USDC && amount <= MAX_TOTAL_USDC ? amount : null;
+  }
+
+  function parseHorizon(value) {
+    const raw = String(value || "").trim();
+    if (/\b(ongoing|continuous|continuing|indefinite|no fixed end|no end date|open[- ]ended|work toward)\b/i.test(raw)) {
+      return { kind: "ongoing", label: "Ongoing", date: null, days: null };
+    }
+    const duration = raw.match(/(?:in\s+)?(\d+)\s*(hour|hours|day|days|week|weeks|month|months|year|years)\b/i);
+    let date = null;
+    if (duration) {
+      const count = Number(duration[1]);
+      const unit = duration[2].toLowerCase();
+      const hours = unit.startsWith("year")
+        ? count * 365 * 24
+        : unit.startsWith("month")
+          ? count * 30 * 24
+          : unit.startsWith("week")
+            ? count * 7 * 24
+            : unit.startsWith("day")
+              ? count * 24
+              : count;
+      if (!Number.isFinite(hours) || hours < 1 || hours > 100 * 365 * 24) return null;
+      date = new Date(Date.now() + hours * 3_600_000);
+    } else {
+      const iso = raw.match(/\b(20\d{2}-\d{2}-\d{2})(?:[T\s](\d{1,2}:\d{2}))?\b/);
+      if (iso) date = new Date(`${iso[1]}T${iso[2] || "23:59"}:00`);
+      else {
+        const parsed = Date.parse(raw);
+        if (Number.isFinite(parsed)) date = new Date(parsed);
+      }
+    }
+    if (!date || !Number.isFinite(date.getTime()) || date.getTime() <= Date.now()) return null;
+    const days = Math.max(1, Math.ceil((date.getTime() - Date.now()) / 86_400_000));
+    if (days > 100 * 365) return null;
+    return {
+      kind: "date",
+      date,
+      days,
+      label: date.toLocaleString(undefined, { year: "numeric", month: "short", day: "numeric" }),
+    };
+  }
+
+  function parseScope(value) {
+    const raw = String(value || "").toLowerCase();
+    if (/\b(mission|ongoing|long[- ]term|larger effort|multiple goals|several goals|many tasks|work toward|continuous)\b/.test(raw)) return "mission";
+    if (/\b(single|one result|one task|one-time|bounded|specific deliverable|finish once)\b/.test(raw)) return "single";
+    return null;
+  }
+
+  function parseTaskWindow(value) {
+    const match = String(value || "").match(/(\d+)\s*(hour|hours|day|days|week|weeks)?/i);
+    if (!match) return null;
+    const count = Number(match[1]);
+    const unit = String(match[2] || "days").toLowerCase();
+    const days = unit.startsWith("hour") ? Math.ceil(count / 24) : unit.startsWith("week") ? count * 7 : count;
+    return Number.isInteger(days) && days >= 1 && days <= MAX_TASK_DAYS ? days : null;
+  }
+
+  function visualInstruction() {
+    return `The evidence_schema must remain a valid JSON Schema object and may include this non-verification annotation: "${VISUAL_EXTENSION}". The annotation must be an object with: version 1; scene chosen from infrastructure, digital, nature, health, research, education, coordination, general; palette containing 2-5 six-digit hex colours; and elements containing 3-10 objects. Each element must have kind chosen from sun, road, lamp, building, tree, water, screen, document, network, tool, person, check, bridge, book, chart; x and y integers from 0 to 100; and size a number from 0.4 to 2.0. Use it to depict the achieved result without words, logos, brands, payment symbols, or claims that the work is already complete. This annotation is only for a bounded pre-publication illustration and will be removed before the evidence schema is published.`;
+  }
+
+  async function requestJson(url, options = {}) {
+    const acceptance = window.AgentBountiesLegal && window.AgentBountiesLegal.latestReceipt();
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        "content-type": "application/json",
+        ...(acceptance ? { "x-agent-bounties-legal-acceptance": acceptance.acceptance_id } : {}),
+        ...(options.headers || {}),
+      },
+    });
+    const text = await response.text();
+    let body = null;
+    if (text) {
+      try { body = JSON.parse(text); } catch (_error) { body = text; }
+    }
+    if (!response.ok) {
+      const message = typeof body === "string"
+        ? body
+        : body && (body.message || body.error)
+          ? body.message || body.error
+          : `Request failed (${response.status}).`;
+      throw new Error(message);
+    }
+    return body;
+  }
+
+  function draftContext(extra = "") {
+    return [
+      "Create one public digital-work bounty draft. Make the result specific, measurable, attainable, and independently inspectable. Ask only questions whose answers materially change the public terms.",
+      visualInstruction(),
+      ...state.context,
+      extra,
+    ].filter(Boolean).join("\n").slice(0, 18_000);
+  }
+
+  async function generateInitialDraft() {
+    ui.submit.disabled = true;
+    ui.input.disabled = true;
+    setStatus("The AI is turning your words into clear, measurable terms…", "pending");
+    try {
+      const readiness = await requestJson(`${API}/v1/cloud-agent/readiness`, { cache: "no-store" });
+      if (!readiness.available || !readiness.public_drafts) throw new Error("The AI composer is temporarily unavailable. Nothing was posted or funded.");
+      const draft = await requestJson(`${API}/v1/cloud-agent/bounty-drafts`, {
+        method: "POST",
+        body: JSON.stringify({
+          objective: state.originalRequest,
+          context: draftContext(),
+          constraints: [],
+          source_url: null,
+          idempotency_key: `web-card:${randomBytes32().slice(2)}`,
+        }),
+      });
+      state.initialDraft = normalizeDraft(draft);
+      state.draft = state.initialDraft;
+      state.aiRounds += 1;
+      queueQuestions(state.draft.questions);
+      advanceConversation();
+    } catch (error) {
+      setStatus(error.message || String(error), "error");
+      ui.input.disabled = false;
+      ui.submit.disabled = false;
+    }
+  }
+
+  function normalizeDraft(draft) {
+    return {
+      ...draft,
+      acceptance_criteria: safeTextList(draft.acceptance_criteria, 20),
+      questions: safeTextList(draft.questions, 10),
+      risk_flags: safeTextList(draft.risk_flags, 10),
+    };
+  }
+
+  function queueQuestions(questions) {
+    for (const question of questions || []) {
+      const normalized = normalizeQuestion(question);
+      if (normalized && !state.askedQuestions.has(normalized)) state.questions.push(question);
+    }
+  }
+
+  function askNextQuestion() {
+    const question = state.questions.shift();
+    if (!question) return false;
+    state.currentQuestion = question;
+    state.askedQuestions.add(normalizeQuestion(question));
+    setComposer({
+      phase: "ai_question",
+      prompt: question,
+      label: "Your answer",
+      placeholder: "Answer naturally. You can type or dictate.",
+      button: "Continue",
+      hint: "The AI will use this answer to improve the bounty terms.",
+    });
+    setStatus("Nothing is posted until you approve the final card.");
+    return true;
+  }
+
+  async function regenerateAfterAnswers() {
+    if (state.aiRounds >= MAX_AI_ROUNDS) {
+      advanceConversation();
+      return;
+    }
+    await generateInitialDraft();
+  }
+
+  function askScope() {
+    setComposer({
+      phase: "scope",
+      prompt: "Is this one result to finish, or a larger or ongoing mission that should be broken into tasks?",
+      label: "Scope",
+      placeholder: "Example: one result, or an ongoing mission",
+      button: "Continue",
+      hint: "Long-running and open-ended missions are allowed. Their individual tasks still need definite results and completion checks.",
+    });
+  }
+
+  function askHorizon() {
+    setComposer({
+      phase: "horizon",
+      prompt: state.scope === "mission"
+        ? "Does the mission have an overall target date, or is it ongoing?"
+        : "When should this result be completed?",
+      label: state.scope === "mission" ? "Mission horizon" : "Completion deadline",
+      placeholder: state.scope === "mission" ? "Example: ongoing, in 18 months, or 2028-06-30" : "Example: in 14 days or 2026-08-15",
+      button: "Continue",
+      hint: state.scope === "mission"
+        ? "The mission may be long-term or ongoing. The AI will break it into bounded tasks."
+        : "A single on-chain task currently has a maximum 30-day work window. Longer efforts are converted into a mission with staged tasks.",
+    });
+  }
+
+  async function buildMissionPlan() {
+    ui.input.disabled = true;
+    ui.submit.disabled = true;
+    setStatus("The AI is breaking the mission into definite, verifiable tasks…", "pending");
+    try {
+      const plan = await requestJson(`${API}/v1/cloud-agent/objective-plans`, {
+        method: "POST",
+        body: JSON.stringify({
+          objective: state.originalRequest,
+          context: [
+            `Clarified draft: ${state.initialDraft.goal}`,
+            `Mission horizon: ${state.horizon.label}`,
+            ...state.context,
+            "Break this mission into independent public digital tasks. Each task must have a definite inspectable artifact and binary acceptance criteria. No individual task should require more than 30 days once claimed.",
+          ].join("\n").slice(0, 16_000),
+          constraints: ["Each task must be bounded, measurable, and independently fundable."],
+          max_tasks: MAX_PLAN_TASKS,
+          solver_budget_usdc: null,
+          source_url: null,
+          idempotency_key: `web-mission:${randomBytes32().slice(2)}`,
+        }),
+      });
+      state.missionPlan = plan;
+      state.selectedTaskId = plan.tasks[0].task_id;
+      state.draft = draftFromTask(plan.tasks[0]);
+      askTaskWindow();
+    } catch (error) {
+      setStatus(error.message || String(error), "error");
+      ui.input.disabled = false;
+      ui.submit.disabled = false;
+    }
+  }
+
+  function draftFromTask(task) {
+    const properties = {};
+    for (const field of task.evidence_schema?.required || task.evidence_fields || []) {
+      properties[field] = { type: "string", minLength: 1 };
+    }
+    const evidenceSchema = task.evidence_schema || {
+      type: "object",
+      additionalProperties: false,
+      required: Object.keys(properties),
+      properties,
+    };
+    return {
+      title: task.title,
+      goal: task.goal,
+      acceptance_criteria: safeTextList(task.acceptance_criteria, 20),
+      benchmark: {
+        verifier: task.verifier,
+        mission_task_id: task.task_id,
+        depends_on: task.depends_on || [],
+      },
+      evidence_schema: evidenceSchema,
+      questions: [],
+      risk_flags: safeTextList(state.missionPlan?.risk_flags, 10),
+    };
+  }
+
+  function askTaskWindow() {
+    setComposer({
+      phase: "task_window",
+      prompt: "How many days should the first funded task have once someone claims it?",
+      label: "Task work window",
+      placeholder: "Example: 14 days",
+      button: "Continue",
+      hint: `The mission may be much longer, but each current bounty task must be staged into a 1–${MAX_TASK_DAYS} day work window.`,
+    });
+  }
+
+  function askFunding() {
+    setComposer({
+      phase: "funding",
+      prompt: state.scope === "mission"
+        ? "How much Base USDC do you want to fund for the selected task?"
+        : "How much Base USDC do you want to deposit as the total bounty reward?",
+      label: "Total bounty funding",
+      placeholder: "Example: 25 USDC",
+      button: "Create bounty card",
+      hint: "The total includes the solver reward and a small verifier reserve. Minimum: 0.02 USDC.",
+    });
+  }
+
+  function advanceConversation() {
+    ui.input.disabled = false;
+    ui.submit.disabled = false;
+    if (askNextQuestion()) return;
+    if (!state.scope) {
+      askScope();
+      return;
+    }
+    if (!state.horizon) {
+      askHorizon();
+      return;
+    }
+    if (state.scope === "mission" && !state.missionPlan) {
+      buildMissionPlan();
+      return;
+    }
+    if (state.scope === "mission" && !state.taskWindowDays) {
+      askTaskWindow();
+      return;
+    }
+    if (state.scope === "single" && !state.taskWindowDays) {
+      state.taskWindowDays = Math.max(1, Math.min(MAX_TASK_DAYS, state.horizon.days || MAX_TASK_DAYS));
+    }
+    if (state.fundingUsdc == null) {
+      askFunding();
+      return;
+    }
+    renderPreview();
+  }
+
+  async function handleComposerSubmit(event) {
+    event.preventDefault();
+    const value = ui.input.value.trim();
+    if (!value) {
+      setStatus("Please answer before continuing.", "error");
+      return;
+    }
+    if (state.phase === "describe") {
+      state.originalRequest = value;
+      state.context = [];
+      state.aiRounds = 0;
+      state.questions = [];
+      state.askedQuestions.clear();
+      state.scope = null;
+      state.horizon = null;
+      state.missionPlan = null;
+      state.taskWindowDays = null;
+      state.fundingUsdc = parseFunding(value);
+      await generateInitialDraft();
+      return;
+    }
+    if (state.phase === "ai_question") {
+      state.context.push(`Question: ${state.currentQuestion}\nAnswer: ${value}`);
+      state.currentQuestion = null;
+      if (state.questions.length) askNextQuestion();
+      else await regenerateAfterAnswers();
+      return;
+    }
+    if (state.phase === "scope") {
+      const scope = parseScope(value);
+      if (!scope) {
+        setStatus("Please say whether this is one result or a larger or ongoing mission.", "error");
+        return;
+      }
+      state.scope = scope;
+      state.context.push(`Scope chosen by the user: ${scope}.`);
+      setStatus("");
+      advanceConversation();
+      return;
+    }
+    if (state.phase === "horizon") {
+      const horizon = parseHorizon(value);
+      if (!horizon) {
+        setStatus("Enter a future date, a duration, or say that the mission is ongoing.", "error");
+        return;
+      }
+      state.horizon = horizon;
+      if (state.scope === "single" && (horizon.kind === "ongoing" || horizon.days > MAX_TASK_DAYS)) {
+        state.scope = "mission";
+        state.context.push("The requested horizon exceeds one bounty work window, so the effort must be staged as a mission with bounded tasks.");
+        setStatus("This is longer than one current bounty work window, so the AI will split it into staged tasks. The overall mission keeps its full horizon.", "pending");
+      } else setStatus("");
+      advanceConversation();
+      return;
+    }
+    if (state.phase === "task_window") {
+      const days = parseTaskWindow(value);
+      if (!days) {
+        setStatus(`Choose a work window from 1 to ${MAX_TASK_DAYS} days. Longer work should be split into another milestone task.`, "error");
+        return;
+      }
+      state.taskWindowDays = days;
+      setStatus("");
+      advanceConversation();
+      return;
+    }
+    if (state.phase === "funding") {
+      const amount = parseFunding(value);
+      if (amount == null) {
+        setStatus(`Enter an amount from ${MIN_TOTAL_USDC.toFixed(2)} to ${MAX_TOTAL_USDC.toLocaleString()} USDC.`, "error");
+        return;
+      }
+      state.fundingUsdc = amount;
+      setStatus("");
+      renderPreview();
+      return;
+    }
+    if (state.phase === "revise") {
+      state.context.push(`Requested revision: ${value}`);
+      state.originalRequest = `${state.draft.goal}\nRevision requested by the user: ${value}`;
+      state.aiRounds = 0;
+      state.questions = [];
+      state.askedQuestions.clear();
+      state.initialDraft = null;
+      state.draft = null;
+      state.missionPlan = null;
+      state.selectedTaskId = null;
+      state.visualCache.clear();
+      state.approved = false;
+      await generateInitialDraft();
+    }
+  }
+
+  function selectedTask() {
+    return state.missionPlan?.tasks.find((task) => task.task_id === state.selectedTaskId) || null;
+  }
+
+  function renderMissionPlan() {
+    const isMission = state.scope === "mission" && state.missionPlan;
+    ui.missionContext.hidden = !isMission;
+    if (!isMission) return;
+    ui.missionTitle.textContent = state.missionPlan.title;
+    ui.missionSummary.textContent = state.missionPlan.success_definition;
+    ui.missionHorizon.textContent = `Mission horizon: ${state.horizon.label}`;
+    ui.missionTasks.replaceChildren();
+    for (const task of state.missionPlan.tasks) {
+      const label = document.createElement("label");
+      label.className = "mission-task-option";
+      const input = document.createElement("input");
+      input.type = "radio";
+      input.name = "mission-task";
+      input.value = task.task_id;
+      input.checked = task.task_id === state.selectedTaskId;
+      const copy = document.createElement("span");
+      const title = document.createElement("strong");
+      title.textContent = task.title;
+      const detail = document.createElement("small");
+      detail.textContent = `${task.acceptance_criteria.length} completion checks${task.depends_on?.length ? ` · depends on ${task.depends_on.join(", ")}` : " · can start independently"}`;
+      copy.append(title, detail);
+      label.append(input, copy);
+      input.addEventListener("change", () => selectMissionTask(task.task_id));
+      ui.missionTasks.append(label);
+    }
+  }
+
+  async function selectMissionTask(taskId) {
+    if (taskId === state.selectedTaskId) return;
+    const task = state.missionPlan.tasks.find((candidate) => candidate.task_id === taskId);
+    if (!task) return;
+    state.selectedTaskId = taskId;
+    state.draft = draftFromTask(task);
+    state.approved = false;
+    ui.fund.disabled = true;
+    ui.approve.dataset.approved = "false";
+    ui.approve.textContent = "Approve bounty card";
+    renderCardText();
+    renderMissionPlan();
+    await renderAiVisualForCurrentDraft();
+  }
+
+  function riskSummary() {
+    const risks = state.draft.risk_flags || [];
+    return risks.length ? `${risks.length} item${risks.length === 1 ? "" : "s"} to review` : "No AI blocker flagged";
+  }
+
+  function renderCardText() {
+    ui.title.textContent = state.draft.title;
+    ui.goal.textContent = state.draft.goal;
+    ui.reward.textContent = `${formatUsdc(state.fundingUsdc)} USDC`;
+    ui.deadline.textContent = state.scope === "mission"
+      ? `${state.taskWindowDays} days for this task · ${state.horizon.label} mission`
+      : state.horizon.label;
+    ui.checks.textContent = `${state.draft.acceptance_criteria.length} check${state.draft.acceptance_criteria.length === 1 ? "" : "s"}`;
+    ui.confidence.textContent = riskSummary();
+    ui.criteria.replaceChildren();
+    for (const criterion of state.draft.acceptance_criteria) {
+      const item = document.createElement("li");
+      item.textContent = criterion;
+      ui.criteria.append(item);
+    }
+    ui.risks.replaceChildren();
+    const risks = state.draft.risk_flags || [];
+    if (!risks.length) {
+      const item = document.createElement("li");
+      item.textContent = "No material blocker was identified by the drafting AI. The creator still accepts feasibility and verification risk.";
+      ui.risks.append(item);
+    } else {
+      for (const risk of risks) {
+        const item = document.createElement("li");
+        item.textContent = risk;
+        ui.risks.append(item);
+      }
+    }
+    ui.badge.textContent = state.scope === "mission" ? "Mission task draft · not posted" : "Draft · not posted";
+  }
+
+  async function renderPreview() {
+    if (!state.draft || state.fundingUsdc == null || !state.horizon || !state.taskWindowDays) return;
+    splitReward(state.fundingUsdc);
+    state.phase = "review";
+    state.approved = false;
+    state.imageReady = false;
+    setProgress("review");
+    renderCardText();
+    renderMissionPlan();
+    ui.approve.disabled = true;
+    ui.approve.dataset.approved = "false";
+    ui.approve.textContent = "Preparing image…";
+    ui.fund.disabled = true;
+    ui.preview.hidden = false;
+    ui.preview.scrollIntoView({ behavior: "smooth", block: "start" });
+    setStatus("Generating a bounded pre-publication illustration from the AI draft. Nothing has been posted or funded.", "pending");
+    await renderAiVisualForCurrentDraft();
+    ui.approve.disabled = false;
+    ui.approve.textContent = "Approve bounty card";
+    setStatus("Review the result, tasks, completion checks, horizon, reward, and creator-verification disclosure. Nothing has been posted or funded.");
+  }
+
+  function validHex(value) {
+    return /^#[0-9a-fA-F]{6}$/.test(String(value || ""));
+  }
+
+  function validateVisualSpec(value) {
+    if (!value || typeof value !== "object" || value.version !== 1 || !ALLOWED_SCENES.has(value.scene)) return null;
+    const palette = safeTextList(value.palette, 5).filter(validHex);
+    if (palette.length < 2) return null;
+    const elements = (Array.isArray(value.elements) ? value.elements : []).slice(0, 10).map((element) => ({
+      kind: String(element?.kind || ""),
+      x: Number(element?.x),
+      y: Number(element?.y),
+      size: Number(element?.size),
+    })).filter((element) => ALLOWED_ELEMENTS.has(element.kind)
+      && Number.isInteger(element.x) && element.x >= 0 && element.x <= 100
+      && Number.isInteger(element.y) && element.y >= 0 && element.y <= 100
+      && Number.isFinite(element.size) && element.size >= 0.4 && element.size <= 2);
+    if (elements.length < 3) return null;
+    return { version: 1, scene: value.scene, palette, elements };
+  }
+
+  function extractVisualSpec(draft) {
+    return validateVisualSpec(draft?.evidence_schema?.[VISUAL_EXTENSION]);
+  }
+
+  function fallbackVisualSpec(text) {
+    const value = String(text || "").toLowerCase();
+    const scene = /street|light|road|bridge|building|infrastructure/.test(value)
+      ? "infrastructure"
+      : /water|tree|climate|nature|environment/.test(value)
+        ? "nature"
+        : /health|medical|care|blood/.test(value)
+          ? "health"
+          : /school|learn|education|course|book/.test(value)
+            ? "education"
+            : /research|report|study|analysis|data/.test(value)
+              ? "research"
+              : /website|app|software|code|platform/.test(value)
+                ? "digital"
+                : "coordination";
+    const elementsByScene = {
+      infrastructure: ["road", "lamp", "lamp", "building", "check"],
+      nature: ["water", "tree", "tree", "sun", "check"],
+      health: ["person", "health", "chart", "check", "sun"].map((kind) => kind === "health" ? "check" : kind),
+      education: ["book", "person", "screen", "check", "sun"],
+      research: ["document", "chart", "document", "check", "network"],
+      digital: ["screen", "network", "tool", "check", "document"],
+      coordination: ["person", "network", "person", "tool", "check"],
+    };
+    return {
+      version: 1,
+      scene,
+      palette: ["#06140d", "#1b5132", "#c9f548", "#7cefd1"],
+      elements: elementsByScene[scene].map((kind, index) => ({ kind, x: 14 + index * 18, y: 62 - (index % 2) * 22, size: 0.8 + (index % 3) * 0.2 })),
+    };
+  }
+
+  async function requestVisualSpecForTask(task) {
+    const cached = state.visualCache.get(task.task_id);
+    if (cached) return cached;
+    try {
+      const visualDraft = await requestJson(`${API}/v1/cloud-agent/bounty-drafts`, {
+        method: "POST",
+        body: JSON.stringify({
+          objective: task.goal,
+          context: draftContext([
+            `Mission: ${state.missionPlan.title}`,
+            `Selected task: ${task.title}`,
+            `Fixed acceptance criteria: ${task.acceptance_criteria.join(" | ")}`,
+            "Do not ask questions. Preserve the selected task. The only extra work is the bounded visual annotation.",
+          ].join("\n")),
+          constraints: task.acceptance_criteria,
+          source_url: null,
+          idempotency_key: `web-task-visual:${task.task_id}:${randomBytes32().slice(2)}`,
+        }),
+      });
+      const spec = extractVisualSpec(visualDraft);
+      if (spec) state.visualCache.set(task.task_id, spec);
+      return spec;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  async function renderAiVisualForCurrentDraft() {
+    ui.imageStatus.textContent = "Generating AI visual…";
+    ui.imageStatus.dataset.tone = "";
+    let spec = extractVisualSpec(state.draft);
+    if (!spec && state.scope === "mission") {
+      const task = selectedTask();
+      if (task) spec = await requestVisualSpecForTask(task);
+    }
+    if (spec) {
+      state.visualSpec = spec;
+      state.visualSource = "ai";
+      ui.imageStatus.textContent = "AI-generated draft visual";
+      ui.imageStatus.dataset.tone = "ai";
+    } else {
+      state.visualSpec = fallbackVisualSpec(`${state.draft.title} ${state.draft.goal}`);
+      state.visualSource = "fallback";
+      ui.imageStatus.textContent = "Bounded fallback visual";
+      ui.imageStatus.dataset.tone = "";
+    }
+    renderVisual(ui.art, state.visualSpec);
+    state.imageReady = true;
+  }
+
+  function renderVisual(canvas, spec) {
+    const width = 1200;
+    const height = 675;
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    const palette = spec.palette;
+    const background = context.createLinearGradient(0, 0, width, height);
+    background.addColorStop(0, palette[0]);
+    background.addColorStop(1, palette[1]);
+    context.fillStyle = background;
+    context.fillRect(0, 0, width, height);
+
+    const glow = context.createRadialGradient(width * .72, height * .2, 10, width * .72, height * .2, 420);
+    glow.addColorStop(0, `${palette[2]}66`);
+    glow.addColorStop(1, `${palette[2]}00`);
+    context.fillStyle = glow;
+    context.fillRect(0, 0, width, height);
+
+    context.lineCap = "round";
+    context.lineJoin = "round";
+    for (const element of spec.elements) drawElement(context, element, palette, width, height);
+
+    context.fillStyle = "rgba(2,11,8,.22)";
+    context.fillRect(0, 0, width, height);
+    context.fillStyle = "rgba(255,255,255,.92)";
+    context.font = "750 28px system-ui, sans-serif";
+    context.fillText("AI outcome visual", 52, 610);
+    context.fillStyle = "rgba(255,255,255,.62)";
+    context.font = "500 20px system-ui, sans-serif";
+    context.fillText("Bounded pre-publication draft · not completion evidence", 52, 642);
+  }
+
+  function drawElement(context, element, palette, width, height) {
+    const x = element.x / 100 * width;
+    const y = element.y / 100 * height;
+    const size = 70 * element.size;
+    const accent = palette[2] || "#c9f548";
+    const secondary = palette[3] || "#7cefd1";
+    context.save();
+    context.translate(x, y);
+    context.strokeStyle = accent;
+    context.fillStyle = secondary;
+    context.lineWidth = Math.max(4, size * .09);
+    switch (element.kind) {
+      case "sun":
+        context.fillStyle = accent;
+        context.beginPath(); context.arc(0, 0, size * .45, 0, Math.PI * 2); context.fill();
+        break;
+      case "road":
+        context.fillStyle = "rgba(1,8,5,.72)";
+        context.beginPath(); context.moveTo(-size, size); context.lineTo(-size * .28, -size); context.lineTo(size * .28, -size); context.lineTo(size, size); context.closePath(); context.fill();
+        context.strokeStyle = accent; context.setLineDash([size * .18, size * .18]); context.beginPath(); context.moveTo(0, size); context.lineTo(0, -size); context.stroke(); context.setLineDash([]);
+        break;
+      case "lamp":
+        context.strokeStyle = secondary; context.beginPath(); context.moveTo(0, size); context.lineTo(0, -size * .55); context.quadraticCurveTo(0, -size, size * .45, -size); context.stroke();
+        context.fillStyle = accent; context.beginPath(); context.arc(size * .45, -size, size * .16, 0, Math.PI * 2); context.fill();
+        break;
+      case "building":
+        context.fillStyle = "rgba(255,255,255,.14)"; context.fillRect(-size * .65, -size, size * 1.3, size * 2);
+        context.fillStyle = accent; for (let row = -1; row <= 1; row += 1) for (let column = -1; column <= 1; column += 1) context.fillRect(column * size * .32 - size * .1, row * size * .45 - size * .1, size * .18, size * .18);
+        break;
+      case "tree":
+        context.strokeStyle = secondary; context.beginPath(); context.moveTo(0, size); context.lineTo(0, -size * .15); context.stroke();
+        context.fillStyle = accent; context.beginPath(); context.arc(0, -size * .45, size * .55, 0, Math.PI * 2); context.fill();
+        break;
+      case "water":
+        context.strokeStyle = secondary; for (let row = -1; row <= 1; row += 1) { context.beginPath(); context.moveTo(-size, row * size * .35); context.bezierCurveTo(-size * .5, row * size * .35 - size * .25, 0, row * size * .35 + size * .25, size, row * size * .35); context.stroke(); }
+        break;
+      case "screen":
+        context.fillStyle = "rgba(1,8,5,.66)"; context.strokeStyle = secondary; context.roundRect(-size, -size * .65, size * 2, size * 1.3, size * .15); context.fill(); context.stroke();
+        context.fillStyle = accent; context.fillRect(-size * .7, -size * .3, size * 1.1, size * .13); context.fillRect(-size * .7, 0, size * 1.4, size * .13);
+        break;
+      case "document":
+        context.fillStyle = "rgba(246,248,232,.86)"; context.roundRect(-size * .65, -size, size * 1.3, size * 2, size * .12); context.fill();
+        context.fillStyle = palette[1]; for (let row = 0; row < 4; row += 1) context.fillRect(-size * .42, -size * .55 + row * size * .38, size * (.8 - row * .08), size * .1);
+        break;
+      case "network":
+        context.strokeStyle = secondary; for (let index = 0; index < 5; index += 1) { const angle = index / 5 * Math.PI * 2; const px = Math.cos(angle) * size * .75; const py = Math.sin(angle) * size * .75; context.beginPath(); context.moveTo(0,0); context.lineTo(px,py); context.stroke(); context.fillStyle = accent; context.beginPath(); context.arc(px,py,size*.12,0,Math.PI*2); context.fill(); } context.beginPath(); context.arc(0,0,size*.18,0,Math.PI*2); context.fill();
+        break;
+      case "tool":
+        context.strokeStyle = accent; context.lineWidth = size * .18; context.beginPath(); context.moveTo(-size * .65, size * .65); context.lineTo(size * .45, -size * .45); context.stroke(); context.beginPath(); context.arc(size * .55, -size * .55, size * .35, Math.PI * .2, Math.PI * 1.3); context.stroke();
+        break;
+      case "person":
+        context.fillStyle = accent; context.beginPath(); context.arc(0, -size * .55, size * .24, 0, Math.PI * 2); context.fill(); context.strokeStyle = secondary; context.beginPath(); context.moveTo(0,-size*.25); context.lineTo(0,size*.5); context.moveTo(0,0); context.lineTo(-size*.5,size*.2); context.moveTo(0,0); context.lineTo(size*.5,size*.2); context.moveTo(0,size*.5); context.lineTo(-size*.4,size); context.moveTo(0,size*.5); context.lineTo(size*.4,size); context.stroke();
+        break;
+      case "check":
+        context.fillStyle = accent; context.beginPath(); context.arc(0,0,size*.8,0,Math.PI*2); context.fill(); context.strokeStyle = palette[0]; context.lineWidth = size*.18; context.beginPath(); context.moveTo(-size*.35,0); context.lineTo(-size*.05,size*.3); context.lineTo(size*.45,-size*.35); context.stroke();
+        break;
+      case "bridge":
+        context.strokeStyle = secondary; context.beginPath(); context.moveTo(-size, size * .45); context.lineTo(size, size * .45); context.moveTo(-size*.75,size*.45); context.quadraticCurveTo(0,-size*.8,size*.75,size*.45); context.stroke();
+        break;
+      case "book":
+        context.fillStyle = "rgba(246,248,232,.84)"; context.beginPath(); context.moveTo(0,size*.7); context.quadraticCurveTo(-size*.45,size*.25,-size,-size*.6); context.lineTo(-size,-size*.9); context.quadraticCurveTo(-size*.35,-size*.5,0,0); context.quadraticCurveTo(size*.35,-size*.5,size,-size*.9); context.lineTo(size,-size*.6); context.quadraticCurveTo(size*.45,size*.25,0,size*.7); context.fill(); context.strokeStyle = accent; context.beginPath(); context.moveTo(0,0); context.lineTo(0,size*.7); context.stroke();
+        break;
+      case "chart":
+        context.strokeStyle = secondary; context.beginPath(); context.moveTo(-size,-size); context.lineTo(-size,size); context.lineTo(size,size); context.stroke(); context.fillStyle = accent; for (let index=0; index<4; index+=1) context.fillRect(-size*.7+index*size*.45,size*.65-(index+1)*size*.32,size*.25,(index+1)*size*.32);
+        break;
+      default:
+        break;
+    }
+    context.restore();
+  }
+
+  function stripVisualExtension(schema) {
+    const clone = JSON.parse(JSON.stringify(schema || { type: "object", additionalProperties: true }));
+    if (clone && typeof clone === "object") delete clone[VISUAL_EXTENSION];
+    return clone;
+  }
+
+  function canonicalJsonValue(value) {
+    if (Array.isArray(value)) return value.map(canonicalJsonValue);
+    if (value && typeof value === "object") {
+      return Object.keys(value).sort().reduce((result, key) => {
+        result[key] = canonicalJsonValue(value[key]);
+        return result;
+      }, {});
+    }
+    return value;
+  }
+
+  function missionBenchmark(base) {
+    const benchmark = JSON.parse(JSON.stringify(base || {}));
+    if (state.scope === "mission" && state.missionPlan) {
+      benchmark.x_agent_bounties_mission = {
+        title: state.missionPlan.title,
+        success_definition: state.missionPlan.success_definition,
+        horizon: state.horizon.label,
+        selected_task_id: state.selectedTaskId,
+        task_window_days: state.taskWindowDays,
+        planned_task_ids: state.missionPlan.tasks.map((task) => task.task_id),
+      };
+    }
+    return benchmark;
+  }
+
+  function wrapCanvasText(context, text, maxWidth, maxLines) {
+    const words = String(text || "").split(/\s+/).filter(Boolean);
+    const lines = [];
+    let line = "";
+    for (const word of words) {
+      const next = line ? `${line} ${word}` : word;
+      if (context.measureText(next).width > maxWidth && line) {
+        lines.push(line);
+        line = word;
+        if (lines.length >= maxLines) break;
+      } else line = next;
+    }
+    if (line && lines.length < maxLines) lines.push(line);
+    if (lines.length === maxLines && lines.join(" ").split(/\s+/).length < words.length) lines[lines.length - 1] = `${lines[lines.length - 1].replace(/[. ]+$/, "")}…`;
+    return lines;
+  }
+
+  async function shareBountyCard() {
+    if (!state.draft || !state.imageReady) return;
+    ui.share.disabled = true;
+    try {
+      const canvas = document.createElement("canvas");
+      canvas.width = 1200;
+      canvas.height = 1500;
+      const context = canvas.getContext("2d");
+      context.fillStyle = "#03110b"; context.fillRect(0,0,1200,1500);
+      context.drawImage(ui.art, 0, 0, 1200, 675);
+      const gradient = context.createLinearGradient(0,620,0,1500); gradient.addColorStop(0,"rgba(6,31,18,.95)"); gradient.addColorStop(1,"#020b08"); context.fillStyle = gradient; context.fillRect(0,610,1200,890);
+      context.fillStyle = "#c9f548"; context.font = "800 29px system-ui"; context.fillText(state.scope === "mission" ? "AGENT BOUNTIES · MISSION TASK" : "AGENT BOUNTIES · BOUNTY CARD", 68, 710);
+      context.fillStyle = "#f4f6ef"; context.font = "850 68px system-ui";
+      let y = 806; for (const line of wrapCanvasText(context,state.draft.title,1060,3)) { context.fillText(line,68,y); y += 76; }
+      context.fillStyle = "#bdc8c0"; context.font = "440 31px system-ui"; y += 10; for (const line of wrapCanvasText(context,state.draft.goal,1060,5)) { context.fillText(line,68,y); y += 43; }
+      const statsY = Math.max(y + 32, 1180);
+      const stats = [["TOTAL REWARD",`${formatUsdc(state.fundingUsdc)} USDC`],["TASK WINDOW",`${state.taskWindowDays} days`],["MISSION HORIZON",state.scope === "mission" ? state.horizon.label : "Single result"]];
+      stats.forEach(([label,value],index) => { const x=68+index*355; context.fillStyle="rgba(201,245,72,.12)"; context.fillRect(x,statsY,325,126); context.fillStyle="#8d9a91"; context.font="800 19px system-ui"; context.fillText(label,x+20,statsY+36); context.fillStyle="#f4f6ef"; context.font="750 27px system-ui"; let lineY=statsY+76; for(const line of wrapCanvasText(context,value,285,2)){context.fillText(line,x+20,lineY);lineY+=31;} });
+      context.fillStyle="#e8c15a"; context.font="650 23px system-ui"; context.fillText("DRAFT · NOT POSTED OR FUNDED · CREATOR VERIFIES COMPLETION",68,1435);
+      const blob = await new Promise((resolve) => canvas.toBlob(resolve,"image/png"));
+      if (!blob) throw new Error("The share image could not be created.");
+      const file = new File([blob],"agent-bounties-card.png",{type:"image/png"});
+      const data = { title: state.draft.title, text: `${state.draft.title} — ${formatUsdc(state.fundingUsdc)} USDC bounty draft on Agent Bounties.`, ...(state.bountyContract ? {url:`https://agentbounties.app/earn.html?bountyContract=${encodeURIComponent(state.bountyContract)}`} : {}) };
+      if (navigator.canShare && navigator.canShare({files:[file]})) await navigator.share({...data,files:[file]});
+      else { const url=URL.createObjectURL(file); const link=document.createElement("a"); link.href=url; link.download=file.name; link.click(); setTimeout(()=>URL.revokeObjectURL(url),1500); if(state.bountyContract&&navigator.clipboard) await navigator.clipboard.writeText(data.url); setStatus(state.bountyContract?"Card downloaded and the funded bounty link was copied.":"Draft card downloaded. It makes no funding claim.","success"); }
+    } catch (error) { if (error?.name !== "AbortError") setStatus(error.message || String(error),"error"); }
+    finally { ui.share.disabled=false; }
+  }
+
+  function approveCard() {
+    if (!state.imageReady) return;
+    state.approved = true;
+    ui.approve.dataset.approved = "true";
+    ui.approve.textContent = "Approved ✓";
+    ui.fund.disabled = false;
+    setProgress("fund");
+    setStatus("Card approved. Funding still requires a separate wallet review and signature.", "success");
+  }
+
+  function reviseCard() {
+    state.approved = false;
+    ui.approve.dataset.approved = "false";
+    ui.approve.textContent = "Approve bounty card";
+    ui.fund.disabled = true;
+    setComposer({ phase:"revise", prompt:"What should the AI change about this bounty or mission plan?", label:"Revision request", placeholder:"Example: Split the research into its own task and extend the mission horizon to one year.", button:"Update card", hint:"Changing the card removes approval until you review it again." });
+    document.querySelector(".composer-shell")?.scrollIntoView({behavior:"smooth",block:"center"});
+  }
+
+  function openFunding() {
+    if (!state.approved) return;
+    ui.dialog.showModal();
+    setPaymentStatus("Choose a payment method. Only a crypto wallet is available today.");
+    ui.walletPanel.hidden = true;
+    ui.readiness.hidden = true;
+    ui.fundNow.disabled = true;
+  }
+
+  function providerName(item) {
+    if (item.info?.name) return item.info.name;
+    if (item.provider.isMetaMask) return "MetaMask";
+    if (item.provider.isCoinbaseWallet) return "Coinbase Wallet";
+    if (item.provider.isBraveWallet) return "Brave Wallet";
+    return "Browser wallet";
+  }
+
+  async function discoverWallets() {
+    window.dispatchEvent(new Event("eip6963:requestProvider"));
+    await new Promise((resolve) => setTimeout(resolve,350));
+    const candidates=[...announcedProviders];
+    const injected=window.ethereum&&Array.isArray(window.ethereum.providers)?window.ethereum.providers:(window.ethereum?[window.ethereum]:[]);
+    for(const provider of injected) if(provider&&typeof provider.request==="function"&&!candidates.some((item)=>item.provider===provider)) candidates.push({provider,info:{}});
+    state.providers=candidates;
+    return candidates;
+  }
+
+  async function chooseCryptoWallet() {
+    ui.cryptoMethod.dataset.active="true";
+    ui.walletPanel.hidden=false;
+    ui.walletOptions.textContent="";
+    ui.walletMessage.textContent="Looking for wallets on this device…";
+    const providers=await discoverWallets();
+    if(!providers.length){ui.walletMessage.textContent="No compatible browser wallet was detected. Install or open a Base-compatible wallet, then try again. Never enter a recovery phrase on this website.";return;}
+    ui.walletMessage.textContent=providers.length===1?"One wallet is available.":`${providers.length} wallets are available. Choose which one to use.`;
+    for(const item of providers){const button=document.createElement("button");button.type="button";button.className="wallet-option";const name=document.createElement("strong");name.textContent=providerName(item);const note=document.createElement("small");note.textContent="Connect and check Base USDC";button.append(name,note);button.addEventListener("click",()=>connectWallet(item));ui.walletOptions.append(button);}
+  }
+
+  async function loadProtocol() {
+    if(state.protocol)return state.protocol;
+    const response=await fetch("protocol.json",{cache:"no-store"});
+    if(!response.ok)throw new Error("Protocol configuration is unavailable.");
+    const protocol=await response.json();
+    if(protocol.status!=="active"||!/^0x[0-9a-fA-F]{40}$/.test(protocol.factory||""))throw new Error("The Base protocol is not active. No transaction was requested.");
+    state.protocol=protocol;return protocol;
+  }
+
+  async function switchToBase(provider,protocol){const current=await provider.request({method:"eth_chainId"});if(String(current).toLowerCase()===String(protocol.chain_id_hex).toLowerCase())return;try{await provider.request({method:"wallet_switchEthereumChain",params:[{chainId:protocol.chain_id_hex}]});}catch(error){if(error&&error.code===4902){await provider.request({method:"wallet_addEthereumChain",params:[{chainId:protocol.chain_id_hex,chainName:"Base",nativeCurrency:{name:"Ether",symbol:"ETH",decimals:18},rpcUrls:["https://mainnet.base.org"],blockExplorerUrls:[protocol.explorer_url]}]});}else throw error;}}
+
+  async function connectWallet(item){state.provider=item.provider;setPaymentStatus(`Connecting ${providerName(item)}…`,"pending");try{const protocol=await loadProtocol();const accounts=await state.provider.request({method:"eth_requestAccounts"});if(!accounts||!accounts[0])throw new Error("The wallet did not return an account.");state.account=accounts[0];await switchToBase(state.provider,protocol);await refreshWalletReadiness();}catch(error){setPaymentStatus(error.message||String(error),"error");}}
+
+  function addressWord(address){return String(address).toLowerCase().replace(/^0x/,"").padStart(64,"0");}
+
+  async function refreshWalletReadiness(){if(!state.provider||!state.account)return;const protocol=await loadProtocol();const required=usdcBaseUnits(state.fundingUsdc);setPaymentStatus("Checking Base USDC and gas readiness…","pending");const[usdcRaw,ethRaw]=await Promise.all([state.provider.request({method:"eth_call",params:[{to:protocol.native_usdc,data:`0x70a08231${addressWord(state.account)}`},"latest"]}),state.provider.request({method:"eth_getBalance",params:[state.account,"latest"]})]);const usdc=BigInt(usdcRaw||"0x0");const eth=BigInt(ethRaw||"0x0");state.balances={usdc,eth,required};const usdcReady=usdc>=required;const ethReady=eth>0n;ui.account.textContent=`${state.account.slice(0,8)}…${state.account.slice(-6)}`;ui.usdcBalance.textContent=`${formatUsdc(Number(usdc)/1_000_000)} USDC`;ui.ethBalance.textContent=`${(Number(eth)/1e18).toFixed(6)} ETH`;ui.requiredUsdc.textContent=`${formatUsdc(state.fundingUsdc)} USDC`;ui.readiness.hidden=false;ui.fundingHelp.hidden=usdcReady&&ethReady;const missing=required>usdc?required-usdc:0n;ui.missingUsdc.textContent=`${formatUsdc(Number(missing)/1_000_000)} USDC`;ui.fundNow.disabled=!(usdcReady&&ethReady);if(usdcReady&&ethReady)setPaymentStatus("Wallet ready. Review the exact amount, legal terms, and wallet request before signing.","success");else if(!usdcReady&&!ethReady)setPaymentStatus("This wallet needs more Base USDC and a small amount of Base ETH for gas.","error");else if(!usdcReady)setPaymentStatus("This wallet does not yet hold enough USDC on Base.","error");else setPaymentStatus("The USDC is available, but the wallet needs a small amount of Base ETH for gas.","error");}
+
+  async function watchUsdcAsset(){try{const protocol=await loadProtocol();await state.provider.request({method:"wallet_watchAsset",params:{type:"ERC20",options:{address:protocol.native_usdc,symbol:"USDC",decimals:6}}});setPaymentStatus("Base USDC was offered to the wallet. This does not buy or transfer tokens.","success");}catch(error){setPaymentStatus(error.message||String(error),"error");}}
+  async function copyUsdcAddress(){const protocol=await loadProtocol();await navigator.clipboard.writeText(protocol.native_usdc);setPaymentStatus("Base USDC contract address copied. Verify the network and address inside your wallet before acquiring tokens.","success");}
+
+  function signatureParts(signature){const value=String(signature).replace(/^0x/,"");if(value.length!==130)throw new Error("The wallet returned an invalid signature.");return{r:`0x${value.slice(0,64)}`,s:`0x${value.slice(64,128)}`,v:Number.parseInt(value.slice(128,130),16)};}
+  async function sendTransaction(transaction){if(!transaction||!transaction.to||!transaction.data||Number(transaction.value_wei||0)!==0)throw new Error("The planned transaction is invalid.");return state.provider.request({method:"eth_sendTransaction",params:[{from:state.account,to:transaction.to,data:transaction.data,value:"0x0"}]});}
+  async function waitReceipt(hash,timeoutMs=150000){const started=Date.now();while(Date.now()-started<timeoutMs){const receipt=await state.provider.request({method:"eth_getTransactionReceipt",params:[hash]});if(receipt){if(receipt.status!=="0x1")throw new Error(`The Base transaction reverted: ${hash}`);return receipt;}await new Promise((resolve)=>setTimeout(resolve,1600));}throw new Error("The transaction is still pending. Check the wallet or Base explorer before trying again.");}
+  async function isContractAccount(){const code=await state.provider.request({method:"eth_getCode",params:[state.account,"latest"]});return code&&code!=="0x"&&code!=="0x0";}
+  async function sendWalletCalls(calls,protocol){try{return await state.provider.request({method:"wallet_sendCalls",params:[{version:"2.0.0",chainId:protocol.chain_id_hex,from:state.account,calls:calls.map((call)=>({to:call.to,data:call.data,value:"0x0"}))}]});}catch(_error){let last=null;for(const call of calls){last=await sendTransaction(call);await waitReceipt(last);}return last;}}
+
+  function contractTerms(protocol,rewards){const now=Math.floor(Date.now()/1000);return{protocol_version:protocol.protocol_version,creator_wallet:state.account,network:protocol.network,settlement_token:protocol.native_usdc,solver_reward:{amount:Number(rewards.solver),currency:"usdc"},verifier_reward:{amount:Number(rewards.verifier),currency:"usdc"},claim_bond:{amount:Number(rewards.verifier),currency:"usdc"},initial_funding:{amount:Number(rewards.total),currency:"usdc"},funding_deadline:now+30*86400,claim_window_seconds:state.taskWindowDays*86400,verification_window_seconds:48*3600,creation_nonce:randomBytes32()};}
+
+  function termsDocument(committed){return{schema_version:"agent-bounties/terms-v1",contract_terms:committed,title:state.draft.title,goal:state.draft.goal,acceptance_criteria:state.draft.acceptance_criteria,benchmark:canonicalJsonValue(missionBenchmark(state.draft.benchmark||{type:"creator_review"})),evidence_schema:canonicalJsonValue(stripVisualExtension(state.draft.evidence_schema)),verification_policy:{mechanism:"signed_quorum",verifier_module:null,verifier_reward_recipient:null,verifiers:[state.account],threshold:1,ai_provider:null,ai_model:null,ai_model_version:null,system_prompt:null,rubric:null,decoding_parameters:{},public_disclosure:"The bounty creator is the single subjective verifier and decides pass or fail against the published acceptance criteria."},source_url:null,discovery_source:"web_ai_bounty_card_composer_v2"};}
+
+  function createPayload(terms,committed){return{creator:state.account,solver_reward:committed.solver_reward,verifier_reward:committed.verifier_reward,terms_hash:terms.terms_hash,policy_hash:terms.policy_hash,acceptance_criteria_hash:terms.acceptance_criteria_hash,benchmark_hash:terms.benchmark_hash,evidence_schema_hash:terms.evidence_schema_hash,funding_deadline:committed.funding_deadline,claim_window_seconds:committed.claim_window_seconds,verification_window_seconds:committed.verification_window_seconds,verification_mode:"signed_quorum",verifier_module:null,verifier_reward_recipient:null,verifiers:[state.account],threshold:1,initial_funding:committed.initial_funding,creation_nonce:committed.creation_nonce};}
+
+  function validateCreationPlan(plan,protocol,create){if(!plan||!/^0x[0-9a-fA-F]{40}$/.test(plan.predicted_bounty_contract||""))throw new Error("The creation plan did not return a valid bounty address.");if(Number(plan.network&&plan.network.chain_id)!==Number(protocol.chain_id))throw new Error("The creation plan targets the wrong network.");if(String(plan.factory_contract||"").toLowerCase()!==String(protocol.factory).toLowerCase())throw new Error("The creation plan does not use the canonical factory.");const target=Number(create.solver_reward.amount)+Number(create.verifier_reward.amount);if(Number(create.initial_funding.amount)!==target)throw new Error("The creation plan is not fully funded.");}
+
+  async function pollCreation(api,bountyId,timeoutMs=100000){const started=Date.now();while(Date.now()-started<timeoutMs){const events=await requestJson(`${api}/v1/base/autonomous-bounties/events?network=base-mainnet&bounty_id=${encodeURIComponent(bountyId)}`,{cache:"no-store"});const created=events.some((event)=>event.kind==="canonical_bounty_created");const funded=events.some((event)=>event.kind==="funding_added");const claimable=events.some((event)=>event.kind==="bounty_became_claimable");if(created&&funded&&claimable)return events;await new Promise((resolve)=>setTimeout(resolve,2500));}return null;}
+
+  async function fetchFeedItem(api,contract){try{const items=await requestJson(`${api}/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false`,{cache:"no-store"});return items.find((item)=>String(item.bounty_contract).toLowerCase()===String(contract).toLowerCase())||null;}catch(_error){return null;}}
+
+  async function fundApprovedBounty(){if(!state.approved||!state.provider||!state.account||!state.balances)return;ui.fundNow.disabled=true;setPaymentStatus("Preparing the exact canonical Base USDC funding request…","pending");try{await refreshWalletReadiness();if(state.balances.usdc<state.balances.required||state.balances.eth===0n)throw new Error("The wallet is not ready to fund this bounty.");if(!window.AgentBountiesLegal)throw new Error("The legal agreement could not be loaded. Reload before using the wallet.");await window.AgentBountiesLegal.requireAcceptance({action:"post_bounty",walletAddress:state.account,scope:ui.dialog});const protocol=await loadProtocol();const api=String(protocol.api_base_url).replace(/\/$/,"");const rewards=splitReward(state.fundingUsdc);const committed=contractTerms(protocol,rewards);const document=termsDocument(committed);const terms=await requestJson(`${api}/v1/base/autonomous-bounties/terms`,{method:"POST",body:JSON.stringify({creator_wallet:state.account,document})});const create=createPayload(terms,committed);const plan=await requestJson(`${api}/v1/base/autonomous-bounties/creation-plan`,{method:"POST",body:JSON.stringify({network:"base-mainnet",create})});validateCreationPlan(plan,protocol,create);setPaymentStatus(["Review the wallet request carefully.",`Exact total funding: ${formatUsdc(state.fundingUsdc)} Base USDC.`,`Predicted bounty: ${plan.predicted_bounty_contract}`,"A signature or transaction hash is not funding evidence."].join("\n"),"pending");let transactionHash=null;if(!(await isContractAccount())&&plan.eip3009_authorization){const signature=await state.provider.request({method:"eth_signTypedData_v4",params:[state.account,JSON.stringify(plan.eip3009_authorization)]});const authorized=await requestJson(`${api}/v1/base/autonomous-bounties/authorized-creation-plan`,{method:"POST",body:JSON.stringify({network:"base-mainnet",create,signature:signatureParts(signature),relayer:state.account})});if(!authorized.relay_transaction||String(authorized.relay_transaction.to).toLowerCase()!==String(protocol.factory).toLowerCase())throw new Error("The authorized transaction does not target the canonical factory.");transactionHash=await sendTransaction(authorized.relay_transaction);await waitReceipt(transactionHash);}else{const result=await sendWalletCalls(plan.wallet_calls,protocol);if(typeof result==="string"&&result.startsWith("0x"))transactionHash=result;}state.bountyContract=plan.predicted_bounty_contract;state.bountyId=plan.bounty_id;setPaymentStatus("Transaction confirmed. Waiting for canonical FundingAdded and BountyBecameClaimable evidence…","pending");const events=await pollCreation(api,plan.bounty_id);if(!events){setPaymentStatus(["The transaction was confirmed, but canonical funding evidence is still pending.",transactionHash?`Transaction: ${protocol.explorer_url}/tx/${transactionHash}`:"Wallet batch submitted.","Do not describe the bounty as funded until FundingAdded and BountyBecameClaimable are confirmed."].join("\n"),"pending");return;}const item=await fetchFeedItem(api,state.bountyContract);if(item?.verification_ready){ui.badge.textContent="Funded · ready to earn";setPaymentStatus(["Bounty funded and ready for public earning.",`Contract: ${state.bountyContract}`,"Solver payment will be proven only by BountySettled."].join("\n"),"success");}else{ui.badge.textContent="Funded · verifier setup required";setPaymentStatus(["Canonical funding is confirmed.",`Contract: ${state.bountyContract}`,"The creator is the committed verifier. The bounty will not appear in the default ready-to-earn inventory until verifier availability is represented by the protocol.","Solver payment will be proven only by BountySettled."].join("\n"),"success");}ui.fundNow.textContent="Funded ✓";ui.fundNow.disabled=true;if(window.agentBountiesTrack)window.agentBountiesTrack("canonical_post_confirmed",{bounty_contract:state.bountyContract});}catch(error){setPaymentStatus(error.message||String(error),"error");ui.fundNow.disabled=false;}}
+
+  function configureSpeech(){const Recognition=window.SpeechRecognition||window.webkitSpeechRecognition;if(!Recognition){ui.mic.hidden=true;ui.hint.textContent="Type naturally. Your words are not posted until you approve the final card.";return;}const recognition=new Recognition();recognition.continuous=false;recognition.interimResults=true;recognition.lang=document.documentElement.lang||navigator.language||"en-US";let original="";recognition.addEventListener("start",()=>{original=ui.input.value.trim();ui.mic.dataset.listening="true";setStatus("Listening…","pending");});recognition.addEventListener("result",(event)=>{let transcript="";for(let index=event.resultIndex;index<event.results.length;index+=1)transcript+=event.results[index][0].transcript;ui.input.value=[original,transcript.trim()].filter(Boolean).join(original?" ":"");});recognition.addEventListener("end",()=>{ui.mic.dataset.listening="false";setStatus("Review the dictated text, then continue.");});recognition.addEventListener("error",(event)=>{ui.mic.dataset.listening="false";setStatus(event.error==="not-allowed"?"Microphone permission was not granted. You can still type.":"Dictation stopped. You can continue typing.","error");});ui.mic.addEventListener("click",()=>{if(ui.mic.dataset.listening==="true")recognition.stop();else recognition.start();});state.speech=recognition;}
+
+  async function prefillFromQuery(){const params=new URLSearchParams(window.location.search);const supplied=params.get("goal")||params.get("draftObjective")||params.get("objective");const title=params.get("title");const goal=params.get("goal");const criteria=params.getAll("criterion");if(supplied||title||goal||criteria.length){ui.input.value=[supplied,title&&`Title: ${title}`,goal&&`Result: ${goal}`,criteria.length&&`Completion checks: ${criteria.join("; ")}`].filter(Boolean).join("\n");state.fundingUsdc=parseFunding(params.get("solverReward"));}const draftId=params.get("socialDraft");if(draftId&&/^[0-9a-f-]{36}$/i.test(draftId)){try{const response=await requestJson(`${API}/v1/social/mention-drafts/${draftId}`);const draft=response&&response.draft;if(draft&&draft.state==="review_required_not_published"){ui.input.value=[draft.draft_objective,draft.goal,...(draft.acceptance_criteria||[])].filter(Boolean).join("\n");const solver=Number(draft.solver_reward&&draft.solver_reward.amount||0);const verifier=Number(draft.verifier_reward&&draft.verifier_reward.amount||0);if(Number.isSafeInteger(solver)&&Number.isSafeInteger(verifier))state.fundingUsdc=(solver+verifier)/1_000_000;setStatus("Draft imported. It has not been posted or funded. Describe any changes, then continue.","pending");}}catch(error){setStatus(error.message||String(error),"error");}}}
+
+  ui.form.addEventListener("submit",handleComposerSubmit);
+  ui.approve.addEventListener("click",approveCard);
+  ui.revise.addEventListener("click",reviseCard);
+  ui.share.addEventListener("click",shareBountyCard);
+  ui.fund.addEventListener("click",openFunding);
+  ui.closeDialog.addEventListener("click",()=>ui.dialog.close());
+  ui.cryptoMethod.addEventListener("click",chooseCryptoWallet);
+  ui.watchUsdc.addEventListener("click",watchUsdcAsset);
+  ui.copyUsdc.addEventListener("click",copyUsdcAddress);
+  ui.recheck.addEventListener("click",()=>refreshWalletReadiness().catch((error)=>setPaymentStatus(error.message||String(error),"error")));
+  ui.fundNow.addEventListener("click",fundApprovedBounty);
+  ui.dialog.addEventListener("click",(event)=>{if(event.target===ui.dialog)ui.dialog.close();});
+
+  configureSpeech();
+  setProgress("describe");
+  prefillFromQuery();
+})();

--- a/site/bounty-composer.css
+++ b/site/bounty-composer.css
@@ -1,0 +1,638 @@
+:root {
+  --composer-bg: #020b08;
+  --composer-panel: rgba(7, 25, 16, 0.92);
+  --composer-panel-strong: #071b11;
+  --composer-line: rgba(188, 239, 55, 0.24);
+  --composer-lime: #c9f548;
+  --composer-mint: #7cefd1;
+  --composer-text: #f4f6ef;
+  --composer-muted: #aab6ad;
+  --composer-danger: #ff9f88;
+  --composer-gold: #e8c15a;
+}
+
+.composer-page {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 50% -12%, rgba(101, 181, 42, 0.18), transparent 34rem),
+    linear-gradient(rgba(30, 91, 54, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(30, 91, 54, 0.055) 1px, transparent 1px),
+    var(--composer-bg);
+  background-size: auto, 42px 42px, 42px 42px, auto;
+}
+
+.composer-main {
+  width: min(1040px, calc(100% - 28px));
+  margin: 0 auto;
+  padding: clamp(34px, 8vw, 86px) 0 90px;
+}
+
+.composer-intro {
+  max-width: 780px;
+  margin: 0 auto 28px;
+  text-align: center;
+}
+
+.composer-intro .eyebrow {
+  color: var(--composer-lime);
+  font-weight: 850;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.composer-intro h1 {
+  margin: 12px 0 14px;
+  font-size: clamp(2.45rem, 8vw, 5.5rem);
+  line-height: 0.96;
+  letter-spacing: -0.06em;
+}
+
+.composer-intro > p:last-of-type {
+  max-width: 660px;
+  margin: 0 auto;
+  color: var(--composer-muted);
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  line-height: 1.55;
+}
+
+.composer-progress {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin: 24px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.composer-progress li {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #748078;
+  font-size: 0.78rem;
+  font-weight: 780;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.composer-progress li::before {
+  content: "";
+  width: 9px;
+  height: 9px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+}
+
+.composer-progress li[data-active="true"] {
+  color: var(--composer-lime);
+}
+
+.composer-progress li[data-complete="true"] {
+  color: var(--composer-mint);
+}
+
+.composer-progress li[data-complete="true"]::before {
+  background: currentColor;
+}
+
+.composer-shell {
+  position: relative;
+  max-width: 820px;
+  margin: 0 auto;
+  border: 1px solid var(--composer-line);
+  border-radius: 28px;
+  padding: clamp(18px, 4vw, 32px);
+  background:
+    linear-gradient(145deg, rgba(16, 51, 28, 0.94), rgba(3, 17, 10, 0.97)),
+    var(--composer-panel);
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.34);
+  overflow: hidden;
+}
+
+.composer-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 100% 0, rgba(201, 245, 72, 0.12), transparent 26rem);
+}
+
+.composer-assistant {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.composer-assistant-mark {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(201, 245, 72, 0.55);
+  border-radius: 12px;
+  color: var(--composer-lime);
+  background: rgba(201, 245, 72, 0.07);
+  font-weight: 900;
+}
+
+.composer-assistant-copy {
+  margin: 2px 0 0;
+  color: var(--composer-text);
+  font-size: clamp(1rem, 2vw, 1.14rem);
+  line-height: 1.5;
+}
+
+.composer-form {
+  position: relative;
+}
+
+.composer-label {
+  display: block;
+  margin-bottom: 9px;
+  color: var(--composer-muted);
+  font-size: 0.86rem;
+  font-weight: 760;
+}
+
+.composer-input-wrap {
+  position: relative;
+}
+
+#bounty-composer-input {
+  width: 100%;
+  min-height: 168px;
+  resize: vertical;
+  border: 1px solid rgba(202, 231, 207, 0.25);
+  border-radius: 20px;
+  padding: 20px 62px 58px 20px;
+  color: var(--composer-text);
+  background: rgba(0, 8, 4, 0.72);
+  font: inherit;
+  font-size: clamp(1rem, 2vw, 1.12rem);
+  line-height: 1.52;
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+#bounty-composer-input:focus {
+  border-color: rgba(201, 245, 72, 0.7);
+  box-shadow: 0 0 0 4px rgba(201, 245, 72, 0.09);
+}
+
+#bounty-composer-input::placeholder {
+  color: #768078;
+}
+
+.composer-mic {
+  position: absolute;
+  right: 14px;
+  bottom: 14px;
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(201, 245, 72, 0.36);
+  border-radius: 999px;
+  color: var(--composer-lime);
+  background: rgba(201, 245, 72, 0.08);
+  cursor: pointer;
+}
+
+.composer-mic[data-listening="true"] {
+  color: #07120d;
+  background: var(--composer-lime);
+  animation: composer-pulse 1.2s infinite;
+}
+
+.composer-mic svg {
+  width: 21px;
+  height: 21px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+@keyframes composer-pulse {
+  50% { box-shadow: 0 0 0 9px rgba(201, 245, 72, 0.12); }
+}
+
+.composer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.composer-hint {
+  margin: 0;
+  color: #849088;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.composer-submit {
+  min-width: 138px;
+}
+
+.composer-status {
+  display: block;
+  min-height: 1.4em;
+  margin-top: 12px;
+  color: var(--composer-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.composer-status[data-tone="error"] { color: var(--composer-danger); }
+.composer-status[data-tone="success"] { color: var(--composer-mint); }
+.composer-status[data-tone="pending"] { color: var(--composer-gold); }
+
+.bounty-preview {
+  max-width: 820px;
+  margin: 34px auto 0;
+}
+
+.bounty-preview[hidden] { display: none; }
+
+.bounty-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(201, 245, 72, 0.3);
+  border-radius: 26px;
+  background: linear-gradient(160deg, #0b2717, #06130c 68%);
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.36);
+}
+
+.bounty-card-visual {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #071a11;
+}
+
+#bounty-card-art {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.bounty-card-badge {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+  padding: 7px 11px;
+  color: white;
+  background: rgba(1, 11, 6, 0.72);
+  backdrop-filter: blur(10px);
+  font-size: 0.72rem;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bounty-card-badge::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--composer-gold);
+}
+
+.bounty-card-body {
+  padding: clamp(20px, 4vw, 34px);
+}
+
+.bounty-card-kicker {
+  margin: 0 0 8px;
+  color: var(--composer-lime);
+  font-size: 0.75rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.bounty-card h2 {
+  margin: 0;
+  color: var(--composer-text);
+  font-size: clamp(1.9rem, 5.5vw, 3.4rem);
+  line-height: 1.03;
+  letter-spacing: -0.05em;
+}
+
+.bounty-card-goal {
+  margin: 14px 0 22px;
+  color: #c4cdc6;
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  line-height: 1.55;
+}
+
+.bounty-card-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 9px;
+  margin: 0 0 24px;
+}
+
+.bounty-stat {
+  min-width: 0;
+  border: 1px solid rgba(201, 245, 72, 0.13);
+  border-radius: 14px;
+  padding: 12px;
+  background: rgba(0, 8, 4, 0.46);
+}
+
+.bounty-stat span {
+  display: block;
+  color: #829087;
+  font-size: 0.66rem;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bounty-stat strong {
+  display: block;
+  margin-top: 5px;
+  color: var(--composer-text);
+  font-size: 0.94rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.bounty-card-grid {
+  display: grid;
+  grid-template-columns: 1.35fr 0.65fr;
+  gap: 22px;
+}
+
+.bounty-card-section h3 {
+  margin: 0 0 9px;
+  color: var(--composer-text);
+  font-size: 0.95rem;
+}
+
+.bounty-card-section ol,
+.bounty-card-section ul {
+  margin: 0;
+  padding-left: 20px;
+  color: #afbbb2;
+  line-height: 1.48;
+}
+
+.bounty-card-section li + li { margin-top: 7px; }
+.bounty-card-section li::marker { color: var(--composer-lime); }
+
+.bounty-card-note {
+  border-left: 2px solid var(--composer-gold);
+  padding-left: 13px;
+  color: #c8c0a0;
+  font-size: 0.83rem;
+  line-height: 1.5;
+}
+
+.bounty-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 26px;
+}
+
+.bounty-card-actions .button {
+  flex: 1 1 170px;
+  justify-content: center;
+}
+
+.bounty-card-actions .button[data-approved="true"] {
+  color: #07120d;
+  background: var(--composer-mint);
+  border-color: var(--composer-mint);
+}
+
+.bounty-card-actions .button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.bounty-card-disclaimer {
+  margin: 14px 0 0;
+  color: #7f8b83;
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
+.payment-dialog {
+  width: min(660px, calc(100% - 24px));
+  max-height: calc(100vh - 32px);
+  overflow: auto;
+  border: 1px solid rgba(201, 245, 72, 0.3);
+  border-radius: 24px;
+  padding: 0;
+  color: var(--composer-text);
+  background: #07160e;
+  box-shadow: 0 30px 100px rgba(0, 0, 0, 0.68);
+}
+
+.payment-dialog::backdrop {
+  background: rgba(0, 5, 3, 0.78);
+  backdrop-filter: blur(8px);
+}
+
+.payment-dialog-inner {
+  padding: clamp(20px, 5vw, 34px);
+}
+
+.payment-dialog-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.payment-dialog h2 {
+  margin: 0;
+  font-size: clamp(1.65rem, 5vw, 2.4rem);
+  letter-spacing: -0.045em;
+}
+
+.payment-dialog-head p {
+  margin: 8px 0 0;
+  color: var(--composer-muted);
+}
+
+.dialog-close {
+  flex: 0 0 auto;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 999px;
+  color: white;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+.payment-methods {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 24px 0;
+}
+
+.payment-method {
+  min-height: 92px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 15px;
+  padding: 14px;
+  color: var(--composer-text);
+  background: rgba(255, 255, 255, 0.025);
+  text-align: left;
+  cursor: pointer;
+}
+
+.payment-method strong,
+.payment-method span { display: block; }
+.payment-method span { margin-top: 4px; color: #7f8b83; font-size: 0.72rem; }
+.payment-method:disabled { opacity: 0.42; cursor: not-allowed; }
+.payment-method[data-active="true"] { border-color: var(--composer-lime); background: rgba(201, 245, 72, 0.08); }
+
+.wallet-picker-panel {
+  border-top: 1px solid rgba(255,255,255,.1);
+  padding-top: 22px;
+}
+
+.wallet-picker-panel h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.wallet-picker-panel > p {
+  margin: 0 0 14px;
+  color: var(--composer-muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.wallet-options {
+  display: grid;
+  gap: 8px;
+}
+
+.wallet-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  border: 1px solid rgba(255,255,255,.14);
+  border-radius: 13px;
+  padding: 13px 15px;
+  color: white;
+  background: rgba(255,255,255,.025);
+  cursor: pointer;
+  text-align: left;
+}
+
+.wallet-option:hover { border-color: rgba(201,245,72,.55); }
+.wallet-option small { color: var(--composer-muted); }
+
+.wallet-readiness {
+  margin-top: 16px;
+  border: 1px solid rgba(201, 245, 72, 0.16);
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(0, 7, 4, 0.42);
+}
+
+.wallet-readiness[hidden] { display: none; }
+
+.wallet-readiness-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.wallet-readiness-grid div {
+  border-radius: 12px;
+  padding: 11px;
+  background: rgba(255,255,255,.035);
+}
+
+.wallet-readiness-grid span { display: block; color: var(--composer-muted); font-size: .72rem; }
+.wallet-readiness-grid strong { display: block; margin-top: 3px; overflow-wrap: anywhere; }
+
+.funding-help {
+  margin-top: 14px;
+  border-left: 2px solid var(--composer-gold);
+  padding-left: 13px;
+  color: #c9c1a5;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.funding-help[hidden] { display: none; }
+.funding-help ol { margin: 7px 0 0; padding-left: 18px; }
+
+.wallet-tools,
+.payment-final-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.wallet-tools .button,
+.payment-final-actions .button { flex: 1 1 150px; justify-content: center; }
+
+.payment-status {
+  display: block;
+  min-height: 1.5em;
+  margin-top: 15px;
+  color: var(--composer-muted);
+  white-space: pre-wrap;
+  line-height: 1.48;
+}
+
+.payment-status[data-tone="error"] { color: var(--composer-danger); }
+.payment-status[data-tone="success"] { color: var(--composer-mint); }
+.payment-status[data-tone="pending"] { color: var(--composer-gold); }
+
+@media (max-width: 700px) {
+  .composer-main { width: min(100% - 20px, 1040px); padding-top: 26px; }
+  .composer-intro { text-align: left; }
+  .composer-progress { justify-content: flex-start; overflow-x: auto; }
+  .composer-progress li { flex: 0 0 auto; }
+  .composer-shell { border-radius: 20px; }
+  .composer-actions { align-items: stretch; flex-direction: column; }
+  .composer-submit { width: 100%; }
+  .bounty-card-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .bounty-card-grid { grid-template-columns: 1fr; }
+  .payment-methods { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 440px) {
+  .composer-main { width: calc(100% - 14px); }
+  .composer-shell { padding: 16px; }
+  #bounty-composer-input { min-height: 190px; }
+  .bounty-card-body { padding: 20px 17px; }
+  .bounty-card-stats { grid-template-columns: 1fr 1fr; }
+  .bounty-card-actions { flex-direction: column; }
+  .bounty-card-actions .button { width: 100%; flex-basis: auto; }
+  .wallet-readiness-grid { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-mic[data-listening="true"] { animation: none; }
+  * { scroll-behavior: auto !important; }
+}

--- a/site/live-guild-build.txt
+++ b/site/live-guild-build.txt
@@ -1,2 +1,2 @@
-20260722-7
-This build keeps Worth Solving together on mobile and updates the homepage search prompt.
+20260722-5
+This build adds long and ongoing mission planning, bounded task funding, and pre-publication AI draft visuals.

--- a/site/objective.html
+++ b/site/objective.html
@@ -5,269 +5,170 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#020b08">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <title>Post something you want done | Agent Bounties</title>
-    <meta name="description" content="Describe what you want, turn it into clear tasks, and post one task with a reward and proof rules.">
+    <title>Post a bounty with AI | Agent Bounties</title>
+    <meta name="description" content="Type or dictate the outcome or mission you want. AI asks the missing questions, breaks long efforts into measurable tasks, creates an illustrated bounty card, and helps you fund one safely with Base USDC.">
     <link rel="canonical" href="https://agentbounties.app/objective.html">
-    <meta property="og:title" content="Post something you want done | Agent Bounties">
-    <meta property="og:description" content="Turn a goal into a clear task and post it for people or AI agents to complete.">
+    <meta property="og:title" content="Post a bounty with AI | Agent Bounties">
+    <meta property="og:description" content="Describe the result or mission you want, approve an illustrated measurable bounty card, and fund it with Base USDC.">
     <meta property="og:url" content="https://agentbounties.app/objective.html">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="guild-pages.css?v=20260722-1">
-    <link rel="stylesheet" href="objective.css">
-    <link rel="stylesheet" href="simple-ux.css?v=1">
+    <link rel="stylesheet" href="bounty-composer.css?v=1">
+    <link rel="stylesheet" href="bounty-composer-v2.css?v=1">
   </head>
-  <body class="guild-interior" data-public-ux="simplified-v1">
+  <body class="composer-page">
     <header class="topbar">
-      <a class="brand" href="index.html" aria-label="Agent Bounties home">Agent Bounties</a>
+      <a class="brand" href="index.html">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Bounty Board</a>
         <a href="how-it-works.html">How It Works</a>
       </nav>
-      <a class="guild-shell-network" href="protocol.json" aria-label="View Base status"><span class="base-rune" aria-hidden="true"></span><span>Base</span></a>
     </header>
 
-    <main>
-      <section class="objective-workspace" aria-labelledby="objective-title">
-        <div class="objective-intro">
-          <p class="eyebrow">Post something you want done</p>
-          <h1 id="objective-title">Start with what you want.</h1>
-          <p>For a big goal, the planner can split it into clear tasks. Choose one task and use it to fill the posting form below.</p>
-          <div class="compiler-readiness" data-compiler-readiness="loading">
-            <span class="live-dot" aria-hidden="true"></span>
-            <span data-readiness-text>Checking the AI helper…</span>
-          </div>
+    <main class="composer-main">
+      <section class="composer-intro" aria-labelledby="composer-title">
+        <p class="eyebrow">Post something you want done</p>
+        <h1 id="composer-title">Tell us what you want.</h1>
+        <p>Write it naturally or dictate it. The AI will ask what is missing, turn one-time results into measurable bounties, and break long or open-ended missions into definite tasks.</p>
+        <p class="composer-scope-note">A mission may last for years or remain ongoing. The current on-chain bounty contract gives each funded task its own definite 1–30 day work window, so very hard efforts are staged into milestones instead of being rejected.</p>
+        <p class="fine">The live autonomous protocol currently supports public digital deliverables. The AI flags goals that need private or physical-world verification rather than pretending they are supported.</p>
+        <ol class="composer-progress" aria-label="Bounty creation progress">
+          <li data-progress-step="describe">Describe</li>
+          <li data-progress-step="clarify">Clarify</li>
+          <li data-progress-step="review">Review</li>
+          <li data-progress-step="fund">Fund</li>
+        </ol>
+      </section>
+
+      <section class="composer-shell" aria-label="AI bounty conversation">
+        <div class="composer-assistant">
+          <span class="composer-assistant-mark" aria-hidden="true">AI</span>
+          <p class="composer-assistant-copy" data-assistant-prompt>What do you want to make happen?</p>
         </div>
-
-        <form id="objective-compiler-form" class="compiler-form">
-          <label>
-            What do you want to make happen?
-            <textarea name="objective" rows="3" required maxlength="12000" placeholder="Example: Create a simple website where people can report broken streetlights."></textarea>
-          </label>
-          <div class="compiler-controls">
-            <label>
-              What rules must it follow? One per line. (Optional)
-              <textarea name="constraints" rows="3" maxlength="4000" placeholder="Works well on a phone&#10;Does not collect unnecessary personal data"></textarea>
-            </label>
-            <fieldset class="task-count">
-              <legend>Most tasks</legend>
-              <div class="segments">
-                <label><input type="radio" name="max_tasks" value="3"><span>3</span></label>
-                <label><input type="radio" name="max_tasks" value="5" checked><span>5</span></label>
-                <label><input type="radio" name="max_tasks" value="8"><span>8</span></label>
-              </div>
-            </fieldset>
-            <label class="budget-input">
-              Total reward budget, USDC
-              <input name="solver_budget_usdc" inputmode="decimal" value="12.00" pattern="[0-9]+(\.[0-9]{1,6})?">
-            </label>
+        <form id="bounty-composer-form" class="composer-form">
+          <label class="composer-label" for="bounty-composer-input" data-composer-label>Describe the result or mission in your own words</label>
+          <div class="composer-input-wrap">
+            <textarea id="bounty-composer-input" maxlength="12000" required placeholder="Example: I want people to report broken streetlights and help make our streets safer. This is an ongoing mission, and I can fund the first task with 25 USDC."></textarea>
+            <button class="composer-mic" type="button" data-dictate aria-label="Dictate your answer" title="Dictate your answer">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="12" rx="4"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3M9 21h6"/></svg>
+            </button>
           </div>
-          <div class="compiler-actions">
-            <button class="button primary" type="submit">Turn this goal into tasks</button>
-            <button class="button secondary" type="button" data-load-example>Try an example</button>
-            <p data-compiler-status role="status">Nothing is posted until you review the form and approve it in your wallet.</p>
+          <div class="composer-actions">
+            <p class="composer-hint" data-composer-hint>Nothing is posted or funded until you approve the final card and confirm the exact wallet request.</p>
+            <button class="button primary composer-submit" type="submit" data-composer-submit>Continue</button>
           </div>
+          <output class="composer-status" data-composer-status aria-live="polite"></output>
         </form>
+      </section>
 
-        <div class="graph-shell" data-graph-state="preview">
-          <div class="graph-toolbar">
+      <section id="bounty-preview" class="bounty-preview" hidden aria-labelledby="bounty-card-title">
+        <article id="bounty-card" class="bounty-card">
+          <div class="bounty-card-visual">
+            <canvas id="bounty-card-art" role="img" aria-label="AI-generated visual preview of the achieved result"></canvas>
+            <span class="bounty-card-badge" data-card-badge>Draft · not posted</span>
+            <span class="image-generation-status" data-image-status>Preparing AI visual…</span>
+          </div>
+          <div class="bounty-card-body">
+            <p class="bounty-card-kicker">Proposed bounty</p>
+
+            <section class="mission-context" data-mission-context hidden>
+              <p class="mission-context-kicker">Part of a larger mission</p>
+              <h3 data-mission-title></h3>
+              <p data-mission-summary></p>
+              <span class="mission-horizon" data-mission-horizon></span>
+              <p>Choose which definite task to fund now. The other tasks remain part of the AI plan and can become separate bounties later.</p>
+              <div class="mission-task-options" data-mission-tasks></div>
+            </section>
+
+            <h2 id="bounty-card-title" data-card-title></h2>
+            <p class="bounty-card-goal" data-card-goal></p>
+
+            <div class="bounty-card-stats" aria-label="Bounty goal stats">
+              <div class="bounty-stat"><span>Total reward</span><strong data-card-reward>—</strong></div>
+              <div class="bounty-stat"><span>Time-bound</span><strong data-card-deadline>—</strong></div>
+              <div class="bounty-stat"><span>Measurable</span><strong data-card-checks>—</strong></div>
+              <div class="bounty-stat"><span>Attainability review</span><strong data-card-confidence>—</strong></div>
+            </div>
+
+            <div class="bounty-card-grid">
+              <section class="bounty-card-section">
+                <h3>Done when</h3>
+                <ol data-card-criteria></ol>
+              </section>
+              <section class="bounty-card-section">
+                <h3>Feasibility notes</h3>
+                <ul data-card-risks></ul>
+                <p class="bounty-card-note"><strong>You are the verifier.</strong> The creator wallet will decide pass or fail against these published completion checks. Contributors can see that subjective risk before claiming.</p>
+              </section>
+            </div>
+
+            <div class="bounty-card-actions">
+              <button class="button secondary" type="button" data-revise-card>Ask AI to revise</button>
+              <button class="button secondary" type="button" data-share-card>Share card</button>
+              <button class="button secondary" type="button" data-approve-card data-approved="false">Approve bounty card</button>
+              <button class="button primary" type="button" data-open-funding disabled>Fund bounty</button>
+            </div>
+            <p class="bounty-card-disclaimer">The AI terms and bounded pre-publication illustration are advisory. Approval does not publish or fund anything. Funding occurs only after a separate wallet confirmation, and payment to a solver is proven only by confirmed <code>BountySettled</code> evidence.</p>
+          </div>
+        </article>
+      </section>
+
+      <dialog id="funding-dialog" class="payment-dialog" aria-labelledby="funding-dialog-title">
+        <div class="payment-dialog-inner">
+          <div class="payment-dialog-head">
             <div>
-              <span data-graph-title>Example task plan</span>
-              <small data-graph-model>Choose a task to see what it means</small>
+              <h2 id="funding-dialog-title">Fund bounty</h2>
+              <p>Choose how to fund the exact reward shown on the approved card.</p>
             </div>
-            <div class="policy-keys" aria-label="Task flow">
-              <span>Do the work</span>
-              <span>Check the proof</span>
-              <span>Pay the reward</span>
+            <button class="dialog-close" type="button" data-close-funding aria-label="Close funding window">×</button>
+          </div>
+
+          <div class="payment-methods" aria-label="Funding methods">
+            <button class="payment-method" type="button" disabled><strong>Stripe</strong><span>Coming soon</span></button>
+            <button class="payment-method" type="button" disabled><strong>PayPal</strong><span>Coming soon</span></button>
+            <button class="payment-method" type="button" data-payment-method="crypto"><strong>Crypto Wallet</strong><span>Base USDC · available now</span></button>
+          </div>
+
+          <section class="wallet-picker-panel" data-wallet-panel hidden>
+            <h3>Choose a wallet on this device</h3>
+            <p data-wallet-message>Looking for compatible wallets…</p>
+            <div class="wallet-options" data-wallet-options></div>
+          </section>
+
+          <section class="wallet-readiness" data-wallet-readiness hidden aria-label="Wallet funding readiness">
+            <div class="wallet-readiness-grid">
+              <div><span>Connected wallet</span><strong data-wallet-account>—</strong></div>
+              <div><span>Required now</span><strong data-wallet-required>—</strong></div>
+              <div><span>Base USDC balance</span><strong data-wallet-usdc>—</strong></div>
+              <div><span>Base ETH for gas</span><strong data-wallet-eth>—</strong></div>
             </div>
-          </div>
-          <div id="objective-graph" class="objective-graph" aria-live="polite"></div>
-          <div id="task-inspector" class="task-inspector" aria-live="polite">
-            Choose a task to see its result, proof, and completion checks.
-          </div>
-          <div class="use-task-bar">
-            <p>Like the selected task? Copy it into the posting form.</p>
-            <button class="button primary" type="button" data-use-selected-task>Use this task</button>
-          </div>
+
+            <div class="funding-help" data-funding-help hidden>
+              <strong>Wallet not ready yet.</strong>
+              <ol>
+                <li>Open the selected wallet and confirm the network is <strong>Base</strong>.</li>
+                <li>Use the wallet’s Buy or Bridge feature to obtain at least <strong data-missing-usdc>—</strong> on Base.</li>
+                <li>Keep a small amount of Base ETH for the creation transaction.</li>
+                <li>Return here and select <strong>Recheck balance</strong>.</li>
+              </ol>
+              <p>Verify the USDC token address before acquiring tokens. Never enter a recovery phrase or private key on this website.</p>
+            </div>
+
+            <div class="wallet-tools">
+              <button class="button secondary" type="button" data-watch-usdc>Add Base USDC to wallet</button>
+              <button class="button secondary" type="button" data-copy-usdc>Copy USDC address</button>
+              <button class="button secondary" type="button" data-recheck-balance>Recheck balance</button>
+            </div>
+
+            <div data-legal-consent data-consent-actions="post_bounty"></div>
+            <div class="payment-final-actions">
+              <button class="button primary" type="button" data-fund-now disabled>Review and fund with wallet</button>
+            </div>
+          </section>
+
+          <output class="payment-status" data-payment-status aria-live="polite">Choose a payment method. A wallet connection is not funding.</output>
         </div>
-      </section>
-
-      <section id="post" class="post-workflow" aria-labelledby="post-title">
-        <div class="post-workflow-head">
-          <div>
-            <p class="eyebrow">Post the task</p>
-            <h2 id="post-title">Review exactly what someone must do.</h2>
-            <p>Fill this out yourself, or use a task from the planner above. You can add the full reward now or let other people help fund it later.</p>
-          </div>
-          <a class="button secondary" href="earn.html">Back to the Bounty Board</a>
-        </div>
-
-        <form id="autonomous-post-form" class="funding-form protocol-form">
-          <div class="form-section">
-            <p class="eyebrow">1. Say what needs to be done</p>
-            <label>
-              Bigger goal (optional)
-              <textarea name="draftObjective" rows="3" placeholder="What larger result will this task help achieve?"></textarea>
-            </label>
-            <div class="actions compact-actions">
-              <button class="button secondary" type="button" data-cloud-draft>Help me write the task</button>
-              <output class="fine" data-cloud-draft-status aria-live="polite">The helper makes a draft. You decide what the final task says.</output>
-            </div>
-            <label>
-              Task name
-              <input name="title" maxlength="200" placeholder="Build a broken-streetlight reporting page" required>
-            </label>
-            <label>
-              What result must be delivered?
-              <textarea name="goal" rows="4" placeholder="Say the clear result the worker must create." required></textarea>
-            </label>
-            <label>
-              How will we know it is done? One check per line.
-              <textarea name="acceptance" rows="5" placeholder="People can submit a streetlight report&#10;The page works on a phone&#10;The main tests pass" required></textarea>
-            </label>
-            <label>
-              Helpful link (optional)
-              <input name="sourceUrl" type="url" placeholder="https://github.com/owner/repo/issues/123">
-            </label>
-          </div>
-
-          <div class="form-section">
-            <p class="eyebrow">2. Choose the reward</p>
-            <div class="form-row">
-              <label>
-                Worker receives, USDC
-                <input name="solverReward" type="number" min="0.01" step="0.01" value="2.00" required>
-              </label>
-              <label>
-                Checker receives, USDC
-                <input name="verifierReward" type="number" min="0.01" step="0.01" value="0.01" required>
-              </label>
-            </div>
-            <p class="fine">The checker reward also sets the refundable bond paid by the worker who claims the task.</p>
-            <label class="check-line">
-              <input name="crowdfund" type="checkbox">
-              Post it now with no reward deposited, so other people can help fund it
-            </label>
-            <p class="fine">An unfunded task is not paid work yet. It becomes claimable only after its full reward is funded.</p>
-            <details class="advanced">
-              <summary>Change the time limits</summary>
-              <div class="form-row three">
-                <label>
-                  Days to fund it
-                  <input name="fundingDays" type="number" min="1" max="90" value="7" required>
-                </label>
-                <label>
-                  Hours to do the work
-                  <input name="claimHours" type="number" min="1" max="720" value="24" required>
-                </label>
-                <label>
-                  Hours to check it
-                  <input name="verificationHours" type="number" min="1" max="168" value="2" required>
-                </label>
-              </div>
-            </details>
-          </div>
-
-          <div class="form-section">
-            <p class="eyebrow">3. Choose how the proof is checked</p>
-            <p class="fine">The reward is paid only when the checking rule you choose accepts the proof.</p>
-            <label>
-              Who or what checks the work?
-              <select name="verificationMode">
-                <option value="deterministic_module">Automatic demo proof checker</option>
-                <option value="signed_quorum">Trusted checker wallets</option>
-                <option value="ai_judge_quorum">Two or more AI checkers</option>
-              </select>
-            </label>
-            <output class="readiness-panel" data-verifier-scope aria-live="polite">The demo checker only checks a small computation. It does not understand whether your requested task is good.</output>
-            <label class="check-line verifier-warning" data-demo-verifier-warning>
-              <input name="demoVerifierAccepted" type="checkbox">
-              <span>I understand that the demo checker does not judge my task or its completion checks.</span>
-            </label>
-            <details class="advanced">
-              <summary>Advanced checking settings</summary>
-              <label>
-                How many signatures are needed?
-                <input name="threshold" type="number" min="1" max="8" value="1" required>
-              </label>
-              <label>
-                Checker wallet addresses
-                <textarea name="verifiers" rows="2" placeholder="0x... 0x..."></textarea>
-              </label>
-              <div class="form-row">
-                <label>
-                  On-chain checker module
-                  <input name="verifierModule" placeholder="Loaded from the active system" readonly>
-                </label>
-                <label>
-                  Module reward wallet
-                  <input name="verifierRewardRecipient" placeholder="0x...">
-                </label>
-              </div>
-              <label>
-                Exact automatic checking rule, JSON
-                <textarea name="benchmark" rows="8" readonly required>{"engine":"leading_zero_work_v1","difficulty_bits":16,"hash_function":"keccak256","preimage_abi_types":["bytes32","uint64","address","bytes32","bytes32","bytes32","uint256"],"proof_encoding":"abi.encode(uint256 nonce)","verifier_module":"0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e","reference_command":"cargo run -p cli -- autonomous-mine-work-proof"}</textarea>
-              </label>
-              <label>
-                Proof record shape, JSON
-                <textarea name="evidenceSchema" rows="5" required>{"type":"object","description":"Public information linked to the submitted proof.","additionalProperties":true}</textarea>
-              </label>
-            </details>
-          </div>
-
-          <details class="form-section advanced">
-            <summary>AI checker settings</summary>
-            <div class="form-row">
-              <label>
-                Provider
-                <input name="aiProvider" placeholder="openai">
-              </label>
-              <label>
-                Model
-                <input name="aiModel" placeholder="model name">
-              </label>
-              <label>
-                Model version
-                <input name="aiModelVersion" placeholder="fixed version">
-              </label>
-            </div>
-            <label>
-              Instructions for the checker
-              <textarea name="systemPrompt" rows="4"></textarea>
-            </label>
-            <label>
-              Scoring rules
-              <textarea name="rubric" rows="4"></textarea>
-            </label>
-            <label>
-              Model settings, JSON
-              <textarea name="decodingParameters" rows="2">{"temperature":0,"seed":0}</textarea>
-            </label>
-          </details>
-
-          <details class="form-section advanced">
-            <summary>How you found us</summary>
-            <label>
-              How did you find Agent Bounties?
-              <textarea name="discoverySource" rows="2" placeholder="ChatGPT, a friend, GitHub, or another agent"></textarea>
-            </label>
-          </details>
-
-          <div data-legal-consent data-consent-actions="post_bounty"></div>
-
-          <div class="actions sticky-actions">
-            <label class="wallet-picker">
-              Wallet
-              <select data-wallet-provider aria-label="Wallet provider">
-                <option>Detecting browser wallets</option>
-              </select>
-            </label>
-            <button class="button secondary" type="button" data-connect-wallet data-output="autonomous-post-output">Connect wallet</button>
-            <button class="button primary" type="submit" data-protocol-action disabled>Review and post the task</button>
-          </div>
-          <output id="autonomous-post-output" class="output readiness-output" aria-live="polite">Nothing is posted until you review and approve the wallet prompt.</output>
-          <a id="chatgpt-return" class="button secondary" data-chatgpt-return hidden rel="noopener">Return to ChatGPT without posting</a>
-        </form>
-      </section>
+      </dialog>
 
       <section class="sr-only" aria-label="Planner compatibility summary">
         <p>Turn one outcome into verifiable paid work with GPT-5.6.</p>
@@ -277,7 +178,7 @@
     </main>
 
     <footer class="guild-shell-footer">
-      <span>Nothing is posted or funded until you approve the exact wallet prompt.</span>
+      <span>Nothing is posted or funded until you approve the card and confirm the exact wallet request.</span>
       <a href="how-it-works.html">How it works</a>
       <a href="terms.html">Terms</a>
       <a href="privacy.html">Privacy</a>
@@ -287,9 +188,8 @@
     <script src="guild-shell.js?v=2"></script>
     <script src="analytics-config.js"></script>
     <script src="analytics.js"></script>
-    <script src="objective.js?v=2"></script>
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
-    <script src="autonomous.js"></script>
+    <script src="bounty-composer-v2.js?v=1"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Replace the long posting form with one conversational input that supports both bounded results and long or open-ended missions.

## User flow

1. Type or dictate what you want in one text box.
2. The hosted AI drafts measurable terms and asks only unresolved questions.
3. The user says whether the request is one result or a larger/ongoing mission.
4. Long efforts keep their full horizon—even years or ongoing—and the AI breaks them into 2–6 definite tasks.
5. The user chooses which task to fund now. Each current on-chain task receives its own 1–30 day work window because that is the deployed autonomous-v1 contract bound.
6. The user supplies the task reward and reviews a shareable bounty card.
7. The card shows the mission context, selected task, measurable completion checks, feasibility notes, deadline, reward, creator-verification disclosure, and a bounded AI-generated draft illustration.
8. The user must explicitly approve the card.
9. **Fund bounty** opens Stripe, PayPal, and Crypto Wallet options; only Crypto Wallet is enabled.
10. The crypto path discovers device wallets, switches to Base, checks Base USDC and gas, explains how to add funds, and requests the exact canonical create-and-fund operation only after legal review.

## Bounded pre-publication image generation

The drafting AI writes a strictly bounded visual annotation inside the temporary draft JSON Schema:

- fixed scene and primitive allowlists;
- 2–5 validated hex colours;
- 3–10 shapes with bounded coordinates and scale;
- no arbitrary SVG, scripts, external URLs, logos, text, or model credentials;
- generated before publication and rendered locally into the bounty card;
- removed from the evidence schema before terms are published;
- labelled as a draft visual and never treated as completion evidence.

Mission task selection may request a second bounded visual annotation for the selected task. If the annotation is missing or invalid, the page uses a safe local fallback rather than publishing malformed model output.

## Verification and evidence boundaries

- The AI is advisory and cannot publish, sign, verify, or pay.
- The approved card is not a posted or funded bounty.
- The creator wallet is committed as the single signed verifier; the card discloses that subjective trust assumption before funding.
- Wallet connection, card approval, a signature, and a transaction hash are not funding evidence.
- The UI says funded only after canonical `FundingAdded` plus `BountyBecameClaimable` evidence.
- If quorum verifier availability is not protocol-ready, the UI says **funded · verifier setup required**, not ready to earn.
- Solver payment remains bound to confirmed `BountySettled`.
- The live protocol is disclosed as public/digital-only; private or physical goals are flagged rather than silently represented as supported.

## Sharing

The card exports as a 1200×1500 PNG through Web Share or download fallback. Draft cards are visibly marked not posted or funded. A funded contract link is included only after canonical creation.

## Files

- Replace `site/objective.html`.
- Add base and mission-aware composer styles.
- Add the mission-aware composer runtime.
- Update Pages validation and production canaries.
- Preserve `/post.html` as the compatibility redirect.

## Open PR coordination

- Supersedes #480’s post-publication mission-poster UI. Its persistent public-poster storage is no longer required for this flow because the visual is generated safely before approval and publication.
- #272 should preserve this card and mission/task funding entry point when rebased.

Closes #516.