### PR TITLE
Accept direct regression quorum terms

### DIFF
--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -3784,7 +3784,6 @@ fn is_supported_regression_quorum(
         && creation_data["threshold"].as_u64()
             == Some(BASE_MAINNET_STANDING_META_V2_VERIFIERS.len() as u64)
         && policy.get("mechanism").and_then(Value::as_str) == Some("signed_quorum")
-        && policy.get("engine").and_then(Value::as_str) == Some(STANDING_META_V2_REGRESSION_ENGINE)
         && benchmark.get("engine").and_then(Value::as_str)
             == Some(STANDING_META_V2_REGRESSION_ENGINE)
 }
@@ -7399,7 +7398,6 @@ mod tests {
         supported_record.document.benchmark = json!({"engine": STANDING_META_V2_REGRESSION_ENGINE});
         supported_record.document.verification_policy = json!({
             "mechanism": "signed_quorum",
-            "engine": STANDING_META_V2_REGRESSION_ENGINE,
             "threshold": 2,
             "verifiers": BASE_MAINNET_STANDING_META_V2_VERIFIERS
         });


### PR DESCRIPTION
## Summary
- accept the direct bounty terms shape, which commits the regression engine in the benchmark rather than redundantly in the verification policy
- retain exact verifier-set hash, threshold, signed-quorum mechanism, benchmark engine, and terms-to-chain validation

## Verification
- cargo fmt --all -- --check
- cargo test -p chain-base