### PR TITLE
refactor: make bounty creation a normal chatbot

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,9 +53,12 @@ jobs:
           node --check site/guild-shell.js
           grep -q 'data-board-search' site/earn.html
           grep -q 'id="fund-bounty-panel"' site/earn.html
+          grep -q 'class="composer-page chat-app-page"' site/objective.html
+          grep -q 'class="chat-app-header"' site/objective.html
           grep -q 'id="bounty-composer-form"' site/objective.html
           grep -q 'data-bounty-chat' site/objective.html
           grep -q 'data-conversation-log' site/objective.html
+          grep -q 'id="bounty-preview"' site/objective.html
           grep -q 'data-mission-context' site/objective.html
           grep -q 'data-image-status' site/objective.html
           grep -q 'data-approve-card' site/objective.html
@@ -63,9 +66,13 @@ jobs:
           grep -q '>Connect wallet<' site/objective.html
           grep -q 'data-payment-method="crypto"' site/objective.html
           grep -q 'bounty-composer-v2.js?v=1' site/objective.html
-          grep -q 'bounty-chat-ui.js?v=1' site/objective.html
-          grep -q 'dataset.bountyComposer = "chat-v1"' site/bounty-chat-ui.js
-          grep -q 'data-conversation-log' site/bounty-chat-ui.js
+          grep -q 'bounty-chat-ui.js?v=2' site/objective.html
+          ! grep -q 'chat-composer-intro' site/objective.html
+          ! grep -q 'draft-panel' site/objective.html
+          grep -q 'dataset.bountyComposer = "chat-v2"' site/bounty-chat-ui.js
+          grep -q 'form.requestSubmit()' site/bounty-chat-ui.js
+          grep -q 'log.append(preview)' site/bounty-chat-ui.js
+          grep -q 'body.classList.contains("chat-app-page")' site/analytics-config.js
           grep -q 'x-agent-bounties-draft-visual' site/bounty-composer-v2.js
           grep -q 'MAX_TASK_DAYS = 30' site/bounty-composer-v2.js
           grep -q 'Ongoing' site/bounty-composer-v2.js
@@ -90,7 +97,7 @@ jobs:
           )
           if count != 1:
               raise SystemExit("analytics configuration assignment was not found exactly once")
-          for required in ("loadGuildShell", "guild-pages.css", "guild-shell.js", "simple-home.js"):
+          for required in ("loadGuildShell", "guild-pages.css", "guild-shell.js", "simple-home.js", "chat-app-page"):
               if required not in updated:
                   raise SystemExit(f"Pages analytics substitution removed {required}")
           path.write_text(updated, encoding="utf-8")
@@ -130,7 +137,7 @@ jobs:
           )
           if count != 1:
               raise SystemExit("analytics configuration assignment was not found exactly once")
-          for required in ("loadGuildShell", "guild-pages.css", "guild-shell.js", "simple-home.js"):
+          for required in ("loadGuildShell", "guild-pages.css", "guild-shell.js", "simple-home.js", "chat-app-page"):
               if required not in updated:
                   raise SystemExit(f"refusing to deploy without {required}")
           path.write_text(updated, encoding="utf-8")
@@ -145,7 +152,7 @@ jobs:
           path: site
       - id: deployment
         uses: actions/deploy-pages@v5
-      - name: Verify the conversational canonical website
+      - name: Verify the normal chatbot experience
         env:
           GH_TOKEN: ${{ github.token }}
           LIVE_CANARY_ISSUE: "499"
@@ -164,6 +171,7 @@ jobs:
             if curl "${common_curl[@]}" "https://agentbounties.app/live-guild-build.txt?verify=${nonce}" -o /tmp/live-canary.txt \
               && curl "${common_curl[@]}" "https://agentbounties.app/earn.html?verify=${nonce}" -o /tmp/live-earn.html \
               && curl "${common_curl[@]}" "https://agentbounties.app/objective.html?verify=${nonce}" -o /tmp/live-objective.html \
+              && curl "${common_curl[@]}" "https://agentbounties.app/bounty-chat.css?verify=${nonce}" -o /tmp/live-chat.css \
               && curl "${common_curl[@]}" "https://agentbounties.app/bounty-composer-v2.js?verify=${nonce}" -o /tmp/live-composer.js \
               && curl "${common_curl[@]}" "https://agentbounties.app/bounty-chat-ui.js?verify=${nonce}" -o /tmp/live-chat-ui.js \
               && curl "${common_curl[@]}" "https://agentbounties.app/how-it-works.html?verify=${nonce}" -o /tmp/live-how.html \
@@ -174,23 +182,24 @@ jobs:
                 && grep -q 'data-public-ux="simplified-v1"' /tmp/live-earn.html \
                 && grep -q 'data-board-search' /tmp/live-earn.html \
                 && grep -q 'id="fund-bounty-panel"' /tmp/live-earn.html \
-                && grep -q 'Post something you want done' /tmp/live-earn.html \
-                && grep -q 'bounty-board.js?v=1' /tmp/live-earn.html \
+                && grep -q 'class="composer-page chat-app-page"' /tmp/live-objective.html \
+                && grep -q 'class="chat-app-header"' /tmp/live-objective.html \
                 && grep -q 'id="bounty-composer-form"' /tmp/live-objective.html \
-                && grep -q 'data-bounty-chat' /tmp/live-objective.html \
                 && grep -q 'data-conversation-log' /tmp/live-objective.html \
-                && grep -q 'data-mission-context' /tmp/live-objective.html \
-                && grep -q 'data-image-status' /tmp/live-objective.html \
+                && grep -q 'id="bounty-preview"' /tmp/live-objective.html \
                 && grep -q 'data-approve-card' /tmp/live-objective.html \
                 && grep -q 'data-open-funding' /tmp/live-objective.html \
                 && grep -q '>Connect wallet<' /tmp/live-objective.html \
-                && grep -q 'data-payment-method="crypto"' /tmp/live-objective.html \
-                && grep -q 'bounty-composer-v2.js?v=1' /tmp/live-objective.html \
-                && grep -q 'bounty-chat-ui.js?v=1' /tmp/live-objective.html \
+                && grep -q 'bounty-chat-ui.js?v=2' /tmp/live-objective.html \
+                && ! grep -q 'chat-composer-intro' /tmp/live-objective.html \
+                && ! grep -q 'draft-panel' /tmp/live-objective.html \
+                && grep -q '.chat-app-header' /tmp/live-chat.css \
+                && grep -q 'grid-template-rows: minmax(0, 1fr) auto auto' /tmp/live-chat.css \
                 && grep -q 'x-agent-bounties-draft-visual' /tmp/live-composer.js \
                 && grep -q 'MAX_TASK_DAYS = 30' /tmp/live-composer.js \
-                && grep -q 'dataset.bountyComposer = "chat-v1"' /tmp/live-chat-ui.js \
-                && grep -q 'data-conversation-log' /tmp/live-chat-ui.js \
+                && grep -q 'dataset.bountyComposer = "chat-v2"' /tmp/live-chat-ui.js \
+                && grep -q 'log.append(preview)' /tmp/live-chat-ui.js \
+                && grep -q 'body.classList.contains("chat-app-page")' /tmp/live-analytics.js \
                 && grep -q 'You ask. Someone helps. They show proof. They get paid.' /tmp/live-how.html \
                 && grep -q 'simple-home.js' /tmp/live-analytics.js \
                 && grep -q '\["earn.html", "Bounty Board"\]' /tmp/live-simple-home.js \
@@ -200,7 +209,7 @@ jobs:
                 failure_detail=""
                 break
               fi
-              failure_detail="expected build ${expected_build}, received ${actual_build:-empty}, or conversational bounty-workflow markers were missing"
+              failure_detail="expected build ${expected_build}, received ${actual_build:-empty}, or minimal chatbot markers were missing"
             else
               failure_detail="one or more live URLs returned a non-success response"
             fi
