### PR TITLE
feat: make bounded-wallet verifier upgrades signatureless

### DIFF
--- a/.github/workflows/durable-verifier-router-deploy.yml
+++ b/.github/workflows/durable-verifier-router-deploy.yml
@@ -1,0 +1,211 @@
+name: Durable verifier router deploy
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/durable-verifier-router-deploy.yml"
+      - "contracts/base-escrow/src/PolicyBoundVerifierRouter.sol"
+      - "contracts/base-escrow/src/CanonicalIndependentChildVerifierV3Routed.sol"
+      - "contracts/base-escrow/test/PolicyBoundVerifierRouter.t.sol"
+      - "scripts/durable_verifier_router_deploy.py"
+      - "scripts/test_durable_verifier_router_deploy.py"
+      - "bounties/autonomous-v1/routed-v3-parent.template.json"
+      - "docs/adr/0003-durable-verifier-router.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/durable-verifier-router-deploy.yml"
+      - "contracts/base-escrow/src/PolicyBoundVerifierRouter.sol"
+      - "contracts/base-escrow/src/CanonicalIndependentChildVerifierV3Routed.sol"
+      - "contracts/base-escrow/test/PolicyBoundVerifierRouter.t.sol"
+      - "scripts/durable_verifier_router_deploy.py"
+      - "scripts/test_durable_verifier_router_deploy.py"
+      - "bounties/autonomous-v1/routed-v3-parent.template.json"
+      - "docs/adr/0003-durable-verifier-router.md"
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: durable-verifier-router-${{ github.ref || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  deterministic-gates:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.number == 571 &&
+       github.event.comment.user.login == 'NSPG13' &&
+       github.event.comment.body == '/agent-bounty deploy-durable-verifier-router')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - name: Deployment helper tests
+        run: python -m unittest scripts.test_durable_verifier_router_deploy -v
+
+      - name: Python syntax
+        run: python -m py_compile scripts/durable_verifier_router_deploy.py
+
+      - name: Router and routed verifier tests
+        run: >-
+          forge test --root contracts/base-escrow
+          --match-contract PolicyBoundVerifierRouterTest
+          --fuzz-runs 1000 -vv
+
+      - name: Contract build and size
+        run: forge build --root contracts/base-escrow --sizes
+
+      - name: Read-only Base preflight
+        env:
+          BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+        run: >-
+          python scripts/durable_verifier_router_deploy.py plan
+          --output target/durable-verifier-router-plan.json
+          --markdown-output target/durable-verifier-router-plan.md
+
+      - name: Publish pull-request preflight
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr comment "$PR_NUMBER" --body-file target/durable-verifier-router-plan.md
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: durable-verifier-router-plan-${{ github.sha }}
+          path: |
+            target/durable-verifier-router-plan.json
+            target/durable-verifier-router-plan.md
+          if-no-files-found: error
+
+  base-mainnet-deploy:
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.number == 571 &&
+       github.event.comment.user.login == 'NSPG13' &&
+       github.event.comment.body == '/agent-bounty deploy-durable-verifier-router')
+    needs: deterministic-gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      issues: write
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      AGENT_BOUNTIES_API_URL: https://api.agentbounties.app
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - name: Publish start notice
+        run: |
+          cat > target/durable-router-start.md <<EOF
+          ## Durable verifier-router deployment started
+
+          Workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          This does not change the bounded-wallet policy or move its USDC. Confirmed runtime and immutable policy evidence are still required.
+          EOF
+          gh issue comment 571 --body-file target/durable-router-start.md
+
+      - name: Deploy and attest router policy
+        id: deploy
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python scripts/durable_verifier_router_deploy.py deploy \
+            --output target/durable-verifier-router-deployment.json \
+            --output-dir target/durable-verifier-router \
+            --markdown-output target/durable-verifier-router-plan.md \
+            2>&1 | tee target/durable-verifier-router-deploy.log
+
+      - name: Publish deployment result
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          outcome = os.environ.get('DEPLOY_OUTCOME', '')
+          run_url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          report_path = Path('target/durable-verifier-router-deployment.json')
+          if outcome == 'success' and report_path.exists():
+              report = json.loads(report_path.read_text())
+              lines = [
+                  '## Durable verifier-router deployment reconciled',
+                  '',
+                  f"- Router: `{report['router']['address']}`",
+                  f"- Router runtime code hash: `{report['router']['runtime_code_hash']}`",
+                  f"- Active routed policy hash: `{report['policy_hash']}`",
+                  f"- Routed V3 adapter: `{report['adapter']['address']}`",
+                  f"- Adapter runtime code hash: `{report['adapter']['runtime_code_hash']}`",
+                  f"- Acceptance criteria hash: `{report['adapter']['acceptance_criteria_hash']}`",
+                  '- Future policy delay: **7 days**',
+                  '- Active mappings are append-only and code-hash pinned.',
+                  '',
+                  f"Workflow: {run_url}",
+                  '',
+                  'This proves verifier infrastructure only. The owner still has one final bounded-wallet PolicyConfigured transaction; no replacement bounty is funded or paid yet.',
+              ]
+          else:
+              tail = ''
+              log_path = Path('target/durable-verifier-router-deploy.log')
+              if log_path.exists():
+                  tail = '\n'.join(log_path.read_text(errors='replace').splitlines()[-40:])
+              lines = [
+                  '## Durable verifier-router deployment failed closed',
+                  '',
+                  f"Workflow: {run_url}",
+                  '',
+                  'No wallet-policy or replacement-funding success is claimed.',
+                  '',
+                  '```text',
+                  tail[:6000],
+                  '```',
+              ]
+          Path('target/durable-router-result.md').write_text('\n'.join(lines) + '\n')
+          PY
+          gh issue comment 571 --body-file target/durable-router-result.md
+        env:
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: durable-verifier-router-mainnet-${{ github.sha }}
+          path: |
+            target/durable-verifier-router-plan.json
+            target/durable-verifier-router-plan.md
+            target/durable-verifier-router-deployment.json
+            target/durable-verifier-router-deploy.log
+            target/durable-verifier-router/
+            target/durable-router-result.md
+          if-no-files-found: warn
+
+      - name: Fail after reporting deployment error
+        if: steps.deploy.outcome != 'success'
+        run: exit 1

--- a/bounties/autonomous-v1/routed-v3-parent.template.json
+++ b/bounties/autonomous-v1/routed-v3-parent.template.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "agent-bounties/terms-v1",
+  "contract_terms": {
+    "protocol_version": "agent-bounties/autonomous-v1",
+    "creator_wallet": "0x1eaa1c68772cf76bc5f4e4174766076e33ace662",
+    "network": "base-mainnet",
+    "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "solver_reward": { "amount": 2000000, "currency": "usdc" },
+    "verifier_reward": { "amount": 10000, "currency": "usdc" },
+    "claim_bond": { "amount": 10000, "currency": "usdc" },
+    "initial_funding": { "amount": 2010000, "currency": "usdc" },
+    "funding_deadline": 1791676800,
+    "claim_window_seconds": 1209600,
+    "verification_window_seconds": 1209600,
+    "creation_nonce": "__CREATION_NONCE__"
+  },
+  "title": "Earn 1 USDC profit by creating a paid __LANE_LABEL__ child bounty",
+  "goal": "Create and fully fund a concrete 1 USDC __LANE_LABEL__ bounty that a different registered participant completes and receives canonical settlement for, then receive the 2 USDC parent reward.",
+  "acceptance_criteria": [
+    "Publish the exact child terms on Base from the parent solver wallet before claiming this bounty.",
+    "Create and fully fund a parent-bound canonical child with a total target of at least 1.00 USDC.",
+    "Keep the child total target at least 1.00 USDC below this bounty solver reward so the parent has positive gross profit.",
+    "Use the committed sandboxed-regression signed verifier quorum and immutable task criteria.",
+    "Have a participant registered before the parent claim, with a different participant ID, complete the child.",
+    "Receive canonical child settlement before submitting the child address to this verifier."
+  ],
+  "benchmark": {
+    "engine": "standing_meta_v3_routed_parent",
+    "lane": "__LANE__",
+    "required_child_engine": "sandboxed_regression_v1",
+    "required_child_status": "settled",
+    "minimum_child_target": 1000000,
+    "minimum_parent_gross_margin": 1000000,
+    "required_child_verifier_set_hash": "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
+    "required_child_verifier_threshold": 2,
+    "participant_registry": "0x9875dcaf570bde8ff1aa62275d3c8985f4fd1294",
+    "terms_registry": "0x35e5d49c12b75c119d33951c2c4f054c5732208c"
+  },
+  "evidence_schema": {
+    "type": "object",
+    "required": ["child_bounty_contract", "discovery_source", "participation_reason", "improvement_feedback"],
+    "properties": {
+      "child_bounty_contract": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+      "discovery_source": { "type": "string" },
+      "participation_reason": { "type": "string" },
+      "improvement_feedback": { "type": "string" }
+    },
+    "additionalProperties": true
+  },
+  "verification_policy": {
+    "mechanism": "deterministic_module",
+    "verifier_module": "__ROUTER_ADDRESS__",
+    "verifier_reward_recipient": "0xc26a630e85134ed30968735c8e7de4576cfa5dbc",
+    "verifiers": [],
+    "threshold": 1,
+    "module_id": "policy_bound_verifier_router_v1",
+    "routed_protocol": "agent-bounties/independent-child-v3-routed",
+    "activation_model": "append_only_policy_hash_with_delayed_registration",
+    "rubric": "The immutable routed standing-meta-v3 policy requires a meaningful child, at least 1 USDC gross parent margin, pre-claim terms, distinct participants, the committed regression quorum, and canonical child settlement.",
+    "self_verification_forbidden": true
+  },
+  "source_url": "https://github.com/NSPG13/agent-bounties/issues/__ISSUE__",
+  "discovery_source": "maintainer-seeded profitable routed standing-meta-v3 inventory"
+}

