### PR TITLE
Fix direct growth activation RPC failover

### DIFF
--- a/scripts/activate_direct_growth_v2.py
+++ b/scripts/activate_direct_growth_v2.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Mapping, Sequence
 
@@ -144,6 +145,39 @@ def http_json(method: str, url: str, body: Mapping[str, object] | None = None) -
         return json.loads(raw)
     except json.JSONDecodeError as error:
         raise ActivationError(f"{method} {url} returned invalid JSON") from error
+
+
+def rpc_chain_id(url: str) -> int:
+    request = urllib.request.Request(
+        url,
+        data=b'{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}',
+        method="POST",
+        headers={
+            "content-type": "application/json",
+            "user-agent": "agent-bounties-direct-growth/2",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return int(str(payload.get("result", "")), 16)
+
+
+def select_rpc_url(value: str) -> str:
+    candidates = [
+        candidate.strip() for candidate in value.split(",") if candidate.strip()
+    ]
+    for candidate in candidates:
+        parsed = urllib.parse.urlparse(candidate)
+        if parsed.scheme != "https" or not parsed.netloc:
+            continue
+        try:
+            if rpc_chain_id(candidate) == 8453:
+                return candidate
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+    raise ActivationError(
+        "no configured HTTPS RPC endpoint returned Base chain ID 8453"
+    )
 
 
 class Cast:
@@ -685,6 +719,7 @@ def main() -> int:
     )
     args = parser.parse_args()
     args.api = args.api.rstrip("/")
+    args.rpc_url = select_rpc_url(args.rpc_url)
     args.output_dir.mkdir(parents=True, exist_ok=True)
     report = activate(args)
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/test_activate_direct_growth_v2.py
+++ b/scripts/test_activate_direct_growth_v2.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 import scripts.activate_direct_growth_v2 as activation
 
@@ -84,6 +85,34 @@ class DirectGrowthActivationTests(unittest.TestCase):
                 task["benchmark_digest"],
                 activation.benchmark_digest(task["benchmark_subdirectory"]),
             )
+
+    def test_rpc_list_selects_first_reachable_base_endpoint(self) -> None:
+        observed: list[str] = []
+
+        def chain_id(url: str) -> int:
+            observed.append(url)
+            if url.endswith("unavailable"):
+                raise OSError("offline")
+            return 8453
+
+        with mock.patch.object(activation, "rpc_chain_id", side_effect=chain_id):
+            selected = activation.select_rpc_url(
+                "https://rpc.example/unavailable, https://rpc.example/base"
+            )
+        self.assertEqual(selected, "https://rpc.example/base")
+        self.assertEqual(
+            observed,
+            ["https://rpc.example/unavailable", "https://rpc.example/base"],
+        )
+
+    def test_rpc_list_rejects_non_base_and_non_https_endpoints(self) -> None:
+        with mock.patch.object(activation, "rpc_chain_id", return_value=1):
+            with self.assertRaisesRegex(
+                activation.ActivationError, "Base chain ID 8453"
+            ):
+                activation.select_rpc_url(
+                    "http://rpc.example,https://rpc.example/ethereum"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause

The activation received the repository's comma-separated BASE_MAINNET_RPC_URL failover list as one URL, so DNS parsing failed before any transaction was broadcast.

## Fix

- parse comma-separated endpoints
- require HTTPS
- probe each candidate for Base chain ID 8453
- use the first valid endpoint
- cover unavailable, non-HTTPS, and wrong-chain cases

## Evidence

- wallet after failed run: 10.05 USDC, lifetime spend 0, delegate nonce 0
- 8 activation unit tests pass
- live probe selected https://base-rpc.publicnode.com`n- core preflight passes