### PR TITLE
feat: deploy profitable standing-meta-v3 policy

### DIFF
--- a/.github/workflows/standing-meta-v3-deploy.yml
+++ b/.github/workflows/standing-meta-v3-deploy.yml
@@ -1,0 +1,138 @@
+name: Standing meta v3 deploy
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/standing-meta-v3-deploy.yml"
+      - "contracts/base-escrow/src/CanonicalIndependentChildVerifierV3.sol"
+      - "contracts/base-escrow/src/StandingMetaV3Bundle.sol"
+      - "contracts/base-escrow/test/CanonicalIndependentChildVerifierV3.t.sol"
+      - "scripts/standing_meta_v3_deploy.py"
+      - "scripts/test_standing_meta_v3_deploy.py"
+      - "docs/standing-meta-v3-profit-invariant.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/standing-meta-v3-deploy.yml"
+      - "contracts/base-escrow/src/CanonicalIndependentChildVerifierV3.sol"
+      - "contracts/base-escrow/src/StandingMetaV3Bundle.sol"
+      - "contracts/base-escrow/test/CanonicalIndependentChildVerifierV3.t.sol"
+      - "scripts/standing_meta_v3_deploy.py"
+      - "scripts/test_standing_meta_v3_deploy.py"
+      - "docs/standing-meta-v3-profit-invariant.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: standing-meta-v3-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deterministic-gates:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - name: Contract, economics, and deployment helper tests
+        run: |
+          python -m unittest scripts.test_standing_meta_v3_deploy -v
+          forge test --root contracts/base-escrow --match-contract CanonicalIndependentChildVerifierV3Test -vv
+          forge build --root contracts/base-escrow --sizes
+
+      - name: Read-only Base activation and funding preflight
+        env:
+          BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+        run: >-
+          python scripts/standing_meta_v3_deploy.py plan
+          --output target/standing-meta-v3-plan.json
+          --markdown-output target/standing-meta-v3-plan.md
+
+      - name: Publish pull-request preflight
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr comment "$PR_NUMBER" --body-file target/standing-meta-v3-plan.md
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: standing-meta-v3-plan-${{ github.sha }}
+          path: |
+            target/standing-meta-v3-plan.json
+            target/standing-meta-v3-plan.md
+          if-no-files-found: error
+
+  base-mainnet-deploy:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: deterministic-gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - name: Deterministically deploy and attest standing-meta-v3
+        run: >-
+          python scripts/standing_meta_v3_deploy.py deploy
+          --output target/standing-meta-v3-deployment.json
+          --markdown-output target/standing-meta-v3-plan.md
+
+      - name: Publish deployment evidence to migration issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('target/standing-meta-v3-deployment.json').read_text())
+          verification = report['verification']
+          transaction = report.get('transaction') or {}
+          tx_hash = transaction.get('transactionHash') or transaction.get('transaction_hash')
+          lines = [
+              '## Standing-meta-v3 Base deployment reconciled',
+              '',
+              f"- Verifier module: `{verification['verifier_module']}`",
+              f"- Runtime code hash: `{verification['runtime_code_hash']}`",
+              f"- Acceptance criteria hash: `{verification['acceptance_criteria_hash']}`",
+              f"- Deployment transaction: `{tx_hash}`" if tx_hash else '- Deployment was already present and re-attested idempotently.',
+              '- Child floor: **1.00 USDC**',
+              '- Guaranteed parent gross-margin floor: **1.00 USDC**',
+              '',
+              'This proves policy deployment only. It does not prove that replacement parents are created, funded, claimable, or paid.',
+          ]
+          Path('target/standing-meta-v3-deployment.md').write_text('\n'.join(lines) + '\n')
+          PY
+          gh issue comment 527 --body-file target/standing-meta-v3-deployment.md
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: standing-meta-v3-mainnet-${{ github.sha }}
+          path: |
+            target/standing-meta-v3-plan.json
+            target/standing-meta-v3-plan.md
+            target/standing-meta-v3-deployment.json
+            target/standing-meta-v3-deployment.md
+          if-no-files-found: warn

