### PR TITLE
Add transparent recovery for five direct bounties

### DIFF
--- a/.github/workflows/direct-recovery-689.yml
+++ b/.github/workflows/direct-recovery-689.yml
@@ -1,0 +1,304 @@
+name: Direct recovery 689
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/direct-recovery-689.yml"
+      - "ops/recovery/direct-mainnet-689.json"
+      - "scripts/direct_recovery_689.py"
+      - "scripts/test_direct_recovery_689.py"
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Exact public recovery authorization
+        required: true
+        type: string
+      revision:
+        description: Exact current main commit to verify and recover
+        required: true
+        type: string
+      pull_request_url:
+        description: Public implementation PR containing the accepted work
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: direct-recovery-689-mainnet
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+      - run: python scripts/test_direct_recovery_689.py -v
+      - run: python -m py_compile scripts/direct_recovery_689.py
+
+  authorize:
+    if: github.event_name == 'workflow_dispatch'
+    needs: contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      revision: ${{ steps.scope.outputs.revision }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          fetch-depth: 0
+      - id: scope
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+          REVISION: ${{ inputs.revision }}
+          PULL_REQUEST_URL: ${{ inputs.pull_request_url }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test "$CONFIRMATION" = "RECOVER ISSUE 689 EXACTLY 10 USDC"
+          [[ "$PULL_REQUEST_URL" =~ ^https://github\.com/NSPG13/agent-bounties/pull/[1-9][0-9]*$ ]]
+          test "$REVISION" = "$(git rev-parse origin/main)"
+          test "$REVISION" = "$(git rev-parse HEAD)"
+          test "$(gh pr view "$PULL_REQUEST_URL" --json state --jq .state)" = "MERGED"
+          test "$(gh pr view "$PULL_REQUEST_URL" --json mergeCommit --jq .mergeCommit.oid)" = "$REVISION"
+          echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
+
+  announce:
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REVISION: ${{ needs.authorize.outputs.revision }}
+      PULL_REQUEST_URL: ${{ inputs.pull_request_url }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - run: |
+          cat > /tmp/recovery-activation.md <<EOF
+          ## Exact direct-recovery activation
+
+          The separately reviewed recovery harness is starting for commit \`$REVISION\`.
+
+          - Implementation review: $PULL_REQUEST_URL
+          - Operator solver: \`0xc26a630e85134ed30968735c8e7de4576cfa5dbc\`
+          - Return recipient: \`0x884834e884d6e93462655a2820140ad03e6747bc\`
+          - Initial refundable solver bonds: **0.05 USDC total**
+          - Maximum exact return after five passing settlements: **10.00 USDC**
+          - Scope: only issues #634-#638 and the five contracts allowlisted in the notice
+          - Exclusions: no organic-loop, adoption, retention, revenue, reputation, leaderboard, or external-solver credit
+
+          Each of the two immutable verifier keys reruns the published checks independently. Any check, hash, signer, contract, revision, state, or payout mismatch fails closed.
+          EOF
+          gh issue comment 689 --repo "$GITHUB_REPOSITORY" --body-file /tmp/recovery-activation.md
+
+  prepare:
+    needs: [authorize, announce]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      REVISION: ${{ needs.authorize.outputs.revision }}
+      PULL_REQUEST_URL: ${{ inputs.pull_request_url }}
+      CHECK_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ needs.authorize.outputs.revision }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - name: Recheck, claim, and submit the exact five contracts
+        run: >-
+          python scripts/direct_recovery_689.py
+          --rpc-url "$BASE_MAINNET_RPC_URL"
+          prepare
+          --revision "$REVISION"
+          --pull-request-url "$PULL_REQUEST_URL"
+          --check-run-url "$CHECK_RUN_URL"
+          --output target/direct-recovery-candidates
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: direct-recovery-candidates
+          path: target/direct-recovery-candidates
+          if-no-files-found: error
+
+  sign-one:
+    needs: [authorize, prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      RECOVERY_VERIFIER_KEY: ${{ secrets.REGRESSION_VERIFIER_ONE_PRIVATE_KEY }}
+      EXPECTED_SIGNER: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
+      REVISION: ${{ needs.authorize.outputs.revision }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ needs.authorize.outputs.revision }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: direct-recovery-candidates
+          path: target/direct-recovery-candidates
+      - run: >-
+          python scripts/direct_recovery_689.py
+          --rpc-url "$BASE_MAINNET_RPC_URL"
+          sign
+          --revision "$REVISION"
+          --candidates target/direct-recovery-candidates
+          --output target/direct-recovery-attestations-one
+          --private-key-env RECOVERY_VERIFIER_KEY
+          --expected-signer "$EXPECTED_SIGNER"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: direct-recovery-attestations-one
+          path: target/direct-recovery-attestations-one
+          if-no-files-found: error
+
+  sign-two:
+    needs: [authorize, prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      RECOVERY_VERIFIER_KEY: ${{ secrets.REGRESSION_VERIFIER_TWO_PRIVATE_KEY }}
+      EXPECTED_SIGNER: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}
+      REVISION: ${{ needs.authorize.outputs.revision }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ needs.authorize.outputs.revision }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: direct-recovery-candidates
+          path: target/direct-recovery-candidates
+      - run: >-
+          python scripts/direct_recovery_689.py
+          --rpc-url "$BASE_MAINNET_RPC_URL"
+          sign
+          --revision "$REVISION"
+          --candidates target/direct-recovery-candidates
+          --output target/direct-recovery-attestations-two
+          --private-key-env RECOVERY_VERIFIER_KEY
+          --expected-signer "$EXPECTED_SIGNER"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: direct-recovery-attestations-two
+          path: target/direct-recovery-attestations-two
+          if-no-files-found: error
+
+  relay:
+    needs: [authorize, sign-one, sign-two]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
+    env:
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      REVISION: ${{ needs.authorize.outputs.revision }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ needs.authorize.outputs.revision }}
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: direct-recovery-candidates
+          path: target/direct-recovery-candidates
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: direct-recovery-attestations-one
+          path: target/direct-recovery-attestations-one
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: direct-recovery-attestations-two
+          path: target/direct-recovery-attestations-two
+      - name: Recheck, settle, and return exactly 10 USDC
+        run: >-
+          python scripts/direct_recovery_689.py
+          --rpc-url "$BASE_MAINNET_RPC_URL"
+          relay
+          --revision "$REVISION"
+          --candidates target/direct-recovery-candidates
+          --attestations target/direct-recovery-attestations-one
+          --attestations target/direct-recovery-attestations-two
+          --output target/direct-recovery-evidence.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: direct-recovery-evidence
+          path: target/direct-recovery-evidence.json
+          if-no-files-found: error
+      - name: Publish final recovery evidence
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path("target/direct-recovery-evidence.json").read_text())
+          lines = [
+              "## Direct recovery completed",
+              "",
+              f"- Exact revision: `{report['revision']}`",
+              f"- Operator solver: `{report['operator_solver']}`",
+              f"- Returned: **{report['return_amount'] / 1_000_000:.2f} USDC** to `{report['return_recipient']}`",
+              f"- Return transaction: `https://basescan.org/tx/{report['return_transfer_tx']}`",
+              f"- Workflow evidence: {os.environ['RUN_URL']}",
+              "",
+              "Settlements:",
+          ]
+          for item in report["settlements"]:
+              evidence_url = (
+                  f"https://basescan.org/tx/{item['tx']}"
+                  if item.get("tx")
+                  else f"https://basescan.org/address/{item['contract']}#events"
+              )
+              lines.append(
+                  f"- #{item['issue']} `{item['contract']}` "
+                  f"({item['state']}): {evidence_url}"
+              )
+          lines.extend(
+              [
+                  "",
+                  "Classification: disclosed operator recovery only. These events receive no "
+                  "organic-loop, adoption, retention, revenue, reputation, leaderboard, or "
+                  "external-solver credit.",
+              ]
+          )
+          Path("/tmp/recovery-result.md").write_text("\n".join(lines) + "\n")
+          PY
+          gh issue comment 689 --repo "$GITHUB_REPOSITORY" --body-file /tmp/recovery-result.md

--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "e5d7667a5e7972db4064c1d22fb8334c77f95249f9b8e0cd94901a6362e40841"
+  "normalized_sha256": "ffe7646fbdd76ff0424b60a442b429c239665a52721ce98feeade3fcf41d303d"
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -3591,7 +3591,7 @@ async fn opportunity_conversion_funnel(
     let generated_at = Utc::now();
     let window_started_at = generated_at - ChronoDuration::hours(i64::from(window_hours));
     let stats = store
-        .opportunity_lifecycle_stats(window_started_at)
+        .opportunity_lifecycle_stats(window_started_at, &state.recovery_reservations.contracts())
         .await
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
     Ok(Json(opportunity_conversion_response(
@@ -4118,6 +4118,22 @@ async fn opportunity_embed_page(
     let payment_state = web_public::escape_html(&item.payment_state);
     let verification = web_public::escape_html(&item.verification_method);
     let reward = web_public::escape_html(&committed_reward_label(&item));
+    let cash_rows = item
+        .cash_economics
+        .as_ref()
+        .map_or_else(String::new, |economics| {
+            format!(
+                "<dt>Refundable claim bond</dt><dd>{}</dd><dt>Required external spend</dt><dd>{}</dd><dt>Gross cash margin (not net profit)</dt><dd>{}</dd><dt>Economics scope</dt><dd class=\"muted\">{}</dd>",
+                web_public::escape_html(&opportunity_amount_label(
+                    &economics.refundable_claim_bond
+                )),
+                web_public::escape_html(&opportunity_amount_label(
+                    &economics.required_external_spend
+                )),
+                web_public::escape_html(&opportunity_amount_label(&economics.gross_cash_margin)),
+                web_public::escape_html(&economics.scope_disclaimer),
+            )
+        });
     let deadline =
         web_public::escape_html(item.deadline.as_deref().unwrap_or("No deadline published"));
     let link = web_public::escape_html(&safe_opportunity_link(&item));
@@ -4143,6 +4159,11 @@ async fn opportunity_embed_page(
     let html = format!(
         r#"<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{title} · Agent Bounties</title><style>:root{{color-scheme:light dark;font-family:Inter,ui-sans-serif,system-ui,sans-serif}}*{{box-sizing:border-box}}body{{margin:0;padding:12px;background:transparent}}article{{max-width:720px;border:1px solid #6b728066;border-radius:16px;padding:20px;background:#111827;color:#f9fafb;box-shadow:0 12px 36px #0003}}header{{display:flex;justify-content:space-between;gap:12px;align-items:flex-start}}.brand{{font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#93c5fd}}h1{{font-size:21px;line-height:1.25;margin:7px 0 16px}}.states{{display:flex;flex-wrap:wrap;gap:8px}}.pill{{padding:5px 9px;border-radius:999px;background:#1f2937;font-size:12px}}dl{{display:grid;grid-template-columns:max-content 1fr;gap:8px 14px;margin:18px 0}}dt{{color:#9ca3af}}dd{{margin:0;overflow-wrap:anywhere}}footer{{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}}a{{color:#bfdbfe}}a.cta{{display:inline-block;background:#2563eb;color:white;text-decoration:none;padding:10px 14px;border-radius:9px;font-weight:700}}.proof{{font-size:12px}}.muted{{color:#9ca3af}}</style></head><body><article data-opportunity-id="{}"><header><div><div class="brand">Agent Bounties opportunity</div><h1>{title}</h1></div><div class="states"><span class="pill">Work: {work_state}</span><span class="pill">Payment: {payment_state}</span></div></header><dl><dt>Committed reward</dt><dd>{reward}</dd><dt>Deadline</dt><dd>{deadline}</dd><dt>Verification</dt><dd>{verification}</dd></dl><footer>{latest}<a class="cta" href="{link}" target="_blank" rel="noopener noreferrer">{cta}</a></footer></article></body></html>"#,
         web_public::escape_html(&item.opportunity_id),
+    );
+    let html = html.replacen(
+        "</dd><dt>Deadline</dt>",
+        &format!("</dd>{cash_rows}<dt>Deadline</dt>"),
+        1,
     );
     Ok((
         [
@@ -4233,12 +4254,22 @@ async fn opportunity_embed_markdown(
         .and_then(|url| safe_external_url(url))
         .map(|url| format!("[Latest result or settlement proof]({url})"))
         .unwrap_or_else(|| "No result or settlement proof published".to_string());
+    let cash_rows = item.cash_economics.as_ref().map_or_else(String::new, |economics| {
+        format!(
+            "| Refundable claim bond | {} |\n| Required external spend | {} |\n| Gross cash margin (not net profit) | {} |\n| Economics scope | {} |\n",
+            markdown_cell(&opportunity_amount_label(&economics.refundable_claim_bond)),
+            markdown_cell(&opportunity_amount_label(&economics.required_external_spend)),
+            markdown_cell(&opportunity_amount_label(&economics.gross_cash_margin)),
+            markdown_cell(&economics.scope_disclaimer),
+        )
+    });
     let markdown = format!(
-        "[![Agent Bounties opportunity]({svg_url})]({embed_url})\n\n### {}\n\n| Field | Current value |\n|---|---|\n| Work state | `{}` |\n| Payment state | `{}` |\n| Committed reward | {} |\n| Deadline | {} |\n| Verification | `{}` |\n| Evidence | {} |\n\n[View opportunity]({})\n",
+        "[![Agent Bounties opportunity]({svg_url})]({embed_url})\n\n### {}\n\n| Field | Current value |\n|---|---|\n| Work state | `{}` |\n| Payment state | `{}` |\n| Committed reward | {} |\n{}| Deadline | {} |\n| Verification | `{}` |\n| Evidence | {} |\n\n[View opportunity]({})\n",
         markdown_cell(&item.title),
         markdown_cell(&item.work_state),
         markdown_cell(&item.payment_state),
         markdown_cell(&committed_reward_label(&item)),
+        cash_rows,
         markdown_cell(item.deadline.as_deref().unwrap_or("No deadline published")),
         markdown_cell(&item.verification_method),
         proof,
@@ -4290,18 +4321,29 @@ fn committed_reward_label(item: &OpportunityItem) -> String {
 }
 
 fn decimal_amount(amount: &str, decimals: u8) -> String {
-    if decimals == 0 || !amount.bytes().all(|byte| byte.is_ascii_digit()) {
+    let (sign, digits) = amount
+        .strip_prefix('-')
+        .map_or(("", amount), |digits| ("-", digits));
+    if decimals == 0 || digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
         return amount.to_string();
     }
     let decimals = usize::from(decimals);
-    let padded = format!("{:0>width$}", amount, width = decimals + 1);
+    let padded = format!("{:0>width$}", digits, width = decimals + 1);
     let split = padded.len() - decimals;
     let fraction = padded[split..].trim_end_matches('0');
     if fraction.is_empty() {
-        padded[..split].to_string()
+        format!("{sign}{}", &padded[..split])
     } else {
-        format!("{}.{}", &padded[..split], fraction)
+        format!("{sign}{}.{}", &padded[..split], fraction)
     }
+}
+
+fn opportunity_amount_label(amount: &opportunities::OpportunityAmount) -> String {
+    format!(
+        "{} {}",
+        decimal_amount(&amount.amount, amount.decimals),
+        amount.currency
+    )
 }
 
 fn safe_opportunity_link(item: &OpportunityItem) -> String {
@@ -8451,7 +8493,7 @@ async fn claim_funnel(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     store
-        .claim_funnel_stats(window_hours)
+        .claim_funnel_stats(window_hours, &state.recovery_reservations.contracts())
         .await
         .map(Json)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
@@ -8724,6 +8766,9 @@ async fn build_agent_eligibility(
         })?;
     let settlements = events.iter().filter(|event| {
         event.kind == AutonomousBountyEventKind::BountySettled
+            && !state
+                .recovery_reservations
+                .contains(&event.contract_address)
             && event.data["solver"]
                 .as_str()
                 .is_some_and(|wallet| wallet.eq_ignore_ascii_case(solver_wallet))
@@ -10695,10 +10740,15 @@ async fn solver_leaderboard(
         .unwrap_or_else(Utc::now);
     let daily_period = leaderboard_period(LeaderboardPeriodKind::Daily, reference_at);
     let weekly_period = leaderboard_period(LeaderboardPeriodKind::Weekly, reference_at);
-    let completions = store
+    let mut completions = store
         .list_canonical_solver_completions(network, weekly_period.starts_at, weekly_period.ends_at)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    completions.retain(|completion| {
+        !state
+            .recovery_reservations
+            .contains(&completion.bounty_contract)
+    });
     let daily_ranking = rank_solver_completions(daily_period, completions.clone());
     let weekly_ranking = rank_solver_completions(weekly_period, completions);
     let reward_contract_env = match network_descriptor.chain_id {
@@ -11678,7 +11728,12 @@ async fn current_social_mention_plan(
     let operator_enabled = env_flag("AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED");
     let github_conversion = if operator_enabled {
         match load_autonomous_bounty_feed(state, "base-mainnet", false).await {
-            Ok(feed) => github_issue_conversion_evidence(&feed),
+            Ok(mut feed) => {
+                state
+                    .recovery_reservations
+                    .exclude_from_reported_outcomes(&mut feed);
+                github_issue_conversion_evidence(&feed)
+            }
             Err(_) => unavailable_github_conversion_evidence(),
         }
     } else {
@@ -13036,6 +13091,9 @@ async fn load_objective_canonical_evidence(
         let mut feed = build_autonomous_bounty_feed(events, terms.clone(), false)
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         state.recovery_reservations.apply(&mut feed, false);
+        state
+            .recovery_reservations
+            .exclude_from_reported_outcomes(&mut feed);
         let mut network_evidence = build_objective_canonical_evidence(&network, &feed);
         evidence.funding.append(&mut network_evidence.funding);
         evidence
@@ -13787,11 +13845,16 @@ mod tests {
             timeout_bond_pool: "0".to_string(),
             target_amount: "2100000".to_string(),
             funded_amount: "2100000".to_string(),
+            required_external_spend: "0".to_string(),
+            gross_cash_margin: "2000000".to_string(),
             terms_hash: terms_hash.clone(),
             terms: None,
             terms_valid: true,
             verification_mode: "deterministic".to_string(),
             verifier_module: None,
+            verifier_set_hash: None,
+            verifier_threshold: Some(1),
+            runner_identifier: Some("test_fixture".to_string()),
             verification_ready: true,
             verification_readiness_reason: "ready".to_string(),
             validation_errors: Vec::new(),
@@ -15193,11 +15256,16 @@ mod tests {
             timeout_bond_pool: "0".to_string(),
             target_amount: "2010000".to_string(),
             funded_amount: "2010000".to_string(),
+            required_external_spend: "0".to_string(),
+            gross_cash_margin: "2000000".to_string(),
             terms_hash: terms.terms_hash.clone(),
             terms: Some(terms),
             terms_valid: true,
             verification_mode: "signed_quorum".to_string(),
             verifier_module: None,
+            verifier_set_hash: None,
+            verifier_threshold: Some(2),
+            runner_identifier: Some("sandboxed_regression_v1".to_string()),
             verification_ready: true,
             verification_readiness_reason: "ready".to_string(),
             validation_errors: vec![],
@@ -17703,11 +17771,16 @@ mod tests {
                 timeout_bond_pool: "0".to_string(),
                 target_amount: "1000000".to_string(),
                 funded_amount: "1000000".to_string(),
+                required_external_spend: "0".to_string(),
+                gross_cash_margin: "900000".to_string(),
                 terms_hash: format!("0x{}", "44".repeat(32)),
                 terms: None,
                 terms_valid: true,
                 verification_mode: "deterministic_module".to_string(),
                 verifier_module: None,
+                verifier_set_hash: None,
+                verifier_threshold: Some(1),
+                runner_identifier: Some("test_fixture".to_string()),
                 verification_ready: true,
                 verification_readiness_reason: "test fixture".to_string(),
                 validation_errors: Vec::new(),

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -81,6 +81,16 @@ pub struct OpportunityImage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct OpportunityCashEconomics {
+    pub solver_reward: OpportunityAmount,
+    pub refundable_claim_bond: OpportunityAmount,
+    pub required_external_spend: OpportunityAmount,
+    pub gross_cash_margin: OpportunityAmount,
+    pub gross_cash_margin_positive: bool,
+    pub scope_disclaimer: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct OpportunityStandingMetaV4Economics {
     pub parent_solver_reward: OpportunityAmount,
     pub parent_verifier_reward: OpportunityAmount,
@@ -159,6 +169,8 @@ pub struct OpportunityItem {
     pub payment_committed: bool,
     pub competition_mode: String,
     pub standing_meta_bounty: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cash_economics: Option<OpportunityCashEconomics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub standing_meta_v4: Option<OpportunityStandingMetaV4>,
     pub decision_authority: String,
@@ -285,6 +297,7 @@ pub fn render_opportunity_feeds(
                 "payment_state": item.payment_state,
                 "payment_committed": item.payment_committed,
                 "reward": item.reward,
+                "cash_economics": item.cash_economics,
                 "verification_method": item.verification_method,
                 "verification_ready": item.verification_ready,
                 "terms_hash": item.terms_hash,
@@ -345,9 +358,26 @@ fn feed_summary(item: &OpportunityItem) -> String {
         .goal
         .as_deref()
         .unwrap_or("No additional goal text was supplied.");
+    let cash_economics = item
+        .cash_economics
+        .as_ref()
+        .map_or_else(String::new, |economics| {
+            format!(
+                " Solver reward: {} {} base units. Refundable claim bond: {} {} base units. Required external spend: {} {} base units. Gross cash margin (not net profit): {} {} base units. {}",
+                economics.solver_reward.amount,
+                economics.solver_reward.currency,
+                economics.refundable_claim_bond.amount,
+                economics.refundable_claim_bond.currency,
+                economics.required_external_spend.amount,
+                economics.required_external_spend.currency,
+                economics.gross_cash_margin.amount,
+                economics.gross_cash_margin.currency,
+                economics.scope_disclaimer,
+            )
+        });
     truncate_feed_text(
         &format!(
-            "{goal}\n\nWork state: {}. Payment state: {}. {reward} Verification: {}. Next action: {}",
+            "{goal}\n\nWork state: {}. Payment state: {}. {reward}{cash_economics} Verification: {}. Next action: {}",
             item.work_state,
             item.payment_state,
             item.verification_method,
@@ -492,6 +522,7 @@ pub fn unfunded_opportunity(
         payment_committed: false,
         competition_mode: "open_unfunded_submission".to_string(),
         standing_meta_bounty: false,
+        cash_economics: None,
         standing_meta_v4: None,
         decision_authority: "The poster reviews this offchain submission; no canonical verifier is configured.".to_string(),
         payment_authority: "None. This opportunity is unfunded and creates no payment promise.".to_string(),
@@ -610,6 +641,7 @@ pub fn legacy_opportunity(
         payment_committed,
         competition_mode: "exclusive_claim".to_string(),
         standing_meta_bounty: false,
+        cash_economics: None,
         standing_meta_v4: None,
         decision_authority: format!("Legacy configured verification path: {verification_method}."),
         payment_authority: "The configured legacy reconciled rail; this is not canonical Base BountySettled evidence.".to_string(),
@@ -730,6 +762,17 @@ pub fn canonical_opportunity(
             mime_type: image.mime_type.clone(),
         })
         .unwrap_or_else(|| fallback_opportunity_image(&embeds, &title));
+    let gross_cash_margin = item.gross_cash_margin.parse::<i128>().ok()?;
+    let cash_economics = OpportunityCashEconomics {
+        solver_reward: OpportunityAmount::usdc_base_units(item.solver_reward.clone()),
+        refundable_claim_bond: OpportunityAmount::usdc_base_units(item.claim_bond.clone()),
+        required_external_spend: OpportunityAmount::usdc_base_units(
+            item.required_external_spend.clone(),
+        ),
+        gross_cash_margin: OpportunityAmount::usdc_base_units(item.gross_cash_margin.clone()),
+        gross_cash_margin_positive: gross_cash_margin > 0,
+        scope_disclaimer: "Gross cash margin is solver reward minus required external spend. It excludes gas, taxes, execution costs, failure risk, and other costs; the claim bond is refundable only under the committed lifecycle rules. It is not guaranteed net profit.".to_string(),
+    };
     Some(OpportunityItem {
         opportunity_id: opportunity_id.clone(),
         source_type: "canonical_base".to_string(),
@@ -746,6 +789,7 @@ pub fn canonical_opportunity(
         payment_committed,
         competition_mode: "exclusive_claim".to_string(),
         standing_meta_bounty: standing_meta_v2_parent_context(item).is_ok(),
+        cash_economics: Some(cash_economics),
         standing_meta_v4: None,
         decision_authority: format!(
             "The immutable canonical verification mode/module configured on {} decides the submission result.",
@@ -850,10 +894,15 @@ fn apply_view(item: &mut OpportunityItem, view: OpportunityView, now: DateTime<U
             let matches = item.work_state == "claimable"
                 && item.payment_state == "escrowed"
                 && item.payment_committed
-                && item.verification_ready;
+                && item.verification_ready
+                && (item.source_type != "canonical_base"
+                    || item
+                        .cash_economics
+                        .as_ref()
+                        .is_some_and(|economics| economics.gross_cash_margin_positive));
             if matches {
                 item.discovery_factors.push(
-                    "view:ready_to_earn;factors=claimable+escrowed+verification_ready".to_string(),
+                    "view:ready_to_earn;factors=claimable+escrowed+verification_ready+positive_gross_cash_margin".to_string(),
                 );
             }
             matches
@@ -1112,7 +1161,10 @@ fn canonical_next_action(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chain_base::{AutonomousBountyEvent, AutonomousBountyEventKind};
+    use chain_base::{
+        build_autonomous_bounty_terms_record, AutonomousBountyEvent, AutonomousBountyEventKind,
+        BASE_MAINNET_STANDING_META_V2_VERIFIER,
+    };
     use domain::{
         AutonomousBountyTermsDocument, AutonomousBountyTermsRecord, BountyImageReference,
     };
@@ -1195,16 +1247,53 @@ mod tests {
             timeout_bond_pool: "0".to_string(),
             target_amount: "1000000".to_string(),
             funded_amount: funded.to_string(),
+            required_external_spend: "0".to_string(),
+            gross_cash_margin: "900000".to_string(),
             terms_hash: terms.terms_hash.clone(),
             terms: Some(terms),
             terms_valid: true,
             verification_mode: "signed_quorum".to_string(),
             verifier_module: None,
+            verifier_set_hash: None,
+            verifier_threshold: Some(2),
+            runner_identifier: Some("sandboxed_regression_v1".to_string()),
             verification_ready,
             verification_readiness_reason: "ready".to_string(),
             validation_errors: Vec::new(),
             events: vec![event],
         }
+    }
+
+    fn standing_meta() -> AutonomousBountyFeedItem {
+        let created_at = DateTime::parse_from_rfc3339("2026-07-17T02:11:34Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let document: AutonomousBountyTermsDocument =
+            serde_json::from_str(include_str!("../../../bounties/autonomous-v1/335.json")).unwrap();
+        let terms = build_autonomous_bounty_terms_record(
+            "0x1eaa1c68772cf76bc5f4e4174766076e33ace662",
+            document,
+            created_at,
+        )
+        .unwrap();
+        let mut item = canonical("claimable", "1000000", true);
+        item.bounty_id =
+            "0x12ad2fa99de272728311a3eb07c3c741048382260cb91ba1e8f001ed3b5759d0".to_string();
+        item.bounty_contract = "0x43d42cb227d76588ab16693f14efd6cff851fa7a".to_string();
+        item.creator = terms.creator_wallet.clone();
+        item.solver_reward = "900000".to_string();
+        item.verifier_reward = "100000".to_string();
+        item.claim_bond = "100000".to_string();
+        item.required_external_spend = "900000".to_string();
+        item.gross_cash_margin = "0".to_string();
+        item.terms_hash = terms.terms_hash.clone();
+        item.terms = Some(terms);
+        item.verification_mode = "deterministic_module".to_string();
+        item.verifier_module = Some(BASE_MAINNET_STANDING_META_V2_VERIFIER.to_string());
+        item.verifier_threshold = Some(1);
+        item.runner_identifier = Some("standing_meta_v2_parent".to_string());
+        item.events.clear();
+        item
     }
 
     #[test]
@@ -1246,6 +1335,92 @@ mod tests {
             unavailable.next_action.action,
             "inspect_verification_readiness"
         );
+    }
+
+    #[test]
+    fn canonical_projection_exposes_cash_economics_without_profit_claims() {
+        let item = canonical_opportunity(
+            &canonical("claimable", "1000000", true),
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+        let economics = item.cash_economics.unwrap();
+        assert_eq!(economics.solver_reward.amount, "900000");
+        assert_eq!(economics.refundable_claim_bond.amount, "100000");
+        assert_eq!(economics.required_external_spend.amount, "0");
+        assert_eq!(economics.gross_cash_margin.amount, "900000");
+        assert!(economics.gross_cash_margin_positive);
+        assert!(economics
+            .scope_disclaimer
+            .contains("not guaranteed net profit"));
+    }
+
+    #[test]
+    fn ready_to_earn_excludes_non_positive_canonical_cash_margin() {
+        let profitable = canonical_opportunity(
+            &canonical("claimable", "1000000", true),
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+        let mut unprofitable_source = canonical("claimable", "1000000", true);
+        unprofitable_source.required_external_spend = "1000000".to_string();
+        unprofitable_source.gross_cash_margin = "-100000".to_string();
+        let unprofitable =
+            canonical_opportunity(&unprofitable_source, "base-mainnet", "https://api.example")
+                .unwrap();
+
+        let items = apply_query(
+            vec![profitable, unprofitable],
+            &OpportunityQuery::default(),
+            Some(OpportunityView::ReadyToEarn),
+            DateTime::<Utc>::from_timestamp(1_800_000_100, 0).unwrap(),
+        );
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0]
+                .cash_economics
+                .as_ref()
+                .unwrap()
+                .gross_cash_margin
+                .amount,
+            "900000"
+        );
+    }
+
+    #[test]
+    fn canonical_cash_economics_cover_direct_standing_meta_and_unprofitable() {
+        let direct = canonical_opportunity(
+            &canonical("claimable", "1000000", true),
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+        let meta =
+            canonical_opportunity(&standing_meta(), "base-mainnet", "https://api.example").unwrap();
+        assert!(!direct.standing_meta_bounty);
+        assert!(
+            direct
+                .cash_economics
+                .as_ref()
+                .unwrap()
+                .gross_cash_margin_positive
+        );
+        assert!(meta.standing_meta_bounty);
+        let meta_economics = meta.cash_economics.as_ref().unwrap();
+        assert_eq!(meta_economics.required_external_spend.amount, "900000");
+        assert_eq!(meta_economics.gross_cash_margin.amount, "0");
+        assert!(!meta_economics.gross_cash_margin_positive);
+
+        let ready = apply_query(
+            vec![direct, meta],
+            &OpportunityQuery::default(),
+            Some(OpportunityView::ReadyToEarn),
+            DateTime::<Utc>::from_timestamp(1_800_000_100, 0).unwrap(),
+        );
+        assert_eq!(ready.len(), 1);
+        assert!(!ready[0].standing_meta_bounty);
     }
 
     #[test]
@@ -1317,5 +1492,35 @@ mod tests {
         assert_eq!(json["items"][0]["_bountyboard"]["payment_committed"], false);
         assert!(!feeds.rss.to_ascii_lowercase().contains("trial"));
         assert_eq!(feeds.updated_at, "Fri, 15 Jan 2027 08:00:00 GMT");
+    }
+
+    #[test]
+    fn live_feed_reuses_canonical_cash_economics() {
+        let item = canonical_opportunity(
+            &canonical("claimable", "1000000", true),
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+        let projection = OpportunityProjectionResponse {
+            schema_version: OPPORTUNITY_PROJECTION_SCHEMA.to_string(),
+            generated_at: "2027-01-15T08:01:00Z".to_string(),
+            network: "base-mainnet".to_string(),
+            applied_view: None,
+            degraded: false,
+            source_statuses: Vec::new(),
+            items: vec![item],
+            evidence_boundary: "Projection only".to_string(),
+        };
+
+        let feeds = render_opportunity_feeds(&projection, "https://api.example/");
+        let json: Value = serde_json::from_str(&feeds.json).unwrap();
+        let economics = &json["items"][0]["_bountyboard"]["cash_economics"];
+        assert_eq!(economics["solver_reward"]["amount"], "900000");
+        assert_eq!(economics["refundable_claim_bond"]["amount"], "100000");
+        assert_eq!(economics["required_external_spend"]["amount"], "0");
+        assert_eq!(economics["gross_cash_margin"]["amount"], "900000");
+        assert!(feeds.rss.contains("Gross cash margin (not net profit)"));
+        assert!(!feeds.rss.to_ascii_lowercase().contains("guaranteed profit"));
     }
 }

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -3398,11 +3398,21 @@ pub struct AutonomousBountyFeedItem {
     pub timeout_bond_pool: String,
     pub target_amount: String,
     pub funded_amount: String,
+    #[serde(default)]
+    pub required_external_spend: String,
+    #[serde(default)]
+    pub gross_cash_margin: String,
     pub terms_hash: String,
     pub terms: Option<AutonomousBountyTermsRecord>,
     pub terms_valid: bool,
     pub verification_mode: String,
     pub verifier_module: Option<String>,
+    #[serde(default)]
+    pub verifier_set_hash: Option<String>,
+    #[serde(default)]
+    pub verifier_threshold: Option<u8>,
+    #[serde(default)]
+    pub runner_identifier: Option<String>,
     pub verification_ready: bool,
     pub verification_readiness_reason: String,
     pub validation_errors: Vec<String>,
@@ -3662,6 +3672,16 @@ impl AutonomousBountyRecoveryReservations {
     pub fn exclude_from_verification_jobs(&self, feed: &mut Vec<AutonomousBountyFeedItem>) {
         feed.retain(|item| !self.contains(&item.bounty_contract));
     }
+
+    pub fn exclude_from_reported_outcomes(&self, feed: &mut Vec<AutonomousBountyFeedItem>) {
+        feed.retain(|item| !self.contains(&item.bounty_contract));
+    }
+
+    pub fn contracts(&self) -> Vec<String> {
+        let mut contracts = self.contracts.iter().cloned().collect::<Vec<_>>();
+        contracts.sort();
+        contracts
+    }
 }
 
 pub fn autonomous_bounty_is_earning_ready(item: &AutonomousBountyFeedItem) -> bool {
@@ -3849,25 +3869,66 @@ fn verifier_set_hash_from_policy(policy: &Value) -> Result<String, ChainBaseErro
     Ok(format!("0x{}", hex::encode(Keccak256::digest(encoded))))
 }
 
+#[cfg(test)]
 fn is_supported_regression_quorum(
     creation_data: &Value,
     terms: Option<&AutonomousBountyTermsRecord>,
 ) -> bool {
+    regression_quorum_readiness(creation_data, terms).0
+}
+
+fn regression_quorum_readiness(
+    creation_data: &Value,
+    terms: Option<&AutonomousBountyTermsRecord>,
+) -> (bool, &'static str) {
     let Some(terms) = terms else {
-        return false;
+        return (false, "quorum terms are unavailable");
     };
     let policy = &terms.document.verification_policy;
     let benchmark = &terms.document.benchmark;
-    creation_data["verifier_set_hash"]
+    if !creation_data["verifier_set_hash"]
         .as_str()
         .is_some_and(|hash| {
             hash.eq_ignore_ascii_case(BASE_MAINNET_STANDING_META_V2_VERIFIER_SET_HASH)
         })
-        && creation_data["threshold"].as_u64()
-            == Some(BASE_MAINNET_STANDING_META_V2_VERIFIERS.len() as u64)
-        && policy.get("mechanism").and_then(Value::as_str) == Some("signed_quorum")
-        && policy.get("engine").and_then(Value::as_str) == Some(STANDING_META_V2_REGRESSION_ENGINE)
-        && valid_regression_benchmark(benchmark)
+    {
+        return (false, "verifier set mismatch");
+    }
+    if creation_data["threshold"].as_u64()
+        != Some(BASE_MAINNET_STANDING_META_V2_VERIFIERS.len() as u64)
+    {
+        return (false, "verifier threshold mismatch");
+    }
+    let configured_signers = policy
+        .get("verifiers")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    if configured_signers.len() < BASE_MAINNET_STANDING_META_V2_VERIFIERS.len() {
+        return (false, "required verifier signer is missing");
+    }
+    if policy.get("mechanism").and_then(Value::as_str) != Some("signed_quorum") {
+        return (false, "signed-quorum policy is unavailable");
+    }
+    if policy.get("engine").and_then(Value::as_str) != Some(STANDING_META_V2_REGRESSION_ENGINE)
+        || benchmark.get("engine").and_then(Value::as_str)
+            != Some(STANDING_META_V2_REGRESSION_ENGINE)
+    {
+        return (
+            false,
+            "regression runner identifier is stale or unsupported",
+        );
+    }
+    if !valid_regression_benchmark(benchmark) {
+        return (
+            false,
+            "regression runner manifest is unavailable or invalid",
+        );
+    }
+    (
+        true,
+        "the exact built-in sandboxed-regression quorum is supported",
+    )
 }
 
 fn valid_regression_benchmark(benchmark: &Value) -> bool {
@@ -4924,15 +4985,55 @@ pub fn build_autonomous_bounty_feed(
             validation_errors.push(error);
         }
         let terms_valid = validation_errors.is_empty();
+        let verifier_set_hash = creation_data["verifier_set_hash"]
+            .as_str()
+            .map(str::to_string);
+        let verifier_threshold = creation_data["threshold"]
+            .as_u64()
+            .and_then(|value| u8::try_from(value).ok());
+        let runner_identifier = terms_record.as_ref().and_then(|terms| {
+            terms
+                .document
+                .benchmark
+                .get("runner_manifest")
+                .and_then(|manifest| manifest.get("runner_id"))
+                .and_then(Value::as_str)
+                .or_else(|| {
+                    terms
+                        .document
+                        .benchmark
+                        .get("engine")
+                        .and_then(Value::as_str)
+                })
+                .or_else(|| {
+                    terms
+                        .document
+                        .verification_policy
+                        .get("mechanism")
+                        .and_then(Value::as_str)
+                })
+                .map(str::to_string)
+        });
+        let required_external_spend = terms_record
+            .as_ref()
+            .and_then(|terms| {
+                let benchmark = &terms.document.benchmark;
+                benchmark
+                    .get("minimum_child_target")
+                    .or_else(|| benchmark.get("required_child_target"))
+                    .and_then(Value::as_u64)
+                    .or_else(|| {
+                        (benchmark.get("engine").and_then(Value::as_str)
+                            == Some("standing_meta_v2_parent"))
+                        .then_some(solver_reward)
+                    })
+            })
+            .unwrap_or(0);
+        let gross_cash_margin = i128::from(solver_reward) - i128::from(required_external_spend);
         let (verification_ready, verification_readiness_reason) = if !terms_valid {
             (false, "content-addressed terms are invalid or unavailable")
-        } else if verification_mode == "signed_quorum"
-            && is_supported_regression_quorum(&creation_data, terms_record.as_ref())
-        {
-            (
-                true,
-                "the exact built-in sandboxed-regression quorum is supported",
-            )
+        } else if verification_mode == "signed_quorum" {
+            regression_quorum_readiness(&creation_data, terms_record.as_ref())
         } else if verification_mode != "deterministic_module" {
             (
                 false,
@@ -4971,11 +5072,16 @@ pub fn build_autonomous_bounty_feed(
             timeout_bond_pool: timeout_bond_pool.to_string(),
             target_amount: target_amount.to_string(),
             funded_amount: funded_amount.to_string(),
+            required_external_spend: required_external_spend.to_string(),
+            gross_cash_margin: gross_cash_margin.to_string(),
             terms_hash: terms_hash.clone(),
             terms: terms_record,
             terms_valid,
             verification_mode: verification_mode.to_string(),
             verifier_module,
+            verifier_set_hash,
+            verifier_threshold,
+            runner_identifier,
             verification_ready,
             verification_readiness_reason: verification_readiness_reason.to_string(),
             validation_errors,
@@ -7145,11 +7251,16 @@ mod tests {
             timeout_bond_pool: "0".to_string(),
             target_amount: "1000000".to_string(),
             funded_amount: "1000000".to_string(),
+            required_external_spend: "900000".to_string(),
+            gross_cash_margin: "0".to_string(),
             terms_hash: terms.terms_hash.clone(),
             terms: Some(terms),
             terms_valid: true,
             verification_mode: "deterministic_module".to_string(),
             verifier_module: Some(BASE_MAINNET_STANDING_META_V2_VERIFIER.to_string()),
+            verifier_set_hash: Some(BASE_MAINNET_STANDING_META_V2_VERIFIER_SET_HASH.to_string()),
+            verifier_threshold: Some(1),
+            runner_identifier: Some("standing_meta_v2_parent".to_string()),
             verification_ready: true,
             verification_readiness_reason: "exact deployed verifier".to_string(),
             validation_errors: vec![],
@@ -7714,7 +7825,15 @@ mod tests {
         assert_eq!(feed.len(), 1);
         assert_eq!(feed[0].status, "paid");
         assert_eq!(feed[0].funded_amount, "1000000");
+        assert_eq!(feed[0].required_external_spend, "0");
+        assert_eq!(feed[0].gross_cash_margin, "900000");
         assert_eq!(feed[0].verification_mode, "ai_judge_quorum");
+        assert_eq!(feed[0].verifier_threshold, Some(2));
+        assert_eq!(
+            feed[0].verifier_set_hash,
+            Some(format!("0x{}", "0a".repeat(32)))
+        );
+        assert_eq!(feed[0].runner_identifier, None);
         assert!(!feed[0].verification_ready);
     }
 
@@ -7889,6 +8008,41 @@ mod tests {
         let supported_record =
             build_autonomous_bounty_terms_record(&record.creator_wallet, supported_document, now)
                 .unwrap();
+        let healthy_quorum = json!({
+            "verifier_set_hash": BASE_MAINNET_STANDING_META_V2_VERIFIER_SET_HASH,
+            "threshold": 2
+        });
+        assert_eq!(
+            regression_quorum_readiness(&healthy_quorum, Some(&supported_record)),
+            (
+                true,
+                "the exact built-in sandboxed-regression quorum is supported"
+            )
+        );
+        let mut missing_signer = supported_record.clone();
+        missing_signer.document.verification_policy["verifiers"] =
+            json!([BASE_MAINNET_STANDING_META_V2_VERIFIERS[0]]);
+        assert_eq!(
+            regression_quorum_readiness(&healthy_quorum, Some(&missing_signer)).1,
+            "required verifier signer is missing"
+        );
+        let mut stale_runner = supported_record.clone();
+        stale_runner.document.verification_policy["engine"] = json!("sandboxed_regression_v0");
+        assert_eq!(
+            regression_quorum_readiness(&healthy_quorum, Some(&stale_runner)).1,
+            "regression runner identifier is stale or unsupported"
+        );
+        assert_eq!(
+            regression_quorum_readiness(
+                &json!({
+                    "verifier_set_hash": format!("0x{}", "00".repeat(32)),
+                    "threshold": 2
+                }),
+                Some(&supported_record),
+            )
+            .1,
+            "verifier set mismatch"
+        );
         let mut supported_create = autonomous_bounty_create_from_terms(&supported_record).unwrap();
         validate_autonomous_creation_for_public_earning(
             "base-mainnet",
@@ -8149,11 +8303,16 @@ mod tests {
             timeout_bond_pool: "0".to_string(),
             target_amount: "1000000".to_string(),
             funded_amount: "1000000".to_string(),
+            required_external_spend: "0".to_string(),
+            gross_cash_margin: "900000".to_string(),
             terms_hash: format!("0x{}", "aa".repeat(32)),
             terms: None,
             terms_valid: true,
             verification_mode: "deterministic_module".to_string(),
             verifier_module: Some("0x5555555555555555555555555555555555555555".to_string()),
+            verifier_set_hash: None,
+            verifier_threshold: Some(1),
+            runner_identifier: Some("fixture".to_string()),
             verification_ready: true,
             verification_readiness_reason: "deterministic verifier module is committed on-chain"
                 .to_string(),
@@ -8213,6 +8372,8 @@ mod tests {
             timeout_bond_pool: "0".to_string(),
             target_amount: "2000000".to_string(),
             funded_amount: "2000000".to_string(),
+            required_external_spend: "0".to_string(),
+            gross_cash_margin: "1900000".to_string(),
             terms_hash: format!("0x{}", "aa".repeat(32)),
             terms: Some(AutonomousBountyTermsRecord {
                 terms_hash: format!("0x{}", "aa".repeat(32)),
@@ -8247,6 +8408,9 @@ mod tests {
             terms_valid: true,
             verification_mode: "deterministic_module".to_string(),
             verifier_module: Some("0x5555555555555555555555555555555555555555".to_string()),
+            verifier_set_hash: None,
+            verifier_threshold: Some(1),
+            runner_identifier: Some("deterministic_module".to_string()),
             verification_ready: true,
             verification_readiness_reason: "deterministic verifier module is committed on-chain"
                 .to_string(),
@@ -8397,6 +8561,8 @@ mod tests {
             timeout_bond_pool: "0".to_string(),
             target_amount: "1000000".to_string(),
             funded_amount: "1000000".to_string(),
+            required_external_spend: "0".to_string(),
+            gross_cash_margin: "900000".to_string(),
             terms_hash: format!("0x{}", "aa".repeat(32)),
             terms: Some(AutonomousBountyTermsRecord {
                 terms_hash: format!("0x{}", "aa".repeat(32)),
@@ -8442,6 +8608,9 @@ mod tests {
             terms_valid: true,
             verification_mode: "signed_quorum".to_string(),
             verifier_module: None,
+            verifier_set_hash: None,
+            verifier_threshold: Some(1),
+            runner_identifier: Some("github_ci".to_string()),
             verification_ready: false,
             verification_readiness_reason:
                 "quorum verifier service availability is not canonically attested".to_string(),
@@ -8547,11 +8716,16 @@ mod tests {
             timeout_bond_pool: "0".to_string(),
             target_amount: "1000000".to_string(),
             funded_amount: "1000000".to_string(),
+            required_external_spend: "0".to_string(),
+            gross_cash_margin: "900000".to_string(),
             terms_hash: format!("0x{}", "aa".repeat(32)),
             terms: None,
             terms_valid: false,
             verification_mode: "signed_quorum".to_string(),
             verifier_module: None,
+            verifier_set_hash: None,
+            verifier_threshold: Some(1),
+            runner_identifier: None,
             verification_ready: false,
             verification_readiness_reason: "content-addressed terms are invalid or unavailable"
                 .to_string(),

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1552,6 +1552,7 @@ impl PostgresStore {
     pub async fn opportunity_lifecycle_stats(
         &self,
         window_started_at: DateTime<Utc>,
+        excluded_bounty_contracts: &[String],
     ) -> DbResult<OpportunityLifecycleStats> {
         let cohort = sqlx::query(
             r#"
@@ -1577,6 +1578,7 @@ impl PostgresStore {
                 ON created.network = progress.network
                AND created.kind = 'canonical_bounty_created'
                AND lower(created.data->>'terms_hash') = lower(progress.terms_hash)
+               AND NOT lower(created.contract_address) = ANY($2)
             ), root_flags AS (
               SELECT roots.unfunded_bounty_id,
                      BOOL_OR(event.kind = 'bounty_became_claimable') AS funded,
@@ -1608,6 +1610,7 @@ impl PostgresStore {
             "#,
         )
         .bind(window_started_at)
+        .bind(excluded_bounty_contracts)
         .fetch_one(&self.pool)
         .await?;
 
@@ -1617,31 +1620,37 @@ impl PostgresStore {
               SELECT network, bounty_id, MIN(occurred_at) AS created_at
               FROM autonomous_bounty_events
               WHERE kind = 'canonical_bounty_created' AND occurred_at >= $1
+                AND NOT lower(contract_address) = ANY($2)
               GROUP BY network, bounty_id
             ), settled AS (
               SELECT network, bounty_id, MIN(occurred_at) AS settled_at
               FROM autonomous_bounty_events
               WHERE kind = 'bounty_settled'
+                AND NOT lower(contract_address) = ANY($2)
               GROUP BY network, bounty_id
             ), posters AS (
               SELECT lower(data->>'creator') AS wallet, COUNT(DISTINCT bounty_id) AS bounties
               FROM autonomous_bounty_events
               WHERE kind = 'canonical_bounty_created' AND occurred_at >= $1
                 AND data ? 'creator'
+                AND NOT lower(contract_address) = ANY($2)
               GROUP BY lower(data->>'creator')
             ), paid_solvers AS (
               SELECT lower(data->>'solver') AS wallet, COUNT(DISTINCT bounty_id) AS bounties
               FROM autonomous_bounty_events
               WHERE kind = 'bounty_settled' AND occurred_at >= $1
                 AND data ? 'solver'
+                AND NOT lower(contract_address) = ANY($2)
               GROUP BY lower(data->>'solver')
             )
             SELECT
               (SELECT COUNT(*) FROM created) AS canonical_created_in_window,
               (SELECT COUNT(DISTINCT (network, bounty_id)) FROM autonomous_bounty_events
-                WHERE kind = 'bounty_claimed' AND occurred_at >= $1) AS canonical_claimed_in_window,
+                WHERE kind = 'bounty_claimed' AND occurred_at >= $1
+                  AND NOT lower(contract_address) = ANY($2)) AS canonical_claimed_in_window,
               (SELECT COUNT(DISTINCT (network, bounty_id)) FROM autonomous_bounty_events
-                WHERE kind = 'bounty_settled' AND occurred_at >= $1) AS canonical_settled_in_window,
+                WHERE kind = 'bounty_settled' AND occurred_at >= $1
+                  AND NOT lower(contract_address) = ANY($2)) AS canonical_settled_in_window,
               (SELECT COUNT(*) FROM posters) AS unique_canonical_poster_wallets,
               (SELECT COUNT(*) FROM posters WHERE bounties > 1) AS repeat_canonical_poster_wallets,
               (SELECT COUNT(*) FROM paid_solvers) AS unique_paid_solver_wallets,
@@ -1652,6 +1661,7 @@ impl PostgresStore {
             "#,
         )
         .bind(window_started_at)
+        .bind(excluded_bounty_contracts)
         .fetch_one(&self.pool)
         .await?;
 
@@ -3045,7 +3055,11 @@ impl PostgresStore {
             .transpose()
     }
 
-    pub async fn claim_funnel_stats(&self, window_hours: u32) -> DbResult<ClaimFunnelStats> {
+    pub async fn claim_funnel_stats(
+        &self,
+        window_hours: u32,
+        excluded_bounty_contracts: &[String],
+    ) -> DbResult<ClaimFunnelStats> {
         let window_hours = window_hours.clamp(1, 720);
         let generated_at = Utc::now();
         let window_started_at = generated_at - chrono::Duration::hours(i64::from(window_hours));
@@ -3066,9 +3080,11 @@ impl PostgresStore {
               COUNT(*) FILTER (WHERE status = 'failed') AS failed
             FROM claim_candidates
             WHERE created_at >= $1
+              AND NOT lower(bounty_contract) = ANY($2)
             "#,
         )
         .bind(window_started_at)
+        .bind(excluded_bounty_contracts)
         .fetch_one(&self.pool)
         .await?;
         let stages = ClaimFunnelStageCounts {
@@ -3100,9 +3116,11 @@ impl PostgresStore {
             FROM bond_sponsorships sponsorship
             JOIN claim_candidates candidate ON candidate.id = sponsorship.claim_candidate_id
             WHERE sponsorship.created_at >= $1
+              AND NOT lower(candidate.bounty_contract) = ANY($2)
             "#,
         )
         .bind(window_started_at)
+        .bind(excluded_bounty_contracts)
         .fetch_one(&self.pool)
         .await?;
         let sponsored_claims_confirmed =
@@ -3124,6 +3142,7 @@ impl PostgresStore {
               FROM autonomous_bounty_events
               WHERE occurred_at >= $1
                 AND kind IN ('bounty_claimed', 'submission_added', 'bounty_settled')
+                AND NOT lower(contract_address) = ANY($2)
             ), paid_solvers AS (
               SELECT solver_wallet, COUNT(*) AS settlement_count
               FROM window_events
@@ -3160,6 +3179,7 @@ impl PostgresStore {
             "#,
         )
         .bind(window_started_at)
+        .bind(excluded_bounty_contracts)
         .fetch_one(&self.pool)
         .await?;
         let canonical_outcomes = CanonicalClaimOutcomeCounts {
@@ -3187,11 +3207,13 @@ impl PostgresStore {
             SELECT failure_code, COUNT(*) AS count
             FROM claim_candidates
             WHERE created_at >= $1 AND status = 'failed' AND failure_code IS NOT NULL
+              AND NOT lower(bounty_contract) = ANY($2)
             GROUP BY failure_code
             ORDER BY failure_code
             "#,
         )
         .bind(window_started_at)
+        .bind(excluded_bounty_contracts)
         .fetch_all(&self.pool)
         .await?;
         let mut failure_codes = BTreeMap::new();
@@ -7309,7 +7331,7 @@ mod tests {
         store.migrate().await.unwrap();
 
         let stats = store
-            .opportunity_lifecycle_stats(Utc::now() - chrono::Duration::hours(1))
+            .opportunity_lifecycle_stats(Utc::now() - chrono::Duration::hours(1), &[])
             .await
             .unwrap();
         assert!(stats.solution_received <= stats.published);
@@ -7545,7 +7567,7 @@ mod tests {
         let database_url = std::env::var("AGENT_BOUNTIES_TEST_DATABASE_URL").unwrap();
         let store = PostgresStore::connect(&database_url).await.unwrap();
         store.migrate().await.unwrap();
-        let baseline = store.claim_funnel_stats(1).await.unwrap();
+        let baseline = store.claim_funnel_stats(1, &[]).await.unwrap();
         let network = format!("funnel-test-{}", Uuid::new_v4());
         let address = |id: Uuid| {
             let value = id.simple().to_string();
@@ -7722,7 +7744,7 @@ mod tests {
                 .unwrap();
         }
 
-        let observed = store.claim_funnel_stats(1).await.unwrap();
+        let observed = store.claim_funnel_stats(1, &[]).await.unwrap();
         assert_eq!(observed.stages.observed, baseline.stages.observed + 2);
         assert_eq!(
             observed.stages.unique_solver_wallets,

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use super::ChatgptFileInput;
 use super::{
     agent_native_claim, compile_objective_with_cloud_agent, fund_bounty_with_x402, get_paid_status,
     get_x402_relay_status, list_autonomous_bounties, list_autonomous_verification_jobs,
@@ -17,6 +15,8 @@ use super::{
     PublishAutonomousSubmissionEvidenceArgs, PublishUnfundedBountyArgs, SharedState,
     SubmitUnfundedBountySolutionArgs, ToolDescriptor, X402BountyFundingArgs,
 };
+#[cfg(test)]
+use super::{AppState, ChatgptFileInput};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -53,6 +53,7 @@ const CHATGPT_FULL_TOOL_NAMES: &[&str] = &[
     "add_bounty_comment",
     "create_share_bundle",
     "prepare_bounty_post",
+    "list_autonomous_bounties",
 ];
 #[derive(Debug, Clone, Deserialize)]
 struct ChatgptFeedArgs {
@@ -708,6 +709,12 @@ fn mcp_tool_descriptor_for_mode(
         value.insert(
             "outputSchema".to_string(),
             feed_output_schema(public_review),
+        );
+    }
+    if descriptor.name == "list_autonomous_bounties" {
+        value.insert(
+            "outputSchema".to_string(),
+            autonomous_bounty_feed_output_schema(),
         );
     }
     if matches!(
@@ -3026,6 +3033,43 @@ fn moonpay_onramp_output_schema() -> Value {
     })
 }
 
+fn autonomous_bounty_feed_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "bounty_id": {"type": "string"},
+                        "bounty_contract": {"type": "string"},
+                        "status": {"type": "string"},
+                        "solver_reward": {"type": "string"},
+                        "claim_bond": {"type": "string"},
+                        "required_external_spend": {"type": "string"},
+                        "gross_cash_margin": {"type": "string"},
+                        "terms_hash": {"type": "string"},
+                        "verification_ready": {"type": "boolean"},
+                        "verification_readiness_reason": {"type": "string"}
+                    },
+                    "required": [
+                        "bounty_id", "bounty_contract", "status", "solver_reward",
+                        "claim_bond", "required_external_spend", "gross_cash_margin",
+                        "terms_hash", "verification_ready",
+                        "verification_readiness_reason"
+                    ],
+                    "additionalProperties": true
+                }
+            },
+            "sandbox": {"type": "boolean"},
+            "evidence_boundary": {"type": "string"}
+        },
+        "required": ["items"],
+        "additionalProperties": true
+    })
+}
+
 fn bounty_action_output_schema() -> Value {
     json!({
         "type": "object",
@@ -3469,6 +3513,9 @@ fn json_rpc_error(id: Value, code: i64, message: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use app::BountyNetwork;
+    use chain_base::{AutonomousBountyRecoveryReservations, BaseRpcUrlConfig};
+    use std::sync::{Arc, Mutex};
 
     fn valid_args() -> PrepareBountyPostArgs {
         PrepareBountyPostArgs {
@@ -3669,6 +3716,16 @@ mod tests {
             .iter()
             .find(|tool| tool["name"] == "get_bounty_action_status")
             .expect("canonical action status tool");
+        let autonomous_feed = tools
+            .iter()
+            .find(|tool| tool["name"] == "list_autonomous_bounties")
+            .expect("canonical autonomous feed tool");
+        assert!(
+            autonomous_feed["outputSchema"]["properties"]["items"]["items"]["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("gross_cash_margin"))
+        );
 
         assert_eq!(prepare["annotations"]["readOnlyHint"], false);
         assert_eq!(prepare["annotations"]["destructiveHint"], false);
@@ -3734,6 +3791,7 @@ mod tests {
             "add_bounty_comment",
             "create_share_bundle",
             "prepare_bounty_post",
+            "list_autonomous_bounties",
         ] {
             assert!(
                 tools.iter().any(|tool| tool["name"] == name),
@@ -3773,6 +3831,43 @@ mod tests {
             .unwrap()
             .iter()
             .any(|field| field == "bounty_image"));
+    }
+
+    fn public_tool_test_state() -> SharedState {
+        Arc::new(AppState {
+            network: Mutex::new(BountyNetwork::default()),
+            eval_runs: Mutex::new(Vec::new()),
+            base_rpc_urls: BaseRpcUrlConfig::default(),
+            base_broadcast_enabled: false,
+            stripe_secret_key: None,
+            stripe_live_execution_enabled: false,
+            stripe_api_base_url: "https://api.stripe.com".to_string(),
+            stripe_payment_method_configuration: None,
+            operator_api_token: None,
+            store: None,
+            recovery_reservations: AutonomousBountyRecoveryReservations::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn mounted_public_inventory_tool_is_callable_and_fails_closed() {
+        let params = json!({
+            "name": "list_autonomous_bounties",
+            "arguments": {"network": "base-mainnet", "claimable_only": true}
+        });
+        let result = call_tool(public_tool_test_state(), &params).await.unwrap();
+        let encoded = serde_json::to_string(&result).unwrap();
+        assert!(!encoded.contains("unknown or unavailable public ChatGPT app tool"));
+        assert!(encoded.contains("DATABASE_URL"));
+        assert!(!encoded.contains("\"paid\":true"));
+
+        let error = call_tool(
+            public_tool_test_state(),
+            &json!({"name": "not_a_real_tool", "arguments": {}}),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("unknown or unavailable public ChatGPT app tool"));
     }
 
     #[test]

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -7021,6 +7021,9 @@ async fn load_objective_canonical_evidence(
         let mut feed = build_autonomous_bounty_feed(events, terms.clone(), false)
             .map_err(|error| error.to_string())?;
         state.recovery_reservations.apply(&mut feed, false);
+        state
+            .recovery_reservations
+            .exclude_from_reported_outcomes(&mut feed);
         let mut network_evidence = build_objective_canonical_evidence(&network, &feed);
         evidence.funding.append(&mut network_evidence.funding);
         evidence

--- a/docs/direct-recovery-689.md
+++ b/docs/direct-recovery-689.md
@@ -1,0 +1,64 @@
+# Direct Recovery 689
+
+Issue [#689](https://github.com/NSPG13/agent-bounties/issues/689) is the
+public accounting record for five Base-mainnet direct bounties that became
+unusable because their committed verifier path was not executable.
+
+This recovery does not bypass the bounties' acceptance criteria. It implements
+the five tasks, runs the repository gate and each task's published check,
+submits the exact resulting commit as evidence, and requires two independent
+signatures from the immutable verifier set before settlement.
+
+## Exact Scope
+
+The machine-readable allowlist is
+`ops/recovery/direct-mainnet-689.json`. The recovery script rejects any
+contract, issue, chain, token, creator, verifier set, terms hash, policy hash,
+acceptance hash, benchmark hash, evidence schema hash, or amount outside that
+manifest.
+
+The five contracts hold 10 USDC in total. The operator solver needs 0.05 USDC
+for five refundable 0.01 USDC claim bonds. Successful settlement returns
+exactly 10 USDC to the disclosed owner wallet and pays 0.025 USDC to each
+immutable verifier wallet.
+
+The external claim on issue #639 and every standing-meta contract are outside
+this recovery. They must not be claimed, signed, settled, or refunded through
+this workflow.
+
+## Evidence Boundary
+
+Recovery settlements are operational accounting, not organic marketplace
+activity. They are excluded from:
+
+- funded-loop and external-solver counts
+- adoption, retention, and conversion metrics
+- revenue and marketplace-volume metrics
+- solver reputation and leaderboards
+
+Only canonical `BountySettled` events prove settlement. A passing command,
+pull-request merge, workflow run, transaction broadcast, or verifier signature
+is not payment evidence.
+
+## Procedure
+
+1. Merge the reviewed implementation PR into `main`.
+2. Transfer exactly 0.05 USDC on Base mainnet to the disclosed operator solver.
+3. Dispatch `Direct recovery 689` from the exact current `main` revision with
+   confirmation `RECOVER ISSUE 689 EXACTLY 10 USDC`.
+4. The workflow comments on #689 before any value-bearing transaction.
+5. The prepare job reruns all checks, claims, and submits the five contracts.
+6. Two isolated signer jobs rerun the checks and sign exact EIP-712
+   attestations.
+7. The relay job reruns the checks, verifies both signer artifacts, settles the
+   exact contracts, returns exactly 10 USDC, and posts transaction evidence.
+8. Reconcile the five canonical events and confirm recovery-excluded metrics.
+
+Use the read-only audit at any time:
+
+```bash
+python scripts/direct_recovery_689.py \
+  --rpc-url https://mainnet.base.org \
+  audit \
+  --output target/direct-recovery-audit.json
+```

--- a/fixtures/profitable-canonical-opportunity.json
+++ b/fixtures/profitable-canonical-opportunity.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "agent-bounties/profitable-inventory-contract-v1",
+  "source_type": "canonical_base",
+  "source_status": "claimable",
+  "work_state": "claimable",
+  "payment_state": "escrowed",
+  "payment_committed": true,
+  "reward": {
+    "amount": "1990000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funded_amount": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funding_target": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "bond": {
+    "amount": "10000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "terms_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "verification_ready": true,
+  "cash_economics": {
+    "solver_reward": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "refundable_claim_bond": {
+      "amount": "10000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "required_external_spend": {
+      "amount": "0",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin_positive": true,
+    "scope_disclaimer": "Gross cash margin excludes gas, compute, taxes, exchange costs, and the opportunity cost of the refundable bond; it is not guaranteed net profit."
+  }
+}

--- a/ops/recovery/direct-mainnet-689.json
+++ b/ops/recovery/direct-mainnet-689.json
@@ -1,0 +1,111 @@
+{
+  "schema": "agent-bounties/direct-recovery-689-v1",
+  "notice_url": "https://github.com/NSPG13/agent-bounties/issues/689",
+  "network": "base-mainnet",
+  "chain_id": 8453,
+  "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  "creator": "0x1eaa1c68772cf76bc5f4e4174766076e33ace662",
+  "operator_solver": "0xc26a630e85134ed30968735c8e7de4576cfa5dbc",
+  "return_recipient": "0x884834e884d6e93462655a2820140ad03e6747bc",
+  "verifiers": [
+    "0xbe6292b9e465f549e2363b918d6dd9187038431e",
+    "0xb7c2ce6430b66fb986e27b6140b29309550d487a"
+  ],
+  "verifier_set_hash": "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
+  "threshold": 2,
+  "solver_reward_per_bounty": 1990000,
+  "verifier_reward_per_bounty": 10000,
+  "claim_bond_per_bounty": 10000,
+  "initial_solver_bond_total": 50000,
+  "exact_return_amount": 10000000,
+  "metrics_classification": "operator_recovery_excluded",
+  "required_repository_command": [
+    "python",
+    "scripts/check.py",
+    "--platform",
+    "posix"
+  ],
+  "bounties": [
+    {
+      "issue": 634,
+      "contract": "0xc13ccf6c6a03b53f836d433c5e628f06bbc1dbf4",
+      "bounty_id": "0x992aabb2ba8bd33947529e9c58b67b611f29dc3a4db5760db470229f04828cbf",
+      "terms_hash": "0x7901e32d509f96be1d2c171cb9dbee2cb7ce8064bc132ea75f2eebca914f67ef",
+      "policy_hash": "0xa59c1b94ede49798d9382c329d49d9f2ce1935a73ad3c972a9315feafe870857",
+      "acceptance_criteria_hash": "0x698d726d66aaeac22857d1709670b467e609ece1ea0a3f94ad58cdf080ed3cb8",
+      "benchmark_hash": "0xe1dc13ea3add4c2dd99afcc089843a6dc9e5aeff8c5fbad92e1be486ac123f9c",
+      "evidence_schema_hash": "0x1aca62507de0bcde1a36e353b228321e6d35b4eaafe64a8fa5027f20b3a2f4e5",
+      "check": [
+        "cargo",
+        "test",
+        "-p",
+        "mcp-server",
+        "mounted_public_inventory_tool_is_callable_and_fails_closed"
+      ]
+    },
+    {
+      "issue": 635,
+      "contract": "0xad4532e45d371ff5b5c40ebbf0c20687ed9e6fc4",
+      "bounty_id": "0x2f317d9500815d7054ddc4a611ac171e0f31fca2f570924d47ca52c875ea1842",
+      "terms_hash": "0x3b7f2ffa749225d07816e20c96922e7b163c3e26069b4755f60b4b679f85841f",
+      "policy_hash": "0xa59c1b94ede49798d9382c329d49d9f2ce1935a73ad3c972a9315feafe870857",
+      "acceptance_criteria_hash": "0x5edd8b4a2b49974b104053c93cca7b2bd47e2f34effb52f801cacb881c35810c",
+      "benchmark_hash": "0xe1dc13ea3add4c2dd99afcc089843a6dc9e5aeff8c5fbad92e1be486ac123f9c",
+      "evidence_schema_hash": "0x1aca62507de0bcde1a36e353b228321e6d35b4eaafe64a8fa5027f20b3a2f4e5",
+      "check": [
+        "python",
+        "scripts/test_profitable_inventory_contract.py",
+        "-v"
+      ]
+    },
+    {
+      "issue": 636,
+      "contract": "0xf2e47a253988e98f535ab60f4b9bd7f8975c1263",
+      "bounty_id": "0x8ec846408afab2725ceedd7ec7f4241e01ed6c881730e6f216612d1a69e2788b",
+      "terms_hash": "0x9c74374f960bdacb5227aaaa60093dcf644362bda50edad0ca5df02aea8ae46f",
+      "policy_hash": "0xa59c1b94ede49798d9382c329d49d9f2ce1935a73ad3c972a9315feafe870857",
+      "acceptance_criteria_hash": "0xf56568606c2185bfe08e0cd8c49989a443c8b8e35249fbac1eded655bd1c8026",
+      "benchmark_hash": "0xe1dc13ea3add4c2dd99afcc089843a6dc9e5aeff8c5fbad92e1be486ac123f9c",
+      "evidence_schema_hash": "0x1aca62507de0bcde1a36e353b228321e6d35b4eaafe64a8fa5027f20b3a2f4e5",
+      "check": [
+        "cargo",
+        "test",
+        "-p",
+        "api",
+        "canonical_cash_economics_cover_direct_standing_meta_and_unprofitable"
+      ]
+    },
+    {
+      "issue": 637,
+      "contract": "0x2afb91d160200fac4b91e6134b2cc9d9bff86f42",
+      "bounty_id": "0xd52391ed936c8d0d4f1c3090bc7fd02ac0a9c46510c8a7d2a2e7e61617a54eaf",
+      "terms_hash": "0xb6e6ffbac5d121e9f6b977a25bfbca5c79a8224f8baa9971503c9face205db73",
+      "policy_hash": "0xa59c1b94ede49798d9382c329d49d9f2ce1935a73ad3c972a9315feafe870857",
+      "acceptance_criteria_hash": "0xd1c78cb6abaa3c40a21428d90a079d0fe7c319ff91521a2c3fbbb5850f61cb4e",
+      "benchmark_hash": "0xe1dc13ea3add4c2dd99afcc089843a6dc9e5aeff8c5fbad92e1be486ac123f9c",
+      "evidence_schema_hash": "0x1aca62507de0bcde1a36e353b228321e6d35b4eaafe64a8fa5027f20b3a2f4e5",
+      "check": [
+        "python",
+        "scripts/test_activate_routed_v3_replacements.py",
+        "-v"
+      ]
+    },
+    {
+      "issue": 638,
+      "contract": "0xc710d54d192ffb0b84cd6e051754ab70acf1130c",
+      "bounty_id": "0x06f8c7e72b25fdc0ba5ea58f9282347bc003139bf3b59e011cbf9c01a6641823",
+      "terms_hash": "0x20f603b3ca9af208da87ea3e85d698fb8d16bf2ae096efda1638a7310ebda2c1",
+      "policy_hash": "0xa59c1b94ede49798d9382c329d49d9f2ce1935a73ad3c972a9315feafe870857",
+      "acceptance_criteria_hash": "0x9d08645b23f6ab3a2a019783a93ecbbaa527090addbf97b7a0778681fdff51b8",
+      "benchmark_hash": "0xe1dc13ea3add4c2dd99afcc089843a6dc9e5aeff8c5fbad92e1be486ac123f9c",
+      "evidence_schema_hash": "0x1aca62507de0bcde1a36e353b228321e6d35b4eaafe64a8fa5027f20b3a2f4e5",
+      "check": [
+        "cargo",
+        "test",
+        "-p",
+        "chain-base",
+        "builds_content_addressed_autonomous_terms_commitments"
+      ]
+    }
+  ]
+}

--- a/scripts/activate_routed_v3_replacements.py
+++ b/scripts/activate_routed_v3_replacements.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 import urllib.error
 import urllib.request
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 import bounded_wallet_policy as active_wallet
 import durable_verifier_router_deploy as durable
@@ -316,15 +316,17 @@ def reconcile(api: str, contract: str, bounty_id: str, timeout_seconds: int = 18
             )
             if not isinstance(feed, list):
                 raise ActivationError("feed endpoint returned a non-list")
-            item = next(
-                (
-                    candidate
-                    for candidate in feed
-                    if isinstance(candidate, dict)
-                    and str(candidate.get("bounty_contract", "")).lower() == contract.lower()
-                ),
-                None,
-            )
+            matches = [
+                candidate
+                for candidate in feed
+                if isinstance(candidate, dict)
+                and str(candidate.get("bounty_contract", "")).lower() == contract.lower()
+            ]
+            if len(matches) > 1:
+                raise ActivationError(
+                    f"canonical activation feed is ambiguous for {contract}"
+                )
+            item = matches[0] if matches else None
             active_statuses = {"claimable", "claimed", "submitted", "verifying"}
             if (
                 item
@@ -335,6 +337,24 @@ def reconcile(api: str, contract: str, bounty_id: str, timeout_seconds: int = 18
                 return {"event_kinds": sorted(kinds), "feed_item": item}
         time.sleep(3)
     raise ActivationError(f"canonical activation did not reconcile for {contract}")
+
+
+def create_if_missing(
+    cast: Cast,
+    predicted: str,
+    spend_available: int,
+    create: Callable[[], str],
+) -> tuple[str | None, int]:
+    canonical = parse_bool(
+        cast.call(FACTORY, "isCanonicalBounty(address)(bool)", predicted),
+        "canonical bounty state",
+    )
+    if canonical:
+        return "already-canonical", spend_available
+    if spend_available <= 0:
+        return None, spend_available
+    transaction_hash = bytes32(create(), "creation transaction hash")
+    return transaction_hash, spend_available - 1
 
 
 def issue_body(
@@ -457,16 +477,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
         plan_path.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         predicted = address(plan.get("predicted_bounty_contract"), f"issue #{issue} predicted bounty")
         bounty_id = bytes32(plan.get("bounty_id"), f"issue #{issue} bounty id")
-        canonical = parse_bool(
-            cast.call(FACTORY, "isCanonicalBounty(address)(bool)", predicted),
-            f"issue #{issue} canonical state",
-        )
-        if canonical:
-            tx_hash = "already-canonical"
-        else:
-            if spend_available <= 0:
-                pending.append(issue)
-                continue
+        def create_bounty() -> str:
             action_path = args.output_dir / f"routed-v3-{issue}-bounded-action.json"
             run(
                 [
@@ -498,8 +509,14 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
                 str(direct.get("data")),
                 private_key,
             )
-            tx_hash = str(sent.get("transactionHash") or sent.get("transaction_hash"))
-            spend_available -= 1
+            return str(sent.get("transactionHash") or sent.get("transaction_hash"))
+
+        tx_hash, spend_available = create_if_missing(
+            cast, predicted, spend_available, create_bounty
+        )
+        if tx_hash is None:
+            pending.append(issue)
+            continue
         reconciled = reconcile(args.api, predicted, bounty_id)
         result = {
             "issue": issue,

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -85,6 +85,10 @@ def compile_python(platform: str) -> None:
         "scripts/standing_meta_v3_deploy.py", "scripts/test_standing_meta_v3_deploy.py",
         "scripts/activate_standing_meta_v3_replacements.py",
         "scripts/test_activate_standing_meta_v3_replacements.py",
+        "scripts/activate_routed_v3_replacements.py",
+        "scripts/test_activate_routed_v3_replacements.py",
+        "scripts/direct_recovery_689.py", "scripts/test_direct_recovery_689.py",
+        "scripts/test_profitable_inventory_contract.py",
         "scripts/standing_meta_v4_deploy.py", "scripts/test_standing_meta_v4_deploy.py",
         "scripts/standing_meta_v4_release_audit.py", "scripts/test_standing_meta_v4_release_audit.py",
         "scripts/standing_meta_v4_rehearsal_audit.py", "scripts/test_standing_meta_v4_rehearsal_audit.py",
@@ -111,6 +115,9 @@ scripts/local_delegate_wallet.py scripts/test_local_delegate_wallet.py scripts/s
 scripts/leaderboard_reward_pipeline.py scripts/test_leaderboard_reward_pipeline.py
 scripts/standing_meta_v3_deploy.py scripts/test_standing_meta_v3_deploy.py
 scripts/activate_standing_meta_v3_replacements.py scripts/test_activate_standing_meta_v3_replacements.py
+scripts/activate_routed_v3_replacements.py scripts/test_activate_routed_v3_replacements.py
+scripts/direct_recovery_689.py scripts/test_direct_recovery_689.py
+scripts/test_profitable_inventory_contract.py
 scripts/standing_meta_v4_deploy.py scripts/test_standing_meta_v4_deploy.py
 scripts/standing_meta_v4_release_audit.py scripts/test_standing_meta_v4_release_audit.py
 scripts/standing_meta_v4_rehearsal_audit.py scripts/test_standing_meta_v4_rehearsal_audit.py
@@ -206,6 +213,12 @@ def main() -> int:
     for name in ("sync_hosted_bounty_inventory", "reconcile_github_bounty_labels", "diagnose_hosted_api", "github_audience_audit", "ruleset_drift_check", "code_size_report", "mcp_tool_registry", "shared_rpc", "relay_autonomous_action", "relay_bounded_wallet_action", "bounded_agent_budget"):
         py(f"scripts/test_{name}.py", "-v")
     for name in ("standing_meta_v3_deploy", "activate_standing_meta_v3_replacements"):
+        py(f"scripts/test_{name}.py", "-v")
+    for name in (
+        "activate_routed_v3_replacements",
+        "direct_recovery_689",
+        "profitable_inventory_contract",
+    ):
         py(f"scripts/test_{name}.py", "-v")
     py("-m", "pip", "install", "-r", "scripts/requirements-wallet.txt")
     for name in ("local_delegate_wallet", "self_heal", "leaderboard_reward_pipeline"):

--- a/scripts/direct_recovery_689.py
+++ b/scripts/direct_recovery_689.py
@@ -1,0 +1,984 @@
+#!/usr/bin/env python3
+"""Execute the exact, disclosed #689 direct-bounty recovery lane."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import time
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = ROOT / "ops" / "recovery" / "direct-mainnet-689.json"
+DEFAULT_RPC = "https://mainnet.base.org"
+MANIFEST_SCHEMA = "agent-bounties/direct-recovery-689-v1"
+CANDIDATE_SCHEMA = "agent-bounties/direct-recovery-candidate-v1"
+ATTESTATION_SCHEMA = "agent-bounties/direct-recovery-attestation-v1"
+EVIDENCE_SCHEMA = "agent-bounties/direct-recovery-evidence-v1"
+EXACT_CONTRACTS = {
+    "0xc13ccf6c6a03b53f836d433c5e628f06bbc1dbf4",
+    "0xad4532e45d371ff5b5c40ebbf0c20687ed9e6fc4",
+    "0xf2e47a253988e98f535ab60f4b9bd7f8975c1263",
+    "0x2afb91d160200fac4b91e6134b2cc9d9bff86f42",
+    "0xc710d54d192ffb0b84cd6e051754ab70acf1130c",
+}
+EXACT_NOTICE_URL = "https://github.com/NSPG13/agent-bounties/issues/689"
+EXACT_SETTLEMENT_TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+EXACT_CREATOR = "0x1eaa1c68772cf76bc5f4e4174766076e33ace662"
+EXACT_OPERATOR_SOLVER = "0xc26a630e85134ed30968735c8e7de4576cfa5dbc"
+EXACT_RETURN_RECIPIENT = "0x884834e884d6e93462655a2820140ad03e6747bc"
+EXACT_VERIFIERS = (
+    "0xbe6292b9e465f549e2363b918d6dd9187038431e",
+    "0xb7c2ce6430b66fb986e27b6140b29309550d487a",
+)
+EXACT_VERIFIER_SET_HASH = (
+    "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
+)
+EXACT_REPOSITORY_CHECK = ["python", "scripts/check.py", "--platform", "posix"]
+EXACT_ISSUE_CHECKS = {
+    634: [
+        "cargo",
+        "test",
+        "-p",
+        "mcp-server",
+        "mounted_public_inventory_tool_is_callable_and_fails_closed",
+    ],
+    635: ["python", "scripts/test_profitable_inventory_contract.py", "-v"],
+    636: [
+        "cargo",
+        "test",
+        "-p",
+        "api",
+        "canonical_cash_economics_cover_direct_standing_meta_and_unprofitable",
+    ],
+    637: ["python", "scripts/test_activate_routed_v3_replacements.py", "-v"],
+    638: [
+        "cargo",
+        "test",
+        "-p",
+        "chain-base",
+        "builds_content_addressed_autonomous_terms_commitments",
+    ],
+}
+ADDRESS = re.compile(r"^0x[0-9a-f]{40}$")
+HASH = re.compile(r"^0x[0-9a-f]{64}$")
+GIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+UINT = re.compile(r"^(?:0x[0-9a-fA-F]+|[0-9]+)")
+
+
+class RecoveryError(RuntimeError):
+    pass
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_text(value: str) -> str:
+    return "0x" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def address(value: object, field: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not ADDRESS.fullmatch(normalized):
+        raise RecoveryError(f"{field} must be a lowercase EVM address")
+    return normalized
+
+
+def bytes32(value: object, field: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not HASH.fullmatch(normalized):
+        raise RecoveryError(f"{field} must be bytes32")
+    return normalized
+
+
+def uint(value: object, field: str) -> int:
+    match = UINT.match(str(value).strip())
+    if not match:
+        raise RecoveryError(f"{field} must be an unsigned integer")
+    return int(match.group(0), 0)
+
+
+def require_https(value: object, field: str) -> str:
+    text = str(value or "").strip()
+    if not text.startswith("https://") or len(text) > 2_000:
+        raise RecoveryError(f"{field} must be a bounded HTTPS URL")
+    return text
+
+
+def require_pull_request_url(value: object) -> str:
+    text = require_https(value, "pull_request_url")
+    if not re.fullmatch(
+        r"https://github\.com/NSPG13/agent-bounties/pull/[1-9][0-9]*",
+        text,
+    ):
+        raise RecoveryError(
+            "pull_request_url must identify the reviewed Agent Bounties PR"
+        )
+    return text
+
+
+def redact(command: Sequence[str]) -> str:
+    result: list[str] = []
+    hide = False
+    for item in command:
+        if hide:
+            result.append("***")
+            hide = False
+            continue
+        result.append(item)
+        hide = item in {"--private-key", "--rpc-url"}
+    return " ".join(result)
+
+
+def run(
+    command: Sequence[str],
+    *,
+    cwd: Path = ROOT,
+    timeout: int = 1_800,
+) -> str:
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RecoveryError(
+            f"command failed ({completed.returncode}): {redact(command)}\n"
+            f"{completed.stdout[-6_000:]}"
+        )
+    return completed.stdout.strip()
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    value = read_json(path)
+    if not isinstance(value, dict) or value.get("schema") != MANIFEST_SCHEMA:
+        raise RecoveryError("recovery manifest schema is invalid")
+    if value.get("network") != "base-mainnet" or value.get("chain_id") != 8453:
+        raise RecoveryError("recovery manifest is not pinned to Base mainnet")
+    if require_https(value.get("notice_url"), "notice_url") != EXACT_NOTICE_URL:
+        raise RecoveryError("recovery notice URL differs from public issue #689")
+    for field in (
+        "settlement_token",
+        "creator",
+        "operator_solver",
+        "return_recipient",
+    ):
+        value[field] = address(value.get(field), field)
+    value["verifier_set_hash"] = bytes32(
+        value.get("verifier_set_hash"), "verifier_set_hash"
+    )
+    verifiers = [address(item, "verifier") for item in value.get("verifiers", [])]
+    if len(verifiers) != 2 or len(set(verifiers)) != 2:
+        raise RecoveryError("manifest must contain two distinct verifiers")
+    value["verifiers"] = verifiers
+    pinned = {
+        "settlement_token": EXACT_SETTLEMENT_TOKEN,
+        "creator": EXACT_CREATOR,
+        "operator_solver": EXACT_OPERATOR_SOLVER,
+        "return_recipient": EXACT_RETURN_RECIPIENT,
+        "verifier_set_hash": EXACT_VERIFIER_SET_HASH,
+    }
+    for field, expected in pinned.items():
+        if value[field] != expected:
+            raise RecoveryError(f"{field} differs from the public recovery scope")
+    if tuple(verifiers) != EXACT_VERIFIERS:
+        raise RecoveryError("verifier order differs from the public recovery scope")
+    if value.get("required_repository_command") != EXACT_REPOSITORY_CHECK:
+        raise RecoveryError("required repository check differs from the reviewed gate")
+    bounties = value.get("bounties")
+    if not isinstance(bounties, list) or len(bounties) != 5:
+        raise RecoveryError("manifest must contain the five disclosed direct bounties")
+    observed = set()
+    issues = set()
+    for item in bounties:
+        if not isinstance(item, dict):
+            raise RecoveryError("bounty manifest entry must be an object")
+        item["contract"] = address(item.get("contract"), "bounty contract")
+        observed.add(item["contract"])
+        issue = uint(item.get("issue"), "issue")
+        issues.add(issue)
+        for field in (
+            "bounty_id",
+            "terms_hash",
+            "policy_hash",
+            "acceptance_criteria_hash",
+            "benchmark_hash",
+            "evidence_schema_hash",
+        ):
+            item[field] = bytes32(item.get(field), field)
+        check = item.get("check")
+        if (
+            not isinstance(check, list)
+            or not check
+            or not all(isinstance(part, str) and part for part in check)
+        ):
+            raise RecoveryError(f"issue #{issue} check is invalid")
+        if check != EXACT_ISSUE_CHECKS.get(issue):
+            raise RecoveryError(f"issue #{issue} check differs from the public criteria")
+    if observed != EXACT_CONTRACTS or issues != {634, 635, 636, 637, 638}:
+        raise RecoveryError("manifest allowlist differs from public notice #689")
+    if value.get("metrics_classification") != "operator_recovery_excluded":
+        raise RecoveryError("recovery metrics exclusion is missing")
+    exact_economics = {
+        "threshold": 2,
+        "solver_reward_per_bounty": 1_990_000,
+        "verifier_reward_per_bounty": 10_000,
+        "claim_bond_per_bounty": 10_000,
+    }
+    for field, expected in exact_economics.items():
+        if uint(value.get(field), field) != expected:
+            raise RecoveryError(f"{field} differs from the public recovery economics")
+    if uint(value.get("initial_solver_bond_total"), "initial_solver_bond_total") != 50_000:
+        raise RecoveryError("initial recovery bond total must be exactly 0.05 USDC")
+    if uint(value.get("exact_return_amount"), "exact_return_amount") != 10_000_000:
+        raise RecoveryError("return amount must be exactly 10 USDC")
+    return value
+
+
+class Cast:
+    def __init__(self, executable: str, rpc_url: str) -> None:
+        self.executable = executable
+        self.rpc_url = rpc_url
+
+    def rpc(self, *args: str, timeout: int = 300) -> str:
+        return run(
+            [self.executable, *args, "--rpc-url", self.rpc_url],
+            timeout=timeout,
+        )
+
+    def call(self, target: str, signature: str, *args: str) -> str:
+        return self.rpc("call", target, signature, *args).strip()
+
+    def code(self, target: str) -> str:
+        return self.rpc("code", target).strip().lower()
+
+    def chain_id(self) -> int:
+        return uint(self.rpc("chain-id"), "chain id")
+
+    def wallet_address(self, key: str) -> str:
+        return address(
+            run([self.executable, "wallet", "address", "--private-key", key]),
+            "private-key address",
+        )
+
+    def balance(self, token: str, account: str) -> int:
+        return uint(
+            self.call(token, "balanceOf(address)(uint256)", account),
+            "token balance",
+        )
+
+    def native_balance(self, account: str) -> int:
+        return uint(self.rpc("balance", account), "native balance")
+
+    def send(self, key: str, target: str, signature: str, *args: str) -> str:
+        raw = self.rpc(
+            "send",
+            "--json",
+            "--private-key",
+            key,
+            target,
+            signature,
+            *args,
+            timeout=300,
+        )
+        try:
+            receipt = json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise RecoveryError("cast send did not return a JSON receipt") from error
+        tx_hash = str(
+            receipt.get("transactionHash") or receipt.get("transaction_hash") or ""
+        ).lower()
+        status = str(receipt.get("status", ""))
+        if not HASH.fullmatch(tx_hash) or status not in {"0x1", "0x01", "1"}:
+            raise RecoveryError("transaction did not return a successful receipt")
+        return tx_hash
+
+    def sign_digest(self, key: str, digest: str) -> str:
+        signature = run(
+            [
+                self.executable,
+                "wallet",
+                "sign",
+                "--no-hash",
+                "--private-key",
+                key,
+                digest,
+            ]
+        ).strip().lower()
+        if not re.fullmatch(r"0x[0-9a-f]{130}", signature):
+            raise RecoveryError("cast returned an invalid signature")
+        return signature
+
+
+def audit_bounty(
+    cast: Cast,
+    manifest: Mapping[str, Any],
+    bounty: Mapping[str, Any],
+) -> dict[str, Any]:
+    contract = str(bounty["contract"])
+    if cast.code(contract) in {"0x", "0x0"}:
+        raise RecoveryError(f"issue #{bounty['issue']} contract has no bytecode")
+    exact = {
+        "creator": address(cast.call(contract, "creator()(address)"), "creator"),
+        "settlement_token": address(
+            cast.call(contract, "settlementToken()(address)"), "settlement token"
+        ),
+        "bounty_id": bytes32(cast.call(contract, "bountyId()(bytes32)"), "bounty id"),
+        "terms_hash": bytes32(cast.call(contract, "termsHash()(bytes32)"), "terms hash"),
+        "policy_hash": bytes32(
+            cast.call(contract, "policyHash()(bytes32)"), "policy hash"
+        ),
+        "acceptance_criteria_hash": bytes32(
+            cast.call(contract, "acceptanceCriteriaHash()(bytes32)"),
+            "acceptance criteria hash",
+        ),
+        "benchmark_hash": bytes32(
+            cast.call(contract, "benchmarkHash()(bytes32)"), "benchmark hash"
+        ),
+        "evidence_schema_hash": bytes32(
+            cast.call(contract, "evidenceSchemaHash()(bytes32)"),
+            "evidence schema hash",
+        ),
+        "verifier_set_hash": bytes32(
+            cast.call(contract, "verifierSetHash()(bytes32)"), "verifier set hash"
+        ),
+    }
+    expected = {
+        "creator": manifest["creator"],
+        "settlement_token": manifest["settlement_token"],
+        "bounty_id": bounty["bounty_id"],
+        "terms_hash": bounty["terms_hash"],
+        "policy_hash": bounty["policy_hash"],
+        "acceptance_criteria_hash": bounty["acceptance_criteria_hash"],
+        "benchmark_hash": bounty["benchmark_hash"],
+        "evidence_schema_hash": bounty["evidence_schema_hash"],
+        "verifier_set_hash": manifest["verifier_set_hash"],
+    }
+    for field, wanted in expected.items():
+        if exact[field] != wanted:
+            raise RecoveryError(
+                f"issue #{bounty['issue']} {field} mismatch: {exact[field]} != {wanted}"
+            )
+    values = {
+        "status": uint(cast.call(contract, "status()(uint8)"), "status"),
+        "solver_reward": uint(
+            cast.call(contract, "solverReward()(uint256)"), "solver reward"
+        ),
+        "verifier_reward": uint(
+            cast.call(contract, "verifierReward()(uint256)"), "verifier reward"
+        ),
+        "target_amount": uint(
+            cast.call(contract, "targetAmount()(uint256)"), "target amount"
+        ),
+        "funded_amount": uint(
+            cast.call(contract, "fundedAmount()(uint256)"), "funded amount"
+        ),
+        "threshold": uint(cast.call(contract, "threshold()(uint8)"), "threshold"),
+        "round": uint(cast.call(contract, "round()(uint64)"), "round"),
+        "active_claim_bond": uint(
+            cast.call(contract, "activeClaimBond()(uint256)"), "active claim bond"
+        ),
+        "solver": address(cast.call(contract, "solver()(address)"), "solver"),
+        "submission_hash": bytes32(
+            cast.call(contract, "submissionHash()(bytes32)"), "submission hash"
+        ),
+        "evidence_hash": bytes32(
+            cast.call(contract, "evidenceHash()(bytes32)"), "evidence hash"
+        ),
+        "verification_expires_at": uint(
+            cast.call(contract, "verificationExpiresAt()(uint64)"),
+            "verification expiry",
+        ),
+    }
+    wanted_values = {
+        "solver_reward": manifest["solver_reward_per_bounty"],
+        "verifier_reward": manifest["verifier_reward_per_bounty"],
+        "target_amount": 2_000_000,
+        "threshold": manifest["threshold"],
+    }
+    for field, wanted in wanted_values.items():
+        if values[field] != wanted:
+            raise RecoveryError(f"issue #{bounty['issue']} {field} drifted")
+    verifier_output = cast.call(contract, "verifiers()(address[])")
+    verifiers = [item.lower() for item in re.findall(r"0x[0-9a-fA-F]{40}", verifier_output)]
+    if verifiers != list(manifest["verifiers"]):
+        raise RecoveryError(f"issue #{bounty['issue']} verifier order drifted")
+    if values["status"] == 1 and values["funded_amount"] != 2_000_000:
+        raise RecoveryError(f"issue #{bounty['issue']} is not fully funded")
+    return {**exact, **values, "contract": contract, "verifiers": verifiers}
+
+
+def current_revision(expected: str | None = None) -> str:
+    revision = run(["git", "rev-parse", "HEAD"]).lower()
+    if not GIT_SHA.fullmatch(revision):
+        raise RecoveryError("current Git revision is invalid")
+    if expected and revision != expected.lower():
+        raise RecoveryError(
+            f"recovery revision is stale: expected {expected.lower()}, got {revision}"
+        )
+    return revision
+
+
+def run_acceptance_checks(manifest: Mapping[str, Any]) -> dict[int, dict[str, Any]]:
+    commands = [manifest["required_repository_command"]] + [
+        item["check"] for item in manifest["bounties"]
+    ]
+    cache: dict[str, dict[str, Any]] = {}
+    by_issue: dict[int, dict[str, Any]] = {}
+    for index, command in enumerate(commands):
+        key = canonical_json(command)
+        if key not in cache:
+            run(command)
+            cache[key] = {
+                "command": command,
+                "exit_code": 0,
+            }
+        if index > 0:
+            by_issue[int(manifest["bounties"][index - 1]["issue"])] = cache[key]
+    repository_check = cache[canonical_json(manifest["required_repository_command"])]
+    for value in by_issue.values():
+        value["repository_check"] = repository_check
+    return by_issue
+
+
+def build_candidate(
+    manifest: Mapping[str, Any],
+    bounty: Mapping[str, Any],
+    revision: str,
+    pull_request_url: str,
+    check_run_urls: Sequence[str],
+    check: Mapping[str, Any],
+) -> dict[str, Any]:
+    artifact_reference = (
+        f"https://github.com/NSPG13/agent-bounties/commit/{revision}"
+    )
+    evidence = {
+        "schema": EVIDENCE_SCHEMA,
+        "classification": manifest["metrics_classification"],
+        "notice_url": manifest["notice_url"],
+        "issue_url": f"https://github.com/NSPG13/agent-bounties/issues/{bounty['issue']}",
+        "repository": "NSPG13/agent-bounties",
+        "commit_sha": revision,
+        "pull_request_url": pull_request_url,
+        "check_run_urls": list(check_run_urls),
+        "artifact_digest": sha256_text(
+            canonical_json(
+                {
+                    "revision": revision,
+                    "issue": bounty["issue"],
+                    "check": check,
+                }
+            )
+        ),
+        "operator_solver": manifest["operator_solver"],
+        "metrics_credit": False,
+        "reputation_credit": False,
+        "leaderboard_credit": False,
+        "organic_completion": False,
+        "check": check,
+    }
+    response = {
+        "classification": manifest["metrics_classification"],
+        "notice_url": manifest["notice_url"],
+        "issue": bounty["issue"],
+        "contract": bounty["contract"],
+        "revision": revision,
+        "verdict": "passed",
+        "artifact_digest": evidence["artifact_digest"],
+    }
+    return {
+        "schema": CANDIDATE_SCHEMA,
+        "issue": bounty["issue"],
+        "contract": bounty["contract"],
+        "bounty_id": bounty["bounty_id"],
+        "revision": revision,
+        "artifact_reference": artifact_reference,
+        "submission_hash": sha256_text(artifact_reference),
+        "evidence": evidence,
+        "evidence_hash": sha256_text(canonical_json(evidence)),
+        "response_hash": sha256_text(canonical_json(response)),
+        "verdict": "passed",
+    }
+
+
+def load_candidates(path: Path, manifest: Mapping[str, Any]) -> dict[int, dict[str, Any]]:
+    summary = read_json(path / "manifest.json")
+    if (
+        not isinstance(summary, dict)
+        or summary.get("schema") != CANDIDATE_SCHEMA
+        or summary.get("classification") != manifest["metrics_classification"]
+    ):
+        raise RecoveryError("candidate manifest is invalid")
+    candidates: dict[int, dict[str, Any]] = {}
+    expected_by_issue = {
+        int(item["issue"]): item for item in manifest["bounties"]
+    }
+    for entry in summary.get("candidates", []):
+        candidate = read_json(path / str(entry["file"]))
+        issue = uint(candidate.get("issue"), "candidate issue")
+        if candidate.get("schema") != CANDIDATE_SCHEMA or issue in candidates:
+            raise RecoveryError("candidate artifact is invalid or duplicated")
+        expected = expected_by_issue.get(issue)
+        evidence = candidate.get("evidence")
+        if (
+            expected is None
+            or candidate.get("contract") != expected["contract"]
+            or candidate.get("bounty_id") != expected["bounty_id"]
+            or candidate.get("revision") != summary.get("revision")
+            or not isinstance(evidence, dict)
+            or evidence.get("classification") != manifest["metrics_classification"]
+            or evidence.get("notice_url") != manifest["notice_url"]
+            or evidence.get("operator_solver") != manifest["operator_solver"]
+            or evidence.get("metrics_credit") is not False
+            or evidence.get("reputation_credit") is not False
+            or evidence.get("leaderboard_credit") is not False
+            or evidence.get("organic_completion") is not False
+        ):
+            raise RecoveryError("candidate artifact differs from the exact recovery scope")
+        candidates[issue] = candidate
+    if set(candidates) != {634, 635, 636, 637, 638}:
+        raise RecoveryError("candidate artifact does not cover the exact recovery set")
+    return candidates
+
+
+def key_from_env(name: str) -> str:
+    key = os.environ.get(name, "").strip()
+    if not re.fullmatch(r"0x[0-9a-fA-F]{64}", key):
+        raise RecoveryError(f"{name} is required and must be a private key")
+    return key
+
+
+def command_audit(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    cast = Cast(args.cast, args.rpc_url)
+    if cast.chain_id() != manifest["chain_id"]:
+        raise RecoveryError("RPC is not Base mainnet")
+    observations = [
+        {"issue": bounty["issue"], **audit_bounty(cast, manifest, bounty)}
+        for bounty in manifest["bounties"]
+    ]
+    report = {
+        "schema": "agent-bounties/direct-recovery-audit-v1",
+        "notice_url": manifest["notice_url"],
+        "classification": manifest["metrics_classification"],
+        "observations": observations,
+    }
+    if args.output:
+        write_json(args.output, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+def command_prepare(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    revision = current_revision(args.revision)
+    pull_request_url = require_pull_request_url(args.pull_request_url)
+    check_run_urls = [
+        require_https(value, "check_run_url") for value in args.check_run_url
+    ]
+    if not check_run_urls:
+        raise RecoveryError("at least one check_run_url is required")
+    checks = run_acceptance_checks(manifest)
+    key = key_from_env(args.keeper_key_env)
+    cast = Cast(args.cast, args.rpc_url)
+    if cast.chain_id() != manifest["chain_id"]:
+        raise RecoveryError("RPC is not Base mainnet")
+    keeper = cast.wallet_address(key)
+    if keeper != manifest["operator_solver"]:
+        raise RecoveryError("keeper key does not match the disclosed operator solver")
+    states = {
+        int(bounty["issue"]): audit_bounty(cast, manifest, bounty)
+        for bounty in manifest["bounties"]
+    }
+    claimable = [
+        bounty
+        for bounty in manifest["bounties"]
+        if states[int(bounty["issue"])]["status"] == 1
+    ]
+    active = [
+        bounty
+        for bounty in manifest["bounties"]
+        if states[int(bounty["issue"])]["status"] != 4
+    ]
+    required_bond = len(claimable) * manifest["claim_bond_per_bounty"]
+    if cast.balance(manifest["settlement_token"], keeper) < required_bond:
+        raise RecoveryError(
+            f"operator solver requires at least {required_bond} USDC base units "
+            "for the still-claimable bonds"
+        )
+    if active and cast.native_balance(keeper) < args.minimum_native_balance:
+        raise RecoveryError("operator solver Base ETH reserve is below the recovery minimum")
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    entries = []
+    for bounty in manifest["bounties"]:
+        issue = int(bounty["issue"])
+        candidate = build_candidate(
+            manifest,
+            bounty,
+            revision,
+            pull_request_url,
+            check_run_urls,
+            checks[issue],
+        )
+        state = audit_bounty(cast, manifest, bounty)
+        transactions: dict[str, str] = {}
+        if state["status"] == 1:
+            transactions["approve"] = cast.send(
+                key,
+                manifest["settlement_token"],
+                "approve(address,uint256)(bool)",
+                bounty["contract"],
+                str(manifest["claim_bond_per_bounty"]),
+            )
+            transactions["claim"] = cast.send(key, bounty["contract"], "claim()")
+            state = audit_bounty(cast, manifest, bounty)
+        if state["status"] == 2:
+            if state["solver"] != keeper:
+                raise RecoveryError(f"issue #{issue} is claimed by another solver")
+            transactions["submit"] = cast.send(
+                key,
+                bounty["contract"],
+                "submit(bytes32,bytes32)",
+                candidate["submission_hash"],
+                candidate["evidence_hash"],
+            )
+            state = audit_bounty(cast, manifest, bounty)
+        if state["status"] not in {3, 4}:
+            raise RecoveryError(f"issue #{issue} did not reach submitted or settled")
+        if state["solver"] != keeper:
+            raise RecoveryError(f"issue #{issue} solver differs from disclosed operator")
+        if (
+            state["submission_hash"] != candidate["submission_hash"]
+            or state["evidence_hash"] != candidate["evidence_hash"]
+        ):
+            raise RecoveryError(f"issue #{issue} submitted hashes differ from evidence")
+        candidate["transactions"] = transactions
+        candidate["round"] = state["round"]
+        candidate["verification_expires_at"] = state["verification_expires_at"]
+        name = f"candidate-{issue}.json"
+        write_json(args.output / name, candidate)
+        entries.append({"issue": issue, "file": name})
+    write_json(
+        args.output / "manifest.json",
+        {
+            "schema": CANDIDATE_SCHEMA,
+            "classification": manifest["metrics_classification"],
+            "notice_url": manifest["notice_url"],
+            "revision": revision,
+            "candidates": entries,
+        },
+    )
+
+
+def command_sign(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    candidates = load_candidates(args.candidates, manifest)
+    revision = current_revision(args.revision)
+    checks = run_acceptance_checks(manifest)
+    expected = address(args.expected_signer, "expected signer")
+    if expected not in manifest["verifiers"]:
+        raise RecoveryError("expected signer is outside the immutable verifier set")
+    key = key_from_env(args.private_key_env)
+    cast = Cast(args.cast, args.rpc_url)
+    if cast.chain_id() != manifest["chain_id"]:
+        raise RecoveryError("RPC is not Base mainnet")
+    if cast.wallet_address(key) != expected:
+        raise RecoveryError("signer key does not match expected signer")
+    args.output.mkdir(parents=True, exist_ok=True)
+    entries = []
+    for bounty in manifest["bounties"]:
+        issue = int(bounty["issue"])
+        candidate = candidates[issue]
+        if candidate.get("revision") != revision:
+            raise RecoveryError("candidate revision is stale")
+        if candidate.get("evidence", {}).get("check") != checks[issue]:
+            raise RecoveryError(f"issue #{issue} independent check evidence drifted")
+        state = audit_bounty(cast, manifest, bounty)
+        if state["status"] != 3:
+            raise RecoveryError(f"issue #{issue} is not submitted")
+        if (
+            state["submission_hash"] != candidate["submission_hash"]
+            or state["evidence_hash"] != candidate["evidence_hash"]
+        ):
+            raise RecoveryError(f"issue #{issue} on-chain evidence drifted")
+        now = int(time.time())
+        deadline = min(now + 3_600, state["verification_expires_at"])
+        if deadline <= now + 120:
+            raise RecoveryError(f"issue #{issue} verification deadline is too close")
+        digest = bytes32(
+            cast.call(
+                bounty["contract"],
+                "attestationDigest(address,bool,bytes32,uint256)(bytes32)",
+                expected,
+                "true",
+                candidate["response_hash"],
+                str(deadline),
+            ),
+            "attestation digest",
+        )
+        attestation = {
+            "schema": ATTESTATION_SCHEMA,
+            "classification": manifest["metrics_classification"],
+            "issue": issue,
+            "contract": bounty["contract"],
+            "revision": revision,
+            "verifier": expected,
+            "passed": True,
+            "response_hash": candidate["response_hash"],
+            "deadline": deadline,
+            "signature": cast.sign_digest(key, digest),
+        }
+        name = f"attestation-{issue}.json"
+        write_json(args.output / name, attestation)
+        entries.append({"issue": issue, "file": name})
+    write_json(
+        args.output / "manifest.json",
+        {
+            "schema": ATTESTATION_SCHEMA,
+            "classification": manifest["metrics_classification"],
+            "revision": revision,
+            "signer": expected,
+            "attestations": entries,
+        },
+    )
+
+
+def load_attestations(
+    paths: Sequence[Path],
+    manifest: Mapping[str, Any],
+) -> dict[int, list[dict[str, Any]]]:
+    by_issue: dict[int, list[dict[str, Any]]] = {
+        issue: [] for issue in (634, 635, 636, 637, 638)
+    }
+    signers = set()
+    for path in paths:
+        summary = read_json(path / "manifest.json")
+        if (
+            summary.get("schema") != ATTESTATION_SCHEMA
+            or summary.get("classification") != manifest["metrics_classification"]
+        ):
+            raise RecoveryError("attestation manifest is invalid")
+        signer = address(summary.get("signer"), "attestation signer")
+        signers.add(signer)
+        for entry in summary.get("attestations", []):
+            item = read_json(path / str(entry["file"]))
+            issue = uint(item.get("issue"), "attestation issue")
+            if (
+                issue not in by_issue
+                or item.get("schema") != ATTESTATION_SCHEMA
+                or item.get("classification") != manifest["metrics_classification"]
+                or address(item.get("verifier"), "verifier") != signer
+                or item.get("revision") != summary.get("revision")
+            ):
+                raise RecoveryError("attestation artifact is invalid")
+            by_issue[issue].append(item)
+    if signers != set(manifest["verifiers"]):
+        raise RecoveryError("attestations do not contain the exact verifier set")
+    if any(len(items) != manifest["threshold"] for items in by_issue.values()):
+        raise RecoveryError("every recovery candidate requires the exact threshold")
+    return by_issue
+
+
+def command_relay(args: argparse.Namespace) -> None:
+    manifest = load_manifest(args.manifest)
+    candidates = load_candidates(args.candidates, manifest)
+    attestations = load_attestations(args.attestations, manifest)
+    revision = current_revision(args.revision)
+    checks = run_acceptance_checks(manifest)
+    key = key_from_env(args.keeper_key_env)
+    cast = Cast(args.cast, args.rpc_url)
+    if cast.chain_id() != manifest["chain_id"]:
+        raise RecoveryError("RPC is not Base mainnet")
+    keeper = cast.wallet_address(key)
+    if keeper != manifest["operator_solver"]:
+        raise RecoveryError("keeper key does not match the disclosed operator solver")
+    token = manifest["settlement_token"]
+    states = {
+        int(bounty["issue"]): audit_bounty(cast, manifest, bounty)
+        for bounty in manifest["bounties"]
+    }
+    if any(state["status"] not in {3, 4} for state in states.values()):
+        raise RecoveryError("every recovery contract must be submitted or already settled")
+    already_settled = sum(state["status"] == 4 for state in states.values())
+    keeper_before = cast.balance(token, keeper)
+    expected_keeper_before = already_settled * 2_000_000
+    if keeper_before != expected_keeper_before:
+        raise RecoveryError(
+            "operator balance does not match resumable partial-settlement accounting"
+        )
+    verifier_before = {
+        verifier: cast.balance(token, verifier) for verifier in manifest["verifiers"]
+    }
+    settlements = []
+    for bounty in manifest["bounties"]:
+        issue = int(bounty["issue"])
+        candidate = candidates[issue]
+        if candidate.get("revision") != revision:
+            raise RecoveryError("candidate revision is stale")
+        if candidate.get("evidence", {}).get("check") != checks[issue]:
+            raise RecoveryError(f"issue #{issue} relay check evidence drifted")
+        state = audit_bounty(cast, manifest, bounty)
+        if state["status"] == 4:
+            settlements.append(
+                {
+                    "issue": issue,
+                    "contract": bounty["contract"],
+                    "tx": None,
+                    "state": "already_settled_before_relay",
+                }
+            )
+            continue
+        if state["status"] != 3:
+            raise RecoveryError(f"issue #{issue} is not submitted")
+        items = sorted(attestations[issue], key=lambda item: item["verifier"])
+        first = items[0]
+        for item in items:
+            if (
+                item["revision"] != revision
+                or item["contract"] != bounty["contract"]
+                or item["passed"] is not True
+                or item["response_hash"] != candidate["response_hash"]
+                or item["response_hash"] != first["response_hash"]
+            ):
+                raise RecoveryError(f"issue #{issue} attestations disagree")
+        tuple_values = ",".join(
+            f"({item['verifier']},true,{item['response_hash']},{item['deadline']},{item['signature']})"
+            for item in items
+        )
+        transaction = cast.send(
+            key,
+            bounty["contract"],
+            "settleWithAttestations((address,bool,bytes32,uint256,bytes)[])",
+            f"[{tuple_values}]",
+        )
+        after = audit_bounty(cast, manifest, bounty)
+        if after["status"] != 4:
+            raise RecoveryError(f"issue #{issue} settlement did not finalize")
+        settlements.append(
+            {
+                "issue": issue,
+                "contract": bounty["contract"],
+                "tx": transaction,
+                "state": "settled_by_relay",
+            }
+        )
+
+    keeper_after_settlement = cast.balance(token, keeper)
+    newly_settled = len(manifest["bounties"]) - already_settled
+    expected_solver_increase = newly_settled * 2_000_000
+    if keeper_after_settlement - keeper_before != expected_solver_increase:
+        raise RecoveryError("solver recovery receipts differ from exact per-bounty accounting")
+    if keeper_after_settlement != manifest["exact_return_amount"]:
+        raise RecoveryError("operator balance does not equal the exact 10 USDC return")
+    for verifier in manifest["verifiers"]:
+        increase = cast.balance(token, verifier) - verifier_before[verifier]
+        if increase != newly_settled * 5_000:
+            raise RecoveryError("verifier recovery receipt differs from exact per-bounty accounting")
+
+    recipient = manifest["return_recipient"]
+    recipient_before = cast.balance(token, recipient)
+    transfer_tx = cast.send(
+        key,
+        token,
+        "transfer(address,uint256)(bool)",
+        recipient,
+        str(manifest["exact_return_amount"]),
+    )
+    recipient_after = cast.balance(token, recipient)
+    if recipient_after - recipient_before != manifest["exact_return_amount"]:
+        raise RecoveryError("return transfer did not increase recipient by exactly 10 USDC")
+    evidence = {
+        "schema": EVIDENCE_SCHEMA,
+        "classification": manifest["metrics_classification"],
+        "notice_url": manifest["notice_url"],
+        "revision": revision,
+        "operator_solver": keeper,
+        "return_recipient": recipient,
+        "return_amount": manifest["exact_return_amount"],
+        "settlements": settlements,
+        "return_transfer_tx": transfer_tx,
+        "metrics_credit": False,
+        "reputation_credit": False,
+        "leaderboard_credit": False,
+        "organic_completion": False,
+        "evidence_boundary": (
+            "These are disclosed operator recovery settlements, not organic paid loops, "
+            "external solver activity, adoption, retention, revenue, reputation, or leaderboard evidence."
+        ),
+    }
+    write_json(args.output, evidence)
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    root.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    root.add_argument("--rpc-url", default=os.environ.get("BASE_MAINNET_RPC_URL", DEFAULT_RPC))
+    root.add_argument("--cast", default=os.environ.get("CAST_BIN", "cast"))
+    commands = root.add_subparsers(dest="command", required=True)
+
+    audit = commands.add_parser("audit")
+    audit.add_argument("--output", type=Path)
+    audit.set_defaults(handler=command_audit)
+
+    prepare = commands.add_parser("prepare")
+    prepare.add_argument("--revision", required=True)
+    prepare.add_argument("--pull-request-url", required=True)
+    prepare.add_argument("--check-run-url", action="append", default=[])
+    prepare.add_argument("--output", type=Path, required=True)
+    prepare.add_argument("--keeper-key-env", default="BASE_KEEPER_PRIVATE_KEY")
+    prepare.add_argument("--minimum-native-balance", type=int, default=100_000_000_000_000)
+    prepare.set_defaults(handler=command_prepare)
+
+    sign = commands.add_parser("sign")
+    sign.add_argument("--revision", required=True)
+    sign.add_argument("--candidates", type=Path, required=True)
+    sign.add_argument("--output", type=Path, required=True)
+    sign.add_argument("--private-key-env", required=True)
+    sign.add_argument("--expected-signer", required=True)
+    sign.set_defaults(handler=command_sign)
+
+    relay = commands.add_parser("relay")
+    relay.add_argument("--revision", required=True)
+    relay.add_argument("--candidates", type=Path, required=True)
+    relay.add_argument("--attestations", type=Path, action="append", required=True)
+    relay.add_argument("--output", type=Path, required=True)
+    relay.add_argument("--keeper-key-env", default="BASE_KEEPER_PRIVATE_KEY")
+    relay.set_defaults(handler=command_relay)
+    return root
+
+
+def main() -> int:
+    try:
+        args = parser().parse_args()
+        args.handler(args)
+    except (RecoveryError, OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"direct recovery #689 failed: {error}", file=os.sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_activate_routed_v3_replacements.py
+++ b/scripts/test_activate_routed_v3_replacements.py
@@ -248,15 +248,83 @@ class ActivateRoutedV3Tests(unittest.TestCase):
             self.assertIn("--from-block 49069936", workflow, name)
             self.assertIn("--to-block 49069936", workflow, name)
 
-    def test_resume_checks_canonical_state_before_transaction_planning(self) -> None:
-        source = (SCRIPTS / "activate_routed_v3_replacements.py").read_text(encoding="utf-8")
-        canonical_check = source.index('cast.call(FACTORY, "isCanonicalBounty(address)(bool)", predicted)')
-        planner_call = source.index('"scripts/plan_bounded_agent_action.py"', canonical_check)
-        self.assertLess(canonical_check, planner_call)
+    def test_resume_skips_planning_and_send_for_an_existing_canonical_contract(self) -> None:
+        cast = mock.Mock()
+        cast.call.return_value = "true"
+        create = mock.Mock(return_value="0x" + "41" * 32)
 
-    def test_reconciliation_accepts_claimed_live_inventory(self) -> None:
-        source = (SCRIPTS / "activate_routed_v3_replacements.py").read_text(encoding="utf-8")
-        self.assertIn('{"claimable", "claimed", "submitted", "verifying"}', source)
+        transaction, remaining = MODULE.create_if_missing(
+            cast, "0x" + "31" * 20, 3, create
+        )
+
+        self.assertEqual(transaction, "already-canonical")
+        self.assertEqual(remaining, 3)
+        create.assert_not_called()
+
+    def test_reconciliation_accepts_every_active_state_and_fails_closed(self) -> None:
+        contract = "0x" + "31" * 20
+        bounty_id = "0x" + "32" * 32
+        events = [
+            {"kind": "canonical_bounty_created"},
+            {"kind": "funding_added"},
+            {"kind": "bounty_became_claimable"},
+        ]
+        for status in ("claimable", "claimed", "submitted", "verifying"):
+            with self.subTest(status=status), mock.patch.object(
+                MODULE,
+                "http_json",
+                side_effect=[
+                    events,
+                    [
+                        {
+                            "bounty_contract": contract,
+                            "status": status,
+                            "terms_valid": True,
+                            "verification_ready": True,
+                        }
+                    ],
+                ],
+            ):
+                result = MODULE.reconcile("https://api.example", contract, bounty_id, 1)
+                self.assertEqual(result["feed_item"]["status"], status)
+
+        failures = [
+            {"status": "claimable", "terms_valid": False, "verification_ready": True},
+            {"status": "claimable", "terms_valid": True, "verification_ready": False},
+            {"status": "settled", "terms_valid": True, "verification_ready": True},
+        ]
+        for item in failures:
+            item["bounty_contract"] = contract
+            with self.subTest(item=item), mock.patch.object(
+                MODULE,
+                "http_json",
+                side_effect=[events, [item]],
+            ), mock.patch.object(MODULE.time, "monotonic", side_effect=[0, 0, 2]), mock.patch.object(
+                MODULE.time, "sleep"
+            ):
+                with self.assertRaisesRegex(MODULE.ActivationError, "did not reconcile"):
+                    MODULE.reconcile("https://api.example", contract, bounty_id, 1)
+
+        with mock.patch.object(
+            MODULE,
+            "http_json",
+            side_effect=[events, [
+                {
+                    "bounty_contract": contract,
+                    "status": "claimable",
+                    "terms_valid": True,
+                    "verification_ready": True,
+                },
+                {
+                    "bounty_contract": contract,
+                    "status": "claimed",
+                    "terms_valid": True,
+                    "verification_ready": True,
+                },
+            ]],
+        ):
+            with self.assertRaisesRegex(MODULE.ActivationError, "ambiguous"):
+                MODULE.reconcile("https://api.example", contract, bounty_id, 1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_direct_recovery_689.py
+++ b/scripts/test_direct_recovery_689.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+SCRIPTS = Path(__file__).resolve().parent
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import direct_recovery_689 as recovery
+
+
+class DirectRecovery689Tests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = recovery.load_manifest(recovery.DEFAULT_MANIFEST)
+
+    def write_manifest(self, value: object, directory: str) -> Path:
+        path = Path(directory) / "manifest.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        return path
+
+    def test_manifest_is_exactly_allowlisted_and_recovery_excluded(self) -> None:
+        self.assertEqual(
+            {item["contract"] for item in self.manifest["bounties"]},
+            recovery.EXACT_CONTRACTS,
+        )
+        self.assertEqual(
+            self.manifest["metrics_classification"],
+            "operator_recovery_excluded",
+        )
+        self.assertEqual(self.manifest["initial_solver_bond_total"], 50_000)
+        self.assertEqual(self.manifest["exact_return_amount"], 10_000_000)
+
+    def test_manifest_rejects_an_arbitrary_recovery_target(self) -> None:
+        changed = copy.deepcopy(self.manifest)
+        changed["bounties"][0]["contract"] = "0x" + "11" * 20
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(recovery.RecoveryError, "allowlist"):
+                recovery.load_manifest(self.write_manifest(changed, directory))
+
+    def test_manifest_rejects_redirected_return_recipient(self) -> None:
+        changed = copy.deepcopy(self.manifest)
+        changed["return_recipient"] = "0x" + "11" * 20
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(recovery.RecoveryError, "return_recipient"):
+                recovery.load_manifest(self.write_manifest(changed, directory))
+
+    def test_manifest_rejects_weakened_acceptance_command(self) -> None:
+        changed = copy.deepcopy(self.manifest)
+        changed["bounties"][0]["check"] = ["python", "-c", "print('pass')"]
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(recovery.RecoveryError, "public criteria"):
+                recovery.load_manifest(self.write_manifest(changed, directory))
+
+    def test_candidate_hashes_are_deterministic_and_disclose_no_credit(self) -> None:
+        bounty = self.manifest["bounties"][0]
+        check = {
+            "command": bounty["check"],
+            "exit_code": 0,
+            "repository_check": {
+                "command": self.manifest["required_repository_command"],
+                "exit_code": 0,
+            },
+        }
+        args = (
+            self.manifest,
+            bounty,
+            "a" * 40,
+            "https://github.com/NSPG13/agent-bounties/pull/690",
+            ["https://github.com/NSPG13/agent-bounties/actions/runs/1"],
+            check,
+        )
+        first = recovery.build_candidate(*args)
+        second = recovery.build_candidate(*args)
+        self.assertEqual(first, second)
+        self.assertTrue(recovery.HASH.fullmatch(first["submission_hash"]))
+        self.assertTrue(recovery.HASH.fullmatch(first["evidence_hash"]))
+        self.assertTrue(recovery.HASH.fullmatch(first["response_hash"]))
+        self.assertFalse(first["evidence"]["metrics_credit"])
+        self.assertFalse(first["evidence"]["reputation_credit"])
+        self.assertFalse(first["evidence"]["leaderboard_credit"])
+        self.assertFalse(first["evidence"]["organic_completion"])
+
+    def test_stale_revision_fails_closed(self) -> None:
+        with self.assertRaisesRegex(recovery.RecoveryError, "stale"):
+            recovery.current_revision("0" * 40)
+
+    def test_pull_request_url_is_pinned_to_the_project(self) -> None:
+        self.assertEqual(
+            recovery.require_pull_request_url(
+                "https://github.com/NSPG13/agent-bounties/pull/690"
+            ),
+            "https://github.com/NSPG13/agent-bounties/pull/690",
+        )
+        with self.assertRaisesRegex(recovery.RecoveryError, "reviewed"):
+            recovery.require_pull_request_url(
+                "https://github.com/attacker/agent-bounties/pull/690"
+            )
+
+    def test_signer_set_requires_both_exact_verifiers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            paths = []
+            for index, verifier in enumerate(self.manifest["verifiers"]):
+                path = root / str(index)
+                path.mkdir()
+                entries = []
+                for bounty in self.manifest["bounties"]:
+                    issue = bounty["issue"]
+                    name = f"attestation-{issue}.json"
+                    recovery.write_json(
+                        path / name,
+                        {
+                            "schema": recovery.ATTESTATION_SCHEMA,
+                            "classification": self.manifest["metrics_classification"],
+                            "issue": issue,
+                            "verifier": verifier,
+                            "revision": "a" * 40,
+                        },
+                    )
+                    entries.append({"issue": issue, "file": name})
+                recovery.write_json(
+                    path / "manifest.json",
+                    {
+                        "schema": recovery.ATTESTATION_SCHEMA,
+                        "classification": self.manifest["metrics_classification"],
+                        "revision": "a" * 40,
+                        "signer": verifier,
+                        "attestations": entries,
+                    },
+                )
+                paths.append(path)
+            observed = recovery.load_attestations(paths, self.manifest)
+            self.assertTrue(all(len(items) == 2 for items in observed.values()))
+            with self.assertRaisesRegex(recovery.RecoveryError, "exact verifier set"):
+                recovery.load_attestations(paths[:1], self.manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_profitable_inventory_contract.py
+++ b/scripts/test_profitable_inventory_contract.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "fixtures" / "profitable-canonical-opportunity.json"
+
+
+class ProfitableInventoryContractTests(unittest.TestCase):
+    def test_one_fixture_matches_every_public_inventory_surface(self) -> None:
+        item = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        self.assertEqual(item["reward"]["amount"], "1990000")
+        self.assertEqual(item["bond"]["amount"], "10000")
+        self.assertEqual(item["funded_amount"], item["funding_target"])
+        self.assertEqual(item["source_status"], "claimable")
+        self.assertEqual(item["work_state"], "claimable")
+        self.assertTrue(item["terms_hash"])
+        self.assertTrue(item["verification_ready"])
+        self.assertGreater(
+            int(item["cash_economics"]["gross_cash_margin"]["amount"]), 0
+        )
+
+        api = (ROOT / "crates" / "api" / "src" / "opportunities.rs").read_text(
+            encoding="utf-8"
+        )
+        mcp = (ROOT / "crates" / "mcp-server" / "src" / "main.rs").read_text(
+            encoding="utf-8"
+        )
+        home = (ROOT / "site" / "home.js").read_text(encoding="utf-8")
+        board = (ROOT / "site" / "bounty-board.js").read_text(encoding="utf-8")
+
+        for field in (
+            "cash_economics",
+            "funded_amount",
+            "funding_target",
+            "terms_hash",
+            "verification_ready",
+        ):
+            self.assertIn(field, api)
+        self.assertIn("/v1/opportunities", mcp)
+        self.assertIn("list_autonomous_bounties", mcp)
+        for public_surface in (home, board):
+            self.assertIn("cash_economics", public_surface)
+            self.assertIn("gross_cash_margin", public_surface)
+            self.assertIn("not net profit", public_surface)
+
+    def test_claimed_fixture_leaves_claimable_only_without_corruption_claim(self) -> None:
+        item = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        item["source_status"] = "claimed"
+        item["work_state"] = "in_progress"
+        claimable_only = [
+            candidate
+            for candidate in [item]
+            if candidate["work_state"] == "claimable"
+            and candidate["verification_ready"]
+        ]
+        self.assertEqual(claimable_only, [])
+        self.assertEqual(item["payment_state"], "escrowed")
+        self.assertTrue(item["terms_hash"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/site/bounty-board.js
+++ b/site/bounty-board.js
@@ -118,6 +118,14 @@
       reward.textContent = `${formatUsdc(item.rewardUsdc)} USDC reward`;
       meta.append(reward);
     }
+    if (item.cash_economics) {
+      const bond = document.createElement("span");
+      bond.textContent = `${formatUsdc(amountInUsdc(item.cash_economics.refundable_claim_bond))} USDC refundable bond`;
+      meta.append(bond);
+      const margin = document.createElement("span");
+      margin.textContent = `${formatUsdc(amountInUsdc(item.cash_economics.gross_cash_margin))} USDC gross cash margin, not net profit`;
+      meta.append(margin);
+    }
     (item.categories || []).slice(0, 2).forEach((category) => {
       const tag = document.createElement("span");
       tag.textContent = category;

--- a/site/home.js
+++ b/site/home.js
@@ -128,6 +128,10 @@
       : item.payment_state === "seeking_funding"
         ? `${formatAmount(item.reward)} proposed reward · not yet committed`
         : "No payment committed";
+    if (item.cash_economics) {
+      const cash = item.cash_economics;
+      economics.textContent += ` · ${formatAmount(cash.required_external_spend)} required external spend · ${formatAmount(cash.gross_cash_margin)} gross cash margin, not net profit`;
+    }
 
     const goal = document.createElement("p");
     goal.className = "fine";


### PR DESCRIPTION
## Purpose

Implements the transparent recovery announced in #689 for exactly five untouched direct bounties (#634-#638). It does not create new work claims or classify the recovery as organic activity.

## Safety boundaries

- Hard-coded allowlist of the five exact Base-mainnet contracts and immutable terms/policy/evidence hashes.
- Excludes these contracts from inventory, funnel, outcome, reputation, social-conversion, leaderboard, and objective metrics.
- Protects the externally claimed 2.01 USDC contract and all five standing-meta contracts by excluding them from this workflow.
- Runs each bounty's published repository and issue checks before claim, again before each independent verifier signature, and again before relay.
- Requires the exact two precommitted verifier keys and the exact verifier-set hash.
- Returns only the five direct solver rewards plus refundable bonds: exactly 10.00 USDC to the published owner recipient; verifier fees remain the precommitted 0.025 USDC each.
- No PR event can move funds. Execution requires this PR merged, exact main revision, exact PR URL, and manual confirmation `RECOVER ISSUE 689 EXACTLY 10 USDC`.
- Transaction hashes and signatures remain evidence inputs; only confirmed canonical `BountySettled` events establish settlement.

## Product fixes included

- Public inventory exposes solver reward, refundable bond, required external spend, gross cash margin, and a strict non-net-profit disclaimer.
- Recovery-reserved contracts are filtered from every public/agent inventory source.
- Regression quorum readiness fails closed on signer-set, threshold, runner, and manifest drift.
- `list_autonomous_bounties` is mounted in the public ChatGPT/MCP tool surface with a structured output schema.
- Routed replacement activation reconciles active lifecycle state instead of relying on source-text tests.

## Verification

- `python scripts/check.py --platform powershell` passed before rebase.
- Rebased on current `main` and reran Cargo format/check for `chain-base`, `db`, `api`, and `mcp-server`.
- API OpenAPI and cash-economics tests pass.
- Public mounted-inventory MCP test passes.
- Recovery allowlist/adversarial tests: 8 passed.
- Profitable inventory tests: 2 passed.
- Routed replacement tests: 12 passed.
- Site contract check passes.

Public notice and immutable accounting scope: #689.