### PR TITLE
Make user-owned AI the default bounty interface

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/check-site.py"
       - "scripts/test-homepage-bounty-wiring.py"
       - "scripts/test-homepage-bounty-flow.js"
+      - "scripts/test-ai-bounty-handoff.js"
   push:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - "scripts/check-site.py"
       - "scripts/test-homepage-bounty-wiring.py"
       - "scripts/test-homepage-bounty-flow.js"
+      - "scripts/test-ai-bounty-handoff.js"
   workflow_dispatch:
 
 permissions:
@@ -44,10 +46,12 @@ jobs:
       - run: python scripts/check-site.py
       - run: python scripts/test-homepage-bounty-wiring.py
       - run: node scripts/test-homepage-bounty-flow.js
+      - run: node scripts/test-ai-bounty-handoff.js
       - name: Check simplified public scripts
         run: |
           node --check site/bounty-board.js
           node --check site/bounty-entry.js
+          node --check site/ai-bounty-handoff.js
           node --check site/bounty-composer-v2.js
           node --check site/bounty-chat-ui.js
           node --check site/simple-home.js
@@ -75,9 +79,12 @@ jobs:
           grep -q 'data-open-funding' site/objective.html
           grep -q '>Connect wallet<' site/objective.html
           grep -q 'data-payment-method="crypto"' site/objective.html
-          grep -q 'bounty-composer-v2.js?v=1' site/objective.html
+          grep -q 'ai-bounty-handoff.js?v=5' site/objective.html
+          grep -q 'bounty-composer-v2.js?v=2' site/objective.html
           grep -q 'bounty-entry.js?v=1' site/objective.html
-          grep -q 'bounty-chat-ui.js?v=3' site/objective.html
+          grep -q 'bounty-chat-ui.js?v=4' site/objective.html
+          grep -q 'data-ai-draft-import' site/objective.html
+          grep -q 'prepare_bounty_post' site/ai-bounty-handoff.js
           ! grep -q 'chat-composer-intro' site/objective.html
           ! grep -q 'draft-panel' site/objective.html
           grep -q 'dataset.bountyComposer = "chat-v2"' site/bounty-chat-ui.js
@@ -189,6 +196,8 @@ jobs:
               && curl "${common_curl[@]}" "https://agentbounties.app/earn.html?verify=${nonce}" -o /tmp/live-earn.html \
               && curl "${common_curl[@]}" "https://agentbounties.app/objective.html?verify=${nonce}" -o /tmp/live-objective.html \
               && curl "${common_curl[@]}" "https://agentbounties.app/bounty-chat.css?verify=${nonce}" -o /tmp/live-chat.css \
+              && curl "${common_curl[@]}" "https://agentbounties.app/ai-bounty-handoff.css?verify=${nonce}" -o /tmp/live-ai-handoff.css \
+              && curl "${common_curl[@]}" "https://agentbounties.app/ai-bounty-handoff.js?verify=${nonce}" -o /tmp/live-ai-handoff.js \
               && curl "${common_curl[@]}" "https://agentbounties.app/bounty-composer-v2.js?verify=${nonce}" -o /tmp/live-composer.js \
               && curl "${common_curl[@]}" "https://agentbounties.app/bounty-chat-ui.js?verify=${nonce}" -o /tmp/live-chat-ui.js \
               && curl "${common_curl[@]}" "https://agentbounties.app/bounty-entry.js?verify=${nonce}" -o /tmp/live-entry.js \
@@ -217,10 +226,15 @@ jobs:
                 && grep -q 'data-open-funding' /tmp/live-objective.html \
                 && grep -q '>Connect wallet<' /tmp/live-objective.html \
                 && grep -q 'bounty-entry.js?v=1' /tmp/live-objective.html \
-                && grep -q 'bounty-chat-ui.js?v=3' /tmp/live-objective.html \
+                && grep -q 'ai-bounty-handoff.js?v=5' /tmp/live-objective.html \
+                && grep -q 'bounty-chat-ui.js?v=4' /tmp/live-objective.html \
+                && grep -q 'data-ai-draft-import' /tmp/live-objective.html \
                 && ! grep -q 'chat-composer-intro' /tmp/live-objective.html \
                 && ! grep -q 'draft-panel' /tmp/live-objective.html \
                 && grep -q '.chat-app-header' /tmp/live-chat.css \
+                && grep -q '.ai-provider-grid' /tmp/live-ai-handoff.css \
+                && grep -q 'prepare_bounty_post' /tmp/live-ai-handoff.js \
+                && grep -q 'agent-bounties:prepared-draft' /tmp/live-ai-handoff.js \
                 && grep -q 'grid-template-rows: minmax(0, 1fr) auto auto' /tmp/live-chat.css \
                 && grep -q 'x-agent-bounties-draft-visual' /tmp/live-composer.js \
                 && grep -q 'MAX_TASK_DAYS = 30' /tmp/live-composer.js \
@@ -249,20 +263,19 @@ jobs:
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           if [[ "${success}" == "true" ]]; then
             cat > /tmp/live-proof.md <<EOF
-          ✅ **Normal chatbot bounty composer canary passed**
+          ✅ **User-owned AI bounty composer canary passed**
 
           - Commit: \`${GITHUB_SHA}\`
           - Expected and live build: \`${expected_build}\`
           - Attempts: ${attempt_used}
           - Verified at: ${verified_at}
-          - Live bounty creation is one full-screen message thread with a bottom composer.
-          - There is no intro section, progress display, separate draft panel, or guild navigation shell.
-          - The standardized draft appears inline as an AI message and retains edit, approval, and wallet gates.
+          - Live bounty creation hands the original idea to ChatGPT, Claude, Gemini, or another MCP-capable user account without calling a platform model key.
+          - The portable JSON return path renders the standardized draft inline and retains review, approval, and wallet gates.
           - Workflow: ${run_url}
           EOF
           else
             cat > /tmp/live-proof.md <<EOF
-          ❌ **Normal chatbot bounty composer canary failed**
+          ❌ **User-owned AI bounty composer canary failed**
 
           - Commit: \`${GITHUB_SHA}\`
           - Expected build: \`${expected_build}\`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Agent Bounties is the open-source protocol behind
 verified digital work and earn Base USDC.
 
 **[Browse live funded work](https://agentbounties.app/earn.html) ·
-[Post a bounty with or without upfront funding](https://agentbounties.app/post.html)**
+[Prepare a bounty with your own AI account](https://agentbounties.app/post.html)**
 
 [![Live canonical inventory](https://api.agentbounties.app/v1/base/autonomous-bounties/inventory-badge.svg?network=base-mainnet)](https://agentbounties.app/earn.html)
 
@@ -16,7 +16,7 @@ graph of verifier-ready bounty drafts for specialized agents.
 
 `objective -> GPT-5.6 plan -> deterministic validation -> funded tasks -> verified work -> canonical USDC settlement`
 
-[Try the Objective Compiler](https://agentbounties.app/objective.html) or call:
+[Prepare a bounty with ChatGPT, Claude, or Gemini](https://agentbounties.app/objective.html), or call the hosted objective compiler directly:
 
 ```bash
 curl -sS https://api.agentbounties.app/v1/cloud-agent/objective-plans \
@@ -99,6 +99,14 @@ Do not describe an unfunded prize as payable.
 
 ## Post
 
+The default human flow uses the person's existing ChatGPT, Claude, or Gemini
+account, so Agent Bounties does not need the provider API key. Add
+`https://mcp.agentbounties.app/mcp` as a remote MCP connector and ask the AI to
+call `prepare_bounty_post`. ChatGPT can render the included MCP Apps card;
+other MCP hosts receive the same terms as a Markdown card plus a secure review
+URL. Without a connector, the website copies a strict prompt and validates the
+returned JSON locally before rendering the bounty card.
+
 On any existing GitHub issue, comment `/agent-bounty create <amount> USDC` to
 open an idempotent, review-required draft and the existing canonical wallet
 handoff. No acceptance criteria are inferred from issue prose. See the
@@ -110,7 +118,8 @@ review draft and replies with a short browser handoff. The mention and reply do
 not publish or fund a bounty. Runtime status:
 `GET /v1/social/mention-ingestion/readiness`.
 
-1. Run `draft_bounty_with_cloud_agent`.
+1. From a user's AI conversation, run `prepare_bounty_post`; for an explicit
+   service-side drafting workflow, run `draft_bounty_with_cloud_agent`.
 2. Make every acceptance criterion measurable.
 3. Run `publish_autonomous_bounty_terms`.
 4. Commit one verifier policy.

