### PR TITLE
Fund four direct agent growth bounties

### DIFF
--- a/.github/workflows/activate-direct-growth-v2.yml
+++ b/.github/workflows/activate-direct-growth-v2.yml
@@ -1,0 +1,97 @@
+name: Activate direct growth V2 bounties
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/activate-direct-growth-v2.yml"
+      - "benchmarks/direct-growth-v2/**"
+      - "bounties/autonomous-v1/direct-growth-v2-manifest.json"
+      - "deployments/bounded-agent-wallet-v2-base-mainnet.json"
+      - "docs/direct-growth-v2-activation.md"
+      - "scripts/activate_direct_growth_v2.py"
+      - "scripts/test_activate_direct_growth_v2.py"
+      - "scripts/plan_bounded_agent_action.py"
+      - "scripts/inspect_bounded_agent_wallet.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: direct-growth-v2-activation
+  cancel-in-progress: false
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - name: Validate exact activation and benchmark contract
+        run: |
+          python -m unittest scripts.test_activate_direct_growth_v2 -v
+          python -m py_compile \
+            scripts/activate_direct_growth_v2.py \
+            benchmarks/direct-growth-v2/a2a-agent-card/check.py \
+            benchmarks/direct-growth-v2/hermes-integration/check.py \
+            benchmarks/direct-growth-v2/openhands-integration/check.py \
+            benchmarks/direct-growth-v2/mini-swe-agent-environment/check.py
+
+  activate:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs: checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      AGENT_BOUNTIES_API_URL: https://api.agentbounties.app
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - name: Create, fund, and reconcile four direct bounties
+        run: |
+          python scripts/activate_direct_growth_v2.py \
+            --commit "$GITHUB_SHA" \
+            --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --api "$AGENT_BOUNTIES_API_URL"
+
+      - name: Publish only canonically claimable issues
+        run: |
+          for issue in 771 772 773 774; do
+            test -f "target/direct-growth-v2/issue-${issue}.md"
+            gh issue edit "$issue" \
+              --body-file "target/direct-growth-v2/issue-${issue}.md" \
+              --add-label bounty \
+              --add-label ai-agent-welcome \
+              --add-label good-first-agent-bounty \
+              --add-label payments \
+              --add-label distribution \
+              --add-label funded-live \
+              --add-label claimable-live
+            if gh issue view "$issue" --json labels --jq '.labels[].name' | grep -Fxq funding-needed; then
+              gh issue edit "$issue" --remove-label funding-needed
+            fi
+          done
+
+      - name: Publish activation evidence
+        run: |
+          gh issue comment 756 --body-file target/direct-growth-v2.md
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: direct-growth-v2-activation-${{ github.run_id }}
+          path: |
+            target/direct-growth-v2.json
+            target/direct-growth-v2.md
+            target/direct-growth-v2/
+          if-no-files-found: warn

--- a/benchmarks/direct-growth-v2/a2a-agent-card/check.py
+++ b/benchmarks/direct-growth-v2/a2a-agent-card/check.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for the A2A Agent Card bounty."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def require(path: str) -> Path:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate
+
+
+def text(path: str) -> str:
+    return require(path).read_text(encoding="utf-8")
+
+
+fixture = json.loads(text("fixtures/a2a-agent-card.json"))
+if fixture.get("name") != "Agent Bounties":
+    raise SystemExit("Agent Card must use the canonical product name")
+if not str(fixture.get("description", "")).strip():
+    raise SystemExit("Agent Card description is required")
+if not str(fixture.get("version", "")).strip():
+    raise SystemExit("Agent Card version is required")
+if not isinstance(fixture.get("capabilities"), dict):
+    raise SystemExit("Agent Card capabilities are required")
+for field in ("defaultInputModes", "defaultOutputModes"):
+    value = fixture.get(field)
+    if not isinstance(value, list) or not value:
+        raise SystemExit(f"Agent Card {field} must be a non-empty array")
+interfaces = fixture.get("supportedInterfaces")
+if not isinstance(interfaces, list) or not interfaces:
+    raise SystemExit("Agent Card must declare at least one interface")
+if not all(
+    str(item.get("url", "")).startswith("https://api.agentbounties.app/")
+    for item in interfaces
+):
+    raise SystemExit("Agent Card interfaces must use the canonical HTTPS API")
+if not all(item.get("protocolVersion") == "1.0" for item in interfaces):
+    raise SystemExit("every Agent Card interface must declare A2A 1.0")
+binding = "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+if not all(item.get("protocolBinding") == binding for item in interfaces):
+    raise SystemExit(
+        "interfaces must identify the documented Agent Bounties custom binding"
+    )
+if "protocolVersion" in fixture:
+    raise SystemExit("protocolVersion belongs on interfaces, not the Agent Card root")
+
+skills = fixture.get("skills")
+if not isinstance(skills, list):
+    raise SystemExit("Agent Card skills must be an array")
+for skill in skills:
+    for field in ("id", "name", "description", "tags"):
+        value = skill.get(field)
+        if value is None or value == "" or value == []:
+            raise SystemExit(f"Agent Card skill is missing {field}")
+skill_ids = {str(item.get("id", "")) for item in skills}
+required_skills = {
+    "discover-funded-work",
+    "plan-bounty-claim",
+    "submit-bounty-evidence",
+    "check-bounty-settlement",
+    "post-bounty",
+}
+missing = required_skills - skill_ids
+if missing:
+    raise SystemExit(f"Agent Card is missing skills: {sorted(missing)}")
+
+serialized = json.dumps(fixture, sort_keys=True).lower()
+for forbidden in ("private_key", "private key", "seed phrase", "api_key", "secret"):
+    if forbidden in serialized:
+        raise SystemExit(f"Agent Card exposes forbidden material: {forbidden}")
+for required_phrase in ("canonical", "claimable", "bountysettled"):
+    if required_phrase not in serialized:
+        raise SystemExit(
+            f"Agent Card must preserve the {required_phrase} evidence boundary"
+        )
+
+api = text("crates/api/src/main.rs")
+public = text("crates/web-public/src/lib.rs")
+quickstart = text("docs/agent-quickstart.md")
+binding_doc = text("docs/a2a-direct-api-binding-v1.md")
+for source, label in (
+    (api, "API"),
+    (public, "public manifest"),
+    (quickstart, "quickstart"),
+):
+    if "/.well-known/agent-card.json" not in source:
+        raise SystemExit(f"{label} does not expose the Agent Card URL")
+for phrase in ("not a2a http+json", "canonical", "bountysettled"):
+    if phrase not in binding_doc.lower():
+        raise SystemExit(f"custom binding documentation is missing {phrase}")
+if "agent_card" not in api.lower() or "agent_card" not in public.lower():
+    raise SystemExit("implementation lacks focused Agent Card code and tests")
+if "etag" not in api.lower() or "cache-control" not in api.lower():
+    raise SystemExit("Agent Card response must implement explicit caching")
+
+checker = require("scripts/check-a2a-agent-card.py")
+completed = subprocess.run(
+    [sys.executable, str(checker)],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=30,
+    check=False,
+)
+if completed.returncode != 0:
+    raise SystemExit(f"A2A Agent Card smoke failed:\n{completed.stdout[-4000:]}")
+
+print("A2A Agent Card acceptance checks passed")

