### PR TITLE
Activate the cancelable bounded-wallet V2 path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/pages.yml"
       - ".github/ISSUE_TEMPLATE/paid-bounty.yml"
       - "deployments/bounded-agent-wallet-base-mainnet.json"
+      - "deployments/bounded-agent-wallet-v2-base-mainnet.json"
       - "docs/posting-a-usable-bounty.md"
       - "site/**"
       - "tools/coinbase-embedded-wallet/**"
@@ -24,6 +25,7 @@ on:
       - ".github/workflows/pages.yml"
       - ".github/ISSUE_TEMPLATE/paid-bounty.yml"
       - "deployments/bounded-agent-wallet-base-mainnet.json"
+      - "deployments/bounded-agent-wallet-v2-base-mainnet.json"
       - "docs/posting-a-usable-bounty.md"
       - "site/**"
       - "tools/coinbase-embedded-wallet/**"
@@ -216,6 +218,7 @@ jobs:
       - name: Stage bounded-wallet deployment manifest
         run: |
           cp deployments/bounded-agent-wallet-base-mainnet.json site/bounded-agent-wallet-base-mainnet.json
+          cp deployments/bounded-agent-wallet-v2-base-mainnet.json site/bounded-agent-wallet-v2-base-mainnet.json
           mkdir -p site/schemas
           cp schemas/discovery-manifest.v2.json site/schemas/discovery-manifest.v2.json
       - uses: actions/upload-pages-artifact@v5

--- a/docs/bounded-agent-wallet.md
+++ b/docs/bounded-agent-wallet.md
@@ -91,7 +91,7 @@ poor choices until a cap, expiry, or owner revocation stops it.
 2. Build and review the deterministic factory manifest:
 
    ```powershell
-   python scripts/build_bounded_agent_wallet_bundle.py
+   python scripts/build_bounded_agent_wallet_bundle.py --version v2
    ```
 
 3. Build the exact owner plan:
@@ -155,9 +155,11 @@ fresh policy-period counter; the review page must disclose that before signing.
 
 ## Activation State
 
-The deterministic contract manifest is
+New activation plans use the V2 deterministic contract manifest:
+[`deployments/bounded-agent-wallet-v2-base-mainnet.json`](../deployments/bounded-agent-wallet-v2-base-mainnet.json).
+The historical V1 manifest remains at
 [`deployments/bounded-agent-wallet-base-mainnet.json`](../deployments/bounded-agent-wallet-base-mainnet.json).
-The live policy constants and owner-transaction evidence are in
+The current live V1 policy constants and owner-transaction evidence are in
 [`scripts/bounded_wallet_policy.py`](../scripts/bounded_wallet_policy.py).
 Runtime inspection remains authoritative. Do not transfer USDC to a predicted
 wallet before deployment and inspection pass.

--- a/scripts/bounded_agent_create.py
+++ b/scripts/bounded_agent_create.py
@@ -26,6 +26,11 @@ SIGNED_QUORUM_VERIFIERS = [
     "0xb7c2ce6430b66fb986e27b6140b29309550d487a",
 ]
 SIGNED_QUORUM_VERIFIER_SET_HASH = "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
