### PR TITLE
fix: make claim next-action helper fail closed

### DIFF
--- a/.github/workflows/synthetic-paid-loop-canary.yml
+++ b/.github/workflows/synthetic-paid-loop-canary.yml
@@ -1,0 +1,83 @@
+name: Synthetic paid-loop canary
+
+on:
+  push:
+    branches: [codex/synthetic-paid-loop-canary]
+    paths:
+      - ".github/workflows/synthetic-paid-loop-canary.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: synthetic-paid-loop-canary-mainnet
+  cancel-in-progress: false
+
+jobs:
+  create-claim-submit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+      KEEPER_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      FACTORY: "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9"
+      WALLET: "0x1eaa1c68772cf76bc5f4e4174766076e33ace662"
+      CREATOR: "0xc26a630e85134ed30968735c8e7de4576cfa5dbc"
+      BOUNTY: "0x5dfcb9e153fb215f5f2c62269ee4888484107763"
+      NONCE: "0xab14bf71a6f14f339c0ff06f94bb3bcecd162f93e06e4704a9d684425d70abf7"
+      ARTIFACT_HASH: "0xbec9450ffe5d0d73921c2cc829b1bab222cd74df3f71d58f071e56e459e2a4f5"
+      EVIDENCE_HASH: "0x9cddbd37c25bf3ba80a2e4b82839e4b0bf2e974333f42f62abc918df0f634848"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+
+      - name: Validate fixed identities and unused address
+        run: |
+          set -euo pipefail
+          test "$(cast wallet address --private-key "$KEEPER_KEY" | tr '[:upper:]' '[:lower:]')" = "$CREATOR"
+          test "$(cast code "$BOUNTY" --rpc-url "$RPC_URL")" = "0x"
+          test "$(cast call "$WALLET" 'policy()(address,uint64,uint64,uint64,uint256,uint256,uint256,uint256,uint8,uint8,address,bytes32,bytes32)' --rpc-url "$RPC_URL" | head -1 | tr '[:upper:]' '[:lower:]')" = "$CREATOR"
+
+      - name: Create zero-funded canonical bounty
+        run: |
+          set -euo pipefail
+          params='(100000,10000,0x8a1e5ef80a8f99ae92f7e8fdc9495739d8e08a19c55dad985b76f5018210e34a,0x7b0960493231743c097b35c7def6d401fda9e96446f06d19318ecf6c1fe126b7,0x5f4adf4e1b5cbd8f1f2bf3ecaf8214ec3d0e7b3c4edcc8692604a8d1ea4ebe7f,0xdcf2d302c4a73b123fc3bb0b0ea40f7547e8febd20c5d4cc8c3998cfc684175e,0xc443416ed8eefd23018c58e526f7fcc0ab182b92e8c286bcc26b5f92ba093595,1800000000,86400,86400,1,0x0000000000000000000000000000000000000000,0x0000000000000000000000000000000000000000,2)'
+          verifiers='[0xbe6292b9e465f549e2363b918d6dd9187038431e,0xb7c2ce6430b66fb986e27b6140b29309550d487a]'
+          cast send "$FACTORY" \
+            'createBounty((uint256,uint256,bytes32,bytes32,bytes32,bytes32,bytes32,uint64,uint64,uint64,uint8,address,address,uint8),address[],uint256,bytes32)' \
+            "$params" "$verifiers" 0 "$NONCE" --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          test "$(cast call "$FACTORY" 'isCanonicalBounty(address)(bool)' "$BOUNTY" --rpc-url "$RPC_URL")" = "true"
+
+      - name: Fund and claim through bounded solver wallet
+        run: |
+          set -euo pipefail
+          cast send "$WALLET" 'fundBounty(address,uint256)' "$BOUNTY" 110000 \
+            --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          test "$(cast call "$BOUNTY" 'fundedAmount()(uint256)' --rpc-url "$RPC_URL" | awk '{print $1}')" = "110000"
+          cast send "$WALLET" 'claimBounty(address)' "$BOUNTY" \
+            --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          test "$(cast call "$BOUNTY" 'solver()(address)' --rpc-url "$RPC_URL" | tr '[:upper:]' '[:lower:]')" = "$WALLET"
+
+      - name: Submit exact public artifact
+        run: |
+          set -euo pipefail
+          cast send "$WALLET" 'submitBounty(address,bytes32,bytes32)' \
+            "$BOUNTY" "$ARTIFACT_HASH" "$EVIDENCE_HASH" \
+            --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          test "$(cast call "$BOUNTY" 'submissionHash()(bytes32)' --rpc-url "$RPC_URL")" = "$ARTIFACT_HASH"
+          test "$(cast call "$BOUNTY" 'evidenceHash()(bytes32)' --rpc-url "$RPC_URL")" = "$EVIDENCE_HASH"
+
+      - name: Record evidence boundary
+        run: |
+          {
+            echo "## Synthetic canary submitted"
+            echo
+            echo "- bounty: \`$BOUNTY\`"
+            echo "- creator: \`$CREATOR\`"
+            echo "- solver: \`$WALLET\`"
+            echo "- funded: 0.11 USDC"
+            echo "- solver reward: 0.10 USDC"
+            echo "- verifier reserve / returned bond: 0.01 USDC"
+            echo
+            echo "This is not payment evidence. Only a confirmed canonical BountySettled event proves payout."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/synthetic-paid-loop-canary.yml
+++ b/.github/workflows/synthetic-paid-loop-canary.yml
@@ -1,10 +1,9 @@
 name: Synthetic paid-loop canary
 
 on:
-  push:
-    branches: [codex/synthetic-paid-loop-canary]
-    paths:
-      - ".github/workflows/synthetic-paid-loop-canary.yml"
+  workflow_dispatch:
+  schedule:
+    - cron: "7 0 29 7 *"
 
 permissions:
   contents: read
@@ -31,39 +30,46 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
 
-      - name: Validate fixed identities and unused address
+      - name: Validate fixed identities
         run: |
           set -euo pipefail
           test "$(cast wallet address --private-key "$KEEPER_KEY" | tr '[:upper:]' '[:lower:]')" = "$CREATOR"
-          test "$(cast code "$BOUNTY" --rpc-url "$RPC_URL")" = "0x"
           test "$(cast call "$WALLET" 'policy()(address,uint64,uint64,uint64,uint256,uint256,uint256,uint256,uint8,uint8,address,bytes32,bytes32)' --rpc-url "$RPC_URL" | head -1 | tr '[:upper:]' '[:lower:]')" = "$CREATOR"
 
       - name: Create zero-funded canonical bounty
         run: |
           set -euo pipefail
-          params='(100000,10000,0x8a1e5ef80a8f99ae92f7e8fdc9495739d8e08a19c55dad985b76f5018210e34a,0x7b0960493231743c097b35c7def6d401fda9e96446f06d19318ecf6c1fe126b7,0x5f4adf4e1b5cbd8f1f2bf3ecaf8214ec3d0e7b3c4edcc8692604a8d1ea4ebe7f,0xdcf2d302c4a73b123fc3bb0b0ea40f7547e8febd20c5d4cc8c3998cfc684175e,0xc443416ed8eefd23018c58e526f7fcc0ab182b92e8c286bcc26b5f92ba093595,1800000000,86400,86400,1,0x0000000000000000000000000000000000000000,0x0000000000000000000000000000000000000000,2)'
-          verifiers='[0xbe6292b9e465f549e2363b918d6dd9187038431e,0xb7c2ce6430b66fb986e27b6140b29309550d487a]'
-          cast send "$FACTORY" \
-            'createBounty((uint256,uint256,bytes32,bytes32,bytes32,bytes32,bytes32,uint64,uint64,uint64,uint8,address,address,uint8),address[],uint256,bytes32)' \
-            "$params" "$verifiers" 0 "$NONCE" --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          if [ "$(cast code "$BOUNTY" --rpc-url "$RPC_URL")" = "0x" ]; then
+            params='(100000,10000,0x8a1e5ef80a8f99ae92f7e8fdc9495739d8e08a19c55dad985b76f5018210e34a,0x7b0960493231743c097b35c7def6d401fda9e96446f06d19318ecf6c1fe126b7,0x5f4adf4e1b5cbd8f1f2bf3ecaf8214ec3d0e7b3c4edcc8692604a8d1ea4ebe7f,0xdcf2d302c4a73b123fc3bb0b0ea40f7547e8febd20c5d4cc8c3998cfc684175e,0xc443416ed8eefd23018c58e526f7fcc0ab182b92e8c286bcc26b5f92ba093595,1800000000,86400,86400,1,0x0000000000000000000000000000000000000000,0x0000000000000000000000000000000000000000,2)'
+            verifiers='[0xbe6292b9e465f549e2363b918d6dd9187038431e,0xb7c2ce6430b66fb986e27b6140b29309550d487a]'
+            cast send "$FACTORY" \
+              'createBounty((uint256,uint256,bytes32,bytes32,bytes32,bytes32,bytes32,uint64,uint64,uint64,uint8,address,address,uint8),address[],uint256,bytes32)' \
+              "$params" "$verifiers" 0 "$NONCE" --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          fi
           test "$(cast call "$FACTORY" 'isCanonicalBounty(address)(bool)' "$BOUNTY" --rpc-url "$RPC_URL")" = "true"
 
       - name: Fund and claim through bounded solver wallet
         run: |
           set -euo pipefail
-          cast send "$WALLET" 'fundBounty(address,uint256)' "$BOUNTY" 110000 \
-            --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          if [ "$(cast call "$BOUNTY" 'fundedAmount()(uint256)' --rpc-url "$RPC_URL" | awk '{print $1}')" = "0" ]; then
+            cast send "$WALLET" 'fundBounty(address,uint256)' "$BOUNTY" 110000 \
+              --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          fi
           test "$(cast call "$BOUNTY" 'fundedAmount()(uint256)' --rpc-url "$RPC_URL" | awk '{print $1}')" = "110000"
-          cast send "$WALLET" 'claimBounty(address)' "$BOUNTY" \
-            --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          if [ "$(cast call "$BOUNTY" 'solver()(address)' --rpc-url "$RPC_URL" | tr '[:upper:]' '[:lower:]')" = "0x0000000000000000000000000000000000000000" ]; then
+            cast send "$WALLET" 'claimBounty(address)' "$BOUNTY" \
+              --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          fi
           test "$(cast call "$BOUNTY" 'solver()(address)' --rpc-url "$RPC_URL" | tr '[:upper:]' '[:lower:]')" = "$WALLET"
 
       - name: Submit exact public artifact
         run: |
           set -euo pipefail
-          cast send "$WALLET" 'submitBounty(address,bytes32,bytes32)' \
-            "$BOUNTY" "$ARTIFACT_HASH" "$EVIDENCE_HASH" \
-            --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          if [ "$(cast call "$BOUNTY" 'submissionHash()(bytes32)' --rpc-url "$RPC_URL")" = "0x0000000000000000000000000000000000000000000000000000000000000000" ]; then
+            cast send "$WALLET" 'submitBounty(address,bytes32,bytes32)' \
+              "$BOUNTY" "$ARTIFACT_HASH" "$EVIDENCE_HASH" \
+              --private-key "$KEEPER_KEY" --rpc-url "$RPC_URL"
+          fi
           test "$(cast call "$BOUNTY" 'submissionHash()(bytes32)' --rpc-url "$RPC_URL")" = "$ARTIFACT_HASH"
           test "$(cast call "$BOUNTY" 'evidenceHash()(bytes32)' --rpc-url "$RPC_URL")" = "$EVIDENCE_HASH"
 

--- a/scripts/next-agent-claim-action.mjs
+++ b/scripts/next-agent-claim-action.mjs
@@ -1,100 +1,82 @@
 #!/usr/bin/env node
-/**
- * Convert Agent Bounties claim response into safe next action.
- * Bounty: 2.00 USDC — NSPG13/agent-bounties #358
- */
 
-const VALID_ACTIONS = [
-    'submit-solution',
-    'wait-for-review',
-    'claim-reward',
-    'verify-payment',
-    'report-error',
-    'escalate-dispute',
-    'retry-submission',
-    'abandon-bounty',
-];
+import { readFileSync } from "node:fs";
 
-function parseClaimResponse(response) {
-    try {
-        return typeof response === 'string' ? JSON.parse(response) : response;
-    } catch {
-        throw new Error('Invalid JSON in claim response');
-    }
+const ADDRESS = /^0x[0-9a-f]{40}$/;
+
+function emit(value, code) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+  process.exit(code);
 }
 
-function determineNextAction(claim) {
-    // Priority-ordered action determination
-    if (claim.status === 'accepted' && claim.requiresSubmission) {
-        return { action: 'submit-solution', reason: 'Bounty accepted, solution required' };
-    }
-    if (claim.status === 'submitted' || claim.status === 'pending_review') {
-        return { action: 'wait-for-review', reason: 'Solution submitted, awaiting review' };
-    }
-    if (claim.status === 'approved' && claim.rewardPending) {
-        return { action: 'claim-reward', reason: 'Solution approved, claim reward' };
-    }
-    if (claim.status === 'paid' && claim.settlementPending) {
-        return { action: 'verify-payment', reason: 'Reward claimed, verify settlement' };
-    }
-    if (claim.status === 'rejected') {
-        return { action: 'report-error', reason: 'Submission rejected', details: claim.rejectionReason };
-    }
-    if (claim.status === 'disputed') {
-        return { action: 'escalate-dispute', reason: 'Dispute raised', details: claim.disputeReason };
-    }
-    if (claim.status === 'error' || claim.status === 'failed') {
-        if (claim.retryCount && claim.retryCount < 3) {
-            return { action: 'retry-submission', reason: 'Error occurred, retry available', retryCount: claim.retryCount };
-        }
-        return { action: 'abandon-bounty', reason: 'Max retries exceeded' };
-    }
-    
-    // Default: wait
-    return { action: 'wait-for-review', reason: 'Unknown state, defaulting to wait', rawStatus: claim.status };
+function fail(error, code = 1) {
+  emit({ ok: false, errors: [error] }, code);
 }
 
-function main() {
-    const args = process.argv.slice(2);
-    let input = '';
+if (process.argv.length !== 3) fail("claim_response_path_required", 2);
 
-    if (args.length > 0) {
-        const { readFileSync, existsSync } = await import('fs');
-        const { resolve } = await import('path');
-        const filePath = resolve(args[0]);
-        if (existsSync(filePath)) {
-            input = readFileSync(filePath, 'utf-8');
-        }
-    }
-
-    if (!input) {
-        // Read from stdin
-        const chunks = [];
-        process.stdin.setEncoding('utf-8');
-        process.stdin.on('data', chunk => chunks.push(chunk));
-        process.stdin.on('end', () => {
-            try {
-                const claim = parseClaimResponse(chunks.join(''));
-                const result = determineNextAction(claim);
-                console.log(JSON.stringify(result, null, 2));
-                process.exit(VALID_ACTIONS.includes(result.action) ? 0 : 1);
-            } catch (err) {
-                console.error('Error:', err.message);
-                process.exit(2);
-            }
-        });
-        return;
-    }
-
-    try {
-        const claim = parseClaimResponse(input);
-        const result = determineNextAction(claim);
-        console.log(JSON.stringify(result, null, 2));
-        process.exit(VALID_ACTIONS.includes(result.action) ? 0 : 1);
-    } catch (err) {
-        console.error('Error:', err.message);
-        process.exit(2);
-    }
+let claim;
+try {
+  claim = JSON.parse(readFileSync(process.argv[2], "utf8"));
+} catch (error) {
+  fail(error instanceof SyntaxError ? "claim_response_invalid_json" : "claim_response_unreadable", 2);
+}
+if (!claim || Array.isArray(claim) || typeof claim !== "object") {
+  fail("claim_response_object_required", 2);
 }
 
-main();
+if (claim.schema_version === "agent-bounties/claim-problem-v1") {
+  emit({
+    ok: true,
+    state: claim.state,
+    action: "follow_error_next_action",
+    may_sign: false,
+    may_start_work: false,
+    error: claim.error,
+    failed_transition: claim.failed_transition,
+  }, 0);
+}
+if (claim.schema_version !== "agent-bounties/agent-native-claim-v1") {
+  fail("claim_schema_unsupported");
+}
+
+const candidate = claim.candidate;
+const state = candidate?.status;
+
+if (state === "waitlisted") {
+  emit({ ok: true, state, action: "poll_same_idempotency_key", may_sign: false, may_start_work: false }, 0);
+}
+if (state === "relaying") {
+  emit({ ok: true, state, action: "replay_same_signed_request", may_sign: false, may_start_work: false }, 0);
+}
+if (state === "authorization_ready") {
+  const request = claim.wallet_request;
+  const replay = claim.next_request;
+  const solver = candidate?.solver_wallet?.toLowerCase();
+  const valid = ADDRESS.test(solver ?? "")
+    && request?.method === "eth_signTypedData_v4"
+    && Array.isArray(request.params)
+    && request.params[0]?.toLowerCase() === solver
+    && typeof request.params[1] === "string"
+    && replay?.method === "POST"
+    && typeof replay.url === "string"
+    && replay.url.startsWith("https://api.agentbounties.app/")
+    && typeof replay.body?.idempotency_key === "string";
+  if (!valid) fail("authorization_request_invalid");
+  emit({ ok: true, state, action: "sign_wallet_request_and_replay", may_sign: true, may_start_work: false }, 0);
+}
+if (state === "claimed") {
+  const eventId = claim.canonical_event_id;
+  if (!eventId || candidate.canonical_event_id !== eventId) {
+    fail("canonical_claim_evidence_invalid");
+  }
+  emit({
+    ok: true,
+    state,
+    action: "start_work",
+    may_sign: false,
+    may_start_work: true,
+    canonical_event_id: eventId,
+  }, 0);
+}
+fail(`claim_state_unsupported:${state}`);


### PR DESCRIPTION
Synthetic paid-loop canary artifact for #664. The code change fixes the precommitted deterministic benchmark. Payment and settlement remain separate and require canonical on-chain evidence.