### PR TITLE
fix: pin recovery Rust toolchain

### DIFF
--- a/.github/workflows/direct-recovery-689.yml
+++ b/.github/workflows/direct-recovery-689.yml
@@ -119,6 +119,7 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
         with:
+          toolchain: 1.88.0
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
@@ -155,6 +156,7 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
         with:
+          toolchain: 1.88.0
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
@@ -195,6 +197,7 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
         with:
+          toolchain: 1.88.0
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
@@ -238,6 +241,7 @@ jobs:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0
         with:
+          toolchain: 1.88.0
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a

--- a/scripts/test_direct_recovery_689.py
+++ b/scripts/test_direct_recovery_689.py
@@ -146,6 +146,7 @@ class DirectRecovery689Tests(unittest.TestCase):
         workflow = (
             SCRIPTS.parent / ".github" / "workflows" / "direct-recovery-689.yml"
         ).read_text(encoding="utf-8")
+        self.assertEqual(workflow.count("toolchain: 1.88.0"), 4)
         self.assertEqual(workflow.count("components: rustfmt, clippy"), 4)
 
 


### PR DESCRIPTION
## Summary
- explicitly pin Rust 1.88.0 when using the rust-toolchain action by commit SHA
- assert all four recovery transaction jobs retain the pinned toolchain and required components

## Root cause
Recovery run https://github.com/NSPG13/agent-bounties/actions/runs/30438299805 installed current stable because a commit-SHA action ref carries no toolchain version. Current stable renders Clap help differently from the project's 1.88.0 compatibility contract. Main CI and the fixture are correct.

## Verification
- python scripts/test_direct_recovery_689.py -v
- ustup run 1.88.0 cargo test -p cli cli_help_matches_compatibility_fixture --locked
- git diff --check

Tracks #689.