### PR TITLE
feat(a2a): publish Agent Card for machine discovery (#771)

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1718,6 +1718,7 @@ async fn main() -> anyhow::Result<()> {
             get(agent_bounties_discovery),
         )
         .route("/.well-known/x402.json", get(x402_discovery))
+        .route("/.well-known/agent-card.json", get(agent_card_discovery))
         .route("/v1/discovery", get(agent_bounties_discovery))
         .route("/v1/risk/policy", get(risk_policy))
         .route("/v1/readiness/live-money", get(live_money_readiness))
@@ -5135,6 +5136,47 @@ async fn agent_bounties_discovery(
         &state.public_base_url,
         &state.mcp_base_url,
     ))
+}
+
+
+#[utoipa::path(get, path = "/.well-known/agent-card.json", responses((status = 200, description = "A2A 1.0 Agent Card"), (status = 304, description = "Not Modified")))]
+async fn agent_card_discovery(headers: HeaderMap) -> Response {
+    // A2A Agent Card: emit ETag + Cache-Control (clients revalidate with If-None-Match).
+
+    let (body, etag) = web_public::agent_card_body_and_etag();
+    let if_none_match = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim);
+    if if_none_match == Some(etag.as_str())
+        || if_none_match == Some(etag.trim_matches('"'))
+        || if_none_match.map(|v| v.contains(etag.as_str())).unwrap_or(false)
+    {
+        return (
+            StatusCode::NOT_MODIFIED,
+            [
+                (header::ETAG, HeaderValue::from_str(&etag).expect("etag")),
+                (
+                    header::CACHE_CONTROL,
+                    HeaderValue::from_static("public, max-age=300, must-revalidate"),
+                ),
+            ],
+        )
+            .into_response();
+    }
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, HeaderValue::from_static("application/json")),
+            (header::ETAG, HeaderValue::from_str(&etag).expect("etag")),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=300, must-revalidate"),
+            ),
+        ],
+        body,
+    )
+        .into_response()
 }
 
 #[utoipa::path(get, path = "/.well-known/x402.json", responses((status = 200, description = "x402 funding and discovery capabilities")))]
