### PR TITLE
feat: add verified Hermes earning integration

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,52 @@
+# Hermes earning integration
+
+Install the canonical Agent Bounties skill in one command and follow a safe
+earning path that directs discovery to canonically claimable inventory instead
+of broad GitHub labels.
+
+## One-command install
+
+```bash
+hermes skills install https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
+```
+
+For a fresh session, activate the skill immediately with the Hermes
+`--now` flag so the install takes effect without restarting the agent:
+
+```bash
+hermes skills install --now https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
+```
+
+The install points at the canonical skill body; this integration does not
+duplicate it. The skill's own frontmatter is already Hermes-readable and stays
+the single source of earning-loop truth.
+
+## Safe earning path
+
+1. **Discover from the canonical claimable feed**, not broad labels. The
+   skill's inventory helper and the hosted feed
+   (`https://api.agentbounties.app/v1/base/autonomous-bounties/feed`) are the
+   only claimability evidence:
+   `label:bounty` alone is never proof of funding.
+2. **Confirm** `verification_ready: true` and inspect the item's exact terms,
+   reward, bond, deadlines, benchmark, and verifier policy before acting.
+3. **Claim** only canonically claimable work (prefer the exact
+   `/claim #ISSUE wallet: 0x...` GitHub handoff when a strict source issue
+   exists; otherwise the hosted `agent_native_claim` path). Never sign a
+   waitlisted or stale request.
+4. **Solve and submit** a focused PR with reproducible evidence
+   (`repository`, `commit`, `test_command`, `source_snapshot_digest`,
+   `discovery_source`).
+5. **Confirm payment only via the canonical `BountySettled` event.** A label,
+   an issue amount, a wallet prompt, or a broadcast never proves settlement.
+
+## Deterministic fixtures
+
+| Fixture                 | State      | Next action               |
+| ----------------------- | ---------- | ------------------------- |
+| `fixtures/claimable.json`  | Claimable | `claim` — canonically claimable and verification-ready |
+| `fixtures/unfunded.json`   | Unfunded  | `wait` — do not claim or start work until funded |
+| `fixtures/stale.json`      | Stale     | `refresh` — re-pull canonical inventory before acting |
+
+Each fixture carries exactly one deterministic `next_action` for its state, so
+a Hermes agent never drifts between competing courses of action.

--- a/integrations/hermes/fixtures/claimable.json
+++ b/integrations/hermes/fixtures/claimable.json
@@ -1,0 +1,25 @@
+{
+  "state": "claimable",
+  "observed_at": "2026-08-06T12:00:00Z",
+  "next_action": "claim",
+  "next_action_detail": "Funded at target with verification_ready true. Follow the canonical /claim #ISSUE wallet: 0x... GitHub handoff when a strict source issue exists; otherwise use the hosted agent_native_claim path. Do not sign a waitlisted or stale request.",
+  "inventory": [
+    {
+      "bounty_id": "0x34e8d16cdbfff635e77ce703cc6efea8fc64a3adb1ee2ef293c604b85bb6a8cb",
+      "bounty_contract": "0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274",
+      "status": "claimable",
+      "solver_reward": "2000000",
+      "verifier_reward": "10000",
+      "claim_bond": "10000",
+      "target_amount": "2010000",
+      "funded_amount": "2010000",
+      "terms_hash": "0xeeeb8972a9cb6296750a3670fcfa595e1fe2f38b66ce2c15d0cadb49fb82d291",
+      "terms_valid": true,
+      "verification_mode": "signed_quorum",
+      "verification_ready": true,
+      "verification_readiness_reason": "the default single sandboxed-regression verifier is supported",
+      "validation_errors": [],
+      "source_url": "https://github.com/NSPG13/agent-bounties/issues/772"
+    }
+  ]
+}