@@ -211,21 +220,20 @@ jobs:
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           if [[ "${success}" == "true" ]]; then
             cat > /tmp/live-proof.md <<EOF
-          ✅ **Conversational bounty composer canary passed**
+          ✅ **Normal chatbot bounty composer canary passed**
 
           - Commit: \`${GITHUB_SHA}\`
           - Expected and live build: \`${expected_build}\`
           - Attempts: ${attempt_used}
           - Verified at: ${verified_at}
-          - Live primary navigation assets contain only **Bounty Board** and **How It Works**.
-          - Live Bounty Board contains search filters, visual open-task cards, inline funding, and the posting entry point.
-          - Live bounty creation is a real message conversation: the AI asks focused questions, updates a standardized draft, accepts continued revision, gates approval, and exposes **Connect wallet** only after approval.
-          - Live How It Works page contains the plain-language explanation.
+          - Live bounty creation is one full-screen message thread with a bottom composer.
+          - There is no intro section, progress display, separate draft panel, or guild navigation shell.
+          - The standardized draft appears inline as an AI message and retains edit, approval, and wallet gates.
           - Workflow: ${run_url}
           EOF
           else
             cat > /tmp/live-proof.md <<EOF
-          ❌ **Conversational bounty composer canary failed**
+          ❌ **Normal chatbot bounty composer canary failed**
 
           - Commit: \`${GITHUB_SHA}\`
           - Expected build: \`${expected_build}\`

--- a/site/analytics-config.js
+++ b/site/analytics-config.js
@@ -14,6 +14,8 @@ window.agentBountiesAnalyticsConfig = Object.freeze({
       : window.location.href;
     const base = new URL(".", source);
 
+    if (body.classList.contains("chat-app-page")) return;
+
     if (body.classList.contains("guild-home")) {
       if (!document.querySelector('script[data-simple-home="true"]')) {
         const script = document.createElement("script");

--- a/site/bounty-chat-controls.css
+++ b/site/bounty-chat-controls.css
@@ -1,0 +1,14 @@
+.chat-send {
+  font-size: 0;
+}
+
+.chat-send svg {
+  display: none;
+}
+
+.chat-send::before {
+  content: "↑";
+  font-size: 20px;
+  font-weight: 900;
+  line-height: 1;
+}

--- a/site/bounty-chat-ui.js
+++ b/site/bounty-chat-ui.js
@@ -66,14 +66,17 @@
     if (waiting) scrollConversation();
   }
 
+  function setDraftState(text, tone) {
+    if (!draftState) return;
+    if (draftState.textContent !== text) draftState.textContent = text;
+    if (draftState.dataset.tone !== tone) draftState.dataset.tone = tone;
+  }
+
   function syncDraft() {
     draftSyncQueued = false;
     if (preview.hidden) return;
-    if (draftState && approve?.dataset.approved !== "true") {
-      draftState.textContent = "Draft · not posted";
-      draftState.dataset.tone = "ready";
-    }
-    log.append(preview);
+    if (approve?.dataset.approved !== "true") setDraftState("Draft · not posted", "ready");
+    if (preview.parentElement !== log || preview !== log.lastElementChild) log.append(preview);
     scrollConversation();
   }
 
@@ -85,11 +88,7 @@
 
   function syncApproval() {
     const isApproved = approve?.dataset.approved === "true";
-    if (draftState) {
-      draftState.textContent = isApproved ? "Approved · not posted" : "Draft · not posted";
-      draftState.dataset.tone = isApproved ? "approved" : "ready";
-    }
-    if (connect) connect.textContent = isApproved ? "Connect wallet" : "Connect wallet";
+    setDraftState(isApproved ? "Approved · not posted" : "Draft · not posted", isApproved ? "approved" : "ready");
 
     if (isApproved && !approvedAnnounced) {
       approvedAnnounced = true;

--- a/site/bounty-chat-ui.js
+++ b/site/bounty-chat-ui.js
@@ -9,9 +9,7 @@
   const status = document.querySelector("[data-composer-status]");
   const thinking = document.querySelector("[data-assistant-thinking]");
   const preview = document.getElementById("bounty-preview");
-  const empty = document.querySelector("[data-draft-empty]");
   const draftState = document.querySelector("[data-draft-state]");
-  const draftTitle = document.querySelector("[data-card-title]");
   const approve = document.querySelector("[data-approve-card]");
   const revise = document.querySelector("[data-revise-card]");
   const connect = document.querySelector("[data-open-funding]");
@@ -21,8 +19,8 @@
   if (!root || !log || !prompt || !form || !input || !preview) return;
 
   let lastAssistantText = "";
-  let lastDraftTitle = "";
   let approvedAnnounced = false;
+  let draftSyncQueued = false;
 
   function scrollConversation() {
     requestAnimationFrame(() => {
@@ -30,18 +28,17 @@
     });
   }
 
-  function message(role, text, kind = "") {
+  function addMessage(role, text) {
     const value = String(text || "").trim();
     if (!value) return;
 
     const article = document.createElement("article");
     article.className = "conversation-message";
     article.dataset.role = role;
-    if (kind) article.dataset.kind = kind;
 
     const avatar = document.createElement("span");
     avatar.className = "conversation-avatar";
-    avatar.textContent = role === "user" ? "YOU" : "AI";
+    avatar.textContent = role === "user" ? "You" : "AI";
     avatar.setAttribute("aria-hidden", "true");
 
     const bubble = document.createElement("div");
@@ -57,7 +54,7 @@
     const value = prompt.textContent.trim();
     if (!value || value === lastAssistantText) return;
     lastAssistantText = value;
-    message("assistant", value);
+    addMessage("assistant", value);
     thinking.hidden = true;
   }
 
@@ -70,40 +67,33 @@
   }
 
   function syncDraft() {
-    const ready = !preview.hidden;
-    if (empty) empty.hidden = ready;
-    if (!draftState) return;
-
-    if (!ready) {
-      draftState.textContent = "Building from the conversation";
-      draftState.dataset.tone = "";
-      return;
+    draftSyncQueued = false;
+    if (preview.hidden) return;
+    if (draftState && approve?.dataset.approved !== "true") {
+      draftState.textContent = "Draft · not posted";
+      draftState.dataset.tone = "ready";
     }
+    log.append(preview);
+    scrollConversation();
+  }
 
-    const title = draftTitle && draftTitle.textContent.trim();
-    draftState.textContent = "Ready for your review";
-    draftState.dataset.tone = "ready";
-    if (title && title !== lastDraftTitle) {
-      lastDraftTitle = title;
-      approvedAnnounced = false;
-      message("assistant", `I have a standardized bounty draft ready: “${title}”. Review it beside the conversation. Tell me what to change, or approve it when it is right.`, "draft");
-    }
+  function scheduleDraftSync() {
+    if (draftSyncQueued) return;
+    draftSyncQueued = true;
+    requestAnimationFrame(syncDraft);
   }
 
   function syncApproval() {
-    const isApproved = approve && approve.dataset.approved === "true";
-    if (draftState && isApproved) {
-      draftState.textContent = "Approved · not posted";
-      draftState.dataset.tone = "approved";
-    } else if (draftState && !preview.hidden) {
-      draftState.textContent = "Ready for your review";
-      draftState.dataset.tone = "ready";
+    const isApproved = approve?.dataset.approved === "true";
+    if (draftState) {
+      draftState.textContent = isApproved ? "Approved · not posted" : "Draft · not posted";
+      draftState.dataset.tone = isApproved ? "approved" : "ready";
     }
+    if (connect) connect.textContent = isApproved ? "Connect wallet" : "Connect wallet";
 
-    if (connect) connect.textContent = isApproved ? "Connect wallet" : "Approve before connecting";
     if (isApproved && !approvedAnnounced) {
       approvedAnnounced = true;
-      message("assistant", "The draft is approved. Connect a wallet when you are ready. Connecting still does not post or fund anything; the wallet will show the exact final request before you confirm it.", "draft");
+      addMessage("assistant", "Draft approved. Connect your wallet when you are ready.");
     }
     if (!isApproved) approvedAnnounced = false;
   }
@@ -112,17 +102,31 @@
     if (preview.hidden || !revise) return;
     const alreadyRevising = /what should the ai change/i.test(prompt.textContent);
     if (alreadyRevising) return;
-
     revise.click();
     input.value = value;
+  }
+
+  function fitInput() {
+    input.style.height = "auto";
+    input.style.height = `${Math.min(input.scrollHeight, 160)}px`;
   }
 
   form.addEventListener("submit", () => {
     const value = input.value.trim();
     if (!value) return;
     prepareNaturalRevision(value);
-    message("user", value);
+    addMessage("user", value);
+    requestAnimationFrame(() => {
+      input.style.height = "auto";
+    });
   }, true);
+
+  input.addEventListener("input", fitInput);
+  input.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
+    event.preventDefault();
+    form.requestSubmit();
+  });
 
   new MutationObserver(syncPrompt).observe(prompt, {
     childList: true,
@@ -138,9 +142,12 @@
     attributeFilter: ["data-tone"],
   });
 
-  new MutationObserver(syncDraft).observe(preview, {
+  new MutationObserver(scheduleDraftSync).observe(preview, {
     attributes: true,
     attributeFilter: ["hidden"],
+    childList: true,
+    characterData: true,
+    subtree: true,
   });
 
   if (approve) {
@@ -154,34 +161,34 @@
   if (revise) {
     revise.addEventListener("click", () => {
       approvedAnnounced = false;
-      setTimeout(() => {
-        document.querySelector(".conversation-panel")?.scrollIntoView({ behavior: "smooth", block: "start" });
-        input.focus({ preventScroll: true });
-      }, 0);
+      setTimeout(() => input.focus({ preventScroll: true }), 0);
     });
   }
 
   if (connect) {
-    connect.textContent = "Approve before connecting";
     connect.addEventListener("click", () => {
       setTimeout(() => {
-        if (dialog && dialog.open && cryptoMethod) cryptoMethod.click();
+        if (dialog?.open && cryptoMethod) cryptoMethod.click();
       }, 0);
     });
   }
 
-  const dialogObserver = dialog && new MutationObserver(() => {
-    if (dialog.open && cryptoMethod) setTimeout(() => cryptoMethod.click(), 0);
-  });
-  if (dialogObserver) dialogObserver.observe(dialog, { attributes: true, attributeFilter: ["open"] });
+  if (dialog) {
+    new MutationObserver(() => {
+      if (dialog.open && cryptoMethod) setTimeout(() => cryptoMethod.click(), 0);
+    }).observe(dialog, { attributes: true, attributeFilter: ["open"] });
+  }
 
-  const supplied = new URLSearchParams(location.search).get("goal")
-    || new URLSearchParams(location.search).get("draftObjective");
-  if (supplied) input.value = supplied;
+  const params = new URLSearchParams(location.search);
+  const supplied = params.get("goal") || params.get("draftObjective") || params.get("objective");
+  if (supplied) {
+    input.value = supplied;
+    fitInput();
+  }
 
   syncPrompt();
   syncStatus();
-  syncDraft();
+  scheduleDraftSync();
   syncApproval();
-  document.documentElement.dataset.bountyComposer = "chat-v1";
+  document.documentElement.dataset.bountyComposer = "chat-v2";
 })();

--- a/site/bounty-chat.css
+++ b/site/bounty-chat.css
@@ -1,453 +1,633 @@
 :root {
-  --chat-bg: #020b08;
-  --chat-panel: rgba(5, 18, 12, 0.96);
-  --chat-panel-soft: rgba(9, 28, 18, 0.88);
-  --chat-line: rgba(194, 242, 74, 0.22);
-  --chat-line-strong: rgba(194, 242, 74, 0.52);
+  --chat-bg: #06100b;
+  --chat-surface: #0b1710;
+  --chat-surface-soft: #112019;
+  --chat-line: rgba(255, 255, 255, 0.11);
+  --chat-text: #f3f5ef;
+  --chat-muted: #98a39b;
   --chat-lime: #c8f548;
   --chat-mint: #7cefd1;
-  --chat-text: #f4f7ef;
-  --chat-muted: #aeb9af;
 }
 
-.chat-composer-page {
+html,
+body.chat-app-page {
+  height: 100%;
+}
+
+body.chat-app-page {
   min-width: 320px;
   margin: 0;
-  background:
-    radial-gradient(circle at 12% 8%, rgba(122, 221, 89, 0.1), transparent 26rem),
-    radial-gradient(circle at 88% 68%, rgba(64, 162, 117, 0.08), transparent 32rem),
-    linear-gradient(180deg, #020b08, #04110b 58%, #020b08);
+  overflow: hidden;
+  background: var(--chat-bg);
   color: var(--chat-text);
   color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-.chat-composer-main {
-  width: min(1500px, calc(100% - 40px));
-  margin: 0 auto;
-  padding: 54px 0 72px;
+.chat-app-page * {
+  box-sizing: border-box;
 }
 
-.chat-composer-intro {
-  max-width: 860px;
-  margin: 0 0 34px;
+.chat-app-page button,
+.chat-app-page textarea {
+  font: inherit;
 }
 
-.chat-composer-intro .eyebrow {
-  color: var(--chat-lime);
-}
-
-.chat-composer-intro h1 {
-  max-width: 760px;
-  margin: 8px 0 16px;
-  font-size: clamp(42px, 7vw, 82px);
-  line-height: 0.96;
-  letter-spacing: -0.055em;
-}
-
-.chat-composer-intro > p:last-child {
-  max-width: 720px;
-  margin: 0;
-  color: var(--chat-muted);
-  font-size: clamp(16px, 2vw, 20px);
-  line-height: 1.55;
-}
-
-.bounty-chat-workspace {
+.chat-app-header {
+  position: fixed;
+  z-index: 50;
+  inset: 0 0 auto;
   display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
-  gap: 24px;
-  align-items: start;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  height: 58px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--chat-line);
+  background: rgba(6, 16, 11, 0.94);
+  backdrop-filter: blur(18px);
 }
 
-.conversation-panel,
-.draft-panel {
-  border: 1px solid var(--chat-line);
-  border-radius: 24px;
-  background:
-    linear-gradient(145deg, rgba(8, 24, 16, 0.98), rgba(3, 13, 8, 0.98));
-  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.34), inset 0 1px rgba(255, 255, 255, 0.025);
+.chat-app-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  justify-self: start;
+  color: var(--chat-text);
+  text-decoration: none;
+}
+
+.chat-app-brand > span {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(200, 245, 72, 0.55);
+  border-radius: 9px;
+  color: var(--chat-lime);
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.chat-app-brand strong {
+  font-size: 14px;
+}
+
+.chat-app-title {
+  color: #dbe1da;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.chat-app-close {
+  display: grid;
+  place-items: center;
+  justify-self: end;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  color: #c8d0c9;
+  font-size: 24px;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.chat-app-close:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: white;
+}
+
+.chat-app {
+  height: calc(100dvh - 58px);
+  margin-top: 58px;
 }
 
 .conversation-panel {
-  position: sticky;
-  top: 82px;
   display: grid;
-  grid-template-rows: auto minmax(360px, 1fr) auto auto;
-  min-height: min(780px, calc(100svh - 112px));
-  overflow: hidden;
-}
-
-.conversation-header {
-  display: grid;
-  gap: 18px;
-  padding: 22px 22px 18px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.conversation-header > div:first-child {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.conversation-ai-mark {
-  display: grid;
-  place-items: center;
-  flex: 0 0 auto;
-  width: 42px;
-  height: 42px;
-  border: 1px solid rgba(124, 239, 209, 0.45);
-  border-radius: 14px;
-  background: rgba(124, 239, 209, 0.08);
-  color: var(--chat-mint);
-  font-size: 12px;
-  font-weight: 900;
-  letter-spacing: 0.08em;
-}
-
-.conversation-header h2,
-.draft-panel-header h2 {
-  margin: 0;
-  color: var(--chat-text);
-  font-size: 20px;
-}
-
-.conversation-header p,
-.draft-panel-header p {
-  margin: 4px 0 0;
-  color: var(--chat-muted);
-  font-size: 12px;
-  line-height: 1.45;
-}
-
-.conversation-header .composer-progress {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 6px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.conversation-header .composer-progress li {
-  min-width: 0;
-  padding: 7px 5px;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 999px;
-  color: #829087;
-  font-size: 9px;
-  font-weight: 800;
-  text-align: center;
-  text-transform: uppercase;
-}
-
-.conversation-header .composer-progress li[data-active="true"] {
-  border-color: var(--chat-line-strong);
-  color: var(--chat-lime);
-  background: rgba(200, 245, 72, 0.07);
-}
-
-.conversation-header .composer-progress li[data-complete="true"] {
-  color: var(--chat-mint);
+  grid-template-rows: minmax(0, 1fr) auto auto;
+  width: min(820px, 100%);
+  height: 100%;
+  margin: 0 auto;
+  background: var(--chat-bg);
 }
 
 .conversation-log {
   display: flex;
   min-height: 0;
   flex-direction: column;
-  gap: 14px;
-  padding: 22px;
+  gap: 18px;
+  padding: 28px 20px 24px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   scroll-behavior: smooth;
-  scrollbar-color: rgba(200, 245, 72, 0.32) transparent;
+  scrollbar-color: rgba(200, 245, 72, 0.28) transparent;
 }
 
 .conversation-message {
-  display: grid;
-  grid-template-columns: 30px minmax(0, 1fr);
-  gap: 9px;
-  align-items: end;
-  max-width: 88%;
-  animation: conversation-message-in 220ms ease both;
+  display: flex;
+  max-width: min(78%, 610px);
+  animation: chat-message-in 180ms ease both;
 }
 
 .conversation-message[data-role="user"] {
-  grid-template-columns: minmax(0, 1fr) 30px;
   align-self: flex-end;
 }
 
 .conversation-avatar {
-  display: grid;
-  place-items: center;
-  width: 30px;
-  height: 30px;
-  border-radius: 10px;
-  background: rgba(124, 239, 209, 0.09);
-  color: var(--chat-mint);
-  font-size: 9px;
-  font-weight: 900;
-}
-
-.conversation-message[data-role="user"] .conversation-avatar {
-  grid-column: 2;
-  background: rgba(200, 245, 72, 0.1);
-  color: var(--chat-lime);
+  display: none;
 }
 
 .conversation-bubble {
-  padding: 12px 14px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 16px 16px 16px 5px;
-  background: rgba(15, 34, 23, 0.92);
-  color: #e9eee7;
-  font-size: 14px;
-  line-height: 1.52;
+  padding: 11px 15px;
+  border: 1px solid var(--chat-line);
+  border-radius: 18px 18px 18px 5px;
+  background: var(--chat-surface-soft);
+  color: #ecf0e9;
+  font-size: 15px;
+  line-height: 1.5;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 
 .conversation-message[data-role="user"] .conversation-bubble {
-  grid-column: 1;
-  grid-row: 1;
-  border-color: rgba(200, 245, 72, 0.24);
-  border-radius: 16px 16px 5px 16px;
-  background: rgba(117, 153, 25, 0.18);
-  color: #f6f8ef;
-}
-
-.conversation-message[data-kind="draft"] .conversation-bubble {
-  border-color: rgba(124, 239, 209, 0.34);
-  background: rgba(124, 239, 209, 0.065);
+  border-color: rgba(200, 245, 72, 0.26);
+  border-radius: 18px 18px 5px 18px;
+  background: rgba(166, 207, 54, 0.16);
+  color: #f7f9f1;
 }
 
 .conversation-thinking {
   display: flex;
   align-items: center;
   gap: 5px;
-  padding: 0 22px 14px;
-  color: #849188;
-  font-size: 11px;
+  width: min(820px, 100%);
+  padding: 0 22px 10px;
 }
 
 .conversation-thinking[hidden] {
   display: none;
 }
 
-.conversation-thinking > span {
-  width: 5px;
-  height: 5px;
+.conversation-thinking span {
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: var(--chat-mint);
+  background: var(--chat-muted);
   animation: chat-dot 1s ease-in-out infinite;
 }
 
-.conversation-thinking > span:nth-child(2) { animation-delay: 120ms; }
-.conversation-thinking > span:nth-child(3) { animation-delay: 240ms; }
-.conversation-thinking small { margin-left: 4px; }
+.conversation-thinking span:nth-child(2) { animation-delay: 120ms; }
+.conversation-thinking span:nth-child(3) { animation-delay: 240ms; }
 
 .chat-composer-form {
-  padding: 16px 18px 18px;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(2, 11, 7, 0.86);
-}
-
-.chat-composer-label {
-  display: block;
-  margin-bottom: 8px;
-  color: #b8c3ba;
-  font-size: 12px;
-  font-weight: 800;
+  position: relative;
+  padding: 12px 16px max(14px, env(safe-area-inset-bottom));
+  border-top: 1px solid var(--chat-line);
+  background: linear-gradient(180deg, rgba(6, 16, 11, 0.84), #06100b 35%);
 }
 
 .chat-composer-input-wrap {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 42px auto;
-  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 38px 42px;
   align-items: end;
-  padding: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.13);
-  border-radius: 18px;
-  background: rgba(0, 8, 4, 0.72);
-  transition: border-color 150ms ease, box-shadow 150ms ease;
+  gap: 5px;
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 24px;
+  background: #101c15;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.24);
 }
 
 .chat-composer-input-wrap:focus-within {
-  border-color: rgba(200, 245, 72, 0.55);
-  box-shadow: 0 0 0 3px rgba(200, 245, 72, 0.075);
+  border-color: rgba(200, 245, 72, 0.48);
+  box-shadow: 0 0 0 3px rgba(200, 245, 72, 0.06), 0 14px 36px rgba(0, 0, 0, 0.24);
 }
 
 .chat-composer-input-wrap textarea {
   width: 100%;
-  min-height: 70px;
-  max-height: 200px;
-  padding: 9px 10px;
-  resize: vertical;
+  min-height: 42px;
+  max-height: 160px;
+  margin: 0;
+  padding: 10px 11px 8px;
+  resize: none;
   border: 0;
   outline: 0;
   background: transparent;
   color: var(--chat-text);
-  font: inherit;
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.chat-composer-input-wrap textarea::placeholder {
+  color: #7f8a82;
+}
+
+.chat-composer-input-wrap .composer-mic,
+.chat-send {
+  position: static;
+  display: grid;
+  place-items: center;
+  align-self: end;
+  border: 0;
+  cursor: pointer;
+}
+
+.chat-composer-input-wrap .composer-mic {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: transparent;
+  color: #9aa69d;
+}
+
+.chat-composer-input-wrap .composer-mic:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: white;
+}
+
+.chat-composer-input-wrap .composer-mic svg,
+.chat-send svg {
+  width: 19px;
+  height: 19px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chat-send {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--chat-lime);
+  color: #0a1208;
+}
+
+.chat-send:hover {
+  transform: scale(1.04);
+}
+
+.chat-send:disabled,
+.composer-mic:disabled {
+  cursor: default;
+  opacity: 0.45;
+  transform: none;
+}
+
+.composer-status {
+  display: block;
+  max-width: 780px;
+  min-height: 0;
+  margin: 7px auto 0;
+  padding: 0 8px;
+  color: #9aa69d;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.composer-status:empty {
+  display: none;
+}
+
+.composer-status[data-tone="error"] { color: #ff9f92; }
+.composer-status[data-tone="pending"] { color: var(--chat-mint); }
+.composer-status[data-tone="success"] { color: var(--chat-lime); }
+
+.conversation-draft {
+  align-self: flex-start;
+  width: min(100%, 680px);
+  margin: 0;
+  border: 0;
+  background: transparent;
+}
+
+.conversation-draft[hidden] {
+  display: none;
+}
+
+.conversation-draft .bounty-card {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(200, 245, 72, 0.28);
+  border-radius: 20px;
+  background: #0b1810;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.conversation-draft .bounty-card-visual {
+  position: relative;
+  height: 190px;
+  overflow: hidden;
+}
+
+.conversation-draft .bounty-card-visual canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.conversation-draft .bounty-card-badge,
+.conversation-draft .image-generation-status {
+  position: absolute;
+  top: 12px;
+  padding: 6px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(4, 13, 8, 0.74);
+  color: #e7ede5;
+  font-size: 10px;
+  font-weight: 750;
+  backdrop-filter: blur(10px);
+}
+
+.conversation-draft .bounty-card-badge { left: 12px; }
+.conversation-draft .image-generation-status { right: 12px; }
+
+.conversation-draft .bounty-card-body {
+  padding: 20px;
+}
+
+.draft-card-heading {
+  margin-bottom: 16px;
+}
+
+.draft-state {
+  display: inline-block;
+  margin-bottom: 8px;
+  color: var(--chat-mint);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.draft-state[data-tone="approved"] {
+  color: var(--chat-lime);
+}
+
+.conversation-draft h2 {
+  margin: 0;
+  color: var(--chat-text);
+  font-size: clamp(22px, 4vw, 30px);
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+}
+
+.conversation-draft .bounty-card-goal {
+  margin: 9px 0 0;
+  color: #b8c2ba;
   font-size: 14px;
   line-height: 1.5;
 }
 
-.chat-composer-input-wrap textarea::placeholder {
-  color: #6f7d73;
-}
-
-.chat-composer-input-wrap .composer-mic {
-  position: static;
+.conversation-draft .bounty-card-stats {
   display: grid;
-  place-items: center;
-  width: 42px;
-  height: 42px;
-  border: 1px solid rgba(124, 239, 209, 0.22);
-  border-radius: 13px;
-  background: rgba(124, 239, 209, 0.05);
-  color: var(--chat-mint);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0 0 18px;
 }
 
-.chat-composer-input-wrap .composer-mic svg {
-  width: 20px;
+.conversation-draft .bounty-stat {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
 }
 
-.chat-send {
-  min-height: 42px;
-  padding-inline: 18px;
-}
-
-.chat-composer-form .composer-hint {
-  margin: 9px 2px 0;
-  color: #7f8c82;
-  font-size: 11px;
-  line-height: 1.4;
-}
-
-.chat-composer-form .composer-status {
+.conversation-draft .bounty-stat span,
+.conversation-draft .bounty-stat strong {
   display: block;
-  min-height: 18px;
-  margin: 8px 2px 0;
-  color: #a9b5ac;
-  font-size: 11px;
-  line-height: 1.4;
 }
 
-.chat-composer-form .composer-status[data-tone="error"] { color: #ff9f92; }
-.chat-composer-form .composer-status[data-tone="pending"] { color: var(--chat-mint); }
-.chat-composer-form .composer-status[data-tone="success"] { color: var(--chat-lime); }
-
-.draft-panel {
-  min-height: 620px;
-  padding: 18px;
-}
-
-.draft-panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 16px;
-  padding: 4px 4px 14px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.draft-panel-header .eyebrow {
-  color: var(--chat-lime);
-  font-size: 10px;
-}
-
-.draft-state {
-  max-width: 190px;
-  padding: 7px 10px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 999px;
-  color: #92a096;
-  font-size: 10px;
-  font-weight: 760;
-  text-align: center;
-}
-
-.draft-state[data-tone="ready"] {
-  border-color: rgba(124, 239, 209, 0.32);
-  color: var(--chat-mint);
-}
-
-.draft-state[data-tone="approved"] {
-  border-color: rgba(200, 245, 72, 0.48);
-  background: rgba(200, 245, 72, 0.075);
-  color: var(--chat-lime);
-}
-
-.draft-empty {
-  display: grid;
-  place-items: center;
-  min-height: 500px;
-  padding: 48px;
-  border: 1px dashed rgba(200, 245, 72, 0.18);
-  border-radius: 20px;
+.conversation-draft .bounty-stat span {
+  margin-bottom: 4px;
   color: #829087;
-  text-align: center;
+  font-size: 10px;
+  text-transform: uppercase;
 }
 
-.draft-empty[hidden] { display: none; }
+.conversation-draft .bounty-stat strong {
+  color: #f2f5ef;
+  font-size: 13px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
 
-.draft-empty > span {
-  display: grid;
-  place-items: center;
-  width: 72px;
-  height: 72px;
-  margin-bottom: 14px;
-  border: 1px solid rgba(200, 245, 72, 0.23);
-  border-radius: 50%;
+.done-when {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.done-when h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+}
+
+.done-when ol {
+  margin: 0;
+  padding-left: 20px;
+  color: #c8d0c9;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.done-when li + li {
+  margin-top: 5px;
+}
+
+.bounty-review-details,
+.mission-context {
+  margin-top: 14px;
+  padding-top: 13px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: #aab5ad;
+  font-size: 12px;
+}
+
+.bounty-review-details summary,
+.mission-context summary {
+  color: #dce2dc;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.bounty-review-details ul {
+  padding-left: 18px;
+  line-height: 1.5;
+}
+
+.bounty-review-details p,
+.mission-context p {
+  line-height: 1.5;
+}
+
+.mission-horizon {
+  display: inline-block;
+  margin-bottom: 8px;
   color: var(--chat-lime);
-  font-size: 28px;
 }
 
-.draft-empty h3 {
-  margin: 0;
-  color: #dfe5dd;
-  font-size: 22px;
+.mission-task-options {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
 }
 
-.draft-empty p {
-  max-width: 430px;
-  margin: 10px 0 0;
-  line-height: 1.55;
+.mission-task-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
+  padding: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 10px;
+  cursor: pointer;
 }
 
-.chat-bounty-preview {
-  margin: 0;
-}
-
-.chat-bounty-preview .bounty-card {
-  margin: 0;
+.mission-task-option small {
+  display: block;
+  margin-top: 3px;
+  color: #86938a;
 }
 
 .chat-draft-actions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
 }
 
 .chat-draft-actions .button {
-  justify-content: center;
+  min-height: 40px;
+  padding: 0 14px;
+  border-radius: 999px;
+  font-size: 12px;
 }
 
 .chat-draft-actions [data-open-funding] {
-  grid-column: 1 / -1;
-  min-height: 52px;
-  font-size: 15px;
+  margin-left: auto;
+}
+
+.chat-wallet-dialog {
+  width: min(520px, calc(100% - 24px));
+  max-height: min(760px, calc(100dvh - 32px));
+  padding: 0;
+  overflow: auto;
+  border: 1px solid rgba(200, 245, 72, 0.28);
+  border-radius: 20px;
+  background: #0a1710;
+  color: var(--chat-text);
+}
+
+.chat-wallet-dialog::backdrop {
+  background: rgba(0, 5, 3, 0.72);
+  backdrop-filter: blur(5px);
 }
 
 .chat-wallet-dialog .payment-dialog-inner {
-  max-width: 760px;
+  padding: 20px;
 }
 
-.chat-wallet-dialog .payment-methods {
-  display: none;
+.chat-wallet-dialog .payment-dialog-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
 }
 
-@keyframes conversation-message-in {
-  from { opacity: 0; transform: translateY(7px); }
+.chat-wallet-dialog .payment-dialog-head h2,
+.chat-wallet-dialog .payment-dialog-head p {
+  margin: 0;
+}
+
+.chat-wallet-dialog .payment-dialog-head p {
+  margin-top: 4px;
+  color: var(--chat-muted);
+  font-size: 12px;
+}
+
+.chat-wallet-dialog .dialog-close {
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  color: white;
+  cursor: pointer;
+  font-size: 22px;
+}
+
+.wallet-options {
+  display: grid;
+  gap: 8px;
+}
+
+.wallet-option {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  padding: 13px;
+  border: 1px solid var(--chat-line);
+  border-radius: 12px;
+  background: var(--chat-surface-soft);
+  color: var(--chat-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.wallet-option small,
+.payment-status,
+.funding-help {
+  color: var(--chat-muted);
+}
+
+.wallet-readiness-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin: 14px 0;
+}
+
+.wallet-readiness-grid > div {
+  padding: 10px;
+  border: 1px solid var(--chat-line);
+  border-radius: 10px;
+}
+
+.wallet-readiness-grid span,
+.wallet-readiness-grid strong {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.wallet-readiness-grid span {
+  margin-bottom: 4px;
+  color: #859188;
+  font-size: 10px;
+}
+
+.wallet-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 12px 0;
+}
+
+.payment-status {
+  display: block;
+  margin-top: 14px;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+@keyframes chat-message-in {
+  from { opacity: 0; transform: translateY(5px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
@@ -456,114 +636,103 @@
   50% { opacity: 1; transform: translateY(-3px); }
 }
 
-@media (max-width: 1050px) {
-  .bounty-chat-workspace {
-    grid-template-columns: 1fr;
+@media (max-width: 620px) {
+  .chat-app-header {
+    height: 54px;
+    padding-inline: 12px;
   }
 
-  .conversation-panel {
-    position: relative;
-    top: auto;
-    min-height: 680px;
-  }
-}
-
-@media (max-width: 700px) {
-  .chat-composer-main {
-    width: calc(100% - 24px);
-    padding-top: 30px;
+  .chat-app {
+    height: calc(100dvh - 54px);
+    margin-top: 54px;
   }
 
-  .chat-composer-intro {
-    margin-bottom: 22px;
-  }
-
-  .chat-composer-intro h1 {
-    font-size: clamp(40px, 13vw, 60px);
-  }
-
-  .bounty-chat-workspace {
-    gap: 14px;
-  }
-
-  .conversation-panel,
-  .draft-panel {
-    border-radius: 18px;
-  }
-
-  .conversation-panel {
-    min-height: 650px;
-    grid-template-rows: auto minmax(330px, 1fr) auto auto;
-  }
-
-  .conversation-header {
-    padding: 17px 15px 14px;
-  }
-
-  .conversation-header .composer-progress {
-    gap: 4px;
-  }
-
-  .conversation-header .composer-progress li {
-    padding-inline: 3px;
-    font-size: 8px;
+  .chat-app-brand strong {
+    display: none;
   }
 
   .conversation-log {
-    padding: 16px 14px;
+    gap: 15px;
+    padding: 20px 12px 18px;
   }
 
   .conversation-message {
-    max-width: 96%;
+    max-width: 88%;
   }
 
   .conversation-bubble {
-    font-size: 13px;
+    font-size: 14px;
   }
 
   .chat-composer-form {
-    padding: 13px;
+    padding-inline: 9px;
   }
 
   .chat-composer-input-wrap {
-    grid-template-columns: minmax(0, 1fr) 40px;
+    grid-template-columns: minmax(0, 1fr) 36px 40px;
+    border-radius: 22px;
+  }
+
+  .chat-composer-input-wrap textarea {
+    min-height: 40px;
+    padding-inline: 9px;
+    font-size: 16px;
+  }
+
+  .chat-composer-input-wrap .composer-mic {
+    width: 36px;
+    height: 36px;
   }
 
   .chat-send {
-    grid-column: 1 / -1;
-    width: 100%;
+    width: 40px;
+    height: 40px;
   }
 
-  .draft-panel {
-    min-height: 480px;
-    padding: 12px;
+  .conversation-draft .bounty-card-visual {
+    height: 150px;
   }
 
-  .draft-empty {
-    min-height: 390px;
-    padding: 34px 22px;
+  .conversation-draft .bounty-card-body {
+    padding: 16px;
   }
 
-  .draft-panel-header {
-    align-items: flex-start;
-  }
-
-  .chat-draft-actions {
+  .conversation-draft .bounty-card-stats {
     grid-template-columns: 1fr;
   }
 
+  .conversation-draft .bounty-stat {
+    display: grid;
+    grid-template-columns: 78px 1fr;
+    align-items: center;
+  }
+
+  .conversation-draft .bounty-stat span {
+    margin: 0;
+  }
+
+  .chat-draft-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
   .chat-draft-actions [data-open-funding] {
-    grid-column: auto;
+    grid-column: 1 / -1;
+    margin-left: 0;
+  }
+
+  .wallet-readiness-grid {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .conversation-message,
-  .conversation-thinking > span {
-    animation: none;
-  }
-
-  .conversation-log {
-    scroll-behavior: auto;
+  .chat-app-page *,
+  .chat-app-page *::before,
+  .chat-app-page *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/site/live-guild-build.txt
+++ b/site/live-guild-build.txt
@@ -1,2 +1,2 @@
-20260722-8
-This build replaces bounty creation with a real chat transcript, iterative standardized draft review, approval, and Connect wallet flow.
+20260722-9
+This build reduces bounty creation to one normal full-screen chatbot with an inline draft, approval, and wallet connection.

--- a/site/objective.html
+++ b/site/objective.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="bounty-composer.css?v=1">
     <link rel="stylesheet" href="bounty-composer-v2.css?v=1">
     <link rel="stylesheet" href="bounty-chat.css?v=2">
+    <link rel="stylesheet" href="bounty-chat-controls.css?v=1">
   </head>
   <body class="composer-page chat-app-page">
     <header class="chat-app-header">

--- a/site/objective.html
+++ b/site/objective.html
@@ -3,149 +3,117 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#020b08">
+    <meta name="theme-color" content="#07110c">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <title>Create a bounty in conversation | Agent Bounties</title>
-    <meta name="description" content="Explain what you need in natural language. AI asks focused questions, builds a standardized bounty draft, and lets you revise it before connecting a wallet.">
+    <title>New bounty | Agent Bounties</title>
+    <meta name="description" content="Chat with AI to turn what you need done into a clear bounty draft, approve it, and connect a wallet.">
     <link rel="canonical" href="https://agentbounties.app/objective.html">
-    <meta property="og:title" content="Create a bounty in conversation | Agent Bounties">
-    <meta property="og:description" content="Talk through the work you need, revise the bounty draft in chat, approve it, and connect a Base wallet only when it is ready.">
+    <meta property="og:title" content="New bounty | Agent Bounties">
+    <meta property="og:description" content="Describe what you need done, refine the draft in chat, approve it, and connect a wallet.">
     <meta property="og:url" content="https://agentbounties.app/objective.html">
     <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="guild-pages.css?v=20260722-1">
     <link rel="stylesheet" href="bounty-composer.css?v=1">
     <link rel="stylesheet" href="bounty-composer-v2.css?v=1">
-    <link rel="stylesheet" href="bounty-chat.css?v=1">
+    <link rel="stylesheet" href="bounty-chat.css?v=2">
   </head>
-  <body class="composer-page chat-composer-page">
-    <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
-      <nav aria-label="Primary navigation">
-        <a href="earn.html">Bounty Board</a>
-        <a href="how-it-works.html">How It Works</a>
-      </nav>
+  <body class="composer-page chat-app-page">
+    <header class="chat-app-header">
+      <a class="chat-app-brand" href="index.html" aria-label="Agent Bounties home">
+        <span aria-hidden="true">A</span>
+        <strong>Agent Bounties</strong>
+      </a>
+      <span class="chat-app-title">New bounty</span>
+      <a class="chat-app-close" href="earn.html" aria-label="Close and return to the Bounty Board">×</a>
     </header>
 
-    <main class="chat-composer-main">
-      <section class="chat-composer-intro" aria-labelledby="composer-title">
-        <p class="eyebrow">Post something you want done</p>
-        <h1 id="composer-title">Talk it through with the AI.</h1>
-        <p>Describe the problem, result, or mission in your own words. The AI asks one useful question at a time and turns the conversation into a clear bounty draft.</p>
-      </section>
-
-      <section class="bounty-chat-workspace" data-bounty-chat aria-label="Bounty drafting conversation">
-        <section class="conversation-panel" aria-labelledby="conversation-title">
-          <header class="conversation-header">
-            <div>
-              <span class="conversation-ai-mark" aria-hidden="true">AI</span>
-              <div>
-                <h2 id="conversation-title">Bounty conversation</h2>
-                <p>Nothing is posted until you approve the draft and confirm it in your wallet.</p>
-              </div>
-            </div>
-            <ol class="composer-progress" aria-label="Bounty creation progress">
-              <li data-progress-step="describe">Describe</li>
-              <li data-progress-step="clarify">Clarify</li>
-              <li data-progress-step="review">Review</li>
-              <li data-progress-step="fund">Connect</li>
-            </ol>
-          </header>
-
-          <div class="conversation-log" data-conversation-log aria-live="polite" aria-label="Conversation messages"></div>
-          <div class="conversation-thinking" data-assistant-thinking hidden>
-            <span></span><span></span><span></span><small>AI is thinking</small>
-          </div>
-
-          <p class="sr-only" data-assistant-prompt>What do you want done?</p>
-          <form id="bounty-composer-form" class="chat-composer-form">
-            <label class="chat-composer-label" for="bounty-composer-input" data-composer-label>Your message</label>
-            <div class="chat-composer-input-wrap">
-              <textarea id="bounty-composer-input" maxlength="12000" required placeholder="Describe what you need done, however you would naturally explain it."></textarea>
-              <button class="composer-mic" type="button" data-dictate aria-label="Dictate your message" title="Dictate your message">
-                <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="12" rx="4"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3M9 21h6"/></svg>
-              </button>
-              <button class="button primary chat-send" type="submit" data-composer-submit>Send</button>
-            </div>
-            <p class="composer-hint" data-composer-hint>You can keep revising the draft by continuing the conversation.</p>
-            <output class="composer-status" data-composer-status aria-live="polite"></output>
-          </form>
-        </section>
-
-        <aside class="draft-panel" aria-labelledby="draft-panel-title">
-          <header class="draft-panel-header">
-            <div>
-              <p class="eyebrow">Standardized draft</p>
-              <h2 id="draft-panel-title">Your bounty</h2>
-            </div>
-            <span class="draft-state" data-draft-state>Waiting for your description</span>
-          </header>
-
-          <div class="draft-empty" data-draft-empty>
-            <span aria-hidden="true">✦</span>
-            <h3>Your draft will appear here.</h3>
-            <p>As the conversation becomes specific enough, the AI will fill in the title, result, completion checks, reward, timing, and verification plan.</p>
-          </div>
-
-          <section id="bounty-preview" class="bounty-preview chat-bounty-preview" hidden aria-labelledby="bounty-card-title">
+    <main class="chat-app" data-bounty-chat aria-label="Bounty creation chat">
+      <section class="conversation-panel">
+        <div class="conversation-log" data-conversation-log aria-live="polite" aria-label="Conversation messages">
+          <section id="bounty-preview" class="bounty-preview conversation-draft" hidden aria-labelledby="bounty-card-title">
             <article id="bounty-card" class="bounty-card">
               <div class="bounty-card-visual">
-                <canvas id="bounty-card-art" role="img" aria-label="Illustrated preview of the achieved result"></canvas>
+                <canvas id="bounty-card-art" role="img" aria-label="Illustrated preview of the requested outcome"></canvas>
                 <span class="bounty-card-badge" data-card-badge>Draft · not posted</span>
                 <span class="image-generation-status" data-image-status>Preparing visual…</span>
               </div>
-              <div class="bounty-card-body">
-                <p class="bounty-card-kicker">Proposed bounty</p>
 
-                <section class="mission-context" data-mission-context hidden>
-                  <p class="mission-context-kicker">Part of a larger mission</p>
-                  <h3 data-mission-title></h3>
+              <div class="bounty-card-body">
+                <div class="draft-card-heading">
+                  <span class="draft-state" data-draft-state>Draft</span>
+                  <h2 id="bounty-card-title" data-card-title></h2>
+                  <p class="bounty-card-goal" data-card-goal></p>
+                </div>
+
+                <div class="bounty-card-stats" aria-label="Bounty summary">
+                  <div class="bounty-stat"><span>Reward</span><strong data-card-reward>—</strong></div>
+                  <div class="bounty-stat"><span>Time</span><strong data-card-deadline>—</strong></div>
+                  <div class="bounty-stat"><span>Checks</span><strong data-card-checks>—</strong></div>
+                  <strong class="sr-only" data-card-confidence>—</strong>
+                </div>
+
+                <details class="mission-context" data-mission-context hidden>
+                  <summary data-mission-title>Mission tasks</summary>
                   <p data-mission-summary></p>
                   <span class="mission-horizon" data-mission-horizon></span>
-                  <p>Choose which definite task to fund now. The others can become separate bounties later.</p>
                   <div class="mission-task-options" data-mission-tasks></div>
+                </details>
+
+                <section class="bounty-card-section done-when">
+                  <h3>Done when</h3>
+                  <ol data-card-criteria></ol>
                 </section>
 
-                <h2 id="bounty-card-title" data-card-title></h2>
-                <p class="bounty-card-goal" data-card-goal></p>
-
-                <div class="bounty-card-stats" aria-label="Bounty draft summary">
-                  <div class="bounty-stat"><span>Total reward</span><strong data-card-reward>—</strong></div>
-                  <div class="bounty-stat"><span>Work window</span><strong data-card-deadline>—</strong></div>
-                  <div class="bounty-stat"><span>Completion checks</span><strong data-card-checks>—</strong></div>
-                  <div class="bounty-stat"><span>Draft confidence</span><strong data-card-confidence>—</strong></div>
-                </div>
-
-                <div class="bounty-card-grid">
-                  <section class="bounty-card-section">
-                    <h3>Done when</h3>
-                    <ol data-card-criteria></ol>
-                  </section>
-                  <section class="bounty-card-section">
-                    <h3>Things to review</h3>
-                    <ul data-card-risks></ul>
-                    <p class="bounty-card-note"><strong>You are the verifier by default.</strong> The creator wallet decides pass or fail against the published completion checks.</p>
-                  </section>
-                </div>
+                <details class="bounty-review-details">
+                  <summary>Details to review</summary>
+                  <ul data-card-risks></ul>
+                  <p><strong>You verify completion.</strong> The published checks decide whether the work passes.</p>
+                </details>
 
                 <div class="bounty-card-actions chat-draft-actions">
-                  <button class="button secondary" type="button" data-revise-card>Keep editing in chat</button>
-                  <button class="button secondary" type="button" data-share-card>Share draft</button>
-                  <button class="button secondary" type="button" data-approve-card data-approved="false">Approve draft</button>
+                  <button class="button secondary" type="button" data-revise-card>Edit in chat</button>
+                  <button type="button" data-share-card hidden>Share draft</button>
+                  <button class="button secondary" type="button" data-approve-card data-approved="false">Approve</button>
                   <button class="button primary" type="button" data-open-funding disabled>Connect wallet</button>
                 </div>
-                <p class="bounty-card-disclaimer">AI output is a draft. Approval does not publish or fund anything. The bounty is created only after a separate wallet confirmation.</p>
               </div>
             </article>
           </section>
-        </aside>
+        </div>
+
+        <div class="conversation-thinking" data-assistant-thinking hidden aria-label="AI is thinking">
+          <span></span><span></span><span></span>
+        </div>
+
+        <p class="sr-only" data-assistant-prompt>What do you want done?</p>
+        <ol class="sr-only" aria-label="Bounty creation progress">
+          <li data-progress-step="describe">Describe</li>
+          <li data-progress-step="clarify">Clarify</li>
+          <li data-progress-step="review">Review</li>
+          <li data-progress-step="fund">Connect</li>
+        </ol>
+
+        <form id="bounty-composer-form" class="chat-composer-form">
+          <label class="sr-only" for="bounty-composer-input" data-composer-label>Your message</label>
+          <div class="chat-composer-input-wrap">
+            <textarea id="bounty-composer-input" maxlength="12000" rows="1" required placeholder="Message Agent Bounties"></textarea>
+            <button class="composer-mic" type="button" data-dictate aria-label="Dictate your message" title="Dictate your message">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="12" rx="4"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3M9 21h6"/></svg>
+            </button>
+            <button class="chat-send" type="submit" data-composer-submit aria-label="Send message">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12 14-7-4 14-3-6-7-1Z"/><path d="m12 13 7-8"/></svg>
+            </button>
+          </div>
+          <p class="sr-only" data-composer-hint>You can keep revising the draft by continuing the conversation.</p>
+          <output class="composer-status" data-composer-status aria-live="polite"></output>
+        </form>
       </section>
 
       <dialog id="funding-dialog" class="payment-dialog chat-wallet-dialog" aria-labelledby="funding-dialog-title">
         <div class="payment-dialog-inner">
           <div class="payment-dialog-head">
             <div>
-              <h2 id="funding-dialog-title">Connect a wallet</h2>
-              <p>Choose a wallet on this device. Connecting does not post or fund the bounty.</p>
+              <h2 id="funding-dialog-title">Connect wallet</h2>
+              <p>Connecting does not post or fund anything.</p>
             </div>
             <button class="dialog-close" type="button" data-close-funding aria-label="Close wallet window">×</button>
           </div>
@@ -153,67 +121,49 @@
           <button type="button" data-payment-method="crypto" hidden>Crypto Wallet</button>
 
           <section class="wallet-picker-panel" data-wallet-panel hidden>
-            <h3>Choose a wallet</h3>
-            <p data-wallet-message>Looking for compatible wallets…</p>
+            <p data-wallet-message>Looking for wallets…</p>
             <div class="wallet-options" data-wallet-options></div>
           </section>
 
-          <section class="wallet-readiness" data-wallet-readiness hidden aria-label="Wallet funding readiness">
+          <section class="wallet-readiness" data-wallet-readiness hidden aria-label="Wallet readiness">
             <div class="wallet-readiness-grid">
-              <div><span>Connected wallet</span><strong data-wallet-account>—</strong></div>
-              <div><span>Required now</span><strong data-wallet-required>—</strong></div>
-              <div><span>Base USDC balance</span><strong data-wallet-usdc>—</strong></div>
-              <div><span>Base ETH for gas</span><strong data-wallet-eth>—</strong></div>
+              <div><span>Wallet</span><strong data-wallet-account>—</strong></div>
+              <div><span>Required</span><strong data-wallet-required>—</strong></div>
+              <div><span>Base USDC</span><strong data-wallet-usdc>—</strong></div>
+              <div><span>Base ETH</span><strong data-wallet-eth>—</strong></div>
             </div>
 
             <div class="funding-help" data-funding-help hidden>
-              <strong>Wallet not ready yet.</strong>
-              <ol>
-                <li>Confirm the wallet network is <strong>Base</strong>.</li>
-                <li>Obtain at least <strong data-missing-usdc>—</strong> in native Base USDC.</li>
-                <li>Keep a small amount of Base ETH for gas.</li>
-                <li>Return here and select <strong>Recheck balance</strong>.</li>
-              </ol>
-              <p>Never enter a recovery phrase or private key on this website.</p>
+              <p>This wallet needs <strong data-missing-usdc>—</strong> and a small amount of Base ETH.</p>
+              <p>Never enter a recovery phrase or private key here.</p>
             </div>
 
             <div class="wallet-tools">
-              <button class="button secondary" type="button" data-watch-usdc>Add Base USDC to wallet</button>
-              <button class="button secondary" type="button" data-copy-usdc>Copy USDC address</button>
-              <button class="button secondary" type="button" data-recheck-balance>Recheck balance</button>
+              <button class="button secondary" type="button" data-watch-usdc>Add USDC</button>
+              <button class="button secondary" type="button" data-copy-usdc>Copy token address</button>
+              <button class="button secondary" type="button" data-recheck-balance>Recheck</button>
             </div>
 
             <div data-legal-consent data-consent-actions="post_bounty"></div>
-            <div class="payment-final-actions">
-              <button class="button primary" type="button" data-fund-now disabled>Review and post with wallet</button>
-            </div>
+            <button class="button primary" type="button" data-fund-now disabled>Review and post</button>
           </section>
 
           <output class="payment-status" data-payment-status aria-live="polite">Approve the draft before connecting a wallet.</output>
         </div>
       </dialog>
 
-      <section class="sr-only" aria-label="Planner compatibility summary">
+      <section class="sr-only" aria-label="Compatibility summary">
         <p>Turn one outcome into verifiable paid work with GPT-5.6.</p>
         <p>Agents have already completed paid loops.</p>
         <p>Post your own bounty.</p>
       </section>
     </main>
 
-    <footer class="guild-shell-footer">
-      <span>Nothing is posted or funded until you approve the draft and confirm the exact wallet request.</span>
-      <a href="how-it-works.html">How it works</a>
-      <a href="terms.html">Terms</a>
-      <a href="privacy.html">Privacy</a>
-      <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
-    </footer>
-
-    <script src="guild-shell.js?v=2"></script>
     <script src="analytics-config.js"></script>
     <script src="analytics.js"></script>
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
     <script src="bounty-composer-v2.js?v=1"></script>
-    <script src="bounty-chat-ui.js?v=1"></script>
+    <script src="bounty-chat-ui.js?v=2"></script>
   </body>
 </html>


### PR DESCRIPTION
Replace the current bounty creation page with a minimal, familiar chatbot interface.

Changes:
- Remove the intro, progress tracker, guild navigation, explanatory blocks, and separate draft column.
- Use one full-screen message thread with a composer fixed at the bottom.
- Show AI questions and user answers as normal chat bubbles.
- Insert the standardized bounty draft inline in the conversation.
- Keep only the essential draft actions: Edit in chat, Approve, and Connect wallet.
- Continue accepting natural-language revisions after the draft exists.
- Keep the existing AI drafting, mission decomposition, visual generation, approval gate, wallet readiness, legal consent, and canonical Base posting engine.
- Prevent the shared guild shell from loading on this chatbot page.

Production build: `20260722-9`. The Pages canary now verifies the absence of the intro, progress UI, and separate draft panel on the custom domain.