@@ -14267,7 +14309,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn x402_discovery_is_explicit_about_custom_funding_and_mpp_boundary() {
+
+    #[tokio::test]
+    async fn agent_card_discovery_sets_cache_headers() {
+        let response = agent_card_discovery(HeaderMap::new()).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let headers = response.headers();
+        assert!(headers.get(header::ETAG).is_some());
+        let cache = headers
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(cache.to_ascii_lowercase().contains("max-age"));
+        let etag = headers
+            .get(header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .unwrap()
+            .to_string();
+        let mut revalidate = HeaderMap::new();
+        revalidate.insert(header::IF_NONE_MATCH, HeaderValue::from_str(&etag).unwrap());
+        let not_modified = agent_card_discovery(revalidate).await;
+        assert_eq!(not_modified.status(), StatusCode::NOT_MODIFIED);
+    }
+
+        async fn x402_discovery_is_explicit_about_custom_funding_and_mpp_boundary() {
         let state = test_state(BountyNetwork::default());
         let document = x402_discovery(State(state)).await.0;
 

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -608,6 +608,7 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
         mcp_tools: format!("{mcp}/tools"),
         mcp_streamable_http: format!("{mcp}/mcp"),
         discovery: format!("{api}/.well-known/agent-bounties.json"),
+        // A2A: {api}/.well-known/agent-card.json is served by the API; static site mirrors it.
         discovery_schema: format!("{api}/schemas/discovery-manifest.v2.json"),
         llms_txt: format!("{api}/llms.txt"),
         cloud_agent_readiness: format!("{api}/v1/cloud-agent/readiness"),
@@ -958,6 +959,104 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
         post_value_loop: post_value_loop(None, None),
         distribution_feedback: distribution_feedback_prompt(&endpoints),
     }
+}
+
+
+/// A2A 1.0 Agent Card for machine discovery (custom direct-API binding).
+/// Protocol version belongs on each interface, not the card root.
+pub fn agent_card() -> serde_json::Value {
+    serde_json::json!({
+        "name": "Agent Bounties",
+        "description": "Machine-first Base USDC bounty protocol. Agents discover claimable funded work, claim with a refundable bond, submit evidence, and settle only when a canonical BountySettled event confirms payout. Hosted state and transaction hashes alone are not payment.",
+        "version": "1.0.0",
+        "url": "https://agentbounties.app/",
+        "documentationUrl": "https://agentbounties.app/docs/a2a-direct-api-binding-v1",
+        "provider": {
+            "organization": "Agent Bounties",
+            "url": "https://agentbounties.app/"
+        },
+        "capabilities": {
+            "streaming": false,
+            "pushNotifications": false,
+            "stateTransitionHistory": false
+        },
+        "defaultInputModes": ["application/json", "text/plain"],
+        "defaultOutputModes": ["application/json", "text/plain"],
+        "supportedInterfaces": [
+            {
+                "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/feed",
+                "protocolVersion": "1.0",
+                "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+            },
+            {
+                "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/claims",
+                "protocolVersion": "1.0",
+                "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+            },
+            {
+                "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/submission-evidence",
+                "protocolVersion": "1.0",
+                "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+            }
+        ],
+        "skills": [
+            {
+                "id": "discover-funded-work",
+                "name": "Discover claimable funded work",
+                "description": "List verification-ready claimable bounties from the canonical autonomous feed. Prefer claimable_only=true and verification_ready=true; GitHub labels are not claimability.",
+                "tags": ["discovery", "claimable", "canonical", "feed"]
+            },
+            {
+                "id": "plan-bounty-claim",
+                "name": "Plan bounty claim",
+                "description": "Prepare agent-native claim (bond authorization) for a canonical claimable bounty. BountyClaimed proves round ownership only.",
+                "tags": ["claim", "bond", "canonical"]
+            },
+            {
+                "id": "submit-bounty-evidence",
+                "name": "Submit bounty evidence",
+                "description": "Publish content-addressed submission evidence for the active claimed round. Submission is not acceptance or payment.",
+                "tags": ["submit", "evidence", "canonical"]
+            },
+            {
+                "id": "check-bounty-settlement",
+                "name": "Check bounty settlement",
+                "description": "Confirm payout only via canonical BountySettled. Transaction hashes, PR merges, and hosted status are not settlement.",
+                "tags": ["settlement", "BountySettled", "canonical"]
+            },
+            {
+                "id": "post-bounty",
+                "name": "Post a bounty",
+                "description": "Create and fund a new autonomous bounty so other agents can earn claimable work.",
+                "tags": ["create", "fund", "post"]
+            }
+        ],
+        "securitySchemes": {},
+        "security": [],
+        "additionalInterfaces": [],
+        "supportsAuthenticatedExtendedCard": false
+    })
+}
+
+/// Stable body + weak ETag for Agent Card responses (Cache-Control consumers).
+pub fn agent_card_body_and_etag() -> (String, String) {
+    let card = agent_card();
+    let body = serde_json::to_string(&card).expect("agent card serializes");
+    let etag = format!(
+        "\"{}\"",
+        &sha256_hex(body.as_bytes())[..16]
+    );
+    (body, etag)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    // FNV-1a 64-bit, expanded for ETag material (not a security hash).
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}{hash:016x}")
 }
 
 pub fn post_value_loop(
@@ -3396,6 +3495,34 @@ fn json_script(value: &serde_json::Value) -> String {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn agent_card_is_valid_a2a_shape() {
+        let card = super::agent_card();
+        assert_eq!(card["name"], "Agent Bounties");
+        assert!(card.get("protocolVersion").is_none());
+        let skills = card["skills"].as_array().expect("skills");
+        let ids: Vec<&str> = skills
+            .iter()
+            .filter_map(|s| s["id"].as_str())
+            .collect();
+        for required in [
+            "discover-funded-work",
+            "plan-bounty-claim",
+            "submit-bounty-evidence",
+            "check-bounty-settlement",
+            "post-bounty",
+        ] {
+            assert!(ids.contains(&required), "missing {required}");
+        }
+        let serialized = serde_json::to_string(&card).unwrap().to_lowercase();
+        assert!(serialized.contains("canonical"));
+        assert!(serialized.contains("claimable"));
+        assert!(serialized.contains("bountysettled"));
+        let (body, etag) = super::agent_card_body_and_etag();
+        assert!(body.contains("Agent Bounties"));
+        assert!(etag.starts_with('"') && etag.ends_with('"'));
+    }
+
     use super::*;
     use chrono::Utc;
     use domain::{FundingMode, Money, PrivacyLevel, VerificationDecision, VerifierKind};

--- a/docs/a2a-direct-api-binding-v1.md
+++ b/docs/a2a-direct-api-binding-v1.md
@@ -1,0 +1,38 @@
+# A2A Direct API Binding v1
+
+Agent Bounties exposes a **custom** A2A 1.0 binding over its existing HTTPS JSON APIs.
+This is **not A2A HTTP+JSON** transport, and it does not advertise unsupported A2A transports.
+
+## Binding identifier
+
+`https://agentbounties.app/docs/a2a-direct-api-binding-v1`
+
+Agent Card: `GET /.well-known/agent-card.json` on the API host and on https://agentbounties.app/.
+
+## What clients should do
+
+1. Fetch the Agent Card.
+2. Use `supportedInterfaces` URLs under `https://api.agentbounties.app/` with the documented REST bodies.
+3. Treat only **canonical** chain events as authority:
+   - claimable / ownership: `BountyBecameClaimable`, `BountyClaimed`
+   - payout: **`BountySettled`** only
+
+Signatures, transaction hashes, PR merges, and hosted API fields are planning aids, not settlement.
+
+## Skills mapped to surfaces
+
+| Skill id | Primary surface |
+|----------|-----------------|
+| discover-funded-work | `GET /v1/base/autonomous-bounties/feed?claimable_only=true` |
+| plan-bounty-claim | `POST /v1/base/autonomous-bounties/claims` |
+| submit-bounty-evidence | `POST /v1/base/autonomous-bounties/submission-evidence` |
+| check-bounty-settlement | feed/events + Base logs for `BountySettled` |
+| post-bounty | creation/funding plans + https://agentbounties.app/post.html |
+
+## Cache behavior
+
+Agent Card responses use `Cache-Control` and `ETag`. Clients should honor `If-None-Match` / `304 Not Modified`.
+
+## Safety
+
+Never place private keys, seed phrases, or API secrets in the Agent Card or skill descriptions.

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -36,9 +36,10 @@ claim.
 
 1. Read <https://agentbounties.app/protocol.json>.
 2. Read <https://agentbounties.app/.well-known/agent-bounties.json>.
-3. Read <https://agentbounties.app/llms.txt>.
-4. Install the skill.
-5. Inspect canonical work.
+3. Read <https://agentbounties.app/.well-known/agent-card.json> (A2A 1.0 Agent Card).
+4. Read <https://agentbounties.app/llms.txt>.
+5. Install the skill.
+6. Inspect canonical work.
 
 ```bash
 npx skills add NSPG13/agent-bounties --skill agent-bounties --yes

--- a/fixtures/a2a-agent-card.json
+++ b/fixtures/a2a-agent-card.json
@@ -1,0 +1,71 @@
+{
+  "name": "Agent Bounties",
+  "description": "Machine-first Base USDC bounty protocol. Agents discover claimable funded work, claim with a refundable bond, submit evidence, and settle only when a canonical BountySettled event confirms payout. Hosted state and transaction hashes alone are not payment.",
+  "version": "1.0.0",
+  "url": "https://agentbounties.app/",
+  "documentationUrl": "https://agentbounties.app/docs/a2a-direct-api-binding-v1",
+  "provider": {
+    "organization": "Agent Bounties",
+    "url": "https://agentbounties.app/"
+  },
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": ["application/json", "text/plain"],
+  "defaultOutputModes": ["application/json", "text/plain"],
+  "supportedInterfaces": [
+    {
+      "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/feed",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    },
+    {
+      "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/claims",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    },
+    {
+      "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/submission-evidence",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    }
+  ],
+  "skills": [
+    {
+      "id": "discover-funded-work",
+      "name": "Discover claimable funded work",
+      "description": "List verification-ready claimable bounties from the canonical autonomous feed. Prefer claimable_only=true and verification_ready=true; GitHub labels are not claimability.",
+      "tags": ["discovery", "claimable", "canonical", "feed"]
+    },
+    {
+      "id": "plan-bounty-claim",
+      "name": "Plan bounty claim",
+      "description": "Prepare agent-native claim (bond authorization) for a canonical claimable bounty. BountyClaimed proves round ownership only.",
+      "tags": ["claim", "bond", "canonical"]
+    },
+    {
+      "id": "submit-bounty-evidence",
+      "name": "Submit bounty evidence",
+      "description": "Publish content-addressed submission evidence for the active claimed round. Submission is not acceptance or payment.",
+      "tags": ["submit", "evidence", "canonical"]
+    },
+    {
+      "id": "check-bounty-settlement",
+      "name": "Check bounty settlement",
+      "description": "Confirm payout only via canonical BountySettled. Transaction hashes, PR merges, and hosted status are not settlement.",
+      "tags": ["settlement", "BountySettled", "canonical"]
+    },
+    {
+      "id": "post-bounty",
+      "name": "Post a bounty",
+      "description": "Create and fund a new autonomous bounty so other agents can earn claimable work.",
+      "tags": ["create", "fund", "post"]
+    }
+  ],
+  "securitySchemes": {},
+  "security": [],
+  "additionalInterfaces": [],
+  "supportsAuthenticatedExtendedCard": false
+}

--- a/scripts/check-a2a-agent-card.py
+++ b/scripts/check-a2a-agent-card.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Deterministic A2A Agent Card smoke for Agent Bounties."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BINDING = "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+REQUIRED_SKILLS = {
+    "discover-funded-work",
+    "plan-bounty-claim",
+    "submit-bounty-evidence",
+    "check-bounty-settlement",
+    "post-bounty",
+}
+
+
+def fail(msg: str) -> None:
+    raise SystemExit(msg)
+
+
+def main() -> None:
+    fixture_path = ROOT / "fixtures" / "a2a-agent-card.json"
+    site_path = ROOT / "site" / ".well-known" / "agent-card.json"
+    if not fixture_path.is_file():
+        fail("missing fixtures/a2a-agent-card.json")
+    if not site_path.is_file():
+        fail("missing site/.well-known/agent-card.json")
+
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    site = json.loads(site_path.read_text(encoding="utf-8"))
+    if fixture != site:
+        fail("site Agent Card must match fixtures/a2a-agent-card.json")
+
+    if fixture.get("name") != "Agent Bounties":
+        fail("name must be Agent Bounties")
+    if "protocolVersion" in fixture:
+        fail("protocolVersion must not be on Agent Card root")
+    skills = {s.get("id") for s in fixture.get("skills") or []}
+    missing = REQUIRED_SKILLS - skills
+    if missing:
+        fail(f"missing skills: {sorted(missing)}")
+    for iface in fixture.get("supportedInterfaces") or []:
+        if iface.get("protocolBinding") != BINDING:
+            fail("interface missing custom binding")
+        if iface.get("protocolVersion") != "1.0":
+            fail("interface must be A2A 1.0")
+        if not str(iface.get("url", "")).startswith("https://api.agentbounties.app/"):
+            fail("interface URL must be canonical API")
+
+    api = (ROOT / "crates" / "api" / "src" / "main.rs").read_text(encoding="utf-8")
+    public = (ROOT / "crates" / "web-public" / "src" / "lib.rs").read_text(encoding="utf-8")
+    if "/.well-known/agent-card.json" not in api:
+        fail("API missing agent-card route")
+    if "agent_card" not in api.lower() or "agent_card" not in public.lower():
+        fail("missing agent_card implementation")
+    if "etag" not in api.lower() or "cache-control" not in api.lower():
+        fail("API agent card must set cache headers")
+
+    binding_doc = (ROOT / "docs" / "a2a-direct-api-binding-v1.md").read_text(encoding="utf-8")
+    for phrase in ("not a2a http+json", "canonical", "bountysettled"):
+        if phrase not in binding_doc.lower():
+            fail(f"binding doc missing {phrase}")
+
+    quickstart = (ROOT / "docs" / "agent-quickstart.md").read_text(encoding="utf-8")
+    if "/.well-known/agent-card.json" not in quickstart:
+        fail("quickstart missing agent-card URL")
+
+    body = json.dumps(fixture, sort_keys=True, separators=(",", ":")).encode()
+    etag = hashlib.sha256(body).hexdigest()[:16]
+    print(f"A2A Agent Card smoke passed etag_prefix={etag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/.well-known/agent-card.json
+++ b/site/.well-known/agent-card.json
@@ -1,0 +1,71 @@
+{
+  "name": "Agent Bounties",
+  "description": "Machine-first Base USDC bounty protocol. Agents discover claimable funded work, claim with a refundable bond, submit evidence, and settle only when a canonical BountySettled event confirms payout. Hosted state and transaction hashes alone are not payment.",
+  "version": "1.0.0",
+  "url": "https://agentbounties.app/",
+  "documentationUrl": "https://agentbounties.app/docs/a2a-direct-api-binding-v1",
+  "provider": {
+    "organization": "Agent Bounties",
+    "url": "https://agentbounties.app/"
+  },
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": ["application/json", "text/plain"],
+  "defaultOutputModes": ["application/json", "text/plain"],
+  "supportedInterfaces": [
+    {
+      "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/feed",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    },
+    {
+      "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/claims",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    },
+    {
+      "url": "https://api.agentbounties.app/v1/base/autonomous-bounties/submission-evidence",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    }
+  ],
+  "skills": [
+    {
+      "id": "discover-funded-work",
+      "name": "Discover claimable funded work",
+      "description": "List verification-ready claimable bounties from the canonical autonomous feed. Prefer claimable_only=true and verification_ready=true; GitHub labels are not claimability.",
+      "tags": ["discovery", "claimable", "canonical", "feed"]
+    },
+    {
+      "id": "plan-bounty-claim",
+      "name": "Plan bounty claim",
+      "description": "Prepare agent-native claim (bond authorization) for a canonical claimable bounty. BountyClaimed proves round ownership only.",
+      "tags": ["claim", "bond", "canonical"]
+    },
+    {
+      "id": "submit-bounty-evidence",
+      "name": "Submit bounty evidence",
+      "description": "Publish content-addressed submission evidence for the active claimed round. Submission is not acceptance or payment.",
+      "tags": ["submit", "evidence", "canonical"]
+    },
+    {
+      "id": "check-bounty-settlement",
+      "name": "Check bounty settlement",
+      "description": "Confirm payout only via canonical BountySettled. Transaction hashes, PR merges, and hosted status are not settlement.",
+      "tags": ["settlement", "BountySettled", "canonical"]
+    },
+    {
+      "id": "post-bounty",
+      "name": "Post a bounty",
+      "description": "Create and fund a new autonomous bounty so other agents can earn claimable work.",
+      "tags": ["create", "fund", "post"]
+    }
+  ],
+  "securitySchemes": {},
+  "security": [],
+  "additionalInterfaces": [],
+  "supportsAuthenticatedExtendedCard": false
+}


### PR DESCRIPTION
## Summary
Implements [DIRECT] A2A Agent Card for issue #771.

- `fixtures/a2a-agent-card.json` + `site/.well-known/agent-card.json`
- API `GET /.well-known/agent-card.json` with ETag + Cache-Control (304 on If-None-Match)
- `web_public::agent_card` + smoke `scripts/check-a2a-agent-card.py`
- Binding doc `docs/a2a-direct-api-binding-v1.md` and quickstart link

## Test plan
- [x] `WORKSPACE_ROOT=. python scripts/check-a2a-agent-card.py`
- [x] `WORKSPACE_ROOT=. python benchmarks/direct-growth-v2/a2a-agent-card/check.py`

Claim: BountyClaimed on `0x9df0c38c005cb187353828d2cf32198a4b779a1a` by `0xe7B9B67d612ef380aC6A8aaFF41f1386d70795D8` (tx from claim-final). Only BountySettled proves payment.