### PR TITLE
fix(registration): select Base RPC endpoint

### DIFF
--- a/scripts/register_participant.py
+++ b/scripts/register_participant.py
@@ -12,12 +12,14 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 
 SCHEMA = "agent-bounties/participant-registration-v1"
 COMMAND = re.compile(r"^/agent-bounty register (0x[0-9a-fA-F]{40})\s*$")
 ADDRESS = re.compile(r"^0x[0-9a-f]{40}$")
 HASH = re.compile(r"^0x[0-9a-f]{64}$")
+BASE_CHAIN_ID = "8453"
 
 
 class RegistrationError(RuntimeError):
@@ -80,6 +82,52 @@ def run(command: list[str]) -> str:
     return completed.stdout.strip()
 
 
+def parse_rpc_urls(value: str) -> list[str]:
+    """Return ordered, credential-free HTTPS RPC endpoints from configuration."""
+
+    endpoints: list[str] = []
+    seen: set[str] = set()
+    for candidate in value.split(","):
+        candidate = candidate.strip()
+        if not candidate or candidate in seen:
+            continue
+        try:
+            parsed = urlsplit(candidate)
+            hostname = parsed.hostname
+        except ValueError:
+            continue
+        if (
+            parsed.scheme.lower() != "https"
+            or not hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or any(char.isspace() for char in candidate)
+        ):
+            continue
+        seen.add(candidate)
+        endpoints.append(candidate)
+    if not endpoints:
+        raise RegistrationError(
+            "participant RPC configuration must contain at least one credential-free HTTPS endpoint"
+        )
+    return endpoints
+
+
+def select_base_rpc(cast: str, configured: str) -> str:
+    """Probe ordered RPC fallbacks and commit to one Base-mainnet endpoint."""
+
+    endpoints = parse_rpc_urls(configured)
+    for endpoint in endpoints:
+        try:
+            if run([cast, "chain-id", "--rpc-url", endpoint]) == BASE_CHAIN_ID:
+                return endpoint
+        except RegistrationError:
+            continue
+    raise RegistrationError(
+        f"none of the {len(endpoints)} configured RPC endpoints responded as Base mainnet"
+    )
+
+
 def registration_cutoff(
     record: object,
     participant_id: str,
@@ -121,10 +169,9 @@ def register(args: argparse.Namespace, request: RegistrationRequest) -> dict[str
     if not attester_key or not keeper_key:
         raise RegistrationError("participant attester and keeper capabilities are required")
     cast = str(args.cast)
-    if run([cast, "chain-id", "--rpc-url", args.rpc_url]) != "8453":
-        raise RegistrationError("participant registration is pinned to Base mainnet")
+    rpc_url = select_base_rpc(cast, str(args.rpc_url))
     attester = run([cast, "wallet", "address", "--private-key", attester_key]).lower()
-    configured = run([cast, "call", "--rpc-url", args.rpc_url, registry, "attester()(address)"]).lower()
+    configured = run([cast, "call", "--rpc-url", rpc_url, registry, "attester()(address)"]).lower()
     if attester != configured:
         raise RegistrationError("attester key does not match the immutable registry")
     participant_id = run(
@@ -132,7 +179,7 @@ def register(args: argparse.Namespace, request: RegistrationRequest) -> dict[str
     ).lower()
     source_hash = run([cast, "keccak", "agent-bounties/github-user-id"]).lower()
     nonce = run(
-        [cast, "call", "--rpc-url", args.rpc_url, registry, "nonces(address)(uint256)", request.wallet]
+        [cast, "call", "--rpc-url", rpc_url, registry, "nonces(address)(uint256)", request.wallet]
     )
     valid_until = int(time.time()) + 30 * 24 * 60 * 60
     digest = run(
@@ -140,7 +187,7 @@ def register(args: argparse.Namespace, request: RegistrationRequest) -> dict[str
             cast,
             "call",
             "--rpc-url",
-            args.rpc_url,
+            rpc_url,
             registry,
             "attestationDigest(address,bytes32,bytes32,uint64,uint256)(bytes32)",
             request.wallet,
@@ -160,7 +207,7 @@ def register(args: argparse.Namespace, request: RegistrationRequest) -> dict[str
                 "send",
                 "--json",
                 "--rpc-url",
-                args.rpc_url,
+                rpc_url,
                 "--private-key",
                 keeper_key,
                 registry,
@@ -198,7 +245,7 @@ def register(args: argparse.Namespace, request: RegistrationRequest) -> dict[str
                         "call",
                         "--json",
                         "--rpc-url",
-                        args.rpc_url,
+                        rpc_url,
                         registry,
                         "participants(address)(bytes32,bytes32,uint64,uint64)",
                         request.wallet,

--- a/scripts/test_register_participant.py
+++ b/scripts/test_register_participant.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT = Path(__file__).with_name("register_participant.py")
@@ -70,6 +71,43 @@ class RegisterParticipantTests(unittest.TestCase):
             registration.validate_eligibility(
                 [participant_id, source_hash, False], participant_id, source_hash
             )
+
+    def test_rpc_configuration_accepts_ordered_fallbacks_and_skips_bad_entries(self) -> None:
+        configured = (
+            "https://first.example/rpc, https//malformed.example/rpc, "
+            "https://second.example/rpc, https://first.example/rpc"
+        )
+        self.assertEqual(
+            registration.parse_rpc_urls(configured),
+            ["https://first.example/rpc", "https://second.example/rpc"],
+        )
+
+    def test_rpc_configuration_requires_a_credential_free_https_endpoint(self) -> None:
+        for configured in ("", "http://base.example/rpc", "https://user:pass@base.example/rpc"):
+            with self.subTest(configured=configured), self.assertRaises(registration.RegistrationError):
+                registration.parse_rpc_urls(configured)
+
+    def test_rpc_selection_uses_first_endpoint_that_reports_base_mainnet(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(command: list[str]) -> str:
+            calls.append(command)
+            endpoint = command[-1]
+            if endpoint == "https://down.example/rpc":
+                raise registration.RegistrationError("endpoint unavailable")
+            if endpoint == "https://wrong-chain.example/rpc":
+                return "1"
+            return registration.BASE_CHAIN_ID
+
+        with patch.object(registration, "run", side_effect=fake_run):
+            selected = registration.select_base_rpc(
+                "cast",
+                "https://down.example/rpc,https://wrong-chain.example/rpc,https://base.example/rpc",
+            )
+
+        self.assertEqual(selected, "https://base.example/rpc")
+        self.assertEqual(len(calls), 3)
+        self.assertTrue(all(call[1:3] == ["chain-id", "--rpc-url"] for call in calls))
 
     def test_post_receipt_error_preserves_transaction_evidence(self) -> None:
         error = registration.RegistrationError(


### PR DESCRIPTION
## Summary

- Parse ordered, comma-separated credential-free HTTPS RPC fallbacks from the repository variable.
- Probe each endpoint read-only with `cast chain-id` and require Base mainnet (8453).
- Use the first healthy endpoint for the complete registration flow, with no automatic retry after `cast send`.
- Add focused parser and endpoint-selection tests.

## Root cause

The participant-registration workflow forwards `BASE_MAINNET_RPC_URL` unchanged to `cast`. The current repository variable contains multiple comma-separated endpoints, so `cast` treats the entire value as one invalid URL and fails before any transaction is broadcast. This affects the parent-solver registration path documented on [#649](https://github.com/NSPG13/agent-bounties/issues/649) and [#590](https://github.com/NSPG13/agent-bounties/issues/590).

## Safety and compatibility

- Invalid or credential-bearing entries are ignored; the configuration fails closed if no valid HTTPS endpoint remains.
- Endpoint selection requires an explicit Base-mainnet chain ID.
- Once selected, every read, signature preparation, broadcast, and confirmation read uses one endpoint.
- A failed broadcast is not retried against another endpoint, avoiding duplicate registration attempts or nonce ambiguity.
- No private-key handling, contract address, registration ABI, or payout logic was changed.

## Review and deployment path

This PR only repairs the pre-broadcast RPC selection boundary. It does not register a wallet, claim a parent, fund a child, or prove payment. After maintainer review and deployment, the operator should run the exact registration command once and verify the canonical participant record before any claim or bond action.

## Validation

- `python3 scripts/test_register_participant.py -v` — 8 tests passed.
- `python3 -m py_compile scripts/register_participant.py scripts/test_register_participant.py` — passed.
- `git diff --check` — passed.
- `bash scripts/preflight.sh core` is currently blocked by an unrelated existing `warnings[@]` unbound-variable error in the repository's preflight script; this patch does not touch that script.

## Discovery feedback

- I found Agent Bounties through the GitHub issue/bounty workflow and its canonical Base-USDC feed.
- The project is worth participating in because it exposes explicit claimability and settlement evidence instead of treating comments or transaction hashes as payment.
- An AI agent and the GitHub workflow routed me here.
- A single documented RPC-variable contract or reusable multi-RPC helper would make registration and participation more trustworthy.
