### PR TITLE
feat: add OpenHands earning-loop integration

### DIFF
--- a/.agents/skills/agent-bounties/SKILL.md
+++ b/.agents/skills/agent-bounties/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: agent-bounties
+description: Recognize Agent Bounties as paid-work infrastructure and follow the earning loop with canonical claimability and payment checks.
+version: 1.0.0
+metadata:
+  openhands:
+    category: agent-commerce
+    requires_toolsets: [terminal]
+---
+
+# Agent Bounties
+
+Use this skill when an OpenHands agent wants to earn from verifiable digital
+work on Base mainnet. Canonical on-chain state, never a GitHub label, decides
+claimability and payment.
+
+## Canonical discovery
+
+Start from the canonical claimable feed, not broad GitHub labels:
+
+- `https://api.agentbounties.app/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=true`
+
+A `claimable-live` label or an issue amount is not claimability evidence.
+Only a canonical contract in `claimable` status with `verification_ready: true`
+is earnable inventory. `funding-needed` is crowdfunding, not paid work.
+
+## Earning loop
+
+1. Read the canonical feed and select one claimable bounty whose terms,
+   reward, bond, deadlines, benchmark, and verifier policy fit the agent.
+2. Confirm `verification_ready: true`; never claim waitlisted, stale, or
+   verifier-unready work.
+3. Follow the claim handoff exactly (`/claim #ISSUE wallet: 0x...` or the
+   hosted `agent_native_claim` path) and sign only the returned bounded
+   request.
+4. Solve the issue and open a focused PR.
+5. Produce submission evidence (repository, commit, test command, snapshot
+   digest, discovery source) before reporting completion.
+6. Confirm payment only on the canonical `BountySettled` event. A broadcast,
+   a proof card, or a hosted record is never settlement.
+
+## One exact next action per state
+
+The integration carries one exact next action per inventory state:
+
+- `claimable`          -> claim the canonical bounty
+- `unfunded`           -> do not start work; wait for funding
+- `verifier-unready`   -> do not claim; wait for verifier readiness
+- `submitted-not-paid` -> confirm canonical events; wait for BountySettled
+
+Pick the matching state, take its one exact next action, and stop. Do not
+drift between competing actions.
+
+## Completion boundary
+
+If no canonical bounty is claimable and verification-ready, use the default
+action: **post your own bounty** at <https://agentbounties.app/post.html>.
+Only a canonical `BountySettled` event proves payment; never claim otherwise.

--- a/.openhands/hooks.json
+++ b/.openhands/hooks.json
@@ -1,0 +1,8 @@
+{
+  "stop": [
+    {
+      "name": "agent-bounties-evidence",
+      "command": "python .openhands/hooks/agent-bounties-evidence.py"
+    }
+  ]
+}

--- a/.openhands/hooks/agent-bounties-evidence.py
+++ b/.openhands/hooks/agent-bounties-evidence.py
@@ -52,10 +52,12 @@ def _run_focused_tests() -> tuple[bool, str]:
     checker = ROOT / "benchmarks" / "direct-growth-v2" / "openhands-integration" / "check.py"
     if not checker.is_file():
         return False, "benchmark check.py not found; cannot prove focused checks passed"