--- a/contracts/base-escrow/src/CanonicalIndependentChildVerifierV3Routed.sol
+++ b/contracts/base-escrow/src/CanonicalIndependentChildVerifierV3Routed.sol
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./IAgentBounty.sol";
+import "./OnchainTermsRegistry.sol";
+import "./ParticipantEligibilityRegistry.sol";
+import "./PolicyBoundVerifierRouter.sol";
+
+interface IRoutedProfitableChildFactoryView {
+    function settlementToken() external view returns (address);
+    function isCanonicalBounty(address bounty) external view returns (bool);
+}
+
+interface IRoutedProfitableChildBountyView {
+    function bountyId() external view returns (bytes32);
+    function creator() external view returns (address);
+    function factory() external view returns (address);
+    function settlementToken() external view returns (address);
+    function solverReward() external view returns (uint256);
+    function targetAmount() external view returns (uint256);
+    function fundedAmount() external view returns (uint256);
+    function termsHash() external view returns (bytes32);
+    function policyHash() external view returns (bytes32);
+    function acceptanceCriteriaHash() external view returns (bytes32);
+    function benchmarkHash() external view returns (bytes32);
+    function evidenceSchemaHash() external view returns (bytes32);
+    function verifierSetHash() external view returns (bytes32);
+    function verificationMode() external view returns (uint8);
+    function verifierModule() external view returns (address);
+    function threshold() external view returns (uint8);
+    function status() external view returns (uint8);
+    function round() external view returns (uint64);
+    function solver() external view returns (address);
+    function activeClaimBond() external view returns (uint256);
+    function submissionHash() external view returns (bytes32);
+    function evidenceHash() external view returns (bytes32);
+    function claimExpiresAt() external view returns (uint64);
+    function claimWindowSeconds() external view returns (uint64);
+}
+
+/// @notice Routed profitable standing-meta verifier. The stable router supplies the
+/// canonical parent address and selects this implementation by the parent's immutable
+/// policy hash. Missing or malformed evidence reverts without rejecting work.
+contract CanonicalIndependentChildVerifierV3Routed is IRoutedAgentBountyVerifier {
+    struct ParentScope {
+        address parentAddress;
+        bytes32 bountyId;
+        uint64 round;
+        address solver;
+        bytes32 submissionHash;
+        bytes32 evidenceHash;
+        bytes32 policyHash;
+    }
+
+    bytes32 public constant PROTOCOL_TAG = keccak256("agent-bounties/independent-child-v3-routed");
+    uint256 public constant MINIMUM_CHILD_TARGET = 1_000_000;
+    uint256 public constant MINIMUM_PARENT_GROSS_MARGIN = 1_000_000;
+    uint8 public constant DETERMINISTIC_MODULE_MODE = 0;
+    uint8 public constant SIGNED_QUORUM_MODE = 1;
+    uint8 public constant SUBMITTED_STATUS = 3;
+    uint8 public constant SETTLED_STATUS = 4;
+
+    string public constant ACCEPTANCE_CRITERIA_JSON = '["Publish the exact child terms on Base from the parent solver wallet before claiming this bounty.",'
+        '"Create and fully fund a parent-bound canonical child with a total target of at least 1.00 USDC.",'
+        '"Keep the child total target at least 1.00 USDC below this bounty solver reward so the parent has positive gross profit.",'
+        '"Use the committed sandboxed-regression signed verifier quorum and immutable task criteria.",'
+        '"Have a participant registered before the parent claim, with a different participant ID, complete the child.",'
+        '"Receive canonical child settlement before submitting the child address to this verifier."]';
+    bytes32 public constant ACCEPTANCE_CRITERIA_HASH = keccak256(bytes(ACCEPTANCE_CRITERIA_JSON));
+
+    address public immutable verifierRouter;
+    bytes32 public immutable committedPolicyHash;
+    address public immutable canonicalFactory;
+    address public immutable settlementToken;
+    ParticipantEligibilityRegistry public immutable participantRegistry;
+    OnchainTermsRegistry public immutable termsRegistry;
+    bytes32 public immutable taskVerifierSetHash;
+    uint8 public immutable taskVerifierThreshold;
+
+    error NotRouter();
+    error PolicyMismatch();
+    error InvalidProof();
+    error InvalidParent();
+    error InvalidChild();
+    error TermsUnavailable();
+    error ParticipantIneligible();
+    error SameParticipant();
+
+    constructor(
+        address verifierRouter_,
+        bytes32 committedPolicyHash_,
+        address canonicalFactory_,
+        address participantRegistry_,
+        address termsRegistry_,
+        bytes32 taskVerifierSetHash_,
+        uint8 taskVerifierThreshold_
+    ) {
+        require(verifierRouter_.code.length > 0, "router missing");
+        require(committedPolicyHash_ != bytes32(0), "policy zero");
+        require(canonicalFactory_ != address(0), "factory zero");
+        require(participantRegistry_.code.length > 0, "participant registry missing");
+        require(termsRegistry_.code.length > 0, "terms registry missing");
+        require(taskVerifierSetHash_ != bytes32(0) && taskVerifierThreshold_ >= 2, "verifier policy invalid");
+        address token = IRoutedProfitableChildFactoryView(canonicalFactory_).settlementToken();
+        require(token != address(0), "token zero");
+        verifierRouter = verifierRouter_;
+        committedPolicyHash = committedPolicyHash_;
+        canonicalFactory = canonicalFactory_;
+        settlementToken = token;
+        participantRegistry = ParticipantEligibilityRegistry(participantRegistry_);
+        termsRegistry = OnchainTermsRegistry(termsRegistry_);
+        taskVerifierSetHash = taskVerifierSetHash_;
+        taskVerifierThreshold = taskVerifierThreshold_;
+    }
+
+    /// @notice The proof is exactly abi.encode(address childBounty).
+    function verifyRouted(
+        address parentBounty,
+        bytes32 parentBountyId,
+        uint64 parentRound,
+        address parentSolver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        bytes calldata proof
+    ) external view returns (bool passed, bytes32 responseHash) {
+        if (msg.sender != verifierRouter) revert NotRouter();
+        if (policyHash != committedPolicyHash) revert PolicyMismatch();
+        if (proof.length != 32) revert InvalidProof();
+        uint256 encodedChild;
+        assembly ("memory-safe") {
+            encodedChild := calldataload(proof.offset)
+        }
+        if (encodedChild >> 160 != 0) revert InvalidProof();
+        // The high-bit check above proves this cast cannot truncate.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        address childAddress = address(uint160(encodedChild));
+
+        ParentScope memory scope = ParentScope({
+            parentAddress: parentBounty,
+            bountyId: parentBountyId,
+            round: parentRound,
+            solver: parentSolver,
+            submissionHash: submissionHash,
+            evidenceHash: evidenceHash,
+            policyHash: policyHash
+        });
+        responseHash = _verify(scope, childAddress);
+        return (true, responseHash);
+    }
+
+    function _verify(ParentScope memory scope, address childAddress) private view returns (bytes32 responseHash) {
+        IRoutedProfitableChildBountyView parent =
+            _validParent(scope.parentAddress, scope.bountyId, scope.round, scope.solver, scope.policyHash);
+        uint64 claimedAt = parent.claimExpiresAt() - parent.claimWindowSeconds();
+        IRoutedProfitableChildBountyView child = _validChild(parent, childAddress, scope.solver);
+        _validTerms(child, scope.bountyId, scope.round, scope.solver, claimedAt);
+        _validParticipants(scope.solver, child.solver(), claimedAt);
+
+        responseHash = keccak256(
+            abi.encode(
+                PROTOCOL_TAG,
+                verifierRouter,
+                address(this),
+                scope,
+                childAddress,
+                child.bountyId(),
+                child.solver(),
+                child.targetAmount(),
+                MINIMUM_CHILD_TARGET,
+                MINIMUM_PARENT_GROSS_MARGIN,
+                child.submissionHash(),
+                child.evidenceHash(),
+                child.termsHash()
+            )
+        );
+    }
+
+    function _validParent(
+        address parentAddress,
+        bytes32 parentBountyId,
+        uint64 parentRound,
+        address parentSolver,
+        bytes32 parentPolicyHash
+    ) private view returns (IRoutedProfitableChildBountyView parent) {
+        if (!IRoutedProfitableChildFactoryView(canonicalFactory).isCanonicalBounty(parentAddress)) revert InvalidParent();
+        parent = IRoutedProfitableChildBountyView(parentAddress);
+        if (
+            parent.bountyId() != parentBountyId || parent.factory() != canonicalFactory
+                || parent.settlementToken() != settlementToken || parent.policyHash() != parentPolicyHash
+                || parentPolicyHash != committedPolicyHash
+                || parent.acceptanceCriteriaHash() != ACCEPTANCE_CRITERIA_HASH
+                || parent.verificationMode() != DETERMINISTIC_MODULE_MODE
+                || parent.verifierModule() != verifierRouter || parent.threshold() != 1
+                || parent.status() != SUBMITTED_STATUS || parent.round() != parentRound
+                || parent.solver() != parentSolver || parent.claimExpiresAt() < parent.claimWindowSeconds()
+                || parent.solverReward() < MINIMUM_CHILD_TARGET + MINIMUM_PARENT_GROSS_MARGIN
+        ) revert InvalidParent();
+    }
+
+    function _validChild(
+        IRoutedProfitableChildBountyView parent,
+        address childAddress,
+        address parentSolver
+    ) private view returns (IRoutedProfitableChildBountyView child) {
+        if (
+            childAddress == address(0) || childAddress == address(parent)
+                || !IRoutedProfitableChildFactoryView(canonicalFactory).isCanonicalBounty(childAddress)
+        ) revert InvalidChild();
+        child = IRoutedProfitableChildBountyView(childAddress);
+        uint256 childTarget = child.targetAmount();
+        if (
+            child.creator() != parentSolver || child.factory() != canonicalFactory
+                || child.settlementToken() != settlementToken || childTarget < MINIMUM_CHILD_TARGET
+                || childTarget > parent.solverReward() - MINIMUM_PARENT_GROSS_MARGIN
+                || child.verificationMode() != SIGNED_QUORUM_MODE || child.verifierModule() != address(0)
+                || child.verifierSetHash() != taskVerifierSetHash || child.threshold() != taskVerifierThreshold
+                || child.status() != SETTLED_STATUS || child.fundedAmount() != 0 || child.activeClaimBond() != 0
+                || child.solver() == address(0) || child.solver() == parentSolver
+                || child.submissionHash() == bytes32(0) || child.evidenceHash() == bytes32(0)
+        ) revert InvalidChild();
+    }
+
+    function _validTerms(
+        IRoutedProfitableChildBountyView child,
+        bytes32 parentBountyId,
+        uint64 parentRound,
+        address parentSolver,
+        uint64 parentClaimedAt
+    ) private view {
+        OnchainTermsRegistry.TermsCommitment memory record = termsRegistry.commitment(child.termsHash());
+        if (record.publishedAt == 0) revert TermsUnavailable();
+        if (
+            record.publisher != parentSolver || record.publishedAt >= parentClaimedAt
+                || record.parentBountyId != parentBountyId || record.parentRound != parentRound
+                || record.policyHash != child.policyHash()
+                || record.acceptanceCriteriaHash != child.acceptanceCriteriaHash()
+                || record.benchmarkHash != child.benchmarkHash()
+                || record.evidenceSchemaHash != child.evidenceSchemaHash()
+                || record.verifierSetHash != taskVerifierSetHash || record.verifierThreshold != taskVerifierThreshold
+        ) revert TermsUnavailable();
+    }
+
+    function _validParticipants(address parentSolver, address childSolver, uint64 parentClaimedAt) private view {
+        (bytes32 parentParticipant,, bool parentEligible) =
+            participantRegistry.eligibleAt(parentSolver, parentClaimedAt);
+        (bytes32 childParticipant,, bool childEligible) = participantRegistry.eligibleAt(childSolver, parentClaimedAt);
+        if (!parentEligible || !childEligible) revert ParticipantIneligible();
+        if (parentParticipant == childParticipant) revert SameParticipant();
+    }
+}

