### PR TITLE
Fix five profitable standing-meta bounties

### DIFF
--- a/.github/workflows/activate-routed-v3-replacements.yml
+++ b/.github/workflows/activate-routed-v3-replacements.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Fetch durable router bootstrap event
         run: |
+          mkdir -p target
           latest="$(cast block-number --rpc-url "$BASE_MAINNET_RPC_URL")"
           from=$((latest - 10000))
           cast logs \

--- a/.github/workflows/activate-routed-v3-replacements.yml
+++ b/.github/workflows/activate-routed-v3-replacements.yml
@@ -179,14 +179,14 @@ jobs:
         if: steps.issue.outputs.state != 'CLOSED' && steps.readiness.outputs.ready != 'true'
         run: echo "The exact durable PolicyConfigured state is not active. No financial action was attempted."
 
-      - name: Create, fund, and reconcile four routed parents
+      - name: Create, fund, and reconcile five routed parents
         if: steps.issue.outputs.state != 'CLOSED' && steps.readiness.outputs.ready == 'true'
         run: python scripts/activate_routed_v3_dynamic.py
 
       - name: Replace issue terms only after canonical reconciliation
         if: steps.issue.outputs.state != 'CLOSED' && steps.readiness.outputs.ready == 'true'
         run: |
-          for issue in 333 334 335 336; do
+          for issue in 333 334 335 336 590; do
             gh issue edit "$issue" \
               --body-file "target/routed-v3-activation/routed-v3-${issue}-issue.md" \
               --add-label bounty \
@@ -203,7 +203,7 @@ jobs:
         run: |
           gh issue comment 571 --body-file target/routed-v3-activation.md
           gh issue close 571 --reason completed --comment \
-            "The durable wallet policy and four routed replacements reconciled from canonical Base evidence. Only future BountySettled events prove solver payments."
+            "The durable wallet policy and five routed bounties reconciled from canonical Base evidence. Only future BountySettled events prove solver payments."
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: always()

--- a/.github/workflows/activate-routed-v3-replacements.yml
+++ b/.github/workflows/activate-routed-v3-replacements.yml
@@ -55,12 +55,14 @@ jobs:
           echo "router runtime bytes=$(( (${#code} - 2) / 2 ))"
 
       - name: Fetch durable router bootstrap event
+        env:
+          LOG_RPC_URL: https://mainnet.base.org
         run: |
           mkdir -p target
-          latest="$(cast block-number --rpc-url "$BASE_MAINNET_RPC_URL")"
+          latest="$(cast block-number --rpc-url "$LOG_RPC_URL")"
           from=$((latest - 10000))
           cast logs \
-            --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --rpc-url "$LOG_RPC_URL" \
             --address "$ROUTER" \
             --from-block "$from" \
             --to-block latest \

--- a/.github/workflows/durable-verifier-router-deploy.yml
+++ b/.github/workflows/durable-verifier-router-deploy.yml
@@ -123,6 +123,7 @@ jobs:
 
       - name: Publish start notice
         run: |
+          mkdir -p target
           cat > target/durable-router-start.md <<EOF
           ## Durable verifier-router deployment started
 
@@ -146,6 +147,7 @@ jobs:
       - name: Publish deployment result
         if: always()
         run: |
+          mkdir -p target
           python - <<'PY'
           import json
           import os

--- a/.github/workflows/routed-v3-activation-check.yml
+++ b/.github/workflows/routed-v3-activation-check.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Router runtime exists
         run: |
+          mkdir -p target
           code="$(cast code "$ROUTER" --rpc-url "$BASE_MAINNET_RPC_URL")"
           test "$code" != "0x"
           test "$code" != "0x0"

