### PR TITLE
Fix legacy bounded-wallet action validation

### DIFF
--- a/scripts/inspect_bounded_agent_wallet.py
+++ b/scripts/inspect_bounded_agent_wallet.py
@@ -10,7 +10,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-from plan_bounded_agent_budget import CAST, ROOT, require_address, require_bytes32, validate_manifest
+from plan_bounded_agent_budget import CAST, ROOT, require_address, require_bytes32, validate_action_manifest
 
 
 DEFAULT_MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-base-mainnet.json"
@@ -107,7 +107,7 @@ def inspect(
     expected_delegate: str | None = None,
     expected_policy_hash: str | None = None,
 ) -> dict:
-    validate_manifest(manifest)
+    validate_action_manifest(manifest)
     safe = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False], 1)
     if not isinstance(safe, dict) or not safe.get("number") or not safe.get("hash"):
         raise RuntimeError("Base safe block is unavailable")
@@ -242,7 +242,7 @@ def main() -> None:
     parser.add_argument("--expect-policy-hash")
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
-    manifest = validate_manifest(json.loads(args.manifest.read_text(encoding="utf-8")))
+    manifest = validate_action_manifest(json.loads(args.manifest.read_text(encoding="utf-8")))
     wallet = require_address(args.wallet, "wallet")
     expected_owner = require_address(args.expect_owner, "expected owner") if args.expect_owner else None
     expected_delegate = require_address(args.expect_delegate, "expected delegate") if args.expect_delegate else None

--- a/scripts/local_delegate_wallet.py
+++ b/scripts/local_delegate_wallet.py
@@ -38,7 +38,7 @@ from plan_bounded_agent_budget import (
     keccak_hex,
     require_address,
     require_bytes32,
-    validate_manifest,
+    validate_action_manifest,
 )
 
 
@@ -258,7 +258,7 @@ def manifest_data(path: Path) -> tuple[dict, str]:
         manifest = json.loads(raw)
     except json.JSONDecodeError:
         fail("bounded-wallet manifest is invalid JSON")
-    validate_manifest(manifest)
+    validate_action_manifest(manifest)
     return manifest, hashlib.sha256(raw).hexdigest()
 
 

--- a/scripts/plan_bounded_agent_action.py
+++ b/scripts/plan_bounded_agent_action.py
@@ -17,7 +17,7 @@ from plan_bounded_agent_budget import (
     require_address,
     require_bytes32,
     usdc_units,
-    validate_manifest,
+    validate_action_manifest,
 )
 
 
@@ -110,7 +110,7 @@ def main() -> None:
     parser.add_argument("--output", type=Path, default=ROOT / "target" / "bounded-agent-action-plan.json")
     args = parser.parse_args()
 
-    manifest = validate_manifest(json.loads(args.manifest.read_text(encoding="utf-8")))
+    manifest = validate_action_manifest(json.loads(args.manifest.read_text(encoding="utf-8")))
     wallet = require_address(args.wallet, "wallet")
     rpc_url = args.rpc_url or manifest["rpc_url"]
     expected_owner = require_address(args.expect_owner, "expected owner") if args.expect_owner else None

--- a/scripts/plan_bounded_agent_budget.py
+++ b/scripts/plan_bounded_agent_budget.py
@@ -31,7 +31,39 @@ EXPECTED_CANONICAL = {
 }
 EXPECTED_CREATE2_DEPLOYER = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
 EXPECTED_CREATE2_DEPLOYER_HASH = "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989"
-EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH = "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2"
+MANIFEST_SCHEMA_V1 = "agent-bounties/bounded-agent-wallet-deployment-v1"
+MANIFEST_SCHEMA_V2 = "agent-bounties/bounded-agent-wallet-deployment-v2"
+EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH_V1 = "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd"
+EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH_V2 = "0x0838846e439ed67544d8a06da2a0f344fb25cd44723ad65839da3f242a72b1f2"
+EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH = EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH_V2
+ACTION_MANIFEST_DEPLOYMENTS = {
+    MANIFEST_SCHEMA_V1: {
+        "signed_quorum": EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH_V1,
+        "source_revision": "dc05b4e01474f09f02bb1bbb69651e4ce4deb338",
+        "wallet_factory": {
+            "address": "0x3840936351049aed639780a16845e6094c1f17f6",
+            "implementation": "0x40d3e16082cf71ece0129ca3044e1b8233e29db8",
+            "salt": "0xc8d6503b5f3f8146d641b204ce16fd78ad17d1ff722747953d1568f4138e7a35",
+            "init_code_hash": "0x491d40083c4232420f0557bd4510ea052ccd1f7bf446e5656b0451e30aa4daa8",
+            "runtime_code_hash": "0x243e248a890daf57cb14cee262bc7bb70b8822c65a014a8bf1c39653bc30aa52",
+            "implementation_runtime_code_hash": "0x7fb59d5add3ac348ac3d7e6a5aa6b22ad542a6e6093a1ceb8d535f747ed536df",
+            "clone_runtime_code_hash": "0xc663bed9b4097e22e5a18c0ecb662561bf45df1829e6412cdd0d8568d05ca1b6",
+        },
+    },
+    MANIFEST_SCHEMA_V2: {
+        "signed_quorum": EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH_V2,
+        "source_revision": "7fbfd7e106e387e12ad5c9b29cbef4344dfead69",
+        "wallet_factory": {
+            "address": "0xe3d4f7b203c5e8576e0225d3e64a8532429d3876",
+            "implementation": "0x00c250bda8fa3c49d80a11d9b6ebd961736b7202",
+            "salt": "0x5ae7271dd6ab1471a4c967a7728c3a8314fe473a2c95874ce922fd7aaf82a42e",
+            "init_code_hash": "0xd3019a33cdd97c704085d88b4bef445779e5f2d28db979f45a9f94dfcd92e954",
+            "runtime_code_hash": "0x254e247c3df7b38c257cd24b5d47c6ca1bc3ed335d6cb062498695bced540cf9",
+            "implementation_runtime_code_hash": "0xade4fb51d0c5c866bb0cc44ca17ad0b254c6bba92ac5b47ddc2ced4963b05d18",
+            "clone_runtime_code_hash": "0xc11ada07afafbcf407387ff2fa7afc52e55301c80a4edd0888520b478fba9209",
+        },
+    },
+}
 
 
 def executable(name: str) -> str:
@@ -85,8 +117,8 @@ def require_bytes32(value: str, label: str) -> str:
     return normalized
 
 
-def validate_manifest(manifest: dict) -> dict:
-    if manifest.get("schema") != "agent-bounties/bounded-agent-wallet-deployment-v2":
+def _validate_manifest(manifest: dict, expected_schema: str, expected_deployment: dict) -> dict:
+    if manifest.get("schema") != expected_schema:
         raise SystemExit("bounded-wallet manifest schema is unsupported")
     if manifest.get("network") != EXPECTED_NETWORK or manifest.get("chain_id") != EXPECTED_CHAIN_ID:
         raise SystemExit("bounded-wallet manifest must target Base mainnet")
@@ -94,8 +126,11 @@ def validate_manifest(manifest: dict) -> dict:
         raise SystemExit("bounded-wallet manifest was generated from dirty contract inputs")
     if manifest.get("contract_source_revision_kind") != "git-tree":
         raise SystemExit("bounded-wallet manifest must use a content-addressed Git tree revision")
-    if not re.fullmatch(r"[0-9a-f]{40}", str(manifest.get("contract_source_revision", ""))):
+    source_revision = str(manifest.get("contract_source_revision", ""))
+    if not re.fullmatch(r"[0-9a-f]{40}", source_revision):
         raise SystemExit("bounded-wallet manifest does not pin a source revision")
