### PR TITLE
fix: keep Worth Solving together on mobile

### DIFF
--- a/site/live-guild-build.txt
+++ b/site/live-guild-build.txt
@@ -1,2 +1,2 @@
-20260722-6
-This build keeps Solving and Make the world you want to live in on their own lines and updates the mission statement.
+20260722-7
+This build keeps Worth Solving together on mobile and updates the homepage search prompt.

--- a/site/simple-home.js
+++ b/site/simple-home.js
@@ -21,12 +21,21 @@
   if (heroTitle) {
     const firstLine = document.createElement("span");
     firstLine.textContent = "The Global Marketplace";
+
     const secondLine = document.createElement("span");
-    secondLine.textContent = "For Problems Worth";
-    const finalLine = document.createElement("em");
-    finalLine.textContent = "Solving.";
+    secondLine.textContent = "For Problems";
+
+    const finalLine = document.createElement("span");
     finalLine.style.display = "block";
     finalLine.style.whiteSpace = "nowrap";
+    finalLine.append(document.createTextNode("Worth "));
+
+    const solving = document.createElement("em");
+    solving.textContent = "Solving.";
+    solving.style.display = "inline";
+    solving.style.whiteSpace = "inherit";
+    finalLine.append(solving);
+
     heroTitle.replaceChildren(firstLine, secondLine, finalLine);
   }
 
@@ -39,6 +48,11 @@
     visionLine.textContent = "Make the world you want to live in.";
     visionLine.style.display = "block";
     heroLede.replaceChildren(actionLine, visionLine);
+  }
+
+  const searchInput = document.getElementById("bounty-query");
+  if (searchInput) {
+    searchInput.placeholder = "What problem do you need to solve?";
   }
 
   const mission = document.querySelector(".charter-copy p");
@@ -77,5 +91,5 @@
   });
 
   document.documentElement.dataset.publicUx = "simplified-v1";
-  document.documentElement.dataset.homeCopy = "marketplace-v3";
+  document.documentElement.dataset.homeCopy = "marketplace-v4";
 })();


### PR DESCRIPTION
Fix the homepage mobile headline so **Worth Solving.** stays together on one line while keeping **Solving.** green.

Also change the homepage search placeholder to:

**What problem do you need to solve?**

Production build marker: `20260722-7`.