--- a/contracts/base-escrow/src/CanonicalIndependentChildVerifierV3.sol
+++ b/contracts/base-escrow/src/CanonicalIndependentChildVerifierV3.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./IAgentBounty.sol";
+import "./OnchainTermsRegistry.sol";
+import "./ParticipantEligibilityRegistry.sol";
+
+interface IProfitableChildFactoryView {
+    function settlementToken() external view returns (address);
+    function isCanonicalBounty(address bounty) external view returns (bool);
+}
+
+interface IProfitableChildBountyView {
+    function bountyId() external view returns (bytes32);
+    function creator() external view returns (address);
+    function factory() external view returns (address);
+    function settlementToken() external view returns (address);
+    function solverReward() external view returns (uint256);
+    function targetAmount() external view returns (uint256);
+    function fundedAmount() external view returns (uint256);
+    function termsHash() external view returns (bytes32);
+    function policyHash() external view returns (bytes32);
+    function acceptanceCriteriaHash() external view returns (bytes32);
+    function benchmarkHash() external view returns (bytes32);
+    function evidenceSchemaHash() external view returns (bytes32);
+    function verifierSetHash() external view returns (bytes32);
+    function verificationMode() external view returns (uint8);
+    function verifierModule() external view returns (address);
+    function threshold() external view returns (uint8);
+    function status() external view returns (uint8);
+    function round() external view returns (uint64);
+    function solver() external view returns (address);
+    function activeClaimBond() external view returns (uint256);
+    function submissionHash() external view returns (bytes32);
+    function evidenceHash() external view returns (bytes32);
+    function claimExpiresAt() external view returns (uint64);
+    function claimWindowSeconds() external view returns (uint64);
+}
+
+/// @notice Settles a standing meta-bounty only after a meaningful child bounty is
+/// independently completed while preserving a guaranteed gross margin for the
+/// parent solver. Missing or malformed evidence reverts without rejecting work.
+contract CanonicalIndependentChildVerifierV3 is IAgentBountyVerifier {
+    struct ParentScope {
+        address parentAddress;
+        bytes32 bountyId;
+        uint64 round;
+        address solver;
+        bytes32 submissionHash;
+        bytes32 evidenceHash;
+        bytes32 policyHash;
+    }
+
+    bytes32 public constant PROTOCOL_TAG = keccak256("agent-bounties/independent-child-v3");
+    uint256 public constant MINIMUM_CHILD_TARGET = 1_000_000;
+    uint256 public constant MINIMUM_PARENT_GROSS_MARGIN = 1_000_000;
+    uint8 public constant DETERMINISTIC_MODULE_MODE = 0;
+    uint8 public constant SIGNED_QUORUM_MODE = 1;
+    uint8 public constant SUBMITTED_STATUS = 3;
+    uint8 public constant SETTLED_STATUS = 4;
+
+    string public constant ACCEPTANCE_CRITERIA_JSON = '["Publish the exact child terms on Base from the parent solver wallet before claiming this bounty.",'
+        '"Create and fully fund a parent-bound canonical child with a total target of at least 1.00 USDC.",'
+        '"Keep the child total target at least 1.00 USDC below this bounty solver reward so the parent has positive gross profit.",'
+        '"Use the committed sandboxed-regression signed verifier quorum and immutable task criteria.",'
+        '"Have a participant registered before the parent claim, with a different participant ID, complete the child.",'
+        '"Receive canonical child settlement before submitting the child address to this verifier."]';
+    bytes32 public constant ACCEPTANCE_CRITERIA_HASH = keccak256(bytes(ACCEPTANCE_CRITERIA_JSON));
+
+    address public immutable canonicalFactory;
+    address public immutable settlementToken;
+    ParticipantEligibilityRegistry public immutable participantRegistry;
+    OnchainTermsRegistry public immutable termsRegistry;
+    bytes32 public immutable taskVerifierSetHash;
+    uint8 public immutable taskVerifierThreshold;
+
+    error InvalidProof();
+    error InvalidParent();
+    error InvalidChild();
+    error TermsUnavailable();
+    error ParticipantIneligible();
+    error SameParticipant();
+
+    constructor(
+        address canonicalFactory_,
+        address participantRegistry_,
+        address termsRegistry_,
+        bytes32 taskVerifierSetHash_,
+        uint8 taskVerifierThreshold_
+    ) {
+        require(canonicalFactory_ != address(0), "factory zero");
+        require(participantRegistry_.code.length > 0, "participant registry missing");
+        require(termsRegistry_.code.length > 0, "terms registry missing");
+        require(taskVerifierSetHash_ != bytes32(0) && taskVerifierThreshold_ >= 2, "verifier policy invalid");
+        address token = IProfitableChildFactoryView(canonicalFactory_).settlementToken();
+        require(token != address(0), "token zero");
+        canonicalFactory = canonicalFactory_;
+        settlementToken = token;
+        participantRegistry = ParticipantEligibilityRegistry(participantRegistry_);
+        termsRegistry = OnchainTermsRegistry(termsRegistry_);
+        taskVerifierSetHash = taskVerifierSetHash_;
+        taskVerifierThreshold = taskVerifierThreshold_;
+    }
+
+    /// @notice The proof is exactly abi.encode(address childBounty).
+    function verify(
+        bytes32 parentBountyId,
+        uint64 parentRound,
+        address parentSolver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        bytes calldata proof
+    ) external view returns (bool passed, bytes32 responseHash) {
+        if (proof.length != 32) revert InvalidProof();
+        uint256 encodedChild;
+        assembly ("memory-safe") {
+            encodedChild := calldataload(proof.offset)
+        }
+        if (encodedChild >> 160 != 0) revert InvalidProof();
+        // The high-bit check above proves this cast cannot truncate.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        address childAddress = address(uint160(encodedChild));
+
+        ParentScope memory scope = ParentScope({
+            parentAddress: msg.sender,
+            bountyId: parentBountyId,
+            round: parentRound,
+            solver: parentSolver,
+            submissionHash: submissionHash,
+            evidenceHash: evidenceHash,
+            policyHash: policyHash
+        });
+        responseHash = _verify(scope, childAddress);
+        return (true, responseHash);
+    }
+
+    function _verify(ParentScope memory scope, address childAddress) private view returns (bytes32 responseHash) {
+        IProfitableChildBountyView parent =
+            _validParent(scope.parentAddress, scope.bountyId, scope.round, scope.solver);
+        uint64 claimedAt = parent.claimExpiresAt() - parent.claimWindowSeconds();
+        IProfitableChildBountyView child = _validChild(parent, childAddress, scope.solver);
+        _validTerms(child, scope.bountyId, scope.round, scope.solver, claimedAt);
+        _validParticipants(scope.solver, child.solver(), claimedAt);
+
+        responseHash = keccak256(
+            abi.encode(
+                PROTOCOL_TAG,
+                scope,
+                childAddress,
+                child.bountyId(),
+                child.solver(),
+                child.targetAmount(),
+                MINIMUM_CHILD_TARGET,
+                MINIMUM_PARENT_GROSS_MARGIN,
+                child.submissionHash(),
+                child.evidenceHash(),
+                child.termsHash()
+            )
+        );
+    }
+
+    function _validParent(address parentAddress, bytes32 parentBountyId, uint64 parentRound, address parentSolver)
+        private
+        view
+        returns (IProfitableChildBountyView parent)
+    {
+        if (!IProfitableChildFactoryView(canonicalFactory).isCanonicalBounty(parentAddress)) revert InvalidParent();
+        parent = IProfitableChildBountyView(parentAddress);
+        if (
+            parent.bountyId() != parentBountyId || parent.factory() != canonicalFactory
+                || parent.settlementToken() != settlementToken
+                || parent.acceptanceCriteriaHash() != ACCEPTANCE_CRITERIA_HASH
+                || parent.verificationMode() != DETERMINISTIC_MODULE_MODE || parent.verifierModule() != address(this)
+                || parent.threshold() != 1 || parent.status() != SUBMITTED_STATUS || parent.round() != parentRound
+                || parent.solver() != parentSolver || parent.claimExpiresAt() < parent.claimWindowSeconds()
+                || parent.solverReward() < MINIMUM_CHILD_TARGET + MINIMUM_PARENT_GROSS_MARGIN
+        ) revert InvalidParent();
+    }
+
+    function _validChild(IProfitableChildBountyView parent, address childAddress, address parentSolver)
+        private
+        view
+        returns (IProfitableChildBountyView child)
+    {
+        if (
+            childAddress == address(0) || childAddress == address(parent)
+                || !IProfitableChildFactoryView(canonicalFactory).isCanonicalBounty(childAddress)
+        ) revert InvalidChild();
+        child = IProfitableChildBountyView(childAddress);
+        uint256 childTarget = child.targetAmount();
+        if (
+            child.creator() != parentSolver || child.factory() != canonicalFactory
+                || child.settlementToken() != settlementToken || childTarget < MINIMUM_CHILD_TARGET
+                || childTarget > parent.solverReward() - MINIMUM_PARENT_GROSS_MARGIN
+                || child.verificationMode() != SIGNED_QUORUM_MODE || child.verifierModule() != address(0)
+                || child.verifierSetHash() != taskVerifierSetHash || child.threshold() != taskVerifierThreshold
+                || child.status() != SETTLED_STATUS || child.fundedAmount() != 0 || child.activeClaimBond() != 0
+                || child.solver() == address(0) || child.solver() == parentSolver
+                || child.submissionHash() == bytes32(0) || child.evidenceHash() == bytes32(0)
+        ) revert InvalidChild();
+    }
+
+    function _validTerms(
+        IProfitableChildBountyView child,
+        bytes32 parentBountyId,
+        uint64 parentRound,
+        address parentSolver,
+        uint64 parentClaimedAt
+    ) private view {
+        OnchainTermsRegistry.TermsCommitment memory record = termsRegistry.commitment(child.termsHash());
+        if (record.publishedAt == 0) revert TermsUnavailable();
+        if (
+            record.publisher != parentSolver || record.publishedAt >= parentClaimedAt
+                || record.parentBountyId != parentBountyId || record.parentRound != parentRound
+                || record.policyHash != child.policyHash()
+                || record.acceptanceCriteriaHash != child.acceptanceCriteriaHash()
+                || record.benchmarkHash != child.benchmarkHash()
+                || record.evidenceSchemaHash != child.evidenceSchemaHash()
+                || record.verifierSetHash != taskVerifierSetHash || record.verifierThreshold != taskVerifierThreshold
+        ) revert TermsUnavailable();
+    }
+
+    function _validParticipants(address parentSolver, address childSolver, uint64 parentClaimedAt) private view {
+        (bytes32 parentParticipant,, bool parentEligible) =
+            participantRegistry.eligibleAt(parentSolver, parentClaimedAt);
+        (bytes32 childParticipant,, bool childEligible) = participantRegistry.eligibleAt(childSolver, parentClaimedAt);
+        if (!parentEligible || !childEligible) revert ParticipantIneligible();
+        if (parentParticipant == childParticipant) revert SameParticipant();
+    }
+}