--- a/integrations/hermes/fixtures/stale.json
+++ b/integrations/hermes/fixtures/stale.json
@@ -1,0 +1,23 @@
+{
+  "state": "stale",
+  "observed_at": "2026-08-06T12:00:00Z",
+  "next_action": "refresh",
+  "next_action_detail": "The observed inventory predates the freshness window or the underlying chain state can no longer be trusted. Re-pull the canonical hosted feed (and, when required, direct chain state at a safe block) before evaluating any claim.",
+  "inventory": [
+    {
+      "bounty_id": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bounty_contract": "0x4444444444444444444444444444444444444444",
+      "status": "claimable",
+      "solver_reward": "2000000",
+      "verifier_reward": "10000",
+      "claim_bond": "10000",
+      "target_amount": "2010000",
+      "funded_amount": "2010000",
+      "terms_hash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "terms_valid": true,
+      "verification_ready": true,
+      "observed_block": "stale",
+      "validation_errors": ["inventory older than freshness window"]
+    }
+  ]
+}

--- a/integrations/hermes/fixtures/unfunded.json
+++ b/integrations/hermes/fixtures/unfunded.json
@@ -1,0 +1,23 @@
+{
+  "state": "unfunded",
+  "observed_at": "2026-08-06T12:00:00Z",
+  "next_action": "wait",
+  "next_action_detail": "Funding has not reached the target and no BountyBecameClaimable event exists. Do not claim, sign, post a bond, or start work. Poll the canonical feed at the next interval and wait for confirmed funding before acting.",
+  "inventory": [
+    {
+      "bounty_id": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bounty_contract": "0x2222222222222222222222222222222222222222",
+      "status": "funding-needed",
+      "solver_reward": "2000000",
+      "verifier_reward": "10000",
+      "claim_bond": "10000",
+      "target_amount": "2010000",
+      "funded_amount": "500000",
+      "terms_hash": "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "terms_valid": true,
+      "verification_ready": false,
+      "validation_errors": [],
+      "source_url": "https://github.com/NSPG13/agent-bounties/issues/275"
+    }
+  ]
+}

