### PR TITLE
Restore funded bounty discovery and claim handoff

### DIFF
--- a/.github/workflows/activate-direct-seed-bounties.yml
+++ b/.github/workflows/activate-direct-seed-bounties.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Publish only reconciled live inventory
         run: |
           for issue in 634 635 636 637 638; do
+            title="$(jq -r --argjson issue "$issue" '.results[] | select(.issue == $issue) | .title' target/direct-seed-activation.json)"
             gh issue edit "$issue" \
+              --title "[DIRECT] $title" \
               --body-file "target/direct-seed-activation/direct-${issue}-issue.md" \
               --add-label bounty \
               --add-label ai-agent-welcome \

--- a/.github/workflows/funded-bounty-pr-claim-guard.yml
+++ b/.github/workflows/funded-bounty-pr-claim-guard.yml
@@ -1,0 +1,28 @@
+name: Funded bounty PR claim guard
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: funded-bounty-pr-claim-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guide-unclaimed-work:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Guide PR-first contributors into the canonical claim
+        run: python3 scripts/github_pr_claim_guard.py
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/paid-bounty-issues.yml
+++ b/.github/workflows/paid-bounty-issues.yml
@@ -15,9 +15,12 @@ concurrency:
 jobs:
   validate:
     if: >-
-      startsWith(github.event.issue.title, '[bounty]')
-      || contains(github.event.issue.body || '', '### Suggested amount')
-      || contains(toJson(github.event.issue.labels), '"bounty"')
+      !contains(toJson(github.event.issue.labels), '"funded-live"')
+      && (
+        startsWith(github.event.issue.title, '[bounty]')
+        || contains(github.event.issue.body || '', '### Suggested amount')
+        || contains(toJson(github.event.issue.labels), '"bounty"')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/activate_direct_seed_bounties.py
+++ b/scripts/activate_direct_seed_bounties.py
@@ -283,6 +283,9 @@ def issue_body(issue: int, config: Mapping[str, Any], result: Mapping[str, Any])
 - Verification: `sandboxed_regression_v1`, pinned threshold-two quorum
 - Status: `claimable`
 
+## First action
+Post `/claim #{issue} wallet: 0xYOUR_PUBLIC_BASE_ADDRESS` on this issue, or call MCP `agent_native_claim` with contract `{result['contract']}`. Follow the returned wallet request and start work only after canonical `BountyClaimed`.
+
 ## Acceptance criteria
 {criteria}
 
@@ -371,6 +374,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
         reconciled = reconcile(args.api, predicted, bounty_id)
         result = {
             "issue": issue,
+            "title": config["title"],
             "contract": predicted,
             "bounty_id": bounty_id,
             "transaction_hash": tx_hash,

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -617,6 +617,17 @@ def main() -> int:
             "end.getTime() - 1",
         ],
     )
