### PR TITLE
Make one verifier the default for coding bounties

### DIFF
--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -773,6 +773,12 @@ pub fn canonical_opportunity(
         gross_cash_margin_positive: gross_cash_margin > 0,
         scope_disclaimer: "Gross cash margin is solver reward minus required external spend. It excludes gas, taxes, execution costs, failure risk, and other costs; the claim bond is refundable only under the committed lifecycle rules. It is not guaranteed net profit.".to_string(),
     };
+    let verification_method =
+        if item.verification_mode == "signed_quorum" && item.verifier_threshold == Some(1) {
+            "single_verifier".to_string()
+        } else {
+            item.verification_mode.clone()
+        };
     Some(OpportunityItem {
         opportunity_id: opportunity_id.clone(),
         source_type: "canonical_base".to_string(),
@@ -808,7 +814,7 @@ pub fn canonical_opportunity(
         bond: OpportunityAmount::usdc_base_units(item.claim_bond.clone()),
         deadline,
         deadline_kind,
-        verification_method: item.verification_mode.clone(),
+        verification_method,
         verification_ready: state.verification_ready,
         evidence_requirements,
         terms_hash: Some(item.terms_hash.clone()),

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -423,6 +423,8 @@ pub const BASE_MAINNET_STANDING_META_V3_ACCEPTANCE_CRITERIA_HASH: &str =
     "0xba3b04ab970dfd91f5ccf1b7eda6670b5a38a854bca16dc980ec8362ed2bcaf9";
 pub const BASE_MAINNET_STANDING_META_V2_VERIFIER_SET_HASH: &str =
     "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd";
+pub const BASE_MAINNET_DEFAULT_REGRESSION_VERIFIER_SET_HASH: &str =
+    "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2";
 pub const BASE_MAINNET_STANDING_META_V2_VERIFIERS: [&str; 2] = [
     "0xbe6292b9e465f549e2363b918d6dd9187038431e",
     "0xb7c2ce6430b66fb986e27b6140b29309550d487a",
@@ -3922,26 +3924,41 @@ fn regression_quorum_readiness(
     };
     let policy = &terms.document.verification_policy;
     let benchmark = &terms.document.benchmark;
-    if !creation_data["verifier_set_hash"]
-        .as_str()
-        .is_some_and(|hash| {
-            hash.eq_ignore_ascii_case(BASE_MAINNET_STANDING_META_V2_VERIFIER_SET_HASH)
-        })
-    {
-        return (false, "verifier set mismatch");
-    }
-    if creation_data["threshold"].as_u64()
-        != Some(BASE_MAINNET_STANDING_META_V2_VERIFIERS.len() as u64)
-    {
+    let Some(threshold) = creation_data["threshold"]
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())
+        .filter(|value| (1..=BASE_MAINNET_STANDING_META_V2_VERIFIERS.len()).contains(value))
+    else {
         return (false, "verifier threshold mismatch");
-    }
+    };
     let configured_signers = policy
         .get("verifiers")
         .and_then(Value::as_array)
         .map(Vec::as_slice)
         .unwrap_or(&[]);
-    if configured_signers.len() < BASE_MAINNET_STANDING_META_V2_VERIFIERS.len() {
+    if configured_signers.len() != threshold
+        || configured_signers
+            .iter()
+            .zip(BASE_MAINNET_STANDING_META_V2_VERIFIERS.iter())
+            .any(|(actual, expected)| {
+                !actual
+                    .as_str()
+                    .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+            })
+    {
         return (false, "required verifier signer is missing");
+    }
+    if policy.get("threshold").and_then(Value::as_u64) != Some(threshold as u64) {
+        return (false, "verifier threshold mismatch");
+    }
+    let Ok(expected_set_hash) = verifier_set_hash_from_policy(policy) else {
+        return (false, "verifier set mismatch");
+    };
+    if !creation_data["verifier_set_hash"]
+        .as_str()
+        .is_some_and(|hash| hash.eq_ignore_ascii_case(&expected_set_hash))
+    {
+        return (false, "verifier set mismatch");
     }
     if policy.get("mechanism").and_then(Value::as_str) != Some("signed_quorum") {
         return (false, "signed-quorum policy is unavailable");
@@ -3961,10 +3978,17 @@ fn regression_quorum_readiness(
             "regression runner manifest is unavailable or invalid",
         );
     }
-    (
-        true,
-        "the exact built-in sandboxed-regression quorum is supported",
-    )
+    if threshold == 1 {
+        (
+            true,
+            "the default single sandboxed-regression verifier is supported",
+        )
+    } else {
+        (
+            true,
+            "the optional two-verifier sandboxed-regression policy is supported",
+        )
+    }
 }
 
 fn valid_regression_benchmark(benchmark: &Value) -> bool {
@@ -6234,15 +6258,23 @@ pub fn validate_autonomous_creation_for_public_earning(
             }
         }
         AutonomousVerificationMode::SignedQuorum => {
-            let exact_verifiers = create.verifiers.len()
-                == BASE_MAINNET_STANDING_META_V2_VERIFIERS.len()
+            let threshold = usize::from(create.threshold);
+            let exact_verifiers = (1..=BASE_MAINNET_STANDING_META_V2_VERIFIERS.len())
+                .contains(&threshold)
+                && create.verifiers.len() == threshold
                 && create
                     .verifiers
                     .iter()
                     .zip(BASE_MAINNET_STANDING_META_V2_VERIFIERS.iter().copied())
                     .all(|(actual, expected)| actual.eq_ignore_ascii_case(expected));
             let exact_policy = create.threshold
-                == BASE_MAINNET_STANDING_META_V2_VERIFIERS.len() as u8
+                == u8::try_from(threshold).expect("supported threshold fits uint8")
+                && terms
+                    .document
+                    .verification_policy
+                    .get("threshold")
+                    .and_then(Value::as_u64)
+                    == Some(threshold as u64)
                 && terms
                     .document
                     .verification_policy
@@ -6252,7 +6284,7 @@ pub fn validate_autonomous_creation_for_public_earning(
                 && valid_regression_benchmark(&terms.document.benchmark);
             if !exact_verifiers || !exact_policy {
                 return Err(ChainBaseError::InvalidVerificationConfiguration(
-                    "public earning inventory permits only the live sandboxed-regression signed quorum with an exact benchmark source and valid runner manifest; unsupported verifier policies must remain unfunded drafts"
+                    "public earning inventory permits the default single sandboxed-regression verifier or the optional exact two-verifier policy with a valid committed benchmark; unsupported verifier policies must remain unfunded drafts"
                         .to_string(),
                 ));
             }
@@ -8109,7 +8141,38 @@ mod tests {
             regression_quorum_readiness(&healthy_quorum, Some(&supported_record)),
             (
                 true,
-                "the exact built-in sandboxed-regression quorum is supported"
+                "the optional two-verifier sandboxed-regression policy is supported"
+            )
+        );
+        let mut single_document = supported_record.document.clone();
+        single_document.verification_policy["threshold"] = json!(1);
+        single_document.verification_policy["verifiers"] =
+            json!([BASE_MAINNET_STANDING_META_V2_VERIFIERS[0]]);
+        let single_record =
+            build_autonomous_bounty_terms_record(&record.creator_wallet, single_document, now)
+                .unwrap();
+        let single_create = autonomous_bounty_create_from_terms(&single_record).unwrap();
+        validate_autonomous_creation_for_public_earning(
+            "base-mainnet",
+            &single_create,
+            &single_record,
+        )
+        .unwrap();
+        assert_eq!(
+            verifier_set_hash_from_policy(&single_record.document.verification_policy).unwrap(),
+            BASE_MAINNET_DEFAULT_REGRESSION_VERIFIER_SET_HASH
+        );
+        assert_eq!(
+            regression_quorum_readiness(
+                &json!({
+                    "verifier_set_hash": BASE_MAINNET_DEFAULT_REGRESSION_VERIFIER_SET_HASH,
+                    "threshold": 1
+                }),
+                Some(&single_record),
+            ),
+            (
+                true,
+                "the default single sandboxed-regression verifier is supported"
             )
         );
         let mut missing_signer = supported_record.clone();

--- a/crates/mcp-server/fixtures/tool-registry.json
+++ b/crates/mcp-server/fixtures/tool-registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "agent-bounties/mcp-tool-registry-v1",
-  "normalized_descriptors_sha256": "29db3cbccef5536f2b6213562f9a8ba69f6d1abc846102116056930674e37554",
+  "normalized_descriptors_sha256": "4d34aa292860c9631be25a6184ef2d1706f75b47fa8983acb41a2ac34b0049f6",
   "tools": [
     "route_blocked_goal",
     "plan_objective_creation",

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -2416,7 +2416,7 @@ async fn tools() -> Json<Vec<ToolDescriptor>> {
                         "additionalProperties": false
                     },
                     "evidence_schema": nullable_object_property("Optional submission schema; defaults to a required sha256 source_snapshot_digest."),
-                    "verifier_reward": nullable_object_property("Optional USDC money object; defaults to 100000 base units and must divide across two verifiers."),
+                    "verifier_reward": nullable_object_property("Optional USDC money object; defaults to 100000 base units and is paid to the precommitted verifier path."),
                     "funding_deadline": nullable_integer_property("Optional child funding deadline; defaults to the immutable parent deadline."),
                     "claim_window_seconds": nullable_integer_property("Optional child claim window; defaults to 259200 seconds."),
                     "verification_window_seconds": nullable_integer_property("Optional child verification window; defaults to 259200 seconds."),
@@ -2947,11 +2947,11 @@ fn autonomous_bounty_create_property() -> Value {
             "funding_deadline": integer_property("Unix timestamp after which an incomplete crowdfund can be cancelled."),
             "claim_window_seconds": integer_property("Seconds a solver has to submit after claiming."),
             "verification_window_seconds": integer_property("Seconds committed verifiers have to settle after submission."),
-            "verification_mode": enum_property(&["deterministic_module", "signed_quorum", "ai_judge_quorum"], "Immutable on-chain verification mechanism."),
+            "verification_mode": enum_property(&["deterministic_module", "signed_quorum", "ai_judge_quorum"], "Immutable on-chain verification mechanism. Use signed_quorum with threshold 1 for one verifier; add verifiers only when higher-risk work needs independent review."),
             "verifier_module": nullable_string_property("Deterministic verifier contract; null for quorum modes."),
             "verifier_reward_recipient": nullable_string_property("Deterministic verifier reward wallet; null for quorum modes."),
             "verifiers": string_array_property("One to eight precommitted verifier wallets for quorum modes; empty for deterministic mode."),
-            "threshold": integer_property("Number of matching verifier signatures required; AI judge mode requires at least two."),
+            "threshold": integer_property("Number of matching verifier signatures required. Default to 1 for signed verification; AI judge mode requires at least 2."),
             "initial_funding": money_property("Creation-time funding. Zero creates a crowdfundable bounty; target funding makes it immediately claimable.", true),
             "creation_nonce": string_property("Unique nonzero random bytes32. It binds the CREATE2 bounty id and address.")
         },

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -868,16 +868,19 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
         verification_modes: vec![
             serde_json::json!({
                 "name": "deterministic_module",
-                "default_for_new_bounties": true,
+                "default_for_new_bounties": false,
                 "default_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
-                "earning_inventory": "ready only for a recognized exact deterministic module whose committed benchmark matches that module; unknown modules fail closed",
+                "earning_inventory": "ready only when an exact recognized on-chain module evaluates the full committed acceptance rule; the built-in leading-zero module is for protocol canaries, not coding work",
                 "settlement": "Any caller supplies proof to the immutable on-chain verifier module; pass settles and fail reopens atomically. The verifier receives the same committed reward for either verdict."
             }),
             serde_json::json!({
                 "name": "signed_quorum",
-                "default_for_new_bounties": false,
-                "earning_inventory": "fails closed until verifier-service availability is canonically attestable",
-                "settlement": "Committed verifier wallets sign the exact round, solver, submission, evidence, result, response, and deadline. A valid pass or fail quorum receives the same reward."
+                "product_label": "single_verifier",
+                "default_for_new_bounties": true,
+                "default_threshold": 1,
+                "default_verifiers": ["0xbe6292b9e465f549e2363b918d6dd9187038431e"],
+                "earning_inventory": "ready when the one precommitted verifier service and exact sandbox benchmark are available",
+                "settlement": "The precommitted verifier signs the exact round, solver, submission, evidence, result, response, and deadline. Multi-verifier review is optional for higher-risk work."
             }),
             serde_json::json!({
                 "name": "ai_judge_quorum",
@@ -889,8 +892,9 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
         ],
         funding: serde_json::json!({
             "default": "fully funded on creation",
-            "default_verification": "deterministic_module",
-            "default_verifier_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
+            "default_verification": "signed_quorum",
+            "default_verifier_threshold": 1,
+            "default_verifier": "0xbe6292b9e465f549e2363b918d6dd9187038431e",
             "crowdfunding": "zero-funded bounties may be created; any wallet may contribute until the target is reached",
             "eoa_fast_path": "Circle USDC EIP-3009 bounded authorization",
             "x402": {
@@ -3713,7 +3717,7 @@ mod tests {
             .iter()
             .find(|mode| mode["name"] == "deterministic_module")
             .unwrap();
-        assert_eq!(deterministic["default_for_new_bounties"], true);
+        assert_eq!(deterministic["default_for_new_bounties"], false);
         assert_eq!(
             deterministic["default_module"],
             "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e"
@@ -3721,11 +3725,17 @@ mod tests {
         assert!(deterministic["earning_inventory"]
             .as_str()
             .unwrap()
-            .contains("unknown modules fail closed"));
-        assert_eq!(
-            manifest.funding["default_verification"],
-            "deterministic_module"
-        );
+            .contains("protocol canaries"));
+        let single = manifest
+            .verification_modes
+            .iter()
+            .find(|mode| mode["name"] == "signed_quorum")
+            .unwrap();
+        assert_eq!(single["default_for_new_bounties"], true);
+        assert_eq!(single["default_threshold"], 1);
+        assert_eq!(single["product_label"], "single_verifier");
+        assert_eq!(manifest.funding["default_verification"], "signed_quorum");
+        assert_eq!(manifest.funding["default_verifier_threshold"], 1);
         assert!(manifest.funding["gas_sponsorship"]
             .as_str()
             .unwrap()

--- a/crates/worker/src/regression_sandbox.rs
+++ b/crates/worker/src/regression_sandbox.rs
@@ -398,12 +398,12 @@ pub fn prepare_regression_run(
             "sandboxed regression verification requires signed_quorum without a verifier module"
         ));
     }
-    if job.threshold < 2
-        || job.eligible_verifiers.len() < usize::from(job.threshold)
+    if job.threshold == 0
+        || job.eligible_verifiers.len() != usize::from(job.threshold)
         || job.verification_expires_at <= observed_at_unix
     {
         return Err(anyhow!(
-            "sandboxed regression verification requires a live quorum threshold of at least two"
+            "sandboxed regression verification requires at least one live precommitted verifier"
         ));
     }
     let mut distinct_verifiers = HashSet::new();
@@ -456,7 +456,7 @@ pub fn prepare_regression_run(
             != Some(u64::from(job.threshold))
     {
         return Err(anyhow!(
-            "verification policy does not commit sandboxed_regression_v1 signed quorum"
+            "verification policy does not commit sandboxed_regression_v1 signed verification"
         ));
     }
     let policy_verifiers = verification_policy
@@ -1116,9 +1116,10 @@ mod tests {
     #[test]
     fn autonomous_job_adapter_rejects_weak_or_wrong_verification_policy() {
         let staging = temp_directory("policy-adapter");
-        let mut threshold_one = verification_job();
-        threshold_one.threshold = 1;
-        assert!(prepare_regression_run(threshold_one, 1_800_000_000, &staging).is_err());
+        let mut threshold_zero = verification_job();
+        threshold_zero.threshold = 0;
+        threshold_zero.terms.document.verification_policy["threshold"] = json!(0);
+        assert!(prepare_regression_run(threshold_zero, 1_800_000_000, &staging).is_err());
 
         let mut duplicate = verification_job();
         duplicate.eligible_verifiers[1] = duplicate.eligible_verifiers[0].clone();
@@ -1138,6 +1139,24 @@ mod tests {
         missing_source.submission_evidence.evidence_hash =
             sha256_canonical_json(&missing_source.submission_evidence.evidence).unwrap();
         assert!(prepare_regression_run(missing_source, 1_800_000_000, &staging).is_err());
+        remove_tree_best_effort(&staging);
+    }
+
+    #[test]
+    fn autonomous_job_adapter_accepts_one_precommitted_verifier() {
+        let staging = temp_directory("single-verifier-adapter");
+        let mut job = verification_job();
+        job.threshold = 1;
+        job.eligible_verifiers.truncate(1);
+        job.terms.document.verification_policy["threshold"] = json!(1);
+        job.terms.document.verification_policy["verifiers"] = json!([job.eligible_verifiers[0]]);
+        job.terms = build_autonomous_bounty_terms_record(
+            &job.terms.creator_wallet,
+            job.terms.document.clone(),
+            job.terms.created_at,
+        )
+        .unwrap();
+        prepare_regression_run(job, 1_800_000_000, &staging).unwrap();
         remove_tree_best_effort(&staging);
     }
 

--- a/deployments/bounded-agent-wallet-v2-base-mainnet.json
+++ b/deployments/bounded-agent-wallet-v2-base-mainnet.json
@@ -10,7 +10,7 @@
     "bounty_factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
     "deterministic_verifier": "0x380c1af742593dd88b6f20387e9ee693a0536731",
-    "signed_quorum_verifier_set_hash": "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
+    "signed_quorum_verifier_set_hash": "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2"
   },
   "deterministic_deployer": {
     "address": "0x4e59b44847b379578588920ca78fbf26c0b4956c",

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -94,7 +94,7 @@ Fallback after `agent_native_claim` reports the hosted relay unavailable: run `p
 14. Call `list_autonomous_verification_jobs`.
 15. Run the verifier named by the job.
 16. For `deterministic_module`, call `plan_autonomous_module_settlement`.
-17. For `quorum`, collect the committed threshold and call `plan_autonomous_attestation_settlement`.
+17. For signed verification, collect the committed threshold (normally one) and call `plan_autonomous_attestation_settlement`.
 18. Relay the exact settlement call.
 19. Call `list_autonomous_bounty_events`.
 20. Confirm `BountySettled` before saying paid.
@@ -270,7 +270,7 @@ If the x402 relay is unavailable, run `plan_autonomous_bounty_contribution`. Sub
 1. Call `list_autonomous_verification_jobs`.
 2. Read the committed terms, benchmark, schema, and evidence hashes.
 3. Execute that verifier exactly.
-4. Submit the required deterministic proof or quorum attestations.
+4. Submit the required deterministic proof or verifier attestation.
 5. Confirm `BountySettled` before reporting payment.
 
 AI output cannot authorize payment. AI-judge settlement requires the precommitted quorum.

--- a/docs/autonomous-protocol.md
+++ b/docs/autonomous-protocol.md
@@ -303,7 +303,7 @@ check passes. See
 [`standing-meta-v4-fair-earning.md`](standing-meta-v4-fair-earning.md) and the
 [`standing-meta-v4 threat model`](security/standing-meta-v4-threat-model.md).
 
-### Signed Quorum
+### Signed Verification
 
 The bounty commits one to eight verifier wallets and a threshold. Each verifier
 signs EIP-712 data bound to:
@@ -320,10 +320,16 @@ The contract rejects unauthorized, duplicate, expired, invalid, or mixed
 verdict signatures. Any caller may relay exactly one threshold through
 `settleWithAttestations`.
 
+Direct bounties default to one verifier and threshold one. The poster may be
+that verifier or delegate the role to an automated service before funding.
+Multiple verifiers are an explicit higher-risk option, not a routine
+participant requirement. The Solidity enum remains `SignedQuorum` for wire
+compatibility.
+
 #### Sandboxed Regression Candidates
 
 Coding bounties may commit `sandboxed_regression_v1` under `signed_quorum` with
-a threshold of at least two. The immutable benchmark contains a complete
+a threshold of one or two. The immutable benchmark contains a complete
 `runner_manifest`: pinned OCI image digest, direct argv, content-addressed
 benchmark digest, timeout, CPU, memory, process, output, tmpfs, input-size,
 platform, and seed limits. Submission evidence must include the exact source
@@ -337,16 +343,18 @@ round, solver, submission and evidence hashes, terms and policy hashes, and the
 verification expiry. Exit zero produces a `passed` candidate; a completed
 ordinary nonzero exit produces `failed`. Timeout, output overflow, resource
 kill, missing input, digest mismatch, malformed policy, or runtime failure
-produces no verdict. The candidate is unsigned and cannot settle funds. Each
-precommitted verifier must independently evaluate and sign the exact current
-scope before the contract can settle.
+produces no verdict. The candidate is unsigned and cannot settle funds. The
+precommitted verifier path must evaluate and sign the exact current scope
+before the contract can settle.
 
 The historical standing-meta-v2 verifier set has a no-secrets scheduled runner,
 two isolated signing jobs, and a separate keeper relay. Each stage re-fetches
 and validates the exact current job before acting. This describes deployed
 automation; it is not an assertion that the signer operators are
-organizationally independent. Arbitrary signed-quorum bounties still fail
-closed unless their own verifier services are operationally attested.
+organizationally independent. New direct coding bounties use the first
+precommitted service with threshold one by default. Arbitrary signed-verifier
+bounties still fail closed unless their own verifier services are
+operationally attested.
 See [`sandboxed-regression-verifier.md`](sandboxed-regression-verifier.md).
 
 Standing-meta-v2 also enforces strict chronology. The exact child terms and

--- a/docs/posting-a-usable-bounty.md
+++ b/docs/posting-a-usable-bounty.md
@@ -33,7 +33,7 @@ For the current coding path, use:
 - an exact public `github_commit` benchmark source
 - a complete `runner_manifest` with a digest-pinned OCI image, direct argv,
   benchmark digest, and resource limits
-- the platform's exact live threshold-two regression verifier set
+- the platform's exact live one-verifier regression policy
 - evidence fields for repository, commit, pull request, check runs, and artifact
   digest
 

--- a/docs/sandboxed-regression-verifier.md
+++ b/docs/sandboxed-regression-verifier.md
@@ -19,28 +19,33 @@ Implemented and enabled for the precommitted Base-mainnet verifier set:
 - no verdict on timeout, output overflow, resource kill, input mismatch, or
   runtime failure;
 - a scheduled no-secrets GitHub runner that emits candidates only;
-- two isolated signing jobs that re-fetch current state before signing;
-- a separate keeper relay that revalidates the exact quorum before broadcast.
+- isolated signing jobs that re-fetch current state before signing;
+- a separate keeper relay that revalidates the exact committed verifier set
+  before broadcast.
 
-The two signer keys are cryptographically distinct but currently share project
-governance; this is automated quorum, not organizationally independent review.
-Only jobs committed to the exact deployed verifier set and threshold two are
-eligible. Workflow success without a canonical job or a confirmed
-`BountySettled` event is not completion or payment evidence.
+Direct coding bounties default to one precommitted automated verifier. A second
+verifier is optional for higher-risk work; the two project signer keys are
+cryptographically distinct but share project governance, so threshold two is
+redundancy rather than organizationally independent review. Workflow success
+without a canonical job or a confirmed `BountySettled` event is not completion
+or payment evidence.
 
 ## Immutable Terms
 
-The verification policy must name the engine and at least two distinct verifier
-wallets:
+The default verification policy names one verifier:
 
 ```json
 {
   "mechanism": "signed_quorum",
   "engine": "sandboxed_regression_v1",
-  "verifiers": ["0xVerifierOne", "0xVerifierTwo"],
-  "threshold": 2
+  "verifiers": ["0xVerifierOne"],
+  "threshold": 1
 }
 ```
+
+For higher-risk work, commit two distinct verifier wallets and threshold two.
+The contract calls both forms `signed_quorum`; product surfaces call threshold
+one **single verifier**.
 
 The benchmark commits the full runner manifest:
 
@@ -114,7 +119,8 @@ Do not mount a Docker socket into the Base indexer or any service holding RPC,
 database, wallet, Stripe, or operator secrets. A hosted runner must be a
 separate no-secrets service with a runner-owned staging volume. Signing must be
 a separate capability that verifies a fresh candidate against the current
-canonical job and requires at least two distinct precommitted verifier paths.
+canonical job and requires exactly the verifier path or paths committed before
+funding.
 
 The signer and keeper workflows read their Base endpoint from the dedicated
 `REGRESSION_VERIFIER_RPC_URL` Actions variable and otherwise use

--- a/scripts/build_bounded_agent_wallet_bundle.py
+++ b/scripts/build_bounded_agent_wallet_bundle.py
@@ -18,7 +18,8 @@ CREATE2_DEPLOYER_CODE_HASH = "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd095
 BOUNTY_FACTORY = "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9"
 USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
 VERIFIER = "0x380c1af742593dd88b6f20387e9ee693a0536731"
-SIGNED_QUORUM_VERIFIER_SET_HASH = "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
+LEGACY_SIGNED_QUORUM_VERIFIER_SET_HASH = "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
+SINGLE_VERIFIER_SET_HASH = "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2"
 SOURCE_INPUTS = ("contracts/base-escrow",)
 VERSIONS = {
     "v1": {
@@ -191,7 +192,11 @@ def build_bundle(version: str = "v1") -> dict:
             "bounty_factory": BOUNTY_FACTORY,
             "settlement_token": USDC,
             "deterministic_verifier": VERIFIER,
-            "signed_quorum_verifier_set_hash": SIGNED_QUORUM_VERIFIER_SET_HASH,
+            "signed_quorum_verifier_set_hash": (
+                SINGLE_VERIFIER_SET_HASH
+                if version == "v2"
+                else LEGACY_SIGNED_QUORUM_VERIFIER_SET_HASH
+            ),
         },
         "deterministic_deployer": {
             "address": CREATE2_DEPLOYER,

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -790,9 +790,8 @@ def main() -> int:
             "Sign and post bounty",
             "Post with 0 USDC now and open it to funding later",
             "Fund on creation",
-            "Automatic demo proof checker",
-            "Trusted verifier wallets",
-            "Two or more AI judges",
+            "One automatic verifier",
+            "Optional independent review for higher-risk work",
             "Benchmark JSON (exact payout condition)",
             "Evidence record schema",
             "does not evaluate my task or acceptance criteria",
@@ -944,15 +943,15 @@ def main() -> int:
     if manifest_protocol.get("payout_authority") != "confirmed canonical BountySettled event":
         fail("static discovery manifest must bind payout to BountySettled")
     default_verification = protocol.get("default_verification", {})
-    if default_verification.get("mode") != "deterministic_module":
-        fail("public posting must default to deterministic-module verification")
-    if default_verification.get("module_id") not in protocol.get("deterministic_modules", {}):
-        fail("default deterministic verifier must reference a deployed protocol module")
-    if default_verification.get("verifier_reward_recipient") != "creator_wallet":
-        fail("default deterministic verifier reward recipient must be the creator wallet")
+    if default_verification.get("mode") != "signed_quorum":
+        fail("public posting must default to one signed verifier")
+    if default_verification.get("product_label") != "single_verifier":
+        fail("public protocol must describe the default as single verifier")
     if default_verification.get("threshold") != 1:
-        fail("default deterministic verifier threshold must be one")
-    default_module = protocol["deterministic_modules"][default_verification["module_id"]]
+        fail("default verifier threshold must be one")
+    if len(default_verification.get("verifiers", [])) != 1:
+        fail("public protocol must commit exactly one default verifier")
+    default_module = protocol["deterministic_modules"]["leading_zero_work_v1"]
     expected_work_benchmark = {
         "engine": "leading_zero_work_v1",
         "difficulty_bits": 16,
@@ -1057,21 +1056,29 @@ def main() -> int:
         fail("static discovery manifest advertises retired escrow tools")
     modes = {mode.get("name"): mode for mode in discovery.get("verification_modes", [])}
     deterministic_mode = modes.get("deterministic_module", {})
-    if deterministic_mode.get("default_for_new_bounties") is not True:
-        fail("discovery must default new bounties to deterministic verification")
+    if deterministic_mode.get("default_for_new_bounties") is not False:
+        fail("deterministic verification must be an explicit posting choice")
     expected_module = protocol["deterministic_modules"]["leading_zero_work_v1"]["contract"]
     if deterministic_mode.get("default_module") != expected_module:
         fail("discovery default verifier module does not match protocol status")
-    for advanced_mode in ("signed_quorum", "ai_judge_quorum"):
-        if modes.get(advanced_mode, {}).get("default_for_new_bounties") is not False:
-            fail(f"advanced verifier mode must not be a posting default: {advanced_mode}")
+    signed_mode = modes.get("signed_quorum", {})
+    if (
+        signed_mode.get("default_for_new_bounties") is not True
+        or signed_mode.get("product_label") != "single_verifier"
+        or signed_mode.get("default_threshold") != 1
+    ):
+        fail("discovery must default direct bounties to one precommitted verifier")
+    if modes.get("ai_judge_quorum", {}).get("default_for_new_bounties") is not False:
+        fail("AI-judge quorum must remain an explicit advanced choice")
     funding = discovery.get("funding", {})
     if "wallet_signature" not in funding.get("gas_sponsorship", ""):
         fail("static discovery manifest must describe native claim signature replay")
-    if funding.get("default_verification") != "deterministic_module":
+    if funding.get("default_verification") != "signed_quorum":
         fail("discovery funding policy has the wrong verification default")
-    if funding.get("default_verifier_module") != expected_module:
-        fail("discovery funding policy has the wrong default verifier module")
+    if funding.get("default_verifier_threshold") != 1:
+        fail("discovery funding policy must use one verifier by default")
+    if funding.get("default_verifier") != protocol["default_verification"]["verifiers"][0]:
+        fail("discovery funding policy has the wrong default verifier")
     if "/agent-bounty relay" not in funding.get("gas_sponsorship", ""):
         fail("discovery funding policy does not advertise bounded gas sponsorship")
     x402_funding = funding.get("x402", {})

--- a/scripts/regression_verifier_pipeline.py
+++ b/scripts/regression_verifier_pipeline.py
@@ -94,6 +94,42 @@ def verification_jobs(api_base: str, network: str, verifier: str) -> list[dict[s
     return value
 
 
+def required_job_signers(job: dict[str, Any]) -> list[str]:
+    if job.get("verification_mode") != "signed_quorum":
+        raise PipelineError("regression job must use signed verification")
+    try:
+        threshold = int(job.get("threshold"))
+    except (TypeError, ValueError) as error:
+        raise PipelineError("regression verifier threshold is invalid") from error
+    signers = [
+        normalize_address(value, "eligible verifier")
+        for value in job.get("eligible_verifiers", [])
+    ]
+    if threshold not in {1, 2} or len(signers) != threshold:
+        raise PipelineError("regression job requires exactly one or two committed verifiers")
+    if len(set(signers)) != len(signers):
+        raise PipelineError("regression job verifier addresses must be distinct")
+    return signers
+
+
+def selected_jobs(
+    jobs: list[dict[str, Any]],
+    configured_verifiers: list[str],
+    maximum: int,
+) -> list[dict[str, Any]]:
+    selected = []
+    for job in jobs:
+        try:
+            signers = required_job_signers(job)
+        except PipelineError:
+            continue
+        if signers == configured_verifiers[: len(signers)]:
+            selected.append(job)
+        if len(selected) == maximum:
+            break
+    return selected
+
+
 def parse_github_commit_url(value: object) -> tuple[str, str]:
     try:
         parsed = urllib.parse.urlparse(str(value))
@@ -352,16 +388,10 @@ def run_job(worker: Path, staging: Path, job: dict[str, Any], scratch: Path) -> 
 
 def command_run(args: argparse.Namespace) -> None:
     verifiers = [normalize_address(value, "verifier") for value in args.verifier]
-    if len(set(verifiers)) != 2:
-        raise PipelineError("runner requires exactly two distinct verifier addresses")
+    if len(verifiers) not in {1, 2} or len(set(verifiers)) != len(verifiers):
+        raise PipelineError("runner requires one or two distinct verifier addresses")
     jobs = verification_jobs(args.api_base, args.network, verifiers[0])
-    selected = [
-        job
-        for job in jobs
-        if [str(value).lower() for value in job.get("eligible_verifiers", [])] == verifiers
-        and job.get("threshold") == 2
-        and job.get("verification_mode") == "signed_quorum"
-    ][: args.max_jobs]
+    selected = selected_jobs(jobs, verifiers, args.max_jobs)
     args.output.mkdir(parents=True, exist_ok=True)
     candidates = []
     for job in selected:
@@ -428,6 +458,8 @@ def command_sign(args: argparse.Namespace) -> None:
         candidate = read_json(args.candidates / entry["file"])
         job = candidate.get("job", {})
         job_id = str(job.get("job_id", ""))
+        if signer not in required_job_signers(job):
+            continue
         current = current_job(args.api_base, args.network, signer, job_id)
         with tempfile.TemporaryDirectory(prefix="agent-bounties-sign-") as temporary:
             validate_candidate(args.worker, candidate, current, Path(temporary))
@@ -497,10 +529,9 @@ def command_relay(args: argparse.Namespace) -> None:
     keeper = os.environ.get(args.keeper_key_env, "").strip()
     if not keeper:
         raise PipelineError(f"{args.keeper_key_env} is required")
-    expected = {
-        normalize_address(args.verifier[0], "verifier"),
-        normalize_address(args.verifier[1], "verifier"),
-    }
+    configured = [normalize_address(value, "verifier") for value in args.verifier]
+    if len(configured) not in {1, 2} or len(set(configured)) != len(configured):
+        raise PipelineError("relay requires one or two distinct configured verifiers")
     candidate_manifest = read_json(args.candidates / "manifest.json")
     manifests = [read_json(path / "manifest.json") for path in args.attestations]
     by_signer: dict[str, dict[str, str]] = {}
@@ -509,16 +540,26 @@ def command_relay(args: argparse.Namespace) -> None:
         if signer in by_signer:
             raise PipelineError("duplicate attestation signer")
         by_signer[signer] = {entry["job_id"]: str(path / entry["file"]) for entry in manifest["attestations"]}
-    if set(by_signer) != expected:
-        raise PipelineError("attestation artifacts do not contain the exact verifier set")
+    if set(by_signer) != set(configured):
+        raise PipelineError("attestation artifacts do not contain every configured verifier")
 
     for entry in candidate_manifest.get("candidates", []):
         job_id = entry["job_id"]
         candidate = read_json(args.candidates / entry["file"])
-        current = current_job(args.api_base, args.network, sorted(expected)[0], job_id)
+        expected = required_job_signers(candidate.get("job", {}))
+        if expected != configured[: len(expected)]:
+            raise PipelineError("candidate verifier set is not supported by this relay")
+        current = current_job(args.api_base, args.network, expected[0], job_id)
+        if required_job_signers(current) != expected:
+            raise PipelineError("current canonical verifier set differs from the candidate")
         with tempfile.TemporaryDirectory(prefix="agent-bounties-relay-") as temporary:
             validate_candidate(args.worker, candidate, current, Path(temporary))
-        attestations = [read_json(Path(by_signer[signer][job_id])) for signer in sorted(expected)]
+        try:
+            attestations = [
+                read_json(Path(by_signer[signer][job_id])) for signer in sorted(expected)
+            ]
+        except KeyError as error:
+            raise PipelineError("required verifier attestation is missing") from error
         first = attestations[0]
         for attestation in attestations:
             if (

--- a/scripts/test-autonomous-wallet-flow.js
+++ b/scripts/test-autonomous-wallet-flow.js
@@ -110,9 +110,9 @@ assert.strictEqual(protocol.chain_id, 8453);
 assert.strictEqual(protocol.status, "active");
 assert.strictEqual(protocol.factory, "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9");
 assert.strictEqual(protocol.implementation, "0x2fa36d2b2327642db3a6cc8cdd91544ad7484eb9");
-assert.strictEqual(protocol.default_verification.mode, "deterministic_module");
-assert.strictEqual(protocol.default_verification.module_id, "leading_zero_work_v1");
-assert.strictEqual(protocol.default_verification.verifier_reward_recipient, "creator_wallet");
+assert.strictEqual(protocol.default_verification.mode, "signed_quorum");
+assert.strictEqual(protocol.default_verification.product_label, "single_verifier");
+assert.strictEqual(protocol.default_verification.verifiers.length, 1);
 assert.strictEqual(protocol.default_verification.threshold, 1);
 assert.strictEqual(protocol.deterministic_modules.leading_zero_work_v1.usage, "protocol_canary_only");
 assert.strictEqual(
@@ -127,11 +127,11 @@ assert.strictEqual(
 
 const postHtml = fs.readFileSync(path.join(repoRoot, "site", "post.html"), "utf8");
 assert(
-  postHtml.indexOf('value="deterministic_module"') < postHtml.indexOf('value="signed_quorum"'),
-  "public posting must default to deterministic verification",
+  postHtml.indexOf('value="signed_quorum" selected') >= 0,
+  "public posting must default to one signed verifier",
 );
-assert(postHtml.includes("Trusted verifier wallets"));
-assert(postHtml.includes("Automatic demo proof checker"));
+assert(postHtml.includes("One automatic verifier"));
+assert(postHtml.includes("Exact on-chain verifier"));
 assert(postHtml.includes("does not evaluate my task or acceptance criteria"));
 assert(postHtml.includes('name="demoVerifierAccepted" type="checkbox"'));
 assert(!postHtml.includes('{"engine":"github_ci"'));

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -832,7 +832,7 @@ test("exact hosted sandboxed-regression quorum is portable earning inventory", a
   item.verifier_module = null;
   item.verification_ready = true;
   item.verification_readiness_reason =
-    "the exact built-in sandboxed-regression quorum is supported";
+    "the default single sandboxed-regression verifier is supported";
   item.terms.document.benchmark = { engine: SUPPORTED_REGRESSION_QUORUM.engine };
   item.terms.document.verification_policy = {
     mechanism: "signed_quorum",
@@ -897,7 +897,7 @@ test("portable quorum validation rejects verifier, threshold, engine, and event 
   ));
   const mutations = [
     (item) => { item.terms.document.verification_policy.verifiers[0] = "0x1111111111111111111111111111111111111111"; },
-    (item) => { item.terms.document.verification_policy.threshold = 1; },
+    (item) => { item.terms.document.verification_policy.threshold = 2; },
     (item) => { item.terms.document.benchmark.engine = "different_runner"; },
     (item) => {
       item.events.find(

--- a/scripts/test_regression_verifier_pipeline.py
+++ b/scripts/test_regression_verifier_pipeline.py
@@ -38,6 +38,52 @@ def archive(entries: list[tuple[str, bytes | None, str]]) -> bytes:
 
 
 class RegressionVerifierPipelineTests(unittest.TestCase):
+    def test_runner_selects_single_verifier_and_legacy_two_verifier_jobs(self) -> None:
+        configured = ["0x" + "1" * 40, "0x" + "2" * 40]
+        jobs = [
+            {
+                "job_id": "single",
+                "verification_mode": "signed_quorum",
+                "eligible_verifiers": configured[:1],
+                "threshold": 1,
+            },
+            {
+                "job_id": "legacy",
+                "verification_mode": "signed_quorum",
+                "eligible_verifiers": configured,
+                "threshold": 2,
+            },
+            {
+                "job_id": "unsupported",
+                "verification_mode": "signed_quorum",
+                "eligible_verifiers": [configured[1]],
+                "threshold": 1,
+            },
+        ]
+        self.assertEqual(
+            [job["job_id"] for job in pipeline.selected_jobs(jobs, configured, 5)],
+            ["single", "legacy"],
+        )
+
+    def test_regression_job_rejects_zero_or_ambiguous_verifiers(self) -> None:
+        base = {
+            "verification_mode": "signed_quorum",
+            "eligible_verifiers": ["0x" + "1" * 40],
+            "threshold": 1,
+        }
+        self.assertEqual(pipeline.required_job_signers(base), base["eligible_verifiers"])
+        for changed in (
+            {**base, "threshold": 0},
+            {**base, "threshold": 2},
+            {
+                **base,
+                "threshold": 2,
+                "eligible_verifiers": ["0x" + "1" * 40, "0x" + "1" * 40],
+            },
+        ):
+            with self.subTest(changed=changed), self.assertRaises(pipeline.PipelineError):
+                pipeline.required_job_signers(changed)
+
     def test_verifier_signing_uses_a_dedicated_rpc_configuration(self) -> None:
         workflow_root = SCRIPT.parent.parent / ".github" / "workflows"
         for name in (

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -175,16 +175,21 @@
   "verification_modes": [
     {
       "name": "deterministic_module",
-      "default_for_new_bounties": true,
+      "default_for_new_bounties": false,
       "default_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
-      "earning_inventory": "ready when terms are valid and a nonzero module is committed on-chain",
+      "earning_inventory": "ready only when an exact recognized on-chain module evaluates the full committed acceptance rule; the built-in leading-zero module is for protocol canaries, not coding work",
       "settlement": "Any caller supplies proof to the immutable on-chain verifier module; pass settles and fail reopens atomically. The verifier receives the same committed reward for either verdict."
     },
     {
       "name": "signed_quorum",
-      "default_for_new_bounties": false,
-      "earning_inventory": "fails closed until verifier-service availability is canonically attestable",
-      "settlement": "The immutable verifier set signs the exact bounty, round, solver, submission, evidence, result, response, and deadline. A valid pass or fail quorum receives the same reward."
+      "product_label": "single_verifier",
+      "default_for_new_bounties": true,
+      "default_threshold": 1,
+      "default_verifiers": [
+        "0xbe6292b9e465f549e2363b918d6dd9187038431e"
+      ],
+      "earning_inventory": "ready when the one precommitted verifier service and exact sandbox benchmark are available",
+      "settlement": "The precommitted verifier signs the exact bounty, round, solver, submission, evidence, result, response, and deadline. Multi-verifier review is optional for higher-risk work."
     },
     {
       "name": "ai_judge_quorum",
@@ -196,8 +201,9 @@
   ],
   "funding": {
     "default": "fully funded on creation",
-    "default_verification": "deterministic_module",
-    "default_verifier_module": "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e",
+    "default_verification": "signed_quorum",
+    "default_verifier_threshold": 1,
+    "default_verifier": "0xbe6292b9e465f549e2363b918d6dd9187038431e",
     "crowdfunding": "zero-funded bounties may be created; any wallet may contribute until the target is reached",
     "eoa_fast_path": "Circle USDC EIP-3009 bounded authorization",
     "x402": {

--- a/site/autonomous.js
+++ b/site/autonomous.js
@@ -513,20 +513,30 @@
 
   function defaultVerification(protocol) {
     const config = protocol.default_verification;
-    if (!config || config.mode !== "deterministic_module" || config.threshold !== 1) {
-      throw new Error("The active protocol does not declare a safe deterministic default.");
+    if (
+      !config
+      || config.mode !== "signed_quorum"
+      || config.threshold !== 1
+      || !Array.isArray(config.verifiers)
+      || config.verifiers.length !== 1
+    ) {
+      throw new Error("The active protocol does not declare one default verifier.");
     }
-    const module = protocol.deterministic_modules && protocol.deterministic_modules[config.module_id];
-    if (!module) throw new Error("The default deterministic verifier is unavailable.");
-    if (!module.benchmark || module.benchmark.engine !== config.module_id) {
-      throw new Error("The default deterministic verifier has no exact benchmark commitment.");
+    const moduleId = "leading_zero_work_v1";
+    const module = protocol.deterministic_modules && protocol.deterministic_modules[moduleId];
+    if (!module || !module.benchmark || module.benchmark.engine !== moduleId) {
+      throw new Error("The optional deterministic verifier is unavailable.");
     }
     return {
       ...config,
-      contract: requiredAddress(module.contract || "", "Deterministic verifier module"),
-      benchmark: module.benchmark,
-      scope_notice: module.scope_notice || "The selected module controls payout.",
-      usage: module.usage || "custom",
+      verifiers: config.verifiers.map((value) => requiredAddress(value, "Default verifier")),
+      deterministic: {
+        module_id: moduleId,
+        contract: requiredAddress(module.contract || "", "Deterministic verifier module"),
+        benchmark: module.benchmark,
+        scope_notice: module.scope_notice || "The selected module controls payout.",
+        usage: module.usage || "custom",
+      },
     };
   }
 
@@ -544,7 +554,7 @@
     const demoWarning = form.querySelector("[data-demo-verifier-warning]");
     const demoAccepted = form.elements.demoVerifierAccepted;
 
-    module.value = defaults.contract;
+    module.value = defaults.deterministic.contract;
     module.readOnly = true;
     module.disabled = !deterministic;
     recipient.disabled = !deterministic;
@@ -554,14 +564,20 @@
     if (demoWarning) demoWarning.hidden = !deterministic;
     if (demoAccepted) demoAccepted.disabled = !deterministic;
     if (deterministic) {
-      threshold.value = String(defaults.threshold);
-      benchmark.value = canonicalJsonString(defaults.benchmark);
-      if (scope) scope.textContent = defaults.scope_notice;
-      if (defaults.verifier_reward_recipient === "creator_wallet" && account && !recipient.value.trim()) {
+      threshold.value = "1";
+      benchmark.value = canonicalJsonString(defaults.deterministic.benchmark);
+      if (scope) scope.textContent = defaults.deterministic.scope_notice;
+      if (account && !recipient.value.trim()) {
         recipient.value = account;
       }
-    } else if (scope) {
-      scope.textContent = "Advanced modes pay only from the verifier wallets and threshold committed in the terms. Confirm verifier availability before funding.";
+    } else {
+      if (!verifiers.value.trim()) verifiers.value = defaults.verifiers.join("\n");
+      if (!threshold.value || mode === defaults.mode) threshold.value = String(defaults.threshold);
+      if (scope) {
+        scope.textContent = mode === "signed_quorum"
+          ? "One precommitted verifier runs the exact benchmark. Add a second only for higher-risk work."
+          : "AI judge verification requires at least two independent committed judges.";
+      }
     }
   }
 
@@ -1261,7 +1277,7 @@
       throw new Error("Confirm that the demo work-proof checker does not evaluate your task.");
     }
     if (mode !== "deterministic_module" && verifiers.length === 0) {
-      throw new Error("Quorum mode requires verifier wallet addresses.");
+      throw new Error("Signed verification requires a verifier wallet.");
     }
     if (mode === "ai_judge_quorum" && threshold < 2) {
       throw new Error("AI judge settlement requires at least two matching verifier signatures.");
@@ -1291,7 +1307,7 @@
   function termsDocument(form, committed, protocol) {
     const mode = form.elements.verificationMode.value;
     const deterministicDefaults = mode === "deterministic_module"
-      ? defaultVerification(protocol)
+      ? defaultVerification(protocol).deterministic
       : null;
     const verifiers = splitAddresses(form.elements.verifiers.value);
     const threshold = Number(form.elements.threshold.value);
@@ -1305,7 +1321,7 @@
       }
     } else {
       if (!verifiers.length || threshold < 1 || threshold > verifiers.length) {
-        throw new Error("Quorum threshold must fit the verifier wallet set.");
+        throw new Error("The signature threshold must fit the verifier wallet list.");
       }
       if (new Set(verifiers.map((address) => address.toLowerCase())).size !== verifiers.length) {
         throw new Error("Verifier wallet addresses must be unique.");

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -10,7 +10,6 @@
   const REGRESSION_ENGINE = "sandboxed_regression_v1";
   const REGRESSION_VERIFIERS = [
     "0xbe6292b9e465f549e2363b918d6dd9187038431e",
-    "0xb7c2ce6430b66fb986e27b6140b29309550d487a",
   ];
   const VISUAL_EXTENSION = "x-agent-bounties-draft-visual";
   const ALLOWED_SCENES = new Set([
@@ -1135,9 +1134,9 @@
       ai_model: null,
       ai_model_version: null,
       system_prompt: null,
-      rubric: "Both pinned verifier agents run the precommitted sandboxed regression and require every acceptance criterion to pass.",
+      rubric: "The pinned verifier agent runs the precommitted sandboxed regression and requires every acceptance criterion to pass.",
       decoding_parameters: {},
-      public_disclosure: "The platform's exact two-verifier sandboxed-regression policy decides pass or fail from the precommitted coding benchmark.",
+      public_disclosure: "One precommitted verifier runs the exact coding benchmark. Multi-verifier review is optional for higher-risk work.",
     };
   }
 

--- a/site/post.html
+++ b/site/post.html
@@ -17,7 +17,7 @@
       <section class="sr-only" aria-label="Compatibility information">
         <h2>Post your own bounty</h2>
         <p>Fund on creation. Post with 0 USDC now and open it to funding later.</p>
-        <p>Sign and post bounty. Automatic demo proof checker. Trusted verifier wallets. Two or more AI judges.</p>
+        <p>Sign and post bounty. One automatic verifier. Optional independent review for higher-risk work.</p>
         <p>Benchmark JSON (exact payout condition). Evidence record schema. The demo checker does not evaluate my task or acceptance criteria.</p>
         <p>How did you find Agent Bounties? Draft measurable terms. The cloud draft is advisory.</p>
         <a href="terms.html">Terms</a><a href="privacy.html">Privacy</a>
@@ -27,8 +27,8 @@
         <template id="autonomous-post-compatibility-contract">
           <select data-wallet-provider aria-label="Wallet provider"><option>Browser wallet</option></select>
           <select name="verificationMode">
-            <option value="deterministic_module" selected>Automatic demo proof checker</option>
-            <option value="signed_quorum">Trusted verifier wallets</option>
+            <option value="signed_quorum" selected>One automatic verifier</option>
+            <option value="deterministic_module">Exact on-chain verifier</option>
           </select>
           <input name="demoVerifierAccepted" type="checkbox">
           <input name="solverReward" type="number" min="0.01" step="0.01" value="2.00">

--- a/site/protocol.json
+++ b/site/protocol.json
@@ -10,9 +10,11 @@
   "deployment_transaction": "0x8c172a34188cc68cf61f7293825e3c93e025a029b878436d34aafd2103c2e70e",
   "deployment_block": 48496662,
   "default_verification": {
-    "mode": "deterministic_module",
-    "module_id": "leading_zero_work_v1",
-    "verifier_reward_recipient": "creator_wallet",
+    "mode": "signed_quorum",
+    "product_label": "single_verifier",
+    "verifiers": [
+      "0xbe6292b9e465f549e2363b918d6dd9187038431e"
+    ],
     "threshold": 1
   },
   "deterministic_modules": {

--- a/skills/agent-bounties/scripts/check-in.mjs
+++ b/skills/agent-bounties/scripts/check-in.mjs
@@ -12,11 +12,10 @@ export const DEFAULT_BASE_RPC_FALLBACK_URLS = Object.freeze([
 export const CLAIM_HANDOFF_SCHEMA_VERSION = "agent-bounties/check-in-claim-handoff-v1";
 export const SUPPORTED_REGRESSION_QUORUM = Object.freeze({
   engine: "sandboxed_regression_v1",
-  verifierSetHash: "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
-  threshold: 2,
+  verifierSetHash: "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2",
+  threshold: 1,
   verifiers: Object.freeze([
     "0xbe6292b9e465f549e2363b918d6dd9187038431e",
-    "0xb7c2ce6430b66fb986e27b6140b29309550d487a",
   ]),
 });
 


### PR DESCRIPTION
Closes #754.

## Change
- make one precommitted sandboxed-regression verifier the default for ordinary coding bounties
- retain two-verifier and AI-judge policies as explicit higher-risk options
- align API, MCP, web composer, worker pipeline, chain readiness, V2 wallet manifest, docs, and the published agent skill
- preserve the existing signed_quorum wire enum for backward compatibility

## Safety
The verifier identity, benchmark, evidence schema, round, solver, submission, verdict, response hash, and deadline remain committed and signed. AI-judge settlement still requires at least two signatures.

## Verification
- cargo test -p worker -q
- cargo test -p chain-base -q
- cargo test -p web-public -q
- cargo test -p api -q
- cargo test -p mcp-server -q
- python scripts/test_regression_verifier_pipeline.py -v
- node scripts/test-autonomous-wallet-flow.js
- node --test scripts/test_agent_bounties_openclaw_skill.mjs
- python scripts/check-site.py
- cargo fmt --all -- --check
- git diff --check