### PR TITLE
Make profitable bounty activation resumable

### DIFF
--- a/.github/workflows/activate-routed-v3-replacements.yml
+++ b/.github/workflows/activate-routed-v3-replacements.yml
@@ -184,12 +184,14 @@ jobs:
 
       - name: Create, fund, and reconcile five routed parents
         if: steps.issue.outputs.state != 'CLOSED' && steps.readiness.outputs.ready == 'true'
+        id: activation
         run: python scripts/activate_routed_v3_dynamic.py
 
       - name: Replace issue terms only after canonical reconciliation
         if: steps.issue.outputs.state != 'CLOSED' && steps.readiness.outputs.ready == 'true'
         run: |
           for issue in 333 334 335 336 590; do
+            test -f "target/routed-v3-activation/routed-v3-${issue}-issue.md" || continue
             gh issue edit "$issue" \
               --body-file "target/routed-v3-activation/routed-v3-${issue}-issue.md" \
               --add-label bounty \
@@ -205,8 +207,11 @@ jobs:
         if: steps.issue.outputs.state != 'CLOSED' && steps.readiness.outputs.ready == 'true'
         run: |
           gh issue comment 571 --body-file target/routed-v3-activation.md
-          gh issue close 571 --reason completed --comment \
-            "The durable wallet policy and five routed bounties reconciled from canonical Base evidence. Only future BountySettled events prove solver payments."
+          complete="$(python -c 'import json; print(str(json.load(open("target/routed-v3-activation.json"))["complete"]).lower())')"
+          if [ "$complete" = "true" ]; then
+            gh issue close 571 --reason completed --comment \
+              "The durable wallet policy and five routed bounties reconciled from canonical Base evidence. Only future BountySettled events prove solver payments."
+          fi
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: always()

--- a/.github/workflows/activate-routed-v3-replacements.yml
+++ b/.github/workflows/activate-routed-v3-replacements.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           mkdir -p target
           latest="$(cast block-number --rpc-url "$LOG_RPC_URL")"
-          from=$((latest - 10000))
+          from=$((latest - 9999))
           cast logs \
             --rpc-url "$LOG_RPC_URL" \
             --address "$ROUTER" \

--- a/.github/workflows/routed-v3-activation-check.yml
+++ b/.github/workflows/routed-v3-activation-check.yml
@@ -43,11 +43,13 @@ jobs:
           test "$code" != "0x0"
 
       - name: Bootstrap event exists
+        env:
+          LOG_RPC_URL: https://mainnet.base.org
         run: |
-          latest="$(cast block-number --rpc-url "$BASE_MAINNET_RPC_URL")"
-          from=$((latest - 10000))
+          latest="$(cast block-number --rpc-url "$LOG_RPC_URL")"
+          from=$((latest - 9999))
           mkdir -p target
-          cast logs --rpc-url "$BASE_MAINNET_RPC_URL" --address "$ROUTER" --from-block "$from" --to-block latest "PolicyBootstrapped(bytes32,address,bytes32)" --json > target/router-bootstrap.json
+          cast logs --rpc-url "$LOG_RPC_URL" --address "$ROUTER" --from-block "$from" --to-block latest "PolicyBootstrapped(bytes32,address,bytes32)" --json > target/router-bootstrap.json
           python -c 'import json; x=json.load(open("target/router-bootstrap.json")); assert isinstance(x,list) and len(x)==1, len(x)'
 
       - name: Dynamic direct-chain attestation passes

--- a/scripts/activate_routed_v3_dynamic.py
+++ b/scripts/activate_routed_v3_dynamic.py
@@ -15,7 +15,7 @@ import activate_routed_v3_replacements as activation
 ROUTER = "0x380c1af742593dd88b6f20387e9ee693a0536731"
 EVENT_SIGNATURE = "PolicyBootstrapped(bytes32,address,bytes32)"
 ACTIVATION_DELAY = 604_800
-LOOKBACK_BLOCKS = 10_000
+LOOKBACK_BLOCKS = 9_999
 
 
 def parse_bootstrap_logs(raw: str) -> dict[str, str | int]:
@@ -57,9 +57,10 @@ def discover_deployment(cast: activation.Cast) -> dict[str, Any]:
     router_code = cast.code(ROUTER)
     if router_code in {"0x", "0x0"}:
         raise activation.ActivationError("durable verifier router runtime code is missing")
-    latest = activation.parse_uint(cast.rpc("block-number"), "latest block")
+    log_cast = activation.Cast(cast.executable, activation.RPC_DEFAULT)
+    latest = activation.parse_uint(log_cast.rpc("block-number"), "latest block")
     from_block = max(0, latest - LOOKBACK_BLOCKS)
