### PR TITLE
feat(distribution): add funded-first Codex plugin

### DIFF
--- a/plugins/agent-bounties/.codex-plugin/plugin.json
+++ b/plugins/agent-bounties/.codex-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "agent-bounties",
+  "version": "0.1.0",
+  "description": "Turn goals into reviewable bounties, find funded AI work, and follow verified Base USDC settlement.",
+  "author": {
+    "name": "Agent Bounties contributors",
+    "url": "https://github.com/NSPG13/agent-bounties"
+  },
+  "homepage": "https://agentbounties.app/",
+  "repository": "https://github.com/NSPG13/agent-bounties",
+  "license": "Apache-2.0",
+  "keywords": [
+    "agents",
+    "bounties",
+    "paid-work",
+    "personal-goals",
+    "professional-goals",
+    "public-good",
+    "base",
+    "usdc",
+    "mcp"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Agent Bounties",
+    "shortDescription": "Turn goals into bounties or find verified AI work that pays USDC.",
+    "longDescription": "Use Agent Bounties directly from a normal AI conversation. Turn a personal, professional, or public-good goal into measurable bounty terms and a review-required funding handoff without giving the platform a model API key. Or discover canonically funded, verification-ready digital work, then follow the guarded claim, evidence, verification, and settlement sequence. Drafts and transaction plans move no funds; only confirmed BountySettled events prove payment.",
+    "developerName": "Agent Bounties",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://agentbounties.app/",
+    "privacyPolicyURL": "https://agentbounties.app/privacy.html",
+    "termsOfServiceURL": "https://agentbounties.app/terms.html",
+    "defaultPrompt": [
+      "Turn this goal into a funded-bounty draft I can review before signing.",
+      "Find funded, verification-ready AI work I can complete to earn USDC.",
+      "Guide me through a selected bounty; do not claim, sign, or move funds yet."
+    ],
+    "brandColor": "#B9EF37"
+  }
+}

--- a/plugins/agent-bounties/.mcp.json
+++ b/plugins/agent-bounties/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "agent-bounties": {
+      "type": "http",
+      "url": "https://mcp.agentbounties.app/mcp"
+    }
+  }
+}

--- a/scripts/test_mcp_tool_registry.py
+++ b/scripts/test_mcp_tool_registry.py
@@ -10,6 +10,7 @@ import unittest
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+CODEX_PLUGIN_ROOT = ROOT / "plugins/agent-bounties"
 
 
 class McpToolRegistryTests(unittest.TestCase):
@@ -27,6 +28,51 @@ class McpToolRegistryTests(unittest.TestCase):
         self.assertEqual(len(names), 106)
         self.assertEqual(len(names), len(set(names)))
         self.assertEqual(names, registry["tools"])
+
+
+class CodexPluginDistributionTests(unittest.TestCase):
+    def test_manifest_routes_funded_posting_and_earning_intents_to_hosted_mcp(self) -> None:
+        manifest = json.loads(
+            (CODEX_PLUGIN_ROOT / ".codex-plugin/plugin.json").read_text(encoding="utf-8")
+        )
+        mcp = json.loads((CODEX_PLUGIN_ROOT / ".mcp.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(manifest["name"], "agent-bounties")
+        self.assertEqual(manifest["mcpServers"], "./.mcp.json")
+        self.assertEqual(
+            mcp["mcpServers"]["agent-bounties"],
+            {"type": "http", "url": "https://mcp.agentbounties.app/mcp"},
+        )
+
+        interface = manifest["interface"]
+        prompts = interface["defaultPrompt"]
+        self.assertEqual(len(prompts), 3)
+        self.assertTrue(all(0 < len(prompt) <= 128 for prompt in prompts))
+        self.assertTrue(any("goal" in prompt and "draft" in prompt for prompt in prompts))
+        self.assertTrue(any("funded" in prompt and "earn USDC" in prompt for prompt in prompts))
+        self.assertTrue(any("do not claim, sign, or move funds" in prompt for prompt in prompts))
+
+        discovery_copy = " ".join(
+            [
+                manifest["description"],
+                interface["shortDescription"],
+                interface["longDescription"],
+                *prompts,
+            ]
+        ).lower()
+        for required_phrase in (
+            "personal",
+            "professional",
+            "public-good",
+            "funded",
+            "verification-ready",
+            "earn usdc",
+            "bountysettled",
+        ):
+            self.assertIn(required_phrase, discovery_copy)
+        self.assertNotIn("private key", discovery_copy)
+        self.assertNotIn("seed phrase", discovery_copy)
+        self.assertNotIn("unfunded", discovery_copy)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- add a repository-owned Codex plugin package for the hosted Agent Bounties MCP endpoint
- make personal, professional, and public-good bounty posting plus funded earning the primary discovery language
- add three safe starter prompts for draft preparation, paid-work discovery, and pre-claim guidance
- state the no-funds draft boundary and canonical `BountySettled` payment boundary in plugin metadata
- extend the MCP registry test with deterministic package, endpoint, intent, prompt-length, and safety assertions

## Why

The installed personal plugin existed only outside the repository and foregrounded unfunded/voluntary flows. That made it a weak test surface for the normal-user objective and gave the project no reviewed source of truth for Codex plugin metadata. The hosted MCP tool descriptors already route funded posting and earning intents correctly; this package makes the installation metadata agree.

Maintainer notice: #585

## Contributor-first review

All 23 open PRs were inspected before edits: #580, #577, #575, #568, #567, #565, #562, #552, #551, #550, #549, #544, #510, #509, #508, #507, #506, #505, #504, #503, #501, #482, and #272. No open PR touches `.codex-plugin`, `.mcp.json`, plugin packaging, or marketplace files. No active PR is known to be affected. #577 remains the separate funded-inventory activation path and is not modified or bypassed.

## Compatibility and migration

This is additive distribution metadata. It changes no contract, API route, MCP schema, wallet policy, funding, claim, verification, or settlement behavior. Existing cached installs continue to work. Local testers should sync this package to the personal plugin source, apply the normal cachebuster/reinstall flow, and start a fresh Codex task so its MCP tool catalog reloads.

## Validation

- plugin-creator `validate_plugin.py plugins/agent-bounties`
- `python scripts/test_mcp_tool_registry.py -v` (2 passed)
- `scripts/preflight.ps1 -Mode core`
- `scripts/check.ps1` / direct cross-platform full gate (passed)
- `git diff --check`
- live MCP `tools/list` verified funded-first posting and earning descriptors
- live read-only `prepare_bounty_post` produced a 25 USDC review-only draft with `bounty_created=false` and no signature request
- live read-only `list_autonomous_bounties(claimable_only=true)` returned the honest empty safe feed

No bounty was published, funded, claimed, signed, verified, or settled during testing.