### PR TITLE
fix: reopen expired recovery submissions

### DIFF
--- a/scripts/direct_recovery_689.py
+++ b/scripts/direct_recovery_689.py
@@ -792,6 +792,39 @@ def key_from_env(name: str) -> str:
     return key
 
 
+def expire_stale_submissions(
+    cast: Cast,
+    manifest: Mapping[str, Any],
+    states: dict[int, dict[str, Any]],
+    key: str,
+    now: int,
+) -> dict[int, str]:
+    transactions: dict[int, str] = {}
+    for bounty in manifest["bounties"]:
+        issue = int(bounty["issue"])
+        state = states[issue]
+        if (
+            state["status"] != 3
+            or state["verification_expires_at"] >= now
+        ):
+            continue
+        transaction = cast.send(key, bounty["contract"], "expireSubmission()")
+        refreshed = audit_bounty(cast, manifest, bounty)
+        if (
+            refreshed["status"] != 1
+            or refreshed["solver"] != "0x0000000000000000000000000000000000000000"
+            or refreshed["active_claim_bond"] != 0
+            or refreshed["submission_hash"] != "0x" + "00" * 32
+            or refreshed["evidence_hash"] != "0x" + "00" * 32
+        ):
+            raise RecoveryError(
+                f"issue #{issue} expired submission did not reset to a clean claimable round"
+            )
+        states[issue] = refreshed
+        transactions[issue] = transaction
+    return transactions
+
+
 def command_audit(args: argparse.Namespace) -> None:
     manifest = load_manifest(args.manifest)
     cast = Cast(args.cast, args.rpc_url)
@@ -833,6 +866,13 @@ def command_prepare(args: argparse.Namespace) -> None:
         int(bounty["issue"]): audit_bounty(cast, manifest, bounty)
         for bounty in manifest["bounties"]
     }
+    expiration_transactions = expire_stale_submissions(
+        cast,
+        manifest,
+        states,
+        key,
+        int(time.time()),
+    )
     claimable = [
         bounty
         for bounty in manifest["bounties"]
@@ -867,6 +907,8 @@ def command_prepare(args: argparse.Namespace) -> None:
         validate_candidate_hashes(candidate)
         state = states[issue]
         transactions: dict[str, str] = {}
+        if issue in expiration_transactions:
+            transactions["expire_submission"] = expiration_transactions[issue]
         if state["status"] == 1:
             transactions["approve"] = cast.send(
                 key,

--- a/scripts/test_direct_recovery_689.py
+++ b/scripts/test_direct_recovery_689.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 SCRIPTS = Path(__file__).resolve().parent
@@ -263,6 +263,61 @@ class DirectRecovery689Tests(unittest.TestCase):
             self.assertRaisesRegex(recovery.RecoveryError, "another pending transaction"),
         ):
             cast.next_nonce("secret")
+
+    def test_expired_submission_is_reset_for_a_new_recovery_round(self) -> None:
+        bounty = self.manifest["bounties"][0]
+        issue = bounty["issue"]
+        states = {
+            issue: {
+                "status": 3,
+                "verification_expires_at": 99,
+            }
+        }
+        refreshed = {
+            "status": 1,
+            "solver": "0x" + "00" * 20,
+            "active_claim_bond": 0,
+            "submission_hash": "0x" + "00" * 32,
+            "evidence_hash": "0x" + "00" * 32,
+        }
+        cast = Mock()
+        cast.send.return_value = "0x" + "11" * 32
+        one_bounty_manifest = {**self.manifest, "bounties": [bounty]}
+        with patch.object(recovery, "audit_bounty", return_value=refreshed):
+            transactions = recovery.expire_stale_submissions(
+                cast,
+                one_bounty_manifest,
+                states,
+                "secret",
+                100,
+            )
+        cast.send.assert_called_once_with(
+            "secret",
+            bounty["contract"],
+            "expireSubmission()",
+        )
+        self.assertEqual(states[issue], refreshed)
+        self.assertEqual(transactions[issue], "0x" + "11" * 32)
+
+    def test_unexpired_submission_is_not_reset(self) -> None:
+        bounty = self.manifest["bounties"][0]
+        issue = bounty["issue"]
+        states = {
+            issue: {
+                "status": 3,
+                "verification_expires_at": 100,
+            }
+        }
+        cast = Mock()
+        transactions = recovery.expire_stale_submissions(
+            cast,
+            {**self.manifest, "bounties": [bounty]},
+            states,
+            "secret",
+            100,
+        )
+        cast.send.assert_not_called()
+        self.assertEqual(transactions, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Summary
- detect submitted recovery contracts whose verification window expired
- permissionlessly call `expireSubmission()` to return the keeper bond and restore `Claimable`
- reclaim and resubmit the exact pinned evidence in a fresh round before generating new quorum attestations
- record the expiry transaction in candidate evidence for resumability

## Safety boundary
Only the five #689 contracts can be touched. Existing candidate hashes, acceptance commands, verifier set, USDC amount, return recipient, and metrics exclusion remain immutable. Unexpired submissions are never reset.

## Verification
- `python scripts/test_direct_recovery_689.py -v` (18 passed)
- `python -m py_compile scripts/direct_recovery_689.py`
- `cargo fmt --all -- --check`
- `git diff --check`

Public change notice: #689.
