### PR TITLE
Compact the generated Coinbase route diagnostic

### DIFF
--- a/.github/workflows/temp-inspect-locked-cdp-sdk.yml
+++ b/.github/workflows/temp-inspect-locked-cdp-sdk.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install exact reviewed dependencies
         run: npm ci --prefix tools/coinbase-embedded-wallet --ignore-scripts --no-audit --no-fund
 
-      - name: Extract generated CDP API client route templates
+      - name: Extract compact generated-client route list
         run: |
           python - <<'PY'
           import json
@@ -37,42 +37,43 @@ jobs:
           from pathlib import Path
 
           root = Path("tools/coinbase-embedded-wallet/node_modules/@coinbase/cdp-api-client")
-          quoted = re.compile(r"[\"'`]([^\"'`\\\n]{1,400})[\"'`]")
-          route_keyword = re.compile(
-              r"(?:^|/)(?:v[0-9]+/)?(?:projects?|end-users?|users?|auth|oauth|mfa|sessions?|evm|solana|wallets?|accounts?|challenges?|config)(?:/|$)",
+          route_patterns = (
+              re.compile(r'["\'`](/v[0-9]+/[^"\'`\\\n]{1,280})["\'`]'),
+              re.compile(r'["\'`](/embedded-wallet-api/[^"\'`\\\n]{1,280})["\'`]'),
+          )
+          symbols = re.compile(
+              r"getProjectConfig|getMfaConfig|signInWithEmail|verifyEmailOTP|signInWithSms|verifySmsOTP|authenticateWithOAuth|link.*Auth|initiate.*OTP|verify.*OTP",
               re.I,
           )
-          symbol_keyword = re.compile(
-              r"getProjectConfig|getMfaConfig|signIn|verify.*OTP|OAuth|link.*Auth|initialize|refreshToken|endUser",
-              re.I,
-          )
-          report = []
-          for path in root.rglob("*"):
+          route_files = {}
+          symbol_files = {}
+          for path in sorted(root.rglob("*")):
               if not path.is_file() or path.stat().st_size > 12_000_000:
                   continue
               text = path.read_text(encoding="utf-8", errors="ignore")
-              routes = sorted({
-                  value
-                  for value in (match.group(1) for match in quoted.finditer(text))
-                  if value.startswith("/") and route_keyword.search(value)
-              })
-              symbol_context = []
-              for match in symbol_keyword.finditer(text):
-                  snippet = " ".join(text[max(0, match.start() - 700):match.end() + 1800].split())[:2500]
-                  symbol_context.append({"symbol": match.group(0), "context": snippet})
-                  if len(symbol_context) >= 30:
-                      break
-              if routes or symbol_context:
-                  report.append({
-                      "file": str(path.relative_to(root)),
-                      "routes": routes[:300],
-                      "contexts": symbol_context,
-                  })
-          Path("/tmp/cdp-api-client-routes.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+              relative = str(path.relative_to(root))
+              for pattern in route_patterns:
+                  for match in pattern.finditer(text):
+                      route = " ".join(match.group(1).split())
+                      route_files.setdefault(route, set()).add(relative)
+              for match in symbols.finditer(text):
+                  symbol_files.setdefault(match.group(0), set()).add(relative)
+          report = {
+              "schema_version": "agent-bounties/cdp-api-client-routes-v1",
+              "routes": [
+                  {"route": route, "files": sorted(files)[:12]}
+                  for route, files in sorted(route_files.items())
+              ],
+              "symbols": [
+                  {"symbol": symbol, "files": sorted(files)[:12]}
+                  for symbol, files in sorted(symbol_files.items(), key=lambda item: item[0].lower())
+              ],
+          }
+          Path("/tmp/cdp-routes.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
           print(json.dumps(report, indent=2))
           PY
 
-      - name: Publish durable generated-client trace
+      - name: Publish compact durable route list
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -80,28 +81,31 @@ jobs:
           import json
           from pathlib import Path
 
-          report = json.loads(Path("/tmp/cdp-api-client-routes.json").read_text(encoding="utf-8"))
+          report = json.loads(Path("/tmp/cdp-routes.json").read_text(encoding="utf-8"))
           lines = [
-              "Generated route and symbol trace from `@coinbase/cdp-api-client@0.0.118`, the exact client used by PR #605.",
+              "Compact route list from `@coinbase/cdp-api-client@0.0.118`, the exact generated client used by PR #605.",
               "",
+              "## Route templates",
           ]
-          for entry in report[:50]:
-              lines.extend([f"## `{entry['file']}`", "", "### Route templates"])
-              if entry["routes"]:
-                  lines.extend(f"- `{route}`" for route in entry["routes"][:200])
-              else:
-                  lines.append("- No standalone quoted route template found.")
-              lines.extend(["", "### Relevant generated-client context"])
-              for context in entry["contexts"][:16]:
-                  clean = context["context"].replace("9dfed88a-0b37-47e8-b867-96f1dfd0d4ee", "<project>")
-                  lines.append(f"- `{context['symbol']}` → `{clean}`")
-              lines.append("")
-          if not report:
-              lines.append("No matching generated client routes or symbols were found.")
-          lines.append("No Coinbase API key, secret, OTP, OAuth credential, wallet key, transaction, or seed phrase was used.")
-          Path("/tmp/generated-client-trace.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          routes = report.get("routes", [])
+          if routes:
+              for item in routes[:300]:
+                  lines.append(f"- `{item['route']}` — `{', '.join(item['files'])}`")
+          else:
+              lines.append("- No quoted `/v…` or embedded-wallet route template was found.")
+          lines.extend(["", "## Exported or referenced auth/config symbols"])
+          for item in report.get("symbols", [])[:120]:
+              lines.append(f"- `{item['symbol']}` — `{', '.join(item['files'])}`")
+          lines.extend([
+              "",
+              "No Coinbase API key, secret, OTP, OAuth credential, wallet key, transaction, or seed phrase was used.",
+          ])
+          body = "\n".join(lines) + "\n"
+          if len(body.encode("utf-8")) > 50_000:
+              raise SystemExit("compact diagnostic unexpectedly exceeds 50 KB")
+          Path("/tmp/cdp-routes.md").write_text(body, encoding="utf-8")
           PY
           url="$(gh issue create --repo "${GITHUB_REPOSITORY}" \
-            --title 'CDP API client 0.0.118 generated route trace' \
-            --body-file /tmp/generated-client-trace.md)"
+            --title 'Compact CDP API client 0.0.118 routes' \
+            --body-file /tmp/cdp-routes.md)"
           gh issue close --repo "${GITHUB_REPOSITORY}" "${url##*/}" --reason completed >/dev/null


### PR DESCRIPTION
Reduces the temporary generated-client diagnostic to exact `/v…` and embedded-wallet route templates plus a bounded symbol index, keeping the resulting evidence under 50 KB. No production or credential behavior changes.