### PR TITLE
fix: install recovery Rust check components

### DIFF
--- a/.github/workflows/direct-recovery-689.yml
+++ b/.github/workflows/direct-recovery-689.yml
@@ -118,6 +118,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+        with:
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
       - name: Recheck, claim, and submit the exact five contracts
@@ -152,6 +154,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+        with:
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -190,6 +194,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+        with:
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -231,6 +237,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
+        with:
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/scripts/test_direct_recovery_689.py
+++ b/scripts/test_direct_recovery_689.py
@@ -142,6 +142,12 @@ class DirectRecovery689Tests(unittest.TestCase):
             with self.assertRaisesRegex(recovery.RecoveryError, "exact verifier set"):
                 recovery.load_attestations(paths[:1], self.manifest)
 
+    def test_transaction_jobs_install_full_rust_check_components(self) -> None:
+        workflow = (
+            SCRIPTS.parent / ".github" / "workflows" / "direct-recovery-689.yml"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(workflow.count("components: rustfmt, clippy"), 4)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- install rustfmt and clippy in every recovery transaction job
- assert all four full-check jobs retain those components

## Incident
Run https://github.com/NSPG13/agent-bounties/actions/runs/30437548782 stopped before any bounty transaction because rustfmt was absent. Contract funds and the keeper bond reserve remain unchanged.

## Verification
- scripts/preflight.ps1 -Mode core
- python scripts/test_direct_recovery_689.py -v
- python -m py_compile scripts/direct_recovery_689.py scripts/test_direct_recovery_689.py
- git diff --check

Tracks #689.