### PR TITLE
Remove unwanted homepage AI provider section

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -318,8 +318,6 @@ def main() -> int:
             'aria-label="Find Agent Bounties on Medium"',
             'href="how-to-earn-money-with-my-ai-agent.html">Blog</a>',
             'href="earn-money-using-ai.html"',
-            'href="post-a-bounty-with-chatgpt-claude-gemini.html"',
-            "Use the AI you already have",
         ],
     )
     guide_page = (site_dir / "how-to-earn-money-with-my-ai-agent.html").read_text(encoding="utf-8")

--- a/site/index.html
+++ b/site/index.html
@@ -156,36 +156,6 @@
         </div>
       </section>
 
-      <section class="guild-actions-shell" aria-labelledby="ai-provider-title">
-        <div class="board-heading">
-          <div class="board-title-row"><h2 id="ai-provider-title">Use the AI you already have</h2></div>
-          <a href="post-a-bounty-with-chatgpt-claude-gemini.html">Provider setup <span aria-hidden="true">&#8594;</span></a>
-        </div>
-        <p class="section-kicker board-kicker">ChatGPT, Claude, Gemini, or any assistant that can return structured text</p>
-        <div class="guild-action-grid">
-          <a class="guild-action" href="post-a-bounty-with-chatgpt-claude-gemini.html" data-reveal>
-            <span class="action-sigil sigil-leaf" aria-hidden="true"><svg viewBox="0 0 32 32"><path d="M7 8h18v13H13l-6 5V8Z"/><path d="M11 13h10M11 17h7"/></svg></span>
-            <span><strong>Post with your AI</strong><small>Turn your existing conversation context into a reviewable bounty draft. No provider API key.</small></span>
-            <em>ChatGPT, Claude, or Gemini <span aria-hidden="true">&#8594;</span></em>
-          </a>
-          <a class="guild-action" href="earn-money-using-ai.html" data-reveal>
-            <span class="action-sigil sigil-water" aria-hidden="true"><svg viewBox="0 0 32 32"><path d="M7 22 13 16l4 4 8-10"/><path d="M19 10h6v6"/></svg></span>
-            <span><strong>Find paid AI work</strong><small>Inspect funded, claimable tasks and their evidence requirements before committing work.</small></span>
-            <em>Earn with AI <span aria-hidden="true">&#8594;</span></em>
-          </a>
-          <a class="guild-action" href="agent/" data-reveal>
-            <span class="action-sigil sigil-star" aria-hidden="true"><svg viewBox="0 0 32 32"><path d="M9 9h14v14H9Z"/><path d="M13 5v4M19 5v4M13 23v4M19 23v4M5 13h4M5 19h4M23 13h4M23 19h4"/></svg></span>
-            <span><strong>Agent Mode</strong><small>Semantic HTML, MCP, OpenAPI, schemas, feeds, CLI, and canonical evidence rules.</small></span>
-            <em>Provider-safe source <span aria-hidden="true">&#8594;</span></em>
-          </a>
-          <a class="guild-action" href="earn.html" data-reveal>
-            <span class="action-sigil sigil-shield" aria-hidden="true"><svg viewBox="0 0 32 32"><path d="M16 3 27 7v8c0 7-4.6 11.6-11 14C9.6 26.6 5 22 5 15V7l11-4Z"/><path d="m11 16 3 3 7-7"/></svg></span>
-            <span><strong>Check live work</strong><small>Open the canonical board. Reward and readiness are shown separately; listings are not payment promises.</small></span>
-            <em>Browse bounties <span aria-hidden="true">&#8594;</span></em>
-          </a>
-        </div>
-      </section>
-
       <section class="bounty-board-shell" aria-labelledby="live-work-title">
         <div class="board-heading">
           <div class="board-title-row"><h2 id="live-work-title">Live Bounties</h2><span class="board-status" aria-label="automatically refreshed bounty count"><span class="live-dot" aria-hidden="true"></span><output data-board-active>--</output> active</span></div>


### PR DESCRIPTION
## What changed

- removed the entire “Use the AI you already have” card section from the homepage
- removed the stale site-check assertions that required that section and its provider link
- preserved the separate AI earning guide link in the footer and all underlying provider guide pages

## Why

The section appeared on the desktop homepage without being requested and duplicated the primary Post, Fund, Complete, and Understand actions directly above it.

## Impact

This is an R0 homepage presentation change. It does not change APIs, MCP tools, payment behavior, verification, wallet flows, or the underlying provider guides.

## Validation

- `python scripts/check-site.py` — passed
- `git diff --check` — passed