### PR TITLE
ops: handle PR 272 patch success or failure in one controlled step

### DIFF
--- a/.github/workflows/maintainer-branch-repair.yml
+++ b/.github/workflows/maintainer-branch-repair.yml
@@ -23,112 +23,101 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Apply the original objective commit onto the repaired migration base
-        id: patch
-        continue-on-error: true
+      - name: Build or preserve the isolated PR 272 patch candidate
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -Eeuo pipefail
+          set -uo pipefail
           exec > >(tee -a /tmp/pr-272-patch-diagnostic.log) 2>&1
 
-          persist_failure() {
+          failure_command=""
+          apply_status=0
+          rejects=()
+
+          fail() {
             status="$1"
-            line="$2"
-            command="$3"
-            trap - ERR
-            set +e
-            mkdir -p .merge-diagnostics
-            {
-              echo "status=$status"
-              echo "line=$line"
-              echo "command=$command"
-              echo "source_pr_branches_modified=no"
-              echo
-              echo "git_status:"
-              git status --short 2>&1 | tail -n 120
-              echo
-              echo "reject_files:"
-              find . -path './.git' -prune -o -name '*.rej' -print 2>/dev/null | sort | tail -n 120
-              echo
-              echo "log_tail:"
-              tail -n 120 /tmp/pr-272-patch-diagnostic.log 2>/dev/null
-            } > .merge-diagnostics/pr-272-patch-failure.txt
-            exit "$status"
+            shift
+            failure_command="$*"
+            return "$status"
           }
-          trap 'persist_failure "$?" "$LINENO" "$BASH_COMMAND"' ERR
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin backup/pr-272-pre-rebase-20260723
+          run_patch() {
+            git config user.name "github-actions[bot]" || fail "$?" "git config user.name"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com" || fail "$?" "git config user.email"
+            git fetch origin backup/pr-272-pre-rebase-20260723 || fail "$?" "git fetch original PR backup"
 
-          original_head="63b2877f2555d22aee7ec116e82afd3dbbed9658"
-          original_base="f3302f7536dceca184878d420123b017b0248b1e"
-          git diff --binary "$original_base" "$original_head" > /tmp/objective-v1.patch
+            original_head="63b2877f2555d22aee7ec116e82afd3dbbed9658"
+            original_base="f3302f7536dceca184878d420123b017b0248b1e"
+            git diff --binary "$original_base" "$original_head" > /tmp/objective-v1.patch || fail "$?" "git diff original objective commit"
 
-          set +e
-          git apply --reject --whitespace=fix /tmp/objective-v1.patch
-          apply_status=$?
-          set -e
+            git apply --reject --whitespace=fix /tmp/objective-v1.patch
+            apply_status=$?
 
-          if [ -f migrations/0004_objective_coordination.sql ]; then
-            mv migrations/0004_objective_coordination.sql migrations/0013_objective_coordination.sql
+            if [ -f migrations/0004_objective_coordination.sql ]; then
+              mv migrations/0004_objective_coordination.sql migrations/0013_objective_coordination.sql || fail "$?" "rename objective migration to 0013"
+            fi
+
+            mapfile -t rejects < <(
+              find . \
+                -path './.git' -prune -o \
+                -path './.merge-diagnostics' -prune -o \
+                -name '*.rej' -print | sort
+            )
+            mkdir -p .merge-diagnostics/rejects || fail "$?" "create reject directory"
+            for reject in "${rejects[@]}"; do
+              destination=".merge-diagnostics/rejects/${reject#./}"
+              mkdir -p "$(dirname "$destination")" || fail "$?" "create reject parent for $reject"
+              mv "$reject" "$destination" || fail "$?" "move reject $reject"
+            done
+
+            {
+              echo "apply_status=$apply_status"
+              echo "base=$(git rev-parse HEAD)"
+              echo "original_head=$original_head"
+              echo "rejects:"
+              find .merge-diagnostics/rejects -type f -print | sort || true
+            } > .merge-diagnostics/pr-272-patch-candidate.txt || fail "$?" "write candidate manifest"
+
+            git add -A || fail "$?" "stage patch candidate"
+            git commit -m "diagnostic: apply objective-v1 patch to repaired base" || fail "$?" "commit patch candidate"
+            git push --force origin HEAD:diagnostic/pr-272-patch-candidate || fail "$?" "push patch candidate"
+
+            reject_count="${#rejects[@]}"
+            gh api "repos/$GITHUB_REPOSITORY/issues/272/comments" \
+              --method POST \
+              --raw-field body="PR #272 patch-candidate diagnostic completed with ${reject_count} rejected file(s). Snapshot: diagnostic/pr-272-patch-candidate. Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+              >/dev/null || true
+            return 0
+          }
+
+          if run_patch; then
+            exit 0
           fi
 
-          mapfile -t rejects < <(
-            find . \
-              -path './.git' -prune -o \
-              -path './.merge-diagnostics' -prune -o \
-              -name '*.rej' -print | sort
-          )
-          mkdir -p .merge-diagnostics/rejects
-          for reject in "${rejects[@]}"; do
-            destination=".merge-diagnostics/rejects/${reject#./}"
-            mkdir -p "$(dirname "$destination")"
-            mv "$reject" "$destination"
-          done
-
-          {
-            echo "apply_status=$apply_status"
-            echo "base=$(git rev-parse HEAD)"
-            echo "original_head=$original_head"
-            echo "rejects:"
-            find .merge-diagnostics/rejects -type f -print | sort || true
-          } > .merge-diagnostics/pr-272-patch-candidate.txt
-
-          git add -A
-          git commit -m "diagnostic: apply objective-v1 patch to repaired base"
-          git push --force origin HEAD:diagnostic/pr-272-patch-candidate
-
-          trap - ERR
-          reject_count="${#rejects[@]}"
-          gh api "repos/$GITHUB_REPOSITORY/issues/272/comments" \
-            --method POST \
-            --raw-field body="PR #272 patch-candidate diagnostic completed with ${reject_count} rejected file(s). Snapshot: diagnostic/pr-272-patch-candidate. Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            >/dev/null
-
-      - name: Persist failed patch state on an isolated branch
-        if: steps.patch.outcome == 'failure'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          status=$?
           mkdir -p .merge-diagnostics
-          if [ ! -f .merge-diagnostics/pr-272-patch-failure.txt ]; then
-            printf '%s\n' 'Patch step failed before its detailed report was written.' > .merge-diagnostics/pr-272-patch-failure.txt
-          fi
+          {
+            echo "status=$status"
+            echo "command=$failure_command"
+            echo "apply_status=$apply_status"
+            echo "source_pr_branches_modified=no"
+            echo
+            echo "git_status:"
+            git status --short 2>&1 | tail -n 160
+            echo
+            echo "reject_files:"
+            find . -path './.git' -prune -o -name '*.rej' -print 2>/dev/null | sort | tail -n 160
+            echo
+            echo "log_tail:"
+            tail -n 160 /tmp/pr-272-patch-diagnostic.log 2>/dev/null
+          } > .merge-diagnostics/pr-272-patch-failure.txt
+
           git add -A
           git commit --allow-empty -m "diagnostic: preserve failed PR 272 patch state"
           git push --force origin HEAD:diagnostic/pr-272-patch-failure
           gh api "repos/$GITHUB_REPOSITORY/issues/272/comments" \
             --method POST \
-            --raw-field body="PR #272 patch-candidate diagnostic failed; the exact partial tree and report were preserved at diagnostic/pr-272-patch-failure. Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID. The source PR branches were not modified." \
-            >/dev/null
-
-      - name: Mark the diagnostic run failed after preserving evidence
-        if: steps.patch.outcome == 'failure'
-        run: exit 1
+            --raw-field body="PR #272 patch-candidate diagnostic failed at '${failure_command}'. The exact partial tree and report were preserved at diagnostic/pr-272-patch-failure. Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID. The source PR branches were not modified." \
+            >/dev/null || true
+          exit "$status"


### PR DESCRIPTION
## Purpose

Remove GitHub Actions step-level recovery semantics from the temporary objective-repair diagnostic. The previous multi-step version skipped its recovery steps after the patch command failed.

## Behavior

One controlled shell step now:

1. applies the original #272 patch to the repaired competitor-intelligence base;
2. renames the new migration to `0013`;
3. moves reject files into an auditable directory;
4. either commits and pushes `diagnostic/pr-272-patch-candidate`, or writes the exact failure report and pushes the complete partial tree to `diagnostic/pr-272-patch-failure` before exiting nonzero.

The step records the failing operation explicitly and keeps issue comments best-effort only. It cannot modify `main`, #272's source branch, #482's source branch, contracts, deployments, wallets, funding, verification, or settlement. The workflow remains temporary.