### PR TITLE
Add exact assistant output schemas

### DIFF
--- a/.github/workflows/standing-meta-v4-maintainer-security-fix.yml
+++ b/.github/workflows/standing-meta-v4-maintainer-security-fix.yml
@@ -67,11 +67,11 @@ jobs:
               "contracts/base-escrow/src/AnonymousProtocolControllerV1.sol",
               """            stakePool_.code.length > 0 && verifierSortition_.code.length > 0 && solverSortition_.code.length > 0
                 && appealableVerifier_.code.length > 0 && standingMetaParentFactory_.code.length > 0,
-""",
+          """,
               """            stakePool_.code.length > 0 && verifierSortition_.code.length > 0 && solverSortition_.code.length > 0
                 && verifierSortition_ != solverSortition_ && appealableVerifier_.code.length > 0
                 && standingMetaParentFactory_.code.length > 0,
-""",
+          """,
           )
 
           # The appeal module may consume VRF and slash stake only for factory-canonical V4 children.
@@ -79,64 +79,64 @@ jobs:
               "contracts/base-escrow/src/AppealableVerifierV1.sol",
               """}
 
-/// @notice Anonymous primary-verifier assignment with symmetric, one-round
-""",
+          /// @notice Anonymous primary-verifier assignment with symmetric, one-round
+          """,
               """}
 
-interface ICanonicalAppealableChildRegistryV1 {
-    function isCanonicalAppealableChild(address bounty) external view returns (bool);
-}
+          interface ICanonicalAppealableChildRegistryV1 {
+              function isCanonicalAppealableChild(address bounty) external view returns (bool);
+          }
 
-/// @notice Anonymous primary-verifier assignment with symmetric, one-round
-""",
+          /// @notice Anonymous primary-verifier assignment with symmetric, one-round
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/AppealableVerifierV1.sol",
               """        IAppealableBountyV1 item = IAppealableBountyV1(bounty);
