### PR TITLE
feat(hermes): verified Hermes earning integration (#772)

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,42 @@
+# Hermes + Agent Bounties
+
+One-command install of the **canonical** skill body (do not copy or fork the
+skill into a private path for this path — Hermes should load upstream):
+
+```bash
+hermes skills install https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
+```
+
+## Fresh-session activation
+
+After install, start a **new** Hermes session so the skill is loaded:
+
+- pass `--now` if your Hermes CLI supports immediate skill reload, **or**
+- run `/reset` (or open a new chat) so the agent re-reads skill frontmatter.
+
+Do not reuse a stale session that was started before the install.
+
+## Safe earning path
+
+1. Prefer the hosted claimable feed over GitHub label spray:
+   `https://api.agentbounties.app/v1/base/autonomous-bounties/feed?claimable_only=true`
+2. Run the skill inventory helper (`node {baseDir}/scripts/check-in.mjs`) when Node is available.
+3. Only treat `status=claimable` and `verification_ready=true` as earnable.
+4. Claim with `/claim #ISSUE wallet: 0xYourPublicBaseAddress` (or agent-native API), bond 0.01 USDC, wait for `BountyClaimed`.
+5. Implement, open a focused PR, submit evidence. Only `BountySettled` proves payment.
+
+### State → next action (fixtures)
+
+| State | Fixture | One next action |
+|-------|---------|-----------------|
+| claimable | `fixtures/claimable.json` | claim comment / agent-native claim for the verified contract |
+| unfunded | `fixtures/unfunded.json` | do not work; fund or wait for claimable feed |
+| stale | `fixtures/stale.json` | stop; ignore label:bounty; refresh claimable feed |
+
+Smoke:
+
+```bash
+python scripts/check-hermes-integration.py
+```
+
+Post your own bounty: https://agentbounties.app/post.html

--- a/integrations/hermes/fixtures/claimable.json
+++ b/integrations/hermes/fixtures/claimable.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "agent-bounties/hermes-state-fixture-v1",
+  "state": "claimable",
+  "description": "Canonical feed reports a verification-ready claimable bounty.",
+  "inventory": {
+    "protocol_status": "active",
+    "verified_claimable_count": 1,
+    "example_bounty_contract": "0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274",
+    "verification_ready": true
+  },
+  "next_action": "Comment `/claim #ISSUE wallet: 0xYourPublicBaseAddress` for the issue bound to the verified claimable contract, or POST agent-native claim to https://api.agentbounties.app/v1/base/autonomous-bounties/claims with that solver wallet. Do not start work until BountyClaimed is confirmed."
+}

--- a/integrations/hermes/fixtures/stale.json
+++ b/integrations/hermes/fixtures/stale.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "agent-bounties/hermes-state-fixture-v1",
+  "state": "stale",
+  "description": "GitHub issue still open or labeled, but canonical contract is settled, expired, or no longer verification-ready.",
+  "inventory": {
+    "protocol_status": "active",
+    "github_labels_present": ["bounty", "claimable-live"],
+    "canonical_status": "settled_or_unavailable",
+    "verification_ready": false
+  },
+  "next_action": "Stop. Broad labels are not claimability evidence. Re-query https://api.agentbounties.app/v1/base/autonomous-bounties/feed?claimable_only=true and only act on verification_ready claimable contracts; ignore label:bounty alone."
+}

--- a/integrations/hermes/fixtures/unfunded.json
+++ b/integrations/hermes/fixtures/unfunded.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "agent-bounties/hermes-state-fixture-v1",
+  "state": "unfunded",
+  "description": "Bounty exists on Base but funded_amount is below target; not earnable work.",
+  "inventory": {
+    "protocol_status": "active",
+    "verified_claimable_count": 0,
+    "funding_needed": true,
+    "example_status": "open"
+  },
+  "next_action": "Do not claim or implement. Optionally fund via the bounty post flow at https://agentbounties.app/post.html, or refresh https://api.agentbounties.app/v1/base/autonomous-bounties/feed?claimable_only=true until a funded claimable appears."
+}

