### PR TITLE
Recover routed activation broadcasts

### DIFF
--- a/scripts/activate_routed_v3_replacements.py
+++ b/scripts/activate_routed_v3_replacements.py
@@ -30,6 +30,7 @@ FACTORY = durable.CANONICAL_FACTORY
 USDC = durable.NATIVE_USDC
 TARGET = durable.PARENT_TARGET
 TOTAL = durable.TOTAL_REPLACEMENT_FUNDING
+BROADCAST_RECOVERY_TIMEOUT = 60
 ISSUES = {
     333: {"lane": "CLI", "old": "0xfffecb0fcd36477c5f6ecec808f6f0cf53819562"},
     335: {"lane": "MCP", "old": "0x43d42cb227d76588ab16693f14efd6cff851fa7a"},
@@ -337,22 +338,57 @@ def reconcile(api: str, contract: str, bounty_id: str, timeout_seconds: int = 18
     raise ActivationError(f"canonical activation did not reconcile for {contract}")
 
 
+def is_canonical(cast: Cast, predicted: str) -> bool:
+    return parse_bool(
+        cast.call(FACTORY, "isCanonicalBounty(address)(bool)", predicted),
+        "canonical bounty state",
+    )
+
+
+def wait_for_canonical(cast: Cast, predicted: str, timeout_seconds: int) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        if is_canonical(cast, predicted):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(2)
+
+
 def create_if_missing(
     cast: Cast,
     predicted: str,
     spend_available: int,
     create: Callable[[], str],
-) -> tuple[str | None, int]:
-    canonical = parse_bool(
-        cast.call(FACTORY, "isCanonicalBounty(address)(bool)", predicted),
-        "canonical bounty state",
-    )
-    if canonical:
-        return "already-canonical", spend_available
+    recovery_timeout: int = BROADCAST_RECOVERY_TIMEOUT,
+) -> tuple[str | None, int, bool]:
+    if is_canonical(cast, predicted):
+        return "already-canonical", spend_available, False
     if spend_available <= 0:
-        return None, spend_available
-    transaction_hash = bytes32(create(), "creation transaction hash")
-    return transaction_hash, spend_available - 1
+        return None, spend_available, False
+    try:
+        transaction_hash = bytes32(create(), "creation transaction hash")
+    except ActivationError:
+        # A provider may accept a transaction and fail while polling its receipt.
+        # The deterministic canonical contract is the authoritative postcondition.
+        if wait_for_canonical(cast, predicted, recovery_timeout):
+            return "recovered-canonical", spend_available - 1, True
+        raise
+    return transaction_hash, spend_available - 1, True
+
+
+def canonical_creation_transaction(reconciliation: Mapping[str, object]) -> str:
+    feed_item = reconciliation.get("feed_item")
+    events = feed_item.get("events") if isinstance(feed_item, Mapping) else None
+    matches = {
+        str(event.get("tx_hash", "")).lower()
+        for event in events or []
+        if isinstance(event, Mapping) and event.get("kind") == "canonical_bounty_created"
+    }
+    valid = {value for value in matches if BYTES32_RE.fullmatch(value)}
+    if len(valid) != 1:
+        raise ActivationError("canonical creation transaction evidence is missing or ambiguous")
+    return valid.pop()
 
 
 def issue_body(
@@ -509,13 +545,17 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
             )
             return str(sent.get("transactionHash") or sent.get("transaction_hash"))
 
-        tx_hash, spend_available = create_if_missing(
+        tx_hash, spend_available, created_now = create_if_missing(
             cast, predicted, spend_available, create_bounty
         )
         if tx_hash is None:
             pending.append(issue)
             continue
         reconciled = reconcile(args.api, predicted, bounty_id)
+        indexed_transaction = canonical_creation_transaction(reconciled)
+        if BYTES32_RE.fullmatch(tx_hash) and tx_hash != indexed_transaction:
+            raise ActivationError(f"issue #{issue} broadcast and indexed transactions differ")
+        tx_hash = indexed_transaction
         result = {
             "issue": issue,
             "lane": config["lane"],
@@ -523,6 +563,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
             "contract": predicted,
             "bounty_id": bounty_id,
             "transaction_hash": tx_hash,
+            "created_now": created_now,
             "terms_hash": bytes32(published.get("terms_hash"), f"issue #{issue} terms hash"),
             "policy_hash": deployment["policy_hash"],
             "reconciliation": reconciled,
@@ -535,7 +576,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
         results.append(result)
 
     after = policy_state(cast, deployment)
-    newly_created = sum(1 for item in results if item["transaction_hash"] != "already-canonical")
+    newly_created = sum(1 for item in results if item["created_now"])
     expected_spend = newly_created * TARGET
     if before["lifetime_spent"] + expected_spend != after["lifetime_spent"]:
         raise ActivationError("wallet lifetime spend did not increase by the exact newly-created amount")

--- a/scripts/test_activate_routed_v3_replacements.py
+++ b/scripts/test_activate_routed_v3_replacements.py
@@ -253,13 +253,53 @@ class ActivateRoutedV3Tests(unittest.TestCase):
         cast.call.return_value = "true"
         create = mock.Mock(return_value="0x" + "41" * 32)
 
-        transaction, remaining = MODULE.create_if_missing(
+        transaction, remaining, created = MODULE.create_if_missing(
             cast, "0x" + "31" * 20, 3, create
         )
 
         self.assertEqual(transaction, "already-canonical")
         self.assertEqual(remaining, 3)
+        self.assertFalse(created)
         create.assert_not_called()
+
+    def test_create_recovers_a_post_broadcast_provider_failure(self) -> None:
+        cast = mock.Mock()
+        cast.call.side_effect = ["false", "true"]
+        create = mock.Mock(side_effect=MODULE.ActivationError("receipt failed"))
+
+        transaction, remaining, created = MODULE.create_if_missing(
+            cast, "0x" + "31" * 20, 3, create, recovery_timeout=0
+        )
+
+        self.assertEqual(transaction, "recovered-canonical")
+        self.assertEqual(remaining, 2)
+        self.assertTrue(created)
+
+    def test_create_preserves_a_pre_broadcast_failure(self) -> None:
+        cast = mock.Mock()
+        cast.call.side_effect = ["false", "false"]
+        create = mock.Mock(side_effect=MODULE.ActivationError("send failed"))
+
+        with self.assertRaisesRegex(MODULE.ActivationError, "send failed"):
+            MODULE.create_if_missing(
+                cast, "0x" + "31" * 20, 3, create, recovery_timeout=0
+            )
+
+    def test_canonical_creation_transaction_requires_one_indexed_hash(self) -> None:
+        transaction = "0x" + "41" * 32
+        reconciliation = {
+            "feed_item": {
+                "events": [
+                    {"kind": "funding_added", "tx_hash": transaction},
+                    {"kind": "canonical_bounty_created", "tx_hash": transaction},
+                ]
+            }
+        }
+        self.assertEqual(
+            MODULE.canonical_creation_transaction(reconciliation), transaction
+        )
+        with self.assertRaisesRegex(MODULE.ActivationError, "missing or ambiguous"):
+            MODULE.canonical_creation_transaction({"feed_item": {"events": []}})
 
     def test_reconciliation_accepts_active_and_canonically_paid_states(self) -> None:
         contract = "0x" + "31" * 20


### PR DESCRIPTION
﻿## What changed

- recover a routed bounty creation when the RPC accepts the broadcast but fails during receipt polling
- treat canonical factory registration of the deterministic predicted contract as the recovery postcondition
- reconcile the exact indexed `canonical_bounty_created` transaction and reject broadcast/index mismatches
- track newly created contracts explicitly so replayed inventory never counts as new spend

## Root cause

While funding #651, PublicNode accepted the transaction and then returned HTTP 403 for Foundry's receipt polling request. The contract was created and funded successfully, but the runner reported failure before reconciliation. The direct-growth activator already handled this provider behavior; the routed activator did not.

## Incident evidence

- successful transaction: `0x664bcf9ef1057610f83897e1efd991dcfb20f9318f96a3507e2d28f69028a2fa`
- canonical contract: `0xaf2ea8641af789a0e6489d61a109a023e44fb0cf`
- wallet delta: 2.01 USDC
- reconciliation rerun: 0 additional spend

## Validation

- `python -m unittest scripts.test_activate_routed_v3_replacements -v` (15 passed)
- Python compile for routed activation scripts
- `git diff --check`

This PR broadcasts no transaction and changes no live bounty state.