+SINGLE_VERIFIER_SET_HASH = "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2"
+SUPPORTED_SIGNED_VERIFIER_SETS = {
+    SINGLE_VERIFIER_SET_HASH: SIGNED_QUORUM_VERIFIERS[:1],
+    SIGNED_QUORUM_VERIFIER_SET_HASH: SIGNED_QUORUM_VERIFIERS,
+}
 HEX_DATA = re.compile(r"^0x(?:[0-9a-fA-F]{2})+$")
 
 PARAM_NAMES = (
@@ -97,15 +102,16 @@ def validate_creation_verification(
         str(canonical.get("signed_quorum_verifier_set_hash", "")),
         "canonical signed quorum verifier set hash",
     )
-    if manifest_hash != SIGNED_QUORUM_VERIFIER_SET_HASH:
+    expected_verifiers = SUPPORTED_SIGNED_VERIFIER_SETS.get(manifest_hash)
+    if expected_verifiers is None:
         fail("bounded-wallet manifest has an unexpected signed quorum")
     if (
         policy["signed_quorum_verifier_set_hash"] != manifest_hash
         or params["verifier_module"] != ZERO_ADDRESS
         or params["verifier_reward_recipient"] != ZERO_ADDRESS
-        or int(params["threshold"]) != len(SIGNED_QUORUM_VERIFIERS)
-        or verifiers != SIGNED_QUORUM_VERIFIERS
-        or int(params["verifier_reward"]) % len(SIGNED_QUORUM_VERIFIERS) != 0
+        or int(params["threshold"]) != len(expected_verifiers)
+        or verifiers != expected_verifiers
+        or int(params["verifier_reward"]) % len(expected_verifiers) != 0
     ):
         fail("bounded creation requires the exact signed regression verifier policy")
 

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -404,8 +404,11 @@ def main() -> int:
     x402_vectors = json.loads((site_dir / "x402-test-vectors.json").read_text(encoding="utf-8"))
     protocol = json.loads((site_dir / "protocol.json").read_text(encoding="utf-8"))
     deployment = json.loads((repo_root / "deployments" / "base-mainnet.json").read_text(encoding="utf-8"))
-    bounded_deployment = json.loads(
+    legacy_bounded_deployment = json.loads(
         (repo_root / "deployments" / "bounded-agent-wallet-base-mainnet.json").read_text(encoding="utf-8")
+    )
+    bounded_deployment = json.loads(
+        (repo_root / "deployments" / "bounded-agent-wallet-v2-base-mainnet.json").read_text(encoding="utf-8")
     )
     standing_meta_deployment = json.loads(
         (repo_root / "deployments" / "standing-meta-v2-base-mainnet.json").read_text(encoding="utf-8")
@@ -1171,7 +1174,8 @@ def main() -> int:
             "Agent delegate address",
             "Initial funding, USDC",
             "Lifetime gross spend, USDC",
-            "two-wallet sandboxed-regression quorum only",
+            "one exact sandboxed-regression verifier",
+            "cancel an unclaimed bounty",
             "Owner escape hatch",
             "Review policy update",
             "Update policy",
@@ -1198,7 +1202,7 @@ def main() -> int:
             'revokePolicy: "0x9eba3667"',
             'configurePolicy: "0x27d3543c"',
             "starts a fresh policy-period spend counter",
-            "exact two-wallet sandboxed-regression quorum",
+            "exact one-verifier regression policy",
             "OBSOLETE_DETERMINISTIC_VERIFIER",
             "manifest.contract_source_dirty !== false",
             "contract_source_revision",
@@ -1218,7 +1222,7 @@ def main() -> int:
     for forbidden in ["privateKey", "mnemonic", "seedInput", "wallet_import"]:
         if forbidden in bounded_javascript:
             fail(f"agent budget activation contains forbidden secret handling: {forbidden}")
-    if bounded_deployment.get("schema") != "agent-bounties/bounded-agent-wallet-deployment-v1":
+    if bounded_deployment.get("schema") != "agent-bounties/bounded-agent-wallet-deployment-v2":
         fail("bounded-wallet deployment manifest has the wrong schema")
     if bounded_deployment.get("chain_id") != 8453 or bounded_deployment.get("network") != "base-mainnet":
         fail("bounded-wallet deployment manifest must target Base mainnet")
@@ -1270,7 +1274,10 @@ def main() -> int:
         fail("historical standing-meta-v2 deployment manifest has the wrong verifier")
     if bounded_deployment["canonical"]["deterministic_verifier"] != "0x380c1af742593dd88b6f20387e9ee693a0536731":
         fail("bounded wallet manifest does not trust the durable verifier router")
-    if standing_components.get("verifier_set_hash") != bounded_deployment["canonical"]["signed_quorum_verifier_set_hash"]:
+    if (
+        standing_components.get("verifier_set_hash")
+        != legacy_bounded_deployment["canonical"]["signed_quorum_verifier_set_hash"]
+    ):
         fail("bounded wallet and standing-meta-v2 manifests disagree on the signed quorum")
     if standing_components.get("verifier_wallets") != [
         "0xbe6292b9e465f549e2363b918d6dd9187038431e",
@@ -1292,6 +1299,8 @@ def main() -> int:
         [
             '"deployments/bounded-agent-wallet-base-mainnet.json"',
             "cp deployments/bounded-agent-wallet-base-mainnet.json site/bounded-agent-wallet-base-mainnet.json",
+            '"deployments/bounded-agent-wallet-v2-base-mainnet.json"',
+            "cp deployments/bounded-agent-wallet-v2-base-mainnet.json site/bounded-agent-wallet-v2-base-mainnet.json",
             "cp schemas/discovery-manifest.v2.json site/schemas/discovery-manifest.v2.json",
         ],
     )

--- a/scripts/plan_bounded_agent_budget.py
+++ b/scripts/plan_bounded_agent_budget.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-base-mainnet.json"
+DEFAULT_MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-v2-base-mainnet.json"
 POLICY_TYPE = (
     "(address,uint64,uint64,uint64,uint256,uint256,uint256,uint256,uint8,uint8,address,bytes32,bytes32)"
 )
@@ -31,7 +31,7 @@ EXPECTED_CANONICAL = {
 }
 EXPECTED_CREATE2_DEPLOYER = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
 EXPECTED_CREATE2_DEPLOYER_HASH = "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989"
-EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH = "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
+EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH = "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2"
 
 
 def executable(name: str) -> str:
@@ -86,7 +86,7 @@ def require_bytes32(value: str, label: str) -> str:
 
 
 def validate_manifest(manifest: dict) -> dict:
-    if manifest.get("schema") != "agent-bounties/bounded-agent-wallet-deployment-v1":
+    if manifest.get("schema") != "agent-bounties/bounded-agent-wallet-deployment-v2":
         raise SystemExit("bounded-wallet manifest schema is unsupported")
     if manifest.get("network") != EXPECTED_NETWORK or manifest.get("chain_id") != EXPECTED_CHAIN_ID:
         raise SystemExit("bounded-wallet manifest must target Base mainnet")

--- a/scripts/test_bounded_agent_budget.py
+++ b/scripts/test_bounded_agent_budget.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "plan_bounded_agent_budget.py"
-MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-base-mainnet.json"
+MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-v2-base-mainnet.json"
 
 
 def load_planner():
@@ -268,20 +268,24 @@ class BoundedAgentBudgetPlannerTests(unittest.TestCase):
             "verifier_module": self.create_helper.ZERO_ADDRESS,
             "verifier_reward_recipient": self.create_helper.ZERO_ADDRESS,
             "verifier_reward": 100_000,
-            "threshold": 2,
+            "threshold": 1,
         }
         policy = {
             "allowed_verification_modes": 3,
             "deterministic_verifier_module": self.manifest["canonical"]["deterministic_verifier"],
             "signed_quorum_verifier_set_hash": self.manifest["canonical"]["signed_quorum_verifier_set_hash"],
         }
-        verifiers = list(self.create_helper.SIGNED_QUORUM_VERIFIERS)
+        verifiers = list(
+            self.create_helper.SUPPORTED_SIGNED_VERIFIER_SETS[
+                self.manifest["canonical"]["signed_quorum_verifier_set_hash"]
+            ]
+        )
         self.create_helper.validate_creation_verification(params, verifiers, policy, self.manifest["canonical"])
 
         with self.assertRaisesRegex(SystemExit, "exact signed regression"):
             self.create_helper.validate_creation_verification(
                 params,
-                list(reversed(verifiers)),
+                ["0x1111111111111111111111111111111111111111"],
                 policy,
                 self.manifest["canonical"],
             )

--- a/site/agent-budget.html
+++ b/site/agent-budget.html
@@ -85,7 +85,7 @@
             </div>
             <div class="readiness-panel">
               <h3>Fixed authority</h3>
-              <p>Base mainnet native USDC; create, fund, claim, and submit; the exact standing-meta module and two-wallet sandboxed-regression quorum only. AI-judge spending is disabled.</p>
+              <p>Base mainnet native USDC; create, fund, claim, and submit; one exact sandboxed-regression verifier. AI-judge spending is disabled.</p>
             </div>
             <label class="check-line">
               <input name="reviewed" type="checkbox" required>
@@ -118,7 +118,7 @@
               <button id="rotate-agent-delegate" class="button secondary" type="button" disabled>Update policy</button>
               <button id="revoke-agent-budget" class="button secondary" type="button" disabled>Revoke agent authority</button>
             </div>
-            <p class="fine">The update replaces the signer and installs only the reviewed durable verifier router plus the exact sandboxed-regression quorum. Recovery-reserved contracts are not eligible for new earning actions. This starts a fresh policy-period counter but preserves lifetime spend. Revocation blocks all new delegate actions. Neither action moves the wallet's USDC.</p>
+            <p class="fine">The update replaces the signer and installs only the reviewed durable verifier router plus the exact one-verifier regression policy. Recovery-reserved contracts are not eligible for new earning actions. This starts a fresh policy-period counter but preserves lifetime spend. Revocation blocks all new delegate actions. Neither action moves the wallet's USDC.</p>
           </div>
         </form>
       </section>
@@ -131,6 +131,7 @@
           </div>
           <div class="copy">
             <p>The owner still makes a deliberate setup decision. EOAs sign one bounded USDC authorization; smart accounts approve the exact amount and call the reviewed factory. After activation, the agent signs with its dedicated delegate key and the contract accepts only in-policy canonical actions.</p>
+            <p>The owner can cancel an unclaimed bounty created by this V2 wallet and recover the wallet's contribution. A claimed bounty cannot be cancelled through this escape hatch, and pooled contributors keep their own refunds.</p>
             <p>The predicted wallet address commits the full policy hash. Changing the delegate, cap, verifier, action set, or expiry changes the USDC authorization destination.</p>
             <p>This release is internally reviewed and fork-rehearsed, not independently audited. Caps limit authority; they do not guarantee that an agent chooses useful work.</p>
             <p>A signature or transaction hash is not funding or payment evidence. Inspect the deployed wallet and native-USDC balance; only canonical bounty events prove later work and payout.</p>

--- a/site/agent-budget.js
+++ b/site/agent-budget.js
@@ -17,18 +17,18 @@
   const CHAIN_ID = "0x2105";
   const ZERO_HASH = `0x${"00".repeat(32)}`;
   const EXPECTED = Object.freeze({
-    sourceRevision: "dc05b4e01474f09f02bb1bbb69651e4ce4deb338",
+    sourceRevision: "7fbfd7e106e387e12ad5c9b29cbef4344dfead69",
     bountyFactory: "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
     settlementToken: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
     deterministicVerifier: "0x380c1af742593dd88b6f20387e9ee693a0536731",
-    signedQuorumVerifierSetHash: "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
+    signedQuorumVerifierSetHash: "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2",
     deterministicDeployer: "0x4e59b44847b379578588920ca78fbf26c0b4956c",
     deterministicDeployerHash: "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989",
-    walletFactory: "0x3840936351049aed639780a16845e6094c1f17f6",
-    implementation: "0x40d3e16082cf71ece0129ca3044e1b8233e29db8",
-    factoryRuntimeHash: "0x243e248a890daf57cb14cee262bc7bb70b8822c65a014a8bf1c39653bc30aa52",
-    implementationRuntimeHash: "0x7fb59d5add3ac348ac3d7e6a5aa6b22ad542a6e6093a1ceb8d535f747ed536df",
-    cloneRuntimeHash: "0xc663bed9b4097e22e5a18c0ecb662561bf45df1829e6412cdd0d8568d05ca1b6",
+    walletFactory: "0xe3d4f7b203c5e8576e0225d3e64a8532429d3876",
+    implementation: "0x00c250bda8fa3c49d80a11d9b6ebd961736b7202",
+    factoryRuntimeHash: "0x254e247c3df7b38c257cd24b5d47c6ca1bc3ed335d6cb062498695bced540cf9",
+    implementationRuntimeHash: "0xade4fb51d0c5c866bb0cc44ca17ad0b254c6bba92ac5b47ddc2ced4963b05d18",
+    cloneRuntimeHash: "0xc11ada07afafbcf407387ff2fa7afc52e55301c80a4edd0888520b478fba9209",
   });
   const OBSOLETE_DETERMINISTIC_VERIFIER = "0xcc6059ceeda5bc4ba8a97ecfbffa7488c8fd579e";
   const SELECTORS = Object.freeze({
@@ -158,8 +158,8 @@
   async function loadManifest() {
     if (state.manifest) return state.manifest;
     const urls = [
-      "bounded-agent-wallet-base-mainnet.json",
-      "https://raw.githubusercontent.com/NSPG13/agent-bounties/main/deployments/bounded-agent-wallet-base-mainnet.json",
+      "bounded-agent-wallet-v2-base-mainnet.json",
+      "https://raw.githubusercontent.com/NSPG13/agent-bounties/main/deployments/bounded-agent-wallet-v2-base-mainnet.json",
     ];
     let manifest = null;
     for (const url of urls) {
@@ -173,7 +173,7 @@
         // Try the source-controlled fallback.
       }
     }
-    if (!manifest || manifest.schema !== "agent-bounties/bounded-agent-wallet-deployment-v1") {
+    if (!manifest || manifest.schema !== "agent-bounties/bounded-agent-wallet-deployment-v2") {
       throw new Error("The reviewed bounded-wallet deployment manifest is unavailable.");
     }
     if (manifest.chain_id !== 8453 || manifest.network !== "base-mainnet") {
@@ -814,7 +814,7 @@
       `Current / next policy version: ${observed.version} / ${observed.version + 1n}`,
       `Current / next policy hash: ${currentHash} / ${nextHash}`,
       `Wallet balance remains ${Number(observed.balance) / 1_000_000} USDC.`,
-      "The next policy permits only the existing deterministic module and the exact two-wallet sandboxed-regression quorum. AI-judge authority remains disabled.",
+      "The next policy permits only the existing deterministic module and the exact one-verifier regression policy. AI-judge authority remains disabled.",
       `Lifetime spend remains ${Number(observed.lifetimeSpent) / 1_000_000} USDC. The deployed wallet starts a fresh policy-period counter; current period spend is ${Number(observed.periodSpent) / 1_000_000} USDC.`,
       "All financial caps, actions, expiry, owner, and wallet balance remain unchanged.",
       "The transaction transfers no USDC or ETH.",


### PR DESCRIPTION
Relates to #704 and #756.

## Change
- switch new budget activation to the deterministic V2 factory and manifest
- pin the one-verifier regression policy for new V2 wallets
- preserve the historical V1 manifest for existing wallet and standing-meta audit compatibility
- package both manifests on Pages
- make creation validation manifest-driven across the V1 and V2 verifier sets
- disclose the V2 owner-only unclaimed cancellation and contribution recovery boundary

## Safety
The V2 owner escape hatch cannot cancel claimed work, target non-canonical or another creator bounty, or recover another contributor principal. Existing V1 bytecode and relay assumptions remain unchanged.

## Verification
- 16 focused V2 Foundry tests pass, including 1,000 pooled-contribution fuzz runs
- python scripts/test_bounded_agent_budget.py -v
- python scripts/check-site.py
- node scripts/test-autonomous-wallet-flow.js
- scripts/preflight.ps1 -Mode core
- git diff --check