--- a/contracts/base-escrow/src/StandingMetaV3Bundle.sol
+++ b/contracts/base-escrow/src/StandingMetaV3Bundle.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./CanonicalIndependentChildVerifierV3.sol";
+
+/// @notice Atomically deploys the immutable profitable standing-meta-v3 policy components.
+/// A failed component deployment reverts the whole bundle, leaving no partial policy.
+contract StandingMetaV3Bundle {
+    address public immutable canonicalFactory;
+    ParticipantEligibilityRegistry public immutable participantRegistry;
+    OnchainTermsRegistry public immutable termsRegistry;
+    CanonicalIndependentChildVerifierV3 public immutable verifierModule;
+
+    constructor(address canonicalFactory_, address attester, address verifierOne, address verifierTwo) {
+        require(canonicalFactory_.code.length > 0, "factory missing");
+        require(attester != address(0), "attester zero");
+        require(
+            verifierOne != address(0) && verifierTwo != address(0) && verifierOne != verifierTwo, "verifiers invalid"
+        );
+
+        address[] memory verifiers = new address[](2);
+        verifiers[0] = verifierOne;
+        verifiers[1] = verifierTwo;
+
+        canonicalFactory = canonicalFactory_;
+        participantRegistry = new ParticipantEligibilityRegistry(attester);
+        termsRegistry = new OnchainTermsRegistry();
+        verifierModule = new CanonicalIndependentChildVerifierV3(
+            canonicalFactory_, address(participantRegistry), address(termsRegistry), keccak256(abi.encode(verifiers)), 2
+        );
+    }
+}

