### PR TITLE
Rename claimable card status to open for competition

### DIFF
--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -2083,7 +2083,7 @@ fn chatgpt_tool_description(name: &str, fallback: &'static str) -> &'static str 
         "list_unfunded_bounties" => "Use this when the person explicitly asks for voluntary or unpaid Agent Bounties work. Keep these records separate from funded earning opportunities and never promise payment.",
         "submit_unfunded_bounty_solution" => "Use this when a registered agent explicitly wants to publish or replace its public solution to an open unfunded request. This public write creates no payment claim.",
         "prepare_bounty_post" => "Use this when the person wants something done with a funded or crowdfunded canonical bounty. Prepare a reviewable wallet handoff only; move no funds, request no secret, and do not claim the bounty exists yet.",
-        "list_autonomous_bounties" => "Use this when the person wants funded Agent Bounties work or canonical lifecycle inventory. Set claimable_only=true for work that is currently funded and ready to compete for.",
+        "list_autonomous_bounties" => "Use this when the person wants funded Agent Bounties work or canonical lifecycle inventory. Set claimable_only=true for work that is currently funded and open for competition.",
         _ => fallback,
     }
 }
@@ -2491,6 +2491,8 @@ mod tests {
         assert!(html.contains("document.execCommand(\"copy\")"));
         assert!(html.contains("Sandbox · no writes"));
         assert!(html.contains("safe fixture data"));
+        assert!(html.contains("open for competition"));
+        assert!(!html.contains("ready to compete"));
         assert!(html.contains("#b9ef37"));
         assert!(html.contains("#18d9ac"));
         assert!(html.contains("#e8bd26"));

--- a/site/chatgpt-bounty-feed-widget.html
+++ b/site/chatgpt-bounty-feed-widget.html
@@ -603,7 +603,7 @@
           if (item.work_state === "completed") return "settled";
           if (item.work_state === "submitted") return "awaiting verification";
           if (item.work_state === "in_progress") return "in progress";
-          if (item.work_state === "claimable") return "ready to compete";
+          if (item.work_state === "claimable") return "open for competition";
           if (item.payment_state === "seeking_funding") return "seeking funding";
           return item.work_state || "open";
         }


### PR DESCRIPTION
## Summary
- rename the claimable in-chat card status from `ready to compete` to `open for competition`
- align the legacy tool description
- add a regression assertion forbidding the old UI phrase

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p mcp-server` (35 passed)
- `python scripts/check-site.py`
- inline widget JavaScript parse check

This is a terminology-only follow-up to #597. It changes no canonical state, payment boundary, or wallet behavior.