### PR TITLE
Add verifier reliability bounty mechanism

### DIFF
--- a/bounties/autonomous-v1/650.json
+++ b/bounties/autonomous-v1/650.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "agent-bounties/terms-v1",
+  "contract_terms": {
+    "protocol_version": "agent-bounties/autonomous-v1",
+    "creator_wallet": "0x6c93cb2ae08e2c44c45619ad5b08819a3b50da9a",
+    "network": "base-mainnet",
+    "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    "solver_reward": { "amount": 2000000, "currency": "usdc" },
+    "verifier_reward": { "amount": 10000, "currency": "usdc" },
+    "claim_bond": { "amount": 10000, "currency": "usdc" },
+    "initial_funding": { "amount": 2010000, "currency": "usdc" },
+    "funding_deadline": 1820000000,
+    "claim_window_seconds": 1209600,
+    "verification_window_seconds": 1209600,
+    "creation_nonce": "0x0000000000000000000000000000000000000000000000000000000000000001"
+  },
+  "title": "verifier reliability child bounty task",
+  "goal": "Produce a concrete coding task that exercises the sandboxed-regression signed verifier quorum and pays the solver 1 USDC.",
+  "acceptance_criteria": [
+    "Publish the exact child terms on Base from the parent solver wallet before claiming.",
+    "Create and fully fund the parent-bound canonical child to at least 1.00 USDC.",
+    "Use the committed sandboxed-regression signed verifier quorum with threshold two.",
+    "Have a different registered participant complete the child and receive canonical settlement.",
+    "Submit the child bounty contract address and discovery feedback to the routed verifier."
+  ],
+  "benchmark": {
+    "engine": "standing_meta_v3_routed_parent",
+    "lane": "verifier_reliability",
+    "required_child_engine": "sandboxed_regression_v1",
+    "required_child_status": "settled",
+    "required_child_verifier_set_hash": "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
+    "required_child_verifier_threshold": 2,
+    "minimum_child_target": 1000000,
+    "minimum_parent_gross_margin": 1000000,
+    "participant_registry": "0x9875dcaf570bde8ff1aa62275d3c8985f4fd1294",
+    "terms_registry": "0x35e5d49c12b75c119d33951c2c4f054c5732208c"
+  },
+  "evidence_schema": {
+    "type": "object",
+    "required": ["child_bounty_contract", "discovery_source", "participation_reason", "improvement_feedback"],
+    "properties": {
+      "child_bounty_contract": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+      "discovery_source": { "type": "string" },
+      "participation_reason": { "type": "string" },
+      "improvement_feedback": { "type": "string" }
+    },
+    "additionalProperties": true
+  },
+  "verification_policy": {
+    "mechanism": "deterministic_module",
+    "verifier_module": "0x380c1af742593dd88b6f20387e9ee693a0536731",
+    "verifier_reward_recipient": "0xc26a630e85134ed30968735c8e7de4576cfa5dbc",
+    "commitment": "See canonical immutable benchmark criteria.",
+    "rejection_penalty": "A canonical rejection frees the child solver bond to a bonus pool but does not refund the parent solver."
+  },
+  "source_url": null,
+  "discovery_source": null,
+  "image": null
+}

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -9381,6 +9381,81 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn routed_v3_verifier_reliability_economics_produce_one_usdc_gross_margin() {
+        let created_at = DateTime::<Utc>::from_timestamp(1_800_000_000, 0).unwrap();
+        let document: AutonomousBountyTermsDocument =
+            serde_json::from_str(include_str!("../../../bounties/autonomous-v1/650.json"))
+                .unwrap();
+        let terms = build_autonomous_bounty_terms_record(
+            "0x6c93cb2ae08e2c44c45619ad5b08819a3b50da9a",
+            document,
+            created_at,
+        )
+        .unwrap();
+
+        let item = AutonomousBountyFeedItem {
+            bounty_id: format!("0x{}", "ab".repeat(32)),
+            bounty_contract: "0x6c93cb2ae08e2c44c45619ad5b08819a3b50da9a".to_string(),
+            creator: "0x6c93cb2ae08e2c44c45619ad5b08819a3b50da9a".to_string(),
+            status: "claimable".to_string(),
+            solver_reward: "2000000".to_string(),
+            verifier_reward: "10000".to_string(),
+            claim_bond: "10000".to_string(),
+            timeout_bond_pool: "0".to_string(),
+            target_amount: "2010000".to_string(),
+            funded_amount: "2010000".to_string(),
+            required_external_spend: "1000000".to_string(),
+            gross_cash_margin: "1000000".to_string(),
+            terms_hash: terms.terms_hash.clone(),
+            terms: Some(terms),
+            terms_valid: true,
+            verification_mode: "deterministic_module".to_string(),
+            verifier_module: Some(BASE_MAINNET_STANDING_META_V3_ROUTER.to_string()),
+            verifier_set_hash: None,
+            verifier_threshold: None,
+            runner_identifier: Some("standing_meta_v3_routed_parent".to_string()),
+            verification_ready: true,
+            verification_readiness_reason:
+                "the routed-v3 verifier and profitable child dependency are supported"
+                    .to_string(),
+            validation_errors: Vec::new(),
+            events: Vec::new(),
+        };
+
+        assert!(is_supported_routed_v3_parent_terms(
+            item.verifier_module.as_deref(),
+            2_000_000,
+            item.terms.as_ref(),
+        ));
+
+        let context = standing_meta_v2_parent_context(&item).unwrap();
+        assert_eq!(context.solver_reward.amount, 2_000_000);
+        assert_eq!(context.child_target.amount, 1_000_000);
+        assert_eq!(
+            context.solver_reward.amount - context.child_target.amount,
+            1_000_000,
+            "parent gross margin must be exactly 1 USDC"
+        );
+        assert_eq!(
+            context.protocol_version,
+            STANDING_META_V3_ROUTED_PROTOCOL_VERSION
+        );
+
+        assert_eq!(
+            item.required_external_spend.parse::<u128>().unwrap(),
+            1_000_000,
+            "required external spend must match minimum_child_target"
+        );
+        assert_eq!(
+            item.gross_cash_margin.parse::<i128>().unwrap(),
+            1_000_000,
+            "gross cash margin must be exactly 1 USDC"
+        );
+        assert!(item.verification_ready);
+        assert!(item.verification_readiness_reason.contains("routed-v3"));
+    }
+
     struct MockTransport {
         seen_request: Arc<Mutex<Option<Value>>>,
         response: Value,


### PR DESCRIPTION
Closes #650. Implements the required logic/structure for the META verifier reliability bounty.