### PR TITLE
Treat claimed routed bounties as live activation inventory

### DIFF
--- a/scripts/activate_routed_v3_replacements.py
+++ b/scripts/activate_routed_v3_replacements.py
@@ -334,9 +334,10 @@ def reconcile(api: str, contract: str, bounty_id: str, timeout_seconds: int = 18
                 ),
                 None,
             )
+            active_statuses = {"claimable", "claimed", "submitted", "verifying"}
             if (
                 item
-                and item.get("status") == "claimable"
+                and item.get("status") in active_statuses
                 and item.get("terms_valid") is True
                 and item.get("verification_ready") is True
             ):

--- a/scripts/test_activate_routed_v3_replacements.py
+++ b/scripts/test_activate_routed_v3_replacements.py
@@ -145,6 +145,10 @@ class ActivateRoutedV3Tests(unittest.TestCase):
         planner_call = source.index('"scripts/plan_bounded_agent_action.py"', canonical_check)
         self.assertLess(canonical_check, planner_call)
 
+    def test_reconciliation_accepts_claimed_live_inventory(self) -> None:
+        source = (SCRIPTS / "activate_routed_v3_replacements.py").read_text(encoding="utf-8")
+        self.assertIn('{"claimable", "claimed", "submitted", "verifying"}', source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- accept funded verification-ready bounties after an organic claim
- keep terms and verifier readiness fail-closed
- allow activation to continue to missing replacements

## Verification
- python -m unittest scripts.test_activate_routed_v3_replacements -v

This addresses the safe failure in run 30312043856 and preserves the organic claim on #334.