### PR TITLE
ops: add one-shot V4 maintainer security-fix workflow

### DIFF
--- a/.github/workflows/standing-meta-v4-maintainer-security-fix.yml
+++ b/.github/workflows/standing-meta-v4-maintainer-security-fix.yml
@@ -1,0 +1,756 @@
+name: Temporary standing-meta V4 maintainer security fix
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  patch-and-test:
+    if: >-
+      github.event.pull_request.head.ref == 'ops/trigger-v4-maintainer-security-fix' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor == 'NSPG13'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: agent/standing-meta-v4-contracts
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Require the reviewed source revision
+        run: test "$(git rev-parse HEAD)" = "686282e7463703ea403f9baa2c73a28d4c766802"
+
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - name: Apply bounded maintainer security fixes and adversarial regressions
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import re
+
+          def read(path: str) -> str:
+              return Path(path).read_text(encoding="utf-8")
+
+          def write(path: str, value: str) -> None:
+              Path(path).write_text(value, encoding="utf-8")
+
+          def replace_once(path: str, old: str, new: str) -> None:
+              value = read(path)
+              count = value.count(old)
+              if count != 1:
+                  raise SystemExit(f"{path}: expected one exact match, found {count}: {old[:100]!r}")
+              write(path, value.replace(old, new, 1))
+
+          def replace_region(path: str, start_marker: str, end_marker: str, replacement: str) -> None:
+              value = read(path)
+              start = value.find(start_marker)
+              if start < 0:
+                  raise SystemExit(f"{path}: start marker missing: {start_marker}")
+              end = value.find(end_marker, start)
+              if end < 0:
+                  raise SystemExit(f"{path}: end marker missing: {end_marker}")
+              write(path, value[:start] + replacement + value[end:])
+
+          # One-time wiring must never collapse verifier and solver randomness into one consumer.
+          replace_once(
+              "contracts/base-escrow/src/AnonymousProtocolControllerV1.sol",
+              """            stakePool_.code.length > 0 && verifierSortition_.code.length > 0 && solverSortition_.code.length > 0
+                && appealableVerifier_.code.length > 0 && standingMetaParentFactory_.code.length > 0,
+""",
+              """            stakePool_.code.length > 0 && verifierSortition_.code.length > 0 && solverSortition_.code.length > 0
+                && verifierSortition_ != solverSortition_ && appealableVerifier_.code.length > 0
+                && standingMetaParentFactory_.code.length > 0,
+""",
+          )
+
+          # The appeal module may consume VRF and slash stake only for factory-canonical V4 children.
+          replace_once(
+              "contracts/base-escrow/src/AppealableVerifierV1.sol",
+              """}
+
+/// @notice Anonymous primary-verifier assignment with symmetric, one-round
+""",
+              """}
+
+interface ICanonicalAppealableChildRegistryV1 {
+    function isCanonicalAppealableChild(address bounty) external view returns (bool);
+}
+
+/// @notice Anonymous primary-verifier assignment with symmetric, one-round
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/AppealableVerifierV1.sol",
+              """        IAppealableBountyV1 item = IAppealableBountyV1(bounty);
+        _validateBounty(item);
+""",
+              """        IAppealableBountyV1 item = IAppealableBountyV1(bounty);
+        _validateBounty(bounty, item);
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/AppealableVerifierV1.sol",
+              """    function _validateBounty(IAppealableBountyV1 item) private view {
+        require(item.settlementToken() == settlementToken, "token mismatch");
+""",
+              """    function _validateBounty(address bounty, IAppealableBountyV1 item) private view {
+        address registry = controller.standingMetaParentFactory();
+        require(
+            controller.configured() && registry.code.length > 0
+                && ICanonicalAppealableChildRegistryV1(registry).isCanonicalAppealableChild(bounty),
+            "bounty not canonical"
+        );
+        require(item.settlementToken() == settlementToken, "token mismatch");
+""",
+          )
+
+          # An early three-vote majority may finalize, but jurors whose window is still open are released, not slashed.
+          replace_once(
+              "contracts/base-escrow/src/AppealableVerifierV1.sol",
+              """        _closeJuryLocks(caseId);
+        item.state = CaseState.Finalized;
+""",
+              """        _closeJuryLocks(caseId, block.timestamp > item.voteDeadline);
+        item.state = CaseState.Finalized;
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/AppealableVerifierV1.sol",
+              """        if (item.state == CaseState.AppealVoting) _closeJuryLocks(caseId);
+""",
+              """        if (item.state == CaseState.AppealVoting) _closeJuryLocks(caseId, true);
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/AppealableVerifierV1.sol",
+              """    function _closeJuryLocks(bytes32 caseId) private {
+        address[] storage wallets = _appellateWallets[caseId];
+        for (uint256 i = 0; i < wallets.length; i++) {
+            address wallet = wallets[i];
+            bytes32 lockId = _juryLockId(caseId, wallet);
+            if (voted[caseId][wallet]) {
+                controller.releaseVerifierStake(lockId, wallet);
+            } else {
+                controller.slashVerifierStake(lockId, wallet, AVAILABILITY_SLASH, address(controller.stakePool()));
+            }
+        }
+    }
+""",
+              """    function _closeJuryLocks(bytes32 caseId, bool slashNonVoters) private {
+        address[] storage wallets = _appellateWallets[caseId];
+        for (uint256 i = 0; i < wallets.length; i++) {
+            address wallet = wallets[i];
+            bytes32 lockId = _juryLockId(caseId, wallet);
+            if (voted[caseId][wallet] || !slashNonVoters) {
+                controller.releaseVerifierStake(lockId, wallet);
+            } else {
+                controller.slashVerifierStake(lockId, wallet, AVAILABILITY_SLASH, address(controller.stakePool()));
+            }
+        }
+    }
+""",
+          )
+
+          # Canonical parent IDs are unique, child selection time is block-derived, and selected solvers are rechecked.
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
+              """    mapping(address => bool) public isCanonicalParent;
+""",
+              """    mapping(address => bool) public isCanonicalParent;
+    mapping(bytes32 => address) public parentByBountyId;
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
+              """        bountyId = keccak256(abi.encode(block.chainid, address(this), msg.sender, config.creationNonce, config));
+        StandingMetaParentV4 parent = new StandingMetaParentV4(
+""",
+              """        bountyId = keccak256(abi.encode(block.chainid, address(this), msg.sender, config.creationNonce, config));
+        require(parentByBountyId[bountyId] == address(0), "parent bounty id already used");
+        StandingMetaParentV4 parent = new StandingMetaParentV4(
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
+              """        parentAddress = address(parent);
+        isCanonicalParent[parentAddress] = true;
+""",
+              """        parentAddress = address(parent);
+        parentByBountyId[bountyId] = parentAddress;
+        isCanonicalParent[parentAddress] = true;
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
+              """        PreparationContext memory context = _preparationContext(parentAddress, parent, request, candidateHash);
+        _validateTermsInput(request.terms, parent, context, request.childParams);
+        bytes32 publishedTermsHash = termsRegistry.publishFor(msg.sender, request.canonicalTerms, request.terms);
+""",
+              """        PreparationContext memory context = _preparationContext(parentAddress, parent, request, candidateHash);
+        OnchainTermsRegistryV4.TermsInput memory resolvedTerms =
+            _resolvedTermsInput(request.terms, parent, context, request.childParams);
+        bytes32 publishedTermsHash = termsRegistry.publishFor(msg.sender, request.canonicalTerms, resolvedTerms);
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
+              """        require(_ranking[parentAddress][parentRound][data.currentRank] == msg.sender, "candidate not selected");
+        require(StandingMetaChildV4(data.child).status() == CLAIMABLE_STATUS, "child not claimable");
+""",
+              """        require(_ranking[parentAddress][parentRound][data.currentRank] == msg.sender, "candidate not selected");
+        _requireCurrentlyEligibleSolver(msg.sender);
+        require(StandingMetaChildV4(data.child).status() == CLAIMABLE_STATUS, "child not claimable");
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
+              """    function authorizedChildSolver(address parent, uint64 parentRound, address child, address solver)
+""",
+              """    function isCanonicalAppealableChild(address bounty) external view returns (bool) {
+        return standingMetaChildFactory.isCanonicalChild(bounty);
+    }
+
+    function authorizedChildSolver(address parent, uint64 parentRound, address child, address solver)
+""",
+          )
+          replace_region(
+              "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
+              "    function _validateTermsInput(",
+              "    function _preparationContext(",
+              """    function _resolvedTermsInput(
+        OnchainTermsRegistryV4.TermsInput calldata terms,
+        StandingMetaParentV4 parent,
+        PreparationContext memory context,
+        AgentBountyFactory.CreateBountyParams calldata params
+    ) private view returns (OnchainTermsRegistryV4.TermsInput memory resolved) {
+        require(
+            terms.selectionCommitment == bytes32(0) && terms.selectionRequestedAt == 0,
+            "selection fields must be derived"
+        );
+        resolved = terms;
+        resolved.selectionCommitment = context.selectionCommitment;
+        resolved.selectionRequestedAt = context.selectionRequestedAt;
+        require(
+            resolved.parent == address(parent) && resolved.child == context.predictedChild
+                && resolved.parentBountyId == parent.bountyId() && resolved.parentRound == context.parentRound,
+            "terms binding invalid"
+        );
+        require(
+            resolved.verifierModule == address(appealableVerifier) && resolved.policyHash == params.policyHash
+                && resolved.acceptanceCriteriaHash == params.acceptanceCriteriaHash
+                && resolved.benchmarkHash == params.benchmarkHash
+                && resolved.evidenceSchemaHash == params.evidenceSchemaHash
+                && resolved.appealPolicyHash == appealableVerifier.appealPolicyHash(),
+            "terms content invalid"
+        );
+        require(
+            resolved.childClaimWindowSeconds == CHILD_WORK_WINDOW
+                && resolved.childVerificationWindowSeconds == CHILD_VERIFICATION_WINDOW
+                && resolved.childFundingTarget == CHILD_TARGET && resolved.childSolverReward == CHILD_SOLVER_REWARD
+                && resolved.childVerifierReward == CHILD_VERIFIER_REWARD,
+            "terms economics invalid"
+        );
+    }
+
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
+              """    function _eligibleChildSolvers(StandingMetaParentV4 parent, address parentSolver)
+""",
+              """    function _requireCurrentlyEligibleSolver(address wallet) private view {
+        (uint128 stake,,, uint64 unbondAt, bool active, bool available) =
+            controller.stakePool().tickets(wallet, AnonymousStakePoolV1.Role.Solver);
+        require(
+            stake == controller.stakePool().STAKE_AMOUNT() && unbondAt == 0 && active && available,
+            "candidate no longer eligible"
+        );
+    }
+
+    function _eligibleChildSolvers(StandingMetaParentV4 parent, address parentSolver)
+""",
+          )
+
+          # Unsolicited token dust must never brick exact-accounting initialization or a parent claim.
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentV4.sol",
+              """        require(IERC20BountyToken(settlementToken).balanceOf(address(this)) == TARGET_AMOUNT, "funding mismatch");
+""",
+              """        require(IERC20BountyToken(settlementToken).balanceOf(address(this)) >= TARGET_AMOUNT, "funding mismatch");
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaParentV4.sol",
+              """            IERC20BountyToken(settlementToken).balanceOf(address(this)) == TARGET_AMOUNT + VERIFIER_REWARD,
+""",
+              """            IERC20BountyToken(settlementToken).balanceOf(address(this)) >= TARGET_AMOUNT + VERIFIER_REWARD,
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaChildV4.sol",
+              """import "./IAgentBounty.sol";
+
+/// @notice Exact-economics V4 child whose claim authority is restricted to the
+""",
+              """import "./IAgentBounty.sol";
+
+interface IAppealableVerifierRewardAllocatorV1 {
+    function allocateVerifierReward(bytes32 caseId) external;
+}
+
+/// @notice Exact-economics V4 child whose claim authority is restricted to the
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaChildV4.sol",
+              """        require(IERC20BountyToken(settlementToken).balanceOf(address(this)) == TARGET_AMOUNT, "funding mismatch");
+""",
+              """        require(IERC20BountyToken(settlementToken).balanceOf(address(this)) >= TARGET_AMOUNT, "funding mismatch");
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/src/StandingMetaChildV4.sol",
+              """    function verifyAndSettle(bytes calldata proof) external nonReentrant {
+        require(_status == Status.Submitted && block.timestamp <= verificationExpiresAt, "verification unavailable");
+        (bool passed, bytes32 responseHash) = IAgentBountyVerifier(verifierModule)
+            .verify(bountyId, round, solver, submissionHash, evidenceHash, policyHash, proof);
+        bytes32 verificationHash = keccak256(abi.encode(verifierModule, responseHash, keccak256(proof)));
+        if (passed) _settle(verificationHash);
+        else _reject(verificationHash);
+    }
+""",
+              """    function verifyAndSettle(bytes calldata proof) external nonReentrant {
+        require(_status == Status.Submitted && block.timestamp <= verificationExpiresAt, "verification unavailable");
+        require(proof.length == 32, "case proof invalid");
+        bytes32 caseId = abi.decode(proof, (bytes32));
+        (bool passed, bytes32 responseHash) = IAgentBountyVerifier(verifierModule)
+            .verify(bountyId, round, solver, submissionHash, evidenceHash, policyHash, proof);
+        bytes32 verificationHash = keccak256(abi.encode(verifierModule, responseHash, keccak256(proof)));
+        if (passed) _settle(verificationHash);
+        else _reject(verificationHash);
+        IAppealableVerifierRewardAllocatorV1(verifierModule).allocateVerifierReward(caseId);
+    }
+""",
+          )
+
+          # Funding an existing subscription also proves the consumers' immutable coordinator/subscription/controller graph.
+          replace_once(
+              "contracts/base-escrow/script/FundStandingMetaV4Subscription.s.sol",
+              """}
+
+/// @notice Funds one already-created V4 subscription with the exact native
+""",
+              """}
+
+interface IStandingMetaV4SortitionFundingView {
+    function vrfCoordinator() external view returns (address);
+    function controller() external view returns (address);
+    function subscriptionId() external view returns (uint256);
+}
+
+interface IStandingMetaV4ControllerFundingView {
+    function configured() external view returns (bool);
+    function verifierSortition() external view returns (address);
+    function solverSortition() external view returns (address);
+}
+
+/// @notice Funds one already-created V4 subscription with the exact native
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/script/FundStandingMetaV4Subscription.s.sol",
+              """    function _validateSubscription(FundingContext memory context) private view returns (uint96) {
+        uint96 nativeBefore;
+        address subscriptionOwner;
+        address[] memory consumers;
+""",
+              """    function _validateSubscription(FundingContext memory context) private view returns (uint96) {
+        require(
+            context.verifierSortition.code.length > 0 && context.solverSortition.code.length > 0,
+            "consumer code missing"
+        );
+        IStandingMetaV4SortitionFundingView verifier =
+            IStandingMetaV4SortitionFundingView(context.verifierSortition);
+        IStandingMetaV4SortitionFundingView solver = IStandingMetaV4SortitionFundingView(context.solverSortition);
+        address protocolController = verifier.controller();
+        require(
+            protocolController != address(0) && protocolController.code.length > 0
+                && solver.controller() == protocolController && verifier.vrfCoordinator() == context.vrf
+                && solver.vrfCoordinator() == context.vrf && verifier.subscriptionId() == context.subscriptionId
+                && solver.subscriptionId() == context.subscriptionId,
+            "consumer wiring mismatch"
+        );
+        IStandingMetaV4ControllerFundingView controller = IStandingMetaV4ControllerFundingView(protocolController);
+        require(
+            controller.configured() && controller.verifierSortition() == context.verifierSortition
+                && controller.solverSortition() == context.solverSortition,
+            "controller wiring mismatch"
+        );
+
+        uint96 nativeBefore;
+        address subscriptionOwner;
+        address[] memory consumers;
+""",
+          )
+
+          # Error paths must redact values from subprocess output, not only from the rendered command.
+          replace_once(
+              "scripts/standing_meta_v4_deploy.py",
+              """def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
+""",
+              """def redacted_output(output: str, command: Sequence[str]) -> str:
+    rendered = output
+    for secret_flag in ("--private-key", "--rpc-url"):
+        for index, item in enumerate(command[:-1]):
+            if item == secret_flag and command[index + 1]:
+                rendered = rendered.replace(command[index + 1], "[redacted]")
+    return rendered
+
+
+def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
+""",
+          )
+          replace_once(
+              "scripts/standing_meta_v4_deploy.py",
+              """            f"command failed ({completed.returncode}): {redacted_command(command)}\n{completed.stdout[-6000:]}"
+""",
+              """            f"command failed ({completed.returncode}): {redacted_command(command)}\n"
+            f"{redacted_output(completed.stdout, command)[-6000:]}"
+""",
+          )
+          replace_once(
+              "scripts/test_standing_meta_v4_deploy.py",
+              """    def test_networks_pin_official_vrf_configuration(self) -> None:
+""",
+              """    def test_release_errors_redact_signer_and_rpc_credentials_from_output(self) -> None:
+        command = [
+            "cast",
+            "send",
+            "--private-key",
+            "0xsupersecret",
+            "--rpc-url",
+            "https://rpc.example/private-token",
+        ]
+        rendered = MODULE.redacted_output(
+            "failed with 0xsupersecret at https://rpc.example/private-token", command
+        )
+        self.assertNotIn("supersecret", rendered)
+        self.assertNotIn("private-token", rendered)
+        self.assertEqual(rendered.count("[redacted]"), 2)
+
+    def test_networks_pin_official_vrf_configuration(self) -> None:
+""",
+          )
+
+          # Test registry for the generic appeal harness; production uses the immutable V4 child factory registry.
+          replace_once(
+              "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
+              """contract AppealVerifierControllerDummy {}
+""",
+              """contract AppealVerifierControllerDummy {
+    mapping(address => bool) public isCanonicalAppealableChild;
+
+    function setCanonicalAppealableChild(address bounty, bool canonical) external {
+        isCanonicalAppealableChild[bounty] = canonical;
+    }
+}
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
+              """    AppealableVerifierV1 private verifier;
+    AppealVerifierActor private solver;
+""",
+              """    AppealableVerifierV1 private verifier;
+    AppealVerifierControllerDummy private parentFactory;
+    AppealVerifierActor private solver;
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
+              """        AppealVerifierControllerDummy parentFactory = new AppealVerifierControllerDummy();
+""",
+              """        parentFactory = new AppealVerifierControllerDummy();
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
+              """        require(juryCredits == 110_000, "slash and verifier reward not shared");
+    }
+""",
+              """        require(juryCredits == 110_000, "slash and verifier reward not shared");
+        for (uint256 i = 3; i < jury.length; i++) {
+            (uint128 stake, uint128 locked,,, bool active,) =
+                pool.tickets(jury[i], AnonymousStakePoolV1.Role.Verifier);
+            require(stake == 5_000_000 && locked == 0 && active, "early nonvoter was slashed");
+        }
+    }
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
+              """    function _prepareCase(uint256 randomWord) private returns (AgentBounty bounty, bytes32 caseId) {
+""",
+              """    function testUnregisteredInterfaceShapedBountyCannotConsumeVrfOrStake() public {
+        AgentBounty bounty = _createSubmittedBounty();
+        parentFactory.setCanonicalAppealableChild(address(bounty), false);
+        uint256 requestBefore = vrf.nextRequestId();
+        (bool opened,) = address(verifier).call(abi.encodeCall(verifier.openCase, (address(bounty))));
+        require(!opened, "unregistered bounty opened a verification case");
+        require(vrf.nextRequestId() == requestBefore, "unregistered bounty consumed VRF");
+    }
+
+    function _prepareCase(uint256 randomWord) private returns (AgentBounty bounty, bytes32 caseId) {
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
+              """        bounty = AgentBounty(bountyAddress);
+        solver.approve(token, address(bounty), type(uint256).max);
+""",
+              """        bounty = AgentBounty(bountyAddress);
+        parentFactory.setCanonicalAppealableChild(bountyAddress, true);
+        solver.approve(token, address(bounty), type(uint256).max);
+""",
+          )
+
+          # Canonical V4 regression coverage for atomic reward allocation, dust, delayed inclusion, IDs and eligibility.
+          replace_once(
+              "contracts/base-escrow/test/StandingMetaV4.t.sol",
+              """        child.verifyAndSettle(abi.encode(caseId));
+        appealableVerifier.allocateVerifierReward(caseId);
+
+        parentSolver.submitParent(parent, address(child));
+""",
+              """        child.verifyAndSettle(abi.encode(caseId));
+        require(appealableVerifier.credits(primary) == 10_000, "atomic verifier reward missing");
+        (bool duplicateAllocation,) =
+            address(appealableVerifier).call(abi.encodeCall(appealableVerifier.allocateVerifierReward, (caseId)));
+        require(!duplicateAllocation, "verifier reward allocated twice");
+
+        parentSolver.submitParent(parent, address(child));
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/StandingMetaV4.t.sol",
+              """        child.verifyAndSettle(abi.encode(caseId));
+        appealableVerifier.allocateVerifierReward(caseId);
+
+        require(child.bountyStatus() == StandingMetaChildV4.Status.Claimable, "rejected child did not reopen");
+""",
+              """        child.verifyAndSettle(abi.encode(caseId));
+        require(appealableVerifier.credits(primary) == 10_000, "atomic rejection reward missing");
+
+        require(child.bountyStatus() == StandingMetaChildV4.Status.Claimable, "rejected child did not reopen");
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/StandingMetaV4.t.sol",
+              """    function _createParent() private returns (StandingMetaParentV4 parent) {
+""",
+              """    function testSelectionCommitmentIsDerivedAtInclusionTime() public {
+        StandingMetaParentV4 parent = _createParent();
+        StandingMetaParentFactoryV4.ClaimAndCreateChildRequest memory request = _claimRequest(parent);
+        require(request.terms.selectionCommitment == bytes32(0), "caller supplied selection commitment");
+        require(request.terms.selectionRequestedAt == 0, "caller supplied selection timestamp");
+        vm.warp(block.timestamp + 5 minutes);
+        address childAddress = parentSolver.claimAndCreate(parentFactory, address(parent), request);
+        bytes32 termsHash = StandingMetaChildV4(childAddress).termsHash();
+        (uint64 selectionRequestedAt,,,,,) = parentFactory.termsRegistry().economicsTiming(termsHash);
+        (,,,,,, bytes32 commitment) = parentFactory.termsRegistry().bindings(termsHash);
+        require(selectionRequestedAt == block.timestamp && commitment != bytes32(0), "selection was not block-derived");
+    }
+
+    function testUnsolicitedDustCannotBrickFundingOrParentClaim() public {
+        StandingMetaParentV4 parent = _createParent();
+        StandingMetaParentFactoryV4.ClaimAndCreateChildRequest memory request = _claimRequest(parent);
+        token.mint(address(this), 2);
+        token.transfer(address(parent), 1);
+        token.transfer(request.terms.child, 1);
+        address childAddress = parentSolver.claimAndCreate(parentFactory, address(parent), request);
+        StandingMetaChildV4 child = StandingMetaChildV4(childAddress);
+        require(child.fundedAmount() == 1_000_000, "child principal accounting drift");
+        require(token.balanceOf(childAddress) == 1_000_001, "child dust was not tolerated");
+        require(parent.bountyStatus() == StandingMetaParentV4.Status.Claimed, "parent claim was dust-bricked");
+
+        StandingMetaParentV4 directParent = new StandingMetaParentV4(
+            keccak256("direct-dust-parent"),
+            address(this),
+            address(this),
+            address(token),
+            address(parentFactory.verifierModule()),
+            keccak256("direct-terms"),
+            keccak256("direct-policy"),
+            parentFactory.verifierModule().ACCEPTANCE_CRITERIA_HASH(),
+            keccak256("direct-benchmark"),
+            keccak256("direct-schema")
+        );
+        token.mint(address(this), 2_010_001);
+        token.transfer(address(directParent), 2_010_001);
+        directParent.recordInitialFunding();
+        require(directParent.fundedAmount() == 2_010_000, "parent principal accounting drift");
+    }
+
+    function testParentBountyIdCannotBeReused() public {
+        token.mint(address(this), 2_010_000);
+        token.approve(address(parentFactory), type(uint256).max);
+        StandingMetaParentFactoryV4.ParentConfig memory config = StandingMetaParentFactoryV4.ParentConfig({
+            termsHash: keccak256("duplicate-parent-terms"),
+            policyHash: keccak256("duplicate-parent-policy"),
+            benchmarkHash: keccak256("duplicate-parent-benchmark"),
+            evidenceSchemaHash: keccak256("duplicate-parent-schema"),
+            creationNonce: keccak256("duplicate-parent-nonce")
+        });
+        (address firstParent, bytes32 bountyId) = parentFactory.createParent(config);
+        (bool duplicate,) = address(parentFactory).call(abi.encodeCall(parentFactory.createParent, (config)));
+        require(!duplicate, "duplicate canonical parent bounty id accepted");
+        require(parentFactory.parentByBountyId(bountyId) == firstParent, "canonical parent id mapping drift");
+    }
+
+    function testSelectedSolverMustRemainEligibleAtClaimTime() public {
+        StandingMetaParentV4 parent = _createParent();
+        StandingMetaChildV4 child = _prepareAtomicChildAndDraw(parent, 616);
+        child;
+        address selected = _selectedChildSolver(parent);
+        StandingMetaV4Actor(selected).setAvailable(pool, AnonymousStakePoolV1.Role.Solver, false);
+        StandingMetaParentFactoryV4.BondAuthorization memory bond =
+            _bondAuthorization(keccak256("ineligible-selected-bond"));
+        (bool claimed,) = address(selected)
+            .call(abi.encodeCall(StandingMetaV4Actor.claimChild, (parentFactory, address(parent), bond)));
+        require(!claimed, "unavailable selected solver claimed child");
+        vm.warp(block.timestamp + 10 minutes + 1);
+        parentFactory.promoteNonresponsiveChildSolver(address(parent));
+        (,, uint8 rank,) = parentFactory.roundTiming(address(parent), parent.round());
+        require(rank == 1, "ineligible selected solver was not promotable");
+    }
+
+    function _createParent() private returns (StandingMetaParentV4 parent) {
+""",
+          )
+          replace_region(
+              "contracts/base-escrow/test/StandingMetaV4.t.sol",
+              "        address[] memory candidates = new address[](childCandidates.length);",
+              "        request.canonicalTerms = canonicalTerms;",
+              """        request.canonicalTerms = canonicalTerms;
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/StandingMetaV4.t.sol",
+              """            selectionCommitment: selectionCommitment,
+""",
+              """            selectionCommitment: bytes32(0),
+""",
+          )
+          replace_once(
+              "contracts/base-escrow/test/StandingMetaV4.t.sol",
+              """            selectionRequestedAt: selectionRequestedAt,
+""",
+              """            selectionRequestedAt: 0,
+""",
+          )
+
+          # Make the changed security assumptions explicit in durable docs and static-analysis triage.
+          replace_once(
+              "docs/standing-meta-v4-fair-earning.md",
+              """6. posts the parent bond and activates the parent claim.
+
+After VRF fulfillment,
+""",
+              """6. posts the parent bond and activates the parent claim.
+
+The caller supplies zero for the typed selection timestamp and commitment. The parent factory derives both from the actual inclusion block and frozen candidate set, so a signed transaction never has to predict a miner-selected timestamp.
+
+After VRF fulfillment,
+""",
+          )
+          replace_once(
+              "docs/standing-meta-v4-fair-earning.md",
+              """This is not guaranteed net profit. It excludes failure risk, labor, compute, taxes, gas outside platform sponsorship, and opportunity cost. A V4 opportunity is not ready to earn if gas sponsorship or the funded and authorized VRF subscription is unavailable.
+""",
+              """This is not guaranteed net profit. It excludes failure risk, labor, compute, taxes, gas outside platform sponsorship, and opportunity cost. A V4 opportunity is not ready to earn if gas sponsorship or the funded and authorized VRF subscription is unavailable. Unsolicited token transfers are not counted as funding, bonds, rewards, or margin and cannot block initialization; any surplus remains outside the immutable accounting.
+""",
+          )
+          replace_once(
+              "docs/security/standing-meta-v4-threat-model.md",
+              """| Candidate joins after seeing a target | Child solver candidates are the already-active, available pool snapshotted inside `claimAndCreateChild` | Availability may change after the snapshot; ranking activation and claims still fail closed |
+""",
+              """| Candidate joins after seeing a target | Child solver candidates are the already-active, available pool snapshotted inside `claimAndCreateChild`; the selected ticket is rechecked immediately before claim | Availability may change after the snapshot; an ineligible selection waits for bounded promotion and never receives claim authority |
+""",
+          )
+          replace_once(
+              "docs/security/standing-meta-v4-threat-model.md",
+              """| Jury result is already decisive | Three matching votes can be finalized immediately | A split or missing quorum waits until timeout and then fails closed |
+""",
+              """| Jury result is already decisive | Three matching votes can be finalized immediately; nonvoters are released while their voting window is still open and are slashed only after the deadline | A split or missing quorum waits until timeout and then fails closed |
+""",
+          )
+          replace_once(
+              "docs/security/standing-meta-v4-threat-model.md",
+              """| Atomic preparation race | Terms publication, child creation/funding, active-pool snapshot, VRF request, round binding, and parent claim occur in one transaction | The transaction can revert for gas, authorization, pool-size, or subscription failures |
+""",
+              """| Atomic preparation race | Terms publication, child creation/funding, active-pool snapshot, VRF request, round binding, and parent claim occur in one transaction; selection time and commitment are derived onchain from the inclusion block | The transaction can revert for gas, authorization, pool-size, or subscription failures |
+| Interface-shaped fake bounty consumes VRF or honest stake | `openCase` requires the immutable parent-factory registry to identify the exact canonical V4 child before any candidate query or VRF request | A wrong one-time controller/factory configuration is permanent and remains an R4 deployment-review gate |
+| Pre-sent token dust blocks exact accounting | Initial funding and bond checks require at least the exact accounted amount; unsolicited surplus is never credited as principal, bond, reward, or margin | Surplus cannot be recovered by the immutable protocol and should be treated as an unsolicited transfer |
+| Child state changes before verifier reward attribution | The canonical child transfers and allocates the exact verifier reward in the same transaction; any allocation failure reverts the child transition | Generic non-V4 bounty implementations are outside this canonical V4 guarantee |
+""",
+          )
+          replace_once(
+              "docs/security/standing-meta-v4-slither-triage.md",
+              """| `incorrect-equality` | 6 | Strict equality is intentional for exact USDC funding, exact commitment binding, unique request initialization, and fixed V4 economics. Accepting surplus funding would break conservation/accounting assumptions. |
+""",
+              """| `incorrect-equality` | 6 | Equality remains intentional for commitments, request initialization, and fixed V4 economics. Token-balance initialization and bond checks use minimum-balance assertions so an unsolicited transfer cannot denial-of-service a predicted contract address; surplus is never credited into protocol accounting. |
+""",
+          )
+          PY
+
+      - name: Format contracts
+        run: forge fmt --root contracts/base-escrow
+
+      - name: Targeted adversarial and protocol tests
+        run: >-
+          forge test --root contracts/base-escrow
+          --match-contract '(AnonymousStakeAndVrfSortitionTest|AppealableVerifierV1Test|StandingMetaV4Test)'
+          --fuzz-runs 1000 -vv
+
+      - name: Contract sizes and Python release tooling tests
+        run: |
+          forge build --root contracts/base-escrow --sizes
+          python -m unittest scripts.test_standing_meta_v4_deploy -v
+          python -m py_compile scripts/standing_meta_v4_deploy.py scripts/test_standing_meta_v4_deploy.py
+          git diff --check
+
+      - name: Commit only the tested V4 security patch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            contracts/base-escrow/script/FundStandingMetaV4Subscription.s.sol \
+            contracts/base-escrow/src/AnonymousProtocolControllerV1.sol \
+            contracts/base-escrow/src/AppealableVerifierV1.sol \
+            contracts/base-escrow/src/StandingMetaChildV4.sol \
+            contracts/base-escrow/src/StandingMetaParentFactoryV4.sol \
+            contracts/base-escrow/src/StandingMetaParentV4.sol \
+            contracts/base-escrow/test/AppealableVerifierV1.t.sol \
+            contracts/base-escrow/test/StandingMetaV4.t.sol \
+            docs/security/standing-meta-v4-slither-triage.md \
+            docs/security/standing-meta-v4-threat-model.md \
+            docs/standing-meta-v4-fair-earning.md \
+            scripts/standing_meta_v4_deploy.py \
+            scripts/test_standing_meta_v4_deploy.py
+          git commit -m "fix: harden standing-meta v4 trust and accounting boundaries"
+          git push origin HEAD:agent/standing-meta-v4-contracts
+          gh pr comment 536 --body "Maintainer security patch pushed after targeted adversarial tests, 1,000-run fuzzing, contract-size checks, Python release-tooling tests, syntax checks, and diff validation. This is maintainer review evidence only; the independent R4 reviewer and protected-environment gates remain open."


### PR DESCRIPTION
## Purpose

Add a temporary, exact-trigger workflow that applies the maintainer security findings to PR #536, runs adversarial regressions and size checks, and pushes the V4 branch only after every assertion passes.

## Bounded scope

The workflow is triggered only by a same-repository PR whose head branch is exactly `ops/trigger-v4-maintainer-security-fix` and whose actor is `NSPG13`. It checks out the reviewed V4 head, requires the exact pre-review SHA, edits only the enumerated V4 contracts/tests/docs/release helpers, and pushes only `agent/standing-meta-v4-contracts`.

The patch addresses:

- canonical-child provenance before VRF or stake use;
- block-derived selection timestamp/commitment;
- unsolicited-token dust denial of service;
- early-majority jury slashing;
- atomic canonical-child verifier reward attribution;
- duplicate parent bounty IDs;
- selected-solver eligibility drift;
- VRF funding consumer/controller wiring; and
- subprocess-output secret redaction.

It runs `forge fmt`, the targeted V4/staking/appeal tests with 1,000 fuzz runs, full contract-size checks, deployment-helper unit tests, Python compilation, and `git diff --check` before committing.

This is temporary maintainer tooling, not independent R4 approval. It will be removed after the patch has landed and PR #536’s normal checks are green.