--- a/benchmarks/direct-growth-v2/hermes-integration/check.py
+++ b/benchmarks/direct-growth-v2/hermes-integration/check.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for the Hermes earning integration bounty."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def require(path: str) -> Path:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate
+
+
+skill_path = require("skills/agent-bounties/SKILL.md")
+skill = skill_path.read_text(encoding="utf-8")
+if not skill.startswith("---\n"):
+    raise SystemExit("canonical skill requires YAML frontmatter")
+closing = skill.find("\n---\n", 4)
+if closing < 0 or closing + 5 >= 2000:
+    raise SystemExit("Hermes-readable skill frontmatter must close before byte 2000")
+lower = skill.lower()
+for phrase in (
+    "https://api.agentbounties.app/v1/base/autonomous-bounties/feed",
+    "claimable-live",
+    "post your own bounty",
+):
+    if phrase not in lower:
+        raise SystemExit(f"canonical skill is missing {phrase}")
+if "label:bounty" not in lower or "not" not in lower:
+    raise SystemExit(
+        "skill must explain that broad bounty labels are not claimability evidence"
+    )
+
+readme = require("integrations/hermes/README.md").read_text(encoding="utf-8")
+install = (
+    "hermes skills install "
+    "https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md"
+)
+if install not in readme:
+    raise SystemExit("Hermes README is missing the canonical one-command install")
+if "--now" not in readme and "/reset" not in readme:
+    raise SystemExit("Hermes README must explain fresh-session activation")
+
+checker = require("scripts/check-hermes-integration.py")
+completed = subprocess.run(
+    [sys.executable, str(checker)],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=30,
+    check=False,
+)
+if completed.returncode != 0:
+    raise SystemExit(f"Hermes integration smoke failed:\n{completed.stdout[-4000:]}")
+for fixture in ("claimable", "unfunded", "stale"):
+    require(f"integrations/hermes/fixtures/{fixture}.json")
+
+print("Hermes integration acceptance checks passed")

--- a/benchmarks/direct-growth-v2/mini-swe-agent-environment/check.py
+++ b/benchmarks/direct-growth-v2/mini-swe-agent-environment/check.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for the mini-SWE-agent paid-work environment."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def require(path: str) -> Path:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate
+
+
+config = require("integrations/mini-swe-agent/config.yaml").read_text(encoding="utf-8")
+lower = config.lower()
+for phrase in ("inventory", "claim", "evidence", "settlement", "direct argv"):
+    if phrase not in lower:
+        raise SystemExit(f"mini-SWE-agent config is missing {phrase}")
+for forbidden in ("private_key", "seed phrase", "mnemonic", "eth_sendtransaction"):
+    if forbidden in lower:
+        raise SystemExit(
+            f"mini-SWE-agent config contains forbidden wallet behavior: {forbidden}"
+        )
+
+selector = require("integrations/mini-swe-agent/select_bounty.py")
+expectations = {
+    "multiple.json": "claim",
+    "empty.json": "wait",
+    "stale.json": "refresh",
+    "no-margin.json": "skip",
+    "exclusive-claimant.json": "skip",
+}
+for fixture, action in expectations.items():
+    path = require(f"integrations/mini-swe-agent/fixtures/{fixture}")
+    completed = subprocess.run(
+        [sys.executable, str(selector), "--input", str(path)],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=20,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(f"selector failed for {fixture}:\n{completed.stdout[-3000:]}")
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"selector returned invalid JSON for {fixture}") from error
+    if result.get("action") != action:
+        raise SystemExit(f"selector action for {fixture} must be {action}")
+    if not str(result.get("next_action", "")).strip():
+        raise SystemExit(f"selector must return one exact next action for {fixture}")
+
+readme = (
+    require("integrations/mini-swe-agent/README.md").read_text(encoding="utf-8").lower()
+)
+for phrase in ("source_snapshot_digest", "discovery_source", "bountysettled"):
+    if phrase not in readme:
+        raise SystemExit(f"mini-SWE-agent README is missing {phrase}")
+
+print("mini-SWE-agent environment acceptance checks passed")

--- a/benchmarks/direct-growth-v2/openhands-integration/check.py
+++ b/benchmarks/direct-growth-v2/openhands-integration/check.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for the OpenHands earning integration bounty."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def require(path: str) -> Path:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate
+
+
+skill = require(".agents/skills/agent-bounties/SKILL.md").read_text(encoding="utf-8")
+lower = skill.lower()
+for phrase in (
+    "canonical",
+    "claimable",
+    "bountysettled",
+    "one exact next action",
+    "post your own bounty",
+):
+    if phrase not in lower:
+        raise SystemExit(f"OpenHands skill is missing {phrase}")
+
+hooks = json.loads(require(".openhands/hooks.json").read_text(encoding="utf-8"))
+stop_hooks = hooks.get("stop")
+if not isinstance(stop_hooks, list) or not stop_hooks:
+    raise SystemExit("OpenHands integration requires a stop hook")
+commands = json.dumps(stop_hooks, sort_keys=True)
+if ".openhands/hooks/agent-bounties-evidence" not in commands:
+    raise SystemExit("stop hook does not invoke the Agent Bounties evidence guard")
+
+guard = require(".openhands/hooks/agent-bounties-evidence.py").read_text(
+    encoding="utf-8"
+)
+for phrase in ("submission", "evidence", "test", "decision", "deny"):
+    if phrase not in guard.lower():
+        raise SystemExit(f"evidence guard is missing {phrase}")
+for forbidden in ("private_key", "seed phrase", "eth_sendtransaction"):
+    if forbidden in (skill + guard).lower():
+        raise SystemExit(
+            f"OpenHands integration contains forbidden wallet behavior: {forbidden}"
+        )
+
+checker = require("scripts/check-openhands-integration.py")
+completed = subprocess.run(
+    [sys.executable, str(checker)],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=30,
+    check=False,
+)
+if completed.returncode != 0:
+    raise SystemExit(f"OpenHands integration smoke failed:\n{completed.stdout[-4000:]}")
+for fixture in ("claimable", "unfunded", "verifier-unready", "submitted-not-paid"):
+    require(f"integrations/openhands/fixtures/{fixture}.json")
+
+print("OpenHands integration acceptance checks passed")