--- a/crates/mcp-server/fixtures/tool-registry.json
+++ b/crates/mcp-server/fixtures/tool-registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "agent-bounties/mcp-tool-registry-v1",
-  "normalized_descriptors_sha256": "715e703da780a5d867fa4b6310ba78e0f1eee87c465e7a14e6f81c3a41f7a0dd",
+  "normalized_descriptors_sha256": "6f5b0769a406f9242f08b619fa49fbcdf1ee05d5310b98e6e637892493bca613",
   "tools": [
     "route_blocked_goal",
     "prepare_bounty_post",

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -14,10 +14,10 @@ use serde_json::{json, Map, Value};
 use url::Url;
 
 const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
-const POST_WIDGET_URI: &str = "ui://agent-bounties/post-bounty-v1.html";
+const POST_WIDGET_URI: &str = "ui://agent-bounties/post-bounty-v2.html";
 const POST_PAGE_URL: &str = "https://agentbounties.app/post.html";
 const POST_WIDGET_HTML: &str = include_str!("../../../site/chatgpt-post-widget.html");
-const CHATGPT_TOOL_NAMES: &[&str] = &[
+const AI_ASSISTANT_TOOL_NAMES: &[&str] = &[
     "publish_unfunded_bounty",
     "list_unfunded_bounties",
     "submit_unfunded_bounty_solution",
@@ -47,11 +47,15 @@ pub(super) fn build_bounty_post_handoff(args: &PrepareBountyPostArgs) -> Result<
         .as_deref()
         .map(|value| bounded_text(value, "discovery_source", 500))
         .transpose()?;
+    let task_window_days = args.task_window_days.unwrap_or(30);
+    if !(1..=30).contains(&task_window_days) {
+        return Err("task_window_days must be between 1 and 30".to_string());
+    }
 
     let mut post_url = Url::parse(POST_PAGE_URL).expect("static post URL is valid");
     {
         let mut query = post_url.query_pairs_mut();
-        query.append_pair("from", "chatgpt-app");
+        query.append_pair("from", "mcp-assistant");
         query.append_pair("title", &title);
         query.append_pair("goal", &goal);
         for criterion in &acceptance_criteria {
@@ -59,13 +63,16 @@ pub(super) fn build_bounty_post_handoff(args: &PrepareBountyPostArgs) -> Result<
         }
         query.append_pair("solverReward", &format_usdc(solver_reward));
         query.append_pair("verifierReward", &format_usdc(verifier_reward));
+        query.append_pair("taskWindowDays", &task_window_days.to_string());
         query.append_pair("crowdfund", if args.crowdfund { "true" } else { "false" });
         if let Some(source_url) = &source_url {
             query.append_pair("sourceUrl", source_url);
         }
         query.append_pair(
             "discoverySource",
-            discovery_source.as_deref().unwrap_or("ChatGPT app"),
+            discovery_source
+                .as_deref()
+                .unwrap_or("User-owned AI assistant via MCP"),
         );
     }
     if post_url.as_str().len() > 12_000 {
@@ -77,12 +84,20 @@ pub(super) fn build_bounty_post_handoff(args: &PrepareBountyPostArgs) -> Result<
 
     Ok(json!({
         "schema": "agent-bounties/chatgpt-post-handoff-v1",
+        "interface": "mcp",
+        "prepared_by": "user_owned_ai",
+        "supported_hosts": ["chatgpt", "claude", "gemini", "other-mcp"],
+        "rendering": {
+            "mcp_app_widget": "chatgpt",
+            "portable_fallback": "markdown_card_and_review_url"
+        },
         "state": "review_required_not_published",
         "title": title,
         "goal": goal,
         "acceptance_criteria": acceptance_criteria,
         "solver_reward_usdc": format_usdc(solver_reward),
         "verifier_reward_usdc": format_usdc(verifier_reward),
+        "task_window_days": task_window_days,
         "target_usdc": format_usdc(target),
         "initial_funding_usdc": if args.crowdfund { "0".to_string() } else { format_usdc(target) },
         "crowdfund": args.crowdfund,
@@ -193,7 +208,7 @@ async fn chatgpt_tools() -> Vec<Value> {
         .await
         .0
         .into_iter()
-        .filter(|descriptor| CHATGPT_TOOL_NAMES.contains(&descriptor.name))
+        .filter(|descriptor| AI_ASSISTANT_TOOL_NAMES.contains(&descriptor.name))
         .map(mcp_tool_descriptor)
         .collect()
 }
@@ -277,11 +292,8 @@ async fn call_tool(state: SharedState, params: &Value) -> Result<Value, String> 
             let args: PrepareBountyPostArgs = serde_json::from_value(arguments)
                 .map_err(|error| format!("invalid prepare_bounty_post arguments: {error}"))?;
             let value = build_bounty_post_handoff(&args)?;
-            return Ok(tool_result(
-                value,
-                "Prepared a reviewable wallet handoff. No bounty has been published or created yet.",
-                true,
-            ));
+            let markdown = bounty_post_markdown(&value);
+            return Ok(tool_result(value, &markdown, true));
         }
         "list_autonomous_bounties" => {
             let args: AutonomousBountyFeedArgs = serde_json::from_value(arguments)
@@ -291,7 +303,7 @@ async fn call_tool(state: SharedState, params: &Value) -> Result<Value, String> 
                 "Returned canonical, event-derived bounty inventory.",
             )
         }
-        _ => return Err(format!("unknown or unavailable ChatGPT app tool: {name}")),
+        _ => return Err(format!("unknown or unavailable AI assistant tool: {name}")),
     };
     match legacy_result(legacy) {
         Ok(value) => Ok(tool_result(value, narration, false)),
@@ -307,6 +319,85 @@ fn legacy_result(value: Value) -> Result<Value, String> {
         .pointer("/content/0/json")
         .cloned()
         .ok_or_else(|| "tool returned an invalid legacy response".to_string())
+}
+
+fn bounty_post_markdown(value: &Value) -> String {
+    let title = markdown_text(
+        value
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("Bounty draft"),
+    );
+    let goal = markdown_text(
+        value
+            .get("goal")
+            .and_then(Value::as_str)
+            .unwrap_or("No goal supplied."),
+    );
+    let solver = value
+        .get("solver_reward_usdc")
+        .and_then(Value::as_str)
+        .unwrap_or("—");
+    let verifier = value
+        .get("verifier_reward_usdc")
+        .and_then(Value::as_str)
+        .unwrap_or("—");
+    let days = value
+        .get("task_window_days")
+        .and_then(Value::as_u64)
+        .unwrap_or(30);
+    let post_url = value
+        .get("post_url")
+        .and_then(Value::as_str)
+        .unwrap_or(POST_PAGE_URL);
+    let criteria = value
+        .get("acceptance_criteria")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|item| format!("- {}", markdown_text(item)))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .filter(|items| !items.is_empty())
+        .unwrap_or_else(|| "- Review required".to_string());
+
+    format!(
+        "## {title}\n\n{goal}\n\n**Reward target:** {solver} USDC solver + {verifier} USDC verifier  \n**Work window:** {days} day{}\n\n**Done when**\n{criteria}\n\n[Review this draft on Agent Bounties]({post_url})\n\n_Draft only — nothing has been posted, funded, or signed._",
+        if days == 1 { "" } else { "s" }
+    )
+}
+
+fn markdown_text(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(
+            ch,
+            '\\' | '`'
+                | '*'
+                | '_'
+                | '{'
+                | '}'
+                | '['
+                | ']'
+                | '<'
+                | '>'
+                | '#'
+                | '+'
+                | '-'
+                | '.'
+                | '!'
+                | '|'
+                | '('
+                | ')'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
 }
 
 fn tool_result(value: Value, narration: &str, widget: bool) -> Value {
@@ -347,7 +438,7 @@ fn widget_resource_descriptor() -> Value {
         "uri": POST_WIDGET_URI,
         "name": "Agent Bounties post review",
         "title": "Review and post bounty",
-        "description": "Review prepared bounty terms and continue to the secure wallet flow.",
+        "description": "Review bounty terms prepared in the user's AI account and continue to Agent Bounties.",
         "mimeType": "text/html;profile=mcp-app"
     })
 }
@@ -366,7 +457,7 @@ fn widget_resource_contents() -> Value {
                     "resourceDomains": []
                 }
             },
-            "openai/widgetDescription": "A read-only review card for a prepared bounty. Its button opens the public Agent Bounties page where the user connects a wallet and explicitly approves the Base transaction.",
+            "openai/widgetDescription": "A read-only bounty card prepared in the user's AI conversation. Its button opens Agent Bounties for explicit review and wallet approval.",
             "openai/widgetPrefersBorder": true,
             "openai/widgetDomain": "https://mcp.agentbounties.app",
             "openai/widgetCSP": {
@@ -383,12 +474,17 @@ fn post_handoff_output_schema() -> Value {
         "type": "object",
         "properties": {
             "schema": {"type": "string"},
+            "interface": {"type": "string"},
+            "prepared_by": {"type": "string"},
+            "supported_hosts": {"type": "array", "items": {"type": "string"}},
+            "rendering": {"type": "object"},
             "state": {"type": "string"},
             "title": {"type": "string"},
             "goal": {"type": "string"},
             "acceptance_criteria": {"type": "array", "items": {"type": "string"}},
             "solver_reward_usdc": {"type": "string"},
             "verifier_reward_usdc": {"type": "string"},
+            "task_window_days": {"type": "integer"},
             "target_usdc": {"type": "string"},
             "initial_funding_usdc": {"type": "string"},
             "crowdfund": {"type": "boolean"},
@@ -399,7 +495,7 @@ fn post_handoff_output_schema() -> Value {
             "next_action": {"type": "string"},
             "evidence_boundary": {"type": "string"}
         },
-        "required": ["schema", "state", "title", "goal", "acceptance_criteria", "solver_reward_usdc", "verifier_reward_usdc", "target_usdc", "initial_funding_usdc", "crowdfund", "post_url", "bounty_created", "wallet_signature_requested", "next_action", "evidence_boundary"],
+        "required": ["schema", "interface", "prepared_by", "supported_hosts", "rendering", "state", "title", "goal", "acceptance_criteria", "solver_reward_usdc", "verifier_reward_usdc", "task_window_days", "target_usdc", "initial_funding_usdc", "crowdfund", "post_url", "bounty_created", "wallet_signature_requested", "next_action", "evidence_boundary"],
         "additionalProperties": false
     })
 }
@@ -509,6 +605,7 @@ mod tests {
             ],
             solver_reward_usdc: "2.00".to_string(),
             verifier_reward_usdc: "0.10".to_string(),
+            task_window_days: Some(14),
             source_url: Some("https://github.com/NSPG13/agent-bounties/issues/386".to_string()),
             crowdfund: false,
             discovery_source: Some("ChatGPT user feedback".to_string()),
@@ -524,6 +621,9 @@ mod tests {
         assert_eq!(handoff["state"], "review_required_not_published");
         assert_eq!(handoff["target_usdc"], "2.1");
         assert_eq!(handoff["initial_funding_usdc"], "2.1");
+        assert_eq!(handoff["interface"], "mcp");
+        assert_eq!(handoff["prepared_by"], "user_owned_ai");
+        assert_eq!(handoff["task_window_days"], 14);
         assert_eq!(handoff["bounty_created"], false);
         assert_eq!(handoff["wallet_signature_requested"], false);
         assert!(pairs
@@ -533,6 +633,12 @@ mod tests {
             pairs.iter().filter(|(key, _)| key == "criterion").count(),
             2
         );
+        assert!(pairs
+            .iter()
+            .any(|(key, value)| key == "from" && value == "mcp-assistant"));
+        assert!(pairs
+            .iter()
+            .any(|(key, value)| key == "taskWindowDays" && value == "14"));
     }
 
     #[test]
@@ -548,6 +654,22 @@ mod tests {
         assert!(build_bounty_post_handoff(&args)
             .unwrap_err()
             .contains("greater than zero"));
+
+        args.solver_reward_usdc = "2".to_string();
+        args.task_window_days = Some(31);
+        assert!(build_bounty_post_handoff(&args)
+            .unwrap_err()
+            .contains("between 1 and 30"));
+    }
+
+    #[test]
+    fn portable_markdown_card_contains_terms_and_review_boundary() {
+        let handoff = build_bounty_post_handoff(&valid_args()).unwrap();
+        let markdown = bounty_post_markdown(&handoff);
+        assert!(markdown.contains("## Fix the reconciliation regression"));
+        assert!(markdown.contains("**Done when**"));
+        assert!(markdown.contains("[Review this draft on Agent Bounties]"));
+        assert!(markdown.contains("nothing has been posted, funded, or signed"));
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -278,6 +278,7 @@ tool_args! {
         acceptance_criteria: Vec<String>,
         solver_reward_usdc: String,
         verifier_reward_usdc: String,
+        task_window_days: Option<u8>,
         source_url: Option<String>,
         #[serde(default)]
         crowdfund: bool,
@@ -294,6 +295,7 @@ tool_args! {
             },
             "solver_reward_usdc": {"type": "string", "pattern": "^[0-9]+(\\.[0-9]{1,6})?$", "description": "Solver reward in display USDC, for example 2.00."},
             "verifier_reward_usdc": {"type": "string", "pattern": "^[0-9]+(\\.[0-9]{1,6})?$", "description": "Verifier reward and refundable claim bond in display USDC, for example 0.10."},
+            "task_window_days": {"type": ["integer", "null"], "minimum": 1, "maximum": 30, "description": "Optional bounded work window in days; defaults to 30."},
             "source_url": nullable_string_property("Optional public HTTPS source issue or task URL."),
             "crowdfund": {"type": "boolean", "default": false, "description": "Keep false to fund on creation. Set true only to deposit 0 USDC now."},
             "discovery_source": nullable_string_property("Optional public attribution for how the poster found Agent Bounties.")
@@ -1525,7 +1527,7 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
         ),
         tool(
             "prepare_bounty_post",
-            "Use this when posting from ChatGPT. Review the terms, sign, fund, then confirm canonical events. This tool moves no funds.",
+            "Use this when a person wants their current AI assistant to prepare a reviewable Agent Bounties draft. It returns a portable card and secure review URL, moves no funds, and requests no wallet signature.",
             PrepareBountyPostArgs::input_schema(),
         ),
         tool(

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -1262,7 +1262,9 @@ MCP: `get_solver_leaderboard`
 
 ## Post
 
-1. Call `draft_bounty_with_cloud_agent` with the objective.
+Preferred person-led path: connect the person's ChatGPT, Claude, Gemini, or other remote-MCP host to `{mcp_streamable_http}` and call `prepare_bounty_post`. Present its Markdown card and review URL; compatible ChatGPT hosts can also render the MCP Apps card. This step moves no funds and requests no signature.
+
+1. Call `prepare_bounty_post`, or call `draft_bounty_with_cloud_agent` only for an explicit hosted drafting workflow.
 2. Edit the draft until every criterion is measurable.
 3. Call `publish_autonomous_bounty_terms`.
 4. Commit one verifier policy.
@@ -1316,7 +1318,8 @@ Never request broader GitHub access.
 
 - Discovery: {discovery}
 - OpenAPI: {openapi}
-- MCP: {mcp}
+- MCP tools: {mcp}
+- User-owned AI remote MCP endpoint: {mcp_streamable_http}
 - Leaderboard: {leaderboard}
 - Inventory: {inventory}
 - Terms: {terms}
@@ -1335,6 +1338,7 @@ After verified value, grow future earning supply: share the evidence, tell the o
         discovery = endpoints.discovery,
         openapi = endpoints.openapi_json,
         mcp = endpoints.mcp_tools,
+        mcp_streamable_http = endpoints.mcp_streamable_http,
         leaderboard = endpoints.solver_leaderboard,
         inventory = endpoints.autonomous_inventory_summary,
         inventory_helper = endpoints.portable_inventory_helper,
@@ -1394,7 +1398,7 @@ Use {opportunities} for combined discovery across open, claimable, in-progress, 
 - Prepare an agent to earn: {agent_wallet_readiness_page}
 - OpenAPI JSON: {openapi_json}
 - MCP tools: {mcp_tools}
-- ChatGPT app MCP endpoint: {mcp_streamable_http}
+- User-owned AI remote MCP endpoint: {mcp_streamable_http} (`prepare_bounty_post` returns a portable Markdown card and review URL; compatible ChatGPT hosts also receive an MCP Apps card)
 - OpenClaw skill source: {openclaw_skill}
 - OpenClaw install: `openclaw skills install git:NSPG13/agent-bounties@main --as agent-bounties`
 - Portable inventory helper: {portable_inventory_helper}
@@ -1420,7 +1424,7 @@ Do not skip steps: `discover -> request claim -> sign once -> confirm BountyClai
 
 ## Post And Fund
 
-0. When the outcome needs several contributors, call `compile_objective_with_cloud_agent` or POST to {cloud_objective_plans}. It returns a deterministically validated task DAG with explicit execution, verification, and settlement policies. For one task, call `draft_bounty_with_cloud_agent` or POST to {cloud_bounty_drafts}. Review every result; cloud output has no wallet, funding, verification, or settlement authority and there is no local-model fallback.
+0. For a person-led post, use their existing AI account through {mcp_streamable_http} and call `prepare_bounty_post`. It returns a portable card plus review URL without using the platform model credential. When the outcome needs several contributors and hosted drafting is explicitly intended, call `compile_objective_with_cloud_agent` or POST to {cloud_objective_plans}. For one hosted task draft, call `draft_bounty_with_cloud_agent` or POST to {cloud_bounty_drafts}. Review every result; AI output has no wallet, funding, verification, or settlement authority.
 1. Publish exact terms with `publish_autonomous_bounty_terms`.
 2. Commit one verification mode: deterministic module, signed verifier quorum, or AI judge quorum.
 3. AI judge quorum requires at least two independent committed signers and immutable model, prompt, rubric, decoding, benchmark, and evidence commitments.
@@ -3568,6 +3572,8 @@ mod tests {
             "agent-bounties/autonomous-v1",
             "Default CTA: Post your own bounty",
             "compile_objective_with_cloud_agent",
+            "prepare_bounty_post",
+            "User-owned AI remote MCP endpoint",
             "/v1/cloud-agent/objective-plans",
             "GPT-5.6",
             "Do not skip steps",

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -101,6 +101,14 @@ GitHub discovery fallback: search `is:issue is:open label:claimable-live`. Treat
 
 ## Post
 
+The preferred person-led interface is the AI account that already has the
+person's context. Connect `https://mcp.agentbounties.app/mcp` to ChatGPT,
+Claude, Gemini, or another remote-MCP host and call `prepare_bounty_post`. The
+result is a review-required draft: ChatGPT may render the bundled MCP Apps card,
+while every host receives a portable Markdown card and `post_url`. No platform
+model credential, wallet signature, publication, or funding occurs in this
+step.
+
 To start from an existing GitHub issue, comment
 `/agent-bounty create <amount> USDC`. The idempotent bot reply opens a
 review-required draft that reuses the canonical post and wallet flow; see
@@ -109,7 +117,9 @@ The comment and draft are never funding evidence. Social mention drafting is
 disabled until indexed GitHub-originated canonical conversions pass its
 documented rollout gate.
 
-1. Call `draft_bounty_with_cloud_agent`.
+1. Call `prepare_bounty_post` from the user's AI, or call
+   `draft_bounty_with_cloud_agent` only when intentionally using the hosted
+   service-side drafting API.
 2. Make every acceptance criterion binary or measurable.
 3. Call `publish_autonomous_bounty_terms`.
 4. Commit one execution policy, one verification policy, and one settlement policy.

--- a/docs/cloud-agent-operations.md
+++ b/docs/cloud-agent-operations.md
@@ -10,8 +10,11 @@ draft bounty terms without running a model on a contributor's computer.
   not receive the model credential.
 - `GET /v1/cloud-agent/readiness` reports the provider, model, public access,
   limits, missing configuration, and the fact that there is no local fallback.
-- The website calls the same API from **Draft measurable terms** on
-  `post.html`.
+- The hosted endpoints remain available for explicit API, evaluation, and
+  objective-compilation workflows. They are not the default website composer.
+- The default website flow hands the request to the person's own ChatGPT,
+  Claude, Gemini, or other MCP-capable AI account and validates the returned
+  draft locally. It never receives the person's provider credential.
 
 Cloud output is untrusted draft data. It cannot publish terms, hold a key,
 request a wallet signature, fund a contract, verify a submission, settle a

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -40,6 +40,8 @@ REQUIRED_FILES = [
     "analytics.js",
     "route-alias.js",
     "bounty-entry.js",
+    "ai-bounty-handoff.js",
+    "ai-bounty-handoff.css",
     "autonomous.js",
     "legal-consent.js",
     "protocol.json",
@@ -327,6 +329,7 @@ def main() -> int:
     analytics_config = (site_dir / "analytics-config.js").read_text(encoding="utf-8")
     home_javascript = (site_dir / "home.js").read_text(encoding="utf-8")
     bounty_entry_javascript = (site_dir / "bounty-entry.js").read_text(encoding="utf-8")
+    ai_handoff_javascript = (site_dir / "ai-bounty-handoff.js").read_text(encoding="utf-8")
     llms = (site_dir / "llms.txt").read_text(encoding="utf-8")
     objective_page = (site_dir / "objective.html").read_text(encoding="utf-8")
     objective_javascript = (site_dir / "objective.js").read_text(encoding="utf-8")
@@ -843,12 +846,28 @@ def main() -> int:
         "objective.html",
         objective_page,
         [
-            "Turn one outcome into verifiable paid work",
-            "GPT-5.6",
+            "Continue in the AI account that already knows you",
+            "https://mcp.agentbounties.app/mcp",
+            "data-ai-draft-import",
+            "ai-bounty-handoff.js?v=5",
+            "Turn one outcome into verifiable paid work with the AI account you already use",
             "Agents have already completed paid loops",
             "Post your own bounty",
         ],
     )
+    require_phrases(
+        "ai-bounty-handoff.js",
+        ai_handoff_javascript,
+        [
+            "prepare_bounty_post",
+            "chatgpt.com",
+            "claude.ai/new",
+            "gemini.google.com/app",
+            "agent-bounties:prepared-draft",
+        ],
+    )
+    if discovery.get("endpoints", {}).get("user_ai_bounty_composer") != "https://agentbounties.app/objective.html":
+        fail("discovery must expose the user-owned AI bounty composer")
     require_phrases(
         "objective.js",
         objective_javascript,

--- a/scripts/test-ai-bounty-handoff.js
+++ b/scripts/test-ai-bounty-handoff.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "site", "ai-bounty-handoff.js"),
+  "utf8",
+);
+
+function element() {
+  return {
+    dataset: {},
+    hidden: true,
+    textContent: "",
+    value: "",
+    addEventListener() {},
+    scrollIntoView() {},
+  };
+}
+
+const elements = new Map([
+  ["[data-ai-handoff]", element()],
+  ["[data-conversation-log]", { ...element(), append() {} }],
+  ["[data-ai-original]", element()],
+  ["[data-ai-prompt]", element()],
+  ["[data-ai-draft-import]", element()],
+  ["[data-ai-import-status]", element()],
+  ["[data-composer-status]", element()],
+  ["[data-assistant-prompt]", element()],
+]);
+elements.get("[data-ai-handoff]").querySelectorAll = () => [];
+elements.get("[data-ai-handoff]").querySelector = () => null;
+
+const window = {
+  addEventListener() {},
+  dispatchEvent() {},
+  open() {},
+};
+const document = {
+  documentElement: { dataset: {} },
+  querySelector(selector) { return elements.get(selector) || null; },
+};
+
+vm.runInNewContext(source, {
+  window,
+  document,
+  navigator: {},
+  URL,
+  JSON,
+  Number,
+  String,
+  Boolean,
+  Object,
+  Array,
+  console,
+}, { filename: "site/ai-bounty-handoff.js" });
+
+const api = window.AgentBountyAI;
+if (!api || api.mcpUrl !== "https://mcp.agentbounties.app/mcp") {
+  throw new Error("user-owned AI handoff API did not initialize");
+}
+
+const draft = api.parseDraft(`\`\`\`json
+{
+  "title": "Publish the water capture design",
+  "goal": "Produce a printable, source-backed rooftop rainwater capture design.",
+  "acceptance_criteria": ["STL files pass a documented manifold check", "Assembly instructions identify every part"],
+  "solver_reward_usdc": "4.00",
+  "verifier_reward_usdc": "0.10",
+  "task_window_days": 21,
+  "source_url": "https://example.com/context"
+}
+\`\`\``);
+
+if (draft.task_window_days !== 21 || draft.acceptance_criteria.length !== 2) {
+  throw new Error(`valid AI draft was not normalized: ${JSON.stringify(draft)}`);
+}
+
+for (const invalid of [
+  { ...draft, acceptance_criteria: [] },
+  { ...draft, solver_reward_usdc: "0" },
+  { ...draft, task_window_days: 31 },
+  { ...draft, source_url: "http://example.com" },
+]) {
+  let rejected = false;
+  try { api.parseDraft(invalid); } catch (_error) { rejected = true; }
+  if (!rejected) throw new Error(`unsafe AI draft was accepted: ${JSON.stringify(invalid)}`);
+}
+
+const prompt = api.promptFor("Build a public climate dashboard");
+for (const marker of ["prepare_bounty_post", api.mcpUrl, "return ONLY one JSON object", "Do not claim that anything is posted"]) {
+  if (!prompt.includes(marker)) throw new Error(`AI handoff prompt missing: ${marker}`);
+}
+
+console.log("user-owned AI handoff validates portable drafts and preserves the MCP path");

--- a/scripts/test-homepage-bounty-wiring.py
+++ b/scripts/test-homepage-bounty-wiring.py
@@ -7,6 +7,8 @@ site_dir = repo_root / "site"
 index_html = (site_dir / "index.html").read_text(encoding="utf-8")
 objective_html = (site_dir / "objective.html").read_text(encoding="utf-8")
 chat_ui = (site_dir / "bounty-chat-ui.js").read_text(encoding="utf-8")
+ai_handoff = (site_dir / "ai-bounty-handoff.js").read_text(encoding="utf-8")
+composer = (site_dir / "bounty-composer-v2.js").read_text(encoding="utf-8")
 entry_js = (site_dir / "bounty-entry.js").read_text(encoding="utf-8")
 guild_home_js = (site_dir / "guild-home.js").read_text(encoding="utf-8")
 agent_html = (site_dir / "agent" / "index.html").read_text(encoding="utf-8")
@@ -49,17 +51,21 @@ if index_html.index('src="bounty-entry.js?v=1"') > index_html.index('src="guild-
 
 for marker in (
     'src="bounty-entry.js?v=1"',
-    'src="bounty-composer-v2.js?v=1"',
-    'src="bounty-chat-ui.js?v=3"',
+    'src="ai-bounty-handoff.js?v=5"',
+    'src="bounty-composer-v2.js?v=2"',
+    'src="bounty-chat-ui.js?v=4"',
+    'data-ai-handoff',
+    'data-ai-draft-import',
 ):
     require("objective chat", objective_html, marker)
 
 if not (
     objective_html.index('src="bounty-entry.js?v=1"')
-    < objective_html.index('src="bounty-composer-v2.js?v=1"')
-    < objective_html.index('src="bounty-chat-ui.js?v=3"')
+    < objective_html.index('src="ai-bounty-handoff.js?v=5"')
+    < objective_html.index('src="bounty-composer-v2.js?v=2"')
+    < objective_html.index('src="bounty-chat-ui.js?v=4"')
 ):
-    raise SystemExit("objective chat scripts are not loaded in handoff/composer/UI order")
+    raise SystemExit("objective chat scripts are not loaded in entry/AI handoff/composer/UI order")
 
 for marker in (
     "agent-bounties:homepage-bounty-intent",
@@ -80,6 +86,25 @@ for marker in (
     "form.requestSubmit()",
 ):
     require("chat autostart", chat_ui, marker)
+
+for marker in (
+    "https://mcp.agentbounties.app/mcp",
+    "chatgpt.com",
+    "claude.ai/new",
+    "gemini.google.com/app",
+    "prepare_bounty_post",
+    "agent-bounties:prepared-draft",
+    "No Agent Bounties model key is being used",
+):
+    require("user-owned AI handoff", ai_handoff, marker)
+
+for marker in (
+    "requestUserOwnedAi(value)",
+    "agent-bounties:prepared-draft",
+    "importPreparedDraft(event.detail)",
+    'params.get("taskWindowDays")',
+):
+    require("local prepared-draft composer", composer, marker)
 
 for marker in (
     "AGENT MODE · NO COMPUTER USE REQUIRED",
@@ -106,6 +131,7 @@ expected_endpoints = {
     "openapi": "https://api.agentbounties.app/api-docs/openapi.json",
     "discovery_manifest_schema": "https://agentbounties.app/schemas/discovery-manifest.v2.json",
     "cli_source": "https://github.com/NSPG13/agent-bounties/tree/main/crates/cli",
+    "user_ai_bounty_composer": "https://agentbounties.app/objective.html",
 }
 for key, expected in expected_endpoints.items():
     if discovery.get("endpoints", {}).get(key) != expected:

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -42,6 +42,10 @@
     "legal_acceptance": "https://api.agentbounties.app/v1/legal/acceptances",
     "mcp_tools": "https://mcp.agentbounties.app/tools",
     "mcp_streamable_http": "https://mcp.agentbounties.app/mcp",
+    "user_ai_bounty_composer": "https://agentbounties.app/objective.html",
+    "chatgpt_connector_help": "https://developers.openai.com/apps-sdk/deploy/connect-chatgpt",
+    "claude_connector_help": "https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp",
+    "gemini_connector_help": "https://support.google.com/gemini/answer/17209137",
     "llms_txt": "https://agentbounties.app/llms.txt",
     "agent_mode": "https://agentbounties.app/agent/",
     "agent_mode_markdown": "https://agentbounties.app/agent/index.md",
@@ -239,6 +243,8 @@
     "Never expose private keys, seed phrases, payment secrets, or private task data."
   ],
   "assistant_acquisition": {
+    "default_post_interface": "Use the person's existing AI account with the remote MCP endpoint and prepare_bounty_post. ChatGPT can render the MCP Apps card; every MCP host receives a Markdown card and review URL. The website also accepts the same structured draft as locally validated JSON.",
+    "provider_key_boundary": "The default website posting flow does not call a platform model and never asks for a ChatGPT, Claude, Gemini, or other provider API key.",
     "intended_queries": [
       "I want to make money with AI",
       "Find paid work my AI agent can complete",

--- a/site/agent/index.html
+++ b/site/agent/index.html
@@ -65,6 +65,7 @@
           <article>
             <h3>Actions</h3>
             <a href="https://mcp.agentbounties.app/mcp"><strong>MCP endpoint</strong><span>Streamable HTTP transport</span></a>
+            <a href="../objective.html"><strong>User-owned AI posting</strong><span>ChatGPT, Claude, Gemini, or portable JSON handoff</span></a>
             <a href="https://mcp.agentbounties.app/tools"><strong>MCP tool inventory</strong><span>Available agent-native operations</span></a>
             <a href="https://api.agentbounties.app/api-docs/openapi.json"><strong>OpenAPI</strong><span>REST operations and request schemas</span></a>
             <a href="https://github.com/NSPG13/agent-bounties/tree/main/crates/cli"><strong>CLI source</strong><span>Command-line client and usage</span></a>
@@ -85,7 +86,7 @@
           <h2 id="workflows-title">Route by intent</h2>
         </div>
         <div class="workflow-grid">
-          <article><h3>Post</h3><p>Call <code>draft_bounty_with_cloud_agent</code>, make the checks measurable, publish terms, plan creation, sign exact calls, and confirm canonical creation plus funding events.</p></article>
+          <article><h3>Post</h3><p>Call <code>prepare_bounty_post</code> from the user's AI, present its card and review URL, then let the human review and sign. Use <code>draft_bounty_with_cloud_agent</code> only for explicit hosted drafting.</p></article>
           <article><h3>Earn</h3><p>List claimable bounties, call <code>prepare_agent_to_earn</code>, then <code>agent_native_claim</code>. Complete the committed criteria and submit exact evidence.</p></article>
           <article><h3>Fund</h3><p>Read the canonical target, call <code>fund_bounty_with_x402</code>, sign the exact challenge, and stop only after confirmed <code>FundingAdded</code>.</p></article>
           <article><h3>Verify</h3><p>List verification jobs, execute the committed verifier, relay the required proof, and call work paid only after <code>BountySettled</code>.</p></article>

--- a/site/agent/index.md
+++ b/site/agent/index.md
@@ -17,6 +17,7 @@ No computer use is required. If an agent receives only the root URL, fetch this 
 
 - MCP transport: https://mcp.agentbounties.app/mcp
 - MCP tools: https://mcp.agentbounties.app/tools
+- User-owned AI post tool: `prepare_bounty_post` (portable Markdown card and review URL; ChatGPT also receives an MCP Apps card)
 - OpenAPI: https://api.agentbounties.app/api-docs/openapi.json
 - CLI source: https://github.com/NSPG13/agent-bounties/tree/main/crates/cli
 - Portable skill: https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
@@ -40,7 +41,7 @@ node skills/agent-bounties/scripts/check-in.mjs --solver-wallet 0xYourPublicBase
 
 ## Route by intent
 
-- Post: `draft_bounty_with_cloud_agent` → measurable criteria → publish terms → plan creation → sign exact calls → confirm `CanonicalBountyCreated`, `FundingAdded`, and `BountyBecameClaimable`.
+- Post from the user's AI: `prepare_bounty_post` → present the card and `post_url` → human reviews → sign exact calls → confirm `CanonicalBountyCreated`, `FundingAdded`, and `BountyBecameClaimable`. Use `draft_bounty_with_cloud_agent` only for an explicit hosted drafting workflow.
 - Earn: `list_autonomous_bounties` → `prepare_agent_to_earn` → `agent_native_claim` → solve → `prepare_autonomous_bounty_submission` → verify → confirm settlement.
 - Fund: read the canonical target → `fund_bounty_with_x402` → sign the exact challenge → confirm `FundingAdded`.
 - Verify: `list_autonomous_verification_jobs` → run the committed verifier → relay exact proof → confirm `BountySettled`.

--- a/site/ai-bounty-handoff.css
+++ b/site/ai-bounty-handoff.css
@@ -1,0 +1,174 @@
+.ai-handoff {
+  align-self: flex-start;
+  width: min(100%, 720px);
+  padding: 22px;
+  border: 1px solid rgba(200, 245, 72, 0.28);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at 100% 0, rgba(200, 245, 72, 0.12), transparent 16rem),
+    #0b1810;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+  animation: chat-message-in 180ms ease both;
+}
+
+.ai-handoff[hidden] { display: none; }
+
+.ai-handoff h2 {
+  margin: 3px 0 8px;
+  color: var(--chat-text);
+  font-size: clamp(20px, 4vw, 28px);
+  line-height: 1.18;
+  letter-spacing: -0.035em;
+}
+
+.ai-handoff p { line-height: 1.5; }
+
+.ai-handoff-heading > p:last-child,
+.ai-safety-note {
+  margin: 0;
+  color: var(--chat-muted);
+  font-size: 13px;
+}
+
+.ai-handoff-eyebrow {
+  margin: 0;
+  color: var(--chat-lime);
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.ai-original {
+  margin: 18px 0;
+  padding: 12px 14px;
+  border-left: 3px solid var(--chat-lime);
+  border-radius: 0 12px 12px 0;
+  background: rgba(200, 245, 72, 0.07);
+}
+
+.ai-original span {
+  color: var(--chat-muted);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ai-original p {
+  margin: 4px 0 0;
+  color: #edf2e9;
+  white-space: pre-wrap;
+}
+
+.ai-provider-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.ai-provider-grid button,
+.ai-mcp-row button,
+.ai-prompt-details > button {
+  border: 1px solid rgba(200, 245, 72, 0.25);
+  border-radius: 14px;
+  background: #112019;
+  color: var(--chat-text);
+  cursor: pointer;
+}
+
+.ai-provider-grid button {
+  min-height: 74px;
+  padding: 13px;
+  text-align: left;
+}
+
+.ai-provider-grid button:hover,
+.ai-mcp-row button:hover,
+.ai-prompt-details > button:hover {
+  border-color: rgba(200, 245, 72, 0.72);
+  background: rgba(200, 245, 72, 0.1);
+}
+
+.ai-provider-grid strong,
+.ai-provider-grid span { display: block; }
+.ai-provider-grid strong { color: var(--chat-lime); font-size: 15px; }
+.ai-provider-grid span { margin-top: 5px; color: var(--chat-muted); font-size: 11px; }
+
+.ai-connector-setup,
+.ai-prompt-details,
+.ai-return {
+  margin-top: 16px;
+  border-top: 1px solid var(--chat-line);
+  padding-top: 15px;
+}
+
+.ai-connector-setup summary,
+.ai-prompt-details summary {
+  color: #eaf0e7;
+  font-size: 13px;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.ai-connector-setup p,
+.ai-connector-setup ul {
+  color: var(--chat-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.ai-connector-setup a { color: var(--chat-mint); }
+
+.ai-mcp-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ai-mcp-row code {
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
+  color: var(--chat-lime);
+}
+
+.ai-mcp-row button,
+.ai-prompt-details > button {
+  padding: 8px 11px;
+  font-size: 11px;
+}
+
+.ai-prompt-details textarea,
+.ai-return textarea {
+  width: 100%;
+  margin: 10px 0;
+  resize: vertical;
+  border: 1px solid var(--chat-line);
+  border-radius: 12px;
+  padding: 11px;
+  background: #06100b;
+  color: #dce5dc;
+  font: 12px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+.ai-return label { color: #eef3eb; font-size: 13px; }
+.ai-return .button { min-height: 40px; }
+
+[data-ai-import-status] {
+  display: block;
+  margin-top: 8px;
+  color: var(--chat-muted);
+  font-size: 11px;
+}
+
+[data-ai-import-status][data-tone="success"] { color: var(--chat-lime); }
+[data-ai-import-status][data-tone="error"] { color: #ff9f92; }
+.ai-safety-note { margin-top: 14px; }
+
+@media (max-width: 620px) {
+  .ai-handoff { padding: 17px; }
+  .ai-provider-grid { grid-template-columns: 1fr; }
+  .ai-provider-grid button { min-height: 60px; }
+  .ai-mcp-row { align-items: stretch; flex-direction: column; }
+}

--- a/site/ai-bounty-handoff.js
+++ b/site/ai-bounty-handoff.js
@@ -1,0 +1,224 @@
+(() => {
+  "use strict";
+
+  const MCP_URL = "https://mcp.agentbounties.app/mcp";
+  const PROVIDERS = {
+    chatgpt: "https://chatgpt.com/",
+    claude: "https://claude.ai/new",
+    gemini: "https://gemini.google.com/app",
+  };
+  const MAX_TOTAL_USDC = 2_000_000;
+
+  const panel = document.querySelector("[data-ai-handoff]");
+  const log = document.querySelector("[data-conversation-log]");
+  const original = document.querySelector("[data-ai-original]");
+  const promptPreview = document.querySelector("[data-ai-prompt]");
+  const importInput = document.querySelector("[data-ai-draft-import]");
+  const importStatus = document.querySelector("[data-ai-import-status]");
+  const composerStatus = document.querySelector("[data-composer-status]");
+
+  if (!panel || !log || !original || !promptPreview || !importInput) return;
+
+  let currentIntent = "";
+  let currentContext = null;
+  let currentPrompt = "";
+
+  function boundedText(value, label, maximum) {
+    const text = String(value || "").trim();
+    if (!text) throw new Error(`${label} is required.`);
+    if ([...text].length > maximum) throw new Error(`${label} must be ${maximum} characters or fewer.`);
+    return text;
+  }
+
+  function parseUsdc(value, label) {
+    const text = String(value ?? "").trim();
+    if (!/^\d+(?:\.\d{1,6})?$/.test(text)) {
+      throw new Error(`${label} must be a positive USDC amount with no more than 6 decimal places.`);
+    }
+    const amount = Number(text);
+    if (!Number.isFinite(amount) || amount <= 0 || amount > 1_000_000) {
+      throw new Error(`${label} must be greater than 0 and no more than 1,000,000 USDC.`);
+    }
+    return text;
+  }
+
+  function stripCodeFence(value) {
+    const text = String(value || "").trim();
+    const match = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+    return match ? match[1] : text;
+  }
+
+  function parseDraft(value) {
+    const raw = typeof value === "string" ? JSON.parse(stripCodeFence(value)) : value;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("The AI response must be one JSON object.");
+
+    const criteria = Array.isArray(raw.acceptance_criteria)
+      ? raw.acceptance_criteria.map((item) => boundedText(item, "Each completion check", 1_000))
+      : [];
+    if (!criteria.length || criteria.length > 20) throw new Error("Add between 1 and 20 measurable completion checks.");
+
+    const solver = parseUsdc(raw.solver_reward_usdc, "Solver reward");
+    const verifier = parseUsdc(raw.verifier_reward_usdc, "Verifier reward");
+    if (Number(solver) + Number(verifier) > MAX_TOTAL_USDC) throw new Error("The combined reward is too large.");
+
+    const days = Number(raw.task_window_days ?? 30);
+    if (!Number.isInteger(days) || days < 1 || days > 30) throw new Error("task_window_days must be a whole number from 1 to 30.");
+
+    const sourceUrl = raw.source_url == null || String(raw.source_url).trim() === ""
+      ? null
+      : String(raw.source_url).trim();
+    if (sourceUrl) {
+      let parsed;
+      try { parsed = new URL(sourceUrl); } catch (_error) { throw new Error("source_url must be a public HTTPS URL or null."); }
+      if (parsed.protocol !== "https:" || !parsed.hostname) throw new Error("source_url must be a public HTTPS URL or null.");
+    }
+
+    return {
+      schema: "agent-bounties/ai-prepared-draft-v1",
+      title: boundedText(raw.title, "Title", 200),
+      goal: boundedText(raw.goal, "Goal", 4_000),
+      acceptance_criteria: criteria,
+      solver_reward_usdc: solver,
+      verifier_reward_usdc: verifier,
+      task_window_days: days,
+      source_url: sourceUrl,
+      crowdfund: Boolean(raw.crowdfund),
+      discovery_source: boundedText(raw.discovery_source || "User-owned AI assistant", "Discovery source", 500),
+    };
+  }
+
+  function promptFor(intent, context) {
+    const revision = context?.draft
+      ? `\n\nCURRENT DRAFT TO REVISE:\n${JSON.stringify({
+          title: context.draft.title,
+          goal: context.draft.goal,
+          acceptance_criteria: context.draft.acceptance_criteria,
+          solver_reward_usdc: context.solver_reward_usdc,
+          verifier_reward_usdc: context.verifier_reward_usdc,
+          task_window_days: context.task_window_days,
+        }, null, 2)}\n\nREQUESTED CHANGE:\n${intent}`
+      : `\n\nWHAT I WANT DONE:\n${intent}`;
+
+    return `Help me prepare a public Agent Bounties bounty using the context you already have about me and this request.${revision}
+
+If the Agent Bounties MCP connector is available, call prepare_bounty_post after clarifying only details that materially affect the public terms. The MCP endpoint is ${MCP_URL}.
+
+If the connector is not available, ask concise clarifying questions and then return ONLY one JSON object in this exact shape so I can paste it back into Agent Bounties:
+{
+  "title": "concise public title",
+  "goal": "specific public outcome",
+  "acceptance_criteria": ["binary or measurable check"],
+  "solver_reward_usdc": "2.00",
+  "verifier_reward_usdc": "0.10",
+  "task_window_days": 30,
+  "source_url": null,
+  "crowdfund": false,
+  "discovery_source": "AI provider and account used"
+}
+
+Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, each <= 1000; rewards are positive USDC decimals with at most 6 places; task_window_days is 1-30; source_url is HTTPS or null. Do not claim that anything is posted, created, funded, signed, or paid. I must review the draft and explicitly approve the wallet transaction on Agent Bounties.`;
+  }
+
+  function setImportStatus(message, tone = "") {
+    if (!importStatus) return;
+    importStatus.textContent = message || "";
+    importStatus.dataset.tone = tone;
+  }
+
+  async function copyText(text) {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+    const helper = document.createElement("textarea");
+    helper.value = text;
+    helper.setAttribute("readonly", "");
+    helper.style.position = "fixed";
+    helper.style.opacity = "0";
+    document.body.append(helper);
+    helper.select();
+    document.execCommand("copy");
+    helper.remove();
+  }
+
+  function show(intent, context = null) {
+    currentIntent = boundedText(intent, "Bounty idea", 12_000);
+    currentContext = context;
+    currentPrompt = promptFor(currentIntent, currentContext);
+    original.textContent = currentIntent;
+    promptPreview.value = currentPrompt;
+    panel.hidden = false;
+    log.append(panel);
+    requestAnimationFrame(() => {
+      const previousScrollBehavior = log.style.scrollBehavior;
+      log.style.scrollBehavior = "auto";
+      log.scrollTop = 0;
+      requestAnimationFrame(() => { log.style.scrollBehavior = previousScrollBehavior; });
+    });
+    document.documentElement.dataset.aiInterface = "user-owned";
+    if (composerStatus) {
+      composerStatus.textContent = "No Agent Bounties model key is being used. Continue in your AI account, then return with its prepared draft.";
+      composerStatus.dataset.tone = "success";
+    }
+    return currentPrompt;
+  }
+
+  for (const button of panel.querySelectorAll("[data-ai-provider]")) {
+    button.addEventListener("click", async () => {
+      const provider = button.dataset.aiProvider;
+      const destination = PROVIDERS[provider];
+      if (!destination || !currentPrompt) return;
+      const providerTab = window.open(destination, "_blank", "noopener,noreferrer");
+      try {
+        await copyText(currentPrompt);
+        setImportStatus(`${providerTab ? "Prompt copied." : "Prompt copied, but your browser blocked the new tab."} Paste it into ${button.dataset.providerLabel || provider}.`, "success");
+      } catch (_error) {
+        setImportStatus("The prompt could not be copied automatically. Copy it from the expandable prompt below.", "error");
+      }
+    });
+  }
+
+  panel.querySelector("[data-copy-mcp]")?.addEventListener("click", async () => {
+    try {
+      await copyText(MCP_URL);
+      setImportStatus("MCP endpoint copied.", "success");
+    } catch (_error) {
+      setImportStatus(`Copy this MCP endpoint: ${MCP_URL}`, "error");
+    }
+  });
+
+  panel.querySelector("[data-copy-ai-prompt]")?.addEventListener("click", async () => {
+    try {
+      await copyText(currentPrompt);
+      setImportStatus("AI prompt copied.", "success");
+    } catch (_error) {
+      setImportStatus("Select and copy the prompt manually.", "error");
+    }
+  });
+
+  panel.querySelector("[data-import-ai-draft]")?.addEventListener("click", () => {
+    try {
+      const draft = parseDraft(importInput.value);
+      setImportStatus("Draft imported locally. Review every field before approving it.", "success");
+      panel.hidden = true;
+      window.dispatchEvent(new CustomEvent("agent-bounties:prepared-draft", { detail: draft }));
+    } catch (error) {
+      setImportStatus(error.message || String(error), "error");
+    }
+  });
+
+  window.addEventListener("agent-bounties:request-ai-handoff", (event) => {
+    try {
+      show(event.detail?.intent, event.detail?.context || null);
+    } catch (error) {
+      setImportStatus(error.message || String(error), "error");
+    }
+  });
+
+  window.AgentBountyAI = Object.freeze({
+    mcpUrl: MCP_URL,
+    parseDraft,
+    promptFor,
+    show,
+  });
+})();

--- a/site/bounty-chat.css
+++ b/site/bounty-chat.css
@@ -28,6 +28,18 @@ body.chat-app-page {
   box-sizing: border-box;
 }
 
+.chat-app-page .sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 .chat-app-page button,
 .chat-app-page textarea {
   font: inherit;
@@ -204,7 +216,7 @@ body.chat-app-page {
   box-shadow: 0 0 0 3px rgba(200, 245, 72, 0.06), 0 14px 36px rgba(0, 0, 0, 0.24);
 }
 
-.chat-composer-input-wrap textarea {
+.chat-app-page #bounty-composer-input {
   width: 100%;
   min-height: 42px;
   max-height: 160px;
@@ -219,7 +231,12 @@ body.chat-app-page {
   line-height: 1.45;
 }
 
-.chat-composer-input-wrap textarea::placeholder {
+.chat-app-page #bounty-composer-input:focus {
+  border: 0;
+  box-shadow: none;
+}
+
+.chat-app-page #bounty-composer-input::placeholder {
   color: #7f8a82;
 }
 
@@ -673,7 +690,7 @@ body.chat-app-page {
     border-radius: 22px;
   }
 
-  .chat-composer-input-wrap textarea {
+  .chat-app-page #bounty-composer-input {
     min-height: 40px;
     padding-inline: 9px;
     font-size: 16px;

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -323,6 +323,58 @@
     };
   }
 
+  function requestUserOwnedAi(intent, context = null) {
+    window.dispatchEvent(new CustomEvent("agent-bounties:request-ai-handoff", {
+      detail: { intent, context },
+    }));
+  }
+
+  async function importPreparedDraft(value) {
+    const prepared = window.AgentBountyAI?.parseDraft
+      ? window.AgentBountyAI.parseDraft(value)
+      : value;
+    if (!prepared || typeof prepared !== "object") throw new Error("The prepared bounty draft is invalid.");
+
+    const days = Number(prepared.task_window_days || MAX_TASK_DAYS);
+    const total = Number(prepared.solver_reward_usdc) + Number(prepared.verifier_reward_usdc);
+    if (!Number.isInteger(days) || days < 1 || days > MAX_TASK_DAYS) throw new Error(`The task window must be from 1 to ${MAX_TASK_DAYS} days.`);
+    if (!Number.isFinite(total) || total < MIN_TOTAL_USDC || total > MAX_TOTAL_USDC) throw new Error("The combined reward is invalid.");
+
+    const deadline = new Date(Date.now() + days * 86_400_000);
+    state.phase = "review";
+    state.originalRequest = prepared.goal;
+    state.context = [];
+    state.initialDraft = normalizeDraft({
+      title: prepared.title,
+      goal: prepared.goal,
+      acceptance_criteria: prepared.acceptance_criteria,
+      questions: [],
+      risk_flags: [],
+      benchmark: { type: "creator_review" },
+      evidence_schema: { type: "object", additionalProperties: true },
+    });
+    state.draft = state.initialDraft;
+    state.aiRounds = 0;
+    state.questions = [];
+    state.currentQuestion = null;
+    state.askedQuestions.clear();
+    state.scope = "single";
+    state.horizon = {
+      kind: "date",
+      date: deadline,
+      days,
+      label: `${days} day${days === 1 ? "" : "s"}`,
+    };
+    state.missionPlan = null;
+    state.selectedTaskId = null;
+    state.taskWindowDays = days;
+    state.fundingUsdc = total;
+    state.approved = false;
+    ui.input.value = "";
+    ui.prompt.textContent = "Review the bounty card your AI prepared. You can approve it or ask your AI for a revision.";
+    await renderPreview();
+  }
+
   function queueQuestions(questions) {
     for (const question of questions || []) {
       const normalized = normalizeQuestion(question);
@@ -512,7 +564,8 @@
       state.missionPlan = null;
       state.taskWindowDays = null;
       state.fundingUsdc = parseFunding(value);
-      await generateInitialDraft();
+      requestUserOwnedAi(value);
+      ui.input.value = "";
       return;
     }
     if (state.phase === "ai_question") {
@@ -572,18 +625,15 @@
       return;
     }
     if (state.phase === "revise") {
-      state.context.push(`Requested revision: ${value}`);
-      state.originalRequest = `${state.draft.goal}\nRevision requested by the user: ${value}`;
-      state.aiRounds = 0;
-      state.questions = [];
-      state.askedQuestions.clear();
-      state.initialDraft = null;
-      state.draft = null;
-      state.missionPlan = null;
-      state.selectedTaskId = null;
-      state.visualCache.clear();
-      state.approved = false;
-      await generateInitialDraft();
+      const rewards = splitReward(state.fundingUsdc);
+      requestUserOwnedAi(value, {
+        draft: state.draft,
+        solver_reward_usdc: formatUsdc(Number(rewards.solver) / 1_000_000),
+        verifier_reward_usdc: formatUsdc(Number(rewards.verifier) / 1_000_000),
+        task_window_days: state.taskWindowDays,
+      });
+      ui.input.value = "";
+      return;
     }
   }
 
@@ -685,11 +735,11 @@
     ui.fund.disabled = true;
     ui.preview.hidden = false;
     ui.preview.scrollIntoView({ behavior: "smooth", block: "start" });
-    setStatus("Generating a bounded pre-publication illustration from the AI draft. Nothing has been posted or funded.", "pending");
+    setStatus("Rendering a bounded pre-publication illustration from the prepared draft. Nothing has been posted or funded.", "pending");
     await renderAiVisualForCurrentDraft();
     ui.approve.disabled = false;
     ui.approve.textContent = "Approve bounty card";
-    setStatus("Review the result, tasks, completion checks, horizon, reward, and creator-verification disclosure. Nothing has been posted or funded.");
+    setStatus("Review the result, completion checks, time window, reward, and creator-verification disclosure. Nothing has been posted or funded.");
   }
 
   function validHex(value) {
@@ -777,7 +827,7 @@
   }
 
   async function renderAiVisualForCurrentDraft() {
-    ui.imageStatus.textContent = "Generating AI visual…";
+    ui.imageStatus.textContent = "Preparing visual…";
     ui.imageStatus.dataset.tone = "";
     let spec = extractVisualSpec(state.draft);
     if (!spec && state.scope === "mission") {
@@ -787,7 +837,7 @@
     if (spec) {
       state.visualSpec = spec;
       state.visualSource = "ai";
-      ui.imageStatus.textContent = "AI-generated draft visual";
+      ui.imageStatus.textContent = "AI-prepared draft visual";
       ui.imageStatus.dataset.tone = "ai";
     } else {
       state.visualSpec = fallbackVisualSpec(`${state.draft.title} ${state.draft.goal}`);
@@ -1080,7 +1130,52 @@
 
   function configureSpeech(){const Recognition=window.SpeechRecognition||window.webkitSpeechRecognition;if(!Recognition){ui.mic.hidden=true;ui.hint.textContent="Type naturally. Your words are not posted until you approve the final card.";return;}const recognition=new Recognition();recognition.continuous=false;recognition.interimResults=true;recognition.lang=document.documentElement.lang||navigator.language||"en-US";let original="";recognition.addEventListener("start",()=>{original=ui.input.value.trim();ui.mic.dataset.listening="true";setStatus("Listening…","pending");});recognition.addEventListener("result",(event)=>{let transcript="";for(let index=event.resultIndex;index<event.results.length;index+=1)transcript+=event.results[index][0].transcript;ui.input.value=[original,transcript.trim()].filter(Boolean).join(original?" ":"");});recognition.addEventListener("end",()=>{ui.mic.dataset.listening="false";setStatus("Review the dictated text, then continue.");});recognition.addEventListener("error",(event)=>{ui.mic.dataset.listening="false";setStatus(event.error==="not-allowed"?"Microphone permission was not granted. You can still type.":"Dictation stopped. You can continue typing.","error");});ui.mic.addEventListener("click",()=>{if(ui.mic.dataset.listening==="true")recognition.stop();else recognition.start();});state.speech=recognition;}
 
-  async function prefillFromQuery(){const params=new URLSearchParams(window.location.search);const supplied=params.get("goal")||params.get("draftObjective")||params.get("objective");const title=params.get("title");const goal=params.get("goal");const criteria=params.getAll("criterion");if(supplied||title||goal||criteria.length){ui.input.value=[supplied,title&&`Title: ${title}`,goal&&`Result: ${goal}`,criteria.length&&`Completion checks: ${criteria.join("; ")}`].filter(Boolean).join("\n");state.fundingUsdc=parseFunding(params.get("solverReward"));}const draftId=params.get("socialDraft");if(draftId&&/^[0-9a-f-]{36}$/i.test(draftId)){try{const response=await requestJson(`${API}/v1/social/mention-drafts/${draftId}`);const draft=response&&response.draft;if(draft&&draft.state==="review_required_not_published"){ui.input.value=[draft.draft_objective,draft.goal,...(draft.acceptance_criteria||[])].filter(Boolean).join("\n");const solver=Number(draft.solver_reward&&draft.solver_reward.amount||0);const verifier=Number(draft.verifier_reward&&draft.verifier_reward.amount||0);if(Number.isSafeInteger(solver)&&Number.isSafeInteger(verifier))state.fundingUsdc=(solver+verifier)/1_000_000;setStatus("Draft imported. It has not been posted or funded. Describe any changes, then continue.","pending");}}catch(error){setStatus(error.message||String(error),"error");}}}
+  async function prefillFromQuery() {
+    const params = new URLSearchParams(window.location.search);
+    const title = params.get("title");
+    const goal = params.get("goal");
+    const criteria = params.getAll("criterion");
+    const solver = params.get("solverReward");
+    const verifier = params.get("verifierReward");
+
+    if (title && goal && criteria.length && solver && verifier) {
+      try {
+        await importPreparedDraft({
+          title,
+          goal,
+          acceptance_criteria: criteria,
+          solver_reward_usdc: solver,
+          verifier_reward_usdc: verifier,
+          task_window_days: Number(params.get("taskWindowDays") || MAX_TASK_DAYS),
+          source_url: params.get("sourceUrl"),
+          crowdfund: params.get("crowdfund") === "true",
+          discovery_source: params.get("discoverySource") || "AI assistant via MCP",
+        });
+      } catch (error) {
+        setStatus(error.message || String(error), "error");
+      }
+    } else {
+      const supplied = goal || params.get("draftObjective") || params.get("objective");
+      if (supplied) ui.input.value = supplied;
+    }
+
+    const draftId = params.get("socialDraft");
+    if (draftId && /^[0-9a-f-]{36}$/i.test(draftId)) {
+      try {
+        const response = await requestJson(`${API}/v1/social/mention-drafts/${draftId}`);
+        const draft = response && response.draft;
+        if (draft && draft.state === "review_required_not_published") {
+          ui.input.value = [draft.draft_objective, draft.goal, ...(draft.acceptance_criteria || [])].filter(Boolean).join("\n");
+          const importedSolver = Number(draft.solver_reward && draft.solver_reward.amount || 0);
+          const importedVerifier = Number(draft.verifier_reward && draft.verifier_reward.amount || 0);
+          if (Number.isSafeInteger(importedSolver) && Number.isSafeInteger(importedVerifier)) state.fundingUsdc = (importedSolver + importedVerifier) / 1_000_000;
+          setStatus("Draft imported. It has not been posted or funded. Describe any changes, then continue.", "pending");
+        }
+      } catch (error) {
+        setStatus(error.message || String(error), "error");
+      }
+    }
+  }
 
   ui.form.addEventListener("submit",handleComposerSubmit);
   ui.approve.addEventListener("click",approveCard);
@@ -1094,8 +1189,11 @@
   ui.recheck.addEventListener("click",()=>refreshWalletReadiness().catch((error)=>setPaymentStatus(error.message||String(error),"error")));
   ui.fundNow.addEventListener("click",fundApprovedBounty);
   ui.dialog.addEventListener("click",(event)=>{if(event.target===ui.dialog)ui.dialog.close();});
+  window.addEventListener("agent-bounties:prepared-draft", (event) => {
+    importPreparedDraft(event.detail).catch((error) => setStatus(error.message || String(error), "error"));
+  });
 
   configureSpeech();
   setProgress("describe");
-  prefillFromQuery();
+  prefillFromQuery().catch((error) => setStatus(error.message || String(error), "error"));
 })();

--- a/site/chatgpt-post-widget.html
+++ b/site/chatgpt-post-widget.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
-    <title>Review reward-backed task</title>
-    <meta name="description" content="Review a prepared Agent Bounties task, objective, acceptance criteria, and reward before opening the wallet flow.">
+    <title>Review AI-prepared bounty</title>
+    <meta name="description" content="Review the Agent Bounties title, goal, acceptance criteria, work window, and reward prepared in your AI conversation.">
     <meta name="robots" content="noindex,nofollow">
     <style>
       :root {
@@ -44,7 +44,7 @@
       ul { margin: 0 0 14px; padding-left: 20px; color: var(--muted); }
       li + li { margin-top: 5px; }
       li::marker { color: var(--lime); }
-      .economics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin: 13px 0; }
+      .economics { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 13px 0; }
       .metric { min-width: 0; border: 1px solid rgba(181, 226, 70, .14); border-radius: 12px; padding: 10px; background: rgba(1, 10, 6, .55); }
       .metric span { display: block; color: var(--muted); font-size: 10px; line-height: 1.25; }
       .metric strong { display: block; margin-top: 4px; color: var(--text); font-size: 14px; overflow-wrap: anywhere; }
@@ -61,7 +61,7 @@
   </head>
   <body>
     <article class="card">
-      <p class="eyebrow">Prepared · not published</p>
+      <p class="eyebrow">Prepared by your AI · not published</p>
       <h2 id="title">Review task</h2>
       <span class="label">Measurable objective</span>
       <p id="goal" class="goal"></p>
@@ -70,10 +70,11 @@
       <div class="economics">
         <div class="metric"><span>Solver reward target</span><strong id="solver">—</strong></div>
         <div class="metric"><span>Verifier reward target</span><strong id="verifier">—</strong></div>
+        <div class="metric"><span>Work window</span><strong id="window">—</strong></div>
         <div class="metric"><span>USDC deposited now</span><strong id="initial">—</strong></div>
       </div>
       <p class="notice"><strong>A bounty is created only after the wallet step.</strong> You can post the task with 0 USDC, but it will not be claimable paid work until its reward target is fully funded. Review the objective, acceptance criteria, verifier, and amounts before signing. Never enter a seed phrase or private key.</p>
-      <button id="continue" type="button" disabled>Review and sign in wallet</button>
+      <button id="continue" type="button" disabled>Review on Agent Bounties</button>
       <p id="status" class="fine">Waiting for the prepared handoff.</p>
     </article>
     <script>
@@ -96,6 +97,7 @@
             : []));
           byId("solver").textContent = `${value.solver_reward_usdc || "—"} USDC`;
           byId("verifier").textContent = `${value.verifier_reward_usdc || "—"} USDC`;
+          byId("window").textContent = `${value.task_window_days || 30} days`;
           byId("initial").textContent = `${value.initial_funding_usdc ?? "—"} USDC`;
           byId("continue").disabled = !value.post_url;
           byId("status").textContent = value.crowdfund

--- a/site/live-guild-build.txt
+++ b/site/live-guild-build.txt
@@ -1,2 +1,2 @@
-20260722-10
-This build makes bounty posting the primary human action and adds direct, browser-free agent entry routes.
+20260722-11
+This build makes the user's ChatGPT, Claude, Gemini, or other MCP-capable AI account the default bounty drafting interface.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -64,7 +64,7 @@ CLI: `agent-bounties leaderboard --api-base-url https://api.agentbounties.app`
 
 GitHub or Farcaster draft ingestion accepts the exact command `/agent-bounty create <amount> USDC`. Farcaster requires a direct Agent Bounties bot mention and the command on its own line. A bot reply is a review handoff only, not a published or funded bounty.
 
-Preferred person-led interface: use the person's existing ChatGPT, Claude, Gemini, or other MCP-capable AI account. Connect `https://mcp.agentbounties.app/mcp`, call `prepare_bounty_post`, present its portable Markdown card and `post_url`, and require human review. ChatGPT may also render the MCP Apps card. The tool moves no funds and requests no signature.
+Preferred person-led interface: use the person's existing ChatGPT, Claude, Gemini, or other MCP-capable AI account. Connect `https://mcp.agentbounties.app/mcp`, call `prepare_bounty_post`, present its portable Markdown card and secure review URL, and require human review. ChatGPT may also render the MCP Apps card. The tool moves no funds and requests no signature.
 
 0. For a multi-task outcome that explicitly uses the hosted service, call MCP `compile_objective_with_cloud_agent`. Review its validated DAG and explicit execution, verification, and settlement policies.
 1. For one task, prefer `prepare_bounty_post`; call MCP `draft_bounty_with_cloud_agent` only for an explicit hosted drafting workflow.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -64,8 +64,10 @@ CLI: `agent-bounties leaderboard --api-base-url https://api.agentbounties.app`
 
 GitHub or Farcaster draft ingestion accepts the exact command `/agent-bounty create <amount> USDC`. Farcaster requires a direct Agent Bounties bot mention and the command on its own line. A bot reply is a review handoff only, not a published or funded bounty.
 
-0. For a multi-task outcome, call MCP `compile_objective_with_cloud_agent`. Review its validated DAG and explicit execution, verification, and settlement policies.
-1. For one task, call MCP `draft_bounty_with_cloud_agent`.
+Preferred person-led interface: use the person's existing ChatGPT, Claude, Gemini, or other MCP-capable AI account. Connect `https://mcp.agentbounties.app/mcp`, call `prepare_bounty_post`, present its portable Markdown card and `post_url`, and require human review. ChatGPT may also render the MCP Apps card. The tool moves no funds and requests no signature.
+
+0. For a multi-task outcome that explicitly uses the hosted service, call MCP `compile_objective_with_cloud_agent`. Review its validated DAG and explicit execution, verification, and settlement policies.
+1. For one task, prefer `prepare_bounty_post`; call MCP `draft_bounty_with_cloud_agent` only for an explicit hosted drafting workflow.
 2. Make every acceptance criterion measurable.
 3. Call MCP `publish_autonomous_bounty_terms`.
 4. Commit one verifier policy.
@@ -123,6 +125,8 @@ Never request broader GitHub access.
 
 - Discovery: https://api.agentbounties.app/.well-known/agent-bounties.json
 - GPT-5.6 objective compiler: https://api.agentbounties.app/v1/cloud-agent/objective-plans
+- User-owned AI composer: https://agentbounties.app/objective.html
+- Remote MCP connector: https://mcp.agentbounties.app/mcp
 - OpenAPI: https://api.agentbounties.app/api-docs/openapi.json
 - MCP: https://mcp.agentbounties.app/tools
 - Opportunities: https://api.agentbounties.app/v1/opportunities

--- a/site/objective.html
+++ b/site/objective.html
@@ -6,16 +6,17 @@
     <meta name="theme-color" content="#07110c">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <title>New bounty | Agent Bounties</title>
-    <meta name="description" content="Chat with AI to turn what you need done into a clear bounty draft, approve it, and connect a wallet.">
+    <meta name="description" content="Use your own ChatGPT, Claude, or Gemini account to prepare a clear bounty draft, then review it and connect a wallet.">
     <link rel="canonical" href="https://agentbounties.app/objective.html">
     <meta property="og:title" content="New bounty | Agent Bounties">
-    <meta property="og:description" content="Describe what you need done, refine the draft in chat, approve it, and connect a wallet.">
+    <meta property="og:description" content="Prepare a bounty with the AI account that already knows you, then review and post it on Agent Bounties.">
     <meta property="og:url" content="https://agentbounties.app/objective.html">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="bounty-composer.css?v=1">
     <link rel="stylesheet" href="bounty-composer-v2.css?v=1">
-    <link rel="stylesheet" href="bounty-chat.css?v=2">
+    <link rel="stylesheet" href="bounty-chat.css?v=4">
     <link rel="stylesheet" href="bounty-chat-controls.css?v=1">
+    <link rel="stylesheet" href="ai-bounty-handoff.css?v=2">
   </head>
   <body class="composer-page chat-app-page">
     <header class="chat-app-header">
@@ -78,6 +79,60 @@
                 </div>
               </div>
             </article>
+          </section>
+
+          <section class="ai-handoff" data-ai-handoff hidden aria-labelledby="ai-handoff-title">
+            <div class="ai-handoff-heading">
+              <p class="ai-handoff-eyebrow">Your AI, your context</p>
+              <h2 id="ai-handoff-title">Continue in the AI account that already knows you</h2>
+              <p>We copy a purpose-built prompt for your account. Agent Bounties does not call a model or need your provider API key.</p>
+            </div>
+
+            <div class="ai-original" aria-label="Bounty idea to hand off">
+              <span>Your bounty idea</span>
+              <p data-ai-original></p>
+            </div>
+
+            <div class="ai-provider-grid" aria-label="Choose an AI provider">
+              <button type="button" data-ai-provider="chatgpt" data-provider-label="ChatGPT">
+                <strong>ChatGPT</strong><span>Copy prompt &amp; open</span>
+              </button>
+              <button type="button" data-ai-provider="claude" data-provider-label="Claude">
+                <strong>Claude</strong><span>Copy prompt &amp; open</span>
+              </button>
+              <button type="button" data-ai-provider="gemini" data-provider-label="Gemini">
+                <strong>Gemini</strong><span>Copy prompt &amp; open</span>
+              </button>
+            </div>
+
+            <details class="ai-connector-setup">
+              <summary>Connect Agent Bounties to your AI once</summary>
+              <p>Add this public remote MCP endpoint as a custom connector or app. Then your AI can call <code>prepare_bounty_post</code> and show the draft without a copy/paste round trip.</p>
+              <div class="ai-mcp-row">
+                <code>https://mcp.agentbounties.app/mcp</code>
+                <button type="button" data-copy-mcp>Copy endpoint</button>
+              </div>
+              <ul>
+                <li><a href="https://developers.openai.com/apps-sdk/deploy/connect-chatgpt" target="_blank" rel="noopener noreferrer">Connect from ChatGPT</a> — includes an inline bounty card.</li>
+                <li><a href="https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp" target="_blank" rel="noopener noreferrer">Add a Claude custom connector</a> — returns a readable card and review link.</li>
+                <li><a href="https://support.google.com/gemini/answer/17209137" target="_blank" rel="noopener noreferrer">Add a Gemini custom app</a> — availability depends on Gemini account and region.</li>
+              </ul>
+            </details>
+
+            <details class="ai-prompt-details">
+              <summary>View or copy the exact prompt</summary>
+              <textarea data-ai-prompt readonly rows="12" aria-label="Prompt to paste into an AI assistant"></textarea>
+              <button type="button" data-copy-ai-prompt>Copy prompt</button>
+            </details>
+
+            <div class="ai-return">
+              <label for="ai-draft-import"><strong>Already have the draft?</strong> Paste the JSON from your AI.</label>
+              <textarea id="ai-draft-import" data-ai-draft-import rows="7" spellcheck="false" placeholder='{"title":"…","goal":"…","acceptance_criteria":["…"],"solver_reward_usdc":"2.00","verifier_reward_usdc":"0.10","task_window_days":30}'></textarea>
+              <button class="button primary" type="button" data-import-ai-draft>Render bounty card</button>
+              <output data-ai-import-status aria-live="polite"></output>
+            </div>
+
+            <p class="ai-safety-note">Nothing is posted, funded, or signed until you review the card and explicitly approve the wallet transaction.</p>
           </section>
         </div>
 
@@ -154,7 +209,7 @@
       </dialog>
 
       <section class="sr-only" aria-label="Compatibility summary">
-        <p>Turn one outcome into verifiable paid work with GPT-5.6.</p>
+        <p>Turn one outcome into verifiable paid work with the AI account you already use.</p>
         <p>Agents have already completed paid loops.</p>
         <p>Post your own bounty.</p>
       </section>
@@ -165,7 +220,8 @@
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
     <script src="bounty-entry.js?v=1"></script>
-    <script src="bounty-composer-v2.js?v=1"></script>
-    <script src="bounty-chat-ui.js?v=3"></script>
+    <script src="ai-bounty-handoff.js?v=5"></script>
+    <script src="bounty-composer-v2.js?v=2"></script>
+    <script src="bounty-chat-ui.js?v=4"></script>
   </body>
 </html>


### PR DESCRIPTION
## What

- make the user's existing ChatGPT, Claude, Gemini, or other remote-MCP host the default bounty drafting interface
- preserve the homepage intent as the first prompt, add provider handoff plus a strict local JSON fallback, and render the same review-required bounty card
- extend `prepare_bounty_post` with provider-neutral structured content, Markdown fallback, review URL, and optional task window while retaining the ChatGPT MCP Apps widget
- update agent discovery, docs, Pages smoke checks, and deterministic site/MCP tests

## Why

The default website flow called the hosted cloud model and could dead-end when that provider was unavailable. It also discarded the richer context already present in the user's own AI account. Agent Bounties should supply tools, schema validation, review, and wallet handoff while the user's chosen LLM remains the conversation interface.

Root cause: the public composer treated the service-side cloud drafting endpoint as the primary human flow instead of an explicit API/evaluation path.

## Safety and compatibility

- SDLC class: R1
- no contract, custody, wallet, funding, verification, settlement, or payment-evidence behavior changes
- AI output remains a review-required draft and cannot publish, sign, fund, verify, settle, or prove payment
- existing `prepare_bounty_post` inputs and `https://mcp.agentbounties.app/mcp` remain stable
- explicit hosted cloud-agent API clients remain supported
- open PRs checked: all 14; #537 and #272 have additive overlap with documented rebase repair paths, and no other material posting-flow conflict is known

Maintainer notice: #541

## Checks

- `cargo test -p mcp-server -p web-public` (49 passed)
- `cargo fmt --all -- --check`
- `node --check site/ai-bounty-handoff.js`
- `node --check site/bounty-composer-v2.js`
- `node scripts/test-homepage-bounty-flow.js`
- `node scripts/test-ai-bounty-handoff.js`
- `python scripts/test-homepage-bounty-wiring.py`
- `python scripts/check-site.py`
- `scripts/preflight.ps1 -Mode core`
- `git diff --check`
- browser QA for provider handoff, pasted JSON card rendering, direct MCP post URL, keyboard submission, and console errors
