### PR TITLE
Pin routed activation to the active bounded-wallet policy

### DIFF
--- a/docs/bounded-agent-wallet.md
+++ b/docs/bounded-agent-wallet.md
@@ -10,36 +10,36 @@ contract wallet, and the agent receives only a dedicated delegate signing key.
 The contract enforces the limits even if the agent, its prompt, the hosted API,
 or a relayer is compromised.
 
-## Initial 89 USDC Policy
+## Active 89 USDC Policy
 
-The proposed first mainnet policy is:
+Base mainnet wallet
+`0x1eaa1c68772cf76bc5f4e4174766076e33ace662` currently uses policy
+version 5:
 
 | Boundary | Value |
 | --- | ---: |
 | Network and asset | Base mainnet native USDC |
-| Initial funding and lifetime gross spend | 89 USDC |
+| Lifetime gross spend | 89 USDC |
 | Maximum one action | 5 USDC |
 | Maximum each fixed 24-hour period | 10 USDC |
 | Maximum bounty target | 5 USDC |
-| Expiry | 30 days |
+| Delegate | `0xc26a630e85134ed30968735c8e7de4576cfa5dbc` |
+| Expiry | No automatic expiry; owner can revoke or replace |
 | Actions | create, fund, claim, submit |
-| Verification | historical standing-meta-v2 module plus exact sandboxed-regression signed quorum |
+| Deterministic verification | durable router `0x380c1af742593dd88b6f20387e9ee693a0536731` |
+| Signed verification | exact `sandboxed_regression_v1` threshold-two set |
 
-The first live policy allowed the permissionless proof-of-work module. Policy
-version two replaced that module with the standing-meta-v2 verifier. The
-reviewed version-three policy keeps that module and adds only verifier set
-`0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd`
-for `sandboxed_regression_v1`; arbitrary signed quorums and AI-judge actions
-remain disabled at the bounded-wallet layer. Until an on-chain inspection
-reports version three and its exact policy hash, version two remains active.
-The five funded standing-meta-v2 parents are now recovery-reserved and must not
-be selected for new delegated earning actions. Adding a future anonymous,
-appealable successor requires an explicit owner policy replacement after its
-deployment evidence is published; the existing policy does not authorize it.
-Returned
-claim bonds and bounty earnings increase the wallet balance but do not restore
-the gross lifetime budget. The owner must explicitly replace the policy to
-extend authority.
+The exact policy hash is
+`0xac8c86836e1cab2b4707420057d414b0dfa675006bda6584df7fb9118caabe88`.
+Owner transaction
+`0x7b6cce94eb19ecb60cbec268fe9fce33847190b2cb7f33af6802b1e223b89201`
+configured it at block `49211742`. Automation must pin all policy fields,
+version, and hash; accepting any live policy is unsafe.
+
+The five funded standing-meta-v2 parents are recovery-reserved and cannot be
+selected for new earning actions. Returned claim bonds and bounty earnings
+increase the wallet balance but do not restore gross lifetime authority. The
+owner must explicitly replace the policy to change that authority.
 
 ## Security Status
 
@@ -123,22 +123,21 @@ delegate actions immediately. The owner may then call
 `withdrawToken(nativeUsdc, owner, balance)` or install a reviewed replacement
 policy. Ownership transfer is two-step.
 
-An existing wallet may add the reviewed regression quorum with one zero-value
-`configurePolicy` transaction. Use a fresh delegate at the same time because
-local bindings are intentionally immutable. The activation page reads the
-complete live policy, accepts only known verifier authority, installs the exact
-dual-mode policy, simulates the call, and verifies the receipt, version, caps,
-balance, and lifetime spend. The deployed wallet starts a fresh policy-period
-counter on every policy replacement; the review page discloses the observed
-period spend before signing instead of claiming it is preserved.
+An existing wallet may replace its policy with one zero-value
+`configurePolicy` transaction. Use a fresh delegate when rotating a compromised
+signer. The activation page must read the complete live policy, accept only
+reviewed verifier authority, simulate the exact call, and verify the receipt,
+version, hash, caps, balance, and lifetime spend. Policy replacement starts a
+fresh policy-period counter; the review page must disclose that before signing.
 
 ## Activation State
 
-The deterministic mainnet manifest is
+The deterministic contract manifest is
 [`deployments/bounded-agent-wallet-base-mainnet.json`](../deployments/bounded-agent-wallet-base-mainnet.json).