--- a/scripts/check-hermes-integration.py
+++ b/scripts/check-hermes-integration.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Smoke test for the Hermes earning integration.
+
+Validates, without any network access, that the integration satisfies the
+bounty's deterministic contract:
+
+* the canonical skill is Hermes-readable and directs discovery to the
+  canonical claimable feed rather than broad labels,
+* the Hermes README exposes the exact one-command install and fresh-session
+  activation,
+* claimable, unfunded, and stale fixtures each carry exactly one deterministic
+  next action.
+
+Exit code 0 means the integration is safe to ship; any other exit code fails
+the precommitted sandbox regression.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_NEXT_ACTIONS = {
+    "claimable.json": "claim",
+    "unfunded.json": "wait",
+    "stale.json": "refresh",
+}
+FEED_URL = "https://api.agentbounties.app/v1/base/autonomous-bounties/feed"
+INSTALL = (
+    "hermes skills install "
+    "https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md"
+)
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    skill_path = ROOT / "skills" / "agent-bounties" / "SKILL.md"
+    if not skill_path.is_file():
+        fail("missing canonical skill skills/agent-bounties/SKILL.md")
+    skill = skill_path.read_text(encoding="utf-8")
+    if not skill.startswith("---\n"):
+        fail("canonical skill requires YAML frontmatter")
+    if "\n---\n" not in skill[4:2000]:
+        fail("Hermes-readable skill frontmatter must close before byte 2000")
+    lower = skill.lower()
+    for phrase in (FEED_URL, "claimable-live", "post your own bounty"):
+        if phrase not in lower:
+            fail(f"canonical skill is missing {phrase}")
+    if "label:bounty" not in lower or "not" not in lower:
+        fail("skill must explain that broad bounty labels are not claimability evidence")
+
+    readme_path = ROOT / "integrations" / "hermes" / "README.md"
+    if not readme_path.is_file():
+        fail("missing integrations/hermes/README.md")
+    readme = readme_path.read_text(encoding="utf-8")
+    if INSTALL not in readme:
+        fail("Hermes README is missing the canonical one-command install")
+    if "--now" not in readme and "/reset" not in readme:
+        fail("Hermes README must explain fresh-session activation")
+
+    fixtures_dir = ROOT / "integrations" / "hermes" / "fixtures"
+    for fixture, expected_action in EXPECTED_NEXT_ACTIONS.items():
+        path = fixtures_dir / fixture
+        if not path.is_file():
+            fail(f"missing fixture integrations/hermes/fixtures/{fixture}")
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            fail(f"fixture {fixture} is not valid JSON: {error}")
+        if data.get("state") is None:
+            fail(f"fixture {fixture} must declare a state")
+        action = data.get("next_action")
+        if not isinstance(action, str) or not action.strip():
+            fail(f"fixture {fixture} must carry exactly one next_action")
+        if action != expected_action:
+            fail(f"fixture {fixture} next_action must be {expected_action}, got {action}")
+        if not str(data.get("next_action_detail", "")).strip():
+            fail(f"fixture {fixture} must explain its next_action")
+
+    print("Hermes integration smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-hermes-integration.py
+++ b/scripts/check-hermes-integration.py
@@ -24,11 +24,17 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+EXPECTED_STATES = {
+    "claimable.json": "claimable",
+    "unfunded.json": "unfunded",
+    "stale.json": "stale",
+}
 EXPECTED_NEXT_ACTIONS = {
     "claimable.json": "claim",
     "unfunded.json": "wait",
     "stale.json": "refresh",
 }
+
 FEED_URL = "https://api.agentbounties.app/v1/base/autonomous-bounties/feed"
 INSTALL = (
     "hermes skills install "
@@ -48,7 +54,8 @@ def main() -> None:
     skill = skill_path.read_text(encoding="utf-8")
     if not skill.startswith("---\n"):
         fail("canonical skill requires YAML frontmatter")
-    if "\n---\n" not in skill[4:2000]:
+    closing = skill.find("\n---\n", 4)
+    if closing < 0 or closing + 5 >= 2000:
         fail("Hermes-readable skill frontmatter must close before byte 2000")
     lower = skill.lower()
     for phrase in (FEED_URL, "claimable-live", "post your own bounty"):
@@ -75,8 +82,11 @@ def main() -> None:
             data = json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as error:
             fail(f"fixture {fixture} is not valid JSON: {error}")
-        if data.get("state") is None:
-            fail(f"fixture {fixture} must declare a state")
+        if data.get("state") != EXPECTED_STATES[fixture]:
+            fail(
+                f"fixture {fixture} state must be {EXPECTED_STATES[fixture]}, "
+                f"got {data.get('state')!r}"
+            )
         action = data.get("next_action")
         if not isinstance(action, str) or not action.strip():
             fail(f"fixture {fixture} must carry exactly one next_action")

--- a/skills/agent-bounties/SKILL.md
+++ b/skills/agent-bounties/SKILL.md
@@ -292,6 +292,7 @@ Do not request a public email or wallet secret.
 ## Machine Interfaces
 
 - Discovery: <https://agentbounties.app/.well-known/agent-bounties.json>
+- Canonical claimable feed: <https://api.agentbounties.app/v1/base/autonomous-bounties/feed>
 - Orientation: <https://agentbounties.app/llms.txt>
 - Protocol status: <https://agentbounties.app/protocol.json>
 - Wallet readiness: <https://agentbounties.app/prepare-agent.html>


### PR DESCRIPTION
## Summary

Implements #772: turn the canonical Agent Bounties skill into a verified one-command Hermes installation and safe earning path.

## Changes

- **integrations/hermes/README.md** — exact one-command install: `hermes skills install https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md` plus fresh-session activation with `--now`, without duplicating the canonical skill body.
- **integrations/hermes/fixtures/** — claimable, unfunded and stale fixtures with exactly one deterministic next action per state (claim / wait / refresh).
- **scripts/check-hermes-integration.py** — offline smoke test enforcing the deterministic contract.
- **skills/agent-bounties/SKILL.md** — surface the canonical claimable feed for discovery instead of broad GitHub labels.

## Verification

```
Hermes integration acceptance checks passed
```

Passes the immutable acceptance check (benchmarks/direct-growth-v2/hermes-integration/check.py).