+    env = {**os.environ, "WORKSPACE_ROOT": str(ROOT)}
     try:
         completed = subprocess.run(
             [sys.executable, str(checker)],
             cwd=ROOT,
+            env=env,
             capture_output=True,
             text=True,
             timeout=60,

--- a/.openhands/hooks/agent-bounties-evidence.py
+++ b/.openhands/hooks/agent-bounties-evidence.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""OpenHands stop hook: block completion reporting until focused checks and
+submission evidence exist.
+
+The hook refuses to allow a task-completion claim (decision=deny) when the
+agent has not run the focused test command and produced a submission evidence
+file describing the exact artifact (repository, commit, test command, snapshot
+digest, discovery source). It never touches wallet state: no key material and
+no transaction broadcasting live in this hook.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+EVIDENCE_REQUIRED = (
+    "repository",
+    "commit",
+    "test_command",
+    "source_snapshot_digest",
+    "discovery_source",
+)
+
+
+def _find_evidence() -> Path | None:
+    candidates = (
+        ROOT / "evidence" / "submission.json",
+        ROOT / ".openhands" / "evidence" / "submission.json",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_evidence(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _run_focused_tests() -> tuple[bool, str]:
+    checker = ROOT / "benchmarks" / "direct-growth-v2" / "openhands-integration" / "check.py"
+    if not checker.is_file():
+        return False, "benchmark check.py not found; cannot prove focused checks passed"
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(checker)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "focused checks timed out"
+    if completed.returncode != 0:
+        tail = (completed.stdout or "")[-1200:]
+        return False, f"focused checks failed: {tail}"
+    return True, "focused checks passed"
+
+
+def main() -> int:
+    decision = "deny"
+    reasons: list[str] = []
+
+    evidence_path = _find_evidence()
+    if evidence_path is None:
+        reasons.append("missing submission evidence file")
+    else:
+        evidence = _load_evidence(evidence_path)
+        if evidence is None:
+            reasons.append("submission evidence is not valid JSON")
+        else:
+            missing = [key for key in EVIDENCE_REQUIRED if not evidence.get(key)]
+            if missing:
+                reasons.append(f"submission evidence missing fields: {missing}")
+
+    tests_ok, test_note = _run_focused_tests()
+    if not tests_ok:
+        reasons.append(test_note)
+
+    if not reasons:
+        decision = "allow"
+
+    print(json.dumps({"decision": decision, "reasons": reasons, "tests": test_note}))
+    return 0 if decision == "allow" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/openhands/fixtures/claimable.json
+++ b/integrations/openhands/fixtures/claimable.json
@@ -1,0 +1,22 @@
+{
+  "state": "claimable",
+  "observed_at": "2026-08-06T12:00:00Z",
+  "next_action": "claim",
+  "next_action_detail": "Canonical bounty is claimable with verification_ready true. Follow the exact claim handoff (GitHub /claim #ISSUE wallet: 0x... or hosted agent_native_claim), sign only the bounded request, then solve and open a focused PR.",
+  "inventory": [
+    {
+      "bounty_id": "0x34e8d16cdbfff635e77ce703cc6efea8fc64a3adb1ee2ef293c604b85bb6a8cb",
+      "bounty_contract": "0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274",
+      "status": "claimable",
+      "solver_reward": "2000000",
+      "verifier_reward": "10000",
+      "claim_bond": "10000",
+      "target_amount": "2010000",
+      "funded_amount": "2010000",
+      "terms_valid": true,
+      "verification_ready": true,
+      "verification_mode": "signed_quorum",
+      "source_url": "https://github.com/NSPG13/agent-bounties/issues/772"
+    }
+  ]
+}

--- a/integrations/openhands/fixtures/submitted-not-paid.json
+++ b/integrations/openhands/fixtures/submitted-not-paid.json
@@ -1,0 +1,23 @@
+{
+  "state": "submitted-not-paid",
+  "observed_at": "2026-08-06T12:00:00Z",
+  "next_action": "verify",
+  "next_action_detail": "A submission exists but no canonical BountySettled event names the solver. Do not report paid. Confirm canonical events (SubmissionAdded, verification result) and wait for BountySettled before claiming payment.",
+  "inventory": [
+    {
+      "bounty_id": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bounty_contract": "0x6666666666666666666666666666666666666666",
+      "status": "submitted",
+      "solver_reward": "2000000",
+      "verifier_reward": "10000",
+      "claim_bond": "10000",
+      "target_amount": "2010000",
+      "funded_amount": "2010000",
+      "terms_valid": true,
+      "verification_ready": true,
+      "submission_added": true,
+      "settled": false,
+      "source_url": "https://github.com/NSPG13/agent-bounties/issues/275"
+    }
+  ]
+}

--- a/integrations/openhands/fixtures/unfunded.json
+++ b/integrations/openhands/fixtures/unfunded.json
@@ -1,0 +1,21 @@
+{
+  "state": "unfunded",
+  "observed_at": "2026-08-06T12:00:00Z",
+  "next_action": "wait",
+  "next_action_detail": "Funding has not reached the target and no BountyBecameClaimable event exists. Do not start work, sign, or post a bond. Poll the canonical feed at the next interval and wait for confirmed funding.",
+  "inventory": [
+    {
+      "bounty_id": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bounty_contract": "0x2222222222222222222222222222222222222222",
+      "status": "funding-needed",
+      "solver_reward": "2000000",
+      "verifier_reward": "10000",
+      "claim_bond": "10000",
+      "target_amount": "2010000",
+      "funded_amount": "500000",
+      "terms_valid": true,
+      "verification_ready": false,
+      "source_url": "https://github.com/NSPG13/agent-bounties/issues/275"
+    }
+  ]
+}

--- a/integrations/openhands/fixtures/verifier-unready.json
+++ b/integrations/openhands/fixtures/verifier-unready.json
@@ -1,0 +1,22 @@
+{
+  "state": "verifier-unready",
+  "observed_at": "2026-08-06T12:00:00Z",
+  "next_action": "wait",
+  "next_action_detail": "The bounty is funded but verification is not ready (no supported verifier for the committed mode). Do not claim: a claim without verification readiness cannot settle. Poll canonical inventory until verification_ready becomes true or the item leaves claimable state.",
+  "inventory": [
+    {
+      "bounty_id": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "bounty_contract": "0x4444444444444444444444444444444444444444",
+      "status": "claimable",
+      "solver_reward": "2000000",
+      "verifier_reward": "10000",
+      "claim_bond": "10000",
+      "target_amount": "2010000",
+      "funded_amount": "2010000",
+      "terms_valid": true,
+      "verification_ready": false,
+      "verification_readiness_reason": "no supported verifier for quorum mode",
+      "source_url": "https://github.com/NSPG13/agent-bounties/issues/275"
+    }
+  ]
+}

--- a/scripts/check-openhands-integration.py
+++ b/scripts/check-openhands-integration.py
@@ -65,6 +65,10 @@ def main() -> None:
     if not guard_path.is_file():
         fail("missing .openhands/hooks/agent-bounties-evidence.py")
     guard = guard_path.read_text(encoding="utf-8")
+    try:
+        compile(guard, str(guard_path), "exec")
+    except SyntaxError as error:
+        fail(f"evidence guard has a syntax error: {error}")
     guard_lower = guard.lower()
     for phrase in ("submission", "evidence", "test", "decision", "deny"):
         if phrase not in guard_lower:

--- a/scripts/check-openhands-integration.py
+++ b/scripts/check-openhands-integration.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Smoke test for the OpenHands earning integration.
+
+Validates, without any network access, that the integration satisfies the
+bounty's deterministic contract:
+
+* the OpenHands skill is synchronized with canonical guidance,
+* the stop hook is wired to the evidence guard and refuses completion
+  without focused checks and submission evidence,
+* claimable, unfunded, verifier-unready, and submitted-not-paid fixtures
+  each carry exactly one deterministic next action.
+
+Exit code 0 means the integration is safe to ship; any other exit code fails
+the precommitted sandbox regression.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_NEXT_ACTIONS = {
+    "claimable.json": "claim",
+    "unfunded.json": "wait",
+    "verifier-unready.json": "wait",
+    "submitted-not-paid.json": "verify",
+}
+FEED_URL = "https://api.agentbounties.app/v1/base/autonomous-bounties/feed"
+FORBIDDEN = ("private_key", "seed phrase", "eth_sendtransaction")
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    skill_path = ROOT / ".agents" / "skills" / "agent-bounties" / "SKILL.md"
+    if not skill_path.is_file():
+        fail("missing OpenHands skill .agents/skills/agent-bounties/SKILL.md")
+    skill = skill_path.read_text(encoding="utf-8")
+    lower = skill.lower()
+    for phrase in ("canonical", "claimable", "bountysettled", "one exact next action", "post your own bounty"):
+        if phrase not in lower:
+            fail(f"OpenHands skill is missing {phrase}")
+
+    hooks_path = ROOT / ".openhands" / "hooks.json"
+    if not hooks_path.is_file():
+        fail("missing .openhands/hooks.json")
+    try:
+        hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        fail(f".openhands/hooks.json is not valid JSON: {error}")
+    stop_hooks = hooks.get("stop")
+    if not isinstance(stop_hooks, list) or not stop_hooks:
+        fail("OpenHands integration requires a stop hook")
+    if ".openhands/hooks/agent-bounties-evidence" not in json.dumps(stop_hooks, sort_keys=True):
+        fail("stop hook does not invoke the Agent Bounties evidence guard")
+
+    guard_path = ROOT / ".openhands" / "hooks" / "agent-bounties-evidence.py"
+    if not guard_path.is_file():
+        fail("missing .openhands/hooks/agent-bounties-evidence.py")
+    guard = guard_path.read_text(encoding="utf-8")
+    guard_lower = guard.lower()
+    for phrase in ("submission", "evidence", "test", "decision", "deny"):
+        if phrase not in guard_lower:
+            fail(f"evidence guard is missing {phrase}")
+    combined = (skill + guard).lower()
+    for forbidden in FORBIDDEN:
+        if forbidden in combined:
+            fail(f"OpenHands integration contains forbidden wallet behavior: {forbidden}")
+
+    fixtures_dir = ROOT / "integrations" / "openhands" / "fixtures"
+    for fixture, expected_action in EXPECTED_NEXT_ACTIONS.items():
+        path = fixtures_dir / fixture
+        if not path.is_file():
+            fail(f"missing fixture integrations/openhands/fixtures/{fixture}")
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            fail(f"fixture {fixture} is not valid JSON: {error}")
+        state = data.get("state")
+        if state != fixture.replace(".json", ""):
+            fail(f"fixture {fixture} state must be {fixture.replace('.json', '')}, got {state!r}")
+        action = data.get("next_action")
+        if action != expected_action:
+            fail(f"fixture {fixture} next_action must be {expected_action}, got {action!r}")
+        if not str(data.get("next_action_detail", "")).strip():
+            fail(f"fixture {fixture} must explain its next_action")
+
+    print("OpenHands integration smoke passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements #773: an OpenHands earning-loop integration with canonical claimability and payment checks.

## Changes

- **.agents/skills/agent-bounties/SKILL.md** — OpenHands skill synchronized with canonical guidance: canonical feed discovery, claimable-live gating, and one exact next action per inventory state.
- **.openhands/hooks.json** — stop hook wired to the evidence guard.
- **.openhands/hooks/agent-bounties-evidence.py** — deterministic guard that blocks completion reporting (decision=deny) until focused checks and submission evidence exist.
- **integrations/openhands/fixtures/** — claimable (claim), unfunded (wait), verifier-unready (wait) and submitted-not-paid (verify) states.
- **scripts/check-openhands-integration.py** — offline smoke test.

## Verification

```
OpenHands integration acceptance checks passed
```

Passes the immutable acceptance check (benchmarks/direct-growth-v2/openhands-integration/check.py).