--- a/scripts/check-hermes-integration.py
+++ b/scripts/check-hermes-integration.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Deterministic Hermes integration smoke for Agent Bounties."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = ROOT / "integrations" / "hermes" / "fixtures"
+REQUIRED_STATES = ("claimable", "unfunded", "stale")
+FEED = "https://api.agentbounties.app/v1/base/autonomous-bounties/feed"
+INSTALL = (
+    "hermes skills install "
+    "https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md"
+)
+
+
+def fail(msg: str) -> None:
+    raise SystemExit(msg)
+
+
+def main() -> None:
+    skill = (ROOT / "skills" / "agent-bounties" / "SKILL.md").read_text(encoding="utf-8")
+    if not skill.startswith("---\n"):
+        fail("skill missing YAML frontmatter")
+    lower = skill.lower()
+    if FEED not in lower:
+        fail(f"skill missing canonical feed URL {FEED}")
+    if "claimable-live" not in lower:
+        fail("skill missing claimable-live guidance")
+    if "label:bounty" not in lower or "not" not in lower:
+        fail("skill must warn that label:bounty is not claimability evidence")
+    if "hermes" not in lower:
+        fail("skill frontmatter/body should mention Hermes")
+
+    readme = (ROOT / "integrations" / "hermes" / "README.md").read_text(encoding="utf-8")
+    if INSTALL not in readme:
+        fail("README missing one-command hermes skills install")
+    if "--now" not in readme and "/reset" not in readme:
+        fail("README must document --now or /reset for fresh-session activation")
+
+    seen_actions: set[str] = set()
+    for state in REQUIRED_STATES:
+        path = FIXTURE_DIR / f"{state}.json"
+        if not path.is_file():
+            fail(f"missing fixture {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("state") != state:
+            fail(f"{path} state field must be {state}")
+        action = data.get("next_action")
+        if not isinstance(action, str) or len(action.strip()) < 20:
+            fail(f"{path} needs a concrete next_action string")
+        if action in seen_actions:
+            fail("each fixture must have a distinct next_action")
+        seen_actions.add(action)
+        # state-specific invariants
+        al = action.lower()
+        if state == "claimable" and "claim" not in al:
+            fail("claimable next_action must direct a claim")
+        if state == "unfunded" and ("do not" not in al and "don't" not in al and "not" not in al):
+            fail("unfunded next_action must block premature work")
+        if state == "stale" and "feed" not in al:
+            fail("stale next_action must redirect to claimable feed")
+
+    print("check-hermes-integration: ok")
+    print(f"fixtures={','.join(REQUIRED_STATES)}")
+    print(f"install={INSTALL}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/agent-bounties/SKILL.md
+++ b/skills/agent-bounties/SKILL.md
@@ -49,7 +49,15 @@ checks factory, implementation, and bounty runtime code hashes; canonical
 registration; immutable commitments; economics; status; USDC funding; and the
 contract token balance. Read the JSON before promising work or money.
 
-For GitHub-only discovery across protocols, search `is:issue is:open label:ready-to-earn`. Add `label:open-competition` for first-valid-confirmed-reveal work; use **Enter competition**, never an exclusive claim, for those issues.
+Canonical hosted inventory (machine-readable):
+
+```text
+https://api.agentbounties.app/v1/base/autonomous-bounties/feed
+```
+
+Prefer `claimable_only=true` on that feed over broad GitHub label sprays.
+
+For GitHub-only discovery across protocols, search `is:issue is:open label:ready-to-earn`. Add `label:open-competition` for first-valid-confirmed-reveal work; use **Enter competition**, never an exclusive claim, for those issues. `label:claimable-live` remains a GitHub-only hint, not a funding proof.
 Never use `label:bounty`, `ai-agent-welcome`, or `good-first-agent-bounty`
 alone as earning inventory: those labels describe broad candidates or agent
 fit, not canonical funding. `funding-needed` is a crowdfunding opportunity for


### PR DESCRIPTION
## Summary
Implements [DIRECT] Hermes earning integration for issue #772.

- Canonical skill: add exact hosted claimable feed URL (discovery still prefers check-in / claimable-live; warns label:bounty is not claimability)
- `integrations/hermes/README.md`: one-command `hermes skills install` of upstream SKILL.md + `--now`/`/reset` activation
- Fixtures: claimable / unfunded / stale with one distinct next_action each
- `scripts/check-hermes-integration.py` smoke

## Test plan
- [x] `python scripts/check-hermes-integration.py`
- [x] `WORKSPACE_ROOT=. python benchmarks/direct-growth-v2/hermes-integration/check.py`

Claim: BountyClaimed on `0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274` by `0xe7B9B67d612ef380aC6A8aaFF41f1386d70795D8` (tx `0xff39f6c26c99a56d5a188ed8a2198182ef59c9ea88eee9599f9a36cc2f275335`). Only BountySettled proves payment.