-    logs_raw = cast.rpc(
+    logs_raw = log_cast.rpc(
         "logs",
         "--address",
         ROUTER,

--- a/scripts/activate_routed_v3_replacements.py
+++ b/scripts/activate_routed_v3_replacements.py
@@ -283,13 +283,14 @@ def policy_state(cast: Cast, deployment: Mapping[str, Any]) -> dict[str, Any]:
     current_bucket = now // state["period_seconds"]
     observed_bucket = parse_uint(cast.call(WALLET, "periodBucket()(uint256)"), "period bucket")
     period_spent = state["period_spent"] if observed_bucket == current_bucket else 0
-    if period_spent + TOTAL > state["max_per_period"]:
-        raise ActivationError("remaining current-period budget is below 8.04 USDC")
-    if state["wallet_balance"] < TOTAL:
-        raise ActivationError("bounded wallet balance is below 8.04 USDC")
-    if state["lifetime_spent"] + TOTAL > state["max_lifetime_spend"]:
-        raise ActivationError("bounded wallet remaining lifetime budget is below 8.04 USDC")
     state["effective_period_spent"] = period_spent
+    state["remaining_period_budget"] = state["max_per_period"] - period_spent
+    state["remaining_lifetime_budget"] = state["max_lifetime_spend"] - state["lifetime_spent"]
+    state["affordable_creations"] = min(
+        state["remaining_period_budget"] // TARGET,
+        state["remaining_lifetime_budget"] // TARGET,
+        state["wallet_balance"] // TARGET,
+    )
     return state
 
 
@@ -438,6 +439,8 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
     manifest = planner_manifest(args.output_dir / "bounded-wallet-routed-v3-manifest.json", deployment["router_address"])
     documents = durable.materialize_terms(ROOT, deployment["router_address"])
     results: list[dict[str, Any]] = []
+    pending: list[int] = []
+    spend_available = int(before["affordable_creations"])
 
     for issue, config in ISSUES.items():
         document = documents[issue]
@@ -495,12 +498,16 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
         if canonical:
             tx_hash = "already-canonical"
         else:
+            if spend_available <= 0:
+                pending.append(issue)
+                continue
             sent = cast.send_data(
                 address(direct.get("to"), "direct transaction target"),
                 str(direct.get("data")),
                 private_key,
             )
             tx_hash = str(sent.get("transactionHash") or sent.get("transaction_hash"))
+            spend_available -= 1
         reconciled = reconcile(args.api, predicted, bounty_id)
         result = {
             "issue": issue,
@@ -538,6 +545,8 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
         "lifetime_spent_before": before["lifetime_spent"],
         "lifetime_spent_after": after["lifetime_spent"],
         "new_spend": expected_spend,
+        "complete": not pending,
+        "pending_issues": pending,
         "results": results,
         "evidence_boundary": (
             "Confirmed canonical creation, FundingAdded, BountyBecameClaimable, valid terms, and verification readiness "
@@ -550,7 +559,11 @@ def markdown(report: Mapping[str, object]) -> str:
     results = report["results"]
     assert isinstance(results, list)
     lines = [
-        "## Five profitable routed-V3 bounties activated",
+        (
+            "## Five profitable routed-V3 bounties activated"
+            if report["complete"]
+            else "## Profitable routed-V3 activation checkpoint"
+        ),
         "",
         f"- Stable verifier router: `{report['router']}`",
         f"- Immutable routed policy: `{report['policy_hash']}`",
@@ -564,6 +577,15 @@ def markdown(report: Mapping[str, object]) -> str:
         assert isinstance(item, dict)
         lines.append(
             f"- #{item['issue']} `{item['contract']}` — 2.00 USDC solver / 0.01 verifier / 0.01 refundable bond"
+        )
+    pending = report.get("pending_issues", [])
+    if pending:
+        lines.extend(
+            [
+                "",
+                "Daily wallet cap reached. The hourly control loop will activate the remaining "
+                f"issue(s) after the next policy-period reset: {', '.join(f'#{issue}' for issue in pending)}.",
+            ]
         )
     lines.extend(
         [


### PR DESCRIPTION
## Summary
- activate only fully funded parents that fit the bounded wallet's current policy period
- publish issue terms only after canonical reconciliation
- leave the migration open so the hourly control loop finishes remaining parents after reset

## Why
Five exact profitable parents require 10.05 USDC while the owner-approved daily cap is 10.00 USDC. This preserves both the 1.00 USDC gross-margin invariant and the wallet cap without another owner-policy increase.

## Verification
- python -m unittest scripts.test_activate_routed_v3_replacements -v
- python -m py_compile scripts/activate_routed_v3_replacements.py scripts/activate_routed_v3_dynamic.py scripts/check_routed_v3_activation_readiness.py
- git diff --check