### PR TITLE
test: make Coinbase live canary cleanup reliable

### DIFF
--- a/.github/workflows/coinbase-embedded-wallet.yml
+++ b/.github/workflows/coinbase-embedded-wallet.yml
@@ -8,6 +8,7 @@ on:
       - "scripts/configure-wallet-providers.py"
       - "scripts/test_configure_wallet_providers.py"
       - "scripts/test-live-coinbase-wallet.mjs"
+      - "scripts/test-live-coinbase-wallet.test.mjs"
       - "scripts/test-wallet-adapter-registry.js"
       - "scripts/test-x402-browser.js"
       - "site/wallet-adapter-registry.js"
@@ -27,6 +28,7 @@ on:
       - "scripts/configure-wallet-providers.py"
       - "scripts/test_configure_wallet_providers.py"
       - "scripts/test-live-coinbase-wallet.mjs"
+      - "scripts/test-live-coinbase-wallet.test.mjs"
       - "scripts/test-wallet-adapter-registry.js"
       - "scripts/test-x402-browser.js"
       - "site/wallet-adapter-registry.js"
@@ -90,7 +92,9 @@ jobs:
         run: python scripts/check-coinbase-embedded-wallet.py
 
       - name: Verify browser helper syntax
-        run: node --check scripts/test-live-coinbase-wallet.mjs
+        run: |
+          node --check scripts/test-live-coinbase-wallet.mjs
+          node --test scripts/test-live-coinbase-wallet.test.mjs
 
       - name: Audit locked production dependencies
         run: npm audit --prefix tools/coinbase-embedded-wallet --omit=dev --audit-level=high

--- a/scripts/test-live-coinbase-wallet.mjs
+++ b/scripts/test-live-coinbase-wallet.mjs
@@ -6,6 +6,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 const DEFAULT_URL = "https://agentbounties.app/earn.html";
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -71,6 +72,35 @@ async function jsonFetch(url, options = {}) {
   const response = await fetch(url, options);
   if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}.`);
   return response.json();
+}
+
+function childExited(child) {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function waitForChildExit(child, timeoutMs) {
+  if (childExited(child)) return true;
+  return Promise.race([
+    new Promise((resolve) => child.once("exit", () => resolve(true))),
+    delay(timeoutMs).then(() => false),
+  ]);
+}
+
+async function stopChrome(chrome, { gracefulTimeoutMs = 2_000, forceTimeoutMs = 2_000 } = {}) {
+  if (childExited(chrome)) return;
+  chrome.kill("SIGTERM");
+  if (await waitForChildExit(chrome, gracefulTimeoutMs)) return;
+  chrome.kill("SIGKILL");
+  await waitForChildExit(chrome, forceTimeoutMs);
+}
+
+async function removeProfile(profile, remove = rm) {
+  await remove(profile, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 200,
+  });
 }
 
 class CdpConnection {
@@ -307,13 +337,8 @@ async function runSmoke(args) {
     throw new Error(`${error.message || error}${stderr ? `\nChrome: ${stderr.slice(-2_000)}` : ""}`);
   } finally {
     cdp?.close();
-    chrome.kill("SIGTERM");
-    await Promise.race([
-      new Promise((resolve) => chrome.once("exit", resolve)),
-      delay(2_000),
-    ]);
-    if (!chrome.killed) chrome.kill("SIGKILL");
-    await rm(profile, { recursive: true, force: true });
+    await stopChrome(chrome);
+    await removeProfile(profile);
   }
 }
 
@@ -339,7 +364,11 @@ async function main() {
   if (!report.success) process.exitCode = 1;
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+export { removeProfile, stopChrome };
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test-live-coinbase-wallet.test.mjs
+++ b/scripts/test-live-coinbase-wallet.test.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+"use strict";
+
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { removeProfile, stopChrome } from "./test-live-coinbase-wallet.mjs";
+
+class FakeChrome extends EventEmitter {
+  constructor({ exitOnTerm = false } = {}) {
+    super();
+    this.exitCode = null;
+    this.signalCode = null;
+    this.exitOnTerm = exitOnTerm;
+    this.signals = [];
+  }
+
+  kill(signal) {
+    this.signals.push(signal);
+    if (signal === "SIGKILL" || this.exitOnTerm) {
+      this.signalCode = signal;
+      queueMicrotask(() => this.emit("exit", null, signal));
+    }
+    return true;
+  }
+}
+
+test("stopChrome escalates when Chromium does not exit after SIGTERM", async () => {
+  const chrome = new FakeChrome();
+  await stopChrome(chrome, { gracefulTimeoutMs: 1, forceTimeoutMs: 100 });
+  assert.deepEqual(chrome.signals, ["SIGTERM", "SIGKILL"]);
+  assert.equal(chrome.signalCode, "SIGKILL");
+});
+
+test("stopChrome does not send SIGKILL after a graceful exit", async () => {
+  const chrome = new FakeChrome({ exitOnTerm: true });
+  await stopChrome(chrome, { gracefulTimeoutMs: 100, forceTimeoutMs: 100 });
+  assert.deepEqual(chrome.signals, ["SIGTERM"]);
+  assert.equal(chrome.signalCode, "SIGTERM");
+});
+
+test("removeProfile retries transient non-empty profile cleanup", async () => {
+  let receivedPath = null;
+  let receivedOptions = null;
+  await removeProfile("/tmp/profile", async (profile, options) => {
+    receivedPath = profile;
+    receivedOptions = options;
+  });
+  assert.equal(receivedPath, "/tmp/profile");
+  assert.deepEqual(receivedOptions, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 200,
+  });
+});


### PR DESCRIPTION
## Summary
- wait for Chromium to exit after SIGTERM and escalate to SIGKILL only when required
- retry transient recursive profile cleanup failures
- add regression coverage for graceful teardown, forced teardown, and cleanup retry options
- run the regression tests in the Coinbase embedded-wallet workflow

## Evidence
- `node --check scripts/test-live-coinbase-wallet.mjs`
- `node --test scripts/test-live-coinbase-wallet.test.mjs` (3 passed)
- `python scripts/check-coinbase-embedded-wallet.py`
- `scripts/preflight.ps1 -Mode core`

## Scope
This fixes only the live smoke harness. It does not change custody, authentication, wallet creation, transaction signing, x402 funding, or settlement behavior. It addresses the `ENOTEMPTY` cleanup failure observed in run 30287860382.

Open collaborator PR #596 does not overlap these files.