--- a/contracts/base-escrow/src/PolicyBoundVerifierRouter.sol
+++ b/contracts/base-escrow/src/PolicyBoundVerifierRouter.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./IAgentBounty.sol";
+
+interface ICanonicalBountyFactoryRouterView {
+    function isCanonicalBounty(address bounty) external view returns (bool);
+}
+
+interface IRoutedAgentBountyVerifier {
+    function verifierRouter() external view returns (address);
+    function committedPolicyHash() external view returns (bytes32);
+    function canonicalFactory() external view returns (address);
+
+    function verifyRouted(
+        address parentBounty,
+        bytes32 bountyId,
+        uint64 round,
+        address solver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        bytes calldata proof
+    ) external view returns (bool passed, bytes32 responseHash);
+}
+
+/// @notice Stable deterministic verifier entrypoint for a bounded autonomous wallet.
+/// @dev Policy records are append-only and bind one immutable policy hash to one
+/// implementation address and runtime code hash. Active records cannot be replaced.
+contract PolicyBoundVerifierRouter is IAgentBountyVerifier {
+    struct PolicyRecord {
+        address verifier;
+        bytes32 runtimeCodeHash;
+        uint64 proposedAt;
+        uint64 activateAfter;
+        uint64 activatedAt;
+        bool vetoed;
+    }
+
+    uint64 public constant MIN_ACTIVATION_DELAY = 1 days;
+    uint64 public constant MAX_ACTIVATION_DELAY = 30 days;
+    uint64 public constant BOOTSTRAP_WINDOW = 1 days;
+
+    address public immutable canonicalFactory;
+    address public immutable registrar;
+    address public immutable guardian;
+    uint64 public immutable activationDelay;
+    uint64 public immutable bootstrapDeadline;
+
+    bool public bootstrapUsed;
+    mapping(bytes32 => PolicyRecord) public policies;
+
+    event PolicyBootstrapped(bytes32 indexed policyHash, address indexed verifier, bytes32 runtimeCodeHash);
+    event PolicyProposed(
+        bytes32 indexed policyHash,
+        address indexed verifier,
+        bytes32 runtimeCodeHash,
+        uint64 activateAfter
+    );
+    event PolicyVetoed(bytes32 indexed policyHash, address indexed actor);
+    event PolicyActivated(bytes32 indexed policyHash, address indexed verifier, bytes32 runtimeCodeHash);
+
+    error NotRegistrar();
+    error NotGuardianOrRegistrar();
+    error InvalidConfiguration();
+    error InvalidPolicy();
+    error PolicyAlreadyExists();
+    error BootstrapUnavailable();
+    error PolicyNotPending();
+    error ActivationTooEarly();
+    error PolicyNotActive();
+    error VerifierCodeChanged();
+    error NonCanonicalCaller();
+
+    constructor(address canonicalFactory_, address registrar_, address guardian_, uint64 activationDelay_) {
+        if (
+            canonicalFactory_.code.length == 0 || registrar_ == address(0) || guardian_ == address(0)
+                || activationDelay_ < MIN_ACTIVATION_DELAY || activationDelay_ > MAX_ACTIVATION_DELAY
+        ) revert InvalidConfiguration();
+        canonicalFactory = canonicalFactory_;
+        registrar = registrar_;
+        guardian = guardian_;
+        activationDelay = activationDelay_;
+        bootstrapDeadline = uint64(block.timestamp) + BOOTSTRAP_WINDOW;
+    }
+
+    function bootstrapPolicy(bytes32 policyHash, address verifier) external {
+        if (msg.sender != registrar) revert NotRegistrar();
+        if (bootstrapUsed || block.timestamp > bootstrapDeadline) revert BootstrapUnavailable();
+        if (_recordExists(policyHash)) revert PolicyAlreadyExists();
+
+        bytes32 runtimeCodeHash = _validateVerifier(policyHash, verifier);
+        bootstrapUsed = true;
+        policies[policyHash] = PolicyRecord({
+            verifier: verifier,
+            runtimeCodeHash: runtimeCodeHash,
+            proposedAt: uint64(block.timestamp),
+            activateAfter: uint64(block.timestamp),
+            activatedAt: uint64(block.timestamp),
+            vetoed: false
+        });
+        emit PolicyBootstrapped(policyHash, verifier, runtimeCodeHash);
+    }
+
+    function proposePolicy(bytes32 policyHash, address verifier) external {
+        if (msg.sender != registrar) revert NotRegistrar();
+        if (_recordExists(policyHash)) revert PolicyAlreadyExists();
+
+        bytes32 runtimeCodeHash = _validateVerifier(policyHash, verifier);
+        uint64 activateAfter = uint64(block.timestamp) + activationDelay;
+        policies[policyHash] = PolicyRecord({
+            verifier: verifier,
+            runtimeCodeHash: runtimeCodeHash,
+            proposedAt: uint64(block.timestamp),
+            activateAfter: activateAfter,
+            activatedAt: 0,
+            vetoed: false
+        });
+        emit PolicyProposed(policyHash, verifier, runtimeCodeHash, activateAfter);
+    }
+
+    function vetoPolicy(bytes32 policyHash) external {
+        if (msg.sender != guardian && msg.sender != registrar) revert NotGuardianOrRegistrar();
+        PolicyRecord storage record = policies[policyHash];
+        if (record.verifier == address(0) || record.activatedAt != 0 || record.vetoed) revert PolicyNotPending();
+        record.vetoed = true;
+        emit PolicyVetoed(policyHash, msg.sender);
+    }
+
+    function activatePolicy(bytes32 policyHash) external {
+        PolicyRecord storage record = policies[policyHash];
+        if (record.verifier == address(0) || record.activatedAt != 0 || record.vetoed) revert PolicyNotPending();
+        if (block.timestamp < record.activateAfter) revert ActivationTooEarly();
+        _assertVerifierStillMatches(policyHash, record);
+        record.activatedAt = uint64(block.timestamp);
+        emit PolicyActivated(policyHash, record.verifier, record.runtimeCodeHash);
+    }
+
+    function isPolicyActive(bytes32 policyHash) external view returns (bool) {
+        PolicyRecord storage record = policies[policyHash];
+        return record.activatedAt != 0 && !record.vetoed && record.verifier != address(0)
+            && record.verifier.codehash == record.runtimeCodeHash;
+    }
+
+    function verify(
+        bytes32 bountyId,
+        uint64 round,
+        address solver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        bytes calldata proof
+    ) external view returns (bool passed, bytes32 responseHash) {
+        if (!ICanonicalBountyFactoryRouterView(canonicalFactory).isCanonicalBounty(msg.sender)) {
+            revert NonCanonicalCaller();
+        }
+        PolicyRecord storage record = policies[policyHash];
+        if (record.activatedAt == 0 || record.vetoed || record.verifier == address(0)) revert PolicyNotActive();
+        _assertVerifierStillMatches(policyHash, record);
+        return IRoutedAgentBountyVerifier(record.verifier).verifyRouted(
+            msg.sender,
+            bountyId,
+            round,
+            solver,
+            submissionHash,
+            evidenceHash,
+            policyHash,
+            proof
+        );
+    }
+
+    function _recordExists(bytes32 policyHash) private view returns (bool) {
+        if (policyHash == bytes32(0)) revert InvalidPolicy();
+        return policies[policyHash].verifier != address(0);
+    }
+
+    function _validateVerifier(bytes32 policyHash, address verifier) private view returns (bytes32 runtimeCodeHash) {
+        if (policyHash == bytes32(0) || verifier.code.length == 0) revert InvalidPolicy();
+        if (
+            IRoutedAgentBountyVerifier(verifier).verifierRouter() != address(this)
+                || IRoutedAgentBountyVerifier(verifier).committedPolicyHash() != policyHash
+                || IRoutedAgentBountyVerifier(verifier).canonicalFactory() != canonicalFactory
+        ) revert InvalidPolicy();
+        runtimeCodeHash = verifier.codehash;
+        if (runtimeCodeHash == bytes32(0)) revert InvalidPolicy();
+    }
+
+    function _assertVerifierStillMatches(bytes32 policyHash, PolicyRecord storage record) private view {
+        if (record.verifier.codehash != record.runtimeCodeHash) revert VerifierCodeChanged();
+        if (
+            IRoutedAgentBountyVerifier(record.verifier).verifierRouter() != address(this)
+                || IRoutedAgentBountyVerifier(record.verifier).committedPolicyHash() != policyHash
+                || IRoutedAgentBountyVerifier(record.verifier).canonicalFactory() != canonicalFactory
+        ) revert VerifierCodeChanged();
+    }
+}

