### PR TITLE
test: verify community pages on the custom domain

### DIFF
--- a/.github/workflows/community-pages-canary.yml
+++ b/.github/workflows/community-pages-canary.yml
@@ -1,0 +1,102 @@
+name: Community Pages Canary
+
+on:
+  workflow_run:
+    workflows: ["Pages"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      - name: Verify live mobile navigation and community pages
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LIVE_CANARY_ISSUE: "499"
+        run: |
+          set -euo pipefail
+          expected_build="$(head -n 1 site/live-guild-build.txt | tr -d '\r\n')"
+          success=false
+          attempts=0
+          failure_detail="deployment has not propagated"
+
+          for attempt in $(seq 1 60); do
+            attempts="$attempt"
+            nonce="${GITHUB_SHA}-${GITHUB_RUN_ATTEMPT}-${attempt}-$(date +%s)"
+            curl_args=(--fail --silent --show-error --location --retry 2 --retry-delay 1 --header "Cache-Control: no-cache" --header "Pragma: no-cache")
+
+            if curl "${curl_args[@]}" "https://agentbounties.app/live-guild-build.txt?verify=${nonce}" -o /tmp/community-build.txt \
+              && curl "${curl_args[@]}" "https://agentbounties.app/simple-home.js?verify=${nonce}" -o /tmp/community-home.js \
+              && curl "${curl_args[@]}" "https://agentbounties.app/home-navigation-v2.css?verify=${nonce}" -o /tmp/community-nav.css \
+              && curl "${curl_args[@]}" "https://agentbounties.app/leaderboard.html?verify=${nonce}" -o /tmp/community-leaderboard.html \
+              && curl "${curl_args[@]}" "https://agentbounties.app/news.html?verify=${nonce}" -o /tmp/community-news.html \
+              && curl "${curl_args[@]}" "https://agentbounties.app/contact.html?verify=${nonce}" -o /tmp/community-contact.html \
+              && curl "${curl_args[@]}" "https://agentbounties.app/community-pages.js?verify=${nonce}" -o /tmp/community-pages.js; then
+              actual_build="$(head -n 1 /tmp/community-build.txt | tr -d '\r\n')"
+              if [[ "$actual_build" == "$expected_build" ]] \
+                && grep -q '\["earn.html", "Bounty Board"\]' /tmp/community-home.js \
+                && grep -q '\["how-it-works.html", "How It Works"\]' /tmp/community-home.js \
+                && grep -q '\["leaderboard.html", "Leaderboard"\]' /tmp/community-home.js \
+                && grep -q '\["news.html", "News"\]' /tmp/community-home.js \
+                && grep -q '\["contact.html", "Contact Us"\]' /tmp/community-home.js \
+                && grep -q 'grid-template-rows: 62px 44px' /tmp/community-nav.css \
+                && grep -q 'home-secondary-navigation' /tmp/community-nav.css \
+                && grep -q 'data-live-leaderboard' /tmp/community-leaderboard.html \
+                && grep -q 'Trust score' /tmp/community-leaderboard.html \
+                && grep -q 'data-weekly-story' /tmp/community-news.html \
+                && grep -q 'mcpmarket.com/server/agent-bounties' /tmp/community-news.html \
+                && grep -q 'https://t.me/nspg13' /tmp/community-contact.html \
+                && grep -q 'zeroismmexico@gmail.com' /tmp/community-contact.html \
+                && grep -q 'v1/base/autonomous-bounties/leaderboard' /tmp/community-pages.js; then
+                success=true
+                failure_detail=""
+                break
+              fi
+              failure_detail="expected build ${expected_build}, received ${actual_build:-empty}, or community navigation/page markers were missing"
+            else
+              failure_detail="one or more community URLs returned a non-success response"
+            fi
+            sleep 5
+          done
+
+          verified_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          if [[ "$success" == "true" ]]; then
+            cat > /tmp/community-proof.md <<EOF
+          ✅ **Community navigation production canary passed**
+
+          - Commit: \`${GITHUB_SHA}\`
+          - Expected and live build: \`${expected_build}\`
+          - Attempts: ${attempts}
+          - Verified at: ${verified_at}
+          - Mobile primary navigation keeps **Bounty Board** and **How It Works** visible.
+          - The hamburger menu assets contain **Leaderboard**, **News**, and **Contact Us**.
+          - Live Leaderboard, News, Contact Us, navigation CSS, and community JavaScript all returned the expected production markers.
+          - Workflow: ${run_url}
+          EOF
+          else
+            cat > /tmp/community-proof.md <<EOF
+          ❌ **Community navigation production canary failed**
+
+          - Commit: \`${GITHUB_SHA}\`
+          - Expected build: \`${expected_build}\`
+          - Attempts: ${attempts}
+          - Last failure: ${failure_detail}
+          - Checked at: ${verified_at}
+          - Workflow: ${run_url}
+          EOF
+          fi
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${LIVE_CANARY_ISSUE}/comments" --raw-field body="$(cat /tmp/community-proof.md)"
+          [[ "$success" == "true" ]]

--- a/site/live-guild-build.txt
+++ b/site/live-guild-build.txt
@@ -1,2 +1,2 @@
-20260722-11
-This build keeps Bounty Board and How It Works visible on mobile and adds live Leaderboard, News, and Contact Us community pages.
+20260722-12
+This build verifies mobile community navigation plus the live Leaderboard, News, and Contact Us pages on the custom domain.


### PR DESCRIPTION
Add a permanent post-Pages production canary for the new community navigation and pages.

It verifies the live custom domain returns:
- the mobile primary links for Bounty Board and How It Works;
- the secondary Leaderboard, News, and Contact Us menu destinations;
- the mobile two-row navigation CSS;
- the live leaderboard page and canonical endpoint client;
- the News page, MCP Market coverage link, and weekly story marker;
- the Contact page with Telegram `@nspg13` and `zeroismmexico@gmail.com`.

The site build marker advances to `20260722-12` so Pages redeploys and the new workflow receives a fresh completed Pages run.