### PR TITLE
Fix routed bounty activation after bootstrap ages out

### DIFF
--- a/.github/workflows/activate-routed-v3-replacements.yml
+++ b/.github/workflows/activate-routed-v3-replacements.yml
@@ -59,13 +59,11 @@ jobs:
           LOG_RPC_URL: https://mainnet.base.org
         run: |
           mkdir -p target
-          latest="$(cast block-number --rpc-url "$LOG_RPC_URL")"
-          from=$((latest - 9999))
           cast logs \
             --rpc-url "$LOG_RPC_URL" \
             --address "$ROUTER" \
-            --from-block "$from" \
-            --to-block latest \
+            --from-block 49069936 \
+            --to-block 49069936 \
             "PolicyBootstrapped(bytes32,address,bytes32)" \
             --json > target/router-bootstrap.json
           python - <<'PY'

--- a/.github/workflows/routed-v3-activation-check.yml
+++ b/.github/workflows/routed-v3-activation-check.yml
@@ -46,10 +46,8 @@ jobs:
         env:
           LOG_RPC_URL: https://mainnet.base.org
         run: |
-          latest="$(cast block-number --rpc-url "$LOG_RPC_URL")"
-          from=$((latest - 9999))
           mkdir -p target
-          cast logs --rpc-url "$LOG_RPC_URL" --address "$ROUTER" --from-block "$from" --to-block latest "PolicyBootstrapped(bytes32,address,bytes32)" --json > target/router-bootstrap.json
+          cast logs --rpc-url "$LOG_RPC_URL" --address "$ROUTER" --from-block 49069936 --to-block 49069936 "PolicyBootstrapped(bytes32,address,bytes32)" --json > target/router-bootstrap.json
           python -c 'import json; x=json.load(open("target/router-bootstrap.json")); assert isinstance(x,list) and len(x)==1, len(x)'
 
       - name: Dynamic direct-chain attestation passes

--- a/scripts/activate_routed_v3_dynamic.py
+++ b/scripts/activate_routed_v3_dynamic.py
@@ -15,7 +15,7 @@ import activate_routed_v3_replacements as activation
 ROUTER = "0x380c1af742593dd88b6f20387e9ee693a0536731"
 EVENT_SIGNATURE = "PolicyBootstrapped(bytes32,address,bytes32)"
 ACTIVATION_DELAY = 604_800
-LOOKBACK_BLOCKS = 9_999
+BOOTSTRAP_BLOCK = 49_069_936
 
 
 def parse_bootstrap_logs(raw: str) -> dict[str, str | int]:
@@ -58,16 +58,14 @@ def discover_deployment(cast: activation.Cast) -> dict[str, Any]:
     if router_code in {"0x", "0x0"}:
         raise activation.ActivationError("durable verifier router runtime code is missing")
     log_cast = activation.Cast(cast.executable, activation.RPC_DEFAULT)
-    latest = activation.parse_uint(log_cast.rpc("block-number"), "latest block")
-    from_block = max(0, latest - LOOKBACK_BLOCKS)
     logs_raw = log_cast.rpc(
         "logs",
         "--address",
         ROUTER,
         "--from-block",
-        str(from_block),
+        str(BOOTSTRAP_BLOCK),
         "--to-block",
-        "latest",
+        str(BOOTSTRAP_BLOCK),
         EVENT_SIGNATURE,
         "--json",
     )

--- a/scripts/test_activate_routed_v3_replacements.py
+++ b/scripts/test_activate_routed_v3_replacements.py
@@ -126,6 +126,7 @@ class ActivateRoutedV3Tests(unittest.TestCase):
         self.assertEqual(MODULE.UINT64_MAX, (1 << 64) - 1)
         self.assertEqual(DYNAMIC.ROUTER, "0x380c1af742593dd88b6f20387e9ee693a0536731")
         self.assertEqual(DYNAMIC.ACTIVATION_DELAY, 604_800)
+        self.assertEqual(DYNAMIC.BOOTSTRAP_BLOCK, 49_069_936)
 
     def test_router_address_is_quoted_in_activation_workflow_yaml(self) -> None:
         expected = 'ROUTER: "0x380c1af742593dd88b6f20387e9ee693a0536731"'
@@ -135,6 +136,8 @@ class ActivateRoutedV3Tests(unittest.TestCase):
         ):
             workflow = (WORKFLOWS / name).read_text(encoding="utf-8")
             self.assertIn(expected, workflow, name)
+            self.assertIn("--from-block 49069936", workflow, name)
+            self.assertIn("--to-block 49069936", workflow, name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- query the canonical router bootstrap at its exact Base block
- remove the expiring 9,999-block lookup from activation and CI
- assert the pinned evidence block in focused tests

## Verification
- python -m unittest scripts.test_activate_routed_v3_replacements -v
- git diff --check

Closes the activation portion of #629.