-        _validateBounty(item);
-""",
+                  _validateBounty(item);
+          """,
               """        IAppealableBountyV1 item = IAppealableBountyV1(bounty);
-        _validateBounty(bounty, item);
-""",
+                  _validateBounty(bounty, item);
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/AppealableVerifierV1.sol",
               """    function _validateBounty(IAppealableBountyV1 item) private view {
-        require(item.settlementToken() == settlementToken, "token mismatch");
-""",
+                  require(item.settlementToken() == settlementToken, "token mismatch");
+          """,
               """    function _validateBounty(address bounty, IAppealableBountyV1 item) private view {
-        address registry = controller.standingMetaParentFactory();
-        require(
+                  address registry = controller.standingMetaParentFactory();
+                  require(
             controller.configured() && registry.code.length > 0
                 && ICanonicalAppealableChildRegistryV1(registry).isCanonicalAppealableChild(bounty),
             "bounty not canonical"
-        );
-        require(item.settlementToken() == settlementToken, "token mismatch");
-""",
+                  );
+                  require(item.settlementToken() == settlementToken, "token mismatch");
+          """,
           )
 
           # An early three-vote majority may finalize, but jurors whose window is still open are released, not slashed.
           replace_once(
               "contracts/base-escrow/src/AppealableVerifierV1.sol",
               """        _closeJuryLocks(caseId);
-        item.state = CaseState.Finalized;
-""",
+                  item.state = CaseState.Finalized;
+          """,
               """        _closeJuryLocks(caseId, block.timestamp > item.voteDeadline);
-        item.state = CaseState.Finalized;
-""",
+                  item.state = CaseState.Finalized;
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/AppealableVerifierV1.sol",
               """        if (item.state == CaseState.AppealVoting) _closeJuryLocks(caseId);
-""",
+          """,
               """        if (item.state == CaseState.AppealVoting) _closeJuryLocks(caseId, true);
-""",
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/AppealableVerifierV1.sol",
               """    function _closeJuryLocks(bytes32 caseId) private {
-        address[] storage wallets = _appellateWallets[caseId];
-        for (uint256 i = 0; i < wallets.length; i++) {
+                  address[] storage wallets = _appellateWallets[caseId];
+                  for (uint256 i = 0; i < wallets.length; i++) {
             address wallet = wallets[i];
             bytes32 lockId = _juryLockId(caseId, wallet);
             if (voted[caseId][wallet]) {
@@ -144,12 +144,12 @@ interface ICanonicalAppealableChildRegistryV1 {
             } else {
                 controller.slashVerifierStake(lockId, wallet, AVAILABILITY_SLASH, address(controller.stakePool()));
             }
-        }
-    }
-""",
+                  }
+              }
+          """,
               """    function _closeJuryLocks(bytes32 caseId, bool slashNonVoters) private {
-        address[] storage wallets = _appellateWallets[caseId];
-        for (uint256 i = 0; i < wallets.length; i++) {
+                  address[] storage wallets = _appellateWallets[caseId];
+                  for (uint256 i = 0; i < wallets.length; i++) {
             address wallet = wallets[i];
             bytes32 lockId = _juryLockId(caseId, wallet);
             if (voted[caseId][wallet] || !slashNonVoters) {
@@ -157,191 +157,191 @@ interface ICanonicalAppealableChildRegistryV1 {
             } else {
                 controller.slashVerifierStake(lockId, wallet, AVAILABILITY_SLASH, address(controller.stakePool()));
             }
-        }
-    }
-""",
+                  }
+              }
+          """,
           )
 
           # Canonical parent IDs are unique, child selection time is block-derived, and selected solvers are rechecked.
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
               """    mapping(address => bool) public isCanonicalParent;
-""",
+          """,
               """    mapping(address => bool) public isCanonicalParent;
-    mapping(bytes32 => address) public parentByBountyId;
-""",
+              mapping(bytes32 => address) public parentByBountyId;
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
               """        bountyId = keccak256(abi.encode(block.chainid, address(this), msg.sender, config.creationNonce, config));
-        StandingMetaParentV4 parent = new StandingMetaParentV4(
-""",
+                  StandingMetaParentV4 parent = new StandingMetaParentV4(
+          """,
               """        bountyId = keccak256(abi.encode(block.chainid, address(this), msg.sender, config.creationNonce, config));
-        require(parentByBountyId[bountyId] == address(0), "parent bounty id already used");
-        StandingMetaParentV4 parent = new StandingMetaParentV4(
-""",
+                  require(parentByBountyId[bountyId] == address(0), "parent bounty id already used");
+                  StandingMetaParentV4 parent = new StandingMetaParentV4(
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
               """        parentAddress = address(parent);
-        isCanonicalParent[parentAddress] = true;
-""",
+                  isCanonicalParent[parentAddress] = true;
+          """,
               """        parentAddress = address(parent);
-        parentByBountyId[bountyId] = parentAddress;
-        isCanonicalParent[parentAddress] = true;
-""",
+                  parentByBountyId[bountyId] = parentAddress;
+                  isCanonicalParent[parentAddress] = true;
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
               """        PreparationContext memory context = _preparationContext(parentAddress, parent, request, candidateHash);
-        _validateTermsInput(request.terms, parent, context, request.childParams);
-        bytes32 publishedTermsHash = termsRegistry.publishFor(msg.sender, request.canonicalTerms, request.terms);
-""",
+                  _validateTermsInput(request.terms, parent, context, request.childParams);
+                  bytes32 publishedTermsHash = termsRegistry.publishFor(msg.sender, request.canonicalTerms, request.terms);
+          """,
               """        PreparationContext memory context = _preparationContext(parentAddress, parent, request, candidateHash);
-        OnchainTermsRegistryV4.TermsInput memory resolvedTerms =
+                  OnchainTermsRegistryV4.TermsInput memory resolvedTerms =
             _resolvedTermsInput(request.terms, parent, context, request.childParams);
-        bytes32 publishedTermsHash = termsRegistry.publishFor(msg.sender, request.canonicalTerms, resolvedTerms);
-""",
+                  bytes32 publishedTermsHash = termsRegistry.publishFor(msg.sender, request.canonicalTerms, resolvedTerms);
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
               """        require(_ranking[parentAddress][parentRound][data.currentRank] == msg.sender, "candidate not selected");
-        require(StandingMetaChildV4(data.child).status() == CLAIMABLE_STATUS, "child not claimable");
-""",
+                  require(StandingMetaChildV4(data.child).status() == CLAIMABLE_STATUS, "child not claimable");
+          """,
               """        require(_ranking[parentAddress][parentRound][data.currentRank] == msg.sender, "candidate not selected");
-        _requireCurrentlyEligibleSolver(msg.sender);
-        require(StandingMetaChildV4(data.child).status() == CLAIMABLE_STATUS, "child not claimable");
-""",
+                  _requireCurrentlyEligibleSolver(msg.sender);
+                  require(StandingMetaChildV4(data.child).status() == CLAIMABLE_STATUS, "child not claimable");
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
               """    function authorizedChildSolver(address parent, uint64 parentRound, address child, address solver)
-""",
+          """,
               """    function isCanonicalAppealableChild(address bounty) external view returns (bool) {
-        return standingMetaChildFactory.isCanonicalChild(bounty);
-    }
+                  return standingMetaChildFactory.isCanonicalChild(bounty);
+              }
 
-    function authorizedChildSolver(address parent, uint64 parentRound, address child, address solver)
-""",
+              function authorizedChildSolver(address parent, uint64 parentRound, address child, address solver)
+          """,
           )
           replace_region(
               "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
               "    function _validateTermsInput(",
               "    function _preparationContext(",
               """    function _resolvedTermsInput(
-        OnchainTermsRegistryV4.TermsInput calldata terms,
-        StandingMetaParentV4 parent,
-        PreparationContext memory context,
-        AgentBountyFactory.CreateBountyParams calldata params
-    ) private view returns (OnchainTermsRegistryV4.TermsInput memory resolved) {
-        require(
+                  OnchainTermsRegistryV4.TermsInput calldata terms,
+                  StandingMetaParentV4 parent,
+                  PreparationContext memory context,
+                  AgentBountyFactory.CreateBountyParams calldata params
+              ) private view returns (OnchainTermsRegistryV4.TermsInput memory resolved) {
+                  require(
             terms.selectionCommitment == bytes32(0) && terms.selectionRequestedAt == 0,
             "selection fields must be derived"
-        );
-        resolved = terms;
-        resolved.selectionCommitment = context.selectionCommitment;
-        resolved.selectionRequestedAt = context.selectionRequestedAt;
-        require(
+                  );
+                  resolved = terms;
+                  resolved.selectionCommitment = context.selectionCommitment;
+                  resolved.selectionRequestedAt = context.selectionRequestedAt;
+                  require(
             resolved.parent == address(parent) && resolved.child == context.predictedChild
                 && resolved.parentBountyId == parent.bountyId() && resolved.parentRound == context.parentRound,
             "terms binding invalid"
-        );
-        require(
+                  );
+                  require(
             resolved.verifierModule == address(appealableVerifier) && resolved.policyHash == params.policyHash
                 && resolved.acceptanceCriteriaHash == params.acceptanceCriteriaHash
                 && resolved.benchmarkHash == params.benchmarkHash
                 && resolved.evidenceSchemaHash == params.evidenceSchemaHash
                 && resolved.appealPolicyHash == appealableVerifier.appealPolicyHash(),
             "terms content invalid"
-        );
-        require(
+                  );
+                  require(
             resolved.childClaimWindowSeconds == CHILD_WORK_WINDOW
                 && resolved.childVerificationWindowSeconds == CHILD_VERIFICATION_WINDOW
                 && resolved.childFundingTarget == CHILD_TARGET && resolved.childSolverReward == CHILD_SOLVER_REWARD
                 && resolved.childVerifierReward == CHILD_VERIFIER_REWARD,
             "terms economics invalid"
-        );
-    }
+                  );
+              }
 
-""",
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentFactoryV4.sol",
               """    function _eligibleChildSolvers(StandingMetaParentV4 parent, address parentSolver)
-""",
+          """,
               """    function _requireCurrentlyEligibleSolver(address wallet) private view {
-        (uint128 stake,,, uint64 unbondAt, bool active, bool available) =
+                  (uint128 stake,,, uint64 unbondAt, bool active, bool available) =
             controller.stakePool().tickets(wallet, AnonymousStakePoolV1.Role.Solver);
-        require(
+                  require(
             stake == controller.stakePool().STAKE_AMOUNT() && unbondAt == 0 && active && available,
             "candidate no longer eligible"
-        );
-    }
+                  );
+              }
 
-    function _eligibleChildSolvers(StandingMetaParentV4 parent, address parentSolver)
-""",
+              function _eligibleChildSolvers(StandingMetaParentV4 parent, address parentSolver)
+          """,
           )
 
           # Unsolicited token dust must never brick exact-accounting initialization or a parent claim.
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentV4.sol",
               """        require(IERC20BountyToken(settlementToken).balanceOf(address(this)) == TARGET_AMOUNT, "funding mismatch");
-""",
+          """,
               """        require(IERC20BountyToken(settlementToken).balanceOf(address(this)) >= TARGET_AMOUNT, "funding mismatch");
-""",
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaParentV4.sol",
               """            IERC20BountyToken(settlementToken).balanceOf(address(this)) == TARGET_AMOUNT + VERIFIER_REWARD,
-""",
+          """,
               """            IERC20BountyToken(settlementToken).balanceOf(address(this)) >= TARGET_AMOUNT + VERIFIER_REWARD,
-""",
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaChildV4.sol",
               """import "./IAgentBounty.sol";
 
-/// @notice Exact-economics V4 child whose claim authority is restricted to the
-""",
+          /// @notice Exact-economics V4 child whose claim authority is restricted to the
+          """,
               """import "./IAgentBounty.sol";
 
-interface IAppealableVerifierRewardAllocatorV1 {
-    function allocateVerifierReward(bytes32 caseId) external;
-}
+          interface IAppealableVerifierRewardAllocatorV1 {
+              function allocateVerifierReward(bytes32 caseId) external;
+          }
 
-/// @notice Exact-economics V4 child whose claim authority is restricted to the
-""",
+          /// @notice Exact-economics V4 child whose claim authority is restricted to the
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaChildV4.sol",
               """        require(IERC20BountyToken(settlementToken).balanceOf(address(this)) == TARGET_AMOUNT, "funding mismatch");
-""",
+          """,
               """        require(IERC20BountyToken(settlementToken).balanceOf(address(this)) >= TARGET_AMOUNT, "funding mismatch");
-""",
+          """,
           )
           replace_once(
               "contracts/base-escrow/src/StandingMetaChildV4.sol",
               """    function verifyAndSettle(bytes calldata proof) external nonReentrant {
-        require(_status == Status.Submitted && block.timestamp <= verificationExpiresAt, "verification unavailable");
-        (bool passed, bytes32 responseHash) = IAgentBountyVerifier(verifierModule)
+                  require(_status == Status.Submitted && block.timestamp <= verificationExpiresAt, "verification unavailable");
+                  (bool passed, bytes32 responseHash) = IAgentBountyVerifier(verifierModule)
             .verify(bountyId, round, solver, submissionHash, evidenceHash, policyHash, proof);
-        bytes32 verificationHash = keccak256(abi.encode(verifierModule, responseHash, keccak256(proof)));
-        if (passed) _settle(verificationHash);
-        else _reject(verificationHash);
-    }
-""",
+                  bytes32 verificationHash = keccak256(abi.encode(verifierModule, responseHash, keccak256(proof)));
+                  if (passed) _settle(verificationHash);
+                  else _reject(verificationHash);
+              }
+          """,
               """    function verifyAndSettle(bytes calldata proof) external nonReentrant {
-        require(_status == Status.Submitted && block.timestamp <= verificationExpiresAt, "verification unavailable");
-        require(proof.length == 32, "case proof invalid");
-        bytes32 caseId = abi.decode(proof, (bytes32));
-        (bool passed, bytes32 responseHash) = IAgentBountyVerifier(verifierModule)
+                  require(_status == Status.Submitted && block.timestamp <= verificationExpiresAt, "verification unavailable");
+                  require(proof.length == 32, "case proof invalid");
+                  bytes32 caseId = abi.decode(proof, (bytes32));
+                  (bool passed, bytes32 responseHash) = IAgentBountyVerifier(verifierModule)
             .verify(bountyId, round, solver, submissionHash, evidenceHash, policyHash, proof);
-        bytes32 verificationHash = keccak256(abi.encode(verifierModule, responseHash, keccak256(proof)));
-        if (passed) _settle(verificationHash);
-        else _reject(verificationHash);
-        IAppealableVerifierRewardAllocatorV1(verifierModule).allocateVerifierReward(caseId);
-    }
-""",
+                  bytes32 verificationHash = keccak256(abi.encode(verifierModule, responseHash, keccak256(proof)));
+                  if (passed) _settle(verificationHash);
+                  else _reject(verificationHash);
+                  IAppealableVerifierRewardAllocatorV1(verifierModule).allocateVerifierReward(caseId);
+              }
+          """,
           )
 
           # Funding an existing subscription also proves the consumers' immutable coordinator/subscription/controller graph.
