### PR TITLE
fix: serialize recovery keeper nonces

### DIFF
--- a/scripts/direct_recovery_689.py
+++ b/scripts/direct_recovery_689.py
@@ -283,6 +283,7 @@ class Cast:
     def __init__(self, executable: str, rpc_url: str) -> None:
         self.executable = executable
         self.rpc_url = rpc_url
+        self._next_nonces: dict[str, int] = {}
 
     def rpc(self, *args: str, timeout: int = 300) -> str:
         return run(
@@ -314,12 +315,33 @@ class Cast:
     def native_balance(self, account: str) -> int:
         return uint(self.rpc("balance", account), "native balance")
 
+    def next_nonce(self, key: str) -> int:
+        if key not in self._next_nonces:
+            signer = self.wallet_address(key)
+            latest = uint(
+                self.rpc("nonce", signer, "--block", "latest"),
+                "latest keeper nonce",
+            )
+            pending = uint(
+                self.rpc("nonce", signer, "--block", "pending"),
+                "pending keeper nonce",
+            )
+            if pending != latest:
+                raise RecoveryError(
+                    "keeper has another pending transaction; retry after it confirms or drops"
+                )
+            self._next_nonces[key] = latest
+        return self._next_nonces[key]
+
     def send(self, key: str, target: str, signature: str, *args: str) -> str:
+        nonce = self.next_nonce(key)
         raw = self.rpc(
             "send",
             "--json",
             "--private-key",
             key,
+            "--nonce",
+            str(nonce),
             target,
             signature,
             *args,
@@ -335,6 +357,7 @@ class Cast:
         status = str(receipt.get("status", ""))
         if not HASH.fullmatch(tx_hash) or status not in {"0x1", "0x01", "1"}:
             raise RecoveryError("transaction did not return a successful receipt")
+        self._next_nonces[key] = nonce + 1
         return tx_hash
 
     def sign_digest(self, key: str, digest: str) -> str:

--- a/scripts/test_direct_recovery_689.py
+++ b/scripts/test_direct_recovery_689.py
@@ -160,6 +160,26 @@ class DirectRecovery689Tests(unittest.TestCase):
             environment = recovery.acceptance_environment()
         self.assertEqual(environment, {"PATH": "public-tool-path"})
 
+    def test_send_uses_one_explicit_sequential_nonce_cursor(self) -> None:
+        cast = recovery.Cast("cast", "https://rpc.example")
+        key = "secret"
+        cast._next_nonces[key] = 62
+        receipt = json.dumps({"transactionHash": "0x" + "11" * 32, "status": "0x1"})
+        with patch.object(cast, "rpc", return_value=receipt) as rpc:
+            cast.send(key, "0x" + "22" * 20, "claim()")
+            cast.send(key, "0x" + "33" * 20, "claim()")
+        self.assertEqual(rpc.call_args_list[0].args[4:6], ("--nonce", "62"))
+        self.assertEqual(rpc.call_args_list[1].args[4:6], ("--nonce", "63"))
+
+    def test_send_rejects_an_existing_pending_keeper_transaction(self) -> None:
+        cast = recovery.Cast("cast", "https://rpc.example")
+        with (
+            patch.object(cast, "wallet_address", return_value="0x" + "11" * 20),
+            patch.object(cast, "rpc", side_effect=["62", "63"]),
+            self.assertRaisesRegex(recovery.RecoveryError, "another pending transaction"),
+        ):
+            cast.next_nonce("secret")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reserve one explicit keeper nonce cursor per recovery process
- pass each nonce to cast send and increment only after a successful receipt
- fail closed when another keeper transaction is already pending

## Incident
Run https://github.com/NSPG13/agent-bounties/actions/runs/30440389834 passed all checks and confirmed the first 0.01 USDC allowance at nonce 61. A load-balanced RPC read then reused stale nonce 61 for claim(), which failed as an underpriced replacement. No bounty was claimed and no USDC left the keeper.

## Verification
- python scripts/test_direct_recovery_689.py -v
- python -m py_compile scripts/direct_recovery_689.py scripts/test_direct_recovery_689.py
- git diff --check

Tracks #689.