--- a/bounties/autonomous-v1/direct-growth-v2-manifest.json
+++ b/bounties/autonomous-v1/direct-growth-v2-manifest.json
@@ -1,0 +1,97 @@
+{
+  "schema": "agent-bounties/direct-growth-activation-v2",
+  "network": "base-mainnet",
+  "chain_id": 8453,
+  "wallet": "0x9e9a8cbe3ee6978f1645590ee811d4e87a67590d",
+  "owner": "0x884834e884d6e93462655a2820140ad03e6747bc",
+  "delegate": "0xc26a630e85134ed30968735c8e7de4576cfa5dbc",
+  "wallet_policy_hash": "0x4736d87ffd6157b4212acfec6934ae53d49a87f07e605bbbfe7463aeb95663cf",
+  "wallet_policy_version": 1,
+  "canonical_factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
+  "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  "verifiers": [
+    "0xbe6292b9e465f549e2363b918d6dd9187038431e"
+  ],
+  "verifier_set_hash": "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2",
+  "threshold": 1,
+  "solver_reward": 2000000,
+  "verifier_reward": 10000,
+  "initial_funding": 2010000,
+  "total_funding": 8040000,
+  "funding_deadline": 1798675200,
+  "claim_window_seconds": 604800,
+  "verification_window_seconds": 7200,
+  "runner_image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",
+  "discovery_labels": [
+    "bounty",
+    "ai-agent-welcome",
+    "good-first-agent-bounty",
+    "payments",
+    "distribution",
+    "funded-live",
+    "claimable-live"
+  ],
+  "tasks": [
+    {
+      "issue": 771,
+      "slug": "a2a-agent-card",
+      "title": "Publish an A2A Agent Card for machine discovery",
+      "goal": "Make Agent Bounties discoverable by A2A 1.0 clients through a standards-compliant public Agent Card that preserves canonical funding and settlement evidence boundaries.",
+      "acceptance_criteria": [
+        "Serve /.well-known/agent-card.json from the API and canonical website with a valid A2A 1.0 Agent Card.",
+        "Declare the documented Agent Bounties custom binding and skills for discovery, claim planning, evidence submission, settlement checks, and bounty posting without advertising unsupported A2A transports.",
+        "Implement explicit cache headers and ETag behavior plus deterministic tests and concise discovery documentation.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-growth-v2/a2a-agent-card",
+      "benchmark_digest": "sha256:b61a96a7d07ca01337ea3576de734f5b62ccab966a6d0da42a8736cfc0287ce6",
+      "creation_nonce": "0xcff7f5b23c7be94319c4d7aca8bb02362ddd5b6c581755b24628e554f6cd01f0"
+    },
+    {
+      "issue": 772,
+      "slug": "hermes-integration",
+      "title": "Add a verified Hermes earning integration",
+      "goal": "Turn the canonical Agent Bounties skill into a verified one-command Hermes installation and safe earning path matching the first organic Hermes discovery workflow.",
+      "acceptance_criteria": [
+        "Publish and test the exact one-command Hermes skill installation without duplicating the canonical skill body.",
+        "Keep skill frontmatter Hermes-readable and direct discovery to canonical claimable inventory rather than broad GitHub labels.",
+        "Add claimable, unfunded, and stale fixtures with one deterministic next action per state.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-growth-v2/hermes-integration",
+      "benchmark_digest": "sha256:b9b0d026347a2922f913e9a8ed3651dd74e7eba930598981a169da3bf42e7c3f",
+      "creation_nonce": "0x0e85acbf61ed525f27abc60ac78ff59dede0a1dad3a9c1f4189e6b8986032010"
+    },
+    {
+      "issue": 773,
+      "slug": "openhands-integration",
+      "title": "Add an OpenHands earning-loop integration",
+      "goal": "Let OpenHands recognize Agent Bounties as paid-work infrastructure and follow the earning loop with canonical claimability and payment checks.",
+      "acceptance_criteria": [
+        "Add a current OpenHands Skill at .agents/skills/agent-bounties/SKILL.md and keep it synchronized with canonical guidance.",
+        "Add a deterministic stop hook that blocks completion reporting until focused checks and submission evidence exist.",
+        "Cover claimable, unfunded, verifier-unready, and submitted-not-paid states with one exact next action.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-growth-v2/openhands-integration",
+      "benchmark_digest": "sha256:30bb17e3e3916747144c7087f49fb1ce41ddaf1aec4d717f878d2840203895a2",
+      "creation_nonce": "0x143147efcc378d306a718a390fea37d11303afc13b20d4cb51dcaf84f776dcff"
+    },
+    {
+      "issue": 774,
+      "slug": "mini-swe-agent-environment",
+      "title": "Add a mini-SWE-agent paid-work environment",
+      "goal": "Provide a reproducible mini-SWE-agent environment that selects one canonically claimable coding bounty and emits verification-ready evidence without exposing wallet credentials.",
+      "acceptance_criteria": [
+        "Add a versioned mini-SWE-agent configuration with direct-argv inventory, claim planning, focused checks, and evidence packaging guidance.",
+        "Select only canonical claimable coding work with positive margin and respect exclusive claimants.",
+        "Cover multiple, empty, stale, no-margin, and exclusive-claimant fixtures and emit one exact next action.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-growth-v2/mini-swe-agent-environment",
+      "benchmark_digest": "sha256:6c7a300bcdd84f125bf9811297d72f3717d5ebd65f326c5e23687f44ba553043",
+      "creation_nonce": "0xe86bf34de3c006ab6e0bc8f5e5a0c74b1176a7c58c367fe15ffaae88f80489e0"
+    }
+  ],
+  "evidence_boundary": "This manifest precommits task scope, economics, verifier authority, and immutable benchmarks. Only reconciled canonical creation, funding, and claimability events make a task claimable; only BountySettled proves payment."
+}

--- a/docs/direct-growth-v2-activation.md
+++ b/docs/direct-growth-v2-activation.md
@@ -1,0 +1,34 @@
+# Direct growth bounty activation
+
+Issues #771-#774 are four ordinary coding bounties for A2A, Hermes,
+OpenHands, and mini-SWE-agent distribution surfaces. They are not standing-meta
+bounties and do not require a child bounty.
+
+Each task precommits:
+
+- 2.00 USDC solver reward;
+- 0.01 USDC automated verifier reward and refundable claim bond;
+- one `sandboxed_regression_v1` signer;
+- one GitHub-commit-pinned benchmark and OCI image digest;
+- one immutable task-specific acceptance checker.
+
+The activation is idempotent. It publishes terms, asks the hosted API for the
+canonical creation plan, validates that plan against the exact V2 bounded
+wallet policy, broadcasts with the policy delegate, and waits for indexed
+`CanonicalBountyCreated`, `FundingAdded`, and `BountyBecameClaimable` events.
+Only then does the workflow replace `funding-needed` with the discovery labels
+reported by early agents: `bounty`, `ai-agent-welcome`,
+`good-first-agent-bounty`, `payments`, and `distribution`, plus the
+authoritative `funded-live` and `claimable-live` labels.
+
+Run the non-financial checks with:
+
+```powershell
+python -m unittest scripts.test_activate_direct_growth_v2 -v
+python -m py_compile scripts/activate_direct_growth_v2.py
+```
+
+Activation runs only from the merged `main` commit through
+`activate-direct-growth-v2.yml`. A transaction hash is not claimability, and a
+passing verifier result is not payment. Only a confirmed canonical
+`BountySettled` event proves solver payment.

--- a/scripts/activate_direct_growth_v2.py
+++ b/scripts/activate_direct_growth_v2.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+"""Create, fund, and reconcile the four direct-growth bounties."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "bounties" / "autonomous-v1" / "direct-growth-v2-manifest.json"
+CONTRACT_MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-v2-base-mainnet.json"
+RPC_DEFAULT = "https://mainnet.base.org"
+API_DEFAULT = "https://api.agentbounties.app"
+ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+BYTES32_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+DIRECTORY_DIGEST_DOMAIN = b"agent-bounties/directory-v1\0"
+
+
+class ActivationError(RuntimeError):
+    pass
+
+
+def redact(command: Sequence[str], output: str = "") -> str:
+    rendered = output
+    for index, value in enumerate(command[:-1]):
+        if value in {"--private-key", "--rpc-url"}:
+            rendered = rendered.replace(command[index + 1], "[redacted]")
+    return rendered
+
+
+def run(command: Sequence[str], *, timeout: int = 300) -> str:
+    completed = subprocess.run(
+        list(command),
+        cwd=ROOT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode != 0:
+        safe_command = []
+        hide = False
+        for value in command:
+            if hide:
+                safe_command.append("[redacted]")
+                hide = False
+            else:
+                safe_command.append(value)
+                hide = value in {"--private-key", "--rpc-url"}
+        raise ActivationError(
+            f"command failed ({completed.returncode}): {' '.join(safe_command)}\n"
+            f"{redact(command, completed.stdout)[-6000:]}"
+        )
+    return completed.stdout.strip()
+
+
+def address(value: object, label: str) -> str:
+    result = str(value).strip().lower()
+    if not ADDRESS_RE.fullmatch(result):
+        raise ActivationError(f"{label} is not an EVM address")
+    return result
+
+
+def bytes32(value: object, label: str) -> str:
+    result = str(value).strip().lower()
+    if not BYTES32_RE.fullmatch(result):
+        raise ActivationError(f"{label} is not bytes32")
+    return result
+
+
+def benchmark_digest(subdirectory: str) -> str:
+    root = ROOT / subdirectory
+    if not root.is_dir():
+        raise ActivationError(f"benchmark directory is missing: {subdirectory}")
+    listed = run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            subdirectory,
+        ]
+    )
+    paths = sorted(
+        line.strip().replace("\\", "/") for line in listed.splitlines() if line.strip()
+    )
+    if not paths:
+        raise ActivationError(
+            f"benchmark directory has no publishable files: {subdirectory}"
+        )
+    hasher = hashlib.sha256(DIRECTORY_DIGEST_DOMAIN)
+    prefix = subdirectory.rstrip("/") + "/"
+    for repository_path in paths:
+        if not repository_path.startswith(prefix):
+            raise ActivationError(
+                f"benchmark file escaped its directory: {repository_path}"
+            )
+        relative = repository_path[len(prefix) :]
+        path_bytes = relative.encode("utf-8")
+        payload = (ROOT / repository_path).read_bytes()
+        hasher.update(len(path_bytes).to_bytes(8, "big"))
+        hasher.update(path_bytes)
+        hasher.update(len(payload).to_bytes(8, "big"))
+        hasher.update(payload)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def http_json(method: str, url: str, body: Mapping[str, object] | None = None) -> Any:
+    payload = None if body is None else json.dumps(body, separators=(",", ":")).encode()
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        method=method,
+        headers={
+            "content-type": "application/json",
+            "user-agent": "agent-bounties-direct-growth/2",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=45) as response:
+            raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise ActivationError(
+            f"{method} {url} failed with HTTP {error.code}: {detail[:2000]}"
+        ) from error
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ActivationError(f"{method} {url} returned invalid JSON") from error
+
+
+class Cast:
+    def __init__(self, executable: str, rpc_url: str) -> None:
+        self.executable = executable
+        self.rpc_url = rpc_url
+
+    def rpc(self, *arguments: str, timeout: int = 300) -> str:
+        return run(
+            [self.executable, *arguments, "--rpc-url", self.rpc_url], timeout=timeout
+        )
+
+    def call(self, target: str, signature: str, *arguments: str) -> str:
+        return self.rpc("call", target, signature, *arguments).strip()
+
+    def send_data(self, target: str, data: str, private_key: str) -> str:
+        raw = self.rpc(
+            "send",
+            target,
+            "--data",
+            data,
+            "--private-key",
+            private_key,
+            "--json",
+            timeout=180,
+        )
+        try:
+            sent = json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise ActivationError("cast send did not return JSON") from error
+        tx_hash = str(sent.get("transactionHash") or sent.get("transaction_hash") or "")
+        bytes32(tx_hash, "transaction hash")
+        receipt = json.loads(self.rpc("receipt", tx_hash, "--json", timeout=180))
+        if receipt.get("status") not in {"0x1", "0x01", 1}:
+            raise ActivationError(f"transaction reverted: {tx_hash}")
+        return tx_hash
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ActivationError(f"invalid activation manifest: {error}") from error
+    if manifest.get("schema") != "agent-bounties/direct-growth-activation-v2":
+        raise ActivationError("activation manifest schema mismatch")
+    if manifest.get("network") != "base-mainnet" or manifest.get("chain_id") != 8453:
+        raise ActivationError("activation manifest is not pinned to Base mainnet")
+    for key in ("wallet", "owner", "delegate", "canonical_factory", "settlement_token"):
+        manifest[key] = address(manifest.get(key), key)
+    manifest["wallet_policy_hash"] = bytes32(
+        manifest.get("wallet_policy_hash"), "policy hash"
+    )
+    manifest["verifier_set_hash"] = bytes32(
+        manifest.get("verifier_set_hash"), "verifier set hash"
+    )
+    manifest["verifiers"] = [
+        address(value, "verifier") for value in manifest.get("verifiers", [])
+    ]
+    if len(manifest["verifiers"]) != 1 or manifest.get("threshold") != 1:
+        raise ActivationError(
+            "direct coding tasks require the committed single regression verifier"
+        )
+    tasks = manifest.get("tasks")
+    if not isinstance(tasks, list) or len(tasks) != 4:
+        raise ActivationError("activation manifest must contain exactly four tasks")
+    issues = set()
+    digests = set()
+    for task in tasks:
+        if not isinstance(task, dict) or not isinstance(task.get("issue"), int):
+            raise ActivationError("task issue is invalid")
+        issues.add(task["issue"])
+        bytes32(task.get("creation_nonce"), "creation nonce")
+        digest = str(task.get("benchmark_digest", ""))
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise ActivationError(f"issue #{task['issue']} benchmark digest is invalid")
+        digests.add(digest)
+        benchmark_subdirectory = str(task.get("benchmark_subdirectory", ""))
+        benchmark = ROOT / benchmark_subdirectory / "check.py"
+        if not benchmark.is_file():
+            raise ActivationError(f"issue #{task['issue']} benchmark is missing")
+        observed_digest = benchmark_digest(benchmark_subdirectory)
+        if observed_digest != digest:
+            raise ActivationError(
+                f"issue #{task['issue']} benchmark digest differs: {observed_digest}"
+            )
+    if len(issues) != 4 or len(digests) != 4:
+        raise ActivationError("task issues and benchmark digests must be unique")
+    expected_total = int(manifest["initial_funding"]) * len(tasks)
+    if expected_total != int(manifest["total_funding"]) or expected_total != 8_040_000:
+        raise ActivationError("activation total must be exactly 8.04 USDC")
+    return manifest
+
+
+def terms_document(
+    manifest: Mapping[str, Any], task: Mapping[str, Any], commit: str
+) -> dict[str, Any]:
+    issue = int(task["issue"])
+    benchmark = {
+        "engine": "sandboxed_regression_v1",
+        "source": {
+            "kind": "github_commit",
+            "repository": "NSPG13/agent-bounties",
+            "commit": commit,
+            "subdirectory": task["benchmark_subdirectory"],
+        },
+        "runner_manifest": {
+            "schema_version": "agent-bounties/regression-sandbox-v1",
+            "image": manifest["runner_image"],
+            "command": ["python", "/benchmark/check.py"],
+            "workdir": "/workspace",
+            "benchmark_digest": task["benchmark_digest"],
+            "timeout_seconds": 120,
+            "cpu_millis": 1000,
+            "memory_bytes": 268435456,
+            "pids_limit": 64,
+            "max_output_bytes": 1048576,
+            "tmpfs_bytes": 134217728,
+            "max_source_bytes": 536870912,
+            "max_source_files": 50000,
+            "max_benchmark_bytes": 1048576,
+            "max_benchmark_files": 100,
+            "platform": "linux/amd64",
+            "test_seed": 1,
+        },
+    }
+    return {
+        "schema_version": "agent-bounties/terms-v1",
+        "contract_terms": {
+            "protocol_version": "agent-bounties/autonomous-v1",
+            "creator_wallet": manifest["wallet"],
+            "network": manifest["network"],
+            "settlement_token": manifest["settlement_token"],
+            "solver_reward": {"amount": manifest["solver_reward"], "currency": "usdc"},
+            "verifier_reward": {
+                "amount": manifest["verifier_reward"],
+                "currency": "usdc",
+            },
+            "claim_bond": {"amount": manifest["verifier_reward"], "currency": "usdc"},
+            "initial_funding": {
+                "amount": manifest["initial_funding"],
+                "currency": "usdc",
+            },
+            "funding_deadline": manifest["funding_deadline"],
+            "claim_window_seconds": manifest["claim_window_seconds"],
+            "verification_window_seconds": manifest["verification_window_seconds"],
+            "creation_nonce": task["creation_nonce"],
+        },
+        "title": task["title"],
+        "goal": task["goal"],
+        "acceptance_criteria": task["acceptance_criteria"],
+        "benchmark": benchmark,
+        "evidence_schema": {
+            "type": "object",
+            "required": [
+                "repository",
+                "commit",
+                "test_command",
+                "source_snapshot_digest",
+                "discovery_source",
+                "participation_reason",
+                "improvement_feedback",
+            ],
+            "additionalProperties": True,
+        },
+        "verification_policy": {
+            "mechanism": "signed_quorum",
+            "engine": "sandboxed_regression_v1",
+            "verifiers": manifest["verifiers"],
+            "threshold": manifest["threshold"],
+            "rubric": "The precommitted sandbox runs the exact benchmark against the submitted GitHub commit. The single verifier signs only the resulting deterministic pass or fail candidate.",
+            "self_verification_forbidden": True,
+        },
+        "source_url": f"https://github.com/NSPG13/agent-bounties/issues/{issue}",
+        "discovery_source": "maintainer-seeded direct growth inventory after organic label-search feedback",
+    }
+
+
+def create_payload(
+    document: Mapping[str, Any], published: Mapping[str, Any]
+) -> dict[str, Any]:
+    terms = document["contract_terms"]
+    policy = document["verification_policy"]
+    return {
+        "creator": terms["creator_wallet"],
+        "solver_reward": terms["solver_reward"],
+        "verifier_reward": terms["verifier_reward"],
+        "terms_hash": published["terms_hash"],
+        "policy_hash": published["policy_hash"],
+        "acceptance_criteria_hash": published["acceptance_criteria_hash"],
+        "benchmark_hash": published["benchmark_hash"],
+        "evidence_schema_hash": published["evidence_schema_hash"],
+        "funding_deadline": terms["funding_deadline"],
+        "claim_window_seconds": terms["claim_window_seconds"],
+        "verification_window_seconds": terms["verification_window_seconds"],
+        "verification_mode": "signed_quorum",
+        "verifier_module": None,
+        "verifier_reward_recipient": None,
+        "verifiers": policy["verifiers"],
+        "threshold": policy["threshold"],
+        "initial_funding": terms["initial_funding"],
+        "creation_nonce": terms["creation_nonce"],
+    }
+
+
+def inspect_wallet(
+    args: argparse.Namespace, manifest: Mapping[str, Any], suffix: str
+) -> dict[str, Any]:
+    output = args.output_dir / f"wallet-{suffix}.json"
+    run(
+        [
+            args.python,
+            "scripts/inspect_bounded_agent_wallet.py",
+            "--wallet",
+            manifest["wallet"],
+            "--manifest",
+            str(CONTRACT_MANIFEST),
+            "--rpc-url",
+            args.rpc_url,
+            "--expect-owner",
+            manifest["owner"],
+            "--expect-delegate",
+            manifest["delegate"],
+            "--expect-policy-hash",
+            manifest["wallet_policy_hash"],
+            "--output",
+            str(output),
+        ]
+    )
+    report = json.loads(output.read_text(encoding="utf-8"))
+    if report.get("ready") is not True:
+        raise ActivationError(f"bounded wallet is not ready: {report.get('failures')}")
+    state = report["state"]
+    if int(state["policy_version"]) != int(manifest["wallet_policy_version"]):
+        raise ActivationError("bounded wallet policy version changed")
+    if int(state["policy"]["max_per_action"]) != int(manifest["initial_funding"]):
+        raise ActivationError("bounded wallet per-action cap changed")
+    if (
+        state["policy"]["signed_quorum_verifier_set_hash"]
+        != manifest["verifier_set_hash"]
+    ):
+        raise ActivationError("bounded wallet signed verifier set changed")
+    return report
+
+
+def event_kinds(api: str, bounty_id: str) -> set[str]:
+    events = http_json(
+        "GET",
+        f"{api}/v1/base/autonomous-bounties/events?network=base-mainnet&bounty_id={bounty_id}",
+    )
+    if not isinstance(events, list):
+        raise ActivationError("events endpoint returned a non-list")
+    return {str(item.get("kind")) for item in events if isinstance(item, dict)}
+
+
+def reconcile(
+    api: str, contract: str, bounty_id: str, timeout_seconds: int
+) -> dict[str, Any]:
+    required = {"canonical_bounty_created", "funding_added", "bounty_became_claimable"}
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        kinds = event_kinds(api, bounty_id)
+        if required.issubset(kinds):
+            feed = http_json(
+                "GET",
+                f"{api}/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false",
+            )
+            if isinstance(feed, list):
+                item = next(
+                    (
+                        value
+                        for value in feed
+                        if isinstance(value, dict)
+                        and str(value.get("bounty_contract", "")).lower()
+                        == contract.lower()
+                    ),
+                    None,
+                )
+                if (
+                    item
+                    and item.get("status") == "claimable"
+                    and item.get("terms_valid") is True
+                    and item.get("verification_ready") is True
+                ):
+                    return {"event_kinds": sorted(kinds), "feed_item": item}
+        time.sleep(4)
+    raise ActivationError(f"canonical activation did not reconcile for {contract}")
+
+
+def issue_body(task: Mapping[str, Any], result: Mapping[str, Any], commit: str) -> str:
+    criteria = "\n".join(f"- {value}" for value in task["acceptance_criteria"])
+    issue = int(task["issue"])
+    return f"""## Goal
+
+{task["goal"]}
+
+## Funded payment contract
+
+**Funded and claimable on Base mainnet.**
+
+- Contract: `{result["contract"]}`
+- Contract explorer: https://basescan.org/address/{result["contract"]}
+- Creation/funding transaction: https://basescan.org/tx/{result["transaction_hash"]}
+- Confirmed funding: **2.01 / 2.01 USDC**
+- Solver reward: **2.00 USDC**
+- Automated verifier reward and refundable claim bond: **0.01 USDC**
+- Verification: `sandboxed_regression_v1`, one precommitted automated signer
+- Immutable benchmark: https://github.com/NSPG13/agent-bounties/tree/{commit}/{task["benchmark_subdirectory"]}
+
+## Acceptance criteria
+
+{criteria}
+
+## Earn it
+
+1. Comment `/claim #{issue} wallet: 0xYOUR_PUBLIC_BASE_ADDRESS`.
+2. Sign the returned bounded claim request. Never share a private key or seed phrase.
+3. Wait for the canonical claim state, then implement only this issue and open a focused PR.
+4. Run the focused checks and submit the requested repository, commit, command, snapshot digest, and discovery feedback evidence.
+5. The precommitted sandbox verifies the submitted commit. A passing result settles automatically; only canonical `BountySettled` proves payment.
+
+How did you find this bounty, what made it worth attempting, and what should be easier next time?
+
+**Post your own bounty:** https://agentbounties.app/post.html
+
+<!-- agent-bounties-github-metadata-v1 -->
+## Automation metadata
+
+### Goal
+{task["goal"]}
+
+### Acceptance criteria
+Pass the immutable benchmark and satisfy every criterion above.
+
+### Template
+small-code-change
+
+### Suggested amount
+2 USDC
+
+### Funding mode
+AutonomousV1BaseUsdc
+
+### Privacy
+Public
+"""
+
+
+def activate(args: argparse.Namespace) -> dict[str, Any]:
+    manifest = load_manifest(args.manifest)
+    commit = args.commit.strip().lower()
+    if not COMMIT_RE.fullmatch(commit):
+        raise ActivationError("--commit must be the exact 40-character merged commit")
+    private_key = os.environ.get("BASE_KEEPER_PRIVATE_KEY", "").strip()
+    if not private_key:
+        raise ActivationError("BASE_KEEPER_PRIVATE_KEY is required")
+    cast = Cast(args.cast, args.rpc_url)
+    delegate = address(
+        run([args.cast, "wallet", "address", "--private-key", private_key]), "delegate"
+    )
+    if delegate != manifest["delegate"]:
+        raise ActivationError(
+            f"delegate key resolves to {delegate}, expected {manifest['delegate']}"
+        )
+
+    before = inspect_wallet(args, manifest, "before")
+    results: list[dict[str, Any]] = []
+    new_spend = 0
+    for task in manifest["tasks"]:
+        issue = int(task["issue"])
+        document = terms_document(manifest, task, commit)
+        published = http_json(
+            "POST",
+            f"{args.api}/v1/base/autonomous-bounties/terms",
+            {"creator_wallet": manifest["wallet"], "document": document},
+        )
+        if not isinstance(published, dict):
+            raise ActivationError(
+                f"issue #{issue} terms publication returned a non-object"
+            )
+        plan = http_json(
+            "POST",
+            f"{args.api}/v1/base/autonomous-bounties/creation-plan",
+            {
+                "network": manifest["network"],
+                "create": create_payload(document, published),
+            },
+        )
+        if not isinstance(plan, dict):
+            raise ActivationError(f"issue #{issue} creation plan returned a non-object")
+        plan_path = args.output_dir / f"issue-{issue}-creation-plan.json"
+        plan_path.write_text(
+            json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        action_path = args.output_dir / f"issue-{issue}-bounded-action.json"
+        run(
+            [
+                args.python,
+                "scripts/plan_bounded_agent_action.py",
+                "create",
+                "--wallet",
+                manifest["wallet"],
+                "--creation-plan",
+                str(plan_path),
+                "--manifest",
+                str(CONTRACT_MANIFEST),
+                "--rpc-url",
+                args.rpc_url,
+                "--expect-owner",
+                manifest["owner"],
+                "--expect-delegate",
+                manifest["delegate"],
+                "--expect-policy-hash",
+                manifest["wallet_policy_hash"],
+                "--output",
+                str(action_path),
+            ]
+        )
+        action = json.loads(action_path.read_text(encoding="utf-8"))
+        direct = action["direct_transaction"]
+        predicted = address(plan.get("predicted_bounty_contract"), "predicted bounty")
+        bounty_id = bytes32(plan.get("bounty_id"), "bounty id")
+        if (
+            cast.call(
+                manifest["canonical_factory"],
+                "isCanonicalBounty(address)(bool)",
+                predicted,
+            ).lower()
+            == "true"
+        ):
+            tx_hash = None
+        else:
+            tx_hash = cast.send_data(
+                address(direct.get("to"), "direct transaction target"),
+                str(direct.get("data")),
+                private_key,
+            )
+            new_spend += int(manifest["initial_funding"])
+        reconciled = reconcile(args.api, predicted, bounty_id, args.reconcile_timeout)
+        feed_events = reconciled["feed_item"].get("events") or []
+        feed_tx = next(
+            (
+                str(event.get("tx_hash", ""))
+                for event in feed_events
+                if isinstance(event, dict)
+                and event.get("kind") == "canonical_bounty_created"
+            ),
+            "",
+        )
+        if tx_hash is None:
+            tx_hash = feed_tx
+        bytes32(tx_hash, "creation transaction hash")
+        result = {
+            "issue": issue,
+            "slug": task["slug"],
+            "contract": predicted,
+            "bounty_id": bounty_id,
+            "transaction_hash": tx_hash,
+            "terms_hash": bytes32(published.get("terms_hash"), "terms hash"),
+            "reconciliation": reconciled,
+        }
+        (args.output_dir / f"issue-{issue}.md").write_text(
+            issue_body(task, result, commit), encoding="utf-8"
+        )
+        results.append(result)
+
+    after = inspect_wallet(args, manifest, "after")
+    before_state = before["state"]
+    after_state = after["state"]
+    if (
+        int(after_state["lifetime_spent"]) - int(before_state["lifetime_spent"])
+        != new_spend
+    ):
+        raise ActivationError(
+            "bounded wallet lifetime-spend delta does not match newly created bounties"
+        )
+    if (
+        int(before_state["wallet_usdc_balance"])
+        - int(after_state["wallet_usdc_balance"])
+        != new_spend
+    ):
+        raise ActivationError(
+            "bounded wallet balance delta does not match newly created bounties"
+        )
+    return {
+        "schema": "agent-bounties/direct-growth-activation-result-v2",
+        "network": manifest["network"],
+        "commit": commit,
+        "wallet": manifest["wallet"],
+        "new_spend": new_spend,
+        "wallet_balance_before": int(before_state["wallet_usdc_balance"]),
+        "wallet_balance_after": int(after_state["wallet_usdc_balance"]),
+        "results": results,
+        "complete": len(results) == 4,
+        "evidence_boundary": "Canonical creation, funding, claimability, valid terms, and verification readiness are reconciled. Only a future BountySettled event proves solver payment.",
+    }
+
+
+def markdown(report: Mapping[str, Any]) -> str:
+    lines = [
+        "## Four direct growth bounties activated",
+        "",
+        f"- New funding: **{int(report['new_spend']) / 1_000_000:.2f} USDC**",
+        f"- Bounded wallet remaining: **{int(report['wallet_balance_after']) / 1_000_000:.2f} USDC**",
+        "",
+    ]
+    for item in report["results"]:
+        lines.append(
+            f"- #{item['issue']} `{item['contract']}` - 2.00 USDC solver / 0.01 USDC verifier"
+        )
+    lines.extend(
+        [
+            "",
+            "Every item reconciled canonical creation, FundingAdded, BountyBecameClaimable, valid terms, and verifier readiness.",
+            "Only a future canonical BountySettled event proves solver payment.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=MANIFEST_PATH)
+    parser.add_argument("--commit", default=os.environ.get("GITHUB_SHA", ""))
+    parser.add_argument(
+        "--rpc-url", default=os.environ.get("BASE_MAINNET_RPC_URL", RPC_DEFAULT)
+    )
+    parser.add_argument("--api", default=API_DEFAULT.rstrip("/"))
+    parser.add_argument("--cast", default=os.environ.get("CAST_BIN", "cast"))
+    parser.add_argument("--python", default=os.environ.get("PYTHON_BIN", "python"))
+    parser.add_argument("--reconcile-timeout", type=int, default=300)
+    parser.add_argument(
+        "--output-dir", type=Path, default=ROOT / "target" / "direct-growth-v2"
+    )
+    parser.add_argument(
+        "--output", type=Path, default=ROOT / "target" / "direct-growth-v2.json"
+    )
+    parser.add_argument(
+        "--markdown-output", type=Path, default=ROOT / "target" / "direct-growth-v2.md"
+    )
+    args = parser.parse_args()
+    args.api = args.api.rstrip("/")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    report = activate(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    args.markdown_output.write_text(markdown(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {"complete": report["complete"], "new_spend": report["new_spend"]},
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_activate_direct_growth_v2.py
+++ b/scripts/test_activate_direct_growth_v2.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+import scripts.activate_direct_growth_v2 as activation
+
+
+class DirectGrowthActivationTests(unittest.TestCase):
+    def test_manifest_pins_four_unique_tasks_and_exact_budget(self) -> None:
+        manifest = activation.load_manifest()
+        self.assertEqual(len(manifest["tasks"]), 4)
+        self.assertEqual(manifest["total_funding"], 8_040_000)
+        self.assertEqual(manifest["initial_funding"], 2_010_000)
+        self.assertEqual(manifest["threshold"], 1)
+        self.assertEqual(
+            manifest["verifier_set_hash"],
+            "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2",
+        )
+        self.assertEqual(
+            {task["issue"] for task in manifest["tasks"]}, {771, 772, 773, 774}
+        )
+
+    def test_terms_use_one_pinned_sandbox_verifier(self) -> None:
+        manifest = activation.load_manifest()
+        commit = "a" * 40
+        document = activation.terms_document(manifest, manifest["tasks"][0], commit)
+        policy = document["verification_policy"]
+        runner = document["benchmark"]["runner_manifest"]
+        self.assertEqual(policy["mechanism"], "signed_quorum")
+        self.assertEqual(policy["threshold"], 1)
+        self.assertTrue(policy["self_verification_forbidden"])
+        self.assertEqual(runner["command"], ["python", "/benchmark/check.py"])
+        self.assertIn("@sha256:", runner["image"])
+        self.assertEqual(document["benchmark"]["source"]["commit"], commit)
+        self.assertEqual(
+            document["contract_terms"]["initial_funding"]["amount"], 2_010_000
+        )
+
+    def test_create_payload_copies_only_published_hashes(self) -> None:
+        manifest = activation.load_manifest()
+        document = activation.terms_document(manifest, manifest["tasks"][0], "b" * 40)
+        published = {
+            "terms_hash": "0x" + "11" * 32,
+            "policy_hash": "0x" + "22" * 32,
+            "acceptance_criteria_hash": "0x" + "33" * 32,
+            "benchmark_hash": "0x" + "44" * 32,
+            "evidence_schema_hash": "0x" + "55" * 32,
+        }
+        payload = activation.create_payload(document, published)
+        self.assertEqual(payload["creator"], manifest["wallet"])
+        self.assertEqual(payload["verification_mode"], "signed_quorum")
+        self.assertIsNone(payload["verifier_module"])
+        self.assertIsNone(payload["verifier_reward_recipient"])
+        self.assertEqual(payload["terms_hash"], published["terms_hash"])
+
+    def test_issue_body_discloses_claim_and_payment_boundaries(self) -> None:
+        task = activation.load_manifest()["tasks"][0]
+        result = {
+            "contract": "0x" + "12" * 20,
+            "transaction_hash": "0x" + "34" * 32,
+        }
+        body = activation.issue_body(task, result, "c" * 40)
+        self.assertIn("Funded and claimable on Base mainnet", body)
+        self.assertIn(f"/claim #{task['issue']} wallet:", body)
+        self.assertIn("BountySettled", body)
+        self.assertIn("Post your own bounty", body)
+
+    def test_manifest_rejects_duplicate_benchmark_digest(self) -> None:
+        source = json.loads(activation.MANIFEST_PATH.read_text(encoding="utf-8"))
+        source["tasks"][1]["benchmark_digest"] = source["tasks"][0]["benchmark_digest"]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "manifest.json"
+            path.write_text(json.dumps(source), encoding="utf-8")
+            with self.assertRaisesRegex(activation.ActivationError, "benchmark digest"):
+                activation.load_manifest(path)
+
+    def test_manifest_digests_match_publishable_benchmark_files(self) -> None:
+        manifest = activation.load_manifest()
+        for task in manifest["tasks"]:
+            self.assertEqual(
+                task["benchmark_digest"],
+                activation.benchmark_digest(task["benchmark_subdirectory"]),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- precommit four non-meta 2 USDC solver bounties for A2A, Hermes, OpenHands, and mini-SWE-agent distribution
- pin immutable sandbox benchmarks and the exact 8.04 USDC bounded-wallet budget
- activate only from merged main, then reconcile canonical funding and claimability before publishing organic-discovery labels

## Evidence

- python -m unittest scripts.test_activate_direct_growth_v2 -v`n- uff check scripts/activate_direct_growth_v2.py scripts/test_activate_direct_growth_v2.py benchmarks/direct-growth-v2`n- scripts/preflight.ps1 -Mode core`n
## Payment boundary

This PR does not itself move funds. The post-merge manual activation uses the existing bounded delegate policy. Labels change from unding-needed only after all four contracts reconcile canonical creation, full funding, claimability, valid terms, and verifier readiness. Only a future canonical BountySettled proves payment.