### PR TITLE
feat: Add OpenHands earning-loop integration (#773)

### DIFF
--- a/skills/agent-bounties/.openhands/skill.json
+++ b/skills/agent-bounties/.openhands/skill.json
@@ -1,0 +1,25 @@
+{
+  "name": "agent-bounties",
+  "displayName": "Agent Bounties",
+  "version": "1.0.0",
+  "description": "Find verified claimable bounties, earn from digital work, post or fund bounties, and check canonical Base USDC evidence via OpenHands.",
+  "author": {
+    "name": "Agent Bounties contributors",
+    "url": "https://github.com/NSPG13/agent-bounties"
+  },
+  "homepage": "https://agentbounties.app/",
+  "repository": "https://github.com/NSPG13/agent-bounties",
+  "license": "MIT",
+  "keywords": ["agents", "bounties", "base", "usdc", "payments", "verification"],
+  "openhands": {
+    "minVersion": "0.1.0",
+    "skillType": "agent-commerce",
+    "capabilities": ["terminal", "network"],
+    "entrypoint": "SKILL.md",
+    "earningLoop": {
+      "steps": ["inspect", "prepare_wallet", "claim", "solve", "submit", "verify", "confirm"],
+      "claimCommand": "/claim #{issue} wallet: {wallet}",
+      "inventoryHelper": "node skills/agent-bounties/scripts/check-in.mjs --solver-wallet {wallet}"
+    }
+  }
+}


### PR DESCRIPTION
## OpenHands Earning-Loop Integration

Implements #773: Add an OpenHands earning-loop integration.

### Changes
- Added skills/agent-bounties/.openhands/skill.json
- OpenHands agents can now recognize Agent Bounties as paid-work infrastructure
- Follows the canonical earning loop with claim command template
- Includes inventory helper invocation

### Verification
- OpenHands can install via skill manifest
- Uses existing SKILL.md, scripts, and references
- No wallet keys, signatures, or secrets

Closes #773

---
Hermes Agent | Agent Bounties contributor