-Until its factory address contains the exact reviewed runtime bytecode, it is a
-deployment plan, not a live wallet. Do not transfer USDC to a predicted address
-before deployment and inspection pass.
+The live policy constants and owner-transaction evidence are in
+[`scripts/bounded_wallet_policy.py`](../scripts/bounded_wallet_policy.py).
+Runtime inspection remains authoritative. Do not transfer USDC to a predicted
+wallet before deployment and inspection pass.
 
 The harness covers policy substitution, unauthorized modules and verifier
 sets, target and spend caps, replay, signature malleability, policy rotation,

--- a/scripts/activate_routed_v3_replacements.py
+++ b/scripts/activate_routed_v3_replacements.py
@@ -14,6 +14,7 @@ import urllib.error
 import urllib.request
 from typing import Any, Mapping, Sequence
 
+import bounded_wallet_policy as active_wallet
 import durable_verifier_router_deploy as durable
 
 
@@ -22,18 +23,15 @@ CHAIN_ID = 8453
 RPC_DEFAULT = "https://mainnet.base.org"
 API_DEFAULT = "https://api.agentbounties.app"
 DEPLOYMENT_PATH = ROOT / "deployments" / "durable-verifier-router-base-mainnet.json"
-WALLET = durable.BOUNDED_WALLET
-OWNER = durable.OWNER
-KEEPER = durable.KEEPER
+WALLET = active_wallet.WALLET
+OWNER = active_wallet.OWNER
+KEEPER = active_wallet.DELEGATE
 FACTORY = durable.CANONICAL_FACTORY
 USDC = durable.NATIVE_USDC
 TARGET = durable.PARENT_TARGET
 TOTAL = durable.TOTAL_REPLACEMENT_FUNDING
-UINT64_MAX = (1 << 64) - 1
-ZERO_HASH = "0x" + "00" * 32
 ISSUES = {
     333: {"lane": "CLI", "old": "0xfffecb0fcd36477c5f6ecec808f6f0cf53819562"},
-    334: {"lane": "API", "old": "0xbe17ef2d154265ebe3142d7bda5e99610d571455"},
     335: {"lane": "MCP", "old": "0x43d42cb227d76588ab16693f14efd6cff851fa7a"},
     336: {"lane": "wallet UX", "old": "0xe8c1d3f046f3e4690bef59ba4abd5d02d2a6984b"},
     590: {"lane": "agent discovery", "old": None},
@@ -265,21 +263,9 @@ def policy_state(cast: Cast, deployment: Mapping[str, Any]) -> dict[str, Any]:
         "wallet_balance": parse_uint(cast.call(USDC, "balanceOf(address)(uint256)", WALLET), "wallet balance"),
         "now": now,
     }
-    expected = {
-        "owner": OWNER,
-        "delegate": KEEPER,
-        "period_seconds": 86_400,
-        "max_per_action": 5_000_000,
-        "max_per_period": 10_000_000,
-        "max_lifetime_spend": 89_000_000,
-        "max_bounty_target": 5_000_000,
-        "allowed_actions": 15,
-        "allowed_verification_modes": 1,
-        "deterministic_verifier": router,
-        "signed_quorum": ZERO_HASH,
-        "ai_quorum": ZERO_HASH,
-        "valid_until": UINT64_MAX,
-    }
+    expected = active_wallet.expected_state()
+    if expected["deterministic_verifier"] != router:
+        raise ActivationError("active wallet verifier does not match the routed verifier deployment")
     for key, wanted in expected.items():
         if state[key] != wanted:
             raise ActivationError(f"durable wallet policy {key} mismatch: expected {wanted}, got {state[key]}")
@@ -545,6 +531,9 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
         "wallet": WALLET,
         "router": deployment["router_address"],
         "policy_hash": deployment["policy_hash"],
+        "wallet_policy_hash": active_wallet.POLICY_HASH,
+        "wallet_policy_version": active_wallet.POLICY_VERSION,
+        "wallet_policy_configuration_transaction": active_wallet.CONFIGURATION_TRANSACTION,
         "adapter": deployment["adapter_address"],
         "wallet_balance_before": before["wallet_balance"],
         "wallet_balance_after": after["wallet_balance"],

