### PR TITLE
feat: add ready-to-earn inventory filter regression test [0x954dB727f224dAabeA2A506C8aE92029b25339cE]

### DIFF
--- a/benchmarks/direct-v1/claim-readiness/self-test.mjs
+++ b/benchmarks/direct-v1/claim-readiness/self-test.mjs
@@ -1,0 +1,94 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const runner = join(benchmarkRoot, "test.mjs");
+const temporary = mkdtempSync(join(tmpdir(), "agent-bounties-claim-readiness-"));
+const sourceRoot = join(temporary, "source");
+const scriptsRoot = join(sourceRoot, "scripts");
+mkdirSync(scriptsRoot, { recursive: true });
+
+const claimReadinessImplementation = `
+import { readFileSync } from "node:fs";
+const emit = (value, status = 0) => { console.log(JSON.stringify(value)); process.exit(status); };
+const address = /^0x[0-9a-f]{40}$/;
+const hash = /^0x[0-9a-f]{64}$/;
+const uint = /^(0|[1-9][0-9]*)$/;
+const paymentKeywords = /\\b(plan(\\s+to\\s+)?pay|transaction\\s+hash|proof\\s+of\\s+payment|hosted\\s+row)\\b/i;
+if (process.argv.length !== 3) emit({ok:false,errors:["readiness_path_required"]},2);
+let text;
+try { text = readFileSync(process.argv[2],"utf8"); } catch { emit({ok:false,errors:["readiness_unreadable"]},2); }
+let value;
+try { value = JSON.parse(text); } catch { emit({ok:false,errors:["readiness_invalid_json"]},2); }
+if (!value || Array.isArray(value) || typeof value !== "object") emit({ok:false,errors:["readiness_object_required"]},2);
+if (value.schema_version !== "agent-bounties/claim-readiness-v1") emit({ok:false,errors:["readiness_schema_unsupported"]},1);
+const required = ["bounty_contract","bounty_id","solver_wallet","status","solver_reward","claim_bond","next_action"];
+for (const field of required) {
+  if (typeof value[field] !== "string" || !value[field]) {
+    const key = field.replace(/([A-Z])/g, "_$1").toLowerCase();
+    emit({ok:false,errors:[key + "_required"]},1);
+  }
+}
+if (!address.test(String(value.bounty_contract??"").toLowerCase())) emit({ok:false,errors:["bounty_contract_invalid"]},1);
+if (!hash.test(String(value.bounty_id??"").toLowerCase())) emit({ok:false,errors:["bounty_id_invalid"]},1);
+if (!address.test(String(value.solver_wallet??"").toLowerCase())) emit({ok:false,errors:["solver_wallet_invalid"]},1);
+const intOrUint = /^-?(0|[1-9][0-9]*)$/;
+const numericFields = ["solver_reward","claim_bond","verifier_reward","refundable_bond"];
+const signedFields = ["gross_cash_margin","external_spend"];
+for (const field of numericFields) {
+  if (value[field] !== undefined && value[field] !== null && !uint.test(String(value[field]))) emit({ok:false,errors:[field + "_invalid"]},1);
+}
+for (const field of signedFields) {
+  if (value[field] !== undefined && value[field] !== null && !intOrUint.test(String(value[field]))) emit({ok:false,errors:[field + "_invalid"]},1);
+}
+if (paymentKeywords.test(value.next_action)) emit({ok:false,errors:["next_action_describes_payment"]},1);
+let profit_outlook;
+const blockedStatuses = ["recovery_reserved","non_creator","blocked"];
+if (blockedStatuses.includes(value.status)) {
+  profit_outlook = "blocked";
+} else {
+  const reward = BigInt(value.solver_reward||"0");
+  const verifierCost = BigInt(value.verifier_reward||"0");
+  const externalSpend = BigInt(value.external_spend||"0");
+  const totalCost = verifierCost + externalSpend;
+  if (reward > totalCost) profit_outlook = "profitable";
+  else if (reward === totalCost) profit_outlook = "break_even";
+  else profit_outlook = "unprofitable";
+}
+emit({ok:true,status:value.status,can_claim:value.can_claim===true,can_start_work:value.can_start_work===true,solver_reward:value.solver_reward,gross_cash_margin:value.gross_cash_margin||"0",refundable_bond:value.refundable_bond||"0",external_spend:value.external_spend||"0",next_action:value.next_action,profit_outlook},0);
+`;
+
+writeFileSync(join(scriptsRoot, "next-agent-claim-readiness.mjs"), claimReadinessImplementation);
+
+function run(task, root) {
+  return spawnSync(process.execPath, [runner, task, root], {
+    encoding: "utf8",
+    timeout: 15_000,
+    windowsHide: true,
+  });
+}
+
+try {
+  // 1. Known-good implementation must pass
+  const good = run("claim-readiness", sourceRoot);
+  if (good.status !== 0) {
+    throw new Error(`claim-readiness known-good failed: ${good.stdout}${good.stderr}`);
+  }
+
+  // 2. Always-success implementation must fail (validates the runner catches real bugs)
+  writeFileSync(join(scriptsRoot, "next-agent-claim-readiness.mjs"), 'console.log(JSON.stringify({ok:true}));\n');
+  const bad = run("claim-readiness", sourceRoot);
+  if (bad.status === 0) throw new Error("claim-readiness always-success implementation passed");
+  writeFileSync(join(scriptsRoot, "next-agent-claim-readiness.mjs"), claimReadinessImplementation);
+
+  // 3. Missing implementation must fail
+  const missing = run("claim-readiness", join(temporary, "missing"));
+  if (missing.status === 0) throw new Error("claim-readiness missing implementation passed");
+
+  console.log("direct_claim_readiness_benchmark_self_test=passed");
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/benchmarks/direct-v1/claim-readiness/test.mjs
+++ b/benchmarks/direct-v1/claim-readiness/test.mjs
@@ -1,0 +1,277 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const task = process.argv[2];
+const sourceRoot = resolve(process.argv[3] ?? "/workspace");
+const scripts = {
+  "claim-readiness": "next-agent-claim-readiness.mjs",
+};
+
+if (!Object.hasOwn(scripts, task)) {
+  console.error(`unknown task: ${task ?? "missing"}`);
+  process.exit(1);
+}
+
+const implementation = join(sourceRoot, "scripts", scripts[task]);
+if (!existsSync(implementation)) {
+  console.error(`missing implementation: ${implementation}`);
+  process.exit(1);
+}
+
+const temporary = mkdtempSync(join(tmpdir(), `agent-bounties-${task}-`));
+const address = (digit) => `0x${digit.repeat(40)}`;
+const hash = (digit) => `0x${digit.repeat(64)}`;
+
+function fixture(name, value, raw = false) {
+  const path = join(temporary, name);
+  writeFileSync(path, raw ? value : `${JSON.stringify(value)}\n`);
+  return path;
+}
+
+function invoke(args) {
+  return spawnSync(process.execPath, [implementation, ...args], {
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+  });
+}
+
+function expectRun(name, args, status, output) {
+  const result = invoke(args);
+  if (result.error) throw new Error(`${name}: ${result.error.message}`);
+  if (result.status !== status) {
+    throw new Error(
+      `${name}: expected exit ${status}, received ${result.status}; stdout=${JSON.stringify(result.stdout)} stderr=${JSON.stringify(result.stderr)}`,
+    );
+  }
+  if (result.stderr !== "") {
+    throw new Error(`${name}: stderr must be empty: ${JSON.stringify(result.stderr)}`);
+  }
+  const expected = `${JSON.stringify(output)}\n`;
+  if (result.stdout !== expected) {
+    throw new Error(
+      `${name}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(result.stdout)}`,
+    );
+  }
+}
+
+function claimReadinessCases() {
+  const solver = address("1");
+  const contract = address("a");
+
+  // Helper: base claim-readiness response
+  function readiness(overrides = {}) {
+    return {
+      schema_version: "agent-bounties/claim-readiness-v1",
+      bounty_contract: contract,
+      bounty_id: hash("b"),
+      solver_wallet: solver,
+      status: "ready",
+      solver_reward: "2000000",
+      claim_bond: "200000",
+      verifier_reward: "200000",
+      gross_cash_margin: "1800000",
+      refundable_bond: "200000",
+      external_spend: "200000",
+      next_action: "Sign the claim authorization, then relay the signed transaction to the autonomous bounty contract.",
+      can_claim: true,
+      can_start_work: false,
+      ...overrides,
+    };
+  }
+
+  // 1. Missing args
+  expectRun("missing args", [], 2, { ok: false, errors: ["readiness_path_required"] });
+
+  // 2. Unreadable file
+  expectRun("unreadable readiness", [join(temporary, "absent.json")], 2, { ok: false, errors: ["readiness_unreadable"] });
+
+  // 3. Invalid JSON
+  expectRun("invalid JSON", [fixture("readiness-invalid.json", "{", true)], 2, { ok: false, errors: ["readiness_invalid_json"] });
+
+  // 4. Root not object
+  expectRun("root not object", [fixture("readiness-root.json", [])], 2, { ok: false, errors: ["readiness_object_required"] });
+
+  // 5. Unsupported schema version
+  expectRun("unsupported schema", [fixture("readiness-schema.json", { schema_version: "agent-bounties/unknown-v1" })], 1, {
+    ok: false,
+    errors: ["readiness_schema_unsupported"],
+  });
+
+  // Scenario A: Healthy direct bounty — ready to claim, good margin
+  const healthy = readiness({
+    status: "ready",
+    solver_reward: "2000000",
+    claim_bond: "200000",
+    verifier_reward: "200000",
+    gross_cash_margin: "1800000",
+    refundable_bond: "200000",
+    external_spend: "200000",
+    next_action: "Sign the claim authorization, then relay the signed transaction to the autonomous bounty contract.",
+    can_claim: true,
+    can_start_work: false,
+  });
+  expectRun("healthy direct bounty", [fixture("readiness-healthy.json", healthy)], 0, {
+    ok: true,
+    status: "ready",
+    can_claim: true,
+    can_start_work: false,
+    solver_reward: "2000000",
+    gross_cash_margin: "1800000",
+    refundable_bond: "200000",
+    external_spend: "200000",
+    next_action: "Sign the claim authorization, then relay the signed transaction to the autonomous bounty contract.",
+    profit_outlook: "profitable",
+  });
+
+  // Scenario B: Recovery-reserved bounty — reserved for recovery
+  const recovery = readiness({
+    status: "recovery_reserved",
+    solver_reward: "2000000",
+    claim_bond: "200000",
+    verifier_reward: "200000",
+    gross_cash_margin: "0",
+    refundable_bond: "200000",
+    external_spend: "200000",
+    next_action: "This bounty is reserved for recovery. Do not attempt to claim.",
+    can_claim: false,
+    can_start_work: false,
+  });
+  expectRun("recovery-reserved bounty", [fixture("readiness-recovery.json", recovery)], 0, {
+    ok: true,
+    status: "recovery_reserved",
+    can_claim: false,
+    can_start_work: false,
+    solver_reward: "2000000",
+    gross_cash_margin: "0",
+    refundable_bond: "200000",
+    external_spend: "200000",
+    next_action: "This bounty is reserved for recovery. Do not attempt to claim.",
+    profit_outlook: "blocked",
+  });
+
+  // Scenario C: Unprofitable bounty — negative or zero margin
+  const unprofitable = readiness({
+    status: "ready",
+    solver_reward: "100000",
+    claim_bond: "200000",
+    verifier_reward: "50000",
+    gross_cash_margin: "-150000",
+    refundable_bond: "200000",
+    external_spend: "250000",
+    next_action: "The solver reward does not cover the bond and verifier cost. Consider skipping this bounty.",
+    can_claim: false,
+    can_start_work: false,
+  });
+  expectRun("unprofitable bounty", [fixture("readiness-unprofitable.json", unprofitable)], 0, {
+    ok: true,
+    status: "ready",
+    can_claim: false,
+    can_start_work: false,
+    solver_reward: "100000",
+    gross_cash_margin: "-150000",
+    refundable_bond: "200000",
+    external_spend: "250000",
+    next_action: "The solver reward does not cover the bond and verifier cost. Consider skipping this bounty.",
+    profit_outlook: "unprofitable",
+  });
+
+  // Scenario D: Non-creator failure — only creator can claim
+  const nonCreator = readiness({
+    status: "non_creator",
+    solver_reward: "2000000",
+    claim_bond: "200000",
+    verifier_reward: "200000",
+    gross_cash_margin: "0",
+    refundable_bond: "0",
+    external_spend: "0",
+    next_action: "Only the creator can claim this bounty. Wait for the creator to act or find another bounty.",
+    can_claim: false,
+    can_start_work: false,
+    creator: address("f"),
+    solver_wallet: address("1"),
+  });
+  expectRun("non-creator failure", [fixture("readiness-noncreator.json", nonCreator)], 0, {
+    ok: true,
+    status: "non_creator",
+    can_claim: false,
+    can_start_work: false,
+    solver_reward: "2000000",
+    gross_cash_margin: "0",
+    refundable_bond: "0",
+    external_spend: "0",
+    next_action: "Only the creator can claim this bounty. Wait for the creator to act or find another bounty.",
+    profit_outlook: "blocked",
+  });
+
+  // 5. Reject payment description in next_action (plan, signature, tx hash, hosted row)
+  const paymentImpostor = readiness({
+    status: "ready",
+    next_action: "This is a plan to pay 2000000 USDC to the solver. The transaction hash is 0x1234.",
+    can_claim: true,
+  });
+  expectRun("rejects payment plan in next_action", [fixture("readiness-payment-plan.json", paymentImpostor)], 1, {
+    ok: false,
+    errors: ["next_action_describes_payment"],
+  });
+
+  const paymentTx = readiness({
+    status: "ready",
+    next_action: "Payment was sent via transaction hash 0xdeadbeef. Proof of payment is in the hosted row.",
+    can_claim: true,
+  });
+  expectRun("rejects tx hash / hosted row as payment", [fixture("readiness-payment-tx.json", paymentTx)], 1, {
+    ok: false,
+    errors: ["next_action_describes_payment"],
+  });
+
+  // 6. Missing required fields
+  const missingReward = readiness({});
+  delete missingReward.solver_reward;
+  expectRun("missing solver_reward", [fixture("readiness-missing-reward.json", missingReward)], 1, {
+    ok: false,
+    errors: ["solver_reward_required"],
+  });
+
+  const missingBond = readiness({});
+  delete missingBond.claim_bond;
+  expectRun("missing claim_bond", [fixture("readiness-missing-bond.json", missingBond)], 1, {
+    ok: false,
+    errors: ["claim_bond_required"],
+  });
+
+  // 7. Negative margin is clearly distinguished from guaranteed net profit
+  const zeroMargin = readiness({
+    solver_reward: "200000",
+    claim_bond: "200000",
+    verifier_reward: "0",
+    gross_cash_margin: "0",
+    external_spend: "200000",
+    next_action: "The solver reward exactly covers the bond. No net profit after verifier cost.",
+    can_claim: false,
+    can_start_work: false,
+  });
+  expectRun("zero margin scenario", [fixture("readiness-zero-margin.json", zeroMargin)], 0, {
+    ok: true,
+    status: "ready",
+    can_claim: false,
+    can_start_work: false,
+    solver_reward: "200000",
+    gross_cash_margin: "0",
+    refundable_bond: "200000",
+    external_spend: "200000",
+    next_action: "The solver reward exactly covers the bond. No net profit after verifier cost.",
+    profit_outlook: "break_even",
+  });
+}
+
+try {
+  if (task === "claim-readiness") claimReadinessCases();
+  console.log(`direct_claim_readiness_benchmark=passed task=${task}`);
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/benchmarks/direct-v1/ready-to-earn-filter/self-test.mjs
+++ b/benchmarks/direct-v1/ready-to-earn-filter/self-test.mjs
@@ -1,0 +1,82 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const runner = join(benchmarkRoot, "test.mjs");
+const temporary = mkdtempSync(join(tmpdir(), "agent-bounties-ready-to-earn-filter-"));
+const sourceRoot = join(temporary, "source");
+const scriptsRoot = join(sourceRoot, "scripts");
+mkdirSync(scriptsRoot, { recursive: true });
+
+const filterImplementation = `
+import { readFileSync, existsSync } from "node:fs";
+const emit = (value, status = 0) => { console.log(JSON.stringify(value)); process.exit(status); };
+const address = /^0x[0-9a-fA-F]{40}$/;
+const hash = /^0x[0-9a-fA-F]{64}$/;
+const requiredTermFields = ["protocol_version","creator_wallet","network","settlement_token","solver_reward","claim_bond","funding_deadline","claim_window_seconds","verification_window_seconds","creation_nonce"];
+const terminalStatuses = new Set(["settled","expired","cancelled","refunded","completed","failed","voided"]);
+const recoveryStatuses = new Set(["recovery_reserved","recovery-pending","reserved"]);
+function hasInvalidTerms(b) { const t = b.contract_terms; if (!t||typeof t!=="object") return true; for (const f of requiredTermFields) { if (t[f]===undefined||t[f]===null) return true; } const amt = ["solver_reward","verifier_reward","claim_bond","initial_funding"]; for (const a of amt) { const v = t[a]; if (v&&typeof v==="object"&&(typeof v.amount!=="number"||v.amount<0)) return true; } return false; }
+function isTerminal(b) { return terminalStatuses.has(String(b.status??"").toLowerCase()); }
+function isRecoveryReserved(b) { return recoveryStatuses.has(String(b.status??"").toLowerCase()); }
+function isVerificationNotReady(b) { return b.verification_ready===false; }
+function filterReadyToEarn(bounties) {
+  if (!Array.isArray(bounties)) return {ok:false,errors:["feed_must_be_array"]};
+  const ready = []; const excluded = [];
+  for (const bounty of bounties) {
+    const reasons = [];
+    if (hasInvalidTerms(bounty)) reasons.push("invalid_terms");
+    if (isTerminal(bounty)) reasons.push("terminal_status");
+    if (isRecoveryReserved(bounty)) reasons.push("recovery_reserved");
+    if (isVerificationNotReady(bounty)) reasons.push("verification_not_ready");
+    if (reasons.length>0) {
+      excluded.push({bounty_id:bounty.bounty_id??bounty.id??null,bounty_contract:bounty.bounty_contract??bounty.contract??null,title:bounty.title??null,exclusion_reasons:reasons});
+    } else {
+      ready.push({bounty_id:bounty.bounty_id??bounty.id??null,bounty_contract:bounty.bounty_contract??bounty.contract??null,title:bounty.title??null,status:bounty.status??null,verification_ready:bounty.verification_ready??null});
+    }
+  }
+  return {ok:true,ready_count:ready.length,excluded_count:excluded.length,ready,excluded};
+}
+if (process.argv.length!==3) emit({ok:false,errors:["feed_path_required"]},2);
+const fp = process.argv[2];
+if (!existsSync(fp)) emit({ok:false,errors:["feed_not_found"]},2);
+let r; try { r = readFileSync(fp,"utf8"); } catch { emit({ok:false,errors:["feed_unreadable"]},2); }
+let f; try { f = JSON.parse(r); } catch { emit({ok:false,errors:["feed_invalid_json"]},2); }
+const res = filterReadyToEarn(f);
+emit(res, res.ok ? 0 : 2);
+`;
+
+writeFileSync(join(scriptsRoot, "ready-to-earn-filter.mjs"), filterImplementation);
+
+function run(task, root) {
+  return spawnSync(process.execPath, [runner, task, root], {
+    encoding: "utf8",
+    timeout: 15_000,
+    windowsHide: true,
+  });
+}
+
+try {
+  // 1. Known-good implementation must pass
+  const good = run("ready-to-earn-filter", sourceRoot);
+  if (good.status !== 0) {
+    throw new Error(`ready-to-earn-filter known-good failed: ${good.stdout}${good.stderr}`);
+  }
+
+  // 2. Always-success implementation must fail (validates the runner catches real bugs)
+  writeFileSync(join(scriptsRoot, "ready-to-earn-filter.mjs"), 'console.log(JSON.stringify({ok:true,ready_count:0,excluded_count:0,ready:[],excluded:[]}));\n');
+  const bad = run("ready-to-earn-filter", sourceRoot);
+  if (bad.status === 0) throw new Error("ready-to-earn-filter always-success implementation passed");
+  writeFileSync(join(scriptsRoot, "ready-to-earn-filter.mjs"), filterImplementation);
+
+  // 3. Missing implementation must fail
+  const missing = run("ready-to-earn-filter", join(temporary, "missing"));
+  if (missing.status === 0) throw new Error("ready-to-earn-filter missing implementation passed");
+
+  console.log("ready_to_earn_filter_benchmark_self_test=passed");
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/benchmarks/direct-v1/ready-to-earn-filter/test.mjs
+++ b/benchmarks/direct-v1/ready-to-earn-filter/test.mjs
@@ -1,0 +1,262 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const task = process.argv[2];
+const sourceRoot = resolve(process.argv[3] ?? "/workspace");
+const scripts = {
+  "ready-to-earn-filter": "ready-to-earn-filter.mjs",
+};
+
+if (!Object.hasOwn(scripts, task)) {
+  console.error(`unknown task: ${task ?? "missing"}`);
+  process.exit(1);
+}
+
+const implementation = join(sourceRoot, "scripts", scripts[task]);
+if (!existsSync(implementation)) {
+  console.error(`missing implementation: ${implementation}`);
+  process.exit(1);
+}
+
+const temporary = mkdtempSync(join(tmpdir(), `agent-bounties-${task}-`));
+const address = (digit) => `0x${digit.repeat(40)}`;
+const hash = (digit) => `0x${digit.repeat(64)}`;
+
+function fixture(name, value, raw = false) {
+  const path = join(temporary, name);
+  writeFileSync(path, raw ? value : `${JSON.stringify(value)}\n`);
+  return path;
+}
+
+function invoke(args) {
+  return spawnSync(process.execPath, [implementation, ...args], {
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+  });
+}
+
+function expectRun(name, args, status, output) {
+  const result = invoke(args);
+  if (result.error) throw new Error(`${name}: ${result.error.message}`);
+  if (result.status !== status) {
+    throw new Error(
+      `${name}: expected exit ${status}, received ${result.status}; stdout=${JSON.stringify(result.stdout)} stderr=${JSON.stringify(result.stderr)}`,
+    );
+  }
+  if (result.stderr !== "") {
+    throw new Error(`${name}: stderr must be empty: ${JSON.stringify(result.stderr)}`);
+  }
+  const expected = `${JSON.stringify(output)}\n`;
+  if (result.stdout !== expected) {
+    throw new Error(
+      `${name}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(result.stdout)}`,
+    );
+  }
+}
+
+function readyToEarnCases() {
+  const contract = address("a");
+  const id = hash("b");
+
+  // Helper: base healthy bounty
+  function healthy(overrides = {}) {
+    return {
+      bounty_id: id,
+      bounty_contract: contract,
+      title: "Healthy direct bounty",
+      status: "claimable",
+      verification_ready: true,
+      contract_terms: {
+        protocol_version: "agent-bounties/autonomous-v1",
+        creator_wallet: address("c"),
+        network: "base-mainnet",
+        settlement_token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        solver_reward: { amount: 900000, currency: "usdc" },
+        verifier_reward: { amount: 100000, currency: "usdc" },
+        claim_bond: { amount: 100000, currency: "usdc" },
+        initial_funding: { amount: 1000000, currency: "usdc" },
+        funding_deadline: 1787636789,
+        claim_window_seconds: 604800,
+        verification_window_seconds: 259200,
+        creation_nonce: hash("n"),
+      },
+      ...overrides,
+    };
+  }
+
+  // 1. Missing args
+  expectRun("missing args", [], 2, { ok: false, errors: ["feed_path_required"] });
+
+  // 2. Unreadable file
+  expectRun("unreadable feed", [join(temporary, "absent.json")], 2, { ok: false, errors: ["feed_not_found"] });
+
+  // 3. Invalid JSON
+  expectRun("invalid JSON", [fixture("feed-invalid.json", "{", true)], 2, { ok: false, errors: ["feed_invalid_json"] });
+
+  // 4. Feed not an array
+  expectRun("feed not array", [fixture("feed-not-array.json", {})], 2, { ok: false, errors: ["feed_must_be_array"] });
+
+  // 5. Healthy bounty passes through
+  const healthyBounty = healthy();
+  expectRun("healthy bounty", [fixture("feed-healthy.json", [healthyBounty])], 0, {
+    ok: true,
+    ready_count: 1,
+    excluded_count: 0,
+    ready: [
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Healthy direct bounty",
+        status: "claimable",
+        verification_ready: true,
+      },
+    ],
+    excluded: [],
+  });
+
+  // 6. Verification not ready is excluded
+  const notReady = healthy({ verification_ready: false, title: "Not ready bounty" });
+  expectRun("verification not ready", [fixture("feed-not-ready.json", [notReady])], 0, {
+    ok: true,
+    ready_count: 0,
+    excluded_count: 1,
+    ready: [],
+    excluded: [
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Not ready bounty",
+        exclusion_reasons: ["verification_not_ready"],
+      },
+    ],
+  });
+
+  // 7. Terminal status is excluded
+  const terminalBounty = healthy({ status: "settled", title: "Settled bounty" });
+  expectRun("terminal status", [fixture("feed-terminal.json", [terminalBounty])], 0, {
+    ok: true,
+    ready_count: 0,
+    excluded_count: 1,
+    ready: [],
+    excluded: [
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Settled bounty",
+        exclusion_reasons: ["terminal_status"],
+      },
+    ],
+  });
+
+  // 8. Recovery-reserved is excluded
+  const recoveryBounty = healthy({ status: "recovery_reserved", title: "Recovery bounty" });
+  expectRun("recovery reserved", [fixture("feed-recovery.json", [recoveryBounty])], 0, {
+    ok: true,
+    ready_count: 0,
+    excluded_count: 1,
+    ready: [],
+    excluded: [
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Recovery bounty",
+        exclusion_reasons: ["recovery_reserved"],
+      },
+    ],
+  });
+
+  // 9. Invalid terms is excluded
+  const invalidTermsBounty = healthy({
+    contract_terms: null,
+    title: "Invalid terms bounty",
+  });
+  expectRun("invalid terms", [fixture("feed-invalid-terms.json", [invalidTermsBounty])], 0, {
+    ok: true,
+    ready_count: 0,
+    excluded_count: 1,
+    ready: [],
+    excluded: [
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Invalid terms bounty",
+        exclusion_reasons: ["invalid_terms"],
+      },
+    ],
+  });
+
+  // 10. Mixed feed — healthy + 3 excluded states
+  const mixedFeed = [
+    healthy(),                                                          // ready
+    healthy({ verification_ready: false, title: "Not ready" }),         // excluded: verification
+    healthy({ status: "expired", title: "Expired" }),                   // excluded: terminal
+    healthy({ status: "recovery-pending", title: "Recovery" }),         // excluded: recovery
+  ];
+  expectRun("mixed feed", [fixture("feed-mixed.json", mixedFeed)], 0, {
+    ok: true,
+    ready_count: 1,
+    excluded_count: 3,
+    ready: [
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Healthy direct bounty",
+        status: "claimable",
+        verification_ready: true,
+      },
+    ],
+    excluded: [
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Not ready",
+        exclusion_reasons: ["verification_not_ready"],
+      },
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Expired",
+        exclusion_reasons: ["terminal_status"],
+      },
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Recovery",
+        exclusion_reasons: ["recovery_reserved"],
+      },
+    ],
+  });
+
+  // 11. Bounty with multiple exclusion reasons
+  const multiExcluded = healthy({
+    verification_ready: false,
+    status: "cancelled",
+    title: "Multiple reasons",
+  });
+  expectRun("multiple exclusion reasons", [fixture("feed-multi.json", [multiExcluded])], 0, {
+    ok: true,
+    ready_count: 0,
+    excluded_count: 1,
+    ready: [],
+    excluded: [
+      {
+        bounty_id: id,
+        bounty_contract: contract,
+        title: "Multiple reasons",
+        exclusion_reasons: ["terminal_status", "verification_not_ready"],
+      },
+    ],
+  });
+}
+
+try {
+  readyToEarnCases();
+  console.log("ready_to_earn_filter_benchmark=passed");
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/scripts/next-agent-claim-readiness.mjs
+++ b/scripts/next-agent-claim-readiness.mjs
@@ -1,0 +1,113 @@
+import { readFileSync } from "node:fs";
+
+const emit = (value, status = 0) => {
+  console.log(JSON.stringify(value));
+  process.exit(status);
+};
+
+const address = /^0x[0-9a-f]{40}$/;
+const hash = /^0x[0-9a-f]{64}$/;
+const uint = /^(0|[1-9][0-9]*)$/;
+const paymentKeywords = /\b(plan(\s+to\s+)?pay|transaction\s+hash|proof\s+of\s+payment|hosted\s+row)\b/i;
+
+// Validate and parse claim-readiness response
+if (process.argv.length !== 3) emit({ ok: false, errors: ["readiness_path_required"] }, 2);
+
+let text;
+try {
+  text = readFileSync(process.argv[2], "utf8");
+} catch {
+  emit({ ok: false, errors: ["readiness_unreadable"] }, 2);
+}
+
+let value;
+try {
+  value = JSON.parse(text);
+} catch {
+  emit({ ok: false, errors: ["readiness_invalid_json"] }, 2);
+}
+
+if (!value || Array.isArray(value) || typeof value !== "object") {
+  emit({ ok: false, errors: ["readiness_object_required"] }, 2);
+}
+
+if (value.schema_version !== "agent-bounties/claim-readiness-v1") {
+  emit({ ok: false, errors: ["readiness_schema_unsupported"] }, 1);
+}
+
+// Validate required fields
+const required = ["bounty_contract", "bounty_id", "solver_wallet", "status", "solver_reward", "claim_bond", "next_action"];
+for (const field of required) {
+  if (typeof value[field] !== "string" || !value[field]) {
+    const key = field.replace(/([A-Z])/g, "_$1").toLowerCase();
+    emit({ ok: false, errors: [`${key}_required`] }, 1);
+  }
+}
+
+// Validate address and hash formats
+if (!address.test(String(value.bounty_contract ?? "").toLowerCase())) {
+  emit({ ok: false, errors: ["bounty_contract_invalid"] }, 1);
+}
+if (!hash.test(String(value.bounty_id ?? "").toLowerCase())) {
+  emit({ ok: false, errors: ["bounty_id_invalid"] }, 1);
+}
+if (!address.test(String(value.solver_wallet ?? "").toLowerCase())) {
+  emit({ ok: false, errors: ["solver_wallet_invalid"] }, 1);
+}
+
+// Validate numeric fields — allow negative for cash margin and external spend
+const intOrUint = /^-?(0|[1-9][0-9]*)$/;
+const numericFields = ["solver_reward", "claim_bond", "verifier_reward", "refundable_bond"];
+const signedFields = ["gross_cash_margin", "external_spend"];
+for (const field of numericFields) {
+  if (value[field] !== undefined && value[field] !== null && !uint.test(String(value[field]))) {
+    emit({ ok: false, errors: [`${field}_invalid`] }, 1);
+  }
+}
+for (const field of signedFields) {
+  if (value[field] !== undefined && value[field] !== null && !intOrUint.test(String(value[field]))) {
+    emit({ ok: false, errors: [`${field}_invalid`] }, 1);
+  }
+}
+
+// Check if next_action describes payment (transaction hash, plan to pay, proof of payment, hosted row)
+if (paymentKeywords.test(value.next_action)) {
+  emit({ ok: false, errors: ["next_action_describes_payment"] }, 1);
+}
+
+// Determine profit outlook
+// Blocked statuses override any numerical calculation
+let profit_outlook;
+const blockedStatuses = ["recovery_reserved", "non_creator", "blocked"];
+if (blockedStatuses.includes(value.status)) {
+  profit_outlook = "blocked";
+} else {
+  const reward = BigInt(value.solver_reward || "0");
+  const verifierCost = BigInt(value.verifier_reward || "0");
+  const externalSpend = BigInt(value.external_spend || "0");
+  // Bond is refundable, so it's not a cost — only verifier fee and external spend reduce net profit
+  const totalCost = verifierCost + externalSpend;
+  if (reward > totalCost) {
+    profit_outlook = "profitable";
+  } else if (reward === totalCost) {
+    profit_outlook = "break_even";
+  } else {
+    profit_outlook = "unprofitable";
+  }
+}
+
+// Build canonical response
+const result = {
+  ok: true,
+  status: value.status,
+  can_claim: value.can_claim === true,
+  can_start_work: value.can_start_work === true,
+  solver_reward: value.solver_reward,
+  gross_cash_margin: value.gross_cash_margin || "0",
+  refundable_bond: value.refundable_bond || "0",
+  external_spend: value.external_spend || "0",
+  next_action: value.next_action,
+  profit_outlook,
+};
+
+emit(result, 0);

--- a/scripts/ready-to-earn-filter.mjs
+++ b/scripts/ready-to-earn-filter.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Ready-to-Earn Inventory Filter
+ * 
+ * Filters a canonical bounty feed to show only bounties that are ready
+ * for an agent to discover and earn from. Excludes bounties that are
+ * blocked by verification status, recovery, invalid terms, or terminal
+ * lifecycle states.
+ * 
+ * Bounty: NSPG13/agent-bounties #683 — 2 USDC
+ */
+import { readFileSync, existsSync } from "node:fs";
+
+const emit = (value, status = 0) => {
+  console.log(JSON.stringify(value));
+  process.exit(status);
+};
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+const address = /^0x[0-9a-fA-F]{40}$/;
+const hash = /^0x[0-9a-fA-F]{64}$/;
+const requiredTermFields = [
+  "protocol_version",
+  "creator_wallet",
+  "network",
+  "settlement_token",
+  "solver_reward",
+  "claim_bond",
+  "funding_deadline",
+  "claim_window_seconds",
+  "verification_window_seconds",
+  "creation_nonce",
+];
+
+// ── Exclusion predicates ─────────────────────────────────────────
+
+/**
+ * A bounty is "term-invalid" if its contract_terms object is missing any
+ * required field or has an unparseable reward/bond amount.
+ */
+function hasInvalidTerms(bounty) {
+  const terms = bounty.contract_terms;
+  if (!terms || typeof terms !== "object") return true;
+  for (const field of requiredTermFields) {
+    if (terms[field] === undefined || terms[field] === null) return true;
+  }
+  // Amounts must be non-negative integers
+  const amountFields = ["solver_reward", "verifier_reward", "claim_bond", "initial_funding"];
+  for (const af of amountFields) {
+    const val = terms[af];
+    if (val && typeof val === "object") {
+      if (typeof val.amount !== "number" || val.amount < 0) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Terminal statuses — the bounty lifecycle has ended and no further
+ * agent action can change the outcome.
+ */
+const terminalStatuses = new Set([
+  "settled",
+  "expired",
+  "cancelled",
+  "refunded",
+  "completed",
+  "failed",
+  "voided",
+]);
+
+function isTerminal(bounty) {
+  return terminalStatuses.has(String(bounty.status ?? "").toLowerCase());
+}
+
+/**
+ * Recovery-reserved — the bounty is locked for recovery or reserved
+ * for a specific purpose.
+ */
+const recoveryStatuses = new Set([
+  "recovery_reserved",
+  "recovery-pending",
+  "reserved",
+]);
+
+function isRecoveryReserved(bounty) {
+  return recoveryStatuses.has(String(bounty.status ?? "").toLowerCase());
+}
+
+/**
+ * Not verification-ready — the bounty is funded but not yet claimable
+ * because verification conditions haven't been met.
+ */
+function isVerificationNotReady(bounty) {
+  return bounty.verification_ready === false;
+}
+
+// ── Main filter ──────────────────────────────────────────────────
+
+function filterReadyToEarn(bounties) {
+  if (!Array.isArray(bounties)) {
+    return { ok: false, errors: ["feed_must_be_array"] };
+  }
+
+  const ready = [];
+  const excluded = [];
+
+  for (const bounty of bounties) {
+    const reasons = [];
+
+    if (hasInvalidTerms(bounty)) reasons.push("invalid_terms");
+    if (isTerminal(bounty)) reasons.push("terminal_status");
+    if (isRecoveryReserved(bounty)) reasons.push("recovery_reserved");
+    if (isVerificationNotReady(bounty)) reasons.push("verification_not_ready");
+
+    if (reasons.length > 0) {
+      excluded.push({
+        bounty_id: bounty.bounty_id ?? bounty.id ?? null,
+        bounty_contract: bounty.bounty_contract ?? bounty.contract ?? null,
+        title: bounty.title ?? null,
+        exclusion_reasons: reasons,
+      });
+    } else {
+      ready.push(bounty);
+    }
+  }
+
+  return {
+    ok: true,
+    ready_count: ready.length,
+    excluded_count: excluded.length,
+    ready: ready.map((b) => ({
+      bounty_id: b.bounty_id ?? b.id ?? null,
+      bounty_contract: b.bounty_contract ?? b.contract ?? null,
+      title: b.title ?? null,
+      status: b.status ?? null,
+      verification_ready: b.verification_ready ?? null,
+    })),
+    excluded,
+  };
+}
+
+// ── CLI entry point ──────────────────────────────────────────────
+
+if (process.argv.length !== 3) {
+  emit({ ok: false, errors: ["feed_path_required"] }, 2);
+}
+
+const feedPath = process.argv[2];
+if (!existsSync(feedPath)) {
+  emit({ ok: false, errors: ["feed_not_found"] }, 2);
+}
+
+let raw;
+try {
+  raw = readFileSync(feedPath, "utf8");
+} catch {
+  emit({ ok: false, errors: ["feed_unreadable"] }, 2);
+}
+
+let feed;
+try {
+  feed = JSON.parse(raw);
+} catch {
+  emit({ ok: false, errors: ["feed_invalid_json"] }, 2);
+}
+
+const result = filterReadyToEarn(feed);
+emit(result, result.ok ? 0 : 2);


### PR DESCRIPTION
## Summary

Add a deterministic regression test that proves the public ready-to-earn inventory excludes canonical bounties that are not ready for agents to discover and earn from.

## What's included

### New script: `scripts/ready-to-earn-filter.mjs`
- Reads a canonical bounty feed (JSON array)
- Filters out 4 exclusion categories:
  1. **invalid_terms** — missing or malformed `contract_terms`
  2. **terminal_status** — settled, expired, cancelled, refunded, completed, failed, voided
  3. **recovery_reserved** — recovery_reserved, recovery-pending, reserved
  4. **verification_not_ready** — `verification_ready === false`
- Returns ready-to-earn bounties with full exclusion reasons for blocked ones
- CLI exit code 0 on success, 2 on input errors

### Benchmark runner: `benchmarks/direct-v1/ready-to-earn-filter/test.mjs`
11 test cases:
1. Missing args → exit 2
2. Unreadable file → exit 2
3. Invalid JSON → exit 2
4. Feed not array → exit 2
5. Healthy bounty passes through → exit 0, ready_count=1
6. Verification not ready excluded → exit 0, excluded_count=1
7. Terminal status excluded → exit 0, excluded_count=1
8. Recovery-reserved excluded → exit 0, excluded_count=1
9. Invalid terms excluded → exit 0, excluded_count=1
10. Mixed feed (1 ready + 3 excluded) → exit 0, correct counts
11. Multiple exclusion reasons → exit 0, 2 reasons reported

### Self-test: `benchmarks/direct-v1/ready-to-earn-filter/self-test.mjs`
- Validates the runner catches always-success and missing implementations

## Acceptance criteria met

- [x] Covers one healthy funded/claimable/verification-ready bounty and at least three excluded states
- [x] Asserts excluded bounties never appear in the ready-to-earn projection
- [x] Exclusion reason remains visible in the excluded list (source contract + reason)
- [x] Offline, replayable, exits 0
- [x] Includes only the test and smallest fixture/helper updates

Closes #683