### PR TITLE
Keep MoonPay top-up usable before partner-key activation

### DIFF
--- a/docs/moonpay-onramp.md
+++ b/docs/moonpay-onramp.md
@@ -29,10 +29,28 @@ The destination is the user's wallet, never the bounty contract. A plain ERC-20 
 
 The fiat amount is only a starting value. MoonPay remains authoritative for its final quote, fees, supported payment methods, purchase limits, eligibility, and received crypto amount.
 
+## Direct consumer fallback
+
+The on-ramp page also exposes a bounded manual fallback through MoonPay's public consumer pages:
+
+- `https://www.moonpay.com/buy/usdc`
+- `https://www.moonpay.com/buy/eth`
+
+This keeps Base wallet top-up available when Agent Bounties' MoonPay partner credentials are not yet active or the signed checkout service is unavailable. It is deliberately less seamless than the partner checkout:
+
+1. Agent Bounties does not append the wallet, asset, network, amount, API key, or signature to the public URL.
+2. The user must explicitly copy the connected wallet address.
+3. Inside MoonPay, the user must select `USDC_BASE` or `ETH_BASE`, verify the Base network, paste the exact address, and review the final amount and fees.
+4. The user is told to stop if MoonPay shows another network or wallet address.
+5. After delivery, the user returns to Agent Bounties, refreshes the wallet balances, and separately authorizes canonical bounty funding.
+
+The fallback is not equivalent to the signed integration. It cannot cryptographically bind the reviewed wallet or context to MoonPay's checkout, and it should disappear as the primary path once approved partner credentials are active. It exists so an account-level credential dependency does not make the user-facing on-ramp unusable.
+
 ## Architecture
 
 - Browser page: `site/onramp.html`
-- Browser controller: `site/moonpay-onramp.js`
+- Signed-checkout browser controller: `site/moonpay-onramp.js`
+- Direct consumer fallback controller: `site/moonpay-direct-fallback.js`
 - Funding-form handoff: `site/moonpay-link.js`
 - Server route: the MoonPay checkout endpoint on the configured MCP origin; its exact registered path is asserted by `scripts/check-moonpay-onramp.py`
 - Server implementation: `crates/mcp-server/src/moonpay.rs`
@@ -44,9 +62,9 @@ MoonPay remains outside `chatgpt_app.rs`. The existing hosted plugin continues t
 
 ## Required environment variables
 
-Set these on the hosted MCP service:
+Set these on the hosted MCP service to activate the prefilled, server-signed partner checkout. The direct consumer fallback does not require these credentials.
 
-| Variable | Required | Example / purpose |
+| Variable | Required for partner checkout | Example / purpose |
 | --- | --- | --- |
 | `MOONPAY_PUBLISHABLE_KEY` | Yes | `pk_test_...` in sandbox or `pk_live_...` in production |
 | `MOONPAY_SECRET_KEY` | Yes | `sk_test_...` in sandbox or `sk_live_...` in production; server only |
@@ -88,6 +106,8 @@ Activation sequence:
 9. Return to the same bounty and complete the separate canonical contribution.
 10. Confirm the matching indexed `FundingAdded` event before describing the bounty as funded.
 
+Until this sequence is complete, the direct consumer fallback remains available but must not be described as wallet-prefilled, signed, or partner-activated.
+
 ## Verification
 
 Run:
@@ -100,6 +120,8 @@ python scripts/check-site.py
 
 The Rust tests include MoonPay's published URL-signing test vector, verify that live URLs are IP-bound and signed with `signature` appended last, verify that the secret never appears in the checkout URL, and assert that every checkout plan reports `bounty_funded: false` with no canonical event.
 
+The static gate also verifies that the direct fallback uses only MoonPay's public consumer URLs, opens with `noopener noreferrer`, does not imitate a signed or wallet-prefilled URL, and keeps the same canonical funding boundary.
+
 ## Deliberate limitations
 
 - No card, bank, PayPal, identity, or KYC data is collected by Agent Bounties.