+    if source_revision != expected_deployment["source_revision"]:
+        raise SystemExit("bounded-wallet manifest has an unexpected source revision")
     canonical = manifest.get("canonical") or {}
     for name, expected in EXPECTED_CANONICAL.items():
         if require_address(str(canonical.get(name, "")), name) != expected:
@@ -103,7 +138,7 @@ def validate_manifest(manifest: dict) -> dict:
     if require_bytes32(
         str(canonical.get("signed_quorum_verifier_set_hash", "")),
         "signed quorum verifier set hash",
-    ) != EXPECTED_SIGNED_QUORUM_VERIFIER_SET_HASH:
+    ) != expected_deployment["signed_quorum"]:
         raise SystemExit("bounded-wallet manifest has an unexpected signed quorum")
     deployer = manifest.get("deterministic_deployer") or {}
     if require_address(str(deployer.get("address", "")), "deterministic deployer") != EXPECTED_CREATE2_DEPLOYER:
@@ -111,14 +146,35 @@ def validate_manifest(manifest: dict) -> dict:
     if require_bytes32(str(deployer.get("runtime_code_hash", "")), "deployer runtime hash") != EXPECTED_CREATE2_DEPLOYER_HASH:
         raise SystemExit("bounded-wallet manifest has an unexpected deterministic deployer runtime")
     wallet_factory = manifest.get("wallet_factory") or {}
-    require_address(str(wallet_factory.get("address", "")), "wallet factory")
-    require_address(str(wallet_factory.get("implementation", "")), "wallet implementation")
+    expected_factory = expected_deployment["wallet_factory"]
+    for name, label in (("address", "wallet factory"), ("implementation", "wallet implementation")):
+        if require_address(str(wallet_factory.get(name, "")), label) != expected_factory[name]:
+            raise SystemExit(f"bounded-wallet manifest has an unexpected {label}")
     for name in ("salt", "init_code_hash", "runtime_code_hash", "implementation_runtime_code_hash", "clone_runtime_code_hash"):
-        require_bytes32(str(wallet_factory.get(name, "")), name.replace("_", " "))
+        if require_bytes32(str(wallet_factory.get(name, "")), name.replace("_", " ")) != expected_factory[name]:
+            raise SystemExit(f"bounded-wallet manifest has an unexpected {name.replace('_', ' ')}")
     transaction = str(wallet_factory.get("deployment_transaction", "")).lower()
     if not re.fullmatch(r"0x(?:[0-9a-f]{2})+", transaction):
         raise SystemExit("bounded-wallet manifest deployment transaction is invalid")
     return manifest
+
+
+def validate_manifest(manifest: dict) -> dict:
+    """Validate the V2 manifest required for creating new bounded budgets."""
+    return _validate_manifest(
+        manifest,
+        MANIFEST_SCHEMA_V2,
+        ACTION_MANIFEST_DEPLOYMENTS[MANIFEST_SCHEMA_V2],
+    )
+
+
+def validate_action_manifest(manifest: dict) -> dict:
+    """Validate an exact deployed-wallet manifest for action planning or inspection."""
+    schema = str(manifest.get("schema", ""))
+    expected_deployment = ACTION_MANIFEST_DEPLOYMENTS.get(schema)
+    if expected_deployment is None:
+        raise SystemExit("bounded-wallet manifest schema is unsupported")
+    return _validate_manifest(manifest, schema, expected_deployment)
 
 
 def usdc_units(value: str, label: str) -> int:

--- a/scripts/test_bounded_agent_budget.py
+++ b/scripts/test_bounded_agent_budget.py
@@ -13,6 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "plan_bounded_agent_budget.py"
 MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-v2-base-mainnet.json"
+LEGACY_MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-base-mainnet.json"
 
 
 def load_planner():