--- a/scripts/bounded_wallet_policy.py
+++ b/scripts/bounded_wallet_policy.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Exact active Base-mainnet bounded-wallet policy approved by its owner."""
+
+WALLET = "0x1eaa1c68772cf76bc5f4e4174766076e33ace662"
+OWNER = "0x884834e884d6e93462655a2820140ad03e6747bc"
+DELEGATE = "0xc26a630e85134ed30968735c8e7de4576cfa5dbc"
+POLICY_HASH = "0xac8c86836e1cab2b4707420057d414b0dfa675006bda6584df7fb9118caabe88"
+POLICY_VERSION = 5
+CONFIGURATION_TRANSACTION = (
+    "0x7b6cce94eb19ecb60cbec268fe9fce33847190b2cb7f33af6802b1e223b89201"
+)
+CONFIGURATION_BLOCK = 49_211_742
+VALID_AFTER = 1_784_223_027
+VALID_UNTIL = (1 << 64) - 1
+PERIOD_SECONDS = 86_400
+MAX_PER_ACTION = 5_000_000
+MAX_PER_PERIOD = 10_000_000
+MAX_LIFETIME_SPEND = 89_000_000
+MAX_BOUNTY_TARGET = 5_000_000
+ALLOWED_ACTIONS = 15
+ALLOWED_VERIFICATION_MODES = 3
+DETERMINISTIC_VERIFIER = "0x380c1af742593dd88b6f20387e9ee693a0536731"
+SIGNED_QUORUM_VERIFIER_SET_HASH = (
+    "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
+)
+AI_JUDGE_VERIFIER_SET_HASH = "0x" + "00" * 32
+
+
+def expected_state() -> dict[str, object]:
+    return {
+        "owner": OWNER,
+        "delegate": DELEGATE,
+        "valid_after": VALID_AFTER,
+        "valid_until": VALID_UNTIL,
+        "period_seconds": PERIOD_SECONDS,
+        "max_per_action": MAX_PER_ACTION,
+        "max_per_period": MAX_PER_PERIOD,
+        "max_lifetime_spend": MAX_LIFETIME_SPEND,
+        "max_bounty_target": MAX_BOUNTY_TARGET,
+        "allowed_actions": ALLOWED_ACTIONS,
+        "allowed_verification_modes": ALLOWED_VERIFICATION_MODES,
+        "deterministic_verifier": DETERMINISTIC_VERIFIER,
+        "signed_quorum": SIGNED_QUORUM_VERIFIER_SET_HASH,
+        "ai_quorum": AI_JUDGE_VERIFIER_SET_HASH,
+        "policy_hash": POLICY_HASH,
+        "policy_version": POLICY_VERSION,
+    }

--- a/scripts/relay_bounded_wallet_action.py
+++ b/scripts/relay_bounded_wallet_action.py
@@ -13,6 +13,7 @@ import sys
 from dataclasses import asdict, dataclass
 from typing import Mapping, Sequence
 
+import bounded_wallet_policy as active_wallet
 from bounded_agent_create import (
     BOUNTY_ID_SIGNATURE,
     CREATE_SELECTOR,
@@ -55,26 +56,19 @@ SCHEMA = "agent-bounties/bounded-wallet-relay-v1"
 COMMAND = "/agent-bounty wallet-relay"
 NETWORK = "base-mainnet"
 RPC_URL = "https://mainnet.base.org"
-WALLET = "0x1eaa1c68772cf76bc5f4e4174766076e33ace662"
+WALLET = active_wallet.WALLET
 WALLET_FACTORY = "0x3840936351049aed639780a16845e6094c1f17f6"
 WALLET_CODEHASH = "0xc663bed9b4097e22e5a18c0ecb662561bf45df1829e6412cdd0d8568d05ca1b6"
-DELEGATE = "0xe98314df0e2f5657dd5ee3325f1e95f5a4249ef5"
-POLICY_HASH = "0xd5b39deb8630b258d165e94b5b74d81cb42073e895f26922e6722904b5fcc4b4"
-REGRESSION_DELEGATE = "0xe46741de0f379bff0ab8b01bce1b79a12d892fdb"
-REGRESSION_POLICY_HASH = "0x4f789c7d284541becfaee6d6136ec59a933ef06027a00d09a94d424c0a878951"
-VERIFIER = "0xe573cb4f471d38b5bf10ce82237251ac902c9867"
+DELEGATE = active_wallet.DELEGATE
+POLICY_HASH = active_wallet.POLICY_HASH
+POLICY_VERSION = active_wallet.POLICY_VERSION
+VERIFIER = active_wallet.DETERMINISTIC_VERIFIER
 POLICY_PROFILES = {
     POLICY_HASH: {
         "delegate": DELEGATE,
-        "policy_version": 2,
-        "allowed_verification_modes": 1,
-        "signed_quorum_verifier_set_hash": ZERO_HASH,
-    },
-    REGRESSION_POLICY_HASH: {
-        "delegate": REGRESSION_DELEGATE,
-        "policy_version": 3,
-        "allowed_verification_modes": 3,
-        "signed_quorum_verifier_set_hash": SIGNED_QUORUM_VERIFIER_SET_HASH,
+        "policy_version": POLICY_VERSION,
+        "allowed_verification_modes": active_wallet.ALLOWED_VERIFICATION_MODES,
+        "signed_quorum_verifier_set_hash": active_wallet.SIGNED_QUORUM_VERIFIER_SET_HASH,
     },
 }
 MAX_COMMENT_BYTES = 12_000
@@ -280,6 +274,7 @@ def validate_wallet(
         "factory": FACTORY,
         "settlement_token": USDC,
         "deployment_factory": WALLET_FACTORY,
+        "owner": active_wallet.OWNER,
         "delegate": profile["delegate"],
         "deterministic_verifier": VERIFIER,
         "signed_quorum_verifier_set_hash": profile["signed_quorum_verifier_set_hash"],

--- a/scripts/test_activate_routed_v3_replacements.py
+++ b/scripts/test_activate_routed_v3_replacements.py
@@ -20,6 +20,72 @@ import activate_routed_v3_replacements as MODULE
 import check_routed_v3_activation_readiness as READINESS
 
 
+NOW = 1_800_000_000
+
+
+class PolicyCast:
+    def __init__(self, **overrides: object) -> None:
+        self.state = MODULE.active_wallet.expected_state()
+        self.state.update(overrides)
+
+    def chain_id(self) -> int:
+        return MODULE.CHAIN_ID
+
+    def code(self, target: str) -> str:
+        return "0x6000"
+
+    def rpc(self, *args: str, timeout: int = 300) -> str:
+        if args == ("block", "latest", "--field", "timestamp"):
+            return str(NOW)
+        raise AssertionError(f"unexpected rpc {args}")
+
+    def call(self, target: str, signature: str, *args: str) -> str:
+        if signature == "isPolicyActive(bytes32)(bool)":
+            return "true"
+        if signature.startswith("policies(bytes32)"):
+            return "\n".join(
+                [
+                    "0x" + "14" * 20,
+                    "0x" + "15" * 32,
+                    "1",
+                    "1",
+                    "1",
+                    "false",
+                ]
+            )
+        if signature.startswith("policy()"):
+            return "\n".join(
+                str(self.state[key])
+                for key in (
+                    "delegate",
+                    "valid_after",
+                    "valid_until",
+                    "period_seconds",
+                    "max_per_action",
+                    "max_per_period",
+                    "max_lifetime_spend",
+                    "max_bounty_target",
+                    "allowed_actions",
+                    "allowed_verification_modes",
+                    "deterministic_verifier",
+                    "signed_quorum",
+                    "ai_quorum",
+                )
+            )
+        values = {
+            "owner()(address)": self.state["owner"],
+            "policyHash()(bytes32)": self.state["policy_hash"],
+            "policyVersion()(uint64)": self.state["policy_version"],
+            "periodSpent()(uint256)": 0,
+            "lifetimeSpent()(uint256)": 25_050_000,
+            "balanceOf(address)(uint256)": 63_950_000,
+            "periodBucket()(uint256)": NOW // 86_400,
+        }
+        if signature in values:
+            return str(values[signature])
+        raise AssertionError(f"unexpected call {target} {signature} {args}")
+
+
 class ActivateRoutedV3Tests(unittest.TestCase):
     def deployment_fixture(self) -> dict:
         return {
@@ -124,13 +190,52 @@ class ActivateRoutedV3Tests(unittest.TestCase):
         self.assertEqual(MODULE.TOTAL, 10_050_000)
         self.assertEqual(
             sorted(MODULE.ISSUES),
-            [333, 334, 335, 336, 590, 647, 648, 649, 650, 651],
+            [333, 335, 336, 590, 647, 648, 649, 650, 651],
         )
-        self.assertEqual(set(MODULE.ISSUES), set(MODULE.durable.LANES))
-        self.assertEqual(MODULE.UINT64_MAX, (1 << 64) - 1)
+        self.assertNotIn(334, MODULE.ISSUES)
+        self.assertEqual(set(MODULE.ISSUES), set(MODULE.durable.LANES) - {334})
         self.assertEqual(DYNAMIC.ROUTER, "0x380c1af742593dd88b6f20387e9ee693a0536731")
         self.assertEqual(DYNAMIC.ACTIVATION_DELAY, 604_800)
         self.assertEqual(DYNAMIC.BOOTSTRAP_BLOCK, 49_069_936)
+
+    def test_exact_active_wallet_policy_is_ready(self) -> None:
+        deployment = self.deployment_fixture()
+        deployment.update(
+            {
+                "router_address": MODULE.active_wallet.DETERMINISTIC_VERIFIER,
+                "adapter_address": deployment["adapter"]["address"],
+                "adapter_runtime_code_hash": deployment["adapter"]["runtime_code_hash"],
+                "policy_hash": deployment["policy_hash"],
+            }
+        )
+        state = MODULE.policy_state(PolicyCast(), deployment)
+        self.assertEqual(state["policy_hash"], MODULE.active_wallet.POLICY_HASH)
+        self.assertEqual(state["policy_version"], 5)
+        self.assertEqual(state["affordable_creations"], 4)
+
+    def test_active_wallet_policy_drift_fails_closed(self) -> None:
+        deployment = self.deployment_fixture()
+        deployment.update(
+            {
+                "router_address": MODULE.active_wallet.DETERMINISTIC_VERIFIER,
+                "adapter_address": deployment["adapter"]["address"],
+                "adapter_runtime_code_hash": deployment["adapter"]["runtime_code_hash"],
+                "policy_hash": deployment["policy_hash"],
+            }
+        )
+        cases = {
+            "owner": "0x" + "91" * 20,
+            "delegate": "0x" + "92" * 20,
+            "allowed_verification_modes": 1,
+            "deterministic_verifier": "0x" + "93" * 20,
+            "signed_quorum": "0x" + "94" * 32,
+            "policy_hash": "0x" + "95" * 32,
+            "policy_version": 6,
+            "max_per_period": 11_000_000,
+        }
+        for field, observed in cases.items():
+            with self.subTest(field=field), self.assertRaisesRegex(MODULE.ActivationError, field):
+                MODULE.policy_state(PolicyCast(**{field: observed}), deployment)
 
     def test_router_address_is_quoted_in_activation_workflow_yaml(self) -> None:
         expected = 'ROUTER: "0x380c1af742593dd88b6f20387e9ee693a0536731"'

--- a/scripts/test_relay_bounded_wallet_action.py
+++ b/scripts/test_relay_bounded_wallet_action.py
@@ -72,7 +72,7 @@ def envelope(**overrides: object) -> dict[str, object]:
         "issue_number": 249,
         "wallet": relay.WALLET,
         "policy_hash": relay.POLICY_HASH,
-        "policy_version": 2,
+        "policy_version": relay.POLICY_VERSION,
         "nonce": 0,
         "deadline": NOW + 600,
         "payload": "0x" + create_data()[10:],
@@ -104,11 +104,11 @@ def wallet_state(**overrides: object) -> relay.WalletState:
         "max_lifetime_spend": 89_000_000,
         "max_bounty_target": 5_000_000,
         "allowed_actions": 15,
-        "allowed_verification_modes": 1,
+        "allowed_verification_modes": 3,
         "deterministic_verifier": relay.VERIFIER,
-        "signed_quorum_verifier_set_hash": relay.ZERO_HASH,
+        "signed_quorum_verifier_set_hash": relay.SIGNED_QUORUM_VERIFIER_SET_HASH,
         "policy_hash": relay.POLICY_HASH,
-        "policy_version": 2,
+        "policy_version": relay.POLICY_VERSION,
         "delegate_nonce": 0,
         "period_bucket": NOW // 86_400,
         "period_spent": 0,
@@ -172,24 +172,24 @@ class RelayClient:
 
 
 class BoundedWalletRelayTests(unittest.TestCase):
-    def test_regression_policy_hash_matches_exact_owner_review(self) -> None:
+    def test_active_policy_hash_matches_exact_owner_review(self) -> None:
         policy = {
-            "delegate": relay.REGRESSION_DELEGATE,
-            "valid_after": 1784223027,
-            "valid_until": 1786815027,
-            "period_seconds": 86_400,
-            "max_per_action": 5_000_000,
-            "max_per_period": 10_000_000,
-            "max_lifetime_spend": 89_000_000,
-            "max_bounty_target": 5_000_000,
-            "allowed_actions": 15,
-            "allowed_verification_modes": 3,
+            "delegate": relay.DELEGATE,
+            "valid_after": relay.active_wallet.VALID_AFTER,
+            "valid_until": relay.active_wallet.VALID_UNTIL,
+            "period_seconds": relay.active_wallet.PERIOD_SECONDS,
+            "max_per_action": relay.active_wallet.MAX_PER_ACTION,
+            "max_per_period": relay.active_wallet.MAX_PER_PERIOD,
+            "max_lifetime_spend": relay.active_wallet.MAX_LIFETIME_SPEND,
+            "max_bounty_target": relay.active_wallet.MAX_BOUNTY_TARGET,
+            "allowed_actions": relay.active_wallet.ALLOWED_ACTIONS,
+            "allowed_verification_modes": relay.active_wallet.ALLOWED_VERIFICATION_MODES,
             "deterministic_verifier_module": relay.VERIFIER,
             "signed_quorum_verifier_set_hash": relay.SIGNED_QUORUM_VERIFIER_SET_HASH,
             "ai_judge_verifier_set_hash": relay.ZERO_HASH,
         }
         encoded = encode(f"f({POLICY_TYPE})", policy_tuple(policy))
-        self.assertEqual(keccak_hex(encoded), relay.REGRESSION_POLICY_HASH)
+        self.assertEqual(keccak_hex(encoded), relay.POLICY_HASH)
 
     def test_comment_requires_exact_command_and_schema(self) -> None:
         body = relay.COMMAND + "\n```json\n" + json.dumps(envelope()) + "\n```"
@@ -217,17 +217,9 @@ class BoundedWalletRelayTests(unittest.TestCase):
 
     def test_exact_regression_creation_passes_and_other_quorums_fail(self) -> None:
         signed_envelope = envelope(
-            policy_hash=relay.REGRESSION_POLICY_HASH,
-            policy_version=3,
             payload="0x" + signed_create_data()[10:],
         )
-        state = wallet_state(
-            delegate=relay.REGRESSION_DELEGATE,
-            allowed_verification_modes=3,
-            signed_quorum_verifier_set_hash=relay.SIGNED_QUORUM_VERIFIER_SET_HASH,
-            policy_hash=relay.REGRESSION_POLICY_HASH,
-            policy_version=3,
-        )
+        state = wallet_state()
         relay.validate_wallet(state, signed_envelope)
         prepared = relay.validate_signed_creation(ValidationClient(), signed_envelope, state)
         self.assertEqual(prepared["initial_funding"], 2_100_000)

--- a/site/agent-budget.html
+++ b/site/agent-budget.html
@@ -118,7 +118,7 @@
               <button id="rotate-agent-delegate" class="button secondary" type="button" disabled>Update policy</button>
               <button id="revoke-agent-budget" class="button secondary" type="button" disabled>Revoke agent authority</button>
             </div>
-            <p class="fine">The update replaces the signer, preserves the historical standing-meta-v2 verifier, and adds only the exact sandboxed-regression quorum. The five funded V2 parents are recovery-reserved and are not eligible for new earning actions. A future anonymous, appealable successor requires a separate owner-reviewed policy replacement. This update starts a fresh policy-period counter but preserves lifetime spend. Revocation blocks all new delegate actions. Neither action moves the wallet's USDC.</p>
+            <p class="fine">The update replaces the signer and installs only the reviewed durable verifier router plus the exact sandboxed-regression quorum. Recovery-reserved contracts are not eligible for new earning actions. This starts a fresh policy-period counter but preserves lifetime spend. Revocation blocks all new delegate actions. Neither action moves the wallet's USDC.</p>
           </div>
         </form>
       </section>


### PR DESCRIPTION
## Summary
- pin replacement activation and wallet relay to the exact owner-authorized Base-mainnet policy v5
- remove closed issue #334 from creation scope while preserving reconciliation for the four live contracts
- fail closed on policy hash, version, delegate, owner, verifier, quorum, or cap drift
- correct bounded-wallet operator documentation

## Evidence
- owner configuration tx: 