### PR TITLE
ops: add temporary maintainer branch-repair workflow

### DIFF
--- a/.github/workflows/maintainer-branch-repair.yml
+++ b/.github/workflows/maintainer-branch-repair.yml
@@ -1,0 +1,60 @@
+name: Temporary maintainer branch repair
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  snapshot-pr-272:
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.issue.number == 272 &&
+      github.actor == 'NSPG13' &&
+      github.event.comment.body == '/maintainer snapshot-pr-272-merge'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: codex/objective-coordination-v1
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build conflict-marker snapshot on a separate branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin codex/competitor-intelligence
+
+          set +e
+          git merge --no-commit --no-ff origin/codex/competitor-intelligence
+          merge_status=$?
+          set -e
+
+          conflicts="$(git diff --name-only --diff-filter=U | sort)"
+          printf '%s\n' "$conflicts"
+
+          if [ "$merge_status" -eq 0 ]; then
+            echo "No conflicts were produced; diagnostic branch is unnecessary."
+            exit 0
+          fi
+          if [ -z "$conflicts" ]; then
+            echo "Merge failed without indexed conflicts." >&2
+            exit 1
+          fi
+
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            git checkout --conflict=merge -- "$path"
+          done <<< "$conflicts"
+
+          mkdir -p .merge-diagnostics
+          printf '%s\n' "$conflicts" > .merge-diagnostics/pr-272-conflicts.txt
+          git add -A
+          git commit -m "diagnostic: snapshot PR 272 merge conflicts"
+          git push --force origin HEAD:diagnostic/pr-272-merge-conflicts


### PR DESCRIPTION
## Purpose

Add one narrowly scoped, temporary maintainer-only workflow to generate an auditable conflict-marker snapshot for PR #272 against the repaired competitor-intelligence branch.

## Authority and containment

- triggers only from an exact issue comment on PR #272;
- requires actor `NSPG13` and exact command `/maintainer snapshot-pr-272-merge`;
- checks out only `codex/objective-coordination-v1`;
- fetches only `codex/competitor-intelligence`;
- never modifies `main`, either source branch, contracts, deployments, wallets, secrets, funding, verification, or settlement;
- force-pushes only the isolated diagnostic branch `diagnostic/pr-272-merge-conflicts`;
- records unresolved paths and conflict markers for review.

The workflow will be removed through a follow-up protected PR after the branch repair is complete. This operational PR does not approve or merge PR #272 or #482.