### PR TITLE
ops: fix PR 272 patch-candidate reject handling

### DIFF
--- a/.github/workflows/maintainer-branch-repair.yml
+++ b/.github/workflows/maintainer-branch-repair.yml
@@ -94,13 +94,18 @@ jobs:
             git mv migrations/0004_objective_coordination.sql migrations/0013_objective_coordination.sql
           fi
 
+          mapfile -t rejects < <(
+            find . \
+              -path './.git' -prune -o \
+              -path './.merge-diagnostics' -prune -o \
+              -name '*.rej' -print | sort
+          )
           mkdir -p .merge-diagnostics/rejects
-          while IFS= read -r reject; do
-            [ -n "$reject" ] || continue
-            destination=".merge-diagnostics/rejects/${reject%.rej}.rej"
+          for reject in "${rejects[@]}"; do
+            destination=".merge-diagnostics/rejects/${reject#./}"
             mkdir -p "$(dirname "$destination")"
             mv "$reject" "$destination"
-          done < <(find . -path './.git' -prune -o -name '*.rej' -print | sort)
+          done
 
           {
             echo "apply_status=$apply_status"


### PR DESCRIPTION
## Purpose

Fix the temporary PR #272 patch diagnostic so rejected hunks are enumerated once before being moved. The previous streaming `find` could rediscover files after they entered `.merge-diagnostics`, preventing the isolated candidate branch from being produced.

## Change

- snapshot the reject list with `mapfile`;
- prune both `.git` and `.merge-diagnostics` from discovery;
- preserve each original rejected-file path under `.merge-diagnostics/rejects`;
- leave the exact maintainer trigger, source refs, destination diagnostic branch, and authority boundaries unchanged.

This remains temporary diagnostic infrastructure. It cannot modify `main`, PR #272's source branch, PR #482's source branch, contracts, deployments, wallets, funding, verification, or settlement, and it will be deleted after the branch repair.