@@ -57,6 +58,7 @@ class BoundedAgentBudgetPlannerTests(unittest.TestCase):
         cls.action_planner = load_action_planner()
         cls.create_helper = load_create_helper()
         cls.manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.legacy_manifest = json.loads(LEGACY_MANIFEST.read_text(encoding="utf-8"))
 
     def test_usdc_amounts_are_exact(self) -> None:
         self.assertEqual(self.planner.usdc_units("89", "amount"), 89_000_000)
@@ -212,6 +214,40 @@ class BoundedAgentBudgetPlannerTests(unittest.TestCase):
         changed = {**self.manifest, "contract_source_dirty": True}
         with self.assertRaises(SystemExit):
             self.planner.validate_manifest(changed)
+
+    def test_budget_manifest_validation_remains_v2_only(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "schema is unsupported"):
+            self.planner.validate_manifest(self.legacy_manifest)
+
+    def test_action_manifest_validation_accepts_exact_deployed_versions(self) -> None:
+        self.planner.validate_action_manifest(self.legacy_manifest)
+        self.planner.validate_action_manifest(self.manifest)
+
+    def test_action_manifest_validation_binds_quorum_to_schema(self) -> None:
+        legacy_with_v2_quorum = json.loads(json.dumps(self.legacy_manifest))
+        legacy_with_v2_quorum["canonical"]["signed_quorum_verifier_set_hash"] = (
+            self.manifest["canonical"]["signed_quorum_verifier_set_hash"]
+        )
+        with self.assertRaisesRegex(SystemExit, "unexpected signed quorum"):
+            self.planner.validate_action_manifest(legacy_with_v2_quorum)
+
+        v2_with_legacy_quorum = json.loads(json.dumps(self.manifest))
+        v2_with_legacy_quorum["canonical"]["signed_quorum_verifier_set_hash"] = (
+            self.legacy_manifest["canonical"]["signed_quorum_verifier_set_hash"]
+        )
+        with self.assertRaisesRegex(SystemExit, "unexpected signed quorum"):
+            self.planner.validate_action_manifest(v2_with_legacy_quorum)
+
+    def test_action_manifest_validation_rejects_unknown_schema(self) -> None:
+        changed = {**self.manifest, "schema": "agent-bounties/bounded-agent-wallet-deployment-v3"}
+        with self.assertRaisesRegex(SystemExit, "schema is unsupported"):
+            self.planner.validate_action_manifest(changed)
+
+    def test_action_manifest_validation_rejects_deployment_drift(self) -> None:
+        changed = json.loads(json.dumps(self.legacy_manifest))
+        changed["wallet_factory"]["address"] = "0x1111111111111111111111111111111111111111"
+        with self.assertRaisesRegex(SystemExit, "unexpected wallet factory"):
+            self.planner.validate_action_manifest(changed)
 
     def test_action_planner_fails_closed_on_remaining_caps(self) -> None:
         report = {


### PR DESCRIPTION
﻿## What changed

- keep new bounded-budget creation strictly on the canonical V2 deployment
- allow action planning, inspection, and explicit local operation for the exact committed V1 or V2 deployment
- bind each schema to its source revision, factory, implementation, runtime hashes, salt, and signed verifier-set hash
- reject unknown schemas, cross-version quorum hashes, and deployment drift

## Root cause

The V2 bounded-wallet migration changed the shared manifest validator to V2-only, while the funded standing wallet and routed-V3 activation runner still intentionally operate the canonical V1 deployment. Activation reached #651 but failed before broadcast during action planning.

## Impact

The existing funded V1 wallet can safely create and fund #651 again. New budget creation remains V2-only.

## Validation

- `scripts/preflight.ps1 -Mode core`
- `python -m unittest scripts.test_bounded_agent_budget scripts.test_activate_routed_v3_replacements -v` (31 passed)
- Python compile for all changed runtime scripts
- live Base-mainnet inspection of the V1 wallet at a safe block (`ready: true`)
- `cargo run -p cli -- docs-contract-check`
- `git diff --check`

No transaction was broadcast by the failed activation attempts.
