### PR TITLE
Expose solver cash margin before claim

### DIFF
--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "94f2c972f9a895395282eb25e64752168b1aa5e405145ab506c546c248ecfac4"
+  "normalized_sha256": "a9ccb1e3c59b14e723afa8e134ecd8fada04d4f96c3bb2c55acf3cfab399d417"
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -369,6 +369,7 @@ use worker::{
         ,OpportunityProjectionResponse
         ,OpportunityItem
         ,opportunities::OpportunityAmount
+        ,opportunities::OpportunityCashEconomics
         ,opportunities::OpportunityNextAction
         ,opportunities::OpportunityEmbedLinks
         ,opportunities::OpportunityStandingMetaV4Economics
@@ -3993,6 +3994,16 @@ async fn opportunity_embed_page(
     let payment_state = web_public::escape_html(&item.payment_state);
     let verification = web_public::escape_html(&item.verification_method);
     let reward = web_public::escape_html(&committed_reward_label(&item));
+    let cash_rows = item.cash_economics.as_ref().map_or_else(String::new, |economics| {
+        format!(
+            "<dt>Solver reward</dt><dd>{}</dd><dt>Refundable claim bond</dt><dd>{}</dd><dt>Required external spend</dt><dd>{}</dd><dt>Gross cash margin (not net profit)</dt><dd>{}</dd><dt>Economics scope</dt><dd class=\"muted\">{}</dd>",
+            web_public::escape_html(&opportunity_amount_label(&economics.solver_reward)),
+            web_public::escape_html(&opportunity_amount_label(&economics.refundable_claim_bond)),
+            web_public::escape_html(&opportunity_amount_label(&economics.required_external_spend)),
+            web_public::escape_html(&opportunity_amount_label(&economics.gross_cash_margin)),
+            web_public::escape_html(&economics.scope_disclaimer),
+        )
+    });
     let deadline =
         web_public::escape_html(item.deadline.as_deref().unwrap_or("No deadline published"));
     let link = web_public::escape_html(&safe_opportunity_link(&item));
@@ -4016,7 +4027,7 @@ async fn opportunity_embed_page(
                 .to_string()
         });
     let html = format!(
-        r#"<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{title} · Agent Bounties</title><style>:root{{color-scheme:light dark;font-family:Inter,ui-sans-serif,system-ui,sans-serif}}*{{box-sizing:border-box}}body{{margin:0;padding:12px;background:transparent}}article{{max-width:720px;border:1px solid #6b728066;border-radius:16px;padding:20px;background:#111827;color:#f9fafb;box-shadow:0 12px 36px #0003}}header{{display:flex;justify-content:space-between;gap:12px;align-items:flex-start}}.brand{{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#93c5fd}}h1{{font-size:21px;line-height:1.25;margin:7px 0 16px}}.states{{display:flex;flex-wrap:wrap;gap:8px}}.pill{{padding:5px 9px;border-radius:999px;background:#1f2937;font-size:12px}}dl{{display:grid;grid-template-columns:max-content 1fr;gap:8px 14px;margin:18px 0}}dt{{color:#9ca3af}}dd{{margin:0;overflow-wrap:anywhere}}footer{{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}}a{{color:#bfdbfe}}a.cta{{display:inline-block;background:#2563eb;color:white;text-decoration:none;padding:10px 14px;border-radius:9px;font-weight:700}}.proof{{font-size:12px}}.muted{{color:#9ca3af}}</style></head><body><article data-opportunity-id="{}"><header><div><div class="brand">Agent Bounties opportunity</div><h1>{title}</h1></div><div class="states"><span class="pill">Work: {work_state}</span><span class="pill">Payment: {payment_state}</span></div></header><dl><dt>Committed reward</dt><dd>{reward}</dd><dt>Deadline</dt><dd>{deadline}</dd><dt>Verification</dt><dd>{verification}</dd></dl><footer>{latest}<a class="cta" href="{link}" target="_blank" rel="noopener noreferrer">{cta}</a></footer></article></body></html>"#,
+        r#"<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{title} · Agent Bounties</title><style>:root{{color-scheme:light dark;font-family:Inter,ui-sans-serif,system-ui,sans-serif}}*{{box-sizing:border-box}}body{{margin:0;padding:12px;background:transparent}}article{{max-width:720px;border:1px solid #6b728066;border-radius:16px;padding:20px;background:#111827;color:#f9fafb;box-shadow:0 12px 36px #0003}}header{{display:flex;justify-content:space-between;gap:12px;align-items:flex-start}}.brand{{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#93c5fd}}h1{{font-size:21px;line-height:1.25;margin:7px 0 16px}}.states{{display:flex;flex-wrap:wrap;gap:8px}}.pill{{padding:5px 9px;border-radius:999px;background:#1f2937;font-size:12px}}dl{{display:grid;grid-template-columns:max-content 1fr;gap:8px 14px;margin:18px 0}}dt{{color:#9ca3af}}dd{{margin:0;overflow-wrap:anywhere}}footer{{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}}a{{color:#bfdbfe}}a.cta{{display:inline-block;background:#2563eb;color:white;text-decoration:none;padding:10px 14px;border-radius:9px;font-weight:700}}.proof{{font-size:12px}}.muted{{color:#9ca3af}}</style></head><body><article data-opportunity-id="{}"><header><div><div class="brand">Agent Bounties opportunity</div><h1>{title}</h1></div><div class="states"><span class="pill">Work: {work_state}</span><span class="pill">Payment: {payment_state}</span></div></header><dl><dt>Committed reward</dt><dd>{reward}</dd>{cash_rows}<dt>Deadline</dt><dd>{deadline}</dd><dt>Verification</dt><dd>{verification}</dd></dl><footer>{latest}<a class="cta" href="{link}" target="_blank" rel="noopener noreferrer">{cta}</a></footer></article></body></html>"#,
         web_public::escape_html(&item.opportunity_id),
     );
     Ok((
@@ -4053,14 +4064,24 @@ async fn opportunity_embed_svg(
     let item = load_embedded_opportunity(&state, &opportunity_id, query.network).await?;
     let title = truncate_chars(&item.title, 70);
     let reward = committed_reward_label(&item);
+    let margin = item.cash_economics.as_ref().map_or_else(
+        || "Unavailable".to_string(),
+        |economics| {
+            format!(
+                "{} (not net profit)",
+                opportunity_amount_label(&economics.gross_cash_margin)
+            )
+        },
+    );
     let deadline = item.deadline.as_deref().unwrap_or("No deadline published");
     let link = safe_opportunity_link(&item);
     let svg = format!(
-        r##"<svg xmlns="http://www.w3.org/2000/svg" width="720" height="240" role="img" aria-label="Agent Bounties opportunity: {title}"><title>Agent Bounties opportunity: {title}</title><rect width="720" height="240" rx="18" fill="#111827"/><rect x="1" y="1" width="718" height="238" rx="17" fill="none" stroke="#4b5563"/><text x="28" y="34" fill="#93c5fd" font-family="Arial,sans-serif" font-size="12" letter-spacing="1.2">BOUNTYBOARD OPPORTUNITY</text><text x="28" y="72" fill="#f9fafb" font-family="Arial,sans-serif" font-size="22" font-weight="700">{title}</text><text x="28" y="112" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Work: {work}  ·  Payment: {payment}</text><text x="28" y="142" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Committed reward: {reward}</text><text x="28" y="172" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Deadline: {deadline}</text><text x="28" y="202" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Verification: {verification}</text><a href="{link}" target="_blank"><rect x="550" y="184" width="142" height="36" rx="8" fill="#2563eb"/><text x="621" y="207" text-anchor="middle" fill="#fff" font-family="Arial,sans-serif" font-size="13" font-weight="700">View opportunity</text></a></svg>"##,
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="720" height="270" role="img" aria-label="Agent Bounties opportunity: {title}"><title>Agent Bounties opportunity: {title}</title><rect width="720" height="270" rx="18" fill="#111827"/><rect x="1" y="1" width="718" height="268" rx="17" fill="none" stroke="#4b5563"/><text x="28" y="34" fill="#93c5fd" font-family="Arial,sans-serif" font-size="12" letter-spacing="1.2">BOUNTYBOARD OPPORTUNITY</text><text x="28" y="72" fill="#f9fafb" font-family="Arial,sans-serif" font-size="22" font-weight="700">{title}</text><text x="28" y="112" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Work: {work}  ·  Payment: {payment}</text><text x="28" y="142" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Committed reward: {reward}</text><text x="28" y="172" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Gross cash margin: {margin}</text><text x="28" y="202" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Deadline: {deadline}</text><text x="28" y="232" fill="#d1d5db" font-family="Arial,sans-serif" font-size="14">Verification: {verification}</text><a href="{link}" target="_blank"><rect x="550" y="214" width="142" height="36" rx="8" fill="#2563eb"/><text x="621" y="237" text-anchor="middle" fill="#fff" font-family="Arial,sans-serif" font-size="13" font-weight="700">View opportunity</text></a></svg>"##,
         title = web_public::escape_html(&title),
         work = web_public::escape_html(&item.work_state),
         payment = web_public::escape_html(&item.payment_state),
         reward = web_public::escape_html(&reward),
+        margin = web_public::escape_html(&margin),
         deadline = web_public::escape_html(deadline),
         verification = web_public::escape_html(&item.verification_method),
         link = web_public::escape_html(&link),
@@ -4108,8 +4129,18 @@ async fn opportunity_embed_markdown(
         .and_then(|url| safe_external_url(url))
         .map(|url| format!("[Latest result or settlement proof]({url})"))
         .unwrap_or_else(|| "No result or settlement proof published".to_string());
+    let cash_rows = item.cash_economics.as_ref().map_or_else(String::new, |economics| {
+        format!(
+            "| Solver reward | {} |\n| Refundable claim bond | {} |\n| Required external spend | {} |\n| Gross cash margin (not net profit) | {} |\n| Economics scope | {} |\n",
+            markdown_cell(&opportunity_amount_label(&economics.solver_reward)),
+            markdown_cell(&opportunity_amount_label(&economics.refundable_claim_bond)),
+            markdown_cell(&opportunity_amount_label(&economics.required_external_spend)),
+            markdown_cell(&opportunity_amount_label(&economics.gross_cash_margin)),
+            markdown_cell(&economics.scope_disclaimer),
+        )
+    });
     let markdown = format!(
-        "[![Agent Bounties opportunity]({svg_url})]({embed_url})\n\n### {}\n\n| Field | Current value |\n|---|---|\n| Work state | `{}` |\n| Payment state | `{}` |\n| Committed reward | {} |\n| Deadline | {} |\n| Verification | `{}` |\n| Evidence | {} |\n\n[View opportunity]({})\n",
+        "[![Agent Bounties opportunity]({svg_url})]({embed_url})\n\n### {}\n\n| Field | Current value |\n|---|---|\n| Work state | `{}` |\n| Payment state | `{}` |\n| Committed reward | {} |\n{cash_rows}| Deadline | {} |\n| Verification | `{}` |\n| Evidence | {} |\n\n[View opportunity]({})\n",
         markdown_cell(&item.title),
         markdown_cell(&item.work_state),
         markdown_cell(&item.payment_state),
@@ -4164,18 +4195,29 @@ fn committed_reward_label(item: &OpportunityItem) -> String {
     )
 }
 
+fn opportunity_amount_label(amount: &opportunities::OpportunityAmount) -> String {
+    format!(
+        "{} {}",
+        decimal_amount(&amount.amount, amount.decimals),
+        amount.currency
+    )
+}
+
 fn decimal_amount(amount: &str, decimals: u8) -> String {
-    if decimals == 0 || !amount.bytes().all(|byte| byte.is_ascii_digit()) {
+    let (sign, digits) = amount
+        .strip_prefix('-')
+        .map_or(("", amount), |digits| ("-", digits));
+    if decimals == 0 || digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
         return amount.to_string();
     }
     let decimals = usize::from(decimals);
-    let padded = format!("{:0>width$}", amount, width = decimals + 1);
+    let padded = format!("{:0>width$}", digits, width = decimals + 1);
     let split = padded.len() - decimals;
     let fraction = padded[split..].trim_end_matches('0');
     if fraction.is_empty() {
-        padded[..split].to_string()
+        format!("{sign}{}", &padded[..split])
     } else {
-        format!("{}.{}", &padded[..split], fraction)
+        format!("{sign}{}.{}", &padded[..split], fraction)
     }
 }
 

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -1,5 +1,5 @@
 use app::BountyStatusResponse;
-use chain_base::{standing_meta_v2_parent_context, AutonomousBountyFeedItem};
+use chain_base::AutonomousBountyFeedItem;
 use chrono::{DateTime, Utc};
 use db::{TrialBounty, UnfundedBountySolution};
 use domain::{BountyStatus, DiscoveryOpportunitySnapshot, DiscoveryRewardFilter, PrivacyLevel};
@@ -68,6 +68,16 @@ pub struct OpportunityEmbedLinks {
     pub svg: String,
     pub markdown: String,
     pub iframe: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct OpportunityCashEconomics {
+    pub solver_reward: OpportunityAmount,
+    pub refundable_claim_bond: OpportunityAmount,
+    pub required_external_spend: OpportunityAmount,
+    pub gross_cash_margin: OpportunityAmount,
+    pub gross_cash_margin_positive: bool,
+    pub scope_disclaimer: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
@@ -149,6 +159,8 @@ pub struct OpportunityItem {
     pub payment_committed: bool,
     pub competition_mode: String,
     pub standing_meta_bounty: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cash_economics: Option<OpportunityCashEconomics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub standing_meta_v4: Option<OpportunityStandingMetaV4>,
     pub decision_authority: String,
@@ -273,6 +285,7 @@ pub fn render_opportunity_feeds(
                 "payment_state": item.payment_state,
                 "payment_committed": item.payment_committed,
                 "reward": item.reward,
+                "cash_economics": item.cash_economics,
                 "verification_method": item.verification_method,
                 "verification_ready": item.verification_ready,
                 "terms_hash": item.terms_hash,
@@ -332,9 +345,23 @@ fn feed_summary(item: &OpportunityItem) -> String {
         .goal
         .as_deref()
         .unwrap_or("No additional goal text was supplied.");
+    let cash_economics = item.cash_economics.as_ref().map_or_else(String::new, |economics| {
+        format!(
+            " Solver reward: {} {} base units. Refundable claim bond: {} {} base units. Required external spend: {} {} base units. Gross cash margin (not net profit): {} {} base units. {}",
+            economics.solver_reward.amount,
+            economics.solver_reward.currency,
+            economics.refundable_claim_bond.amount,
+            economics.refundable_claim_bond.currency,
+            economics.required_external_spend.amount,
+            economics.required_external_spend.currency,
+            economics.gross_cash_margin.amount,
+            economics.gross_cash_margin.currency,
+            economics.scope_disclaimer,
+        )
+    });
     truncate_feed_text(
         &format!(
-            "{goal}\n\nWork state: {}. Payment state: {}. {reward} Verification: {}. Next action: {}",
+            "{goal}\n\nWork state: {}. Payment state: {}. {reward}{cash_economics} Verification: {}. Next action: {}",
             item.work_state,
             item.payment_state,
             item.verification_method,
@@ -477,6 +504,7 @@ pub fn unfunded_opportunity(
         payment_committed: false,
         competition_mode: "open_unfunded_submission".to_string(),
         standing_meta_bounty: false,
+        cash_economics: None,
         standing_meta_v4: None,
         decision_authority: "The poster reviews this offchain submission; no canonical verifier is configured.".to_string(),
         payment_authority: "None. This opportunity is unfunded and creates no payment promise.".to_string(),
@@ -592,6 +620,7 @@ pub fn legacy_opportunity(
         payment_committed,
         competition_mode: "exclusive_claim".to_string(),
         standing_meta_bounty: false,
+        cash_economics: None,
         standing_meta_v4: None,
         decision_authority: format!("Legacy configured verification path: {verification_method}."),
         payment_authority: "The configured legacy reconciled rail; this is not canonical Base BountySettled evidence.".to_string(),
@@ -699,6 +728,12 @@ pub fn canonical_opportunity(
         .into_iter()
         .collect();
     let opportunity_id = format!("canonical:{network}:{}", item.bounty_contract);
+    let benchmark = terms.map(|record| &record.document.benchmark);
+    let standing_meta_bounty = benchmark
+        .and_then(|value| value.get("engine"))
+        .and_then(Value::as_str)
+        .is_some_and(|engine| engine.starts_with("standing_meta_"));
+    let cash_economics = canonical_cash_economics(item, benchmark);
     Some(OpportunityItem {
         opportunity_id: opportunity_id.clone(),
         source_type: "canonical_base".to_string(),
@@ -714,7 +749,8 @@ pub fn canonical_opportunity(
         payment_state: payment_state.to_string(),
         payment_committed,
         competition_mode: "exclusive_claim".to_string(),
-        standing_meta_bounty: standing_meta_v2_parent_context(item).is_ok(),
+        standing_meta_bounty,
+        cash_economics,
         standing_meta_v4: None,
         decision_authority: format!(
             "The immutable canonical verification mode/module configured on {} decides the submission result.",
@@ -818,15 +854,63 @@ fn apply_view(item: &mut OpportunityItem, view: OpportunityView, now: DateTime<U
             let matches = item.work_state == "claimable"
                 && item.payment_state == "escrowed"
                 && item.payment_committed
-                && item.verification_ready;
+                && item.verification_ready
+                && (item.source_type != "canonical_base"
+                    || item
+                        .cash_economics
+                        .as_ref()
+                        .is_some_and(|economics| economics.gross_cash_margin_positive));
             if matches {
                 item.discovery_factors.push(
-                    "view:ready_to_earn;factors=claimable+escrowed+verification_ready".to_string(),
+                    "view:ready_to_earn;factors=claimable+escrowed+verification_ready+positive_gross_cash_margin".to_string(),
                 );
             }
             matches
         }
     }
+}
+
+fn canonical_cash_economics(
+    item: &AutonomousBountyFeedItem,
+    benchmark: Option<&Value>,
+) -> Option<OpportunityCashEconomics> {
+    let solver_reward = item.solver_reward.parse::<i128>().ok()?;
+    let claim_bond = item.claim_bond.parse::<i128>().ok()?;
+    if solver_reward < 0 || claim_bond < 0 {
+        return None;
+    }
+    let engine = benchmark
+        .and_then(|value| value.get("engine"))
+        .and_then(Value::as_str);
+    let required_external_spend = match engine {
+        Some("standing_meta_v2_parent") => solver_reward,
+        Some(engine) if engine.starts_with("standing_meta_") => benchmark
+            .and_then(|value| value.get("minimum_child_target"))
+            .and_then(json_integer)?,
+        _ => 0,
+    };
+    if required_external_spend < 0 {
+        return None;
+    }
+    let gross_cash_margin = solver_reward.checked_sub(required_external_spend)?;
+    Some(OpportunityCashEconomics {
+        solver_reward: OpportunityAmount::usdc_base_units(solver_reward.to_string()),
+        refundable_claim_bond: OpportunityAmount::usdc_base_units(claim_bond.to_string()),
+        required_external_spend: OpportunityAmount::usdc_base_units(
+            required_external_spend.to_string(),
+        ),
+        gross_cash_margin: OpportunityAmount::usdc_base_units(gross_cash_margin.to_string()),
+        gross_cash_margin_positive: gross_cash_margin > 0,
+        scope_disclaimer: "Gross cash margin is solver reward minus required external spend. It excludes gas, taxes, execution costs, failure risk, and other costs; the claim bond is refundable only under the committed lifecycle rules. It is not guaranteed net profit.".to_string(),
+    })
+}
+
+fn json_integer(value: &Value) -> Option<i128> {
+    value
+        .as_u64()
+        .map(i128::from)
+        .or_else(|| value.as_i64().map(i128::from))
+        .or_else(|| value.as_str().and_then(|value| value.parse::<i128>().ok()))
 }
 
 fn taxonomy_view(item: &mut OpportunityItem, view: &str) -> bool {
@@ -1202,6 +1286,78 @@ mod tests {
     }
 
     #[test]
+    fn direct_bounty_exposes_positive_cash_margin_and_refundable_bond() {
+        let item = canonical_opportunity(
+            &canonical("claimable", "1000000", true),
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+        let economics = item.cash_economics.unwrap();
+        assert_eq!(economics.solver_reward.amount, "900000");
+        assert_eq!(economics.refundable_claim_bond.amount, "100000");
+        assert_eq!(economics.required_external_spend.amount, "0");
+        assert_eq!(economics.gross_cash_margin.amount, "900000");
+        assert!(economics.gross_cash_margin_positive);
+        assert!(economics
+            .scope_disclaimer
+            .contains("not guaranteed net profit"));
+    }
+
+    #[test]
+    fn standing_meta_bounty_subtracts_required_child_outlay() {
+        let mut source = canonical("claimable", "1000000", true);
+        source.terms.as_mut().unwrap().document.benchmark = json!({
+            "engine": "standing_meta_v3_parent",
+            "minimum_child_target": 500000
+        });
+        let item = canonical_opportunity(&source, "base-mainnet", "https://api.example").unwrap();
+        let economics = item.cash_economics.unwrap();
+        assert!(item.standing_meta_bounty);
+        assert_eq!(economics.required_external_spend.amount, "500000");
+        assert_eq!(economics.gross_cash_margin.amount, "400000");
+        assert!(economics.gross_cash_margin_positive);
+    }
+
+    #[test]
+    fn ready_to_earn_filters_unprofitable_standing_meta_inventory() {
+        let mut profitable = canonical("claimable", "1000000", true);
+        profitable.terms.as_mut().unwrap().document.benchmark = json!({
+            "engine": "standing_meta_v3_parent",
+            "minimum_child_target": 500000
+        });
+        let mut unprofitable = canonical("claimable", "1000000", true);
+        unprofitable.terms.as_mut().unwrap().document.benchmark = json!({
+            "engine": "standing_meta_v3_parent",
+            "minimum_child_target": 1000000
+        });
+        let unprofitable_item =
+            canonical_opportunity(&unprofitable, "base-mainnet", "https://api.example").unwrap();
+        let unprofitable_economics = unprofitable_item.cash_economics.as_ref().unwrap();
+        assert_eq!(unprofitable_economics.gross_cash_margin.amount, "-100000");
+        assert!(!unprofitable_economics.gross_cash_margin_positive);
+        let items = apply_query(
+            vec![
+                canonical_opportunity(&profitable, "base-mainnet", "https://api.example").unwrap(),
+                unprofitable_item,
+            ],
+            &OpportunityQuery::default(),
+            Some(OpportunityView::ReadyToEarn),
+            DateTime::<Utc>::from_timestamp(1_800_000_100, 0).unwrap(),
+        );
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0]
+                .cash_economics
+                .as_ref()
+                .unwrap()
+                .gross_cash_margin
+                .amount,
+            "400000"
+        );
+    }
+
+    #[test]
     fn discovery_views_explain_deterministic_inclusion() {
         let item = canonical_opportunity(
             &canonical("claimable", "1000000", true),
@@ -1257,5 +1413,34 @@ mod tests {
         assert_eq!(json["items"][0]["_bountyboard"]["payment_committed"], false);
         assert!(!feeds.rss.to_ascii_lowercase().contains("trial"));
         assert_eq!(feeds.updated_at, "Fri, 15 Jan 2027 08:00:00 GMT");
+    }
+
+    #[test]
+    fn live_feed_exposes_cash_economics_without_profit_guarantee() {
+        let item = canonical_opportunity(
+            &canonical("claimable", "1000000", true),
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+        let projection = OpportunityProjectionResponse {
+            schema_version: OPPORTUNITY_PROJECTION_SCHEMA.to_string(),
+            generated_at: "2027-01-15T08:01:00Z".to_string(),
+            network: "base-mainnet".to_string(),
+            applied_view: None,
+            degraded: false,
+            source_statuses: Vec::new(),
+            items: vec![item],
+            evidence_boundary: "Projection only".to_string(),
+        };
+        let feeds = render_opportunity_feeds(&projection, "https://api.example/");
+        let json: Value = serde_json::from_str(&feeds.json).unwrap();
+        let economics = &json["items"][0]["_bountyboard"]["cash_economics"];
+        assert_eq!(economics["solver_reward"]["amount"], "900000");
+        assert_eq!(economics["refundable_claim_bond"]["amount"], "100000");
+        assert_eq!(economics["required_external_spend"]["amount"], "0");
+        assert_eq!(economics["gross_cash_margin"]["amount"], "900000");
+        assert!(feeds.rss.contains("Gross cash margin (not net profit)"));
+        assert!(!feeds.rss.to_ascii_lowercase().contains("guaranteed profit"));
     }
 }


### PR DESCRIPTION
Closes #636

## What Changed
- Expose solver reward, refundable claim bond, required external spend, gross cash margin, and a scope disclaimer in the unified opportunity projection and JSON/RSS/Atom feeds.
- Render the same economics in HTML, SVG, and Markdown embeds without presenting gross margin as guaranteed net profit.
- Exclude canonical inventory with missing or non-positive gross cash margin from `ready_to_earn`; legacy inventory remains compatible.

## Linked Bounty Or Issue
- Funded bounty: #636
- Canonical Base contract: `0xf2e47a253988e98f535ab60f4b9bd7f8975c1263`

## Maintainer Change Notice
not maintainer-owned

- Notice issue/comment: not applicable
- Open PR queue checked before edits: yes; no overlapping implementation found
- Active PR impact or repair path: forward-fix or revert these two commits
- Collaboration branch impact, if any: none

## Discovery Feedback
- How did you find Agent Bounties? Public claimable inventory and the funded-live GitHub issue.
- What made this bounty or project worth participating in? The task had escrowed funding, deterministic verification, and a concrete pre-claim trust gap.
- If an AI agent helped you find or complete this work, what led it here? Codex followed the public inventory feed and issue #636, then verified the canonical contract and terms before implementation.
- What would make the project easier or more trustworthy? Showing cash economics before claim, which this PR implements.

## Acceptance Criteria
- [x] The PR has a clear verifier or review path.
- [x] Deterministic behavior has tests or a documented manual check.
- [x] Payment, settlement, and payout behavior is unchanged or explicitly covered by tests and docs.

## SDLC And Recovery
- Change class: `R1`
- Authoritative source of truth: canonical opportunity projection in `crates/api/src/opportunities.rs`
- Expected failure modes: malformed amounts or missing standing-meta spend data fail closed and are excluded from `ready_to_earn`
- Idempotency or replay key: not applicable; read-only projection
- Rollback or forward-repair path: revert the two commits or adjust the projection/fixture in a follow-up
- Health/readiness/SLO signal: API tests and OpenAPI contract hash
- Recovery fixture added or reason not applicable: not applicable; no state mutation
- Release/canary impact: additive response fields; no migration or payment-path change

## Local Checks
`cargo test -p api opportunities::tests` — 9 passed

`cargo test -p api -- --skip base_broadcast_signed_transaction_endpoint_returns_tx_hash --skip live_stripe_checkout_endpoint_returns_execution_report --skip public_stripe_funding_intent_checkout_executes_bounty_checkout` — 108 passed, 0 failed, 4 ignored; the three skipped tests require local socket surfaces unavailable in this Windows runner

## Review Lane
- [x] I believe this is ready for `main`.
- [ ] If useful but not main-ready, I am comfortable with maintainers preserving this work on a `collab/pr-<number>-<topic>` branch for follow-up PRs.
- [ ] This touches risky paths and needs manual maintainer security review.
