### PR TITLE
Verify the actual Coinbase SDK browser routes

### DIFF
--- a/.github/workflows/temp-verify-coinbase-allowlist.yml
+++ b/.github/workflows/temp-verify-coinbase-allowlist.yml
@@ -18,84 +18,156 @@ jobs:
     env:
       PROJECT_ID: 9dfed88a-0b37-47e8-b867-96f1dfd0d4ee
       ORIGIN: https://agentbounties.app
+      API_BASE: https://api.cdp.coinbase.com/platform
     steps:
-      - name: Probe exact Coinbase Embedded Wallet browser preflight
-        id: preflight
+      - name: Probe the exact public project-config request used by CDP 0.0.118
+        id: config
         shell: bash
         run: |
           set -u
-          endpoint="https://api.cdp.coinbase.com/embedded-wallet-api/projects/${PROJECT_ID}"
+          endpoint="${API_BASE}/v2/embedded-wallet-api/projects/${PROJECT_ID}/config"
           status="$(curl --silent --show-error \
-            --output /tmp/body \
-            --dump-header /tmp/headers \
+            --output /tmp/config-body \
+            --dump-header /tmp/config-headers \
+            --write-out '%{http_code}' \
+            --request GET "${endpoint}" \
+            --header "Origin: ${ORIGIN}" \
+            --header 'Accept: application/json' \
+            --max-time 30)"
+          curl_status=$?
+          allow_origin="$(tr -d '\r' < /tmp/config-headers | sed -nE 's/^access-control-allow-origin:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
+          allow_credentials="$(tr -d '\r' < /tmp/config-headers | sed -nE 's/^access-control-allow-credentials:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
+          content_type="$(tr -d '\r' < /tmp/config-headers | sed -nE 's/^content-type:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
+          json_ok=false
+          python -m json.tool /tmp/config-body >/dev/null 2>&1 && json_ok=true
+          http_ok=false
+          origin_ok=false
+          credentials_ok=false
+          [[ "${curl_status}" -eq 0 && "${status}" -ge 200 && "${status}" -lt 300 ]] && http_ok=true
+          [[ "${allow_origin}" = "${ORIGIN}" ]] && origin_ok=true
+          [[ "${allow_credentials,,}" = "true" ]] && credentials_ok=true
+          {
+            echo "http_status=${status:-curl-${curl_status}}"
+            echo "allow_origin=${allow_origin:-missing}"
+            echo "allow_credentials=${allow_credentials:-missing}"
+            echo "content_type=${content_type:-missing}"
+            echo "http_ok=${http_ok}"
+            echo "origin_ok=${origin_ok}"
+            echo "credentials_ok=${credentials_ok}"
+            echo "json_ok=${json_ok}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Probe the exact auth-init browser preflight used by CDP 0.0.118
+        id: auth
+        shell: bash
+        run: |
+          set -u
+          endpoint="${API_BASE}/v2/embedded-wallet-api/projects/${PROJECT_ID}/auth/init"
+          requested_headers='content-type,x-idempotency-key,authorization,x-wallet-auth'
+          status="$(curl --silent --show-error \
+            --output /tmp/auth-body \
+            --dump-header /tmp/auth-headers \
             --write-out '%{http_code}' \
             --request OPTIONS "${endpoint}" \
             --header "Origin: ${ORIGIN}" \
             --header 'Access-Control-Request-Method: POST' \
-            --header 'Access-Control-Request-Headers: content-type' \
+            --header "Access-Control-Request-Headers: ${requested_headers}" \
             --max-time 30)"
           curl_status=$?
-          origin="$(tr -d '\r' < /tmp/headers | sed -nE 's/^access-control-allow-origin:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
-          methods="$(tr -d '\r' < /tmp/headers | sed -nE 's/^access-control-allow-methods:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
-          allowed_headers="$(tr -d '\r' < /tmp/headers | sed -nE 's/^access-control-allow-headers:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
-
+          allow_origin="$(tr -d '\r' < /tmp/auth-headers | sed -nE 's/^access-control-allow-origin:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
+          allow_credentials="$(tr -d '\r' < /tmp/auth-headers | sed -nE 's/^access-control-allow-credentials:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
+          methods="$(tr -d '\r' < /tmp/auth-headers | sed -nE 's/^access-control-allow-methods:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
+          allowed_headers="$(tr -d '\r' < /tmp/auth-headers | sed -nE 's/^access-control-allow-headers:[[:space:]]*(.*)$/\1/Ip' | tail -n1)"
           http_ok=false
           origin_ok=false
+          credentials_ok=false
           method_ok=false
-          header_ok=false
+          headers_ok=true
           [[ "${curl_status}" -eq 0 && "${status}" -ge 200 && "${status}" -lt 300 ]] && http_ok=true
-          [[ "${origin}" = "${ORIGIN}" ]] && origin_ok=true
+          [[ "${allow_origin}" = "${ORIGIN}" ]] && origin_ok=true
+          [[ "${allow_credentials,,}" = "true" ]] && credentials_ok=true
           printf '%s' "${methods}" | grep -Eiq '(^|,[[:space:]]*)POST([[:space:]]*,|$)' && method_ok=true
-          printf '%s' "${allowed_headers}" | grep -Eiq '(^|,[[:space:]]*)content-type([[:space:]]*,|$)' && header_ok=true
-
+          for required in content-type x-idempotency-key authorization x-wallet-auth; do
+            printf '%s' "${allowed_headers}" | tr '[:upper:]' '[:lower:]' | grep -Eiq "(^|,[[:space:]]*)${required}([[:space:]]*,|$)" || headers_ok=false
+          done
           {
             echo "http_status=${status:-curl-${curl_status}}"
-            echo "allow_origin=${origin:-missing}"
+            echo "allow_origin=${allow_origin:-missing}"
+            echo "allow_credentials=${allow_credentials:-missing}"
             echo "allow_methods=${methods:-missing}"
             echo "allow_headers=${allowed_headers:-missing}"
             echo "http_ok=${http_ok}"
             echo "origin_ok=${origin_ok}"
+            echo "credentials_ok=${credentials_ok}"
             echo "method_ok=${method_ok}"
-            echo "header_ok=${header_ok}"
+            echo "headers_ok=${headers_ok}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Publish durable redacted verdict
+      - name: Publish durable redacted real-route verdict
         env:
           GH_TOKEN: ${{ github.token }}
-          STATUS: ${{ steps.preflight.outputs.http_status }}
-          ALLOW_ORIGIN: ${{ steps.preflight.outputs.allow_origin }}
-          ALLOW_METHODS: ${{ steps.preflight.outputs.allow_methods }}
-          ALLOW_HEADERS: ${{ steps.preflight.outputs.allow_headers }}
-          HTTP_OK: ${{ steps.preflight.outputs.http_ok }}
-          ORIGIN_OK: ${{ steps.preflight.outputs.origin_ok }}
-          METHOD_OK: ${{ steps.preflight.outputs.method_ok }}
-          HEADER_OK: ${{ steps.preflight.outputs.header_ok }}
+          CONFIG_HTTP: ${{ steps.config.outputs.http_ok }}
+          CONFIG_ORIGIN: ${{ steps.config.outputs.origin_ok }}
+          CONFIG_CREDENTIALS: ${{ steps.config.outputs.credentials_ok }}
+          CONFIG_JSON: ${{ steps.config.outputs.json_ok }}
+          CONFIG_STATUS: ${{ steps.config.outputs.http_status }}
+          CONFIG_CONTENT_TYPE: ${{ steps.config.outputs.content_type }}
+          AUTH_HTTP: ${{ steps.auth.outputs.http_ok }}
+          AUTH_ORIGIN: ${{ steps.auth.outputs.origin_ok }}
+          AUTH_CREDENTIALS: ${{ steps.auth.outputs.credentials_ok }}
+          AUTH_POST: ${{ steps.auth.outputs.method_ok }}
+          AUTH_HEADERS: ${{ steps.auth.outputs.headers_ok }}
+          AUTH_STATUS: ${{ steps.auth.outputs.http_status }}
+          AUTH_METHODS: ${{ steps.auth.outputs.allow_methods }}
+          AUTH_ALLOWED_HEADERS: ${{ steps.auth.outputs.allow_headers }}
         run: |
-          title="Coinbase allowlist verdict H-${HTTP_OK} O-${ORIGIN_OK} P-${METHOD_OK} C-${HEADER_OK}"
+          title="Coinbase real-route verdict config-${CONFIG_HTTP}-${CONFIG_ORIGIN} auth-${AUTH_HTTP}-${AUTH_ORIGIN}-${AUTH_POST}"
           cat > /tmp/verdict.md <<EOF
-          One-shot exact-origin Coinbase Embedded Wallet CORS verdict.
+          Exact browser-origin verification against the routes used by \`@coinbase/cdp-api-client@0.0.118\`.
 
-          - HTTP: \`${STATUS:-unavailable}\`
-          - Access-Control-Allow-Origin: \`${ALLOW_ORIGIN:-missing}\`
-          - Access-Control-Allow-Methods: \`${ALLOW_METHODS:-missing}\`
-          - Access-Control-Allow-Headers: \`${ALLOW_HEADERS:-missing}\`
-          - Project: \`9dfe…d4ee\`
-          - Requested origin: \`https://agentbounties.app\`
-          - Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          ## Project config GET
+          - HTTP: \`${CONFIG_STATUS:-unavailable}\` / valid: \`${CONFIG_HTTP}\`
+          - Exact origin authorized: \`${CONFIG_ORIGIN}\`
+          - Credentials allowed: \`${CONFIG_CREDENTIALS}\`
+          - JSON body valid: \`${CONFIG_JSON}\`
+          - Content-Type: \`${CONFIG_CONTENT_TYPE:-missing}\`
 
-          No Coinbase secret, OTP, OAuth credential, wallet key, or seed phrase was used.
+          ## Authentication POST preflight
+          - HTTP: \`${AUTH_STATUS:-unavailable}\` / valid: \`${AUTH_HTTP}\`
+          - Exact origin authorized: \`${AUTH_ORIGIN}\`
+          - Credentials allowed: \`${AUTH_CREDENTIALS}\`
+          - POST allowed: \`${AUTH_POST}\`
+          - Required SDK headers allowed: \`${AUTH_HEADERS}\`
+          - Methods: \`${AUTH_METHODS:-missing}\`
+          - Headers: \`${AUTH_ALLOWED_HEADERS:-missing}\`
+
+          Project: \`9dfe…d4ee\`  
+          Origin: \`https://agentbounties.app\`  
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          No Coinbase API key, secret, OTP, OAuth credential, wallet key, transaction, or seed phrase was used.
           EOF
           url="$(gh issue create --repo "${GITHUB_REPOSITORY}" --title "${title}" --body-file /tmp/verdict.md)"
           gh issue close --repo "${GITHUB_REPOSITORY}" "${url##*/}" --reason completed >/dev/null
 
-      - name: Enforce complete browser authorization
+      - name: Enforce actual SDK browser authorization
         env:
-          HTTP_OK: ${{ steps.preflight.outputs.http_ok }}
-          ORIGIN_OK: ${{ steps.preflight.outputs.origin_ok }}
-          METHOD_OK: ${{ steps.preflight.outputs.method_ok }}
-          HEADER_OK: ${{ steps.preflight.outputs.header_ok }}
+          CONFIG_HTTP: ${{ steps.config.outputs.http_ok }}
+          CONFIG_ORIGIN: ${{ steps.config.outputs.origin_ok }}
+          CONFIG_CREDENTIALS: ${{ steps.config.outputs.credentials_ok }}
+          CONFIG_JSON: ${{ steps.config.outputs.json_ok }}
+          AUTH_HTTP: ${{ steps.auth.outputs.http_ok }}
+          AUTH_ORIGIN: ${{ steps.auth.outputs.origin_ok }}
+          AUTH_CREDENTIALS: ${{ steps.auth.outputs.credentials_ok }}
+          AUTH_POST: ${{ steps.auth.outputs.method_ok }}
+          AUTH_HEADERS: ${{ steps.auth.outputs.headers_ok }}
         run: |
-          test "${HTTP_OK}" = true
-          test "${ORIGIN_OK}" = true
-          test "${METHOD_OK}" = true
-          test "${HEADER_OK}" = true
+          test "${CONFIG_HTTP}" = true
+          test "${CONFIG_ORIGIN}" = true
+          test "${CONFIG_CREDENTIALS}" = true
+          test "${CONFIG_JSON}" = true
+          test "${AUTH_HTTP}" = true
+          test "${AUTH_ORIGIN}" = true
+          test "${AUTH_CREDENTIALS}" = true
+          test "${AUTH_POST}" = true
+          test "${AUTH_HEADERS}" = true


### PR DESCRIPTION
Replaces the obsolete documentation-example probe with the exact public config GET and auth-init POST preflight used by the locked `@coinbase/cdp-api-client@0.0.118`. It verifies exact origin, credentialed CORS, POST, and SDK request headers without initiating authentication or using any secret.