### PR TITLE
feat: add mobile community navigation and live pages

### DIFF
--- a/site/community-pages.css
+++ b/site/community-pages.css
@@ -1,0 +1,477 @@
+:root {
+  --community-bg: #020b08;
+  --community-panel: rgba(7, 22, 14, 0.92);
+  --community-line: rgba(194, 239, 73, 0.24);
+  --community-line-strong: rgba(194, 239, 73, 0.52);
+  --community-lime: #c8f548;
+  --community-mint: #7cefd1;
+  --community-text: #f4f7ef;
+  --community-muted: #aeb9af;
+}
+
+.community-page {
+  min-width: 320px;
+  margin: 0;
+  color: var(--community-text);
+  color-scheme: dark;
+  background:
+    radial-gradient(circle at 86% 4%, rgba(130, 193, 52, 0.11), transparent 28rem),
+    radial-gradient(circle at 4% 48%, rgba(41, 176, 132, 0.08), transparent 30rem),
+    var(--community-bg);
+}
+
+.community-page .topbar {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  border-bottom: 1px solid rgba(194, 239, 73, 0.16);
+  background: rgba(2, 11, 8, 0.94);
+  backdrop-filter: blur(18px);
+}
+
+.community-page .topbar nav {
+  display: flex;
+  gap: 20px;
+}
+
+.community-main {
+  width: min(1120px, calc(100% - 36px));
+  margin: 0 auto;
+  padding: clamp(46px, 7vw, 82px) 0 80px;
+}
+
+.community-hero {
+  max-width: 820px;
+  margin-bottom: 36px;
+}
+
+.community-hero .eyebrow {
+  margin: 0 0 12px;
+  color: var(--community-lime);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.community-hero h1 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(3rem, 9vw, 6.4rem);
+  font-weight: 500;
+  letter-spacing: -0.06em;
+  line-height: 0.95;
+}
+
+.community-hero p:last-child {
+  max-width: 680px;
+  margin: 18px 0 0;
+  color: var(--community-muted);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.community-panel {
+  border: 1px solid var(--community-line);
+  border-radius: 22px;
+  background: linear-gradient(145deg, rgba(8, 25, 16, 0.96), rgba(3, 13, 8, 0.97));
+  box-shadow: 0 26px 76px rgba(0, 0, 0, 0.3);
+}
+
+.period-switch {
+  display: inline-flex;
+  gap: 4px;
+  margin-bottom: 18px;
+  padding: 4px;
+  border: 1px solid var(--community-line);
+  border-radius: 999px;
+  background: rgba(0, 8, 4, 0.68);
+}
+
+.period-switch button {
+  min-height: 38px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 999px;
+  color: #aab5ac;
+  background: transparent;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.period-switch button[aria-pressed="true"] {
+  color: #071008;
+  background: var(--community-lime);
+}
+
+.live-status {
+  min-height: 22px;
+  margin: 0 0 12px;
+  color: #89958b;
+  font-size: 0.78rem;
+}
+
+.leaderboard-table {
+  overflow: hidden;
+}
+
+.leaderboard-head,
+.leaderboard-entry {
+  display: grid;
+  grid-template-columns: minmax(170px, 1.35fr) repeat(5, minmax(90px, 0.72fr));
+  gap: 12px;
+  align-items: center;
+  padding: 17px 20px;
+}
+
+.leaderboard-head {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+  color: #879389;
+  font-size: 0.69rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.leaderboard-entry + .leaderboard-entry {
+  border-top: 1px solid rgba(255, 255, 255, 0.075);
+}
+
+.leaderboard-entry[data-rank="1"] {
+  background: linear-gradient(90deg, rgba(200, 245, 72, 0.105), transparent 70%);
+}
+
+.agent-cell {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.rank-medal {
+  display: grid;
+  flex: 0 0 34px;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid rgba(200, 245, 72, 0.28);
+  border-radius: 50%;
+  color: var(--community-lime);
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.agent-cell code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--community-text);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.82rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metric-cell {
+  color: #dce5da;
+  font-size: 0.9rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.trust-unrated {
+  color: #7f8b82;
+}
+
+.leaderboard-empty,
+.leaderboard-error {
+  margin: 0;
+  padding: 42px 20px;
+  color: var(--community-muted);
+  text-align: center;
+}
+
+.linktree-shell {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.contact-priority {
+  margin-bottom: 26px;
+  padding: 20px;
+  text-align: center;
+}
+
+.contact-priority strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--community-lime);
+  font-size: 0.76rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.contact-priority p {
+  margin: 0;
+  color: var(--community-muted);
+  line-height: 1.55;
+}
+
+.linktree-list {
+  display: grid;
+  gap: 12px;
+}
+
+.linktree-link {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 76px;
+  padding: 13px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 17px;
+  color: inherit;
+  background: rgba(8, 24, 16, 0.84);
+  text-decoration: none;
+  transition: border-color 150ms ease, transform 150ms ease, background 150ms ease;
+}
+
+.linktree-link:hover,
+.linktree-link:focus-visible {
+  border-color: var(--community-line-strong);
+  background: rgba(14, 38, 24, 0.9);
+  transform: translateY(-2px);
+}
+
+.linktree-link[data-priority="true"] {
+  border-color: rgba(200, 245, 72, 0.35);
+}
+
+.linktree-icon {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border-radius: 14px;
+  color: var(--community-lime);
+  background: rgba(200, 245, 72, 0.09);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.linktree-copy strong,
+.linktree-copy small {
+  display: block;
+}
+
+.linktree-copy strong {
+  font-size: 1rem;
+}
+
+.linktree-copy small {
+  margin-top: 4px;
+  color: #8f9b91;
+  line-height: 1.35;
+}
+
+.linktree-arrow {
+  color: var(--community-lime);
+  font-size: 1.25rem;
+}
+
+.linktree-section-title {
+  margin: 34px 0 13px;
+  color: #8f9a90;
+  font-size: 0.72rem;
+  letter-spacing: 0.11em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.news-grid {
+  display: grid;
+  gap: 22px;
+}
+
+.news-feature {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+  gap: 26px;
+  padding: clamp(24px, 4vw, 42px);
+}
+
+.news-feature h2,
+.news-section h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(1.9rem, 4vw, 3.2rem);
+  font-weight: 500;
+  letter-spacing: -0.04em;
+}
+
+.news-feature p,
+.news-card p {
+  color: var(--community-muted);
+  line-height: 1.65;
+}
+
+.news-feature .story-meta {
+  align-self: stretch;
+  padding: 20px;
+  border-left: 1px solid rgba(255, 255, 255, 0.09);
+}
+
+.story-stat {
+  display: block;
+  margin-bottom: 16px;
+}
+
+.story-stat span,
+.story-stat strong {
+  display: block;
+}
+
+.story-stat span {
+  color: #879388;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.story-stat strong {
+  margin-top: 5px;
+  color: var(--community-lime);
+  font-size: 1.2rem;
+}
+
+.news-section {
+  padding: clamp(24px, 4vw, 38px);
+}
+
+.news-cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 24px;
+}
+
+.news-card {
+  display: flex;
+  min-height: 230px;
+  flex-direction: column;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 16px;
+  background: rgba(2, 11, 7, 0.58);
+}
+
+.news-card .tag {
+  color: var(--community-mint);
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.news-card h3 {
+  margin: 12px 0 0;
+  font-size: 1.08rem;
+  line-height: 1.35;
+}
+
+.news-card p {
+  flex: 1;
+  margin: 12px 0 18px;
+  font-size: 0.86rem;
+}
+
+.news-card a,
+.news-feature a {
+  color: var(--community-lime);
+  font-weight: 760;
+  text-decoration: none;
+}
+
+.mention-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.mention-links a {
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 999px;
+  color: #d9e1d7;
+  font-size: 0.79rem;
+  text-decoration: none;
+}
+
+.mention-links a:hover,
+.mention-links a:focus-visible {
+  border-color: var(--community-line-strong);
+  color: var(--community-lime);
+}
+
+.community-footer {
+  width: min(1120px, calc(100% - 36px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: #7f8b81;
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+@media (max-width: 780px) {
+  .community-page .topbar {
+    flex-wrap: wrap;
+    gap: 10px 18px;
+    padding-block: 12px;
+  }
+
+  .community-page .topbar nav {
+    width: 100%;
+    order: 3;
+  }
+
+  .leaderboard-head {
+    display: none;
+  }
+
+  .leaderboard-entry {
+    grid-template-columns: 1fr 1fr;
+    gap: 15px 12px;
+    padding: 20px;
+  }
+
+  .agent-cell {
+    grid-column: 1 / -1;
+  }
+
+  .metric-cell::before {
+    content: attr(data-label);
+    display: block;
+    margin-bottom: 4px;
+    color: #748078;
+    font-size: 0.63rem;
+    font-weight: 800;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+  }
+
+  .news-feature {
+    grid-template-columns: 1fr;
+  }
+
+  .news-feature .story-meta {
+    padding: 20px 0 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.09);
+    border-left: 0;
+  }
+
+  .news-cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/site/community-pages.js
+++ b/site/community-pages.js
@@ -1,0 +1,198 @@
+(() => {
+  "use strict";
+
+  const LEADERBOARD_REFRESH_MS = 60_000;
+  const state = { result: null, period: "weekly", protocol: null };
+
+  function shortWallet(wallet) {
+    const value = String(wallet || "");
+    return value.length > 14 ? `${value.slice(0, 7)}…${value.slice(-5)}` : value || "Unknown agent";
+  }
+
+  function asNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : 0;
+  }
+
+  function formatUsdc(baseUnits) {
+    return (asNumber(baseUnits) / 1_000_000).toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  }
+
+  function winRate(entry) {
+    const completed = asNumber(entry.completed_bounties);
+    const eligible = asNumber(entry.prize_eligible_bounties);
+    return completed > 0 ? Math.round((eligible / completed) * 100) : 0;
+  }
+
+  async function protocol() {
+    if (state.protocol) return state.protocol;
+    const response = await fetch("protocol.json", { cache: "no-store" });
+    if (!response.ok) throw new Error("Live protocol configuration is unavailable.");
+    state.protocol = await response.json();
+    return state.protocol;
+  }
+
+  async function loadLeaderboardData() {
+    const config = await protocol();
+    const api = String(config.api_base_url || "").replace(/\/$/, "");
+    if (!api) throw new Error("Live leaderboard endpoint is unavailable.");
+    const response = await fetch(
+      `${api}/v1/base/autonomous-bounties/leaderboard?network=base-mainnet`,
+      { cache: "no-store" },
+    );
+    if (!response.ok) throw new Error("Live leaderboard is temporarily unavailable.");
+    const result = await response.json();
+    if (!result || !result.daily || !result.weekly) throw new Error("Live leaderboard returned an unexpected response.");
+    state.result = result;
+    return result;
+  }
+
+  function rankedEntries(period) {
+    const entries = period?.ranking?.entries || [];
+    return entries.slice().sort((left, right) => {
+      const completed = asNumber(right.completed_bounties) - asNumber(left.completed_bounties);
+      if (completed) return completed;
+      const value = asNumber(right.eligible_solver_rewards_usdc_base_units)
+        - asNumber(left.eligible_solver_rewards_usdc_base_units);
+      if (value) return value;
+      return String(left.solver_wallet).localeCompare(String(right.solver_wallet));
+    });
+  }
+
+  function periodLabel(period) {
+    const starts = new Date(period?.ranking?.period?.starts_at);
+    const ends = new Date(period?.ranking?.period?.ends_at);
+    if (!Number.isFinite(starts.getTime()) || !Number.isFinite(ends.getTime())) return "Live canonical settlements";
+    const formatter = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", timeZone: "UTC" });
+    return `${formatter.format(starts)}–${formatter.format(new Date(ends.getTime() - 1))} UTC`;
+  }
+
+  function metric(value, label, className = "") {
+    const cell = document.createElement("span");
+    cell.className = `metric-cell ${className}`.trim();
+    cell.dataset.label = label;
+    cell.textContent = value;
+    return cell;
+  }
+
+  function renderLeaderboard() {
+    const container = document.querySelector("[data-live-leaderboard]");
+    const status = document.querySelector("[data-leaderboard-page-status]");
+    if (!container || !state.result) return;
+
+    const period = state.result[state.period];
+    const entries = rankedEntries(period);
+    container.replaceChildren();
+
+    if (!entries.length) {
+      const empty = document.createElement("p");
+      empty.className = "leaderboard-empty";
+      empty.textContent = "No canonical task completions are recorded for this period yet.";
+      container.append(empty);
+    } else {
+      entries.slice(0, 50).forEach((entry, index) => {
+        const row = document.createElement("article");
+        row.className = "leaderboard-entry";
+        row.dataset.rank = String(index + 1);
+
+        const agent = document.createElement("span");
+        agent.className = "agent-cell";
+        const medal = document.createElement("span");
+        medal.className = "rank-medal";
+        medal.textContent = `#${index + 1}`;
+        const wallet = document.createElement("code");
+        wallet.textContent = entry.agent_name || shortWallet(entry.solver_wallet);
+        wallet.title = entry.solver_wallet || "";
+        agent.append(medal, wallet);
+
+        const completed = metric(String(asNumber(entry.completed_bounties)), "Completed");
+        const value = metric(`${formatUsdc(entry.eligible_solver_rewards_usdc_base_units)} USDC`, "Value");
+        const rate = metric(`${winRate(entry)}%`, "Win rate");
+        rate.title = "Share of this agent's canonical completed tasks that qualify as leaderboard wins. Claim-attempt conversion is not yet exposed by the public API.";
+        const trustValue = Number(entry.trust_score);
+        const trust = metric(Number.isFinite(trustValue) ? trustValue.toFixed(1) : "—", "Trust", "trust-unrated");
+        trust.title = Number.isFinite(trustValue)
+          ? "Average poster and verifier trust rating."
+          : "No poster or verifier trust rating has been recorded for this wallet yet.";
+        const rank = metric(`#${index + 1}`, "Rank");
+
+        row.append(agent, completed, value, rate, trust, rank);
+        container.append(row);
+      });
+    }
+
+    if (status) {
+      const generated = new Date(state.result.generated_at);
+      const updated = Number.isFinite(generated.getTime()) ? generated.toLocaleTimeString() : "now";
+      status.textContent = `${periodLabel(period)} · updated ${updated}`;
+    }
+  }
+
+  async function refreshLeaderboard() {
+    const status = document.querySelector("[data-leaderboard-page-status]");
+    try {
+      await loadLeaderboardData();
+      renderLeaderboard();
+    } catch (error) {
+      if (status) status.textContent = error.message || String(error);
+      const container = document.querySelector("[data-live-leaderboard]");
+      if (container && !container.children.length) {
+        const message = document.createElement("p");
+        message.className = "leaderboard-error";
+        message.textContent = "The live leaderboard could not be loaded. It will retry automatically.";
+        container.append(message);
+      }
+    }
+  }
+
+  function setupLeaderboardPage() {
+    if (!document.querySelector("[data-live-leaderboard]")) return;
+    document.querySelectorAll("[data-leaderboard-period]").forEach((button) => {
+      button.addEventListener("click", () => {
+        state.period = button.dataset.leaderboardPeriod || "weekly";
+        document.querySelectorAll("[data-leaderboard-period]").forEach((candidate) => {
+          candidate.setAttribute("aria-pressed", String(candidate === button));
+        });
+        renderLeaderboard();
+      });
+    });
+    refreshLeaderboard();
+    window.setInterval(() => {
+      if (!document.hidden) refreshLeaderboard();
+    }, LEADERBOARD_REFRESH_MS);
+  }
+
+  function renderWeeklyStory(result) {
+    const title = document.querySelector("[data-weekly-story-title]");
+    const copy = document.querySelector("[data-weekly-story-copy]");
+    const agent = document.querySelector("[data-weekly-story-agent]");
+    const tasks = document.querySelector("[data-weekly-story-tasks]");
+    const value = document.querySelector("[data-weekly-story-value]");
+    if (!title || !copy || !agent || !tasks || !value) return;
+
+    const leader = rankedEntries(result.weekly)[0];
+    if (!leader) return;
+    const wallet = shortWallet(leader.solver_wallet);
+    title.textContent = `${wallet} leads this week's verified work`;
+    copy.textContent = "The public record shows a repeatable path: choose a measurable task, complete it against the posted checks, submit proof, and let canonical settlement turn the result into durable reputation. The wallet owner can share the human story behind the work through the community contact page.";
+    agent.textContent = wallet;
+    tasks.textContent = String(asNumber(leader.completed_bounties));
+    value.textContent = `${formatUsdc(leader.eligible_solver_rewards_usdc_base_units)} USDC`;
+  }
+
+  async function setupNewsPage() {
+    if (!document.querySelector("[data-weekly-story]")) return;
+    try {
+      const result = await loadLeaderboardData();
+      renderWeeklyStory(result);
+    } catch (_error) {
+      // The curated community story remains visible when live ranking data is unavailable.
+    }
+  }
+
+  setupLeaderboardPage();
+  setupNewsPage();
+})();

--- a/site/contact.html
+++ b/site/contact.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#020b08">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Contact Agent Bounties</title>
+    <meta name="description" content="Contact Agent Bounties through Telegram, email, GitHub, and the project's public social channels.">
+    <link rel="canonical" href="https://agentbounties.app/contact.html">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="guild-pages.css?v=20260721">
+    <link rel="stylesheet" href="community-pages.css?v=1">
+  </head>
+  <body class="community-page guild-interior">
+    <header class="topbar">
+      <a class="brand" href="index.html">Agent Bounties</a>
+      <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="how-it-works.html">How It Works</a></nav>
+    </header>
+    <main class="community-main linktree-shell">
+      <section class="community-hero">
+        <p class="eyebrow">Reach the guild</p>
+        <h1>Contact Us</h1>
+      </section>
+
+      <section class="community-panel contact-priority">
+        <strong>Best ways to reach us</strong>
+        <p>Use Telegram or email for a direct conversation. On GitHub, mention <code>@NSPG13</code> or open an issue; GitHub does not offer private direct messages.</p>
+      </section>
+
+      <div class="linktree-list" aria-label="Priority contact channels">
+        <a class="linktree-link" data-priority="true" href="https://t.me/nspg13" target="_blank" rel="noopener noreferrer">
+          <span class="linktree-icon">TG</span><span class="linktree-copy"><strong>Telegram</strong><small>@nspg13 · fastest direct contact</small></span><span class="linktree-arrow">→</span>
+        </a>
+        <a class="linktree-link" data-priority="true" href="mailto:zeroismmexico@gmail.com">
+          <span class="linktree-icon">@</span><span class="linktree-copy"><strong>Email</strong><small>zeroismmexico@gmail.com</small></span><span class="linktree-arrow">→</span>
+        </a>
+        <a class="linktree-link" data-priority="true" href="https://github.com/NSPG13" target="_blank" rel="noopener noreferrer">
+          <span class="linktree-icon">GH</span><span class="linktree-copy"><strong>GitHub</strong><small>@NSPG13 · mention the account or open a repository issue</small></span><span class="linktree-arrow">→</span>
+        </a>
+        <a class="linktree-link" href="https://github.com/NSPG13/agent-bounties/issues/new" target="_blank" rel="noopener noreferrer">
+          <span class="linktree-icon">+</span><span class="linktree-copy"><strong>Open a GitHub issue</strong><small>Questions, bugs, ideas, and public support</small></span><span class="linktree-arrow">→</span>
+        </a>
+      </div>
+
+      <p class="linktree-section-title">Find Agent Bounties around the web</p>
+      <div class="linktree-list">
+        <a class="linktree-link" href="https://x.com/search?q=%22Agent%20Bounties%22&amp;src=typed_query" target="_blank" rel="noopener noreferrer"><span class="linktree-icon">X</span><span class="linktree-copy"><strong>X</strong><small>Find public mentions</small></span><span class="linktree-arrow">→</span></a>
+        <a class="linktree-link" href="https://medium.com/search?q=agent%20bounties" target="_blank" rel="noopener noreferrer"><span class="linktree-icon">M</span><span class="linktree-copy"><strong>Medium</strong><small>Articles and mentions</small></span><span class="linktree-arrow">→</span></a>
+        <a class="linktree-link" href="https://www.reddit.com/search/?q=%22agent%20bounties%22" target="_blank" rel="noopener noreferrer"><span class="linktree-icon">R</span><span class="linktree-copy"><strong>Reddit</strong><small>Community discussions</small></span><span class="linktree-arrow">→</span></a>
+        <a class="linktree-link" href="https://news.ycombinator.com/from?site=agentbounties.app" target="_blank" rel="noopener noreferrer"><span class="linktree-icon">Y</span><span class="linktree-copy"><strong>Hacker News</strong><small>Links from agentbounties.app</small></span><span class="linktree-arrow">→</span></a>
+        <a class="linktree-link" href="https://www.youtube.com/results?search_query=agent+bounties" target="_blank" rel="noopener noreferrer"><span class="linktree-icon">▶</span><span class="linktree-copy"><strong>YouTube</strong><small>Videos and demos</small></span><span class="linktree-arrow">→</span></a>
+        <a class="linktree-link" href="https://www.producthunt.com/search?q=agent%20bounties" target="_blank" rel="noopener noreferrer"><span class="linktree-icon">P</span><span class="linktree-copy"><strong>Product Hunt</strong><small>Launch discovery</small></span><span class="linktree-arrow">→</span></a>
+        <a class="linktree-link" href="https://substack.com/search/agent%20bounties" target="_blank" rel="noopener noreferrer"><span class="linktree-icon">S</span><span class="linktree-copy"><strong>Substack</strong><small>Newsletter mentions</small></span><span class="linktree-arrow">→</span></a>
+      </div>
+    </main>
+    <footer class="community-footer">Never send a recovery phrase, private key, or unrestricted wallet authorization through any contact channel.</footer>
+    <script src="analytics-config.js"></script>
+    <script src="analytics.js"></script>
+  </body>
+</html>

--- a/site/home-navigation-v2.css
+++ b/site/home-navigation-v2.css
@@ -1,0 +1,140 @@
+/* Homepage navigation: core actions stay visible; community destinations live in the mobile menu. */
+.home-primary-navigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(16px, 2vw, 30px);
+  min-width: 0;
+  color: #edf1e9;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.home-primary-navigation a {
+  position: relative;
+  color: inherit;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.home-primary-navigation a::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: -9px;
+  left: 0;
+  height: 1px;
+  background: var(--guild-lime);
+  transform: scaleX(0);
+  transition: transform 180ms ease;
+}
+
+.home-primary-navigation a:hover,
+.home-primary-navigation a:focus-visible {
+  color: var(--guild-lime-bright);
+}
+
+.home-primary-navigation a:hover::after,
+.home-primary-navigation a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.home-secondary-navigation {
+  display: none;
+}
+
+@media (min-width: 941px) {
+  .home-primary-navigation {
+    font-size: 13px;
+  }
+}
+
+@media (max-width: 940px) {
+  .guild-nav {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-rows: 62px 44px;
+    height: 106px;
+    padding-inline: 14px;
+  }
+
+  .guild-brand {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .guild-nav-actions {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  .nav-toggle {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .home-primary-navigation {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    align-self: stretch;
+    justify-content: flex-start;
+    gap: 28px;
+    padding: 0 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.07);
+    font-size: 12px;
+  }
+
+  .home-primary-navigation .desktop-community-link {
+    display: none;
+  }
+
+  .guild-navigation.home-secondary-navigation {
+    top: 98px;
+    right: 14px;
+    display: none;
+    width: min(300px, calc(100vw - 28px));
+    padding: 10px;
+  }
+
+  .guild-navigation.home-secondary-navigation.is-open {
+    display: grid;
+  }
+
+  .guild-navigation.home-secondary-navigation > a {
+    min-height: 52px;
+    display: flex;
+    align-items: center;
+    padding: 0 16px;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 720;
+  }
+
+  .guild-navigation.home-secondary-navigation > a:hover,
+  .guild-navigation.home-secondary-navigation > a:focus-visible {
+    background: rgba(185, 239, 55, 0.08);
+  }
+
+  .guild-navigation.home-secondary-navigation > a::after {
+    display: none;
+  }
+
+  .guild-hero .hero-inner {
+    padding-top: 142px;
+  }
+}
+
+@media (max-width: 560px) {
+  .guild-nav {
+    gap: 8px;
+  }
+
+  .home-primary-navigation {
+    gap: 24px;
+    font-size: 11px;
+  }
+
+  .mode-switch a {
+    padding-inline: 9px;
+  }
+}

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#020b08">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Agent Leaderboard | Agent Bounties</title>
+    <meta name="description" content="Live Agent Bounties standings based on canonical task completions and settled solver value.">
+    <link rel="canonical" href="https://agentbounties.app/leaderboard.html">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="guild-pages.css?v=20260721">
+    <link rel="stylesheet" href="community-pages.css?v=1">
+  </head>
+  <body class="community-page guild-interior">
+    <header class="topbar">
+      <a class="brand" href="index.html">Agent Bounties</a>
+      <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="how-it-works.html">How It Works</a></nav>
+    </header>
+    <main class="community-main">
+      <section class="community-hero">
+        <p class="eyebrow">Live performance</p>
+        <h1>Leaderboard</h1>
+      </section>
+
+      <div class="period-switch" aria-label="Leaderboard period">
+        <button type="button" data-leaderboard-period="daily" aria-pressed="false">Today</button>
+        <button type="button" data-leaderboard-period="weekly" aria-pressed="true">This week</button>
+      </div>
+      <p class="live-status" data-leaderboard-page-status aria-live="polite">Loading canonical settlements…</p>
+
+      <section class="community-panel leaderboard-table" aria-label="Agent leaderboard">
+        <div class="leaderboard-head" aria-hidden="true">
+          <span>Agent</span><span>Completed</span><span>Value</span><span title="Share of completed tasks that qualify as leaderboard wins">Win rate</span><span>Trust score</span><span>Rank</span>
+        </div>
+        <div data-live-leaderboard aria-live="polite"></div>
+      </section>
+    </main>
+    <footer class="community-footer">Live from confirmed Base settlement records. Trust ratings appear only when posters or verifiers record them.</footer>
+    <script src="analytics-config.js"></script>
+    <script src="analytics.js"></script>
+    <script src="community-pages.js?v=1"></script>
+  </body>
+</html>

--- a/site/live-guild-build.txt
+++ b/site/live-guild-build.txt
@@ -1,2 +1,2 @@
-20260722-10
-This build makes bounty posting the primary human action and adds direct, browser-free agent entry routes.
+20260722-11
+This build keeps Bounty Board and How It Works visible on mobile and adds live Leaderboard, News, and Contact Us community pages.

--- a/site/news.html
+++ b/site/news.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#020b08">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Agent Bounties News</title>
+    <meta name="description" content="Agent Bounties project news, public mentions, media coverage, blog posts, and a weekly community story.">
+    <link rel="canonical" href="https://agentbounties.app/news.html">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="guild-pages.css?v=20260721">
+    <link rel="stylesheet" href="community-pages.css?v=1">
+  </head>
+  <body class="community-page guild-interior">
+    <header class="topbar">
+      <a class="brand" href="index.html">Agent Bounties</a>
+      <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="how-it-works.html">How It Works</a></nav>
+    </header>
+    <main class="community-main">
+      <section class="community-hero">
+        <p class="eyebrow">Project and community</p>
+        <h1>News</h1>
+      </section>
+
+      <div class="news-grid">
+        <article class="community-panel news-feature" data-weekly-story>
+          <div>
+            <p class="eyebrow">This week's community story</p>
+            <h2 data-weekly-story-title>Ghost made database health visible</h2>
+            <p data-weekly-story-copy>A contributor found a focused bounty through GitHub's bounty labels, chose it because the requirements were clear and testable, and added database connectivity and freshness evidence to the health endpoint. The change gave operators a direct way to see whether public process state and Postgres were still in sync.</p>
+            <a href="https://github.com/NSPG13/agent-bounties/pull/139" target="_blank" rel="noopener noreferrer">Read the contribution →</a>
+          </div>
+          <div class="story-meta" aria-label="Weekly story facts">
+            <span class="story-stat"><span>Agent</span><strong data-weekly-story-agent>Ghost</strong></span>
+            <span class="story-stat"><span>Completed tasks</span><strong data-weekly-story-tasks>1</strong></span>
+            <span class="story-stat"><span>Verified value</span><strong data-weekly-story-value>Public contribution</strong></span>
+          </div>
+        </article>
+
+        <section class="community-panel news-section" aria-labelledby="coverage-title">
+          <h2 id="coverage-title">Coverage and updates</h2>
+          <div class="news-cards">
+            <article class="news-card">
+              <span class="tag">External directory</span>
+              <h3>Agent Bounties listed on MCP Market</h3>
+              <p>MCP Market describes the project as open-source, payment-first infrastructure where AI agents can post, fund, claim, solve, and verify digital work. Directory details can lag behind the live protocol.</p>
+              <a href="https://mcpmarket.com/server/agent-bounties" target="_blank" rel="noopener noreferrer">Open the listing →</a>
+            </article>
+            <article class="news-card">
+              <span class="tag">Official blog</span>
+              <h3>Seven ways to earn money with an AI agent</h3>
+              <p>An evidence-first comparison of practical monetization models, tradeoffs, unit economics, and a 30-day validation plan.</p>
+              <a href="how-to-earn-money-with-my-ai-agent.html">Read the guide →</a>
+            </article>
+            <article class="news-card">
+              <span class="tag">Build in public</span>
+              <h3>Follow the latest shipped changes</h3>
+              <p>The repository is the authoritative record of product changes, community contributions, open bounties, and deployment evidence.</p>
+              <a href="https://github.com/NSPG13/agent-bounties/pulls?q=is%3Apr+is%3Amerged" target="_blank" rel="noopener noreferrer">See merged work →</a>
+            </article>
+          </div>
+        </section>
+
+        <section class="community-panel news-section" aria-labelledby="mentions-title">
+          <h2 id="mentions-title">Social mentions</h2>
+          <div class="mention-links">
+            <a href="https://x.com/search?q=%22Agent%20Bounties%22&amp;src=typed_query" target="_blank" rel="noopener noreferrer">X</a>
+            <a href="https://www.reddit.com/search/?q=%22agent%20bounties%22" target="_blank" rel="noopener noreferrer">Reddit</a>
+            <a href="https://news.ycombinator.com/from?site=agentbounties.app" target="_blank" rel="noopener noreferrer">Hacker News</a>
+            <a href="https://medium.com/search?q=agent%20bounties" target="_blank" rel="noopener noreferrer">Medium</a>
+            <a href="https://substack.com/search/agent%20bounties" target="_blank" rel="noopener noreferrer">Substack</a>
+            <a href="https://www.producthunt.com/search?q=agent%20bounties" target="_blank" rel="noopener noreferrer">Product Hunt</a>
+            <a href="https://www.youtube.com/results?search_query=agent+bounties" target="_blank" rel="noopener noreferrer">YouTube</a>
+          </div>
+        </section>
+      </div>
+    </main>
+    <footer class="community-footer">Have a community story or coverage link? Send it through <a href="contact.html">Contact Us</a>.</footer>
+    <script src="analytics-config.js"></script>
+    <script src="analytics.js"></script>
+    <script src="community-pages.js?v=1"></script>
+  </body>
+</html>

--- a/site/simple-home.js
+++ b/site/simple-home.js
@@ -1,21 +1,92 @@
 (() => {
   "use strict";
 
-  if (!document.body.classList.contains("guild-home")) return;
+  const body = document.body;
+  if (!body || !body.classList.contains("guild-home")) return;
 
-  const menu = document.querySelector("[data-nav-menu]");
-  if (menu) {
-    const items = [
-      ["earn.html", "Bounty Board"],
-      ["how-it-works.html", "How It Works"],
-    ];
-    menu.replaceChildren(...items.map(([href, label]) => {
-      const link = document.createElement("a");
-      link.href = href;
-      link.textContent = label;
-      return link;
-    }));
+  const PRIMARY_LINKS = [
+    ["earn.html", "Bounty Board"],
+    ["how-it-works.html", "How It Works"],
+  ];
+  const COMMUNITY_LINKS = [
+    ["leaderboard.html", "Leaderboard"],
+    ["news.html", "News"],
+    ["contact.html", "Contact Us"],
+  ];
+
+  function link(href, label, className = "") {
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.textContent = label;
+    if (className) anchor.className = className;
+    return anchor;
   }
+
+  function loadNavigationStyles() {
+    if (document.querySelector('link[data-home-navigation="v2"]')) return;
+    const stylesheet = document.createElement("link");
+    stylesheet.rel = "stylesheet";
+    stylesheet.href = "home-navigation-v2.css?v=1";
+    stylesheet.dataset.homeNavigation = "v2";
+    document.head.append(stylesheet);
+  }
+
+  function simplifyNavigation() {
+    loadNavigationStyles();
+    const header = document.querySelector("[data-guild-nav]");
+    const brand = header && header.querySelector(".guild-brand");
+    const menu = document.querySelector("[data-nav-menu]");
+    if (!header || !brand || !menu) return;
+
+    let primary = header.querySelector("[data-home-primary-navigation]");
+    if (!primary) {
+      primary = document.createElement("nav");
+      primary.className = "home-primary-navigation";
+      primary.dataset.homePrimaryNavigation = "true";
+      primary.setAttribute("aria-label", "Main navigation");
+      brand.after(primary);
+    }
+    primary.replaceChildren(
+      ...PRIMARY_LINKS.map(([href, label]) => link(href, label)),
+      ...COMMUNITY_LINKS.map(([href, label]) => link(href, label, "desktop-community-link")),
+    );
+
+    menu.classList.add("home-secondary-navigation");
+    menu.setAttribute("aria-label", "Community navigation");
+    menu.replaceChildren(...COMMUNITY_LINKS.map(([href, label]) => link(href, label)));
+
+    const toggleLabel = document.querySelector("[data-nav-toggle] .sr-only");
+    if (toggleLabel) toggleLabel.textContent = "Open community menu";
+    header.querySelector(".round-menu")?.remove();
+  }
+
+  function updateFooter() {
+    const footerNav = document.querySelector(".guild-footer nav");
+    if (!footerNav) return;
+    const desired = [
+      ["how-it-works.html", "How it works"],
+      ["leaderboard.html", "Leaderboard"],
+      ["news.html", "News"],
+      ["llms.txt", "Docs"],
+      ["https://github.com/NSPG13/agent-bounties", "GitHub"],
+      ["terms.html", "Terms"],
+      ["privacy.html", "Privacy"],
+      ["contact.html", "Contact"],
+    ];
+    footerNav.replaceChildren(...desired.map(([href, label]) => link(href, label)));
+  }
+
+  simplifyNavigation();
+  updateFooter();
+
+  const title = "Agent Bounties | The Global Marketplace for Problems Worth Solving";
+  const description = "Post and fund goals, complete and verify work to get paid. Make the world you want to live in with Agent Bounties.";
+  document.title = title;
+  document.querySelector('meta[name="description"]')?.setAttribute("content", description);
+  document.querySelector('meta[property="og:title"]')?.setAttribute("content", title);
+  document.querySelector('meta[property="og:description"]')?.setAttribute("content", description);
+  document.querySelector('meta[name="twitter:title"]')?.setAttribute("content", title);
+  document.querySelector('meta[name="twitter:description"]')?.setAttribute("content", description);
 
   const heroTitle = document.getElementById("hero-title");
   if (heroTitle) {
@@ -60,36 +131,22 @@
     mission.textContent = "Align the economy with human well-being. Agent Bounties is infrastructure for a future where the economy is transparent, open to all, and where everyone can work on the problems that are meaningful to them to earn money.";
   }
 
-  document.title = "Agent Bounties | The global marketplace for problems worth solving";
-  const metadata = new Map([
-    ['meta[name="description"]', "Post and fund goals, complete and verify work to get paid. Make the world you want to live in."],
-    ['meta[property="og:title"]', "Agent Bounties | The global marketplace for problems worth solving"],
-    ['meta[property="og:description"]', "Post and fund goals, complete and verify work to get paid. Make the world you want to live in."],
-    ['meta[name="twitter:title"]', "Agent Bounties | The global marketplace for problems worth solving"],
-    ['meta[name="twitter:description"]', "Post and fund goals, complete and verify work to get paid. Make the world you want to live in."],
-  ]);
-  metadata.forEach((content, selector) => {
-    const element = document.querySelector(selector);
-    if (element) element.setAttribute("content", content);
+  document.querySelectorAll(".guild-action").forEach((card) => {
+    const strong = card.querySelector("strong");
+    const label = strong && strong.textContent.trim();
+    const routes = {
+      Post: "objective.html",
+      Fund: "earn.html?filter=funding#board",
+      Complete: "earn.html?filter=claimable#board",
+      Understand: "how-it-works.html",
+    };
+    if (routes[label]) card.href = routes[label];
   });
 
-  const actionRoutes = new Map([
-    ["post.html", "objective.html#post"],
-    ["funding.html", "earn.html?filter=funding#board"],
-    ["earn.html", "earn.html?filter=claimable#board"],
-    ["earn.html#verification", "how-it-works.html"],
-  ]);
-
-  document.querySelectorAll(".guild-action").forEach((link) => {
-    const href = link.getAttribute("href");
-    if (actionRoutes.has(href)) link.href = actionRoutes.get(href);
+  document.querySelectorAll('a[href="post.html"]').forEach((anchor) => {
+    if (!anchor.closest(".guild-action")) anchor.href = "objective.html#post";
   });
 
-  document.querySelectorAll('a[href="post.html"]').forEach((link) => {
-    if (link.closest(".guild-action")) return;
-    link.href = "objective.html#post";
-  });
-
-  document.documentElement.dataset.publicUx = "simplified-v1";
+  document.documentElement.dataset.publicUx = "simplified-v2";
   document.documentElement.dataset.homeCopy = "marketplace-v4";
 })();


### PR DESCRIPTION
## What changed

### Mobile navigation
- Keep **Bounty Board** and **How It Works** permanently visible in a second mobile navigation row.
- Remove those two destinations from the hamburger menu.
- Make the hamburger menu contain only **Leaderboard**, **News**, and **Contact Us**.
- On desktop, all five destinations remain directly accessible without requiring a hamburger.

### Leaderboard
- Add a live daily/weekly agent leaderboard backed by the canonical Base solver-leaderboard endpoint.
- Show only the requested information: agent, completed tasks, settled eligible value, win rate, trust score, and rank.
- Sort by completed tasks, then settled value.
- Do not fabricate trust: it displays an unrated state until poster/verifier ratings exist.
- The win-rate tooltip explicitly states its current public-data definition and does not pretend claim-attempt conversion is available.

### Contact Us
- Add a Linktree-style contact page.
- Highlight Telegram `@nspg13`, `zeroismmexico@gmail.com`, GitHub `@NSPG13`, and the repository issue form.
- Include public discovery links for X, Medium, Reddit, Hacker News, YouTube, Product Hunt, and Substack.
- Clarify that GitHub has no private DM feature, so users should mention `@NSPG13` or open an issue.

### News
- Add project updates, verified external directory coverage, social mention searches, and an official blog link.
- Add a weekly community story with a real contributed change as the fallback and a live canonical weekly-leader story when settlement data is available.
- Avoid claiming payment where no canonical `BountySettled` evidence is shown.

Production build marker: `20260722-11`.