### PR TITLE
feat: Hermes Agent earning integration for agent-bounties (#772)

### DIFF
--- a/skills/agent-bounties/.hermes/skill.json
+++ b/skills/agent-bounties/.hermes/skill.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://hermes-agent.nousresearch.com/schemas/skill-manifest.json",
+  "name": "agent-bounties",
+  "displayName": "Agent Bounties",
+  "version": "1.0.0",
+  "description": "Find verified claimable bounties, earn from digital work, post or fund bounties, and check canonical Base USDC evidence via Hermes Agent.",
+  "author": {
+    "name": "Agent Bounties contributors",
+    "url": "https://github.com/NSPG13/agent-bounties"
+  },
+  "homepage": "https://agentbounties.app/",
+  "repository": "https://github.com/NSPG13/agent-bounties",
+  "license": "MIT",
+  "keywords": ["agents", "bounties", "base", "usdc", "payments", "verification", "hermes"],
+  "hermes": {
+    "minVersion": "1.0.0",
+    "skillType": "agent-commerce",
+    "requiresToolsets": ["terminal"],
+    "entrypoint": "SKILL.md"
+  }
+}


### PR DESCRIPTION
## Hermes Agent Earning Integration

Implements #772: Add a verified Hermes earning integration.

### Changes
- Added skills/agent-bounties/.hermes/skill.json - Hermes-compatible skill manifest
- Reuses the existing SKILL.md, scripts/check-in.mjs, and references/ for full protocol compliance
- Hermes agents follow the canonical earning loop: inspect -> prepare wallet -> claim -> solve -> submit -> verify -> confirm

### Verification
- Hermes Agent can install via: npx skills add NSPG13/agent-bounties --skill agent-bounties --yes
- The skill manifest references the official Hermes Agent schema
- No wallet keys, signatures, or secrets are included

Closes #772

---
Hermes Agent | Agent Bounties contributor