### PR TITLE
fix: isolate regression verifier RPC configuration

### DIFF
--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -102,7 +102,7 @@ jobs:
       cancel-in-progress: false
     env:
       API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://api.agentbounties.app' }}
-      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      BASE_MAINNET_RPC_URL: ${{ vars.REGRESSION_VERIFIER_RPC_URL || 'https://mainnet.base.org' }}
       BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
       VERIFIER_ONE: ${{ vars.REGRESSION_VERIFIER_ONE_ADDRESS }}
       VERIFIER_TWO: ${{ vars.REGRESSION_VERIFIER_TWO_ADDRESS }}

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 20
     env:
       API_BASE_URL: ${{ vars.PRODUCTION_API_BASE_URL || 'https://api.agentbounties.app' }}
-      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      BASE_MAINNET_RPC_URL: ${{ vars.REGRESSION_VERIFIER_RPC_URL || 'https://mainnet.base.org' }}
       REGRESSION_VERIFIER_PRIVATE_KEY: ${{ secrets.verifier_private_key }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a

--- a/docs/sandboxed-regression-verifier.md
+++ b/docs/sandboxed-regression-verifier.md
@@ -116,6 +116,14 @@ separate no-secrets service with a runner-owned staging volume. Signing must be
 a separate capability that verifies a fresh candidate against the current
 canonical job and requires at least two distinct precommitted verifier paths.
 
+The signer and keeper workflows read their Base endpoint from the dedicated
+`REGRESSION_VERIFIER_RPC_URL` Actions variable and otherwise use
+`https://mainnet.base.org`. Keep this separate from the application's general
+`BASE_MAINNET_RPC_URL`: an unavailable shared provider must not disable the
+isolated verification path. Any configured endpoint remains subject to the
+same exact current-job revalidation and on-chain signature checks; an RPC
+response, signature, or broadcast is never settlement evidence.
+
 Only confirmed canonical `BountySettled` is payout evidence. A runner receipt,
 response hash, verifier signature, quorum plan, relay transaction hash, or
 hosted database row is not payment evidence.

--- a/scripts/test_regression_verifier_pipeline.py
+++ b/scripts/test_regression_verifier_pipeline.py
@@ -38,6 +38,17 @@ def archive(entries: list[tuple[str, bytes | None, str]]) -> bytes:
 
 
 class RegressionVerifierPipelineTests(unittest.TestCase):
+    def test_verifier_signing_uses_a_dedicated_rpc_configuration(self) -> None:
+        workflow_root = SCRIPT.parent.parent / ".github" / "workflows"
+        for name in (
+            "regression-verifier-signing-reusable.yml",
+            "regression-verifier-signer.yml",
+        ):
+            with self.subTest(workflow=name):
+                workflow = (workflow_root / name).read_text(encoding="utf-8")
+                self.assertIn("vars.REGRESSION_VERIFIER_RPC_URL", workflow)
+                self.assertNotIn("vars.BASE_MAINNET_RPC_URL", workflow)
+
     def test_stale_runner_revision_skips_every_signing_job(self) -> None:
         workflow = (
             SCRIPT.parent.parent / ".github" / "workflows" / "regression-verifier-signer.yml"


### PR DESCRIPTION
## Summary

Isolate the sandboxed-regression signer and keeper relay from the repository's
general `BASE_MAINNET_RPC_URL` variable.

Both workflows now read an optional dedicated
`REGRESSION_VERIFIER_RPC_URL` Actions variable and otherwise use the existing
`https://mainnet.base.org` default. No verifier keys, contract authority,
attestation scope, relay calldata, or payout evidence rules change.

## Why

The submitted issue #650 child passed the immutable runner and both committed
verifiers, but settlement run
https://github.com/NSPG13/agent-bounties/actions/runs/30623466270 failed when the
global RPC variable resolved to `https://1rpc.io/base` and returned Cloudflare
HTTP 403. A second scheduled cycle
https://github.com/NSPG13/agent-bounties/actions/runs/30630973082 failed on the
same endpoint before the second signer could produce its attestation.

Public incident evidence and the immediate operator remediation are recorded
at https://github.com/NSPG13/agent-bounties/issues/650#issuecomment-5142104372.

This patch prevents an unavailable application-wide provider from disabling
the isolated regression-verification path while retaining an explicit,
reviewable override for a managed verifier RPC.

## Risk and compatibility

- Change class: R3 operational configuration surface because the workflows
  hold signer/keeper capabilities; this patch does not alter those capabilities.
- Existing `PRODUCTION_API_BASE_URL`, verifier-address variables, and secrets
  are unchanged.
- Existing installations that intentionally use a managed provider for this
  path should set `REGRESSION_VERIFIER_RPC_URL` to that reviewed endpoint.
- Without the new variable, both workflows use their pre-existing Base default.
- The canonical feed and `BountySettled` remain the only payment evidence.

## Open PR impact

Checked the open PR queue. PRs #710 and #730 mention issue #650 but touch only
the bounty manifest/chain planner and activation template/workflow respectively;
neither overlaps these verifier workflows, test, or runbook. No active PR is
known to require rework.

## Validation

- `python3 scripts/test_regression_verifier_pipeline.py -v` — 7 passed
- `python3 -m py_compile scripts/regression_verifier_pipeline.py scripts/test_regression_verifier_pipeline.py`
- `bash scripts/preflight.sh core` — passed
- PyYAML parse of both modified workflow files — passed
- live `https://mainnet.base.org` `eth_chainId` probe — HTTP 200, chain ID 8453
- `git diff --check` — passed

## Distribution feedback

- How did you find Agent Bounties?
- What made this bounty or project worth participating in?
- Did an AI agent, tool, prompt, link, label, scanner, or workflow route you here?
- What would make participation easier or more trustworthy?