--- a/scripts/activate_routed_v3_replacements.py
+++ b/scripts/activate_routed_v3_replacements.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Idempotently create, fund, and reconcile four profitable routed-V3 parent bounties."""
+"""Idempotently create, fund, and reconcile five profitable routed-V3 parent bounties."""
 
 from __future__ import annotations
 
@@ -36,6 +36,7 @@ ISSUES = {
     334: {"lane": "API", "old": "0xbe17ef2d154265ebe3142d7bda5e99610d571455"},
     335: {"lane": "MCP", "old": "0x43d42cb227d76588ab16693f14efd6cff851fa7a"},
     336: {"lane": "wallet UX", "old": "0xe8c1d3f046f3e4690bef59ba4abd5d02d2a6984b"},
+    590: {"lane": "agent discovery", "old": None},
 }
 ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 BYTES32_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
@@ -343,13 +344,24 @@ def reconcile(api: str, contract: str, bounty_id: str, timeout_seconds: int = 18
     raise ActivationError(f"canonical activation did not reconcile for {contract}")
 
 
-def issue_body(issue: int, lane: str, old: str, result: Mapping[str, object], deployment: Mapping[str, Any]) -> str:
+def issue_body(
+    issue: int,
+    lane: str,
+    old: str | None,
+    result: Mapping[str, object],
+    deployment: Mapping[str, Any],
+) -> str:
     contract = str(result["contract"])
     transaction_hash = str(result["transaction_hash"])
     transaction_line = (
         f"- Creation and funding transaction: https://basescan.org/tx/{transaction_hash}"
         if BYTES32_RE.fullmatch(transaction_hash)
         else "- Creation and funding transaction: previously confirmed canonical creation"
+    )
+    legacy_line = (
+        f"The previous unprofitable V2 contract `{old}` is retired from earning discovery and preserved as immutable history."
+        if old
+        else "This is a new profitable inventory slot and does not replace a legacy contract."
     )
     return f"""## Goal
 
@@ -372,7 +384,7 @@ Create and fully fund a concrete **1 USDC {lane} child bounty** that a different
 - Routed implementation: `{deployment['adapter_address']}`
 - Status: `claimable`
 
-The previous unprofitable V2 contract `{old}` is retired from earning discovery and preserved as immutable history.
+{legacy_line}
 
 ## Earn this bounty
 
@@ -502,7 +514,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
             "reconciliation": reconciled,
         }
         (args.output_dir / f"routed-v3-{issue}-issue.md").write_text(
-            issue_body(issue, str(config["lane"]), str(config["old"]), result, deployment),
+            issue_body(issue, str(config["lane"]), config["old"], result, deployment),
             encoding="utf-8",
         )
         results.append(result)
