### PR TITLE
ops: trigger isolated PR 272 patch diagnostic

### DIFF
--- a/.ops-trigger/pr-272-patch-pr.txt
+++ b/.ops-trigger/pr-272-patch-pr.txt
@@ -1,0 +1,3 @@
+Open a same-repository control PR to trigger the temporary, isolated PR #272 patch-candidate diagnostic.
+
+This file has no product, deployment, contract, wallet, funding, verification, or settlement effect and will never be merged.


### PR DESCRIPTION
Temporary control PR. Opening it triggers the protected default-branch workflow to apply the original #272 commit onto the repaired competitor-intelligence base and write only `diagnostic/pr-272-patch-candidate`. This marker PR will be closed without merge as soon as the diagnostic branch and result comment exist.