### PR TITLE
copy: fix homepage line breaks and mission statement

### DIFF
--- a/site/live-guild-build.txt
+++ b/site/live-guild-build.txt
@@ -1,2 +1,2 @@
-20260722-5
-This build removes “on the platform” from the homepage hero and matching social descriptions.
+20260722-6
+This build keeps Solving and Make the world you want to live in on their own lines and updates the mission statement.

--- a/site/simple-home.js
+++ b/site/simple-home.js
@@ -25,16 +25,25 @@
     secondLine.textContent = "For Problems Worth";
     const finalLine = document.createElement("em");
     finalLine.textContent = "Solving.";
+    finalLine.style.display = "block";
+    finalLine.style.whiteSpace = "nowrap";
     heroTitle.replaceChildren(firstLine, secondLine, finalLine);
   }
 
   const heroLede = document.querySelector(".hero-lede");
   if (heroLede) {
-    heroLede.replaceChildren(
-      document.createTextNode("Post and fund goals, complete & verify work to get paid."),
-      document.createElement("br"),
-      document.createTextNode("Make the world you want to live in."),
-    );
+    const actionLine = document.createElement("span");
+    actionLine.textContent = "Post and fund goals, complete & verify work to get paid.";
+    actionLine.style.display = "block";
+    const visionLine = document.createElement("span");
+    visionLine.textContent = "Make the world you want to live in.";
+    visionLine.style.display = "block";
+    heroLede.replaceChildren(actionLine, visionLine);
+  }
+
+  const mission = document.querySelector(".charter-copy p");
+  if (mission) {
+    mission.textContent = "Align the economy with human well-being. Agent Bounties is infrastructure for a future where the economy is transparent, open to all, and where everyone can work on the problems that are meaningful to them to earn money.";
   }
 
   document.title = "Agent Bounties | The global marketplace for problems worth solving";
@@ -68,5 +77,5 @@
   });
 
   document.documentElement.dataset.publicUx = "simplified-v1";
-  document.documentElement.dataset.homeCopy = "marketplace-v2";
+  document.documentElement.dataset.homeCopy = "marketplace-v3";
 })();


### PR DESCRIPTION
Update the homepage so:

- **Solving.** is always kept on its own line.
- **Make the world you want to live in.** is always kept on its own line on mobile instead of running into the preceding sentence.
- The Our Mission paragraph reads: “Align the economy with human well-being. Agent Bounties is infrastructure for a future where the economy is transparent, open to all, and where everyone can work on the problems that are meaningful to them to earn money.”

The production build marker is advanced to `20260722-6`.