+    bounty_board_javascript = (site_dir / "bounty-board.js").read_text(encoding="utf-8")
+    require_phrases(
+        "bounty-board.js claim telemetry",
+        bounty_board_javascript,
+        [
+            'claim.dataset.analyticsEvent = "funded_bounty_click"',
+            "claim.dataset.analyticsOpportunityId = item.opportunity_id",
+            "claim.dataset.analyticsBountyContract = item.source_id",
+            "source=bounty-board#claim-workflow",
+        ],
+    )
     require_phrases(
         "index.html adoption metrics",
         pages["index.html"],

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -65,7 +65,9 @@ def compile_python(platform: str) -> None:
     ]
     scripts = [
         "scripts/_shared/github_actions.py", "scripts/_shared/evm.py", "scripts/_shared/rpc.py",
-        "scripts/github_issue_plan_comment.py", "scripts/github_funding_comment.py",
+        "scripts/github_issue_plan_comment.py", "scripts/test_github_issue_plan_comment.py",
+        "scripts/github_pr_claim_guard.py", "scripts/test_github_pr_claim_guard.py",
+        "scripts/github_funding_comment.py",
         "scripts/github_claim_comment.py", "scripts/github_proof_comment.py",
         "scripts/sync_hosted_bounty_inventory.py", "scripts/test_sync_hosted_bounty_inventory.py",
         "scripts/reconcile_github_bounty_labels.py", "scripts/test_reconcile_github_bounty_labels.py",
@@ -112,7 +114,9 @@ scripts/activate_standing_meta_v3_replacements.py scripts/test_activate_standing
 scripts/standing_meta_v4_deploy.py scripts/test_standing_meta_v4_deploy.py
 scripts/standing_meta_v4_release_audit.py scripts/test_standing_meta_v4_release_audit.py
 scripts/standing_meta_v4_rehearsal_audit.py scripts/test_standing_meta_v4_rehearsal_audit.py
-scripts/github_issue_plan_comment.py scripts/github_funding_comment.py scripts/github_claim_comment.py
+scripts/github_issue_plan_comment.py scripts/test_github_issue_plan_comment.py
+scripts/github_pr_claim_guard.py scripts/test_github_pr_claim_guard.py
+scripts/github_funding_comment.py scripts/github_claim_comment.py
 scripts/github_proof_comment.py scripts/sync_hosted_bounty_inventory.py
 scripts/test_sync_hosted_bounty_inventory.py scripts/reconcile_github_bounty_labels.py
 scripts/test_reconcile_github_bounty_labels.py scripts/validate_real_funding_rehearsal.py
@@ -198,6 +202,7 @@ def main() -> int:
     run_many(commands)
     for name in ("github_issue_plan_comment", "github_create_comment", "github_funding_comment", "github_claim_comment", "github_proof_comment"):
         py(f"scripts/{name}.py", "--self-test")
+    py("scripts/test_github_pr_claim_guard.py", "-v")
     for name in ("sync_hosted_bounty_inventory", "reconcile_github_bounty_labels", "diagnose_hosted_api", "github_audience_audit", "ruleset_drift_check", "code_size_report", "mcp_tool_registry", "shared_rpc", "relay_autonomous_action", "relay_bounded_wallet_action", "bounded_agent_budget"):
         py(f"scripts/test_{name}.py", "-v")
     for name in ("standing_meta_v3_deploy", "activate_standing_meta_v3_replacements"):

--- a/scripts/github_pr_claim_guard.py
+++ b/scripts/github_pr_claim_guard.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Guide PR-first contributors into the canonical funded-bounty claim flow."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import urllib.request
+from collections.abc import Mapping
+
+from _shared.github_actions import find_executable, publish_issue_comment
+
+
+MARKER = "<!-- agent-bounties-pr-claim-guard -->"
+LINKED_ISSUE_RE = re.compile(
+    r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([1-9][0-9]{0,8})\b"
+)
+CONTRACT_RE = re.compile(r"Contract:\s*`(0x[0-9a-fA-F]{40})`")
+API_FEED = (
+    "https://api.agentbounties.app/v1/base/autonomous-bounties/feed"
+    "?network=base-mainnet&claimable_only=false"
+)
+
+
+class UserError(RuntimeError):
+    pass
+
+
+def linked_issue_numbers(body: str) -> list[int]:
+    return list(dict.fromkeys(int(value) for value in LINKED_ISSUE_RE.findall(body)))[:5]
+
+
+def label_names(issue: Mapping[str, object]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {
+        str(label.get("name") or "").strip().lower()
+        for label in labels
+        if isinstance(label, dict)
+    }
+
+
+def claimable_links(
+    issue_numbers: list[int],
+    issues: Mapping[int, Mapping[str, object]],
+    inventory: list[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    by_contract = {
+        str(item.get("bounty_contract") or "").lower(): item
+        for item in inventory
+        if isinstance(item, Mapping)
+    }
+    result = []
+    for number in issue_numbers:
+        issue = issues.get(number)
+        if not issue or "funded-live" not in label_names(issue):
+            continue
+        match = CONTRACT_RE.search(str(issue.get("body") or ""))
+        if not match:
+            continue
+        contract = match.group(1).lower()
+        item = by_contract.get(contract)
+        if not item:
+            continue
+        if (
+            item.get("status") == "claimable"
+            and item.get("terms_valid") is True
+            and item.get("verification_ready") is True
+        ):
+            result.append(
+                {
+                    "issue": number,
+                    "contract": contract,
+                    "url": str(issue.get("html_url") or ""),
+                }
+            )
+    return result
+
+
+def render_comment(links: list[Mapping[str, object]]) -> str:
+    lines = [
+        MARKER,
+        "### Claim the funded bounty before continuing",
+        "",
+        "This PR is reviewable, but it does not reserve or earn the linked bounty.",
+        "Complete this missing transition:",
+        "",
+    ]
+    for link in links:
+        issue = int(link["issue"])
+        lines.append(
+            f"- On [#{issue}]({link['url']}), post "
+            f"`/claim #{issue} wallet: 0xYOUR_PUBLIC_BASE_ADDRESS`, or call MCP "
+            f"`agent_native_claim` with `{link['contract']}`."
+        )
+    lines.extend(
+        [
+            "",
+            "Follow the returned wallet request. Continue only after canonical "
+            "`BountyClaimed`; only canonical `BountySettled` proves payment.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def load_event() -> dict[str, object]:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise UserError("GITHUB_EVENT_PATH is required")
+    event = json.loads(pathlib.Path(event_path).read_text(encoding="utf-8"))
+    if not isinstance(event, dict) or not isinstance(event.get("pull_request"), dict):
+        raise UserError("pull_request_target event is required")
+    return event
+
+
+def fetch_issue(gh: str, repository: str, number: int) -> dict[str, object]:
+    value = json.loads(
+        subprocess.check_output(
+            [gh, "api", f"repos/{repository}/issues/{number}"],
+            env=dict(os.environ),
+            text=True,
+        )
+    )
+    if not isinstance(value, dict):
+        raise UserError(f"issue #{number} response is invalid")
+    return value
+
+
+def fetch_inventory() -> list[Mapping[str, object]]:
+    fixture = os.environ.get("AGENT_BOUNTIES_PR_CLAIM_FEED_FILE")
+    if fixture:
+        value = json.loads(pathlib.Path(fixture).read_text(encoding="utf-8"))
+    else:
+        request = urllib.request.Request(
+            API_FEED, headers={"Accept": "application/json", "User-Agent": "agent-bounties-pr-claim-guard/1"}
+        )
+        with urllib.request.urlopen(request, timeout=20) as response:
+            value = json.load(response)
+    if not isinstance(value, list):
+        raise UserError("canonical bounty feed must be an array")
+    return [item for item in value if isinstance(item, dict)]
+
+
+def main() -> int:
+    try:
+        event = load_event()
+        pull_request = event["pull_request"]
+        repository = str(
+            os.environ.get("GITHUB_REPOSITORY")
+            or (event.get("repository") or {}).get("full_name")
+            or ""
+        )
+        number = int(pull_request.get("number") or event.get("number") or 0)
+        linked = linked_issue_numbers(str(pull_request.get("body") or ""))
+        if not repository or not number or not linked:
+            return 0
+        gh = find_executable(["gh", "gh.exe"])
+        if not gh:
+            raise UserError("gh is required")
+        issues = {issue: fetch_issue(gh, repository, issue) for issue in linked}
+        links = claimable_links(linked, issues, fetch_inventory())
+        if not links:
+            return 0
+        comment = render_comment(links)
+        if os.environ.get("DRY_RUN") == "1":
+            print(comment)
+            return 0
+        publish_issue_comment(
+            os.environ,
+            repository,
+            number,
+            MARKER,
+            comment,
+            "pr-claim-guard.md",
+            "gh is required",
+            UserError,
+        )
+        return 0
+    except (OSError, ValueError, UserError) as error:
+        print(f"PR claim guard failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile_github_bounty_labels.py
+++ b/scripts/reconcile_github_bounty_labels.py
@@ -487,6 +487,7 @@ def canonical_records(
         verification_ready = [
             candidate
             for candidate in candidates
+            if candidate["status"] in {"claimable", "claimed", "submitted", "paid"}
             if candidate.get("terms_valid") is True
             and candidate.get("verification_ready") is True
         ]

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -9,6 +9,7 @@ import {
   normalizeApiBaseUrl,
   rpcBatchTransport,
   STANDING_META_BOUNTY,
+  SUPPORTED_REGRESSION_QUORUM,
   verifyClaimableItem,
   verifyDirectChainInventory,
 } from "../skills/agent-bounties/scripts/check-in.mjs";
@@ -661,7 +662,7 @@ test("hosted check-in emits an exact side-effect-free claim handoff", async () =
   assert.equal(handoff.ready_scope, "claim_handoff_only");
   assert.equal(handoff.wallet_readiness_checked, false);
   assert.equal(handoff.reason, "claim_handoff_complete");
-  assert.equal(handoff.preferred_path, "github_claim_comment");
+  assert.equal(handoff.preferred_path, "agent_native_claim");
   assert.equal(handoff.github_claim.issue_url, bounty.source_url);
   assert.equal(handoff.github_claim.comment_body, `/claim #275 wallet: ${solver}`);
   assert.equal(handoff.mcp.tool, "agent_native_claim");
@@ -682,13 +683,13 @@ test("hosted check-in emits an exact side-effect-free claim handoff", async () =
   assert.match(handoff.evidence_boundary, /did not post a comment/);
   assert.deepEqual(report.next_action, {
     schema_version: "agent-bounties/check-in-claim-handoff-v1",
-    action: "post_github_claim_comment",
+    action: "call_agent_native_claim",
     ready: true,
     ready_scope: "claim_handoff_only",
     bounty_id: bounty.id,
-    source_issue_number: 275,
-    issue_url: bounty.source_url,
-    comment_body: `/claim #275 wallet: ${solver}`,
+    mcp: handoff.mcp,
+    api: handoff.api,
+    github_fallback: handoff.github_claim,
     follow_up: handoff.follow_up,
   });
 });
@@ -822,6 +823,96 @@ test("hosted quorum bounty is excluded without a service availability attestatio
     ok: false,
     reason: "verification_path_not_executable",
   });
+});
+
+test("exact hosted sandboxed-regression quorum is portable earning inventory", async () => {
+  const input = await fixture("verified-claimable.json");
+  const item = structuredClone(input.autonomous_feed.body[0]);
+  item.verification_mode = "signed_quorum";
+  item.verifier_module = null;
+  item.verification_ready = true;
+  item.verification_readiness_reason =
+    "the exact built-in sandboxed-regression quorum is supported";
+  item.terms.document.benchmark = { engine: SUPPORTED_REGRESSION_QUORUM.engine };
+  item.terms.document.verification_policy = {
+    mechanism: "signed_quorum",
+    verifiers: [...SUPPORTED_REGRESSION_QUORUM.verifiers],
+    threshold: SUPPORTED_REGRESSION_QUORUM.threshold,
+  };
+  item.events = item.events.map((event) => (
+    event.kind === "canonical_bounty_verification_configured"
+      ? {
+        ...event,
+        data: {
+          verification_mode: 1,
+          verifier_module: "0x0000000000000000000000000000000000000000",
+          verifier_set_hash: SUPPORTED_REGRESSION_QUORUM.verifierSetHash,
+          threshold: SUPPORTED_REGRESSION_QUORUM.threshold,
+        },
+      }
+      : event
+  ));
+
+  assert.deepEqual(verifyClaimableItem(item, input.protocol.body), {
+    ok: true,
+    reason: "confirmed_canonical_autonomous_bounty",
+  });
+
+  input.autonomous_feed.body = [item];
+  const report = await collectInventory({
+    apiBaseUrl: "https://api.example.test",
+    fixture: input,
+  });
+  const bounty = report.verified_claimable_bounties[0];
+  assert.equal(bounty.verification_mode, "signed_quorum");
+  assert.equal(bounty.verification_engine, SUPPORTED_REGRESSION_QUORUM.engine);
+  assert.equal(bounty.verifier_set_hash, SUPPORTED_REGRESSION_QUORUM.verifierSetHash);
+  assert.equal(bounty.verifier_threshold, SUPPORTED_REGRESSION_QUORUM.threshold);
+});
+
+test("portable quorum validation rejects verifier, threshold, engine, and event drift", async () => {
+  const input = await fixture("verified-claimable.json");
+  const base = structuredClone(input.autonomous_feed.body[0]);
+  base.verification_mode = "signed_quorum";
+  base.verifier_module = null;
+  base.verification_ready = true;
+  base.terms.document.benchmark = { engine: SUPPORTED_REGRESSION_QUORUM.engine };
+  base.terms.document.verification_policy = {
+    mechanism: "signed_quorum",
+    verifiers: [...SUPPORTED_REGRESSION_QUORUM.verifiers],
+    threshold: SUPPORTED_REGRESSION_QUORUM.threshold,
+  };
+  base.events = base.events.map((event) => (
+    event.kind === "canonical_bounty_verification_configured"
+      ? {
+        ...event,
+        data: {
+          verification_mode: 1,
+          verifier_module: "0x0000000000000000000000000000000000000000",
+          verifier_set_hash: SUPPORTED_REGRESSION_QUORUM.verifierSetHash,
+          threshold: SUPPORTED_REGRESSION_QUORUM.threshold,
+        },
+      }
+      : event
+  ));
+  const mutations = [
+    (item) => { item.terms.document.verification_policy.verifiers[0] = "0x1111111111111111111111111111111111111111"; },
+    (item) => { item.terms.document.verification_policy.threshold = 1; },
+    (item) => { item.terms.document.benchmark.engine = "different_runner"; },
+    (item) => {
+      item.events.find(
+        (event) => event.kind === "canonical_bounty_verification_configured",
+      ).data.verifier_set_hash = `0x${"66".repeat(32)}`;
+    },
+  ];
+  for (const mutate of mutations) {
+    const item = structuredClone(base);
+    mutate(item);
+    assert.deepEqual(verifyClaimableItem(item, input.protocol.body), {
+      ok: false,
+      reason: "verification_path_not_executable",
+    });
+  }
 });
 
 test("unavailable hosted API cannot create imaginary inventory", async () => {

--- a/scripts/test_github_issue_plan_comment.py
+++ b/scripts/test_github_issue_plan_comment.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Tests for paid-bounty issue validation routing."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "paid-bounty-issues.yml"
+
+
+class PaidBountyIssueWorkflowTests(unittest.TestCase):
+    def test_canonical_funded_inventory_skips_intake_validation(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "!contains(toJson(github.event.issue.labels), '\"funded-live\"')",
+            workflow,
+        )
+        self.assertLess(
+            workflow.index("!contains(toJson(github.event.issue.labels)"),
+            workflow.index("startsWith(github.event.issue.title"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_github_pr_claim_guard.py
+++ b/scripts/test_github_pr_claim_guard.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Tests for PR-first funded-bounty recovery guidance."""
+
+from __future__ import annotations
+
+import unittest
+
+import github_pr_claim_guard as guard
+
+
+CONTRACT = "0x" + "12" * 20
+
+
+class GitHubPrClaimGuardTests(unittest.TestCase):
+    def test_linked_issue_parser_is_bounded_and_deduplicated(self) -> None:
+        self.assertEqual(
+            guard.linked_issue_numbers("Fixes #635\nCloses #635\nResolves #637"),
+            [635, 637],
+        )
+
+    def test_claimable_funded_issue_gets_one_exact_recovery_action(self) -> None:
+        issues = {
+            635: {
+                "labels": [{"name": "bounty"}, {"name": "funded-live"}],
+                "body": f"Contract: `{CONTRACT}`",
+                "html_url": "https://github.com/example/repo/issues/635",
+            }
+        }
+        inventory = [
+            {
+                "bounty_contract": CONTRACT,
+                "status": "claimable",
+                "terms_valid": True,
+                "verification_ready": True,
+            }
+        ]
+
+        links = guard.claimable_links([635], issues, inventory)
+        comment = guard.render_comment(links)
+
+        self.assertEqual(len(links), 1)
+        self.assertIn("/claim #635 wallet: 0xYOUR_PUBLIC_BASE_ADDRESS", comment)
+        self.assertIn("only canonical `BountySettled` proves payment", comment)
+
+    def test_noncanonical_or_already_claimed_work_does_not_get_claim_prompt(self) -> None:
+        issues = {
+            635: {
+                "labels": [{"name": "bounty"}, {"name": "funded-live"}],
+                "body": f"Contract: `{CONTRACT}`",
+            }
+        }
+        inventory = [
+            {
+                "bounty_contract": CONTRACT,
+                "status": "claimed",
+                "terms_valid": True,
+                "verification_ready": True,
+            }
+        ]
+
+        self.assertEqual(guard.claimable_links([635], issues, inventory), [])
+        self.assertEqual(guard.claimable_links([999], issues, inventory), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_reconcile_github_bounty_labels.py
+++ b/scripts/test_reconcile_github_bounty_labels.py
@@ -373,6 +373,23 @@ class GitHubBountyLabelReconciliationTests(unittest.TestCase):
         )
         self.assertEqual(plan.remove_labels, ["verification-unavailable"])
 
+    def test_terminal_ready_history_does_not_hide_active_ready_replacement(self) -> None:
+        retired = feed_item(1, "cancelled")
+        replacement = feed_item(2, "claimable")
+        replacement["terms"]["document"]["source_url"] = retired["terms"]["document"][
+            "source_url"
+        ]
+        plan = build_plans(
+            [issue(1, "bounty")],
+            [retired, replacement],
+            [dict(replacement)],
+            REPOSITORY,
+        )[0]
+        self.assertEqual(plan.bounty_contract, CONTRACTS[2])
+        self.assertEqual(
+            plan.desired_managed_labels, ["claimable-live", "funded-live"]
+        )
+
     def test_duplicate_ready_issue_mapping_and_invalid_earning_record_are_rejected(self) -> None:
         first = feed_item(1, "claimable")
         duplicate = feed_item(2, "claimable")

--- a/site/bounty-board.js
+++ b/site/bounty-board.js
@@ -161,11 +161,15 @@
     actions.className = "board-task-actions";
 
     if (item.source_type === "canonical_base" && item.boardState === "claimable") {
-      actions.append(buttonLink(
+      const claim = buttonLink(
         "Claim task",
-        `earn.html?bountyContract=${encodeURIComponent(item.source_id)}#claim-workflow`,
+        `earn.html?bountyContract=${encodeURIComponent(item.source_id)}&source=bounty-board#claim-workflow`,
         true,
-      ));
+      );
+      claim.dataset.analyticsEvent = "funded_bounty_click";
+      claim.dataset.analyticsOpportunityId = item.opportunity_id;
+      claim.dataset.analyticsBountyContract = item.source_id;
+      actions.append(claim);
     }
 
     if (item.source_type === "canonical_base" && item.boardState === "funding") {

--- a/skills/agent-bounties/scripts/check-in.mjs
+++ b/skills/agent-bounties/scripts/check-in.mjs
@@ -10,9 +10,19 @@ export const DEFAULT_BASE_RPC_FALLBACK_URLS = Object.freeze([
   "https://mainnet.base.org",
 ]);
 export const CLAIM_HANDOFF_SCHEMA_VERSION = "agent-bounties/check-in-claim-handoff-v1";
+export const SUPPORTED_REGRESSION_QUORUM = Object.freeze({
+  engine: "sandboxed_regression_v1",
+  verifierSetHash: "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
+  threshold: 2,
+  verifiers: Object.freeze([
+    "0xbe6292b9e465f549e2363b918d6dd9187038431e",
+    "0xb7c2ce6430b66fb986e27b6140b29309550d487a",
+  ]),
+});
 
 const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
 const HASH = /^0x[0-9a-fA-F]{64}$/;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const EMPTY_CODE_HASH = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
 const UINT64_MASK = (1n << 64n) - 1n;
 const KECCAK_RATE_BYTES = 136;
@@ -268,7 +278,7 @@ export function buildClaimHandoff(bounty, solverWallet, apiBaseUrl) {
     wallet_readiness_checked: false,
     reason,
     required_input: requiredInput,
-    preferred_path: githubAvailable ? "github_claim_comment" : "agent_native_claim",
+    preferred_path: "agent_native_claim",
     rerun_command: ready
       ? null
       : `node skills/agent-bounties/scripts/check-in.mjs --solver-wallet ${addressTemplate}`,
@@ -322,19 +332,6 @@ function nextActionFor(verified) {
       never_request: ["private_key", "seed_phrase"],
     };
   }
-  if (handoff.github_claim) {
-    return {
-      schema_version: CLAIM_HANDOFF_SCHEMA_VERSION,
-      action: "post_github_claim_comment",
-      ready: true,
-      ready_scope: "claim_handoff_only",
-      bounty_id: selected.id,
-      source_issue_number: selected.source_issue_number,
-      issue_url: handoff.github_claim.issue_url,
-      comment_body: handoff.github_claim.comment_body,
-      follow_up: handoff.follow_up,
-    };
-  }
   return {
     schema_version: CLAIM_HANDOFF_SCHEMA_VERSION,
     action: "call_agent_native_claim",
@@ -343,6 +340,7 @@ function nextActionFor(verified) {
     bounty_id: selected.id,
     mcp: handoff.mcp,
     api: handoff.api,
+    github_fallback: handoff.github_claim,
     follow_up: handoff.follow_up,
   };
 }
@@ -1056,11 +1054,7 @@ export function verifyClaimableItem(item, protocol) {
   if (!item.terms_valid || !item.terms?.document?.contract_terms) {
     return { ok: false, reason: "terms_or_contract_commitments_invalid" };
   }
-  if (
-    item.verification_ready !== true
-    || item.verification_mode !== "deterministic_module"
-    || !ADDRESS.test(item.verifier_module || "")
-  ) {
+  if (item.verification_ready !== true || !supportedVerificationPath(item)) {
     return { ok: false, reason: "verification_path_not_executable" };
   }
   if (!ADDRESS.test(item.bounty_contract || "") || !ADDRESS.test(item.creator || "")) {
@@ -1116,6 +1110,47 @@ export function verifyClaimableItem(item, protocol) {
   return { ok: true, reason: "confirmed_canonical_autonomous_bounty" };
 }
 
+function supportedVerificationPath(item) {
+  if (
+    item.verification_mode === "deterministic_module"
+    && ADDRESS.test(item.verifier_module || "")
+    && String(item.verifier_module).toLowerCase() !== ZERO_ADDRESS
+  ) {
+    return true;
+  }
+  if (
+    item.verification_mode !== "signed_quorum"
+    || (item.verifier_module !== null
+      && String(item.verifier_module || "").toLowerCase() !== ZERO_ADDRESS)
+  ) {
+    return false;
+  }
+  const policy = item.terms?.document?.verification_policy;
+  const benchmark = item.terms?.document?.benchmark;
+  const verifiers = Array.isArray(policy?.verifiers)
+    ? policy.verifiers.map((value) => String(value).toLowerCase())
+    : [];
+  const configured = (Array.isArray(item.events) ? item.events : []).filter(
+    (event) => event?.kind === "canonical_bounty_verification_configured",
+  );
+  if (configured.length !== 1) return false;
+  const data = configured[0]?.data;
+  return (
+    policy?.mechanism === "signed_quorum"
+    && Number(policy?.threshold) === SUPPORTED_REGRESSION_QUORUM.threshold
+    && benchmark?.engine === SUPPORTED_REGRESSION_QUORUM.engine
+    && verifiers.length === SUPPORTED_REGRESSION_QUORUM.verifiers.length
+    && verifiers.every(
+      (verifier, index) => verifier === SUPPORTED_REGRESSION_QUORUM.verifiers[index],
+    )
+    && Number(data?.verification_mode) === 1
+    && Number(data?.threshold) === SUPPORTED_REGRESSION_QUORUM.threshold
+    && String(data?.verifier_set_hash || "").toLowerCase()
+      === SUPPORTED_REGRESSION_QUORUM.verifierSetHash
+    && String(data?.verifier_module || ZERO_ADDRESS).toLowerCase() === ZERO_ADDRESS
+  );
+}
+
 function normalizedBounty(item, apiBaseUrl, standingMetaAttestation = null) {
   const sourceUrl = sourceUrlFromDocument(item.terms.document);
   const normalized = {
@@ -1135,7 +1170,15 @@ function normalizedBounty(item, apiBaseUrl, standingMetaAttestation = null) {
     claim_plan_url: `${apiBaseUrl}/v1/base/autonomous-bounties/claim-plan`,
     verification_mode: item.verification_mode,
     verifier_module: item.verifier_module?.toLowerCase() || null,
+    verifier_set_hash: item.verification_mode === "signed_quorum"
+      ? SUPPORTED_REGRESSION_QUORUM.verifierSetHash
+      : null,
+    verifier_threshold: item.verification_mode === "signed_quorum"
+      ? SUPPORTED_REGRESSION_QUORUM.threshold
+      : 1,
+    verification_engine: item.terms.document.benchmark?.engine || null,
     verification_ready: item.verification_ready === true,
+    verification_readiness_reason: item.verification_readiness_reason || null,
   };
   if (hostedStandingMetaCandidate(item) && standingMetaAttestation?.ready) {
     normalized.standing_meta_bounty = standingMetaDescriptor({


### PR DESCRIPTION
## Summary
- admit the exact hosted `sandboxed_regression_v1` quorum into the documented agent check-in helper instead of silently filtering all five profitable direct bounties
- make machine-native claim the default handoff, retain GitHub as a fallback, and add exact claim commands to generated/live seed issues
- add funded-bounty click telemetry and repair lifecycle-aware GitHub label reconciliation
- stop legacy issue-form validation from falsely rejecting canonical funded issues
- guide PR-first contributors to the missing canonical claim without executing untrusted branch code

## Evidence behind the change
- #634-#638 were each canonically funded with 2.00 USDC and verification-ready, but had zero claims after funding
- the documented `check-in.mjs` reported only 4 older bounties and excluded all five new contracts as `verification_path_not_executable`
- 7-day site analytics recorded 167 market-view sessions, zero recorded funded-bounty clicks, and zero claim starts; the board had no click telemetry
- GitHub traffic declined from 14-21 unique viewers/day around July 17-20 to mostly 3-6/day around July 23-25
- after the live issues received exact first actions, external PRs #643 and #644 appeared within minutes, but both skipped canonical claim and pasted invalid diff text into an unrelated file; both received constructive change requests
- editing the five canonical issues triggered false `ActionRequired: missing template` comments from the intake validator; those comments are removed and the workflow now excludes `funded-live`

## Safety
- arbitrary signed quorums remain rejected; support is pinned to the exact engine, threshold, verifier addresses, verifier-set hash, zero module, and one canonical configuration event
- standing-meta V2 remains recovery-reserved; this PR does not weaken its fail-closed inventory guard
- the PR claim guard runs only default-branch code under `pull_request_target` and treats PR text as bounded issue-number input
- only canonical `BountyClaimed` owns a round and only canonical `BountySettled` proves payment

## Verification
- `scripts/check.ps1` (full repository gate)
- 26 agent check-in tests
- 15 reconciliation tests
- 5 direct activation tests
- 4 new GitHub routing/PR-claim tests
- site contract checks, Rust workspace tests, API/MCP smoke tests, and Foundry tests included in the full gate

Closes #642