### PR TITLE
Fix routed activation after settled bounties

### DIFF
--- a/.github/workflows/activate-routed-v3-replacements.yml
+++ b/.github/workflows/activate-routed-v3-replacements.yml
@@ -189,18 +189,25 @@ jobs:
         if: steps.issue.outputs.state != 'CLOSED' && steps.readiness.outputs.ready == 'true'
         run: |
           for issue in 647 648 649 650 651; do
-            test -f "target/routed-v3-activation/routed-v3-${issue}-issue.md" || continue
-            lane="$(jq -r --argjson issue "$issue" '.results[] | select(.issue == $issue) | .lane' target/routed-v3-activation.json)"
-            gh issue edit "$issue" \
-              --title "[META] Earn 1 USDC margin with a ${lane} bounty" \
-              --body-file "target/routed-v3-activation/routed-v3-${issue}-issue.md" \
-              --add-label bounty \
-              --add-label ai-agent-welcome \
-              --add-label payments \
-              --add-label good-first-agent-bounty \
-              --add-label funded-live \
-              --add-label claimable-live
-            gh issue edit "$issue" --remove-label verification-unavailable || true
+            status="$(jq -r --argjson issue "$issue" '.results[] | select(.issue == $issue) | .reconciliation.feed_item.status' target/routed-v3-activation.json)"
+            if [ "$status" = "claimable" ]; then
+              lane="$(jq -r --argjson issue "$issue" '.results[] | select(.issue == $issue) | .lane' target/routed-v3-activation.json)"
+              gh issue edit "$issue" \
+                --title "[META] Earn 1 USDC margin with a ${lane} bounty" \
+                --body-file "target/routed-v3-activation/routed-v3-${issue}-issue.md" \
+                --add-label bounty \
+                --add-label ai-agent-welcome \
+                --add-label payments \
+                --add-label good-first-agent-bounty \
+                --add-label funded-live \
+                --add-label claimable-live
+              gh issue edit "$issue" --remove-label verification-unavailable || true
+            else
+              gh issue edit "$issue" --remove-label claimable-live || true
+              if [ "$status" = "paid" ]; then
+                gh issue edit "$issue" --remove-label funded-live || true
+              fi
+            fi
           done
 
       - name: Publish evidence and close completed replacement run

--- a/scripts/activate_routed_v3_replacements.py
+++ b/scripts/activate_routed_v3_replacements.py
@@ -328,12 +328,10 @@ def reconcile(api: str, contract: str, bounty_id: str, timeout_seconds: int = 18
                 )
             item = matches[0] if matches else None
             active_statuses = {"claimable", "claimed", "submitted", "verifying"}
-            if (
-                item
-                and item.get("status") in active_statuses
-                and item.get("terms_valid") is True
-                and item.get("verification_ready") is True
-            ):
+            status = item.get("status") if item else None
+            active = status in active_statuses and item.get("verification_ready") is True
+            settled = status == "paid" and "bounty_settled" in kinds
+            if item and item.get("terms_valid") is True and (active or settled):
                 return {"event_kinds": sorted(kinds), "feed_item": item}
         time.sleep(3)
     raise ActivationError(f"canonical activation did not reconcile for {contract}")
@@ -529,10 +527,11 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
             "policy_hash": deployment["policy_hash"],
             "reconciliation": reconciled,
         }
-        (args.output_dir / f"routed-v3-{issue}-issue.md").write_text(
-            issue_body(issue, str(config["lane"]), config["old"], result, deployment),
-            encoding="utf-8",
-        )
+        if reconciled["feed_item"]["status"] == "claimable":
+            (args.output_dir / f"routed-v3-{issue}-issue.md").write_text(
+                issue_body(issue, str(config["lane"]), config["old"], result, deployment),
+                encoding="utf-8",
+            )
         results.append(result)
 
     after = policy_state(cast, deployment)

--- a/scripts/test_activate_routed_v3_replacements.py
+++ b/scripts/test_activate_routed_v3_replacements.py
@@ -261,7 +261,7 @@ class ActivateRoutedV3Tests(unittest.TestCase):
         self.assertEqual(remaining, 3)
         create.assert_not_called()
 
-    def test_reconciliation_accepts_every_active_state_and_fails_closed(self) -> None:
+    def test_reconciliation_accepts_active_and_canonically_paid_states(self) -> None:
         contract = "0x" + "31" * 20
         bounty_id = "0x" + "32" * 32
         events = [
@@ -288,10 +288,29 @@ class ActivateRoutedV3Tests(unittest.TestCase):
                 result = MODULE.reconcile("https://api.example", contract, bounty_id, 1)
                 self.assertEqual(result["feed_item"]["status"], status)
 
+        paid_events = [*events, {"kind": "bounty_settled"}]
+        with mock.patch.object(
+            MODULE,
+            "http_json",
+            side_effect=[
+                paid_events,
+                [
+                    {
+                        "bounty_contract": contract,
+                        "status": "paid",
+                        "terms_valid": True,
+                        "verification_ready": False,
+                    }
+                ],
+            ],
+        ):
+            result = MODULE.reconcile("https://api.example", contract, bounty_id, 1)
+            self.assertEqual(result["feed_item"]["status"], "paid")
+
         failures = [
             {"status": "claimable", "terms_valid": False, "verification_ready": True},
             {"status": "claimable", "terms_valid": True, "verification_ready": False},
-            {"status": "settled", "terms_valid": True, "verification_ready": True},
+            {"status": "paid", "terms_valid": True, "verification_ready": True},
         ]
         for item in failures:
             item["bounty_contract"] = contract


### PR DESCRIPTION
## What changed

- allow routed activation to replay a previously paid canonical slot only when `bounty_settled` is present
- publish earning terms only for contracts whose current state is `claimable`
- remove stale `claimable-live` and `funded-live` labels as lifecycle state advances
- add positive paid-state and missing-settlement regression coverage

## Incident

#651 funding was blocked because replay stopped for paid #650 before reaching the pending slot. No transaction was attempted by the failed runs.

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/652#issuecomment-5201325817

## Checks

- `python -m unittest scripts.test_activate_routed_v3_replacements -v`
- `python -m py_compile scripts/activate_routed_v3_dynamic.py scripts/activate_routed_v3_replacements.py scripts/check_routed_v3_activation_readiness.py`
- `cargo run -p cli -- docs-contract-check`
- `git diff --check`

This PR does not itself prove funding or payment. Canonical Base events remain authoritative.