@@ -349,242 +349,242 @@ interface IAppealableVerifierRewardAllocatorV1 {
               "contracts/base-escrow/script/FundStandingMetaV4Subscription.s.sol",
               """}
 
-/// @notice Funds one already-created V4 subscription with the exact native
-""",
+          /// @notice Funds one already-created V4 subscription with the exact native
+          """,
               """}
 
-interface IStandingMetaV4SortitionFundingView {
-    function vrfCoordinator() external view returns (address);
-    function controller() external view returns (address);
-    function subscriptionId() external view returns (uint256);
-}
+          interface IStandingMetaV4SortitionFundingView {
+              function vrfCoordinator() external view returns (address);
+              function controller() external view returns (address);
+              function subscriptionId() external view returns (uint256);
+          }
 
-interface IStandingMetaV4ControllerFundingView {
-    function configured() external view returns (bool);
-    function verifierSortition() external view returns (address);
-    function solverSortition() external view returns (address);
-}
+          interface IStandingMetaV4ControllerFundingView {
+              function configured() external view returns (bool);
+              function verifierSortition() external view returns (address);
+              function solverSortition() external view returns (address);
+          }
 
-/// @notice Funds one already-created V4 subscription with the exact native
-""",
+          /// @notice Funds one already-created V4 subscription with the exact native
+          """,
           )
           replace_once(
               "contracts/base-escrow/script/FundStandingMetaV4Subscription.s.sol",
               """    function _validateSubscription(FundingContext memory context) private view returns (uint96) {
-        uint96 nativeBefore;
-        address subscriptionOwner;
-        address[] memory consumers;
-""",
+                  uint96 nativeBefore;
+                  address subscriptionOwner;
+                  address[] memory consumers;
+          """,
               """    function _validateSubscription(FundingContext memory context) private view returns (uint96) {
-        require(
+                  require(
             context.verifierSortition.code.length > 0 && context.solverSortition.code.length > 0,
             "consumer code missing"
-        );
-        IStandingMetaV4SortitionFundingView verifier =
+                  );
+                  IStandingMetaV4SortitionFundingView verifier =
             IStandingMetaV4SortitionFundingView(context.verifierSortition);
-        IStandingMetaV4SortitionFundingView solver = IStandingMetaV4SortitionFundingView(context.solverSortition);
-        address protocolController = verifier.controller();
-        require(
+                  IStandingMetaV4SortitionFundingView solver = IStandingMetaV4SortitionFundingView(context.solverSortition);
+                  address protocolController = verifier.controller();
+                  require(
             protocolController != address(0) && protocolController.code.length > 0
                 && solver.controller() == protocolController && verifier.vrfCoordinator() == context.vrf
                 && solver.vrfCoordinator() == context.vrf && verifier.subscriptionId() == context.subscriptionId
                 && solver.subscriptionId() == context.subscriptionId,
             "consumer wiring mismatch"
-        );
-        IStandingMetaV4ControllerFundingView controller = IStandingMetaV4ControllerFundingView(protocolController);
-        require(
+                  );
+                  IStandingMetaV4ControllerFundingView controller = IStandingMetaV4ControllerFundingView(protocolController);
+                  require(
             controller.configured() && controller.verifierSortition() == context.verifierSortition
                 && controller.solverSortition() == context.solverSortition,
             "controller wiring mismatch"
-        );
+                  );
 
-        uint96 nativeBefore;
-        address subscriptionOwner;
-        address[] memory consumers;
-""",
+                  uint96 nativeBefore;
+                  address subscriptionOwner;
+                  address[] memory consumers;
+          """,
           )
 
           # Error paths must redact values from subprocess output, not only from the rendered command.
           replace_once(
               "scripts/standing_meta_v4_deploy.py",
               """def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
-""",
+          """,
               """def redacted_output(output: str, command: Sequence[str]) -> str:
-    rendered = output
-    for secret_flag in ("--private-key", "--rpc-url"):
-        for index, item in enumerate(command[:-1]):
+              rendered = output
+              for secret_flag in ("--private-key", "--rpc-url"):
+                  for index, item in enumerate(command[:-1]):
             if item == secret_flag and command[index + 1]:
                 rendered = rendered.replace(command[index + 1], "[redacted]")
-    return rendered
+              return rendered
 
 
-def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
-""",
+          def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
+          """,
           )
           replace_once(
               "scripts/standing_meta_v4_deploy.py",
               """            f"command failed ({completed.returncode}): {redacted_command(command)}\n{completed.stdout[-6000:]}"
-""",
+          """,
               """            f"command failed ({completed.returncode}): {redacted_command(command)}\n"
             f"{redacted_output(completed.stdout, command)[-6000:]}"
-""",
+          """,
           )
           replace_once(
               "scripts/test_standing_meta_v4_deploy.py",
               """    def test_networks_pin_official_vrf_configuration(self) -> None:
-""",
+          """,
               """    def test_release_errors_redact_signer_and_rpc_credentials_from_output(self) -> None:
-        command = [
+                  command = [
             "cast",
             "send",
             "--private-key",
             "0xsupersecret",
             "--rpc-url",
             "https://rpc.example/private-token",
-        ]
-        rendered = MODULE.redacted_output(
+                  ]
+                  rendered = MODULE.redacted_output(
             "failed with 0xsupersecret at https://rpc.example/private-token", command
-        )
-        self.assertNotIn("supersecret", rendered)
-        self.assertNotIn("private-token", rendered)
-        self.assertEqual(rendered.count("[redacted]"), 2)
+                  )
+                  self.assertNotIn("supersecret", rendered)
+                  self.assertNotIn("private-token", rendered)
+                  self.assertEqual(rendered.count("[redacted]"), 2)
 
-    def test_networks_pin_official_vrf_configuration(self) -> None:
-""",
+              def test_networks_pin_official_vrf_configuration(self) -> None:
+          """,
           )
 
           # Test registry for the generic appeal harness; production uses the immutable V4 child factory registry.
           replace_once(
               "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
               """contract AppealVerifierControllerDummy {}
-""",
+          """,
               """contract AppealVerifierControllerDummy {
-    mapping(address => bool) public isCanonicalAppealableChild;
+              mapping(address => bool) public isCanonicalAppealableChild;
 
-    function setCanonicalAppealableChild(address bounty, bool canonical) external {
-        isCanonicalAppealableChild[bounty] = canonical;
-    }
-}
-""",
+              function setCanonicalAppealableChild(address bounty, bool canonical) external {
+                  isCanonicalAppealableChild[bounty] = canonical;
+              }
+          }
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
               """    AppealableVerifierV1 private verifier;
-    AppealVerifierActor private solver;
-""",
+              AppealVerifierActor private solver;
+          """,
               """    AppealableVerifierV1 private verifier;
-    AppealVerifierControllerDummy private parentFactory;
-    AppealVerifierActor private solver;
-""",
+              AppealVerifierControllerDummy private parentFactory;
+              AppealVerifierActor private solver;
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
               """        AppealVerifierControllerDummy parentFactory = new AppealVerifierControllerDummy();
-""",
+          """,
               """        parentFactory = new AppealVerifierControllerDummy();
-""",
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
               """        require(juryCredits == 110_000, "slash and verifier reward not shared");
-    }
-""",
+              }
+          """,
               """        require(juryCredits == 110_000, "slash and verifier reward not shared");
-        for (uint256 i = 3; i < jury.length; i++) {
+                  for (uint256 i = 3; i < jury.length; i++) {
             (uint128 stake, uint128 locked,,, bool active,) =
                 pool.tickets(jury[i], AnonymousStakePoolV1.Role.Verifier);
             require(stake == 5_000_000 && locked == 0 && active, "early nonvoter was slashed");
-        }
-    }
-""",
+                  }
+              }
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
               """    function _prepareCase(uint256 randomWord) private returns (AgentBounty bounty, bytes32 caseId) {
-""",
+          """,
               """    function testUnregisteredInterfaceShapedBountyCannotConsumeVrfOrStake() public {
-        AgentBounty bounty = _createSubmittedBounty();
-        parentFactory.setCanonicalAppealableChild(address(bounty), false);
-        uint256 requestBefore = vrf.nextRequestId();
-        (bool opened,) = address(verifier).call(abi.encodeCall(verifier.openCase, (address(bounty))));
-        require(!opened, "unregistered bounty opened a verification case");
-        require(vrf.nextRequestId() == requestBefore, "unregistered bounty consumed VRF");
-    }
+                  AgentBounty bounty = _createSubmittedBounty();
+                  parentFactory.setCanonicalAppealableChild(address(bounty), false);
+                  uint256 requestBefore = vrf.nextRequestId();
+                  (bool opened,) = address(verifier).call(abi.encodeCall(verifier.openCase, (address(bounty))));
+                  require(!opened, "unregistered bounty opened a verification case");
+                  require(vrf.nextRequestId() == requestBefore, "unregistered bounty consumed VRF");
+              }
 