@@ -108,4 +130,5 @@ The Rust tests include MoonPay's published URL-signing test vector, verify that 
 - No checkout URL is persisted in browser storage.
 - No email or other personal identifier is sent to MoonPay from Agent Bounties.
 - No affiliate fee is added in this version. This keeps the first implementation focused on reducing entry friction rather than creating an incentive to encourage unnecessary purchases.
+- The direct consumer fallback cannot prefill or bind the user's wallet, Base network, asset, or amount; the user must verify all four inside MoonPay.
 - The in-memory rate limit is appropriate for the current single-service deployment. A horizontally scaled deployment should replace it with a shared rate limiter before increasing traffic.

--- a/scripts/check-moonpay-onramp.py
+++ b/scripts/check-moonpay-onramp.py
@@ -158,8 +158,10 @@ def main() -> int:
         SITE / "moonpay-onramp.js",
         SITE / "moonpay-direct-fallback.js",
         SITE / "moonpay-link.js",
+        ROOT / "scripts/test-moonpay-direct-fallback.js",
     ):
         subprocess.run(["node", "--check", str(script)], cwd=ROOT, check=True)
+    subprocess.run(["node", "scripts/test-moonpay-direct-fallback.js"], cwd=ROOT, check=True)
 
     # The official MoonPay documentation vector is intentionally committed as a Rust unit test.
     if "oIJxSghyzll/BLhUFdQZhkxf7DAS8REFaWr/ibO+K8Q=" not in backend:

--- a/scripts/check-moonpay-onramp.py
+++ b/scripts/check-moonpay-onramp.py
@@ -57,9 +57,15 @@ def main() -> int:
             '<meta name="referrer" content="no-referrer">',
             "Buying crypto does not fund the bounty.",
             "Only the matching indexed <code>FundingAdded</code> event",
+            "Direct MoonPay fallback",
+            "cannot prefill or cryptographically bind your wallet",
             'data-start-moonpay',
+            'data-direct-moonpay',
+            'data-copy-direct-wallet',
+            'rel="noopener noreferrer"',
             'data-return-link',
             'src="moonpay-onramp.js?v=1"',
+            'src="moonpay-direct-fallback.js?v=1"',
         ],
     )
     if any(term in onramp.lower() for term in ('name="card', 'name="cvv', 'name="cvc')):
@@ -90,6 +96,23 @@ def main() -> int:
             "wallet_switchEthereumChain",
         ],
     )