--- a/contracts/base-escrow/test/PolicyBoundVerifierRouter.t.sol
+++ b/contracts/base-escrow/test/PolicyBoundVerifierRouter.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../src/PolicyBoundVerifierRouter.sol";
+
+interface RouterVm {
+    function warp(uint256 timestamp) external;
+}
+
+contract RouterFactoryMock {
+    mapping(address => bool) public isCanonicalBounty;
+
+    function setCanonical(address bounty, bool canonical) external {
+        isCanonicalBounty[bounty] = canonical;
+    }
+}
+
+contract RoutedVerifierMock is IRoutedAgentBountyVerifier {
+    address public immutable verifierRouter;
+    bytes32 public immutable committedPolicyHash;
+    address public immutable canonicalFactory;
+    bool public immutable verdict;
+
+    constructor(address router_, bytes32 policyHash_, address factory_, bool verdict_) {
+        verifierRouter = router_;
+        committedPolicyHash = policyHash_;
+        canonicalFactory = factory_;
+        verdict = verdict_;
+    }
+
+    function verifyRouted(
+        address parentBounty,
+        bytes32 bountyId,
+        uint64 round,
+        address solver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        bytes calldata proof
+    ) external view returns (bool passed, bytes32 responseHash) {
+        require(msg.sender == verifierRouter, "not router");
+        require(policyHash == committedPolicyHash, "wrong policy");
+        responseHash = keccak256(
+            abi.encode(
+                parentBounty,
+                bountyId,
+                round,
+                solver,
+                submissionHash,
+                evidenceHash,
+                policyHash,
+                keccak256(proof)
+            )
+        );
+        return (verdict, responseHash);
+    }
+}
+
+contract GuardianActor {
+    function veto(PolicyBoundVerifierRouter router, bytes32 policyHash) external {
+        router.vetoPolicy(policyHash);
+    }
+}
+
+contract CanonicalRouterCaller {
+    function verify(
+        PolicyBoundVerifierRouter router,
+        bytes32 bountyId,
+        uint64 round,
+        address solver,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 policyHash,
+        bytes calldata proof
+    ) external view returns (bool passed, bytes32 responseHash) {
+        return router.verify(bountyId, round, solver, submissionHash, evidenceHash, policyHash, proof);
+    }
+}
+
+contract PolicyBoundVerifierRouterTest {
+    RouterVm private constant vm = RouterVm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    uint64 private constant DELAY = 7 days;
+
+    RouterFactoryMock private factory;
+    GuardianActor private guardian;
+    PolicyBoundVerifierRouter private router;
+    CanonicalRouterCaller private parent;
+
+    function setUp() public {
+        factory = new RouterFactoryMock();
+        guardian = new GuardianActor();
+        router = new PolicyBoundVerifierRouter(address(factory), address(this), address(guardian), DELAY);
+        parent = new CanonicalRouterCaller();
+        factory.setCanonical(address(parent), true);
+    }
+
+    function testBootstrapRoutesOneImmutablePolicy() public {
+        bytes32 policyHash = keccak256("bootstrap-policy");
+        RoutedVerifierMock verifier = new RoutedVerifierMock(address(router), policyHash, address(factory), true);
+        router.bootstrapPolicy(policyHash, address(verifier));
+
+        require(router.isPolicyActive(policyHash), "bootstrap inactive");
+        (bool passed, bytes32 responseHash) = parent.verify(
+            router,
+            keccak256("bounty"),
+            3,
+            address(0xBEEF),
+            keccak256("submission"),
+            keccak256("evidence"),
+            policyHash,
+            hex"1234"
+        );
+        require(passed, "verdict changed");
+        require(responseHash != bytes32(0), "response missing");
+
+        (bool duplicateOk,) = address(router).call(
+            abi.encodeCall(PolicyBoundVerifierRouter.bootstrapPolicy, (policyHash, address(verifier)))
+        );
+        require(!duplicateOk, "active policy replaced");
+
+        bytes32 secondPolicy = keccak256("second-bootstrap");
+        RoutedVerifierMock secondVerifier =
+            new RoutedVerifierMock(address(router), secondPolicy, address(factory), true);
+        (bool secondOk,) = address(router).call(
+            abi.encodeCall(PolicyBoundVerifierRouter.bootstrapPolicy, (secondPolicy, address(secondVerifier)))
+        );
+        require(!secondOk, "bootstrap reused");
+    }
+
+    function testProposedPolicyCannotActivateBeforeDelay() public {
+        bytes32 policyHash = keccak256("delayed-policy");
+        RoutedVerifierMock verifier = new RoutedVerifierMock(address(router), policyHash, address(factory), true);
+        router.proposePolicy(policyHash, address(verifier));
+
+        (bool earlyOk,) = address(router).call(
+            abi.encodeCall(PolicyBoundVerifierRouter.activatePolicy, (policyHash))
+        );
+        require(!earlyOk, "delay bypassed");
+        require(!router.isPolicyActive(policyHash), "policy active early");
+
+        vm.warp(block.timestamp + DELAY);
+        router.activatePolicy(policyHash);
+        require(router.isPolicyActive(policyHash), "policy not active after delay");
+    }
+
+    function testGuardianCanVetoPendingPolicyButCannotRewriteIt() public {
+        bytes32 policyHash = keccak256("veto-policy");
+        RoutedVerifierMock verifier = new RoutedVerifierMock(address(router), policyHash, address(factory), true);
+        router.proposePolicy(policyHash, address(verifier));
+        guardian.veto(router, policyHash);
+
+        vm.warp(block.timestamp + DELAY);
+        (bool activateOk,) = address(router).call(
+            abi.encodeCall(PolicyBoundVerifierRouter.activatePolicy, (policyHash))
+        );
+        require(!activateOk, "veto ignored");
+
+        RoutedVerifierMock replacement = new RoutedVerifierMock(address(router), policyHash, address(factory), false);
+        (bool replaceOk,) = address(router).call(
+            abi.encodeCall(PolicyBoundVerifierRouter.proposePolicy, (policyHash, address(replacement)))
+        );
+        require(!replaceOk, "vetoed identity reused");
+    }
+
+    function testRejectsNonCanonicalCaller() public {
+        bytes32 policyHash = keccak256("canonical-policy");
+        RoutedVerifierMock verifier = new RoutedVerifierMock(address(router), policyHash, address(factory), true);
+        router.bootstrapPolicy(policyHash, address(verifier));
+
+        (bool ok,) = address(router).staticcall(
+            abi.encodeCall(
+                PolicyBoundVerifierRouter.verify,
+                (
+                    keccak256("bounty"),
+                    1,
+                    address(0xBEEF),
+                    keccak256("submission"),
+                    keccak256("evidence"),
+                    policyHash,
+                    hex""
+                )
+            )
+        );
+        require(!ok, "non-canonical caller routed");
+    }
+
+    function testRejectsMismatchedVerifierMetadata() public {
+        bytes32 policyHash = keccak256("metadata-policy");
+        RoutedVerifierMock wrongRouter = new RoutedVerifierMock(address(0x1234), policyHash, address(factory), true);
+        (bool wrongRouterOk,) = address(router).call(
+            abi.encodeCall(PolicyBoundVerifierRouter.proposePolicy, (policyHash, address(wrongRouter)))
+        );
+        require(!wrongRouterOk, "wrong router accepted");
+
+        RoutedVerifierMock wrongPolicy =
+            new RoutedVerifierMock(address(router), keccak256("other-policy"), address(factory), true);
+        (bool wrongPolicyOk,) = address(router).call(
+            abi.encodeCall(PolicyBoundVerifierRouter.proposePolicy, (policyHash, address(wrongPolicy)))
+        );
+        require(!wrongPolicyOk, "wrong policy accepted");
+
+        RouterFactoryMock otherFactory = new RouterFactoryMock();
+        RoutedVerifierMock wrongFactory =
+            new RoutedVerifierMock(address(router), policyHash, address(otherFactory), true);
+        (bool wrongFactoryOk,) = address(router).call(
+            abi.encodeCall(PolicyBoundVerifierRouter.proposePolicy, (policyHash, address(wrongFactory)))
+        );
+        require(!wrongFactoryOk, "wrong factory accepted");
+    }
+}

--- a/docs/adr/0003-durable-verifier-router.md
+++ b/docs/adr/0003-durable-verifier-router.md
@@ -1,0 +1,28 @@
+# ADR 0003: Durable policy-bound verifier routing
+
+## Status
+
+Proposed for the bounded-agent wallet migration tracked in issues #527 and #571.
+
+## Decision
+
+The existing Base bounded-agent wallet remains the custody account. Its owner makes one final policy update that preserves the live delegate, action mask, verifier-set commitments, and spending caps while replacing the single version-specific deterministic verifier with one stable `PolicyBoundVerifierRouter` address and extending the policy validity horizon.
+
+The router is not upgradeable and cannot move funds. It routes `IAgentBountyVerifier.verify` by the bounty's immutable `policyHash` to one append-only implementation record. Each active record pins the implementation address and runtime code hash forever. Existing active records cannot be replaced, cancelled, or redirected.
+
+A protected registrar may propose a new policy without the wallet owner. New policies activate only after a seven-day public delay. The wallet owner is the guardian and may veto a pending proposal during that delay, but routine activation requires no owner signature. The deployment has one bounded bootstrap slot so the initial routed profitable V3 policy can be activated atomically with deployment.
+
+Routed implementations receive the canonical parent bounty address explicitly from the router and must commit their router and policy hash as immutable metadata. The router checks that metadata and the runtime code hash when registering and on every verification call.
+
+## Consequences
+
+- Routine bounty creation, funding, claiming, and submission continue without owner signatures inside the bounded-wallet caps.
+- Future verifier versions do not require another wallet policy signature.
+- A new policy cannot alter the payout rules of an already funded bounty because its `policyHash -> implementation` record is immutable.
+- A compromised registrar cannot activate a policy immediately; the seven-day delay provides a public veto window.
+- The guardian is not a routine approval authority. Its signature is needed only for veto or custody recovery.
+- V4 and later deterministic policies should implement the routed verifier interface instead of requesting another bounded-wallet verifier change.
+
+## Evidence boundary
+
+Source, CI, a predicted address, a policy proposal, or an owner signature is not deployment or funding evidence. Runtime bytecode, immutable router state, the confirmed `PolicyConfigured` event, canonical bounty creation/funding events, and ultimately `BountySettled` remain authoritative.

