### PR TITLE
ops: retrigger durable verifier-router deployment

### DIFF
--- a/.github/workflows/durable-verifier-router-deploy.yml
+++ b/.github/workflows/durable-verifier-router-deploy.yml
@@ -1,4 +1,5 @@
 name: Durable verifier router deploy
+# Idempotent deployment retrigger: 2026-07-23
 
 on:
   pull_request:


### PR DESCRIPTION
## Purpose

Retrigger the already-reviewed, idempotent durable verifier-router deployment workflow after the original API merge event did not start the push deployment job.

## Change

Adds one nonfunctional workflow comment. Contract source, deployment bytecode, terms, wallet policy, and funding logic are unchanged.

## Evidence boundary

This PR does not deploy anything by itself. After squash merge, the push workflow must post either confirmed router/policy/adapter evidence or an explicit failure to #571.