--- a/contracts/base-escrow/test/CanonicalIndependentChildVerifierV3.t.sol
+++ b/contracts/base-escrow/test/CanonicalIndependentChildVerifierV3.t.sol
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../src/AgentBountyFactory.sol";
+import "../src/CanonicalIndependentChildVerifierV3.sol";
+import "../src/StandingMetaV3Bundle.sol";
+
+interface ProfitableChildVm {
+    function addr(uint256 privateKey) external returns (address);
+    function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+    function warp(uint256 timestamp) external;
+}
+
+contract ProfitableChildToken {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+}
+
+contract ProfitableChildActor {
+    function approve(ProfitableChildToken token, address spender, uint256 amount) external {
+        token.approve(spender, amount);
+    }
+
+    function create(
+        AgentBountyFactory factory,
+        AgentBountyFactory.CreateBountyParams calldata params,
+        address[] calldata verifiers,
+        uint256 initialFunding,
+        bytes32 creationNonce
+    ) external returns (AgentBounty bounty) {
+        (address bountyAddress,) = factory.createBounty(params, verifiers, initialFunding, creationNonce);
+        bounty = AgentBounty(bountyAddress);
+    }
+
+    function publish(
+        OnchainTermsRegistry registry,
+        bytes calldata terms,
+        OnchainTermsRegistry.TermsInput calldata input
+    ) external returns (bytes32) {
+        return registry.publish(terms, input);
+    }
+
+    function claim(AgentBounty bounty) external {
+        bounty.claim();
+    }
+
+    function submit(AgentBounty bounty, bytes32 submissionHash, bytes32 evidenceHash) external {
+        bounty.submit(submissionHash, evidenceHash);
+    }
+}
+
+contract CanonicalIndependentChildVerifierV3Test {
+    ProfitableChildVm private constant vm =
+        ProfitableChildVm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    uint256 private constant ELIGIBILITY_ATTESTER_KEY = 0xA11CE;
+    uint256 private constant TASK_VERIFIER_ONE_KEY = 0xBEEF;
+    uint256 private constant TASK_VERIFIER_TWO_KEY = 0xCAFE;
+    bytes32 private constant POLICY_HASH = keccak256("sandboxed-regression-policy-v1");
+    bytes32 private constant CHILD_CRITERIA_HASH = keccak256("child-criteria");
+    bytes32 private constant CHILD_BENCHMARK_HASH = keccak256("child-benchmark");
+    bytes32 private constant EVIDENCE_SCHEMA_HASH = keccak256("child-evidence-schema");
+    bytes32 private constant SOURCE_HASH = keccak256("github-source-v1");
+    bytes32 private constant PARENT_PARTICIPANT = keccak256("participant-parent");
+    bytes32 private constant CHILD_PARTICIPANT = keccak256("participant-child");
+    bytes private constant CHILD_TERMS = '{"schema":"agent-bounties/test-child-v3"}';
+    uint256 private constant PARENT_REWARD = 2_000_000;
+    uint256 private constant PARENT_VERIFIER_REWARD = 10_000;
+    uint256 private constant CHILD_TARGET = 1_000_000;
+    uint256 private constant CHILD_VERIFIER_REWARD = 10_000;
+
+    ProfitableChildToken private token;
+    AgentBountyFactory private factory;
+    ParticipantEligibilityRegistry private participantRegistry;
+    OnchainTermsRegistry private termsRegistry;
+    CanonicalIndependentChildVerifierV3 private module;
+    ProfitableChildActor private parentSolver;
+    ProfitableChildActor private childSolver;
+    ProfitableChildActor private verifierRewardRecipient;
+    address[] private taskVerifiers;
+    uint256 private nonce;
+
+    function setUp() public {
+        token = new ProfitableChildToken();
+        factory = new AgentBountyFactory(address(token));
+        participantRegistry = new ParticipantEligibilityRegistry(vm.addr(ELIGIBILITY_ATTESTER_KEY));
+        termsRegistry = new OnchainTermsRegistry();
+        taskVerifiers.push(vm.addr(TASK_VERIFIER_ONE_KEY));
+        taskVerifiers.push(vm.addr(TASK_VERIFIER_TWO_KEY));
+        module = new CanonicalIndependentChildVerifierV3(
+            address(factory),
+            address(participantRegistry),
+            address(termsRegistry),
+            keccak256(abi.encode(taskVerifiers)),
+            2
+        );
+        parentSolver = new ProfitableChildActor();
+        childSolver = new ProfitableChildActor();
+        verifierRewardRecipient = new ProfitableChildActor();
+        token.mint(address(this), 20_000_000);
+        token.approve(address(factory), type(uint256).max);
+    }
+
+    function testOneUsdcChildLeavesOneUsdcGrossParentProfit() public {
+        (AgentBounty parent, AgentBounty child) =
+            _prepareSettledChild(PARENT_REWARD, CHILD_TARGET, CHILD_PARTICIPANT, true);
+
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+        parent.verifyAndSettle(abi.encode(address(child)));
+
+        require(parent.bountyStatus() == AgentBounty.BountyStatus.Settled, "parent not settled");
+        require(child.bountyStatus() == AgentBounty.BountyStatus.Settled, "child not settled");
+        require(token.balanceOf(address(childSolver)) == CHILD_TARGET, "child solver payout mismatch");
+        require(
+            token.balanceOf(address(parentSolver)) == PARENT_REWARD + PARENT_VERIFIER_REWARD,
+            "parent balance does not preserve one-USDC gross profit"
+        );
+        require(
+            token.balanceOf(address(parentSolver)) - (CHILD_TARGET + PARENT_VERIFIER_REWARD) == 1_000_000,
+            "parent gross profit mismatch"
+        );
+        require(
+            token.balanceOf(address(verifierRewardRecipient)) == PARENT_VERIFIER_REWARD,
+            "parent verifier payout mismatch"
+        );
+    }
+
+    function testChildBelowOneUsdcFloorCannotSettleParent() public {
+        (AgentBounty parent, AgentBounty child) =
+            _prepareSettledChild(PARENT_REWARD, CHILD_TARGET - 1, CHILD_PARTICIPANT, true);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "sub-minimum child settled parent");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testChildThatConsumesRequiredMarginCannotSettleParent() public {
+        (AgentBounty parent, AgentBounty child) =
+            _prepareSettledChild(PARENT_REWARD, CHILD_TARGET + 1, CHILD_PARTICIPANT, true);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "unprofitable child settled parent");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testParentBelowTwoUsdcCannotUsePolicy() public {
+        (AgentBounty parent, AgentBounty child) =
+            _prepareSettledChild(PARENT_REWARD - 1, CHILD_TARGET, CHILD_PARTICIPANT, true);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "underfunded parent settled");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testSameParticipantCannotSettleParent() public {
+        (AgentBounty parent, AgentBounty child) =
+            _prepareSettledChild(PARENT_REWARD, CHILD_TARGET, PARENT_PARTICIPANT, true);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "same participant settled parent");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testTermsPublishedAfterClaimCannotSettleParent() public {
+        (AgentBounty parent, AgentBounty child) =
+            _prepareSettledChild(PARENT_REWARD, CHILD_TARGET, CHILD_PARTICIPANT, false);
+        parentSolver.submit(parent, keccak256("parent-submission"), keccak256("parent-evidence"));
+
+        (bool ok,) = address(parent).call(abi.encodeCall(parent.verifyAndSettle, (abi.encode(address(child)))));
+
+        require(!ok, "late terms settled parent");
+        _assertParentAttemptPreserved(parent);
+    }
+
+    function testBundleDeploysExactProfitPolicyAtomically() public {
+        StandingMetaV3Bundle bundle = new StandingMetaV3Bundle(
+            address(factory),
+            vm.addr(ELIGIBILITY_ATTESTER_KEY),
+            vm.addr(TASK_VERIFIER_ONE_KEY),
+            vm.addr(TASK_VERIFIER_TWO_KEY)
+        );
+        CanonicalIndependentChildVerifierV3 bundledModule = bundle.verifierModule();
+
+        require(bundle.canonicalFactory() == address(factory), "bundle factory mismatch");
+        require(bundledModule.canonicalFactory() == address(factory), "module factory mismatch");
+        require(
+            address(bundledModule.participantRegistry()) == address(bundle.participantRegistry()),
+            "bundle participant registry mismatch"
+        );
+        require(address(bundledModule.termsRegistry()) == address(bundle.termsRegistry()), "bundle terms mismatch");
+        require(bundledModule.taskVerifierSetHash() == keccak256(abi.encode(taskVerifiers)), "bundle quorum mismatch");
+        require(bundledModule.taskVerifierThreshold() == 2, "bundle threshold mismatch");
+        require(bundledModule.MINIMUM_CHILD_TARGET() == CHILD_TARGET, "child floor mismatch");
+        require(bundledModule.MINIMUM_PARENT_GROSS_MARGIN() == 1_000_000, "profit floor mismatch");
+    }
+
+    function _prepareSettledChild(
+        uint256 parentReward,
+        uint256 childTarget,
+        bytes32 childParticipant,
+        bool publishBeforeClaim
+    ) private returns (AgentBounty parent, AgentBounty child) {
+        parent = _createParent(parentReward);
+        _register(address(parentSolver), PARENT_PARTICIPANT);
+        _register(address(childSolver), childParticipant);
+        if (publishBeforeClaim) {
+            _publishChildTerms(parent);
+            vm.warp(block.timestamp + 1);
+        }
+
+        token.mint(address(parentSolver), childTarget + PARENT_VERIFIER_REWARD);
+        parentSolver.approve(token, address(parent), PARENT_VERIFIER_REWARD);
+        parentSolver.claim(parent);
+
+        if (!publishBeforeClaim) {
+            vm.warp(block.timestamp + 1);
+            _publishChildTerms(parent);
+        }
+        parentSolver.approve(token, address(factory), childTarget);
+        child = parentSolver.create(factory, _childParams(childTarget), taskVerifiers, childTarget, _nextNonce());
+
+        token.mint(address(childSolver), CHILD_VERIFIER_REWARD);
+        childSolver.approve(token, address(child), CHILD_VERIFIER_REWARD);
+        childSolver.claim(child);
+        childSolver.submit(child, keccak256("child-submission"), keccak256("child-evidence"));
+        _settleChild(child);
+    }
+
+    function _createParent(uint256 parentReward) private returns (AgentBounty parent) {
+        AgentBountyFactory.CreateBountyParams memory params = AgentBountyFactory.CreateBountyParams({
+            solverReward: parentReward,
+            verifierReward: PARENT_VERIFIER_REWARD,
+            termsHash: keccak256(abi.encode("parent-terms", parentReward)),
+            policyHash: keccak256("parent-policy"),
+            acceptanceCriteriaHash: module.ACCEPTANCE_CRITERIA_HASH(),
+            benchmarkHash: keccak256("parent-benchmark"),
+            evidenceSchemaHash: keccak256("parent-evidence-schema"),
+            fundingDeadline: uint64(block.timestamp + 1 days),
+            claimWindowSeconds: 1 hours,
+            verificationWindowSeconds: 1 days,
+            verificationMode: AgentBounty.VerificationMode.DeterministicModule,
+            verifierModule: address(module),
+            verifierRewardRecipient: address(verifierRewardRecipient),
+            threshold: 1
+        });
+        (address parentAddress,) =
+            factory.createBounty(params, new address[](0), parentReward + PARENT_VERIFIER_REWARD, _nextNonce());
+        parent = AgentBounty(parentAddress);
+    }
+
+    function _publishChildTerms(AgentBounty parent) private {
+        OnchainTermsRegistry.TermsInput memory input = OnchainTermsRegistry.TermsInput({
+            parentBountyId: parent.bountyId(),
+            parentRound: 1,
+            policyHash: POLICY_HASH,
+            acceptanceCriteriaHash: CHILD_CRITERIA_HASH,
+            benchmarkHash: CHILD_BENCHMARK_HASH,
+            evidenceSchemaHash: EVIDENCE_SCHEMA_HASH,
+            verifierSetHash: keccak256(abi.encode(taskVerifiers)),
+            verifierThreshold: 2
+        });
+        parentSolver.publish(termsRegistry, CHILD_TERMS, input);
+    }
+
+    function _childParams(uint256 childTarget)
+        private
+        view
+        returns (AgentBountyFactory.CreateBountyParams memory)
+    {
+        return AgentBountyFactory.CreateBountyParams({
+            solverReward: childTarget - CHILD_VERIFIER_REWARD,
+            verifierReward: CHILD_VERIFIER_REWARD,
+            termsHash: keccak256(CHILD_TERMS),
+            policyHash: POLICY_HASH,
+            acceptanceCriteriaHash: CHILD_CRITERIA_HASH,
+            benchmarkHash: CHILD_BENCHMARK_HASH,
+            evidenceSchemaHash: EVIDENCE_SCHEMA_HASH,
+            fundingDeadline: uint64(block.timestamp + 1 days),
+            claimWindowSeconds: 1 hours,
+            verificationWindowSeconds: 1 days,
+            verificationMode: AgentBounty.VerificationMode.SignedQuorum,
+            verifierModule: address(0),
+            verifierRewardRecipient: address(0),
+            threshold: 2
+        });
+    }
+
+    function _settleChild(AgentBounty child) private {
+        AgentBounty.Attestation[] memory attestations = new AgentBounty.Attestation[](2);
+        uint256 deadline = block.timestamp + 1 hours;
+        for (uint256 i = 0; i < 2; i++) {
+            bytes32 responseHash = keccak256(abi.encode("sandbox-pass", i));
+            address verifier = taskVerifiers[i];
+            bytes32 digest = child.attestationDigest(verifier, true, responseHash, deadline);
+            uint256 key = i == 0 ? TASK_VERIFIER_ONE_KEY : TASK_VERIFIER_TWO_KEY;
+            attestations[i] = AgentBounty.Attestation({
+                verifier: verifier,
+                passed: true,
+                responseHash: responseHash,
+                deadline: deadline,
+                signature: _sign(key, digest)
+            });
+        }
+        child.settleWithAttestations(attestations);
+    }
+
+    function _register(address wallet, bytes32 participantId) private {
+        uint64 validUntil = uint64(block.timestamp + 14 days);
+        uint256 registrationNonce = participantRegistry.nonces(wallet);
+        bytes32 digest =
+            participantRegistry.attestationDigest(wallet, participantId, SOURCE_HASH, validUntil, registrationNonce);
+        participantRegistry.register(
+            wallet, participantId, SOURCE_HASH, validUntil, _sign(ELIGIBILITY_ATTESTER_KEY, digest)
+        );
+    }
+
+    function _sign(uint256 key, bytes32 digest) private returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _assertParentAttemptPreserved(AgentBounty parent) private view {
+        require(parent.bountyStatus() == AgentBounty.BountyStatus.Submitted, "parent state changed");
+        require(parent.fundedAmount() == parent.targetAmount(), "parent funding changed");
+        require(parent.solver() == address(parentSolver), "parent solver cleared");
+        require(parent.activeClaimBond() == PARENT_VERIFIER_REWARD, "parent bond changed");
+    }
+
+    function _nextNonce() private returns (bytes32) {
+        nonce += 1;
+        return bytes32(nonce);
+    }
+}

