### PR TITLE
fix: preserve bounded budget drafts

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -1216,6 +1216,9 @@ def main() -> int:
             "Smart-account activation requires one exact USDC approval",
             "waitForFactoryAllowance",
             "Confirmed USDC allowance is",
+            "DRAFT_STORAGE_KEY",
+            "new URLSearchParams(window.location.search)",
+            "Never enter its private key or recovery phrase",
         ],
     )
     if "This owner is a contract account. Use the manifest's approve" in bounded_javascript:

--- a/scripts/test_bounded_agent_budget.py
+++ b/scripts/test_bounded_agent_budget.py
@@ -80,6 +80,28 @@ class BoundedAgentBudgetPlannerTests(unittest.TestCase):
         self.assertIn("await waitForFactoryAllowance(0n)", activation)
         self.assertNotIn("Confirmed USDC allowance differs", activation)
 
+    def test_browser_persists_only_non_secret_budget_draft_fields(self) -> None:
+        source = (ROOT / "site" / "agent-budget.js").read_text(encoding="utf-8")
+        persistence = source.split("function persistDraft", 1)[1].split(
+            "function snapshot", 1
+        )[0]
+
+        for field in (
+            "delegate",
+            "initialFunding",
+            "maxPerAction",
+            "maxPerPeriod",
+            "maxLifetime",
+            "maxBountyTarget",
+            "expiryDays",
+        ):
+            draft_fields = source.split("const DRAFT_FIELDS", 1)[1].split("];", 1)[0]
+            self.assertIn(f'"{field}"', draft_fields)
+        self.assertIn("new URLSearchParams(window.location.search)", persistence)
+        self.assertIn("validDraftValue", persistence)
+        for secret in ("signature", "privateKey", "mnemonic", "approvalHash", "transactionHash"):
+            self.assertNotIn(secret, persistence)
+
     def test_policy_changes_authorization_destination(self) -> None:
         base = {
             "delegate": "0x1111111111111111111111111111111111111111",

--- a/site/agent-budget.html
+++ b/site/agent-budget.html
@@ -48,7 +48,7 @@
               Agent delegate address
               <input name="delegate" placeholder="0x... dedicated agent signer" autocomplete="off" required>
             </label>
-            <p class="fine">Use a dedicated agent signer, not the owner address or seed phrase. The delegate cannot withdraw or make arbitrary calls.</p>
+            <p class="fine">Enter only the agent signer's public Base address. This address and the limits are saved in this browser; keys, signatures, consent, and approvals are never stored.</p>
           </div>
 
           <div data-legal-consent data-consent-actions="activate_agent_budget update_agent_policy revoke_agent_policy"></div>

--- a/site/agent-budget.js
+++ b/site/agent-budget.js
@@ -15,6 +15,16 @@
   };
   const announcedProviders = [];
   const CHAIN_ID = "0x2105";
+  const DRAFT_STORAGE_KEY = "agent-bounties:bounded-budget-draft:v1";
+  const DRAFT_FIELDS = Object.freeze([
+    "delegate",
+    "initialFunding",
+    "maxPerAction",
+    "maxPerPeriod",
+    "maxLifetime",
+    "maxBountyTarget",
+    "expiryDays",
+  ]);
   const ZERO_HASH = `0x${"00".repeat(32)}`;
   const EXPECTED = Object.freeze({
     sourceRevision: "7fbfd7e106e387e12ad5c9b29cbef4344dfead69",
@@ -261,6 +271,45 @@
     return units;
   }
 
+  function validDraftValue(name, value) {
+    const normalized = String(value || "").trim();
+    if (name === "delegate") {
+      return /^0x[0-9a-fA-F]{40}$/.test(normalized) && normalized.toLowerCase() !== `0x${"00".repeat(20)}`;
+    }
+    if (name === "expiryDays") return /^\d+$/.test(normalized) && Number(normalized) >= 1 && Number(normalized) <= 30;
+    return /^\d+(?:\.\d{1,6})?$/.test(normalized) && Number(normalized) > 0 && Number(normalized) <= 89;
+  }
+
+  function persistDraft() {
+    try {
+      const draft = Object.fromEntries(DRAFT_FIELDS.map((name) => [name, form().elements[name].value.trim()]));
+      localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+    } catch (_error) {
+      // Storage can be unavailable in private browsing; the form still works for the current page load.
+    }
+  }
+
+  function restoreDraft() {
+    let stored = {};
+    try {
+      stored = JSON.parse(localStorage.getItem(DRAFT_STORAGE_KEY) || "{}") || {};
+    } catch (_error) {
+      stored = {};
+    }
+    const parameters = new URLSearchParams(window.location.search);
+    for (const name of DRAFT_FIELDS) {
+      const fromUrl = parameters.has(name);
+      const value = fromUrl ? parameters.get(name) : stored[name];
+      if (value === undefined || value === null || value === "") continue;
+      if (!validDraftValue(name, value)) {
+        if (fromUrl) throw new Error(`Recovery link contains an invalid ${name} value.`);
+        continue;
+      }
+      form().elements[name].value = String(value).trim();
+    }
+    persistDraft();
+  }
+
   function snapshot() {
     const data = new FormData(form());
     return JSON.stringify({
@@ -428,6 +477,10 @@
 
   function buildPolicy(chainTimestamp) {
     const values = new FormData(form());
+    if (!String(values.get("delegate") || "").trim()) {
+      form().elements.delegate.focus();
+      throw new Error("Enter the public Base address of the agent signer. Never enter its private key or recovery phrase.");
+    }
     const delegate = requiredAddress(values.get("delegate"), "Agent delegate");
     if (delegate === state.account) throw new Error("Use a dedicated delegate address, not the owner wallet.");
     const initialFunding = usdcUnits(values.get("initialFunding"), "Initial funding");
@@ -943,6 +996,7 @@
   }
 
   function invalidatePlan(event) {
+    if (DRAFT_FIELDS.includes(event.target.name)) persistDraft();
     if (event.target.name === "reviewed" || event.target.name === "rotationReviewed") {
       updateButtons();
       return;
@@ -988,6 +1042,7 @@
       updateButtons();
     });
     try {
+      restoreDraft();
       await loadManifest();
       await discoverProviders();
       status("Ready for owner connection", "pending");


### PR DESCRIPTION
## What changed\n- persist only the public delegate and six bounded-policy values before wallet prompts\n- restore validated values after refresh or from an explicit recovery URL\n- keep keys, signatures, consent, approvals, and transaction state out of storage\n- replace the empty-delegate error with an actionable public-address instruction\n- add focused regression and public-site gates\n\n## Browser evidence\nA local real-browser run loaded the exact 10.05 USDC / 2.01 USDC recovery URL, then navigated to the query-free page. The delegate and all six policy values remained exact after the second load. Consent remained unchecked and no wallet authorization was restored.\n\n## Verification\n- node --check site/agent-budget.js\n- python scripts/test_bounded_agent_budget.py\n- python scripts/check-site.py\n- git diff --check\n\nCloses #768