--- a/docs/adr/0003-durable-verifier-router.md
+++ b/docs/adr/0003-durable-verifier-router.md
@@ -6,21 +6,28 @@ Proposed for the bounded-agent wallet migration tracked in issues #527 and #571.
 
 ## Decision
 
-The existing Base bounded-agent wallet remains the custody account. Its owner makes one final policy update that preserves the live delegate, action mask, verifier-set commitments, and spending caps while replacing the single version-specific deterministic verifier with one stable `PolicyBoundVerifierRouter` address and extending the policy validity horizon.
+The existing Base bounded-agent wallet remains the custody account. Its owner makes one final policy update that preserves the live action mask, verifier-set commitments, and spending caps while:
+
+1. rotating the delegate from the externally signed relay wallet to the protected production keeper that already holds the deployment signer;
+2. replacing the single version-specific deterministic verifier with one stable `PolicyBoundVerifierRouter` address; and
+3. extending the policy validity horizon so routine operation does not expire back into an owner-signature requirement.
+
+The delegate rotation is necessary because the current delegate is operated through externally supplied signed relay envelopes. Keeping it would preserve the recurring signature dependency this migration is intended to remove. The keeper cannot exceed the unchanged on-chain per-action, period, lifetime, bounty-target, action, or verification-mode limits.
 
 The router is not upgradeable and cannot move funds. It routes `IAgentBountyVerifier.verify` by the bounty's immutable `policyHash` to one append-only implementation record. Each active record pins the implementation address and runtime code hash forever. Existing active records cannot be replaced, cancelled, or redirected.
 
-A protected registrar may propose a new policy without the wallet owner. New policies activate only after a seven-day public delay. The wallet owner is the guardian and may veto a pending proposal during that delay, but routine activation requires no owner signature. The deployment has one bounded bootstrap slot so the initial routed profitable V3 policy can be activated atomically with deployment.
+The protected keeper is also the router registrar and may propose a new policy without the wallet owner. New policies activate only after a seven-day public delay. The wallet owner is the guardian and may veto a pending proposal during that delay, but routine activation requires no owner signature. The deployment has one bounded bootstrap slot so the initial routed profitable V3 policy can be activated atomically with deployment.
 
 Routed implementations receive the canonical parent bounty address explicitly from the router and must commit their router and policy hash as immutable metadata. The router checks that metadata and the runtime code hash when registering and on every verification call.
 
 ## Consequences
 
-- Routine bounty creation, funding, claiming, and submission continue without owner signatures inside the bounded-wallet caps.
+- Routine bounty creation, funding, claiming, and submission continue without owner signatures inside the unchanged bounded-wallet caps.
 - Future verifier versions do not require another wallet policy signature.
 - A new policy cannot alter the payout rules of an already funded bounty because its `policyHash -> implementation` record is immutable.
-- A compromised registrar cannot activate a policy immediately; the seven-day delay provides a public veto window.
-- The guardian is not a routine approval authority. Its signature is needed only for veto or custody recovery.
+- A compromised keeper cannot activate a new verification policy immediately; the seven-day delay provides a public veto window.
+- A compromised keeper also remains financially bounded by the existing wallet action and spend caps and cannot call arbitrary contracts or withdraw custody funds.
+- The guardian is not a routine approval authority. Its signature is needed only for veto, custody recovery, or an intentional future change to the financial/action caps.
 - V4 and later deterministic policies should implement the routed verifier interface instead of requesting another bounded-wallet verifier change.
 
 ## Evidence boundary