--- a/docs/standing-meta-v3-profit-invariant.md
+++ b/docs/standing-meta-v3-profit-invariant.md
@@ -1,0 +1,80 @@
+# Standing Meta V3 Profit Invariant
+
+Tracking issue: [#527](https://github.com/NSPG13/agent-bounties/issues/527)
+
+## Why V3 exists
+
+Standing-meta-v2 requires a child target greater than or equal to the parent solver reward. If the parent solver funds the child, gross profit is never positive:
+
+```text
+parent reward - required child funding <= 0
+```
+
+A refundable bond reduction does not repair that incentive. V3 makes positive gross profit an immutable settlement condition while retaining a meaningful paid child opportunity.
+
+## Immutable economic floors
+
+`CanonicalIndependentChildVerifierV3` commits:
+
+- minimum child target: **1.00 native Base USDC**;
+- minimum parent gross margin: **1.00 native Base USDC**;
+- minimum parent solver reward implied by those constraints: **2.00 USDC**.
+
+A child qualifies only when:
+
+```text
+child target >= 1.00 USDC
+child target <= parent solver reward - 1.00 USDC
+```
+
+The initial replacement parents should use:
+
+| Component | Amount |
+| --- | ---: |
+| Parent solver reward | 2.00 USDC |
+| Parent verifier reward | 0.01 USDC |
+| Parent refundable bond | 0.01 USDC |
+| Parent total funding | 2.01 USDC |
+| Child total target | 1.00 USDC |
+| Guaranteed gross parent margin | 1.00 USDC |
+
+The parent bond still equals its verifier reward. Acceptance returns the bond; verifier timeout returns it; no-submission timeout forfeits it under autonomous-v1.
+
+## Retained anti-gaming conditions
+
+V3 still requires:
+
+1. canonical parent and child contracts from the pinned factory;
+2. child creation by the active parent solver;
+3. complete child terms published on-chain before the parent claim;
+4. parent and child wallets registered before the parent claim with different immutable participant IDs;
+5. the exact threshold-two sandboxed-regression verifier set;
+6. a fully funded and canonically settled child;
+7. nonzero child solver, submission hash, evidence hash, and terms hash;
+8. exact parent acceptance criteria and V3 verifier module.
+
+A tiny or fake child cannot satisfy the 1 USDC floor. An expensive child that eliminates the promised margin cannot settle the parent.
+
+## What profit means
+
+The guaranteed amount is **gross protocol profit**:
+
+```text
+parent solver reward - child total target
+```
+
+It does not include taxes, exchange costs, optional external services, or unsponsored gas. Eligible public gas paths should remain sponsored. External co-funding may increase the parent solver's realized return, but settlement eligibility does not infer who economically supplied each child contribution.
+
+## Deployment boundary
+
+V2 contracts and their acceptance hash are immutable. V3 requires a new module deployment and new parent contracts. Before activation require:
+
+- focused unit and adversarial tests;
+- 1,000-run fuzz coverage where applicable;
+- Base Sepolia rehearsal;
+- Base-mainnet fork rehearsal against the pinned factory and native USDC;
+- runtime bytecode and immutable getter attestation;
+- reviewed API, MCP, bounded-wallet, discovery, and verifier-runner compatibility;
+- exact canonical creation and funding evidence for replacements.
+
+Source code, a deployment plan, terms, signature, or transaction hash is not a live bounty or payout. `BountyBecameClaimable` proves claimability; only `BountySettled` proves payment.

--- a/scripts/standing_meta_v3_deploy.py
+++ b/scripts/standing_meta_v3_deploy.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Plan, preflight, and idempotently deploy profitable standing-meta-v3 on Base."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import time
+from typing import Any, Sequence
+
+
+BASE_CHAIN_ID = 8453
+BASE_RPC_DEFAULT = "https://mainnet.base.org"
+SINGLETON_FACTORY = "0xce0042b868300000d44a59004da54a005ffdcf9f"
+CANONICAL_FACTORY = "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9"
+NATIVE_USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+PARTICIPANT_REGISTRY = "0x9875dcaf570bde8ff1aa62275d3c8985f4fd1294"
+TERMS_REGISTRY = "0x35e5d49c12b75c119d33951c2c4f054c5732208c"
+VERIFIER_ONE = "0xbe6292b9e465f549e2363b918d6dd9187038431e"
+VERIFIER_TWO = "0xb7c2ce6430b66fb986e27b6140b29309550d487a"
+EXPECTED_KEEPER = "0xc26a630e85134ed30968735c8e7de4576cfa5dbc"
+BOUNDED_WALLET = "0x1eaa1c68772cf76bc5f4e4174766076e33ace662"
+DEPLOYMENT_SALT_TEXT = "agent-bounties/standing-meta-v3/base-mainnet/v1"
+MIN_KEEPER_ETH_WEI = 100_000_000_000_000
+REPLACEMENT_COUNT = 4
+PARENT_TARGET_BASE_UNITS = 2_010_000
+REPLACEMENT_FUNDING_REQUIRED = REPLACEMENT_COUNT * PARENT_TARGET_BASE_UNITS
+ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+BYTES32_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
+UINT_RE = re.compile(r"^(?:0x[0-9a-fA-F]+|[0-9]+)")
+
+
+class DeploymentError(RuntimeError):
+    pass
+
+
+def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise DeploymentError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n{completed.stdout[-6000:]}"
+        )
+    return completed.stdout.strip()
+
+
+def require_address(value: object, label: str) -> str:
+    text = str(value).strip().lower()
+    if not ADDRESS_RE.fullmatch(text):
+        raise DeploymentError(f"{label} is not an EVM address")
+    return text
+
+
+def require_bytes32(value: object, label: str) -> str:
+    text = str(value).strip().lower()
+    if not BYTES32_RE.fullmatch(text):
+        raise DeploymentError(f"{label} is not bytes32")
+    return text
+
+
+def parse_uint(value: object, label: str) -> int:
+    text = str(value).strip()
+    match = UINT_RE.match(text)
+    if not match:
+        raise DeploymentError(f"{label} is not an unsigned integer: {text!r}")
+    return int(match.group(0), 0)
+
+
+class Foundry:
+    def __init__(self, repo: Path, rpc_url: str, forge: str, cast: str) -> None:
+        self.repo = repo
+        self.contracts = repo / "contracts" / "base-escrow"
+        self.rpc_url = rpc_url
+        self.forge = forge
+        self.cast = cast
+
+    def command(self, *args: str, cwd: Path | None = None, timeout: int = 300) -> str:
+        return run([self.cast, *args], cwd=cwd or self.repo, timeout=timeout)
+
+    def rpc(self, *args: str, timeout: int = 300) -> str:
+        return self.command(*args, "--rpc-url", self.rpc_url, timeout=timeout)
+
+    def chain_id(self) -> int:
+        return parse_uint(self.rpc("chain-id"), "chain id")
+
+    def code(self, address: str) -> str:
+        return self.rpc("code", address).strip().lower()
+
+    def call(self, address: str, signature: str, *args: str) -> str:
+        return self.rpc("call", address, signature, *args).strip()
+
+    def balance(self, address: str) -> int:
+        return parse_uint(self.rpc("balance", address), "native balance")
+
+    def bytecode(self) -> str:
+        value = run(
+            [
+                self.forge,
+                "inspect",
+                "src/CanonicalIndependentChildVerifierV3.sol:CanonicalIndependentChildVerifierV3",
+                "bytecode",
+            ],
+            cwd=self.contracts,
+        ).strip()
+        if not value.startswith("0x") or len(value) < 4:
+            raise DeploymentError("forge did not return V3 creation bytecode")
+        return value.lower()
+
+    def abi_encode(self, signature: str, *args: str) -> str:
+        value = self.command("abi-encode", signature, *args).strip().lower()
+        if not value.startswith("0x"):
+            raise DeploymentError("cast abi-encode returned malformed bytes")
+        return value
+
+    def keccak(self, value: str) -> str:
+        return require_bytes32(self.command("keccak", value), "keccak result")
+
+
+def build_plan(foundry: Foundry) -> dict[str, Any]:
+    if foundry.chain_id() != BASE_CHAIN_ID:
+        raise DeploymentError("standing-meta-v3 is pinned to Base mainnet chain 8453")
+    for label, address in {
+        "ERC-2470 singleton factory": SINGLETON_FACTORY,
+        "canonical bounty factory": CANONICAL_FACTORY,
+        "participant registry": PARTICIPANT_REGISTRY,
+        "terms registry": TERMS_REGISTRY,
+        "native USDC": NATIVE_USDC,
+    }.items():
+        if foundry.code(address) in {"0x", "0x0"}:
+            raise DeploymentError(f"{label} has no runtime code at {address}")
+
+    verifier_array = foundry.abi_encode("f(address[])", f"[{VERIFIER_ONE},{VERIFIER_TWO}]")
+    verifier_set_hash = foundry.keccak(verifier_array)
+    constructor = foundry.abi_encode(
+        "f(address,address,address,bytes32,uint8)",
+        CANONICAL_FACTORY,
+        PARTICIPANT_REGISTRY,
+        TERMS_REGISTRY,
+        verifier_set_hash,
+        "2",
+    )
+    init_code = foundry.bytecode() + constructor[2:]
+    init_code_hash = foundry.keccak(init_code)
+    salt = foundry.keccak(DEPLOYMENT_SALT_TEXT)
+    create2_preimage = "0xff" + SINGLETON_FACTORY[2:] + salt[2:] + init_code_hash[2:]
+    prediction_hash = foundry.keccak(create2_preimage)
+    predicted = require_address("0x" + prediction_hash[-40:], "predicted verifier")
+
+    keeper_usdc = parse_uint(
+        foundry.call(NATIVE_USDC, "balanceOf(address)(uint256)", EXPECTED_KEEPER),
+        "keeper USDC balance",
+    )
+    bounded_wallet_usdc = parse_uint(
+        foundry.call(NATIVE_USDC, "balanceOf(address)(uint256)", BOUNDED_WALLET),
+        "bounded wallet USDC balance",
+    )
+    policy_hash = require_bytes32(
+        foundry.call(BOUNDED_WALLET, "policyHash()(bytes32)"), "bounded wallet policy hash"
+    )
+    policy_version = parse_uint(
+        foundry.call(BOUNDED_WALLET, "policyVersion()(uint64)"), "bounded wallet policy version"
+    )
+    current_module = require_address(
+        foundry.call(
+            BOUNDED_WALLET,
+            "policy()(address,uint64,uint64,uint64,uint256,uint256,uint256,uint256,uint8,uint8,address,bytes32,bytes32)",
+        ).splitlines()[10],
+        "bounded wallet deterministic verifier",
+    )
+    existing_code = foundry.code(predicted)
+
+    return {
+        "schema": "agent-bounties/standing-meta-v3-deployment-plan-v1",
+        "network": "base-mainnet",
+        "chain_id": BASE_CHAIN_ID,
+        "singleton_factory": SINGLETON_FACTORY,
+        "canonical_factory": CANONICAL_FACTORY,
+        "participant_registry": PARTICIPANT_REGISTRY,
+        "terms_registry": TERMS_REGISTRY,
+        "settlement_token": NATIVE_USDC,
+        "verifier_wallets": [VERIFIER_ONE, VERIFIER_TWO],
+        "verifier_set_hash": verifier_set_hash,
+        "verifier_threshold": 2,
+        "deployment_salt": salt,
+        "init_code_hash": init_code_hash,
+        "predicted_verifier_module": predicted,
+        "already_deployed": existing_code not in {"0x", "0x0"},
+        "existing_runtime_code_hash": None
+        if existing_code in {"0x", "0x0"}
+        else foundry.keccak(existing_code),
+        "keeper": {
+            "address": EXPECTED_KEEPER,
+            "eth_balance_wei": foundry.balance(EXPECTED_KEEPER),
+            "usdc_balance_base_units": keeper_usdc,
+            "can_fund_four_replacements": keeper_usdc >= REPLACEMENT_FUNDING_REQUIRED,
+        },
+        "bounded_wallet": {
+            "address": BOUNDED_WALLET,
+            "usdc_balance_base_units": bounded_wallet_usdc,
+            "policy_version": policy_version,
+            "policy_hash": policy_hash,
+            "deterministic_verifier_module": current_module,
+            "requires_owner_policy_update": current_module != predicted,
+        },
+        "replacement_economics": {
+            "count": REPLACEMENT_COUNT,
+            "solver_reward_each": 2_000_000,
+            "verifier_reward_each": 10_000,
+            "claim_bond_each": 10_000,
+            "total_parent_funding_each": PARENT_TARGET_BASE_UNITS,
+            "total_funding_required": REPLACEMENT_FUNDING_REQUIRED,
+            "required_child_target_each": 1_000_000,
+            "guaranteed_gross_margin_each": 1_000_000,
+        },
+        "init_code": init_code,
+        "evidence_boundary": (
+            "This is read-only chain and compiler evidence. It is not deployment, policy activation, "
+            "bounty funding, claimability, or payout evidence."
+        ),
+    }
+
+
+def wait_for_code(foundry: Foundry, address: str, timeout_seconds: int = 90) -> str:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        code = foundry.code(address)
+        if code not in {"0x", "0x0"}:
+            return code
+        if time.monotonic() >= deadline:
+            raise DeploymentError(f"no runtime code appeared at {address}")
+        time.sleep(2)
+
+
+def verify_deployment(foundry: Foundry, plan: dict[str, Any]) -> dict[str, Any]:
+    module = plan["predicted_verifier_module"]
+    code = wait_for_code(foundry, module)
+    checks: dict[str, tuple[object, object]] = {
+        "canonical_factory": (
+            require_address(foundry.call(module, "canonicalFactory()(address)"), "module factory"),
+            CANONICAL_FACTORY,
+        ),
+        "settlement_token": (
+            require_address(foundry.call(module, "settlementToken()(address)"), "module token"),
+            NATIVE_USDC,
+        ),
+        "participant_registry": (
+            require_address(foundry.call(module, "participantRegistry()(address)"), "module participant registry"),
+            PARTICIPANT_REGISTRY,
+        ),
+        "terms_registry": (
+            require_address(foundry.call(module, "termsRegistry()(address)"), "module terms registry"),
+            TERMS_REGISTRY,
+        ),
+        "verifier_set_hash": (
+            require_bytes32(foundry.call(module, "taskVerifierSetHash()(bytes32)"), "module verifier set"),
+            plan["verifier_set_hash"],
+        ),
+        "verifier_threshold": (
+            parse_uint(foundry.call(module, "taskVerifierThreshold()(uint8)"), "module verifier threshold"),
+            2,
+        ),
+        "minimum_child_target": (
+            parse_uint(foundry.call(module, "MINIMUM_CHILD_TARGET()(uint256)"), "minimum child target"),
+            1_000_000,
+        ),
+        "minimum_parent_gross_margin": (
+            parse_uint(
+                foundry.call(module, "MINIMUM_PARENT_GROSS_MARGIN()(uint256)"),
+                "minimum parent gross margin",
+            ),
+            1_000_000,
+        ),
+    }
+    mismatches = {
+        label: {"observed": observed, "expected": expected}
+        for label, (observed, expected) in checks.items()
+        if observed != expected
+    }
+    if mismatches:
+        raise DeploymentError(f"V3 immutable mismatch: {mismatches}")
+    return {
+        "verifier_module": module,
+        "runtime_code_hash": foundry.keccak(code),
+        "acceptance_criteria_hash": require_bytes32(
+            foundry.call(module, "ACCEPTANCE_CRITERIA_HASH()(bytes32)"),
+            "acceptance criteria hash",
+        ),
+        "immutable_checks": {label: observed for label, (observed, _) in checks.items()},
+    }
+
+
+def deploy(foundry: Foundry, plan: dict[str, Any]) -> dict[str, Any]:
+    private_key = os.environ.get("BASE_KEEPER_PRIVATE_KEY", "").strip()
+    if not private_key:
+        raise DeploymentError("BASE_KEEPER_PRIVATE_KEY is required for deployment")
+    deployer = require_address(
+        foundry.command("wallet", "address", "--private-key", private_key), "keeper private-key address"
+    )
+    if deployer != EXPECTED_KEEPER:
+        raise DeploymentError(f"keeper key resolves to {deployer}, expected {EXPECTED_KEEPER}")
+    balance_before = foundry.balance(deployer)
+    if balance_before < MIN_KEEPER_ETH_WEI:
+        raise DeploymentError("keeper ETH reserve is below the protected deployment floor")
+
+    transaction: dict[str, Any] | None = None
+    module = plan["predicted_verifier_module"]
+    if foundry.code(module) in {"0x", "0x0"}:
+        raw = foundry.rpc(
+            "send",
+            SINGLETON_FACTORY,
+            "deploy(bytes,bytes32)(address)",
+            plan["init_code"],
+            plan["deployment_salt"],
+            "--private-key",
+            private_key,
+            "--json",
+            timeout=180,
+        )
+        try:
+            transaction = json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise DeploymentError("cast send did not return JSON") from error
+
+    verified = verify_deployment(foundry, plan)
+    balance_after = foundry.balance(deployer)
+    if balance_after < MIN_KEEPER_ETH_WEI:
+        raise DeploymentError("deployment depleted the keeper below its protected ETH reserve")
+    return {
+        "schema": "agent-bounties/standing-meta-v3-deployment-v1",
+        "network": "base-mainnet",
+        "chain_id": BASE_CHAIN_ID,
+        "deployer": deployer,
+        "transaction": transaction,
+        "idempotent_existing_deployment": transaction is None,
+        "keeper_balance_before_wei": balance_before,
+        "keeper_balance_after_wei": balance_after,
+        "plan": {key: value for key, value in plan.items() if key != "init_code"},
+        "verification": verified,
+        "evidence_boundary": (
+            "Confirmed runtime code and immutable getter checks prove policy deployment. They do not prove "
+            "replacement bounty creation, funding, claimability, or payout."
+        ),
+    }
+
+
+def markdown(report: dict[str, Any]) -> str:
+    keeper = report["keeper"]
+    wallet = report["bounded_wallet"]
+    economics = report["replacement_economics"]
+    lines = [
+        "## Standing-meta-v3 activation preflight",
+        "",
+        f"- Predicted verifier: `{report['predicted_verifier_module']}`",
+        f"- Already deployed: **{str(report['already_deployed']).lower()}**",
+        f"- Keeper USDC: **{keeper['usdc_balance_base_units'] / 1_000_000:.6f}**",
+        f"- Four replacement parents require: **{economics['total_funding_required'] / 1_000_000:.6f} USDC**",
+        f"- Keeper can fund all four directly: **{str(keeper['can_fund_four_replacements']).lower()}**",
+        f"- Bounded wallet USDC: **{wallet['usdc_balance_base_units'] / 1_000_000:.6f}**",
+        f"- Current bounded-wallet deterministic verifier: `{wallet['deterministic_verifier_module']}`",
+        f"- Owner policy update required before bounded-wallet funding: **{str(wallet['requires_owner_policy_update']).lower()}**",
+        "",
+        "Deployment is deterministic through the ERC-2470 singleton factory and reuses the live V2 participant and terms registries.",
+        "This preflight is not deployment or funding evidence.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("plan", "deploy"))
+    parser.add_argument("--rpc-url", default=os.environ.get("BASE_MAINNET_RPC_URL", BASE_RPC_DEFAULT))
+    parser.add_argument("--forge", default=os.environ.get("FORGE_BIN", "forge"))
+    parser.add_argument("--cast", default=os.environ.get("CAST_BIN", "cast"))
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--markdown-output", type=Path)
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    foundry = Foundry(repo, args.rpc_url, args.forge, args.cast)
+    plan = build_plan(foundry)
+    report = plan if args.mode == "plan" else deploy(foundry, plan)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_output.write_text(markdown(plan), encoding="utf-8")
+    print(json.dumps({
+        "mode": args.mode,
+        "predicted_verifier_module": plan["predicted_verifier_module"],
+        "keeper_can_fund_four_replacements": plan["keeper"]["can_fund_four_replacements"],
+        "bounded_wallet_requires_owner_policy_update": plan["bounded_wallet"]["requires_owner_policy_update"],
+        "output": str(args.output),
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_standing_meta_v3_deploy.py
+++ b/scripts/test_standing_meta_v3_deploy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("standing_meta_v3_deploy.py")
+SPEC = importlib.util.spec_from_file_location("standing_meta_v3_deploy", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class StandingMetaV3DeployTests(unittest.TestCase):
+    def test_economics_require_exact_four_parent_funding(self) -> None:
+        self.assertEqual(MODULE.PARENT_TARGET_BASE_UNITS, 2_010_000)
+        self.assertEqual(MODULE.REPLACEMENT_COUNT, 4)
+        self.assertEqual(MODULE.REPLACEMENT_FUNDING_REQUIRED, 8_040_000)
+
+    def test_addresses_and_salt_are_pinned(self) -> None:
+        for value in (
+            MODULE.SINGLETON_FACTORY,
+            MODULE.CANONICAL_FACTORY,
+            MODULE.NATIVE_USDC,
+            MODULE.PARTICIPANT_REGISTRY,
+            MODULE.TERMS_REGISTRY,
+            MODULE.VERIFIER_ONE,
+            MODULE.VERIFIER_TWO,
+            MODULE.EXPECTED_KEEPER,
+            MODULE.BOUNDED_WALLET,
+        ):
+            self.assertRegex(value, r"^0x[0-9a-f]{40}$")
+        self.assertEqual(
+            MODULE.DEPLOYMENT_SALT_TEXT,
+            "agent-bounties/standing-meta-v3/base-mainnet/v1",
+        )
+
+    def test_parse_uint_accepts_cast_decimal_and_hex_prefixes(self) -> None:
+        self.assertEqual(MODULE.parse_uint("8040000", "amount"), 8_040_000)
+        self.assertEqual(MODULE.parse_uint("0x7ab620 [8.04e6]", "amount"), 0x7AB620)
+
+    def test_parse_uint_rejects_non_numeric_output(self) -> None:
+        with self.assertRaises(MODULE.DeploymentError):
+            MODULE.parse_uint("not-a-number", "amount")
+
+    def test_address_and_bytes32_validation_fail_closed(self) -> None:
+        self.assertEqual(
+            MODULE.require_address(MODULE.CANONICAL_FACTORY.upper().replace("0X", "0x"), "factory"),
+            MODULE.CANONICAL_FACTORY,
+        )
+        self.assertEqual(MODULE.require_bytes32("0x" + "ab" * 32, "hash"), "0x" + "ab" * 32)
+        with self.assertRaises(MODULE.DeploymentError):
+            MODULE.require_address("0x1234", "factory")
+        with self.assertRaises(MODULE.DeploymentError):
+            MODULE.require_bytes32("0x1234", "hash")
+
+    def test_markdown_discloses_funding_and_policy_boundaries(self) -> None:
+        report = {
+            "predicted_verifier_module": "0x" + "11" * 20,
+            "already_deployed": False,
+            "keeper": {
+                "usdc_balance_base_units": 0,
+                "can_fund_four_replacements": False,
+            },
+            "bounded_wallet": {
+                "usdc_balance_base_units": 89_000_000,
+                "deterministic_verifier_module": "0x" + "22" * 20,
+                "requires_owner_policy_update": True,
+            },
+            "replacement_economics": {"total_funding_required": 8_040_000},
+        }
+        text = MODULE.markdown(report)
+        self.assertIn("Keeper can fund all four directly: **false**", text)
+        self.assertIn("Owner policy update required", text)
+        self.assertIn("not deployment or funding evidence", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the structural incentive failure in #527 and adds the production activation path.

The deployed V2 verifier requires `child.targetAmount() >= parent.solverReward()`, making positive parent profit impossible when the parent solver funds the child. This PR adds an immutable V3 successor that requires both:

- a meaningful child target of at least **1.00 USDC**; and
- a guaranteed parent gross margin of at least **1.00 USDC**.

The intended replacement-parent economics are **2.00 USDC solver reward, 0.01 USDC verifier reward, and 0.01 USDC refundable bond**, funding a 1.00 USDC child.

## Contract changes

- add `CanonicalIndependentChildVerifierV3` with exact child-floor and profit-floor constants;
- retain canonical factory, terms chronology, participant independence, threshold-two regression quorum, settled-child, and evidence checks;
- add `StandingMetaV3Bundle` for isolated testing;
- add focused adversarial tests proving the profit invariant and the existing identity/chronology protections.

## Production activation

- add an idempotent deterministic deployment through the live ERC-2470 singleton factory;
- reuse the already deployed V2 participant and terms registries so existing registrations and chronology remain meaningful;
- verify the exact canonical factory, native USDC, registries, verifier set, threshold, economic floors, acceptance hash, runtime code, and keeper reserve;
- add a read-only PR preflight that reports the predicted V3 address, keeper USDC, bounded-wallet USDC, and whether its owner policy must change;
- on squash merge to `main`, automatically deploy and attest V3 with the existing protected Base keeper secret and publish evidence to #527.

## Funding authority boundary

The merge may deploy V3 automatically. It must not pretend replacement funding succeeded unless one of these exact conditions is true:

1. the keeper preflight shows at least **8.04 USDC**, allowing it to create and fully fund all four replacements directly; or
2. the owner updates the 89-USDC bounded-wallet policy from the immutable V2 verifier to the newly deployed V3 verifier, after which separately signed bounded actions can create and fund the four parents.

The current bounded wallet cannot spend on an unapproved deterministic module. Admin merge authority is not wallet authority.

## Evidence boundary

Source code, CI, a predicted address, merge, transaction request, or deployment alone does not make #333–#336 replaced. Each replacement becomes live only after confirmed canonical creation, `FundingAdded`, `BountyBecameClaimable`, valid terms, and `verification_ready=true`. Only `BountySettled` proves solver payment.