### PR TITLE
draft: replace unprofitable standing-meta-v2 economics

### DIFF
--- a/docs/standing-meta-low-bond-migration.md
+++ b/docs/standing-meta-low-bond-migration.md
@@ -1,0 +1,68 @@
+# Standing Meta Low-Bond Migration
+
+Tracking issue: [#527](https://github.com/NSPG13/agent-bounties/issues/527)
+
+## Approved economics
+
+Each replacement parent remains fully funded with 1 native Base USDC:
+
+| Component | Old | Replacement |
+| --- | ---: | ---: |
+| Solver reward | 0.90 USDC | **0.99 USDC** |
+| Verifier reward | 0.10 USDC | **0.01 USDC** |
+| Refundable claim bond | 0.10 USDC | **0.01 USDC** |
+| Initial funding | 1.00 USDC | **1.00 USDC** |
+
+The claim bond must equal the verifier reward under `agent-bounties/autonomous-v1`.
+
+## Contracts being replaced
+
+- #333 CLI: `0xfffecb0fcd36477c5f6ecec808f6f0cf53819562`
+- #334 API: `0xbe17ef2d154265ebe3142d7bda5e99610d571455`
+- #335 MCP: `0x43d42cb227d76588ab16693f14efd6cff851fa7a`
+- #336 wallet UX: `0xe8c1d3f046f3e4690bef59ba4abd5d02d2a6984b`
+
+The old terms under `bounties/autonomous-v1/333.json` through `336.json` are immutable historical evidence and must not be edited.
+
+## Prepare exact replacement terms
+
+```bash
+python scripts/prepare_low_bond_standing_meta_migration.py
+python scripts/test_prepare_low_bond_standing_meta_migration.py -v
+```
+
+The generator fails closed if the old economics, creator wallet, source issue, or standing-meta engine changed. It writes four replacement terms and `manifest.json` under `target/standing-meta-low-bond-migration/`.
+
+Generated files are plans only. They do not publish terms or move funds.
+
+## Execution order
+
+1. Re-read all four canonical contracts at one current Base `safe` block. Stop if any contract is no longer claimable, has a solver, has a submission, or differs from the immutable old terms.
+2. Reserve the old contracts in hosted discovery during migration:
+
+   ```text
+   0xfffecb0fcd36477c5f6ecec808f6f0cf53819562,0xbe17ef2d154265ebe3142d7bda5e99610d571455,0x43d42cb227d76588ab16693f14efd6cff851fa7a,0xe8c1d3f046f3e4690bef59ba4abd5d02d2a6984b
+   ```
+
+   Append these addresses to `BASE_RECOVERY_RESERVED_BOUNTY_CONTRACTS`; do not remove existing reservations. Confirm the hosted earning feed excludes them or marks `verification_ready=false` with an explicit migration reason.
+3. Publish each generated terms document through the hosted terms store and verify the returned hash against the generated manifest.
+4. Build fresh creation plans against the current canonical factory and one exact safe block.
+5. Use the active bounded wallet `0x1eaa1c68772cf76bc5f4e4174766076e33ace662` to create and fully fund each replacement. Its existing reviewed policy permits creation and funding for the standing-meta-v2 module, subject to live caps and expiry.
+6. Require confirmed `CanonicalBountyCreated`, `CanonicalBountyTermsCommitted`, `CanonicalBountyEconomicsConfigured`, `CanonicalBountyVerificationConfigured`, `FundingAdded`, and `BountyBecameClaimable` events before updating #333–#336.
+7. Independently verify each replacement reports 0.99 USDC solver reward, 0.01 USDC verifier reward, 0.01 USDC bond, valid terms, and `verification_ready=true`.
+8. Update the source issues and labels only from reconciled canonical state.
+
+## Old-fund recovery
+
+The old contracts were created by the bounded wallet. Its current delegate policy permits create, fund, claim, and submit, but not cancel or refund withdrawal. Do not broaden that authority casually.
+
+Recover the four old deposits only through either:
+
+- an owner-reviewed replacement policy that adds exact canonical `cancel` and `withdrawRefund` actions with narrow targets and caps; or
+- a separately reviewed one-shot recovery adapter bound to these four contracts and the owner destination.
+
+Only confirmed `BountyCancelled` and `RefundWithdrawn` events prove recovery. Until then, the old funds remain locked in their canonical contracts.
+
+## Evidence boundary
+
+A source file, generated terms hash, API response, pull request, wallet plan, signature request, or transaction hash is not replacement funding. Canonical events prove lifecycle transitions; only `BountySettled` proves solver payment.

--- a/scripts/prepare_low_bond_standing_meta_migration.py
+++ b/scripts/prepare_low_bond_standing_meta_migration.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Prepare exact low-bond replacement terms for standing-meta issues 333-336.
+
+This script never publishes terms, signs, broadcasts, cancels, refunds, funds, or
+claims a bounty. It preserves the original immutable terms and writes replacement
+candidates plus a manifest for operator review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+MIGRATION_ISSUE = "https://github.com/NSPG13/agent-bounties/issues/527"
+CREATOR_WALLET = "0x1eaa1c68772cf76bc5f4e4174766076e33ace662"
+OLD_ECONOMICS = (900_000, 100_000, 100_000, 1_000_000)
+NEW_ECONOMICS = (990_000, 10_000, 10_000, 1_000_000)
+REPLACEMENTS = {
+    333: "0xfffecb0fcd36477c5f6ecec808f6f0cf53819562",
+    334: "0xbe17ef2d154265ebe3142d7bda5e99610d571455",
+    335: "0x43d42cb227d76588ab16693f14efd6cff851fa7a",
+    336: "0xe8c1d3f046f3e4690bef59ba4abd5d02d2a6984b",
+}
+
+
+class MigrationError(RuntimeError):
+    pass
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def terms_hash(value: dict[str, Any]) -> str:
+    return "0x" + hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def replacement_nonce(issue_number: int) -> str:
+    seed = f"agent-bounties:standing-meta-low-bond:{issue_number}:migration-527:v1"
+    return "0x" + hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def amount(document: dict[str, Any], field: str) -> int:
+    value = document["contract_terms"][field]
+    if value.get("currency") != "usdc" or not isinstance(value.get("amount"), int):
+        raise MigrationError(f"{field} must be integer native-USDC base units")
+    return value["amount"]
+
+
+def load_original(repo_root: Path, issue_number: int) -> dict[str, Any]:
+    path = repo_root / "bounties" / "autonomous-v1" / f"{issue_number}.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    terms = document.get("contract_terms") or {}
+    observed = (
+        amount(document, "solver_reward"),
+        amount(document, "verifier_reward"),
+        amount(document, "claim_bond"),
+        amount(document, "initial_funding"),
+    )
+    if observed != OLD_ECONOMICS:
+        raise MigrationError(
+            f"#{issue_number} economics drift: expected {OLD_ECONOMICS}, got {observed}"
+        )
+    if str(terms.get("creator_wallet", "")).lower() != CREATOR_WALLET:
+        raise MigrationError(f"#{issue_number} creator wallet drift")
+    expected_source = f"https://github.com/NSPG13/agent-bounties/issues/{issue_number}"
+    if document.get("source_url") != expected_source:
+        raise MigrationError(f"#{issue_number} source URL drift")
+    if document.get("benchmark", {}).get("engine") != "standing_meta_v2_parent":
+        raise MigrationError(f"#{issue_number} is not a standing-meta-v2 parent")
+    return document
+
+
+def prepare(repo_root: Path, output_dir: Path) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    entries: list[dict[str, Any]] = []
+
+    for issue_number, old_contract in REPLACEMENTS.items():
+        document = copy.deepcopy(load_original(repo_root, issue_number))
+        terms = document["contract_terms"]
+        solver, verifier, bond, initial = NEW_ECONOMICS
+        terms["solver_reward"]["amount"] = solver
+        terms["verifier_reward"]["amount"] = verifier
+        terms["claim_bond"]["amount"] = bond
+        terms["initial_funding"]["amount"] = initial
+        terms["creation_nonce"] = replacement_nonce(issue_number)
+        document["discovery_source"] = (
+            "maintainer-seeded standing-meta-v2 inventory; low-bond migration #527"
+        )
+
+        if verifier != bond:
+            raise MigrationError("claim bond must equal verifier reward")
+        if solver + verifier != initial:
+            raise MigrationError("solver plus verifier reward must equal initial funding")
+
+        target = output_dir / f"{issue_number}.json"
+        target.write_text(
+            json.dumps(document, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        entries.append(
+            {
+                "source_issue_number": issue_number,
+                "source_issue_url": document["source_url"],
+                "old_contract": old_contract,
+                "replacement_terms_path": target.as_posix(),
+                "replacement_terms_hash": terms_hash(document),
+                "creation_nonce": terms["creation_nonce"],
+                "solver_reward_base_units": solver,
+                "verifier_reward_base_units": verifier,
+                "claim_bond_base_units": bond,
+                "initial_funding_base_units": initial,
+            }
+        )
+
+    manifest = {
+        "schema_version": "agent-bounties/standing-meta-low-bond-migration-v1",
+        "migration_issue": MIGRATION_ISSUE,
+        "network": "base-mainnet",
+        "creator_wallet": CREATOR_WALLET,
+        "reserved_contracts_csv": ",".join(REPLACEMENTS.values()),
+        "replacements": entries,
+        "required_confirmation_events": [
+            "CanonicalBountyCreated",
+            "FundingAdded",
+            "BountyBecameClaimable",
+        ],
+        "old_contract_recovery_events": ["BountyCancelled", "RefundWithdrawn"],
+        "evidence_boundary": (
+            "Generated terms and plans are not publication, funding, cancellation, "
+            "refund, claim, settlement, or payment evidence."
+        ),
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("target/standing-meta-low-bond-migration"),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manifest = prepare(args.repo_root.resolve(), args.output_dir.resolve())
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_prepare_low_bond_standing_meta_migration.py
+++ b/scripts/test_prepare_low_bond_standing_meta_migration.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Focused tests for prepare_low_bond_standing_meta_migration.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+import prepare_low_bond_standing_meta_migration as migration
+
+
+class LowBondStandingMetaMigrationTests(unittest.TestCase):
+    def test_prepares_four_exact_low_bond_replacements_without_mutating_sources(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        original_bytes = {
+            issue: (repo_root / "bounties" / "autonomous-v1" / f"{issue}.json").read_bytes()
+            for issue in migration.REPLACEMENTS
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            manifest = migration.prepare(repo_root, output)
+
+            self.assertEqual(len(manifest["replacements"]), 4)
+            self.assertEqual(
+                manifest["reserved_contracts_csv"],
+                ",".join(migration.REPLACEMENTS.values()),
+            )
+            self.assertEqual(
+                manifest["required_confirmation_events"],
+                ["CanonicalBountyCreated", "FundingAdded", "BountyBecameClaimable"],
+            )
+
+            hashes: set[str] = set()
+            nonces: set[str] = set()
+            for entry in manifest["replacements"]:
+                issue = entry["source_issue_number"]
+                document = json.loads((output / f"{issue}.json").read_text(encoding="utf-8"))
+                terms = document["contract_terms"]
+                self.assertEqual(terms["solver_reward"]["amount"], 990_000)
+                self.assertEqual(terms["verifier_reward"]["amount"], 10_000)
+                self.assertEqual(terms["claim_bond"]["amount"], 10_000)
+                self.assertEqual(terms["initial_funding"]["amount"], 1_000_000)
+                self.assertEqual(
+                    terms["verifier_reward"]["amount"],
+                    terms["claim_bond"]["amount"],
+                )
+                self.assertEqual(
+                    terms["solver_reward"]["amount"] + terms["verifier_reward"]["amount"],
+                    terms["initial_funding"]["amount"],
+                )
+                self.assertEqual(entry["replacement_terms_hash"], migration.terms_hash(document))
+                hashes.add(entry["replacement_terms_hash"])
+                nonces.add(entry["creation_nonce"])
+
+            self.assertEqual(len(hashes), 4)
+            self.assertEqual(len(nonces), 4)
+            self.assertTrue((output / "manifest.json").is_file())
+
+        for issue, before in original_bytes.items():
+            path = repo_root / "bounties" / "autonomous-v1" / f"{issue}.json"
+            self.assertEqual(path.read_bytes(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Status: superseded design, do not merge

The initial version of this PR prepared 0.99 / 0.01 / 0.01 replacement parents while retaining the deployed `CanonicalIndependentChildVerifierV2`.

That design is economically invalid. The V2 verifier requires:

```solidity
child.targetAmount() >= parent.solverReward()
```

Its immutable acceptance criteria also require the child to be funded to at least the parent solver reward. A parent solver therefore cannot earn a positive gross profit; lowering the bond alone does not solve engagement.

The corrected successor design tracked in #527 is:

- parent solver reward: **2.00 USDC**
- parent verifier reward: **0.01 USDC**
- parent refundable claim bond: **0.01 USDC**
- required qualifying child target: **1.00 USDC**
- guaranteed gross parent margin when self-funding the child: **1.00 USDC**

This requires a new immutable verifier and acceptance hash, plus new parent contracts. The current generator must not be used to publish or fund replacements.

The PR remains open temporarily only to preserve the failed approach and its review context while the focused V3 implementation is prepared. No transaction has occurred and the existing #333–#336 contracts remain unchanged.