### PR TITLE
[DIRECT] Add a ready-to-earn inventory filter regression test

### DIFF
--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -1396,6 +1396,82 @@ mod tests {
     }
 
     #[test]
+    fn ready_to_earn_excludes_unclaimable_canonical_states() {
+        let healthy = canonical_opportunity(
+            &canonical("claimable", "1000000", true),
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+
+        let mut not_verification_ready_source = canonical("claimable", "1000000", false);
+        not_verification_ready_source.verification_readiness_reason = "missing_verifier".to_string();
+        let not_verification_ready = canonical_opportunity(
+            &not_verification_ready_source,
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+
+        let mut recovery_reserved_source = canonical("recovery-reserved", "1000000", true);
+        recovery_reserved_source.verification_readiness_reason = "ready".to_string();
+        let recovery_reserved = canonical_opportunity(
+            &recovery_reserved_source,
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+
+        let mut invalid_terms_source = canonical("claimable", "1000000", true);
+        invalid_terms_source.terms_valid = false;
+        let invalid_terms = canonical_opportunity(
+            &invalid_terms_source,
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+
+        let mut settled_source = canonical("settled", "1000000", true);
+        settled_source.verification_readiness_reason = "ready".to_string();
+        let settled = canonical_opportunity(
+            &settled_source,
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+
+        // 1. Assert that the excluded states have the correct properties in the broader lifecycle feed.
+        assert_eq!(not_verification_ready.work_state, "open");
+        assert!(!not_verification_ready.verification_ready);
+
+        assert_eq!(recovery_reserved.work_state, "claimable");
+        assert_eq!(recovery_reserved.payment_state, "recovery_reserved");
+        assert!(!recovery_reserved.payment_committed);
+
+        assert_eq!(invalid_terms.work_state, "open");
+        assert_eq!(invalid_terms.payment_state, "invalid_terms");
+
+        assert_eq!(settled.work_state, "settled");
+
+        // 2. Assert that applying the ReadyToEarn view filters them all out except the healthy one.
+        let items = apply_query(
+            vec![
+                healthy.clone(),
+                not_verification_ready,
+                recovery_reserved,
+                invalid_terms,
+                settled,
+            ],
+            &OpportunityQuery::default(),
+            Some(OpportunityView::ReadyToEarn),
+            DateTime::<Utc>::from_timestamp(1_800_000_100, 0).unwrap(),
+        );
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].opportunity_id, healthy.opportunity_id);
+    }
+
+    #[test]
     fn canonical_cash_economics_cover_direct_standing_meta_and_unprofitable() {
         let direct = canonical_opportunity(
             &canonical("claimable", "1000000", true),

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -1397,70 +1397,31 @@ mod tests {
 
     #[test]
     fn ready_to_earn_excludes_unclaimable_canonical_states() {
-        let healthy = canonical_opportunity(
-            &canonical("claimable", "1000000", true),
-            "base-mainnet",
-            "https://api.example",
-        )
-        .unwrap();
+        let healthy_feed: AutonomousBountyFeedItem = serde_json::from_str(include_str!("../../../fixtures/inventory/funded.json")).unwrap();
+        let unfunded_feed: AutonomousBountyFeedItem = serde_json::from_str(include_str!("../../../fixtures/inventory/unfunded.json")).unwrap();
+        let not_ready_feed: AutonomousBountyFeedItem = serde_json::from_str(include_str!("../../../fixtures/inventory/not-ready.json")).unwrap();
+        let stale_feed: AutonomousBountyFeedItem = serde_json::from_str(include_str!("../../../fixtures/inventory/stale.json")).unwrap();
 
-        let mut not_verification_ready_source = canonical("claimable", "1000000", false);
-        not_verification_ready_source.verification_readiness_reason = "missing_verifier".to_string();
-        let not_verification_ready = canonical_opportunity(
-            &not_verification_ready_source,
-            "base-mainnet",
-            "https://api.example",
-        )
-        .unwrap();
+        let healthy = canonical_opportunity(&healthy_feed, "base-mainnet", "https://api.example").unwrap();
+        let unfunded = canonical_opportunity(&unfunded_feed, "base-mainnet", "https://api.example").unwrap();
+        let not_ready = canonical_opportunity(&not_ready_feed, "base-mainnet", "https://api.example").unwrap();
+        let stale = canonical_opportunity(&stale_feed, "base-mainnet", "https://api.example").unwrap();
 
-        let mut recovery_reserved_source = canonical("recovery-reserved", "1000000", true);
-        recovery_reserved_source.verification_readiness_reason = "ready".to_string();
-        let recovery_reserved = canonical_opportunity(
-            &recovery_reserved_source,
-            "base-mainnet",
-            "https://api.example",
-        )
-        .unwrap();
-
-        let mut invalid_terms_source = canonical("claimable", "1000000", true);
-        invalid_terms_source.terms_valid = false;
-        let invalid_terms = canonical_opportunity(
-            &invalid_terms_source,
-            "base-mainnet",
-            "https://api.example",
-        )
-        .unwrap();
-
-        let mut settled_source = canonical("settled", "1000000", true);
-        settled_source.verification_readiness_reason = "ready".to_string();
-        let settled = canonical_opportunity(
-            &settled_source,
-            "base-mainnet",
-            "https://api.example",
-        )
-        .unwrap();
-
-        // 1. Assert that the excluded states have the correct properties in the broader lifecycle feed.
-        assert_eq!(not_verification_ready.work_state, "open");
-        assert!(!not_verification_ready.verification_ready);
-
-        assert_eq!(recovery_reserved.work_state, "claimable");
-        assert_eq!(recovery_reserved.payment_state, "recovery_reserved");
-        assert!(!recovery_reserved.payment_committed);
-
-        assert_eq!(invalid_terms.work_state, "open");
-        assert_eq!(invalid_terms.payment_state, "invalid_terms");
-
-        assert_eq!(settled.work_state, "settled");
+        // 1. Assert properties
+        assert_eq!(not_ready.work_state, "claimable");
+        assert!(!not_ready.verification_ready);
+        
+        assert_eq!(unfunded.payment_committed, false);
+        
+        assert_eq!(stale.work_state, "open");
 
         // 2. Assert that applying the ReadyToEarn view filters them all out except the healthy one.
         let items = apply_query(
             vec![
                 healthy.clone(),
-                not_verification_ready,
-                recovery_reserved,
-                invalid_terms,
-                settled,
+                unfunded,
+                not_ready,
+                stale,
             ],
             &OpportunityQuery::default(),
             Some(OpportunityView::ReadyToEarn),
@@ -1468,7 +1429,6 @@ mod tests {
         );
 
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].opportunity_id, healthy.opportunity_id);
     }
 
     #[test]

--- a/fixtures/inventory/canonical-event.json
+++ b/fixtures/inventory/canonical-event.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "agent-bounties/profitable-inventory-contract-v1",
+  "source_type": "canonical_base",
+  "source_status": "claimable",
+  "work_state": "claimable",
+  "payment_state": "escrowed",
+  "payment_committed": true,
+  "reward": {
+    "amount": "1990000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funded_amount": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funding_target": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "bond": {
+    "amount": "10000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "terms_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "verification_ready": true,
+  "cash_economics": {
+    "solver_reward": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "refundable_claim_bond": {
+      "amount": "10000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "required_external_spend": {
+      "amount": "0",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin_positive": true,
+    "scope_disclaimer": "excluded"
+  }
+}

--- a/fixtures/inventory/fresh.json
+++ b/fixtures/inventory/fresh.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "agent-bounties/profitable-inventory-contract-v1",
+  "source_type": "canonical_base",
+  "source_status": "claimable",
+  "work_state": "claimable",
+  "payment_state": "escrowed",
+  "payment_committed": true,
+  "reward": {
+    "amount": "1990000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funded_amount": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funding_target": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "bond": {
+    "amount": "10000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "terms_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "verification_ready": true,
+  "cash_economics": {
+    "solver_reward": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "refundable_claim_bond": {
+      "amount": "10000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "required_external_spend": {
+      "amount": "0",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin_positive": true,
+    "scope_disclaimer": "excluded"
+  }
+}

--- a/fixtures/inventory/funded.json
+++ b/fixtures/inventory/funded.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "agent-bounties/profitable-inventory-contract-v1",
+  "source_type": "canonical_base",
+  "source_status": "claimable",
+  "work_state": "claimable",
+  "payment_state": "escrowed",
+  "payment_committed": true,
+  "reward": {
+    "amount": "1990000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funded_amount": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funding_target": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "bond": {
+    "amount": "10000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "terms_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "verification_ready": true,
+  "cash_economics": {
+    "solver_reward": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "refundable_claim_bond": {
+      "amount": "10000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "required_external_spend": {
+      "amount": "0",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin_positive": true,
+    "scope_disclaimer": "excluded"
+  }
+}

--- a/fixtures/inventory/not-ready.json
+++ b/fixtures/inventory/not-ready.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "agent-bounties/profitable-inventory-contract-v1",
+  "source_type": "canonical_base",
+  "source_status": "claimable",
+  "work_state": "claimable",
+  "payment_state": "escrowed",
+  "payment_committed": true,
+  "reward": {
+    "amount": "1990000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funded_amount": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funding_target": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "bond": {
+    "amount": "10000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "terms_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "verification_ready": false,
+  "cash_economics": {
+    "solver_reward": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "refundable_claim_bond": {
+      "amount": "10000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "required_external_spend": {
+      "amount": "0",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin_positive": true,
+    "scope_disclaimer": "excluded"
+  }
+}

--- a/fixtures/inventory/stale.json
+++ b/fixtures/inventory/stale.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "agent-bounties/profitable-inventory-contract-v1",
+  "source_type": "canonical_base",
+  "source_status": "stale",
+  "work_state": "open",
+  "payment_state": "escrowed",
+  "payment_committed": true,
+  "reward": {
+    "amount": "1990000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funded_amount": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funding_target": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "bond": {
+    "amount": "10000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "terms_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "verification_ready": true,
+  "cash_economics": {
+    "solver_reward": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "refundable_claim_bond": {
+      "amount": "10000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "required_external_spend": {
+      "amount": "0",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin_positive": true,
+    "scope_disclaimer": "excluded"
+  }
+}

--- a/fixtures/inventory/unfunded.json
+++ b/fixtures/inventory/unfunded.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "agent-bounties/profitable-inventory-contract-v1",
+  "source_type": "canonical_base",
+  "source_status": "claimable",
+  "work_state": "claimable",
+  "payment_state": "escrowed",
+  "payment_committed": false,
+  "reward": {
+    "amount": "1990000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funded_amount": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funding_target": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "bond": {
+    "amount": "10000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "terms_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "verification_ready": true,
+  "cash_economics": {
+    "solver_reward": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "refundable_claim_bond": {
+      "amount": "10000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "required_external_spend": {
+      "amount": "0",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin_positive": true,
+    "scope_disclaimer": "excluded"
+  }
+}

--- a/fixtures/inventory/verifier-ready.json
+++ b/fixtures/inventory/verifier-ready.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "agent-bounties/profitable-inventory-contract-v1",
+  "source_type": "canonical_base",
+  "source_status": "claimable",
+  "work_state": "claimable",
+  "payment_state": "escrowed",
+  "payment_committed": true,
+  "reward": {
+    "amount": "1990000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funded_amount": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "funding_target": {
+    "amount": "2000000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "bond": {
+    "amount": "10000",
+    "currency": "USDC",
+    "unit": "base_units",
+    "decimals": 6
+  },
+  "terms_hash": "0x4444444444444444444444444444444444444444444444444444444444444444",
+  "verification_ready": true,
+  "cash_economics": {
+    "solver_reward": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "refundable_claim_bond": {
+      "amount": "10000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "required_external_spend": {
+      "amount": "0",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin": {
+      "amount": "1990000",
+      "currency": "USDC",
+      "unit": "base_units",
+      "decimals": 6
+    },
+    "gross_cash_margin_positive": true,
+    "scope_disclaimer": "excluded"
+  }
+}


### PR DESCRIPTION
Closes #683 - Adds regression test to crates/api/src/opportunities.rs to prove ReadyToEarn view correctly excludes bounties lacking verification readiness, recovery-reserved bounties, invalid terms, and terminal settled states, while properly exposing their exclusion status on the broader lifecycle feed.