+    fallback = require(
+        SITE / "moonpay-direct-fallback.js",
+        [
+            "https://www.moonpay.com/buy/usdc",
+            "https://www.moonpay.com/buy/eth",
+            "USDC on Base (USDC_BASE)",
+            "ETH on Base (ETH_BASE)",
+            "navigator.clipboard.writeText",
+            'setAttribute("aria-disabled"',
+            "stop if the final screen shows another network or address",
+        ],
+    )
+    if any(term in fallback for term in ("apiKey=", "walletAddress=", "signature=")):
+        fail("The direct MoonPay fallback must not imitate a signed or wallet-prefilled partner URL")
+    if 'target="_blank"' not in onramp or 'rel="noopener noreferrer"' not in onramp:
+        fail("The direct MoonPay fallback must open with noopener and noreferrer")
+
     require(SITE / "moonpay-link.js", ["onramp.html", "bountyContract", "amount", "intent"])
     require(SITE / "onramp.css", [".onramp-page", ".onramp-action", "@media"])
     require(
@@ -101,6 +124,8 @@ def main() -> int:
             "FundingAdded",
             "Base ETH",
             "MoonPay sandbox",
+            "Direct consumer fallback",
+            "www.moonpay.com/buy/usdc",
         ],
     )
     render = require(
@@ -126,10 +151,14 @@ def main() -> int:
     if "moonpay" in chatgpt_app.lower():
         fail("MoonPay must remain a first-party web handoff, not expand the public ChatGPT tool surface")
 
-    if "localStorage" in browser:
+    if "localStorage" in browser or "localStorage" in fallback:
         fail("The MoonPay browser handoff must not persist checkout URLs or provider credentials")
 
-    for script in (SITE / "moonpay-onramp.js", SITE / "moonpay-link.js"):
+    for script in (
+        SITE / "moonpay-onramp.js",
+        SITE / "moonpay-direct-fallback.js",
+        SITE / "moonpay-link.js",
+    ):
         subprocess.run(["node", "--check", str(script)], cwd=ROOT, check=True)
 
     # The official MoonPay documentation vector is intentionally committed as a Rust unit test.

--- a/scripts/test-moonpay-direct-fallback.js
+++ b/scripts/test-moonpay-direct-fallback.js
@@ -1,0 +1,145 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "site", "moonpay-direct-fallback.js"),
+  "utf8",
+);
+
+function element(properties = {}) {
+  const listeners = new Map();
+  const attributes = new Map();
+  return {
+    textContent: "",
+    value: "",
+    checked: false,
+    disabled: false,
+    href: "#",
+    dataset: {},
+    ...properties,
+    addEventListener(type, listener) {
+      listeners.set(type, listener);
+    },
+    setAttribute(name, value) {
+      attributes.set(name, String(value));
+    },
+    getAttribute(name) {
+      return attributes.get(name);
+    },
+    dispatch(type, event = {}) {
+      const listener = listeners.get(type);
+      if (!listener) throw new Error(`missing ${type} listener`);
+      return listener(event);
+    },
+  };
+}
+
+async function main() {
+  const wallet = "0x1234567890abcdef1234567890abcdef12345678";
+  const nodes = new Map([
+    ["[data-wallet-address]", element({ textContent: "Not connected" })],
+    ["[data-onramp-asset]", element({ value: "usdc" })],
+    ["[data-fiat-amount]", element({ value: "42.50" })],
+    ["[data-onramp-ack]", element({ checked: true })],
+    ["[data-direct-moonpay]", element()],
+    ["[data-copy-direct-wallet]", element({ disabled: true })],
+    ["[data-direct-asset]", element()],
+    ["[data-direct-amount]", element()],
+    ["[data-direct-wallet]", element()],
+    ["[data-direct-moonpay-output]", element()],
+    ["[data-connect-wallet]", element()],
+    ["[data-wallet-provider]", element()],
+  ]);
+
+  let mutationCallback = null;
+  let copied = null;
+  const context = {
+    document: {
+      querySelector(selector) {
+        return nodes.get(selector) || null;
+      },
+      createRange() {
+        return { selectNodeContents() {} };
+      },
+    },
+    navigator: {
+      clipboard: {
+        async writeText(value) {
+          copied = value;
+        },
+      },
+    },
+    window: {
+      getSelection() {
+        return { removeAllRanges() {}, addRange() {} };
+      },
+    },
+    MutationObserver: class {
+      constructor(callback) {
+        mutationCallback = callback;
+      }
+      observe() {}
+    },
+    setTimeout(callback) {
+      callback();
+      return 1;
+    },
+  };
+
+  vm.runInNewContext(source, context, { filename: "site/moonpay-direct-fallback.js" });
+
+  const link = nodes.get("[data-direct-moonpay]");
+  const copy = nodes.get("[data-copy-direct-wallet]");
+  if (link.href !== "https://www.moonpay.com/buy/usdc") {
+    throw new Error(`USDC fallback URL mismatch: ${link.href}`);
+  }
+  if (link.getAttribute("aria-disabled") !== "true" || copy.disabled !== true) {
+    throw new Error("fallback opened before a valid destination wallet was present");
+  }
+
+  nodes.get("[data-wallet-address]").textContent = wallet;
+  mutationCallback();
+  if (link.getAttribute("aria-disabled") !== "false" || copy.disabled !== false) {
+    throw new Error("fallback did not enable after wallet connection and acknowledgement");
+  }
+  if (nodes.get("[data-direct-wallet]").textContent !== wallet) {
+    throw new Error("connected wallet was not presented for manual verification");
+  }
+  if (link.href.includes(wallet) || link.href.includes("walletAddress")) {
+    throw new Error("manual fallback leaked the wallet into MoonPay's public URL");
+  }
+
+  let prevented = false;
+  link.dispatch("click", { preventDefault() { prevented = true; } });
+  if (prevented) throw new Error("ready direct checkout was unexpectedly blocked");
+
+  nodes.get("[data-onramp-asset]").value = "eth";
+  nodes.get("[data-onramp-asset]").dispatch("change");
+  if (link.href !== "https://www.moonpay.com/buy/eth") {
+    throw new Error(`ETH fallback URL mismatch: ${link.href}`);
+  }
+  if (nodes.get("[data-direct-asset]").textContent !== "ETH on Base (ETH_BASE)") {
+    throw new Error("ETH Base review label was not rendered");
+  }
+
+  await copy.dispatch("click");
+  if (copied !== wallet) throw new Error(`copied wallet mismatch: ${copied}`);
+
+  nodes.get("[data-onramp-ack]").checked = false;
+  nodes.get("[data-onramp-ack]").dispatch("change");
+  prevented = false;
+  link.dispatch("click", { preventDefault() { prevented = true; } });
+  if (!prevented || link.getAttribute("aria-disabled") !== "true") {
+    throw new Error("manual checkout was not blocked after acknowledgement was withdrawn");
+  }
+
+  console.log("MoonPay direct fallback preserves wallet, Base asset, and funding boundaries");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/test-moonpay-direct-fallback.js
+++ b/scripts/test-moonpay-direct-fallback.js
@@ -15,6 +15,7 @@ function element(properties = {}) {
   return {
     textContent: "",
     value: "",
+    min: "",
     checked: false,
     disabled: false,
     href: "#",
@@ -44,6 +45,8 @@ async function main() {
     ["[data-onramp-asset]", element({ value: "usdc" })],
     ["[data-fiat-amount]", element({ value: "42.50" })],
     ["[data-onramp-ack]", element({ checked: true })],
+    ["[data-start-moonpay]", element()],
+    ["[data-onramp-output]", element()],
     ["[data-direct-moonpay]", element()],
     ["[data-copy-direct-wallet]", element({ disabled: true })],
     ["[data-direct-asset]", element()],
@@ -93,6 +96,11 @@ async function main() {
 
   const link = nodes.get("[data-direct-moonpay]");
   const copy = nodes.get("[data-copy-direct-wallet]");
+  const amount = nodes.get("[data-fiat-amount]");
+  const partnerButton = nodes.get("[data-start-moonpay]");
+  if (amount.min !== "20") {
+    throw new Error(`MoonPay minimum was not applied to the amount input: ${amount.min}`);
+  }
   if (link.href !== "https://www.moonpay.com/buy/usdc") {
     throw new Error(`USDC fallback URL mismatch: ${link.href}`);
   }
@@ -103,7 +111,7 @@ async function main() {
   nodes.get("[data-wallet-address]").textContent = wallet;
   mutationCallback();
   if (link.getAttribute("aria-disabled") !== "false" || copy.disabled !== false) {
-    throw new Error("fallback did not enable after wallet connection and acknowledgement");
+    throw new Error("fallback did not enable after wallet connection, amount review, and acknowledgement");
   }
   if (nodes.get("[data-direct-wallet]").textContent !== wallet) {
     throw new Error("connected wallet was not presented for manual verification");
@@ -112,7 +120,30 @@ async function main() {
     throw new Error("manual fallback leaked the wallet into MoonPay's public URL");
   }
 
+  amount.value = "19.99";
+  amount.dispatch("input");
+  if (link.getAttribute("aria-disabled") !== "true") {
+    throw new Error("direct checkout remained enabled below MoonPay's minimum");
+  }
+  if (!nodes.get("[data-direct-amount]").textContent.includes("below MoonPay minimum")) {
+    throw new Error("the below-minimum amount was not made visible to the user");
+  }
   let prevented = false;
+  let propagationStopped = false;
+  partnerButton.dispatch("click", {
+    preventDefault() { prevented = true; },
+    stopImmediatePropagation() { propagationStopped = true; },
+  });
+  if (!prevented || !propagationStopped) {
+    throw new Error("signed partner checkout was not stopped below MoonPay's minimum");
+  }
+  if (!nodes.get("[data-onramp-output]").textContent.includes("at least $20.00")) {
+    throw new Error("the partner checkout did not explain MoonPay's minimum");
+  }
+
+  amount.value = "42.50";
+  amount.dispatch("input");
+  prevented = false;
   link.dispatch("click", { preventDefault() { prevented = true; } });
   if (prevented) throw new Error("ready direct checkout was unexpectedly blocked");
 
@@ -136,7 +167,7 @@ async function main() {
     throw new Error("manual checkout was not blocked after acknowledgement was withdrawn");
   }
 
-  console.log("MoonPay direct fallback preserves wallet, Base asset, and funding boundaries");
+  console.log("MoonPay direct fallback preserves minimum, wallet, Base asset, and funding boundaries");
 }
 
 main().catch((error) => {

--- a/site/moonpay-direct-fallback.js
+++ b/site/moonpay-direct-fallback.js
@@ -1,0 +1,130 @@
+(() => {
+  "use strict";
+
+  const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+  const DIRECT_BUY_URLS = Object.freeze({
+    usdc: "https://www.moonpay.com/buy/usdc",
+    eth: "https://www.moonpay.com/buy/eth",
+  });
+
+  const select = (selector) => document.querySelector(selector);
+
+  function connectedWallet() {
+    const value = String(select("[data-wallet-address]")?.textContent || "").trim();
+    return ADDRESS.test(value) ? value.toLowerCase() : "";
+  }
+
+  function selectedAsset() {
+    return select("[data-onramp-asset]")?.value === "eth" ? "eth" : "usdc";
+  }
+
+  function assetLabel(asset) {
+    return asset === "eth" ? "ETH on Base (ETH_BASE)" : "USDC on Base (USDC_BASE)";
+  }
+
+  function startingAmount() {
+    const value = String(select("[data-fiat-amount]")?.value || "").trim();
+    return /^\d+(?:\.\d{1,2})?$/.test(value) && Number(value) > 0 ? `$${value} USD` : "Set above";
+  }
+
+  function setDirectOutput(message, tone = "") {
+    const output = select("[data-direct-moonpay-output]");
+    if (!output) return;
+    output.textContent = message;
+    output.dataset.tone = tone;
+  }
+
+  function renderDirectFallback() {
+    const asset = selectedAsset();
+    const wallet = connectedWallet();
+    const acknowledged = Boolean(select("[data-onramp-ack]")?.checked);
+    const link = select("[data-direct-moonpay]");
+    const copy = select("[data-copy-direct-wallet]");
+
+    select("[data-direct-asset]").textContent = assetLabel(asset);
+    select("[data-direct-amount]").textContent = startingAmount();
+    select("[data-direct-wallet]").textContent = wallet || "Connect a Base wallet above";
+
+    link.href = DIRECT_BUY_URLS[asset];
+    link.dataset.asset = asset;
+    link.setAttribute("aria-disabled", String(!(wallet && acknowledged)));
+    copy.disabled = !wallet;
+
+    if (!wallet) {
+      setDirectOutput("Connect the destination wallet before opening the manual MoonPay fallback.");
+    } else if (!acknowledged) {
+      setDirectOutput("Acknowledge that buying crypto and funding the bounty are separate actions.");
+    } else {
+      setDirectOutput(
+        `Ready for manual MoonPay checkout. Select ${assetLabel(asset)}, paste ${wallet}, and verify Base on the final review screen.`,
+        "pending",
+      );
+    }
+  }
+
+  async function copyWallet() {
+    const wallet = connectedWallet();
+    if (!wallet) {
+      setDirectOutput("Connect the destination wallet before copying its address.", "error");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(wallet);
+      setDirectOutput(`Copied destination wallet ${wallet}. Verify the same address inside MoonPay.`, "success");
+    } catch (_error) {
+      const range = document.createRange();
+      range.selectNodeContents(select("[data-direct-wallet]"));
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      setDirectOutput("The wallet address is selected. Copy it, then verify the full address inside MoonPay.", "pending");
+    }
+  }
+
+  function openDirectCheckout(event) {
+    renderDirectFallback();
+    const wallet = connectedWallet();
+    const acknowledged = Boolean(select("[data-onramp-ack]")?.checked);
+    if (!wallet || !acknowledged) {
+      event.preventDefault();
+      setDirectOutput(
+        !wallet
+          ? "Connect the destination wallet before opening MoonPay."
+          : "Acknowledge the purchase and funding boundary before opening MoonPay.",
+        "error",
+      );
+      return;
+    }
+    const asset = selectedAsset();
+    setDirectOutput(
+      `MoonPay is opening in a new tab. Choose ${assetLabel(asset)}, use the starting amount shown here, paste ${wallet}, and stop if the final screen shows another network or address.`,
+      "pending",
+    );
+  }
+
+  function initialize() {
+    const link = select("[data-direct-moonpay]");
+    const copy = select("[data-copy-direct-wallet]");
+    if (!link || !copy) return;
+
+    link.addEventListener("click", openDirectCheckout);
+    copy.addEventListener("click", copyWallet);
+    select("[data-onramp-asset]")?.addEventListener("change", renderDirectFallback);
+    select("[data-fiat-amount]")?.addEventListener("input", renderDirectFallback);
+    select("[data-onramp-ack]")?.addEventListener("change", renderDirectFallback);
+    select("[data-connect-wallet]")?.addEventListener("click", () => setTimeout(renderDirectFallback, 0));
+    select("[data-wallet-provider]")?.addEventListener("change", renderDirectFallback);
+
+    const walletAddress = select("[data-wallet-address]");
+    if (walletAddress) {
+      new MutationObserver(renderDirectFallback).observe(walletAddress, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+    }
+    renderDirectFallback();
+  }
+
+  initialize();
+})();

--- a/site/moonpay-direct-fallback.js
+++ b/site/moonpay-direct-fallback.js
@@ -2,6 +2,7 @@
   "use strict";
 
   const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+  const MIN_FIAT_USD = 20;
   const DIRECT_BUY_URLS = Object.freeze({
     usdc: "https://www.moonpay.com/buy/usdc",
     eth: "https://www.moonpay.com/buy/eth",
@@ -22,9 +23,23 @@
     return asset === "eth" ? "ETH on Base (ETH_BASE)" : "USDC on Base (USDC_BASE)";
   }
 
-  function startingAmount() {
+  function fiatAmount() {
     const value = String(select("[data-fiat-amount]")?.value || "").trim();
-    return /^\d+(?:\.\d{1,2})?$/.test(value) && Number(value) > 0 ? `$${value} USD` : "Set above";
+    if (!/^\d+(?:\.\d{1,2})?$/.test(value)) return null;
+    const amount = Number(value);
+    return Number.isFinite(amount) && amount > 0 ? amount : null;
+  }
+
+  function amountReady() {
+    const amount = fiatAmount();
+    return amount !== null && amount >= MIN_FIAT_USD;
+  }
+
+  function startingAmount() {
+    const amount = fiatAmount();
+    if (amount === null) return `Enter at least $${MIN_FIAT_USD.toFixed(2)} USD`;
+    const suffix = amount < MIN_FIAT_USD ? " (below MoonPay minimum)" : "";
+    return `$${amount.toFixed(2)} USD${suffix}`;
   }
 
   function setDirectOutput(message, tone = "") {
@@ -34,10 +49,22 @@
     output.dataset.tone = tone;
   }
 
+  function setPartnerOutput(message, tone = "") {
+    const output = select("[data-onramp-output]");
+    if (!output) return;
+    output.textContent = message;
+    output.dataset.tone = tone;
+  }
+
+  function minimumMessage() {
+    return `Enter at least $${MIN_FIAT_USD.toFixed(2)} USD. MoonPay may apply a higher minimum based on asset, region, payment method, and network conditions.`;
+  }
+
   function renderDirectFallback() {
     const asset = selectedAsset();
     const wallet = connectedWallet();
     const acknowledged = Boolean(select("[data-onramp-ack]")?.checked);
+    const hasValidAmount = amountReady();
     const link = select("[data-direct-moonpay]");
     const copy = select("[data-copy-direct-wallet]");
 
@@ -47,13 +74,15 @@
 
     link.href = DIRECT_BUY_URLS[asset];
     link.dataset.asset = asset;
-    link.setAttribute("aria-disabled", String(!(wallet && acknowledged)));
+    link.setAttribute("aria-disabled", String(!(wallet && acknowledged && hasValidAmount)));
     copy.disabled = !wallet;
 
     if (!wallet) {
       setDirectOutput("Connect the destination wallet before opening the manual MoonPay fallback.");
     } else if (!acknowledged) {
       setDirectOutput("Acknowledge that buying crypto and funding the bounty are separate actions.");
+    } else if (!hasValidAmount) {
+      setDirectOutput(minimumMessage(), "error");
     } else {
       setDirectOutput(
         `Ready for manual MoonPay checkout. Select ${assetLabel(asset)}, paste ${wallet}, and verify Base on the final review screen.`,
@@ -85,12 +114,15 @@
     renderDirectFallback();
     const wallet = connectedWallet();
     const acknowledged = Boolean(select("[data-onramp-ack]")?.checked);
-    if (!wallet || !acknowledged) {
+    const hasValidAmount = amountReady();
+    if (!wallet || !acknowledged || !hasValidAmount) {
       event.preventDefault();
       setDirectOutput(
         !wallet
           ? "Connect the destination wallet before opening MoonPay."
-          : "Acknowledge the purchase and funding boundary before opening MoonPay.",
+          : (!acknowledged
+            ? "Acknowledge the purchase and funding boundary before opening MoonPay."
+            : minimumMessage()),
         "error",
       );
       return;
@@ -102,15 +134,28 @@
     );
   }
 
+  function enforceMinimumForPartnerCheckout(event) {
+    if (amountReady()) return;
+    event.preventDefault();
+    event.stopImmediatePropagation?.();
+    const message = minimumMessage();
+    setPartnerOutput(message, "error");
+    setDirectOutput(message, "error");
+  }
+
   function initialize() {
     const link = select("[data-direct-moonpay]");
     const copy = select("[data-copy-direct-wallet]");
     if (!link || !copy) return;
 
+    const amountInput = select("[data-fiat-amount]");
+    if (amountInput) amountInput.min = String(MIN_FIAT_USD);
+
     link.addEventListener("click", openDirectCheckout);
     copy.addEventListener("click", copyWallet);
+    select("[data-start-moonpay]")?.addEventListener("click", enforceMinimumForPartnerCheckout, true);
     select("[data-onramp-asset]")?.addEventListener("change", renderDirectFallback);
-    select("[data-fiat-amount]")?.addEventListener("input", renderDirectFallback);
+    amountInput?.addEventListener("input", renderDirectFallback);
     select("[data-onramp-ack]")?.addEventListener("change", renderDirectFallback);
     select("[data-connect-wallet]")?.addEventListener("click", () => setTimeout(renderDirectFallback, 0));
     select("[data-wallet-provider]")?.addEventListener("change", renderDirectFallback);

--- a/site/onramp.html
+++ b/site/onramp.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="simple-ux.css?v=1">
     <link rel="stylesheet" href="onramp.css?v=1">
   </head>
-  <body class="guild-interior" data-guild-build="20260725-moonpay-1" data-public-ux="simplified-v1">
+  <body class="guild-interior" data-guild-build="20260725-moonpay-2" data-public-ux="simplified-v1">
     <header class="topbar">
       <a class="brand" href="index.html">Agent Bounties</a>
       <nav aria-label="Primary navigation">
@@ -99,7 +99,7 @@
 
       <section class="onramp-action" aria-labelledby="moonpay-action-title">
         <div>
-          <p class="eyebrow">MoonPay checkout</p>
+          <p class="eyebrow">MoonPay partner checkout</p>
           <h2 id="moonpay-action-title">Continue only after checking the wallet and amount.</h2>
           <p>MoonPay is a separate provider with its own eligibility, terms, fees, identity checks, and support. Agent Bounties does not decide whether MoonPay approves a purchase.</p>
           <label class="onramp-acknowledgement">
@@ -112,6 +112,31 @@
           <a class="button secondary" href="earn.html#fund-bounty-panel" data-return-link>Skip purchase and return</a>
         </div>
         <output class="output" data-onramp-output aria-live="polite">No checkout has been created.</output>
+      </section>
+
+      <section class="onramp-action" aria-labelledby="direct-moonpay-title" data-direct-moonpay-fallback>
+        <div>
+          <p class="eyebrow">Direct MoonPay fallback</p>
+          <h2 id="direct-moonpay-title">Top up even before partner credentials are activated.</h2>
+          <p>This opens MoonPay's public consumer checkout in a new tab. It cannot prefill or cryptographically bind your wallet, asset, network, or amount, so verify each one yourself before paying.</p>
+          <dl class="onramp-facts">
+            <div><dt>Asset to select</dt><dd><strong data-direct-asset>USDC on Base (USDC_BASE)</strong></dd></div>
+            <div><dt>Network to verify</dt><dd><strong>Base</strong></dd></div>
+            <div><dt>Starting amount</dt><dd><strong data-direct-amount>Set above</strong></dd></div>
+            <div><dt>Wallet to paste</dt><dd><code data-direct-wallet>Connect a Base wallet above</code></dd></div>
+          </dl>
+          <ol>
+            <li>Copy the connected wallet address below.</li>
+            <li>Inside MoonPay, choose the exact Base asset shown here and enter the starting amount.</li>
+            <li>Paste the wallet address and stop if MoonPay's final review shows another network or address.</li>
+            <li>After delivery, return here and refresh balances before separately funding the bounty.</li>
+          </ol>
+        </div>
+        <div class="onramp-action-buttons">
+          <button class="button secondary" type="button" data-copy-direct-wallet disabled>Copy wallet address</button>
+          <a class="button primary" href="#" target="_blank" rel="noopener noreferrer" aria-disabled="true" data-direct-moonpay>Open MoonPay direct checkout</a>
+        </div>
+        <output class="output" data-direct-moonpay-output aria-live="polite">Connect the destination wallet before opening the manual MoonPay fallback.</output>
       </section>
 
       <section class="onramp-return-status" data-return-status hidden aria-labelledby="return-status-title">
@@ -131,5 +156,6 @@
     </footer>
     <script src="guild-shell.js?v=2"></script>
     <script src="moonpay-onramp.js?v=1"></script>
+    <script src="moonpay-direct-fallback.js?v=1"></script>
   </body>
 </html>


### PR DESCRIPTION
## Problem

The signed MoonPay integration is deployed, but production correctly returns `503 moonpay_not_configured` because the MoonPay partner publishable key has not yet been provisioned in Render. Faking or committing credentials would make the integration look green while leaving checkout broken.

## Solution

Add an explicit direct-consumer fallback alongside the signed partner path:

- opens only MoonPay's official public USDC or ETH purchase page;
- requires the user to connect the same Base wallet and acknowledge that purchase and bounty funding are separate;
- shows the exact Base asset, starting amount, and wallet to verify;
- provides an explicit copy-wallet action;
- never appends wallet, amount, API key, signature, or bounty context to the public URL;
- tells the user to stop if MoonPay's final review shows another network or address;
- blocks both direct and signed checkout below MoonPay's current $20 public minimum, while warning that MoonPay may impose a higher region- or payment-specific minimum;
- returns the user to balance refresh and the separate canonical contribution flow.

The server-signed path remains primary and automatically becomes the seamless route when approved partner credentials are configured.

## Verification

- extends the MoonPay static/evidence-boundary gate;
- syntax-checks the new browser controller;
- adds a deterministic browser-behavior test for wallet connection, minimum enforcement, acknowledgement, USDC/ETH Base selection, wallet copying, external navigation, and withdrawn consent;
- proves the wallet never enters the public MoonPay URL;
- documents the degraded-mode guarantees and limitations;
- preserves `FundingAdded` as the only authority for funded state.