### PR TITLE
fix: isolate recovery acceptance environment

### DIFF
--- a/scripts/direct_recovery_689.py
+++ b/scripts/direct_recovery_689.py
@@ -41,6 +41,18 @@ EXACT_VERIFIER_SET_HASH = (
     "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
 )
 EXACT_REPOSITORY_CHECK = ["python", "scripts/check.py", "--platform", "posix"]
+ACCEPTANCE_ENV_EXCLUSIONS = frozenset(
+    {
+        "BASE_MAINNET_RPC_URL",
+        "BASE_KEEPER_PRIVATE_KEY",
+        "RECOVERY_VERIFIER_KEY",
+        "EXPECTED_SIGNER",
+        "REVISION",
+        "PULL_REQUEST_URL",
+        "CHECK_RUN_URL",
+        "GH_TOKEN",
+    }
+)
 EXACT_ISSUE_CHECKS = {
     634: [
         "cargo",
@@ -151,10 +163,12 @@ def run(
     *,
     cwd: Path = ROOT,
     timeout: int = 1_800,
+    env: Mapping[str, str] | None = None,
 ) -> str:
     completed = subprocess.run(
         list(command),
         cwd=cwd,
+        env=env,
         text=True,
         encoding="utf-8",
         errors="replace",
@@ -169,6 +183,14 @@ def run(
             f"{completed.stdout[-6_000:]}"
         )
     return completed.stdout.strip()
+
+
+def acceptance_environment() -> dict[str, str]:
+    return {
+        name: value
+        for name, value in os.environ.items()
+        if name not in ACCEPTANCE_ENV_EXCLUSIONS
+    }
 
 
 def load_manifest(path: Path) -> dict[str, Any]:
@@ -447,10 +469,11 @@ def run_acceptance_checks(manifest: Mapping[str, Any]) -> dict[int, dict[str, An
     ]
     cache: dict[str, dict[str, Any]] = {}
     by_issue: dict[int, dict[str, Any]] = {}
+    check_env = acceptance_environment()
     for index, command in enumerate(commands):
         key = canonical_json(command)
         if key not in cache:
-            run(command)
+            run(command, env=check_env)
             cache[key] = {
                 "command": command,
                 "exit_code": 0,

--- a/scripts/test_direct_recovery_689.py
+++ b/scripts/test_direct_recovery_689.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 
 SCRIPTS = Path(__file__).resolve().parent
@@ -148,6 +149,16 @@ class DirectRecovery689Tests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertEqual(workflow.count("toolchain: 1.88.0"), 4)
         self.assertEqual(workflow.count("components: rustfmt, clippy"), 4)
+
+    def test_acceptance_environment_excludes_recovery_runtime_values(self) -> None:
+        injected = {
+            name: f"private-{index}"
+            for index, name in enumerate(recovery.ACCEPTANCE_ENV_EXCLUSIONS)
+        }
+        injected["PATH"] = "public-tool-path"
+        with patch.dict(recovery.os.environ, injected, clear=True):
+            environment = recovery.acceptance_environment()
+        self.assertEqual(environment, {"PATH": "public-tool-path"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove recovery-only RPC, key, signer, and activation variables from acceptance-command subprocesses
- keep on-chain audit and broadcast context outside those subprocesses
- prove the sanitized environment preserves ordinary tool discovery

## Root cause
BASE_MAINNET_RPC_URL is a Clap-backed CLI environment value. The recovery job inherited it while running the public repository gate, changing rendered help and correctly tripping the compatibility fixture. Normal CI does not set it.

## Verification
- python scripts/test_direct_recovery_689.py -v
- reproduced the failure with BASE_MAINNET_RPC_URL set
- reran the pinned CLI compatibility test through cceptance_environment() with recovery values present; it passes
- python -m py_compile scripts/direct_recovery_689.py scripts/test_direct_recovery_689.py
- git diff --check

Tracks #689.