-    function _prepareCase(uint256 randomWord) private returns (AgentBounty bounty, bytes32 caseId) {
-""",
+              function _prepareCase(uint256 randomWord) private returns (AgentBounty bounty, bytes32 caseId) {
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/AppealableVerifierV1.t.sol",
               """        bounty = AgentBounty(bountyAddress);
-        solver.approve(token, address(bounty), type(uint256).max);
-""",
+                  solver.approve(token, address(bounty), type(uint256).max);
+          """,
               """        bounty = AgentBounty(bountyAddress);
-        parentFactory.setCanonicalAppealableChild(bountyAddress, true);
-        solver.approve(token, address(bounty), type(uint256).max);
-""",
+                  parentFactory.setCanonicalAppealableChild(bountyAddress, true);
+                  solver.approve(token, address(bounty), type(uint256).max);
+          """,
           )
 
           # Canonical V4 regression coverage for atomic reward allocation, dust, delayed inclusion, IDs and eligibility.
           replace_once(
               "contracts/base-escrow/test/StandingMetaV4.t.sol",
               """        child.verifyAndSettle(abi.encode(caseId));
-        appealableVerifier.allocateVerifierReward(caseId);
+                  appealableVerifier.allocateVerifierReward(caseId);
 
-        parentSolver.submitParent(parent, address(child));
-""",
+                  parentSolver.submitParent(parent, address(child));
+          """,
               """        child.verifyAndSettle(abi.encode(caseId));
-        require(appealableVerifier.credits(primary) == 10_000, "atomic verifier reward missing");
-        (bool duplicateAllocation,) =
+                  require(appealableVerifier.credits(primary) == 10_000, "atomic verifier reward missing");
+                  (bool duplicateAllocation,) =
             address(appealableVerifier).call(abi.encodeCall(appealableVerifier.allocateVerifierReward, (caseId)));
-        require(!duplicateAllocation, "verifier reward allocated twice");
+                  require(!duplicateAllocation, "verifier reward allocated twice");
 
-        parentSolver.submitParent(parent, address(child));
-""",
+                  parentSolver.submitParent(parent, address(child));
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/StandingMetaV4.t.sol",
               """        child.verifyAndSettle(abi.encode(caseId));
-        appealableVerifier.allocateVerifierReward(caseId);
+                  appealableVerifier.allocateVerifierReward(caseId);
 
-        require(child.bountyStatus() == StandingMetaChildV4.Status.Claimable, "rejected child did not reopen");
-""",
+                  require(child.bountyStatus() == StandingMetaChildV4.Status.Claimable, "rejected child did not reopen");
+          """,
               """        child.verifyAndSettle(abi.encode(caseId));
-        require(appealableVerifier.credits(primary) == 10_000, "atomic rejection reward missing");
+                  require(appealableVerifier.credits(primary) == 10_000, "atomic rejection reward missing");
 
-        require(child.bountyStatus() == StandingMetaChildV4.Status.Claimable, "rejected child did not reopen");
-""",
+                  require(child.bountyStatus() == StandingMetaChildV4.Status.Claimable, "rejected child did not reopen");
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/StandingMetaV4.t.sol",
               """    function _createParent() private returns (StandingMetaParentV4 parent) {
-""",
+          """,
               """    function testSelectionCommitmentIsDerivedAtInclusionTime() public {
-        StandingMetaParentV4 parent = _createParent();
-        StandingMetaParentFactoryV4.ClaimAndCreateChildRequest memory request = _claimRequest(parent);
-        require(request.terms.selectionCommitment == bytes32(0), "caller supplied selection commitment");
-        require(request.terms.selectionRequestedAt == 0, "caller supplied selection timestamp");
-        vm.warp(block.timestamp + 5 minutes);
-        address childAddress = parentSolver.claimAndCreate(parentFactory, address(parent), request);
-        bytes32 termsHash = StandingMetaChildV4(childAddress).termsHash();
-        (uint64 selectionRequestedAt,,,,,) = parentFactory.termsRegistry().economicsTiming(termsHash);
-        (,,,,,, bytes32 commitment) = parentFactory.termsRegistry().bindings(termsHash);
-        require(selectionRequestedAt == block.timestamp && commitment != bytes32(0), "selection was not block-derived");
-    }
+                  StandingMetaParentV4 parent = _createParent();
+                  StandingMetaParentFactoryV4.ClaimAndCreateChildRequest memory request = _claimRequest(parent);
+                  require(request.terms.selectionCommitment == bytes32(0), "caller supplied selection commitment");
+                  require(request.terms.selectionRequestedAt == 0, "caller supplied selection timestamp");
+                  vm.warp(block.timestamp + 5 minutes);
+                  address childAddress = parentSolver.claimAndCreate(parentFactory, address(parent), request);
+                  bytes32 termsHash = StandingMetaChildV4(childAddress).termsHash();
+                  (uint64 selectionRequestedAt,,,,,) = parentFactory.termsRegistry().economicsTiming(termsHash);
+                  (,,,,,, bytes32 commitment) = parentFactory.termsRegistry().bindings(termsHash);
+                  require(selectionRequestedAt == block.timestamp && commitment != bytes32(0), "selection was not block-derived");
+              }
 
-    function testUnsolicitedDustCannotBrickFundingOrParentClaim() public {
-        StandingMetaParentV4 parent = _createParent();
-        StandingMetaParentFactoryV4.ClaimAndCreateChildRequest memory request = _claimRequest(parent);
-        token.mint(address(this), 2);
-        token.transfer(address(parent), 1);
-        token.transfer(request.terms.child, 1);
-        address childAddress = parentSolver.claimAndCreate(parentFactory, address(parent), request);
-        StandingMetaChildV4 child = StandingMetaChildV4(childAddress);
-        require(child.fundedAmount() == 1_000_000, "child principal accounting drift");
-        require(token.balanceOf(childAddress) == 1_000_001, "child dust was not tolerated");
-        require(parent.bountyStatus() == StandingMetaParentV4.Status.Claimed, "parent claim was dust-bricked");
+              function testUnsolicitedDustCannotBrickFundingOrParentClaim() public {
+                  StandingMetaParentV4 parent = _createParent();
+                  StandingMetaParentFactoryV4.ClaimAndCreateChildRequest memory request = _claimRequest(parent);
+                  token.mint(address(this), 2);
+                  token.transfer(address(parent), 1);
+                  token.transfer(request.terms.child, 1);
+                  address childAddress = parentSolver.claimAndCreate(parentFactory, address(parent), request);
+                  StandingMetaChildV4 child = StandingMetaChildV4(childAddress);
+                  require(child.fundedAmount() == 1_000_000, "child principal accounting drift");
+                  require(token.balanceOf(childAddress) == 1_000_001, "child dust was not tolerated");
+                  require(parent.bountyStatus() == StandingMetaParentV4.Status.Claimed, "parent claim was dust-bricked");
 
-        StandingMetaParentV4 directParent = new StandingMetaParentV4(
+                  StandingMetaParentV4 directParent = new StandingMetaParentV4(
             keccak256("direct-dust-parent"),
             address(this),
             address(this),
@@ -595,69 +595,69 @@ def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
             parentFactory.verifierModule().ACCEPTANCE_CRITERIA_HASH(),
             keccak256("direct-benchmark"),
             keccak256("direct-schema")
-        );
-        token.mint(address(this), 2_010_001);
-        token.transfer(address(directParent), 2_010_001);
-        directParent.recordInitialFunding();
-        require(directParent.fundedAmount() == 2_010_000, "parent principal accounting drift");
-    }
+                  );
+                  token.mint(address(this), 2_010_001);
+                  token.transfer(address(directParent), 2_010_001);
+                  directParent.recordInitialFunding();
+                  require(directParent.fundedAmount() == 2_010_000, "parent principal accounting drift");
+              }
 
-    function testParentBountyIdCannotBeReused() public {
-        token.mint(address(this), 2_010_000);
-        token.approve(address(parentFactory), type(uint256).max);
-        StandingMetaParentFactoryV4.ParentConfig memory config = StandingMetaParentFactoryV4.ParentConfig({
+              function testParentBountyIdCannotBeReused() public {
+                  token.mint(address(this), 2_010_000);
+                  token.approve(address(parentFactory), type(uint256).max);
+                  StandingMetaParentFactoryV4.ParentConfig memory config = StandingMetaParentFactoryV4.ParentConfig({
             termsHash: keccak256("duplicate-parent-terms"),
             policyHash: keccak256("duplicate-parent-policy"),
             benchmarkHash: keccak256("duplicate-parent-benchmark"),
             evidenceSchemaHash: keccak256("duplicate-parent-schema"),
             creationNonce: keccak256("duplicate-parent-nonce")
-        });
-        (address firstParent, bytes32 bountyId) = parentFactory.createParent(config);
-        (bool duplicate,) = address(parentFactory).call(abi.encodeCall(parentFactory.createParent, (config)));
-        require(!duplicate, "duplicate canonical parent bounty id accepted");
-        require(parentFactory.parentByBountyId(bountyId) == firstParent, "canonical parent id mapping drift");
-    }
+                  });
+                  (address firstParent, bytes32 bountyId) = parentFactory.createParent(config);
+                  (bool duplicate,) = address(parentFactory).call(abi.encodeCall(parentFactory.createParent, (config)));
+                  require(!duplicate, "duplicate canonical parent bounty id accepted");
+                  require(parentFactory.parentByBountyId(bountyId) == firstParent, "canonical parent id mapping drift");
+              }
 
-    function testSelectedSolverMustRemainEligibleAtClaimTime() public {
-        StandingMetaParentV4 parent = _createParent();
-        StandingMetaChildV4 child = _prepareAtomicChildAndDraw(parent, 616);
-        child;
-        address selected = _selectedChildSolver(parent);
-        StandingMetaV4Actor(selected).setAvailable(pool, AnonymousStakePoolV1.Role.Solver, false);
-        StandingMetaParentFactoryV4.BondAuthorization memory bond =
+              function testSelectedSolverMustRemainEligibleAtClaimTime() public {
+                  StandingMetaParentV4 parent = _createParent();
+                  StandingMetaChildV4 child = _prepareAtomicChildAndDraw(parent, 616);
+                  child;
+                  address selected = _selectedChildSolver(parent);
+                  StandingMetaV4Actor(selected).setAvailable(pool, AnonymousStakePoolV1.Role.Solver, false);
+                  StandingMetaParentFactoryV4.BondAuthorization memory bond =
             _bondAuthorization(keccak256("ineligible-selected-bond"));
-        (bool claimed,) = address(selected)
+                  (bool claimed,) = address(selected)
             .call(abi.encodeCall(StandingMetaV4Actor.claimChild, (parentFactory, address(parent), bond)));
-        require(!claimed, "unavailable selected solver claimed child");
-        vm.warp(block.timestamp + 10 minutes + 1);
-        parentFactory.promoteNonresponsiveChildSolver(address(parent));
-        (,, uint8 rank,) = parentFactory.roundTiming(address(parent), parent.round());
-        require(rank == 1, "ineligible selected solver was not promotable");
-    }
+                  require(!claimed, "unavailable selected solver claimed child");
+                  vm.warp(block.timestamp + 10 minutes + 1);
+                  parentFactory.promoteNonresponsiveChildSolver(address(parent));
+                  (,, uint8 rank,) = parentFactory.roundTiming(address(parent), parent.round());
+                  require(rank == 1, "ineligible selected solver was not promotable");
+              }
 
-    function _createParent() private returns (StandingMetaParentV4 parent) {
-""",
+              function _createParent() private returns (StandingMetaParentV4 parent) {
+          """,
           )
           replace_region(
               "contracts/base-escrow/test/StandingMetaV4.t.sol",
               "        address[] memory candidates = new address[](childCandidates.length);",
               "        request.canonicalTerms = canonicalTerms;",
               """        request.canonicalTerms = canonicalTerms;
-""",
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/StandingMetaV4.t.sol",
               """            selectionCommitment: selectionCommitment,
-""",
+          """,
               """            selectionCommitment: bytes32(0),
-""",
+          """,
           )
           replace_once(
               "contracts/base-escrow/test/StandingMetaV4.t.sol",
               """            selectionRequestedAt: selectionRequestedAt,
-""",
+          """,
               """            selectionRequestedAt: 0,
-""",
+          """,
           )
 
           # Make the changed security assumptions explicit in durable docs and static-analysis triage.
@@ -665,52 +665,52 @@ def run(command: Sequence[str], *, cwd: Path, timeout: int = 300) -> str:
               "docs/standing-meta-v4-fair-earning.md",
               """6. posts the parent bond and activates the parent claim.
 
-After VRF fulfillment,
-""",
+          After VRF fulfillment,
+          """,
               """6. posts the parent bond and activates the parent claim.
 
-The caller supplies zero for the typed selection timestamp and commitment. The parent factory derives both from the actual inclusion block and frozen candidate set, so a signed transaction never has to predict a miner-selected timestamp.
+          The caller supplies zero for the typed selection timestamp and commitment. The parent factory derives both from the actual inclusion block and frozen candidate set, so a signed transaction never has to predict a miner-selected timestamp.
 
-After VRF fulfillment,
-""",
+          After VRF fulfillment,
+          """,
           )
           replace_once(
               "docs/standing-meta-v4-fair-earning.md",
               """This is not guaranteed net profit. It excludes failure risk, labor, compute, taxes, gas outside platform sponsorship, and opportunity cost. A V4 opportunity is not ready to earn if gas sponsorship or the funded and authorized VRF subscription is unavailable.
-""",
+          """,
               """This is not guaranteed net profit. It excludes failure risk, labor, compute, taxes, gas outside platform sponsorship, and opportunity cost. A V4 opportunity is not ready to earn if gas sponsorship or the funded and authorized VRF subscription is unavailable. Unsolicited token transfers are not counted as funding, bonds, rewards, or margin and cannot block initialization; any surplus remains outside the immutable accounting.
-""",
+          """,
           )
           replace_once(
               "docs/security/standing-meta-v4-threat-model.md",
               """| Candidate joins after seeing a target | Child solver candidates are the already-active, available pool snapshotted inside `claimAndCreateChild` | Availability may change after the snapshot; ranking activation and claims still fail closed |
-""",
+          """,
               """| Candidate joins after seeing a target | Child solver candidates are the already-active, available pool snapshotted inside `claimAndCreateChild`; the selected ticket is rechecked immediately before claim | Availability may change after the snapshot; an ineligible selection waits for bounded promotion and never receives claim authority |
-""",
+          """,
           )
           replace_once(
               "docs/security/standing-meta-v4-threat-model.md",
               """| Jury result is already decisive | Three matching votes can be finalized immediately | A split or missing quorum waits until timeout and then fails closed |
-""",
+          """,
               """| Jury result is already decisive | Three matching votes can be finalized immediately; nonvoters are released while their voting window is still open and are slashed only after the deadline | A split or missing quorum waits until timeout and then fails closed |
-""",
+          """,
           )
           replace_once(
               "docs/security/standing-meta-v4-threat-model.md",
               """| Atomic preparation race | Terms publication, child creation/funding, active-pool snapshot, VRF request, round binding, and parent claim occur in one transaction | The transaction can revert for gas, authorization, pool-size, or subscription failures |
-""",
+          """,
               """| Atomic preparation race | Terms publication, child creation/funding, active-pool snapshot, VRF request, round binding, and parent claim occur in one transaction; selection time and commitment are derived onchain from the inclusion block | The transaction can revert for gas, authorization, pool-size, or subscription failures |
-| Interface-shaped fake bounty consumes VRF or honest stake | `openCase` requires the immutable parent-factory registry to identify the exact canonical V4 child before any candidate query or VRF request | A wrong one-time controller/factory configuration is permanent and remains an R4 deployment-review gate |
-| Pre-sent token dust blocks exact accounting | Initial funding and bond checks require at least the exact accounted amount; unsolicited surplus is never credited as principal, bond, reward, or margin | Surplus cannot be recovered by the immutable protocol and should be treated as an unsolicited transfer |
-| Child state changes before verifier reward attribution | The canonical child transfers and allocates the exact verifier reward in the same transaction; any allocation failure reverts the child transition | Generic non-V4 bounty implementations are outside this canonical V4 guarantee |
-""",
+          | Interface-shaped fake bounty consumes VRF or honest stake | `openCase` requires the immutable parent-factory registry to identify the exact canonical V4 child before any candidate query or VRF request | A wrong one-time controller/factory configuration is permanent and remains an R4 deployment-review gate |
+          | Pre-sent token dust blocks exact accounting | Initial funding and bond checks require at least the exact accounted amount; unsolicited surplus is never credited as principal, bond, reward, or margin | Surplus cannot be recovered by the immutable protocol and should be treated as an unsolicited transfer |
+          | Child state changes before verifier reward attribution | The canonical child transfers and allocates the exact verifier reward in the same transaction; any allocation failure reverts the child transition | Generic non-V4 bounty implementations are outside this canonical V4 guarantee |
+          """,
           )
           replace_once(
               "docs/security/standing-meta-v4-slither-triage.md",
               """| `incorrect-equality` | 6 | Strict equality is intentional for exact USDC funding, exact commitment binding, unique request initialization, and fixed V4 economics. Accepting surplus funding would break conservation/accounting assumptions. |
-""",
+          """,
               """| `incorrect-equality` | 6 | Equality remains intentional for commitments, request initialization, and fixed V4 economics. Token-balance initialization and bond checks use minimum-balance assertions so an unsolicited transfer cannot denial-of-service a predicted contract address; surplus is never credited into protocol accounting. |
-""",
+          """,
           )
           PY
 

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -245,8 +245,11 @@ fn mcp_tool_descriptor(descriptor: ToolDescriptor) -> Value {
         }),
     );
     value.insert("securitySchemes".to_string(), json!([{"type": "noauth"}]));
+    value.insert(
+        "outputSchema".to_string(),
+        assistant_tool_output_schema(descriptor.name),
+    );
     if descriptor.name == "prepare_bounty_post" {
-        value.insert("outputSchema".to_string(), post_handoff_output_schema());
         value.insert(
             "_meta".to_string(),
             json!({
@@ -302,6 +305,7 @@ async fn call_tool(state: SharedState, params: &Value) -> Result<Value, String> 
             let args: PrepareBountyPostArgs = serde_json::from_value(arguments)
                 .map_err(|error| format!("invalid prepare_bounty_post arguments: {error}"))?;
             let value = build_bounty_post_handoff(&args)?;
+            let value = normalize_assistant_tool_output(name, value)?;
             let markdown = bounty_post_markdown(&value);
             return Ok(tool_result(value, &markdown, true));
         }
@@ -366,7 +370,10 @@ async fn call_tool(state: SharedState, params: &Value) -> Result<Value, String> 
         _ => return Err(format!("unknown or unavailable AI assistant tool: {name}")),
     };
     match legacy_result(legacy) {
-        Ok(value) => Ok(tool_result(value, narration, false)),
+        Ok(value) => match normalize_assistant_tool_output(name, value) {
+            Ok(value) => Ok(tool_result(value, narration, false)),
+            Err(error) => Ok(tool_error(error)),
+        },
         Err(error) => Ok(tool_error(error)),
     }
 }
@@ -379,6 +386,31 @@ fn legacy_result(value: Value) -> Result<Value, String> {
         .pointer("/content/0/json")
         .cloned()
         .ok_or_else(|| "tool returned an invalid legacy response".to_string())
+}
+
+fn normalize_assistant_tool_output(name: &str, value: Value) -> Result<Value, String> {
+    let value = match name {
+        "list_unfunded_bounties" | "list_autonomous_bounties" => {
+            if !value.is_array() {
+                return Err(format!("{name} returned a non-array bounty list"));
+            }
+            json!({"bounties": value})
+        }
+        "list_autonomous_bounty_events" => {
+            if !value.is_array() {
+                return Err("list_autonomous_bounty_events returned a non-array event list".into());
+            }
+            json!({"events": value})
+        }
+        _ => value,
+    };
+    validate_output_schema_value(
+        &assistant_tool_output_schema(name),
+        &value,
+        "structuredContent",
+    )
+    .map_err(|error| format!("{name} returned invalid structured content: {error}"))?;
+    Ok(value)
 }
 
 fn bounty_post_markdown(value: &Value) -> String {
@@ -537,7 +569,15 @@ fn post_handoff_output_schema() -> Value {
             "interface": {"type": "string"},
             "prepared_by": {"type": "string"},
             "supported_hosts": {"type": "array", "items": {"type": "string"}},
-            "rendering": {"type": "object"},
+            "rendering": {
+                "type": "object",
+                "properties": {
+                    "mcp_app_widget": {"type": "string"},
+                    "portable_fallback": {"type": "string"}
+                },
+                "required": ["mcp_app_widget", "portable_fallback"],
+                "additionalProperties": false
+            },
             "state": {"type": "string"},
             "title": {"type": "string"},
             "goal": {"type": "string"},
@@ -555,9 +595,445 @@ fn post_handoff_output_schema() -> Value {
             "next_action": {"type": "string"},
             "evidence_boundary": {"type": "string"}
         },
-        "required": ["schema", "interface", "prepared_by", "supported_hosts", "rendering", "state", "title", "goal", "acceptance_criteria", "solver_reward_usdc", "verifier_reward_usdc", "task_window_days", "target_usdc", "initial_funding_usdc", "crowdfund", "post_url", "bounty_created", "wallet_signature_requested", "next_action", "evidence_boundary"],
+        "required": ["schema", "interface", "prepared_by", "supported_hosts", "rendering", "state", "title", "goal", "acceptance_criteria", "solver_reward_usdc", "verifier_reward_usdc", "task_window_days", "target_usdc", "initial_funding_usdc", "crowdfund", "source_url", "post_url", "bounty_created", "wallet_signature_requested", "next_action", "evidence_boundary"],
         "additionalProperties": false
     })
+}
+
+fn assistant_tool_output_schema(name: &str) -> Value {
+    match name {
+        "publish_unfunded_bounty" => unfunded_bounty_output_schema(),
+        "list_unfunded_bounties" => json!({
+            "type": "object",
+            "properties": {
+                "bounties": {
+                    "type": "array",
+                    "items": unfunded_bounty_output_schema()
+                }
+            },
+            "required": ["bounties"],
+            "additionalProperties": false
+        }),
+        "submit_unfunded_bounty_solution" => unfunded_solution_output_schema(),
+        "prepare_bounty_post" => post_handoff_output_schema(),
+        "list_autonomous_bounties" => json!({
+            "type": "object",
+            "properties": {
+                "bounties": {
+                    "type": "array",
+                    "items": autonomous_bounty_output_schema()
+                }
+            },
+            "required": ["bounties"],
+            "additionalProperties": false
+        }),
+        "prepare_agent_to_earn" | "agent_native_claim" => hosted_api_output_schema(),
+        "prepare_autonomous_bounty_submission" => autonomous_submission_output_schema(),
+        "publish_autonomous_submission_evidence" => submission_evidence_output_schema(),
+        "list_autonomous_bounty_events" => json!({
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": autonomous_event_output_schema()
+                }
+            },
+            "required": ["events"],
+            "additionalProperties": false
+        }),
+        _ => json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": false
+        }),
+    }
+}
+
+fn hosted_api_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "http_status": {"type": "integer"},
+            "body": {"type": "object"}
+        },
+        "required": ["http_status", "body"],
+        "additionalProperties": false
+    })
+}
+
+fn unfunded_solution_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "solution_id": {"type": "string"},
+            "agent_id": {"type": "string"},
+            "summary": {"type": "string"},
+            "deliverable_markdown": {"type": "string"},
+            "evidence": {},
+            "attribution_status": {"type": "string"},
+            "created_at": {"type": "string"},
+            "updated_at": {"type": "string"}
+        },
+        "required": [
+            "solution_id",
+            "agent_id",
+            "summary",
+            "deliverable_markdown",
+            "evidence",
+            "attribution_status",
+            "created_at",
+            "updated_at"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn cloud_demo_solution_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "schema_version": {"type": "string"},
+            "provider": {"type": "string"},
+            "model": {"type": "string"},
+            "agent_name": {"type": "string"},
+            "completion_status": {"type": "string"},
+            "summary": {"type": "string"},
+            "deliverable_markdown": {"type": "string"},
+            "evidence": {},
+            "limitations": {"type": "array", "items": {"type": "string"}},
+            "payment_due_usdc": {"type": "string"},
+            "evidence_boundary": {"type": "string"}
+        },
+        "required": [
+            "schema_version",
+            "provider",
+            "model",
+            "agent_name",
+            "completion_status",
+            "summary",
+            "deliverable_markdown",
+            "evidence",
+            "limitations",
+            "payment_due_usdc",
+            "evidence_boundary"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn unfunded_bounty_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "schema_version": {"type": "string"},
+            "bounty_id": {"type": "string"},
+            "bounty_kind": {"type": "string"},
+            "funding_status": {"type": "string"},
+            "status": {"type": "string"},
+            "title": {"type": "string"},
+            "goal": {"type": "string"},
+            "acceptance_criteria": {"type": "array", "items": {"type": "string"}},
+            "source_url": {"type": ["string", "null"]},
+            "demo_agent_solution": cloud_demo_solution_output_schema(),
+            "agent_solutions": {
+                "type": "array",
+                "items": unfunded_solution_output_schema()
+            },
+            "wallet_required": {"type": "boolean"},
+            "initial_funding_usdc": {"type": "string"},
+            "payment_promised": {"type": "boolean"},
+            "canonical_bounty_created": {"type": "boolean"},
+            "public_url": {"type": "string"},
+            "upgrade_url": {"type": "string"},
+            "created_at": {"type": "string"},
+            "expires_at": {"type": "string"},
+            "evidence_boundary": {"type": "string"}
+        },
+        "required": [
+            "schema_version",
+            "bounty_id",
+            "bounty_kind",
+            "funding_status",
+            "status",
+            "title",
+            "goal",
+            "acceptance_criteria",
+            "source_url",
+            "demo_agent_solution",
+            "agent_solutions",
+            "wallet_required",
+            "initial_funding_usdc",
+            "payment_promised",
+            "canonical_bounty_created",
+            "public_url",
+            "upgrade_url",
+            "created_at",
+            "expires_at",
+            "evidence_boundary"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn network_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "chain_id": {"type": "integer"},
+            "rpc_url_env": {"type": "string"},
+            "native_usdc_token_address": {"type": "string"}
+        },
+        "required": [
+            "name",
+            "chain_id",
+            "rpc_url_env",
+            "native_usdc_token_address"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn autonomous_event_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "log_key": {"type": "string"},
+            "tx_hash": {"type": "string"},
+            "block_number": {"type": "integer"},
+            "log_index": {"type": "integer"},
+            "contract_address": {"type": "string"},
+            "bounty_id": {"type": "string"},
+            "kind": {"type": "string"},
+            "data": {},
+            "occurred_at": {"type": "string"}
+        },
+        "required": [
+            "id",
+            "log_key",
+            "tx_hash",
+            "block_number",
+            "log_index",
+            "contract_address",
+            "bounty_id",
+            "kind",
+            "data",
+            "occurred_at"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn autonomous_bounty_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "bounty_id": {"type": "string"},
+            "bounty_contract": {"type": "string"},
+            "creator": {"type": "string"},
+            "status": {"type": "string"},
+            "solver_reward": {"type": "string"},
+            "verifier_reward": {"type": "string"},
+            "claim_bond": {"type": "string"},
+            "timeout_bond_pool": {"type": "string"},
+            "target_amount": {"type": "string"},
+            "funded_amount": {"type": "string"},
+            "terms_hash": {"type": "string"},
+            "terms": {"type": ["object", "null"]},
+            "terms_valid": {"type": "boolean"},
+            "verification_mode": {"type": "string"},
+            "verifier_module": {"type": ["string", "null"]},
+            "verification_ready": {"type": "boolean"},
+            "verification_readiness_reason": {"type": "string"},
+            "validation_errors": {"type": "array", "items": {"type": "string"}},
+            "events": {"type": "array", "items": autonomous_event_output_schema()}
+        },
+        "required": [
+            "bounty_id",
+            "bounty_contract",
+            "creator",
+            "status",
+            "solver_reward",
+            "verifier_reward",
+            "claim_bond",
+            "timeout_bond_pool",
+            "target_amount",
+            "funded_amount",
+            "terms_hash",
+            "terms",
+            "terms_valid",
+            "verification_mode",
+            "verifier_module",
+            "verification_ready",
+            "verification_readiness_reason",
+            "validation_errors",
+            "events"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn autonomous_submission_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "protocol_version": {"type": "string"},
+            "network": network_output_schema(),
+            "bounty_contract": {"type": "string"},
+            "bounty_id": {"type": "string"},
+            "current_bounty_state": {"type": "string"},
+            "expected_bounty_state": {"type": "string"},
+            "expected_canonical_event": {"type": "string"},
+            "solver": {"type": "string"},
+            "round": {"type": "integer"},
+            "claim_expires_at": {"type": "integer"},
+            "authorization_deadline": {"type": "integer"},
+            "artifact_reference": {"type": "string"},
+            "submission_hash": {"type": "string"},
+            "evidence_hash": {"type": "string"},
+            "policy_hash": {"type": "string"},
+            "signing_payload": {"type": "object"},
+            "unsigned_relay_envelope": {"type": "object"},
+            "evidence_publication": {"type": "object"},
+            "relay_issue_url": {"type": ["string", "null"]},
+            "evidence_boundary": {"type": "string"}
+        },
+        "required": [
+            "protocol_version",
+            "network",
+            "bounty_contract",
+            "bounty_id",
+            "current_bounty_state",
+            "expected_bounty_state",
+            "expected_canonical_event",
+            "solver",
+            "round",
+            "claim_expires_at",
+            "authorization_deadline",
+            "artifact_reference",
+            "submission_hash",
+            "evidence_hash",
+            "policy_hash",
+            "signing_payload",
+            "unsigned_relay_envelope",
+            "evidence_publication",
+            "relay_issue_url",
+            "evidence_boundary"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn submission_evidence_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "network": {"type": "string"},
+            "bounty_contract": {"type": "string"},
+            "bounty_id": {"type": "string"},
+            "round": {"type": "integer"},
+            "solver_wallet": {"type": "string"},
+            "artifact_reference": {"type": "string"},
+            "artifact_hash": {"type": "string"},
+            "evidence": {},
+            "evidence_hash": {"type": "string"},
+            "created_at": {"type": "string"}
+        },
+        "required": [
+            "network",
+            "bounty_contract",
+            "bounty_id",
+            "round",
+            "solver_wallet",
+            "artifact_reference",
+            "artifact_hash",
+            "evidence",
+            "evidence_hash",
+            "created_at"
+        ],
+        "additionalProperties": false
+    })
+}
+
+fn validate_output_schema_value(schema: &Value, value: &Value, path: &str) -> Result<(), String> {
+    if let Some(expected) = schema.get("type") {
+        let matches = match expected {
+            Value::String(kind) => output_type_matches(kind, value),
+            Value::Array(kinds) => kinds
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|kind| output_type_matches(kind, value)),
+            _ => false,
+        };
+        if !matches {
+            return Err(format!(
+                "{path} has JSON type {}, expected {}",
+                output_value_type(value),
+                expected
+            ));
+        }
+    }
+
+    if let Some(object) = value.as_object() {
+        if let Some(required) = schema.get("required").and_then(Value::as_array) {
+            for property in required.iter().filter_map(Value::as_str) {
+                if !object.contains_key(property) {
+                    return Err(format!("{path}.{property} is required"));
+                }
+            }
+        }
+        if let Some(properties) = schema.get("properties").and_then(Value::as_object) {
+            for (property, property_value) in object {
+                if let Some(property_schema) = properties.get(property) {
+                    validate_output_schema_value(
+                        property_schema,
+                        property_value,
+                        &format!("{path}.{property}"),
+                    )?;
+                } else if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
+                    return Err(format!("{path}.{property} is not declared"));
+                }
+            }
+        }
+    }
+
+    if let Some(array) = value.as_array() {
+        if let Some(item_schema) = schema.get("items") {
+            for (index, item) in array.iter().enumerate() {
+                validate_output_schema_value(item_schema, item, &format!("{path}[{index}]"))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn output_type_matches(kind: &str, value: &Value) -> bool {
+    match kind {
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "string" => value.is_string(),
+        "integer" => value
+            .as_number()
+            .is_some_and(|number| number.is_i64() || number.is_u64()),
+        "number" => value.is_number(),
+        "boolean" => value.is_boolean(),
+        "null" => value.is_null(),
+        _ => false,
+    }
+}
+
+fn output_value_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
 }
 
 fn tool_title(name: &str) -> &'static str {
@@ -799,6 +1275,10 @@ mod tests {
                 "assistant tool {name} has a non-discoverable description: {}",
                 descriptor["description"]
             );
+            assert_eq!(
+                descriptor["outputSchema"]["type"], "object",
+                "assistant tool {name} must declare an object outputSchema"
+            );
         }
         let prepare = tools
             .iter()
@@ -860,6 +1340,62 @@ mod tests {
             .unwrap();
         assert_eq!(settlement["title"], "Confirm bounty lifecycle and payment");
         assert_eq!(settlement["annotations"]["readOnlyHint"], true);
+        assert_eq!(
+            settlement["outputSchema"]["properties"]["events"]["type"],
+            "array"
+        );
+        let funded = tools
+            .iter()
+            .find(|tool| tool["name"] == "list_autonomous_bounties")
+            .unwrap();
+        assert_eq!(
+            funded["outputSchema"]["properties"]["bounties"]["type"],
+            "array"
+        );
+    }
+
+    #[test]
+    fn assistant_output_schemas_are_total_and_runtime_checked() {
+        let handoff = build_bounty_post_handoff(&valid_args()).unwrap();
+        assert!(normalize_assistant_tool_output("prepare_bounty_post", handoff).is_ok());
+
+        for name in ["list_unfunded_bounties", "list_autonomous_bounties"] {
+            let normalized = normalize_assistant_tool_output(name, json!([])).unwrap();
+            assert_eq!(normalized, json!({"bounties": []}));
+            assert!(validate_output_schema_value(
+                &assistant_tool_output_schema(name),
+                &json!([]),
+                "structuredContent"
+            )
+            .is_err());
+        }
+
+        let normalized =
+            normalize_assistant_tool_output("list_autonomous_bounty_events", json!([])).unwrap();
+        assert_eq!(normalized, json!({"events": []}));
+
+        let hosted = json!({"http_status": 200, "body": {"ready": true}});
+        assert!(normalize_assistant_tool_output("prepare_agent_to_earn", hosted.clone()).is_ok());
+        let invalid_hosted = json!({
+            "http_status": 200,
+            "body": {"ready": true},
+            "unexpected": true
+        });
+        assert!(normalize_assistant_tool_output("prepare_agent_to_earn", invalid_hosted).is_err());
+
+        let solution = json!({
+            "solution_id": "5cfbdc18-6abc-4709-9fb8-1322e52aa84a",
+            "agent_id": "913e03f2-4c07-4dd4-b28e-e83aff3d65a7",
+            "summary": "Delivered",
+            "deliverable_markdown": "Artifact",
+            "evidence": {"commit": "abc"},
+            "attribution_status": "registered_agent",
+            "created_at": "2026-07-23T00:00:00Z",
+            "updated_at": "2026-07-23T00:00:00Z"
+        });
+        assert!(
+            normalize_assistant_tool_output("submit_unfunded_bounty_solution", solution).is_ok()
+        );
     }
 
     #[test]

--- a/docs/chatgpt-app-submission.md
+++ b/docs/chatgpt-app-submission.md
@@ -46,6 +46,19 @@ a publisher name in this document.
 | `publish_autonomous_submission_evidence` | false | true | true | Upserts the public artifact and evidence preimages for a confirmed canonical submission. |
 | `list_autonomous_bounty_events` | true | false | false | Reads confirmed canonical lifecycle events without changing state. |
 
+## Output contract
+
+All ten tools declare an object `outputSchema`, and the MCP adapter validates
+each successful `structuredContent` result before returning it to the host.
+List results use stable object roots instead of bare arrays:
+
+- `list_unfunded_bounties` returns `{"bounties": [...]}`;
+- `list_autonomous_bounties` returns `{"bounties": [...]}`;
+- `list_autonomous_bounty_events` returns `{"events": [...]}`.
+
+If an upstream response drifts from its declared schema, the app returns a tool
+error rather than exposing malformed structured content to the conversation.
+
 ## Positive tests
 
 1. **Prepare a funded bounty**
@@ -102,7 +115,9 @@ actions remain bounded and user-reviewed.
 - Wait until the exact release revision is live, then select `Scan Tools`.
   Review all ten discovered names, descriptions, schemas, security schemes,
   annotations, `_meta` values, output structures, MCP instructions, linked UI
-  metadata, and widget CSP. Fix discrepancies in source and scan again.
+  metadata, and widget CSP. Confirm every tool has an object `outputSchema` and
+  that the three list tools use their documented object wrappers. Fix
+  discrepancies in source and scan again.
 - Audit representative production MCP responses against the privacy policy.
   Remove unnecessary personal data, authentication secrets, debug payloads,
   trace/session identifiers, and undisclosed user-related fields.


### PR DESCRIPTION
## What changed
- add explicit object-root `outputSchema` contracts for all ten assistant-facing MCP tools
- normalize list results into `{ bounties: [...] }` or `{ events: [...] }` before returning structured content
- validate successful structured content against its declared schema at runtime and return a tool error on upstream contract drift
- document the completed output contract in the ChatGPT app submission checklist

## Why
The ChatGPT Apps submission audit found nine assistant tools without declared output schemas. Models could not reliably reason about those results, and list tools returned bare arrays even though Apps structured content is object-shaped.

## User and developer impact
ChatGPT, Claude, Gemini Spark, and other MCP clients receive stable machine-readable result shapes. Existing tool inputs, public endpoints, database state, wallet boundaries, and on-chain behavior are unchanged. The three assistant list tools now return object wrappers instead of bare arrays.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p mcp-server -- -D warnings`
- `cargo test -p mcp-server` (23 passed before the clean rebase; no conflicts in the rebase)
- `cli service-smoke-spawn` (`service_smoke: ok`, 91 tools)
- `python scripts/check-site.py`
- `python -m json.tool chatgpt-app-submission.json`
- submission package counts: 10 tools, 5 positive tests, 3 negative tests
- `git diff --check`

Closes #569.

## Maintainer coordination
Open pull requests were inspected before implementation. No contributor-owned pull request changes `crates/mcp-server/src/chatgpt_app.rs`; adjacent `main.rs` and site work remains intact.
## Upstream workflow repair
The latest `main` introduced `.github/workflows/standing-meta-v4-maintainer-security-fix.yml` with 299 under-indented heredoc lines, causing GitHub to reject the workflow at line 70 on every branch push. This PR restores only the missing YAML block prefix; the recovered 677-line payload is unchanged, its embedded Python parses, and the workflow now parses with the expected job.