--- a/scripts/durable_verifier_router_deploy.py
+++ b/scripts/durable_verifier_router_deploy.py
@@ -1,0 +1,733 @@
+#!/usr/bin/env python3
+"""Plan and deploy the durable policy-bound verifier router and routed V3 policy on Base."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Mapping, Sequence
+
+
+BASE_CHAIN_ID = 8453
+BASE_RPC_DEFAULT = "https://mainnet.base.org"
+API_DEFAULT = "https://api.agentbounties.app"
+SINGLETON_FACTORY = "0xce0042b868300000d44a59004da54a005ffdcf9f"
+CANONICAL_FACTORY = "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9"
+NATIVE_USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+PARTICIPANT_REGISTRY = "0x9875dcaf570bde8ff1aa62275d3c8985f4fd1294"
+TERMS_REGISTRY = "0x35e5d49c12b75c119d33951c2c4f054c5732208c"
+VERIFIER_ONE = "0xbe6292b9e465f549e2363b918d6dd9187038431e"
+VERIFIER_TWO = "0xb7c2ce6430b66fb986e27b6140b29309550d487a"
+KEEPER = "0xc26a630e85134ed30968735c8e7de4576cfa5dbc"
+OWNER = "0x884834e884d6e93462655a2820140ad03e6747bc"
+BOUNDED_WALLET = "0x1eaa1c68772cf76bc5f4e4174766076e33ace662"
+ROUTER_ACTIVATION_DELAY = 7 * 24 * 60 * 60
+ROUTER_SALT_TEXT = "agent-bounties/policy-bound-verifier-router/base-mainnet/v1"
+ADAPTER_SALT_PREFIX = "agent-bounties/independent-child-v3-routed/base-mainnet/v1"
+MIN_KEEPER_ETH_WEI = 100_000_000_000_000
+PARENT_TARGET = 2_010_000
+TOTAL_REPLACEMENT_FUNDING = 4 * PARENT_TARGET
+TEMPLATE_PATH = Path("bounties/autonomous-v1/routed-v3-parent.template.json")
+LANES: dict[int, tuple[str, str]] = {
+    333: ("cli", "CLI"),
+    334: ("api", "API"),
+    335: ("mcp", "MCP"),
+    336: ("wallet_ux", "wallet UX"),
+}
+ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+BYTES32_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
+UINT_RE = re.compile(r"^(?:0x[0-9a-fA-F]+|[0-9]+)")
+
+
+class DeploymentError(RuntimeError):
+    pass
+
+
+def redact_command(command: Sequence[str]) -> str:
+    result: list[str] = []
+    hide_next = False
+    for item in command:
+        if hide_next:
+            result.append("***")
+            hide_next = False
+            continue
+        result.append(item)
+        if item in {"--private-key", "--rpc-url"}:
+            hide_next = True
+    return " ".join(result)
+
+
+def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise DeploymentError(
+            f"command failed ({completed.returncode}): {redact_command(command)}\n{completed.stdout[-6000:]}"
+        )
+    return completed.stdout.strip()
+
+
+def require_address(value: object, label: str) -> str:
+    text = str(value).strip().lower()
+    if not ADDRESS_RE.fullmatch(text):
+        raise DeploymentError(f"{label} is not an EVM address")
+    return text
+
+
+def require_bytes32(value: object, label: str) -> str:
+    text = str(value).strip().lower()
+    if not BYTES32_RE.fullmatch(text):
+        raise DeploymentError(f"{label} is not bytes32")
+    return text
+
+
+def parse_uint(value: object, label: str) -> int:
+    text = str(value).strip()
+    match = UINT_RE.match(text)
+    if not match:
+        raise DeploymentError(f"{label} is not an unsigned integer: {text!r}")
+    return int(match.group(0), 0)
+
+
+def parse_bool(value: object, label: str) -> bool:
+    text = str(value).strip().lower()
+    if text in {"true", "1", "0x1", "0x01"}:
+        return True
+    if text in {"false", "0", "0x0", "0x00"}:
+        return False
+    raise DeploymentError(f"{label} is not boolean: {text!r}")
+
+
+def nonempty_lines(value: str, expected: int, label: str) -> list[str]:
+    result = [line.strip() for line in value.splitlines() if line.strip()]
+    if len(result) != expected:
+        raise DeploymentError(f"{label} returned {len(result)} values; expected {expected}")
+    return result
+
+
+def http_json(method: str, url: str, body: Mapping[str, object] | None = None) -> Any:
+    data = None if body is None else json.dumps(body, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={"content-type": "application/json", "user-agent": "agent-bounties-durable-router/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=45) as response:
+            raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise DeploymentError(f"{method} {url} failed with HTTP {error.code}: {detail[:2000]}") from error
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise DeploymentError(f"{method} {url} returned invalid JSON") from error
+
+
+class Foundry:
+    def __init__(self, repo: Path, rpc_url: str, forge: str, cast: str) -> None:
+        self.repo = repo
+        self.contracts = repo / "contracts" / "base-escrow"
+        self.rpc_url = rpc_url
+        self.forge = forge
+        self.cast = cast
+
+    def command(self, *args: str, cwd: Path | None = None, timeout: int = 300) -> str:
+        return run([self.cast, *args], cwd=cwd or self.repo, timeout=timeout)
+
+    def rpc(self, *args: str, timeout: int = 300) -> str:
+        return self.command(*args, "--rpc-url", self.rpc_url, timeout=timeout)
+
+    def chain_id(self) -> int:
+        return parse_uint(self.rpc("chain-id"), "chain id")
+
+    def code(self, target: str) -> str:
+        return self.rpc("code", target).strip().lower()
+
+    def call(self, target: str, signature: str, *args: str) -> str:
+        return self.rpc("call", target, signature, *args).strip()
+
+    def balance(self, target: str) -> int:
+        return parse_uint(self.rpc("balance", target), "native balance")
+
+    def bytecode(self, contract: str) -> str:
+        value = run([self.forge, "inspect", contract, "bytecode"], cwd=self.contracts).strip().lower()
+        if not value.startswith("0x") or len(value) < 4:
+            raise DeploymentError(f"forge did not return creation bytecode for {contract}")
+        return value
+
+    def abi_encode(self, signature: str, *args: str) -> str:
+        value = self.command("abi-encode", signature, *args).strip().lower()
+        if not value.startswith("0x"):
+            raise DeploymentError("cast abi-encode returned malformed bytes")
+        return value
+
+    def keccak(self, value: str) -> str:
+        return require_bytes32(self.command("keccak", value), "keccak result")
+
+    def predict(self, init_code: str, salt_text: str) -> tuple[str, str, str]:
+        salt = self.keccak(salt_text)
+        init_hash = self.keccak(init_code)
+        preimage = "0xff" + SINGLETON_FACTORY[2:] + salt[2:] + init_hash[2:]
+        prediction_hash = self.keccak(preimage)
+        predicted = require_address("0x" + prediction_hash[-40:], "predicted contract")
+        return predicted, salt, init_hash
+
+    def send(self, target: str, signature: str, *args: str, private_key: str) -> dict[str, Any]:
+        raw = self.rpc(
+            "send", target, signature, *args, "--private-key", private_key, "--json", timeout=180
+        )
+        try:
+            transaction = json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise DeploymentError("cast send did not return JSON") from error
+        tx_hash = transaction.get("transactionHash") or transaction.get("transaction_hash")
+        if not isinstance(tx_hash, str) or not BYTES32_RE.fullmatch(tx_hash):
+            raise DeploymentError("cast send JSON is missing a transaction hash")
+        receipt_raw = self.rpc("receipt", tx_hash, "--json", timeout=180)
+        try:
+            receipt = json.loads(receipt_raw)
+        except json.JSONDecodeError as error:
+            raise DeploymentError("cast receipt did not return JSON") from error
+        if receipt.get("status") not in {"0x1", "0x01", 1}:
+            raise DeploymentError(f"transaction reverted: {tx_hash}")
+        transaction["receipt"] = receipt
+        return transaction
+
+
+def creation_nonce(issue: int) -> str:
+    return "0x" + hashlib.sha256(f"agent-bounties/routed-v3/{issue}/v1".encode()).hexdigest()
+
+
+def materialize_terms(repo: Path, router: str) -> dict[int, dict[str, Any]]:
+    template = (repo / TEMPLATE_PATH).read_text(encoding="utf-8")
+    result: dict[int, dict[str, Any]] = {}
+    for issue, (lane, label) in LANES.items():
+        rendered = (
+            template.replace("__ROUTER_ADDRESS__", router)
+            .replace("__CREATION_NONCE__", creation_nonce(issue))
+            .replace("__LANE_LABEL__", label)
+            .replace("__LANE__", lane)
+            .replace("__ISSUE__", str(issue))
+        )
+        if "__" in rendered:
+            raise DeploymentError(f"unresolved routed terms placeholder for issue #{issue}")
+        try:
+            document = json.loads(rendered)
+        except json.JSONDecodeError as error:
+            raise DeploymentError(f"rendered routed terms for issue #{issue} are invalid JSON") from error
+        policy = document.get("verification_policy")
+        if not isinstance(policy, dict) or str(policy.get("verifier_module", "")).lower() != router:
+            raise DeploymentError(f"routed terms for issue #{issue} do not bind the router")
+        result[issue] = document
+    return result
+
+
+def create_payload(document: Mapping[str, Any], published: Mapping[str, Any]) -> dict[str, Any]:
+    terms = document["contract_terms"]
+    policy = document["verification_policy"]
+    return {
+        "creator": terms["creator_wallet"],
+        "solver_reward": terms["solver_reward"],
+        "verifier_reward": terms["verifier_reward"],
+        "terms_hash": published["terms_hash"],
+        "policy_hash": published["policy_hash"],
+        "acceptance_criteria_hash": published["acceptance_criteria_hash"],
+        "benchmark_hash": published["benchmark_hash"],
+        "evidence_schema_hash": published["evidence_schema_hash"],
+        "funding_deadline": terms["funding_deadline"],
+        "claim_window_seconds": terms["claim_window_seconds"],
+        "verification_window_seconds": terms["verification_window_seconds"],
+        "verification_mode": "deterministic_module",
+        "verifier_module": policy["verifier_module"],
+        "verifier_reward_recipient": policy["verifier_reward_recipient"],
+        "verifiers": [],
+        "threshold": 1,
+        "initial_funding": terms["initial_funding"],
+        "creation_nonce": terms["creation_nonce"],
+    }
+
+
+def build_router_plan(foundry: Foundry) -> dict[str, Any]:
+    if foundry.chain_id() != BASE_CHAIN_ID:
+        raise DeploymentError("durable verifier router is pinned to Base mainnet chain 8453")
+    for label, target in {
+        "ERC-2470 singleton factory": SINGLETON_FACTORY,
+        "canonical bounty factory": CANONICAL_FACTORY,
+        "native USDC": NATIVE_USDC,
+        "participant registry": PARTICIPANT_REGISTRY,
+        "terms registry": TERMS_REGISTRY,
+        "bounded wallet": BOUNDED_WALLET,
+    }.items():
+        if foundry.code(target) in {"0x", "0x0"}:
+            raise DeploymentError(f"{label} has no runtime code at {target}")
+
+    constructor = foundry.abi_encode(
+        "f(address,address,address,uint64)", CANONICAL_FACTORY, KEEPER, OWNER, str(ROUTER_ACTIVATION_DELAY)
+    )
+    init_code = foundry.bytecode(
+        "src/PolicyBoundVerifierRouter.sol:PolicyBoundVerifierRouter"
+    ) + constructor[2:]
+    router, salt, init_hash = foundry.predict(init_code, ROUTER_SALT_TEXT)
+    verifier_array = foundry.abi_encode("f(address[])", f"[{VERIFIER_ONE},{VERIFIER_TWO}]")
+    verifier_set_hash = foundry.keccak(verifier_array)
+
+    policy_lines = nonempty_lines(
+        foundry.call(
+            BOUNDED_WALLET,
+            "policy()(address,uint64,uint64,uint64,uint256,uint256,uint256,uint256,uint8,uint8,address,bytes32,bytes32)",
+        ),
+        13,
+        "bounded wallet policy",
+    )
+    wallet_balance = parse_uint(
+        foundry.call(NATIVE_USDC, "balanceOf(address)(uint256)", BOUNDED_WALLET), "bounded wallet USDC"
+    )
+    return {
+        "schema": "agent-bounties/durable-verifier-router-plan-v1",
+        "network": "base-mainnet",
+        "chain_id": BASE_CHAIN_ID,
+        "singleton_factory": SINGLETON_FACTORY,
+        "canonical_factory": CANONICAL_FACTORY,
+        "settlement_token": NATIVE_USDC,
+        "participant_registry": PARTICIPANT_REGISTRY,
+        "terms_registry": TERMS_REGISTRY,
+        "registrar": KEEPER,
+        "guardian": OWNER,
+        "activation_delay_seconds": ROUTER_ACTIVATION_DELAY,
+        "router_salt": salt,
+        "router_init_code_hash": init_hash,
+        "predicted_router": router,
+        "router_already_deployed": foundry.code(router) not in {"0x", "0x0"},
+        "verifier_set_hash": verifier_set_hash,
+        "verifier_threshold": 2,
+        "keeper_eth_balance_wei": foundry.balance(KEEPER),
+        "bounded_wallet": {
+            "address": BOUNDED_WALLET,
+            "owner": require_address(foundry.call(BOUNDED_WALLET, "owner()(address)"), "wallet owner"),
+            "usdc_balance_base_units": wallet_balance,
+            "can_fund_four_replacements": wallet_balance >= TOTAL_REPLACEMENT_FUNDING,
+            "policy_version": parse_uint(
+                foundry.call(BOUNDED_WALLET, "policyVersion()(uint64)"), "wallet policy version"
+            ),
+            "policy_hash": require_bytes32(
+                foundry.call(BOUNDED_WALLET, "policyHash()(bytes32)"), "wallet policy hash"
+            ),
+            "policy": {
+                "delegate": require_address(policy_lines[0], "policy delegate"),
+                "valid_after": parse_uint(policy_lines[1], "valid after"),
+                "valid_until": parse_uint(policy_lines[2], "valid until"),
+                "period_seconds": parse_uint(policy_lines[3], "period seconds"),
+                "max_per_action": parse_uint(policy_lines[4], "max per action"),
+                "max_per_period": parse_uint(policy_lines[5], "max per period"),
+                "max_lifetime_spend": parse_uint(policy_lines[6], "max lifetime spend"),
+                "max_bounty_target": parse_uint(policy_lines[7], "max bounty target"),
+                "allowed_actions": parse_uint(policy_lines[8], "allowed actions"),
+                "allowed_verification_modes": parse_uint(policy_lines[9], "allowed verification modes"),
+                "deterministic_verifier": require_address(policy_lines[10], "deterministic verifier"),
+                "signed_quorum_hash": require_bytes32(policy_lines[11], "signed quorum hash"),
+                "ai_quorum_hash": require_bytes32(policy_lines[12], "AI quorum hash"),
+            },
+        },
+        "replacement_economics": {
+            "count": 4,
+            "target_each": PARENT_TARGET,
+            "total_funding_required": TOTAL_REPLACEMENT_FUNDING,
+            "solver_reward_each": 2_000_000,
+            "verifier_reward_each": 10_000,
+            "claim_bond_each": 10_000,
+            "minimum_child_target_each": 1_000_000,
+            "minimum_parent_margin_each": 1_000_000,
+        },
+        "router_init_code": init_code,
+        "evidence_boundary": (
+            "This plan is compiler and read-only chain evidence. It is not router deployment, wallet policy activation, "
+            "replacement funding, claimability, or payment evidence."
+        ),
+    }
+
+
+def wait_for_code(foundry: Foundry, target: str, timeout_seconds: int = 120) -> str:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        code = foundry.code(target)
+        if code not in {"0x", "0x0"}:
+            return code
+        time.sleep(2)
+    raise DeploymentError(f"no runtime code appeared at {target}")
+
+
+def deploy_singleton(
+    foundry: Foundry,
+    target: str,
+    init_code: str,
+    salt: str,
+    private_key: str,
+) -> dict[str, Any] | None:
+    if foundry.code(target) not in {"0x", "0x0"}:
+        return None
+    transaction = foundry.send(
+        SINGLETON_FACTORY,
+        "deploy(bytes,bytes32)(address)",
+        init_code,
+        salt,
+        private_key=private_key,
+    )
+    wait_for_code(foundry, target)
+    return transaction
+
+
+def publish_terms(api: str, documents: Mapping[int, Mapping[str, Any]]) -> dict[int, dict[str, Any]]:
+    published: dict[int, dict[str, Any]] = {}
+    policy_hashes: set[str] = set()
+    for issue, document in documents.items():
+        response = http_json(
+            "POST",
+            f"{api.rstrip('/')}/v1/base/autonomous-bounties/terms",
+            {"creator_wallet": BOUNDED_WALLET, "document": document},
+        )
+        if not isinstance(response, dict):
+            raise DeploymentError(f"terms publication for issue #{issue} returned a non-object")
+        for key in (
+            "terms_hash",
+            "policy_hash",
+            "acceptance_criteria_hash",
+            "benchmark_hash",
+            "evidence_schema_hash",
+        ):
+            require_bytes32(response.get(key), f"issue #{issue} {key}")
+        policy_hashes.add(str(response["policy_hash"]).lower())
+        published[issue] = response
+    if len(policy_hashes) != 1:
+        raise DeploymentError("routed replacement terms did not produce one shared policy hash")
+    return published
+
+
+def build_adapter_plan(
+    foundry: Foundry,
+    router: str,
+    policy_hash: str,
+    verifier_set_hash: str,
+) -> dict[str, Any]:
+    constructor = foundry.abi_encode(
+        "f(address,bytes32,address,address,address,bytes32,uint8)",
+        router,
+        policy_hash,
+        CANONICAL_FACTORY,
+        PARTICIPANT_REGISTRY,
+        TERMS_REGISTRY,
+        verifier_set_hash,
+        "2",
+    )
+    init_code = foundry.bytecode(
+        "src/CanonicalIndependentChildVerifierV3Routed.sol:CanonicalIndependentChildVerifierV3Routed"
+    ) + constructor[2:]
+    adapter, salt, init_hash = foundry.predict(init_code, f"{ADAPTER_SALT_PREFIX}:{policy_hash}")
+    return {
+        "policy_hash": policy_hash,
+        "predicted_adapter": adapter,
+        "adapter_salt": salt,
+        "adapter_init_code_hash": init_hash,
+        "adapter_init_code": init_code,
+        "already_deployed": foundry.code(adapter) not in {"0x", "0x0"},
+    }
+
+
+def verify_router(foundry: Foundry, plan: Mapping[str, Any]) -> dict[str, Any]:
+    router = require_address(plan["predicted_router"], "router")
+    code = wait_for_code(foundry, router)
+    checks: dict[str, tuple[object, object]] = {
+        "canonical_factory": (
+            require_address(foundry.call(router, "canonicalFactory()(address)"), "router factory"),
+            CANONICAL_FACTORY,
+        ),
+        "registrar": (require_address(foundry.call(router, "registrar()(address)"), "router registrar"), KEEPER),
+        "guardian": (require_address(foundry.call(router, "guardian()(address)"), "router guardian"), OWNER),
+        "activation_delay": (
+            parse_uint(foundry.call(router, "activationDelay()(uint64)"), "router activation delay"),
+            ROUTER_ACTIVATION_DELAY,
+        ),
+    }
+    mismatches = {
+        key: {"observed": observed, "expected": expected}
+        for key, (observed, expected) in checks.items()
+        if observed != expected
+    }
+    if mismatches:
+        raise DeploymentError(f"router immutable mismatch: {mismatches}")
+    return {
+        "address": router,
+        "runtime_code_hash": foundry.keccak(code),
+        "immutable_checks": {key: observed for key, (observed, _) in checks.items()},
+    }
+
+
+def verify_adapter(
+    foundry: Foundry,
+    adapter_plan: Mapping[str, Any],
+    router: str,
+    verifier_set_hash: str,
+) -> dict[str, Any]:
+    adapter = require_address(adapter_plan["predicted_adapter"], "adapter")
+    policy_hash = require_bytes32(adapter_plan["policy_hash"], "adapter policy hash")
+    code = wait_for_code(foundry, adapter)
+    checks: dict[str, tuple[object, object]] = {
+        "verifier_router": (
+            require_address(foundry.call(adapter, "verifierRouter()(address)"), "adapter router"),
+            router,
+        ),
+        "committed_policy_hash": (
+            require_bytes32(foundry.call(adapter, "committedPolicyHash()(bytes32)"), "adapter policy"),
+            policy_hash,
+        ),
+        "canonical_factory": (
+            require_address(foundry.call(adapter, "canonicalFactory()(address)"), "adapter factory"),
+            CANONICAL_FACTORY,
+        ),
+        "settlement_token": (
+            require_address(foundry.call(adapter, "settlementToken()(address)"), "adapter token"),
+            NATIVE_USDC,
+        ),
+        "participant_registry": (
+            require_address(foundry.call(adapter, "participantRegistry()(address)"), "adapter participant registry"),
+            PARTICIPANT_REGISTRY,
+        ),
+        "terms_registry": (
+            require_address(foundry.call(adapter, "termsRegistry()(address)"), "adapter terms registry"),
+            TERMS_REGISTRY,
+        ),
+        "verifier_set_hash": (
+            require_bytes32(foundry.call(adapter, "taskVerifierSetHash()(bytes32)"), "adapter verifier set"),
+            verifier_set_hash,
+        ),
+        "verifier_threshold": (
+            parse_uint(foundry.call(adapter, "taskVerifierThreshold()(uint8)"), "adapter threshold"),
+            2,
+        ),
+        "minimum_child_target": (
+            parse_uint(foundry.call(adapter, "MINIMUM_CHILD_TARGET()(uint256)"), "minimum child target"),
+            1_000_000,
+        ),
+        "minimum_parent_margin": (
+            parse_uint(
+                foundry.call(adapter, "MINIMUM_PARENT_GROSS_MARGIN()(uint256)"),
+                "minimum parent margin",
+            ),
+            1_000_000,
+        ),
+    }
+    mismatches = {
+        key: {"observed": observed, "expected": expected}
+        for key, (observed, expected) in checks.items()
+        if observed != expected
+    }
+    if mismatches:
+        raise DeploymentError(f"routed adapter immutable mismatch: {mismatches}")
+    return {
+        "address": adapter,
+        "runtime_code_hash": foundry.keccak(code),
+        "acceptance_criteria_hash": require_bytes32(
+            foundry.call(adapter, "ACCEPTANCE_CRITERIA_HASH()(bytes32)"), "adapter acceptance hash"
+        ),
+        "immutable_checks": {key: observed for key, (observed, _) in checks.items()},
+    }
+
+
+def bootstrap_router(
+    foundry: Foundry,
+    router: str,
+    policy_hash: str,
+    adapter: str,
+    private_key: str,
+) -> dict[str, Any] | None:
+    if parse_bool(foundry.call(router, "isPolicyActive(bytes32)(bool)", policy_hash), "router policy active"):
+        return None
+    transaction = foundry.send(
+        router,
+        "bootstrapPolicy(bytes32,address)",
+        policy_hash,
+        adapter,
+        private_key=private_key,
+    )
+    if not parse_bool(foundry.call(router, "isPolicyActive(bytes32)(bool)", policy_hash), "router policy active"):
+        raise DeploymentError("router bootstrap transaction confirmed without an active policy")
+    return transaction
+
+
+def deploy(
+    foundry: Foundry,
+    plan: dict[str, Any],
+    api: str,
+    output_dir: Path,
+) -> dict[str, Any]:
+    private_key = os.environ.get("BASE_KEEPER_PRIVATE_KEY", "").strip()
+    if not private_key:
+        raise DeploymentError("BASE_KEEPER_PRIVATE_KEY is required for deployment")
+    deployer = require_address(
+        foundry.command("wallet", "address", "--private-key", private_key), "keeper private-key address"
+    )
+    if deployer != KEEPER:
+        raise DeploymentError(f"keeper key resolves to {deployer}, expected {KEEPER}")
+    balance_before = foundry.balance(deployer)
+    if balance_before < MIN_KEEPER_ETH_WEI:
+        raise DeploymentError("keeper ETH reserve is below the protected deployment floor")
+
+    router = require_address(plan["predicted_router"], "predicted router")
+    router_tx = deploy_singleton(
+        foundry,
+        router,
+        str(plan["router_init_code"]),
+        str(plan["router_salt"]),
+        private_key,
+    )
+    router_verification = verify_router(foundry, plan)
+
+    documents = materialize_terms(foundry.repo, router)
+    published = publish_terms(api, documents)
+    policy_hash = require_bytes32(next(iter(published.values()))["policy_hash"], "shared policy hash")
+    for issue, response in published.items():
+        if str(response["policy_hash"]).lower() != policy_hash:
+            raise DeploymentError(f"issue #{issue} policy hash drifted")
+
+    adapter_plan = build_adapter_plan(foundry, router, policy_hash, str(plan["verifier_set_hash"]))
+    adapter = require_address(adapter_plan["predicted_adapter"], "predicted adapter")
+    adapter_tx = deploy_singleton(
+        foundry,
+        adapter,
+        str(adapter_plan["adapter_init_code"]),
+        str(adapter_plan["adapter_salt"]),
+        private_key,
+    )
+    adapter_verification = verify_adapter(
+        foundry,
+        adapter_plan,
+        router,
+        str(plan["verifier_set_hash"]),
+    )
+    bootstrap_tx = bootstrap_router(foundry, router, policy_hash, adapter, private_key)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    materialized: dict[str, str] = {}
+    for issue, document in documents.items():
+        path = output_dir / f"routed-v3-{issue}.json"
+        path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        materialized[str(issue)] = str(path)
+
+    balance_after = foundry.balance(deployer)
+    if balance_after < MIN_KEEPER_ETH_WEI:
+        raise DeploymentError("deployment depleted the keeper below its protected ETH reserve")
+    return {
+        "schema": "agent-bounties/durable-verifier-router-deployment-v1",
+        "network": "base-mainnet",
+        "chain_id": BASE_CHAIN_ID,
+        "deployer": deployer,
+        "router_transaction": router_tx,
+        "adapter_transaction": adapter_tx,
+        "bootstrap_transaction": bootstrap_tx,
+        "idempotent": {
+            "router_existing": router_tx is None,
+            "adapter_existing": adapter_tx is None,
+            "policy_existing": bootstrap_tx is None,
+        },
+        "keeper_balance_before_wei": balance_before,
+        "keeper_balance_after_wei": balance_after,
+        "router": router_verification,
+        "policy_hash": policy_hash,
+        "adapter": adapter_verification,
+        "published_terms": {str(key): value for key, value in published.items()},
+        "materialized_terms": materialized,
+        "wallet_policy_required": {
+            "wallet": BOUNDED_WALLET,
+            "owner": OWNER,
+            "durable_router": router,
+            "one_final_owner_transaction": True,
+        },
+        "replacement_funding_required_base_units": TOTAL_REPLACEMENT_FUNDING,
+        "evidence_boundary": (
+            "Confirmed router, adapter, and active append-only policy evidence proves verifier infrastructure only. "
+            "The bounded wallet is not authorized for the router until PolicyConfigured is confirmed, and replacements "
+            "are not funded or claimable until canonical lifecycle events reconcile."
+        ),
+    }
+
+
+def markdown(report: Mapping[str, Any]) -> str:
+    wallet = report["bounded_wallet"]
+    economics = report["replacement_economics"]
+    return "\n".join(
+        [
+            "## Durable verifier-router preflight",
+            "",
+            f"- Predicted stable router: `{report['predicted_router']}`",
+            f"- Router already deployed: **{str(report['router_already_deployed']).lower()}**",
+            f"- Registrar: `{report['registrar']}`",
+            f"- Guardian: `{report['guardian']}`",
+            f"- Future-policy activation delay: **{report['activation_delay_seconds'] // 86400} days**",
+            f"- Bounded wallet: `{wallet['address']}`",
+            f"- Bounded-wallet USDC: **{wallet['usdc_balance_base_units'] / 1_000_000:.6f}**",
+            f"- Four replacement parents require: **{economics['total_funding_required'] / 1_000_000:.6f} USDC**",
+            f"- Expected balance after funding: **{(wallet['usdc_balance_base_units'] - economics['total_funding_required']) / 1_000_000:.6f} USDC**",
+            f"- Current wallet verifier: `{wallet['policy']['deterministic_verifier']}`",
+            "",
+            "The router is non-upgradeable, cannot move funds, and permanently pins each active policy hash to one implementation code hash.",
+            "This preflight is not deployment, owner-policy activation, replacement funding, claimability, or payment evidence.",
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("plan", "deploy"))
+    parser.add_argument("--rpc-url", default=os.environ.get("BASE_MAINNET_RPC_URL", BASE_RPC_DEFAULT))
+    parser.add_argument("--api", default=os.environ.get("AGENT_BOUNTIES_API_URL", API_DEFAULT))
+    parser.add_argument("--forge", default=os.environ.get("FORGE_BIN", "forge"))
+    parser.add_argument("--cast", default=os.environ.get("CAST_BIN", "cast"))
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path("target/durable-verifier-router"))
+    parser.add_argument("--markdown-output", type=Path)
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parents[1]
+    foundry = Foundry(repo, args.rpc_url, args.forge, args.cast)
+    plan = build_router_plan(foundry)
+    report = plan if args.mode == "plan" else deploy(foundry, plan, args.api, args.output_dir)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.markdown_output:
+        args.markdown_output.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_output.write_text(markdown(plan), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "mode": args.mode,
+                "predicted_router": plan["predicted_router"],
+                "wallet_usdc_base_units": plan["bounded_wallet"]["usdc_balance_base_units"],
+                "output": str(args.output),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_durable_verifier_router_deploy.py
+++ b/scripts/test_durable_verifier_router_deploy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("durable_verifier_router_deploy.py")
+SPEC = importlib.util.spec_from_file_location("durable_verifier_router_deploy", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class DurableVerifierRouterDeployTests(unittest.TestCase):
+    def test_materialized_terms_share_router_policy_and_unique_nonces(self) -> None:
+        router = "0x" + "12" * 20
+        documents = MODULE.materialize_terms(Path(__file__).resolve().parents[1], router)
+        self.assertEqual(sorted(documents), [333, 334, 335, 336])
+        nonces = set()
+        policies = []
+        for issue, document in documents.items():
+            self.assertEqual(document["verification_policy"]["verifier_module"], router)
+            self.assertEqual(document["contract_terms"]["initial_funding"]["amount"], 2_010_000)
+            self.assertEqual(document["contract_terms"]["claim_bond"]["amount"], 10_000)
+            self.assertIn(str(issue), document["source_url"])
+            nonces.add(document["contract_terms"]["creation_nonce"])
+            policies.append(document["verification_policy"])
+        self.assertEqual(len(nonces), 4)
+        self.assertTrue(all(policy == policies[0] for policy in policies))
+
+    def test_create_payload_uses_published_commitments_and_router(self) -> None:
+        router = "0x" + "34" * 20
+        document = MODULE.materialize_terms(Path(__file__).resolve().parents[1], router)[333]
+        published = {
+            "terms_hash": "0x" + "01" * 32,
+            "policy_hash": "0x" + "02" * 32,
+            "acceptance_criteria_hash": "0x" + "03" * 32,
+            "benchmark_hash": "0x" + "04" * 32,
+            "evidence_schema_hash": "0x" + "05" * 32,
+        }
+        payload = MODULE.create_payload(document, published)
+        self.assertEqual(payload["verifier_module"], router)
+        self.assertEqual(payload["policy_hash"], published["policy_hash"])
+        self.assertEqual(payload["threshold"], 1)
+        self.assertEqual(payload["verifiers"], [])
+        self.assertEqual(payload["initial_funding"]["amount"], 2_010_000)
+
+    def test_redaction_hides_private_key_and_rpc_value(self) -> None:
+        rendered = MODULE.redact_command(
+            ["cast", "send", "--private-key", "secret", "--rpc-url", "credentialed", "--json"]
+        )
+        self.assertNotIn("secret", rendered)
+        self.assertNotIn("credentialed", rendered)
+        self.assertEqual(rendered.count("***"), 2)
+
+    def test_markdown_reports_durable_signature_boundary(self) -> None:
+        report = {
+            "predicted_router": "0x" + "56" * 20,
+            "router_already_deployed": False,
+            "registrar": MODULE.KEEPER,
+            "guardian": MODULE.OWNER,
+            "activation_delay_seconds": MODULE.ROUTER_ACTIVATION_DELAY,
+            "bounded_wallet": {
+                "address": MODULE.BOUNDED_WALLET,
+                "usdc_balance_base_units": 37_000_000,
+                "policy": {"deterministic_verifier": "0x" + "78" * 20},
+            },
+            "replacement_economics": {"total_funding_required": 8_040_000},
+        }
+        value = MODULE.markdown(report)
+        self.assertIn("7 days", value)
+        self.assertIn("28.960000 USDC", value)
+        self.assertIn("cannot move funds", value)
+        self.assertIn("not deployment", value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Complete the infrastructure half of #571 so the existing Base bounded-agent wallet can make one final owner policy transaction and then adopt future deterministic verifier policies without recurring owner approvals.

## What this PR ships

- a non-upgradeable, fundless `PolicyBoundVerifierRouter` at a deterministic Base address;
- routing by each bounty's immutable `policyHash`;
- append-only active policy records pinned to an implementation address and runtime code hash;
- one bounded bootstrap policy, followed by seven-day delayed registrar proposals with guardian veto;
- a routed profitable V3 implementation that explicitly validates the canonical parent address supplied by the router;
- exact routed V3 parent terms materialization for #333–#336;
- deterministic router/adapter deployment, terms publication, bootstrap, immutable attestation, and observable failure reporting;
- adversarial tests for replacement, bootstrap reuse, delay bypass, veto bypass, non-canonical callers, and metadata mismatch;
- ADR 0003 documenting the one-time production delegate rotation and unchanged financial caps.

## Verified preflight

- predicted stable router: `0x380c1af742593dd88b6f20387e9ee693a0536731`;
- current bounded-wallet balance: **37.000000 USDC**;
- replacement funding required: **8.040000 USDC**;
- expected post-funding balance: **28.960000 USDC**;
- current caps remain 5 USDC/action, 10 USDC/day, 89 USDC lifetime, 5 USDC/bounty;
- future routed policies have a seven-day public veto window.

## Follow-up after deployment

A separate evidence-backed activation PR will commit the confirmed router/policy/adapter manifest, publish the final owner page, and add the event-gated replacement executor. The owner page will copy the live action and financial caps unchanged, rotate the delegate once to the protected production keeper, pin this stable router, and extend expiry.

## Authority boundary

This PR's source and merge do not themselves prove deployment, owner-policy activation, replacement funding, claimability, or payment. The deployment workflow posts confirmed runtime and immutable-policy evidence to #571. Only the later `PolicyConfigured` event authorizes the wallet, and canonical bounty lifecycle events govern funding and payout.