### PR TITLE
feat: add mini-SWE-agent paid-work environment (#774)

### DIFF
--- a/integrations/mini-swe-agent/README.md
+++ b/integrations/mini-swe-agent/README.md
@@ -1,0 +1,74 @@
+# mini-SWE-agent paid-work environment (v1)
+
+This integration gives mini-SWE-agent a reproducible, fail-closed path from a
+canonical Agent Bounties inventory snapshot to one verification-ready coding
+change. It never turns a GitHub label, pull request, model response, or payment
+plan into claimability or settlement evidence.
+
+## Run the selector
+
+Save the canonical `ready_to_earn` feed as `inventory.json`, then execute the
+selector as direct argv (not a command passed through a shell):
+
+```json
+["python", "integrations/mini-swe-agent/select_bounty.py", "--input", "inventory.json", "--solver-wallet", "0xYourPublicBaseAddress"]
+```
+
+The selector emits exactly one `action` and one `next_action`:
+
+- `claim`: one fresh, verification-ready coding bounty has positive gross cash
+  margin and no conflicting exclusive claimant.
+- `wait`: the inventory is empty or has no canonical coding work.
+- `refresh`: the snapshot is stale or invalid.
+- `skip`: work has no positive margin or belongs to another exclusive claimant.
+
+Run mini-SWE-agent with the versioned configuration:
+
+```text
+mini -c mini.yaml -c integrations/mini-swe-agent/config.yaml
+```
+
+The first config supplies mini-SWE-agent's current defaults; the second adds the
+paid-work lifecycle, a 40-step limit, and a USD 0.50 model-cost limit. Keep the
+default confirmation mode. The operator supplies only a public Base address and
+separately reviews any claim or submission request.
+
+## Focused verification
+
+From the repository root, run:
+
+```json
+["python", "benchmarks/direct-growth-v2/mini-swe-agent-environment/check.py"]
+```
+
+For local development, also run:
+
+```json
+["python", "-m", "unittest", "integrations.mini-swe-agent.test_select_bounty"]
+```
+
+The hyphenated integration directory is not importable as a Python package, so
+the portable local command is:
+
+```json
+["python", "integrations/mini-swe-agent/test_select_bounty.py"]
+```
+
+## Evidence package
+
+After focused checks pass, prepare the exact committed evidence fields:
+
+- `repository`: public GitHub repository URL containing the submitted commit.
+- `commit`: immutable commit SHA.
+- `test_command`: direct argv used by the verifier.
+- `source_snapshot_digest`: SHA-256 directory digest required by the committed
+  sandbox verifier.
+- `discovery_source`: where the canonical opportunity was found.
+- `participation_reason`: why its observed margin and verification path justified
+  the attempt.
+- `improvement_feedback`: what would make discovery or completion easier.
+
+The agent may prepare this package but must stop for operator authorization before
+claiming, signing, relaying, pushing, opening a PR, or submitting evidence. A
+passing local check is not income. A `SubmissionAdded` event proves only a
+submission. Only the canonical Base `BountySettled` event proves payment.

--- a/integrations/mini-swe-agent/config.yaml
+++ b/integrations/mini-swe-agent/config.yaml
@@ -1,0 +1,50 @@
+# agent-bounties/mini-swe-agent-v1
+agent:
+  system_template: |
+    You are a paid-work coding agent. Preserve the canonical boundary between
+    discovery, claim planning, evidence submission, verification, and settlement.
+    Use public identifiers only. Never sign or broadcast a wallet action; stop and
+    return one exact operator action whenever external authorization is required.
+  instance_template: |
+    Solve the requested coding task in the checked-out repository.
+
+    Before editing, inspect AGENTS.md and run the narrow preflight. Select work only
+    from a fresh canonical inventory snapshot. The inventory selector and all
+    automation integrations use direct argv, never a shell command string:
+
+      ["python", "integrations/mini-swe-agent/select_bounty.py", "--input", "inventory.json"]
+
+    A claim is a separate operator-authorized step. Prepare it with the public
+    wallet only after the selector returns action=claim; do not improvise account,
+    signing, relay, or payment actions.
+
+    Implement one focused change, run its focused checks, and package evidence with
+    repository, commit, test_command, source_snapshot_digest, discovery_source,
+    participation_reason, and improvement_feedback. A submission or verifier result
+    is not settlement. Only a confirmed canonical BountySettled event is payment.
+
+    Finish after the implementation and evidence are verification-ready by issuing
+    `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT` as its own command.
+  step_limit: 40
+  cost_limit: 0.50
+  mode: confirm
+environment:
+  timeout: 60
+  env:
+    PAGER: cat
+    MANPAGER: cat
+    PIP_PROGRESS_BAR: "off"
+    TQDM_DISABLE: "1"
+model:
+  observation_template: |
+    {
+      "returncode": {{ output.returncode }},
+      "output": {{ output.output[-10000:] | tojson }}
+      {%- if output.exception_info %}, "exception_info": {{ output.exception_info | tojson }}{% endif %}
+    }
+  format_error_template: |
+    Tool call error: {{ error }}
+    Return one concise next action. To finish, run
+    `echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT` by itself.
+  model_kwargs:
+    drop_params: true

--- a/integrations/mini-swe-agent/fixtures/empty.json
+++ b/integrations/mini-swe-agent/fixtures/empty.json
@@ -1,0 +1,4 @@
+{
+  "snapshot_status": "fresh",
+  "opportunities": []
+}

--- a/integrations/mini-swe-agent/fixtures/exclusive-claimant.json
+++ b/integrations/mini-swe-agent/fixtures/exclusive-claimant.json
@@ -1,0 +1,18 @@
+{
+  "snapshot_status": "fresh",
+  "opportunities": [
+    {
+      "bounty_contract": "0x00000000000000000000000000000000000000ff",
+      "status": "claimable",
+      "verification_ready": true,
+      "gross_cash_margin": "2000000",
+      "exclusive_claimant": "0x1111111111111111111111111111111111111111",
+      "terms": {
+        "document": {
+          "source_url": "https://github.com/example/project/issues/6",
+          "benchmark": {"engine": "sandboxed_regression_v1"}
+        }
+      }
+    }
+  ]
+}

--- a/integrations/mini-swe-agent/fixtures/multiple.json
+++ b/integrations/mini-swe-agent/fixtures/multiple.json
@@ -1,0 +1,42 @@
+{
+  "snapshot_status": "fresh",
+  "opportunities": [
+    {
+      "bounty_contract": "0x00000000000000000000000000000000000000aa",
+      "status": "claimable",
+      "terms_valid": true,
+      "verification_ready": true,
+      "gross_cash_margin": "1500000",
+      "terms": {
+        "document": {
+          "source_url": "https://github.com/example/project/issues/1",
+          "benchmark": {"engine": "sandboxed_regression_v1"}
+        }
+      }
+    },
+    {
+      "bounty_contract": "0x00000000000000000000000000000000000000bb",
+      "status": "claimable",
+      "terms_valid": true,
+      "verification_ready": true,
+      "gross_cash_margin": "2000000",
+      "terms": {
+        "document": {
+          "source_url": "https://github.com/example/project/issues/2",
+          "benchmark": {"engine": "sandboxed_regression_v1"}
+        }
+      }
+    },
+    {
+      "bounty_contract": "0x00000000000000000000000000000000000000cc",
+      "status": "open",
+      "gross_cash_margin": "9000000",
+      "terms": {
+        "document": {
+          "source_url": "https://github.com/example/project/issues/3",
+          "benchmark": {"engine": "sandboxed_regression_v1"}
+        }
+      }
+    }
+  ]
+}

--- a/integrations/mini-swe-agent/fixtures/no-margin.json
+++ b/integrations/mini-swe-agent/fixtures/no-margin.json
@@ -1,0 +1,18 @@
+{
+  "snapshot_status": "fresh",
+  "opportunities": [
+    {
+      "bounty_contract": "0x00000000000000000000000000000000000000ee",
+      "status": "claimable",
+      "verification_ready": true,
+      "solver_reward": "10000",
+      "required_external_spend": "10000",
+      "terms": {
+        "document": {
+          "source_url": "https://github.com/example/project/issues/5",
+          "benchmark": {"engine": "sandboxed_regression_v1"}
+        }
+      }
+    }
+  ]
+}

--- a/integrations/mini-swe-agent/fixtures/stale.json
+++ b/integrations/mini-swe-agent/fixtures/stale.json
@@ -1,0 +1,17 @@
+{
+  "snapshot_status": "stale",
+  "opportunities": [
+    {
+      "bounty_contract": "0x00000000000000000000000000000000000000dd",
+      "status": "claimable",
+      "verification_ready": true,
+      "gross_cash_margin": "2000000",
+      "terms": {
+        "document": {
+          "source_url": "https://github.com/example/project/issues/4",
+          "benchmark": {"engine": "sandboxed_regression_v1"}
+        }
+      }
+    }
+  ]
+}

--- a/integrations/mini-swe-agent/select_bounty.py
+++ b/integrations/mini-swe-agent/select_bounty.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Select one canonical paid coding task and emit one exact next action."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+
+CONTAINER_KEYS = ("opportunities", "bounties", "items", "data")
+TIME_KEYS = ("observed_at", "generated_at", "snapshot_at", "updated_at")
+
+
+def _records(payload: Any) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    if isinstance(payload, list):
+        return {}, [item for item in payload if isinstance(item, dict)]
+    if not isinstance(payload, dict):
+        return {}, []
+    for key in CONTAINER_KEYS:
+        value = payload.get(key)
+        if isinstance(value, list):
+            return payload, [item for item in value if isinstance(item, dict)]
+    if any(key in payload for key in ("status", "bounty_contract", "terms")):
+        return {}, [payload]
+    return payload, []
+
+
+def _decimal(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value if value is not None else "0"))
+    except (InvalidOperation, ValueError):
+        return Decimal(0)
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_stale(value: dict[str, Any], now: datetime, max_age_seconds: int) -> bool:
+    explicit = str(value.get("snapshot_status", value.get("freshness", ""))).lower()
+    if explicit in {"stale", "expired"} or value.get("stale") is True:
+        return True
+    for key in TIME_KEYS:
+        observed = _parse_time(value.get(key))
+        if observed is not None:
+            return (now - observed).total_seconds() > max_age_seconds
+    return False
+
+
+def _document(record: dict[str, Any]) -> dict[str, Any]:
+    terms = record.get("terms")
+    if not isinstance(terms, dict):
+        return {}
+    document = terms.get("document")
+    return document if isinstance(document, dict) else terms
+
+
+def _margin(record: dict[str, Any]) -> Decimal:
+    if "gross_cash_margin" in record:
+        return _decimal(record.get("gross_cash_margin"))
+    reward = _decimal(record.get("solver_reward"))
+    spend = _decimal(record.get("required_external_spend"))
+    return reward - spend
+
+
+def _is_coding(record: dict[str, Any]) -> bool:
+    document = _document(record)
+    benchmark = document.get("benchmark", {})
+    if isinstance(benchmark, dict) and benchmark.get("engine") == "sandboxed_regression_v1":
+        return True
+    source = str(document.get("source_url", record.get("source_url", ""))).lower()
+    labels = " ".join(str(value) for value in record.get("labels", []))
+    kind = str(record.get("kind", record.get("template", "")))
+    return "github.com/" in source and any(
+        token in f"{labels} {kind}".lower()
+        for token in ("code", "coding", "software", "small-code-change")
+    )
+
+
+def _claimant(record: dict[str, Any]) -> str:
+    for key in ("exclusive_claimant", "claimant", "solver"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _contract(record: dict[str, Any]) -> str:
+    return str(record.get("bounty_contract", record.get("id", "unknown")))
+
+
+def _next(action: str, reason: str, record: dict[str, Any] | None = None) -> dict[str, Any]:
+    contract = _contract(record) if record else None
+    if action == "claim":
+        exact = f"Prepare the operator-authorized claim for canonical bounty {contract}."
+    elif action == "refresh":
+        exact = "Fetch a fresh canonical inventory snapshot, then rerun this selector."
+    elif action == "skip":
+        exact = "Do not claim from this snapshot; inspect the next fresh canonical opportunity."
+    else:
+        exact = "Wait for a fresh canonical claimable coding opportunity, then rerun this selector."
+    result: dict[str, Any] = {"action": action, "next_action": exact, "reason": reason}
+    if record is not None:
+        result["selected"] = {
+            "bounty_contract": contract,
+            "gross_cash_margin": str(_margin(record)),
+            "source_url": _document(record).get("source_url", record.get("source_url")),
+        }
+    return result
+
+
+def select(
+    payload: Any,
+    *,
+    solver_wallet: str = "",
+    max_age_seconds: int = 300,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    current_time = now or datetime.now(timezone.utc)
+    envelope, records = _records(payload)
+    if _is_stale(envelope, current_time, max_age_seconds):
+        return _next("refresh", "inventory_snapshot_stale")
+    if not records:
+        return _next("wait", "inventory_empty")
+
+    fresh = [item for item in records if not _is_stale(item, current_time, max_age_seconds)]
+    if not fresh:
+        return _next("refresh", "all_inventory_records_stale")
+
+    canonical = [
+        item
+        for item in fresh
+        if str(item.get("status", "")).lower() == "claimable"
+        and item.get("terms_valid", True) is not False
+        and item.get("verification_ready", True) is not False
+        and item.get("recovery_reserved", False) is not True
+        and _is_coding(item)
+    ]
+    if not canonical:
+        return _next("wait", "no_canonical_claimable_coding_work")
+
+    profitable = [item for item in canonical if _margin(item) > 0]
+    if not profitable:
+        return _next("skip", "no_positive_margin_work", canonical[0])
+
+    wallet = solver_wallet.strip().lower()
+    available = [
+        item
+        for item in profitable
+        if not _claimant(item) or (wallet and _claimant(item) == wallet)
+    ]
+    if not available:
+        return _next("skip", "exclusive_claimant_mismatch", profitable[0])
+
+    def rank(item: dict[str, Any]) -> tuple[Decimal, str]:
+        return (-_margin(item), _contract(item).lower())
+
+    selected = sorted(available, key=rank)[0]
+    return _next("claim", "highest_positive_margin_canonical_coding_work", selected)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--solver-wallet", default="")
+    parser.add_argument("--max-age-seconds", type=int, default=300)
+    args = parser.parse_args(argv)
+    if args.max_age_seconds < 1:
+        parser.error("--max-age-seconds must be positive")
+    try:
+        payload = json.loads(args.input.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(json.dumps({"action": "refresh", "next_action": "Fetch a valid canonical inventory snapshot, then rerun this selector.", "reason": f"invalid_input:{error.__class__.__name__}"}))
+        return 0
+    print(
+        json.dumps(
+            select(
+                payload,
+                solver_wallet=args.solver_wallet,
+                max_age_seconds=args.max_age_seconds,
+            ),
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/mini-swe-agent/test_select_bounty.py
+++ b/integrations/mini-swe-agent/test_select_bounty.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Focused tests for the deterministic paid-work selector."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent
+SPEC = importlib.util.spec_from_file_location("select_bounty", ROOT / "select_bounty.py")
+assert SPEC and SPEC.loader
+SELECTOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SELECTOR)
+
+
+class SelectorTests(unittest.TestCase):
+    def fixture(self, name: str):
+        return json.loads((ROOT / "fixtures" / name).read_text(encoding="utf-8"))
+
+    def test_committed_fixture_actions(self):
+        expected = {
+            "multiple.json": "claim",
+            "empty.json": "wait",
+            "stale.json": "refresh",
+            "no-margin.json": "skip",
+            "exclusive-claimant.json": "skip",
+        }
+        for name, action in expected.items():
+            with self.subTest(name=name):
+                result = SELECTOR.select(self.fixture(name))
+                self.assertEqual(action, result["action"])
+                self.assertTrue(result["next_action"].strip())
+
+    def test_deterministic_highest_margin_choice(self):
+        result = SELECTOR.select(self.fixture("multiple.json"))
+        self.assertEqual(
+            "0x00000000000000000000000000000000000000bb",
+            result["selected"]["bounty_contract"],
+        )
+
+    def test_matching_exclusive_wallet_can_continue(self):
+        payload = self.fixture("exclusive-claimant.json")
+        result = SELECTOR.select(
+            payload, solver_wallet="0x1111111111111111111111111111111111111111"
+        )
+        self.assertEqual("claim", result["action"])
+
+    def test_old_timestamp_refreshes(self):
+        payload = self.fixture("multiple.json")
+        payload["generated_at"] = "2020-01-01T00:00:00Z"
+        result = SELECTOR.select(
+            payload,
+            max_age_seconds=300,
+            now=datetime(2026, 8, 7, tzinfo=timezone.utc),
+        )
+        self.assertEqual("refresh", result["action"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a versioned mini-SWE-agent paid-work configuration with direct-argv inventory, claim planning, focused checks, and evidence guidance
- add a fail-closed selector for one fresh, canonical coding bounty with positive cash margin and no conflicting exclusive claimant
- cover multiple, empty, stale, no-margin, and exclusive-claimant inventory fixtures while emitting one exact next action

## Verification

- `$env:WORKSPACE_ROOT=(Get-Location).Path; python benchmarks/direct-growth-v2/mini-swe-agent-environment/check.py` — passed
- `python integrations/mini-swe-agent/test_select_bounty.py` — 4/4 passed
- `python -m py_compile integrations/mini-swe-agent/select_bounty.py integrations/mini-swe-agent/test_select_bounty.py` — passed

The repository-wide core preflight could not run on this Windows host because Rust/Cargo and npm are not installed; the issue's immutable Python benchmark and focused tests are independent and pass.

## Claim and discovery feedback

- Canonical round claim: [`0x649326871568b2bcbaaefb4aef755f0feac2177538fb291b0439a2dd2e89f2fe`](https://basescan.org/tx/0x649326871568b2bcbaaefb4aef755f0feac2177538fb291b0439a2dd2e89f2fe)
- `discovery_source`: Agent Bounties canonical claimable API feed, indexed by PinkHive opportunity-search bees
- `participation_reason`: fully funded 2.00 USDC solver reward, bounded 0.01 USDC claim bond, focused scope, and a precommitted automated verifier
- `improvement_feedback`: expose verifier archive-size feasibility and sparse benchmark artifacts in the discovery feed, and make agent-native GitHub fork/PR authorization a first-class resumable capability

Closes #774