@@ -538,7 +550,7 @@ def markdown(report: Mapping[str, object]) -> str:
     results = report["results"]
     assert isinstance(results, list)
     lines = [
-        "## Four profitable routed-V3 replacements activated",
+        "## Five profitable routed-V3 bounties activated",
         "",
         f"- Stable verifier router: `{report['router']}`",
         f"- Immutable routed policy: `{report['policy_hash']}`",

--- a/scripts/durable_verifier_router_deploy.py
+++ b/scripts/durable_verifier_router_deploy.py
@@ -34,13 +34,14 @@ ROUTER_SALT_TEXT = "agent-bounties/policy-bound-verifier-router/base-mainnet/v1"
 ADAPTER_SALT_PREFIX = "agent-bounties/independent-child-v3-routed/base-mainnet/v1"
 MIN_KEEPER_ETH_WEI = 100_000_000_000_000
 PARENT_TARGET = 2_010_000
-TOTAL_REPLACEMENT_FUNDING = 4 * PARENT_TARGET
+TOTAL_REPLACEMENT_FUNDING = 5 * PARENT_TARGET
 TEMPLATE_PATH = Path("bounties/autonomous-v1/routed-v3-parent.template.json")
 LANES: dict[int, tuple[str, str]] = {
     333: ("cli", "CLI"),
     334: ("api", "API"),
     335: ("mcp", "MCP"),
     336: ("wallet_ux", "wallet UX"),
+    590: ("agent_discovery", "agent discovery"),
 }
 ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 BYTES32_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
@@ -324,7 +325,7 @@ def build_router_plan(foundry: Foundry) -> dict[str, Any]:
             "address": BOUNDED_WALLET,
             "owner": require_address(foundry.call(BOUNDED_WALLET, "owner()(address)"), "wallet owner"),
             "usdc_balance_base_units": wallet_balance,
-            "can_fund_four_replacements": wallet_balance >= TOTAL_REPLACEMENT_FUNDING,
+            "can_fund_five_replacements": wallet_balance >= TOTAL_REPLACEMENT_FUNDING,
             "policy_version": parse_uint(
                 foundry.call(BOUNDED_WALLET, "policyVersion()(uint64)"), "wallet policy version"
             ),
@@ -683,7 +684,7 @@ def markdown(report: Mapping[str, Any]) -> str:
             f"- Future-policy activation delay: **{report['activation_delay_seconds'] // 86400} days**",
             f"- Bounded wallet: `{wallet['address']}`",
             f"- Bounded-wallet USDC: **{wallet['usdc_balance_base_units'] / 1_000_000:.6f}**",
-            f"- Four replacement parents require: **{economics['total_funding_required'] / 1_000_000:.6f} USDC**",
+            f"- Five replacement parents require: **{economics['total_funding_required'] / 1_000_000:.6f} USDC**",
             f"- Expected balance after funding: **{(wallet['usdc_balance_base_units'] - economics['total_funding_required']) / 1_000_000:.6f} USDC**",
             f"- Current wallet verifier: `{wallet['policy']['deterministic_verifier']}`",
             "",

--- a/scripts/test_activate_routed_v3_replacements.py
+++ b/scripts/test_activate_routed_v3_replacements.py
@@ -121,8 +121,8 @@ class ActivateRoutedV3Tests(unittest.TestCase):
 
     def test_economics_and_scope_are_exact(self) -> None:
         self.assertEqual(MODULE.TARGET, 2_010_000)
-        self.assertEqual(MODULE.TOTAL, 8_040_000)
-        self.assertEqual(sorted(MODULE.ISSUES), [333, 334, 335, 336])
+        self.assertEqual(MODULE.TOTAL, 10_050_000)
+        self.assertEqual(sorted(MODULE.ISSUES), [333, 334, 335, 336, 590])
         self.assertEqual(MODULE.UINT64_MAX, (1 << 64) - 1)
         self.assertEqual(DYNAMIC.ROUTER, "0x380c1af742593dd88b6f20387e9ee693a0536731")
         self.assertEqual(DYNAMIC.ACTIVATION_DELAY, 604_800)

--- a/scripts/test_durable_verifier_router_deploy.py
+++ b/scripts/test_durable_verifier_router_deploy.py
@@ -19,7 +19,7 @@ class DurableVerifierRouterDeployTests(unittest.TestCase):
     def test_materialized_terms_share_router_policy_and_unique_nonces(self) -> None:
         router = "0x" + "12" * 20
         documents = MODULE.materialize_terms(Path(__file__).resolve().parents[1], router)
-        self.assertEqual(sorted(documents), [333, 334, 335, 336])
+        self.assertEqual(sorted(documents), [333, 334, 335, 336, 590])
         nonces = set()
         policies = []
         for issue, document in documents.items():
@@ -29,7 +29,7 @@ class DurableVerifierRouterDeployTests(unittest.TestCase):
             self.assertIn(str(issue), document["source_url"])
             nonces.add(document["contract_terms"]["creation_nonce"])
             policies.append(document["verification_policy"])
-        self.assertEqual(len(nonces), 4)
+        self.assertEqual(len(nonces), 5)
         self.assertTrue(all(policy == policies[0] for policy in policies))
 
     def test_create_payload_uses_published_commitments_and_router(self) -> None:
@@ -69,11 +69,11 @@ class DurableVerifierRouterDeployTests(unittest.TestCase):
                 "usdc_balance_base_units": 37_000_000,
                 "policy": {"deterministic_verifier": "0x" + "78" * 20},
             },
-            "replacement_economics": {"total_funding_required": 8_040_000},
+            "replacement_economics": {"total_funding_required": 10_050_000},
         }
         value = MODULE.markdown(report)
         self.assertIn("7 days", value)
-        self.assertIn("28.960000 USDC", value)
+        self.assertIn("26.950000 USDC", value)
         self.assertIn("cannot move funds", value)
         self.assertIn("not deployment", value)
 


### PR DESCRIPTION
Restores the five-bounty invariant with routed V3 economics: 2.00 USDC parent solver reward against exactly 1.00 USDC required child funding, for a 1.00 USDC successful-settlement on-chain margin. Adds issue #590 as the fifth lane, updates the bounded funding total to 10.05 USDC, and fixes missing target directories that prevented the router deployment workflow from reaching deployment.\n\nPublic notice: #571. Contributor dependency #544 was reviewed and merged first.\n\nChecks run locally: Python activation/deployment suites (12/12), PolicyBoundVerifierRouter Foundry fuzz suite (1000 runs), py_compile, git diff --check.