### PR TITLE
fix: reconcile confirmed wallet allowance

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -1214,7 +1214,8 @@ def main() -> int:
             "clone_runtime_code_hash",
             "policy-bound wallet",
             "Smart-account activation requires one exact USDC approval",
-            "Factory allowance was not fully consumed by activation",
+            "waitForFactoryAllowance",
+            "Confirmed USDC allowance is",
         ],
     )
     if "This owner is a contract account. Use the manifest's approve" in bounded_javascript:

--- a/scripts/test_bounded_agent_budget.py
+++ b/scripts/test_bounded_agent_budget.py
@@ -64,6 +64,22 @@ class BoundedAgentBudgetPlannerTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.planner.usdc_units("0.0000001", "amount")
 
+    def test_browser_activation_waits_for_confirmed_allowance_state(self) -> None:
+        source = (ROOT / "site" / "agent-budget.js").read_text(encoding="utf-8")
+        helper = source.split("async function waitForFactoryAllowance", 1)[1].split(
+            "async function activateWithAllowance", 1
+        )[0]
+        activation = source.split("async function activateWithAllowance", 1)[1].split(
+            "async function deployFactory", 1
+        )[0]
+
+        self.assertIn("while (observed !== expected", helper)
+        self.assertIn("await sleep(1_500)", helper)
+        self.assertIn("Confirmed USDC allowance is", helper)
+        self.assertIn("await waitForFactoryAllowance(plan.initialFunding)", activation)
+        self.assertIn("await waitForFactoryAllowance(0n)", activation)
+        self.assertNotIn("Confirmed USDC allowance differs", activation)
+
     def test_policy_changes_authorization_destination(self) -> None:
         base = {
             "delegate": "0x1111111111111111111111111111111111111111",

--- a/site/agent-budget.js
+++ b/site/agent-budget.js
@@ -543,6 +543,27 @@
     return resultUint(await call(state.manifest.canonical.settlement_token, data));
   }
 
+  function formatUsdc(units) {
+    const whole = units / 1_000_000n;
+    const fraction = (units % 1_000_000n).toString().padStart(6, "0").replace(/0+$/, "");
+    return fraction ? `${whole}.${fraction}` : String(whole);
+  }
+
+  async function waitForFactoryAllowance(expected, timeoutMs = 45_000) {
+    const started = Date.now();
+    let observed = await ownerFactoryAllowance();
+    while (observed !== expected && Date.now() - started < timeoutMs) {
+      await sleep(1_500);
+      observed = await ownerFactoryAllowance();
+    }
+    if (observed !== expected) {
+      throw new Error(
+        `Confirmed USDC allowance is ${formatUsdc(observed)} USDC; ${formatUsdc(expected)} USDC was expected.`,
+      );
+    }
+    return observed;
+  }
+
   async function activateWithAllowance(plan) {
     const factory = state.manifest.wallet_factory.address;
     const token = state.manifest.canonical.settlement_token;
@@ -558,8 +579,7 @@
       const approvalData = `${SELECTORS.approve}${addressWord(factory)}${uintWord(plan.initialFunding)}`;
       approvalHash = await sendTransaction(token, approvalData);
       await waitReceipt(approvalHash);
-      allowance = await ownerFactoryAllowance();
-      if (allowance !== plan.initialFunding) throw new Error("Confirmed USDC allowance differs from the reviewed amount.");
+      allowance = await waitForFactoryAllowance(plan.initialFunding);
     }
     const activationData = `${SELECTORS.createAndFund}`
       + `${plan.policyWords.join("")}${bytes32Word(plan.userSalt)}${uintWord(plan.initialFunding)}`;
@@ -571,8 +591,7 @@
     await ensureConnectedOwner();
     const transactionHash = await sendTransaction(factory, activationData);
     await waitReceipt(transactionHash);
-    const remainingAllowance = await ownerFactoryAllowance();
-    if (remainingAllowance !== 0n) throw new Error("Factory allowance was not fully consumed by activation.");
+    await waitForFactoryAllowance(0n);
     return { transactionHash, approvalHash };
   }
 


### PR DESCRIPTION
## What changed\n- poll the canonical Base USDC allowance after a confirmed approval receipt\n- poll until the one-time factory allowance is consumed after activation\n- fail closed after 45 seconds with exact observed and expected USDC values\n- add focused bounded-wallet and public-site regression coverage\n\n## Evidence\nThe affected owner currently has exactly 10.05 USDC approved to the canonical V2 factory, while the old page displayed a mismatch immediately after the successful receipt. No USDC moved. This is an RPC read-after-write consistency fix; contracts, reviewed limits, amounts, and settlement semantics are unchanged.\n\n## Verification\n- node --check site/agent-budget.js\n- python scripts/test_bounded_agent_budget.py\n- python scripts/check-site.py\n- git diff --check\n\nCloses #756