### PR TITLE
ops: recover missing Open Competition Render worker

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,26 +70,30 @@ succeeds on a push to `main`, the workflow:
 
 1. checks out the exact successful-CI SHA;
 2. verifies it is the latest successful CI revision reachable from `main`;
-3. resolves all three Render services by exact name and verifies repository,
+3. resolves all four Render services by exact name and verifies repository,
    branch, and service type;
-4. disables any drifted native auto-deploy setting;
-5. reconciles `PUBLIC_BASE_URL`, `MCP_BASE_URL`, and `WEBSITE_BASE_URL` on
+4. if and only if the additive Open Competition V1 indexer is absent, validates
+   exactly one Blueprint bound to this repository, `main`, and `render.yaml`,
+   cycles its supported Auto Sync setting, waits for the exact typed worker,
+   and then revalidates every service binding;
+5. disables any drifted native auto-deploy setting;
+6. reconciles `PUBLIC_BASE_URL`, `MCP_BASE_URL`, and `WEBSITE_BASE_URL` on
    both public services;
-6. reconciles all nonsecret cloud-agent settings on API and copies the optional
+7. reconciles all nonsecret cloud-agent settings on API and copies the optional
    GitHub-held model key without including its value in evidence;
-7. creates or updates the optional FID-filtered Neynar provider webhook and
+8. creates or updates the optional FID-filtered Neynar provider webhook and
    reconciles its bot identity, reply signer, and generated signing secret on
    API without including their values in evidence;
-8. calls Render's deploy API with the exact commit for API, MCP, and worker;
-9. waits for all three deploys to reach `live` and fails on terminal errors;
-10. verifies exact revision and protocol headers from API and MCP `/health`;
-11. attests cloud readiness and fails if a supplied model credential did not
+9. calls Render's deploy API with the exact commit for API, MCP, and both workers;
+10. waits for all four deploys to reach `live` and fails on terminal errors;
+11. verifies exact revision and protocol headers from API and MCP `/health`;
+12. attests cloud readiness and fails if a supplied model credential did not
     become usable;
-12. attests social mention readiness when provider values were supplied;
-13. stores a redacted 30-day deployment evidence artifact.
+13. attests social mention readiness when provider values were supplied;
+14. stores a redacted 30-day deployment evidence artifact.
 
 Configure the GitHub Actions secret `RENDER_API_KEY`. Create it in the
-Render Dashboard for the workspace that owns these three services, then store
+Render Dashboard for the workspace that owns these four services, then store
 it only under repository **Settings > Secrets and variables > Actions**. Never
 put the key in Render variables, workflow inputs, logs, issues, or Git. A
 missing key is a visible workflow failure, not a silent manual-deploy fallback.

--- a/docs/self-healing-operations.md
+++ b/docs/self-healing-operations.md
@@ -39,15 +39,19 @@ Base indexer -> poll -> persist heartbeat/events/cursor
 malformed log/cursor/config/integrity failure -> failed heartbeat -> halt ingestion
                                                     +-> contain + incident
 
-successful main CI -> exact-SHA Render deploy controller -> API/MCP/worker live
+successful main CI -> exact-SHA Render deploy controller -> API/MCP/workers live
                                                        +-> exact web revision proof
 ```
 
 The deploy controller is separate from the public observer. It is allowed to
 deploy the latest successful reviewed application revision reachable from
 main. It resolves services against the canonical repository and branch,
-disables native commit-trigger deploys, polls all three Render deploy records,
-and writes redacted evidence. A newer failed main commit cannot suppress the
+disables native commit-trigger deploys, polls all four Render deploy records,
+and writes redacted evidence. If only the allowlisted additive Open Competition
+indexer is missing, it first verifies the exact repository Blueprint identity,
+cycles Auto Sync through Render's supported API, waits for the typed resource,
+and revalidates all bindings. Any other missing or ambiguous service fails
+closed. A newer failed main commit cannot suppress the
 last known-good release, and an older successful run skips after a newer
 successful run exists. It cannot deploy an unrelated branch, contract, wallet,
 or payment action. A missing credential, ambiguous service, failed build,

--- a/docs/software-development-lifecycle.md
+++ b/docs/software-development-lifecycle.md
@@ -185,8 +185,12 @@ activate from an unattended CI wallet.
 Reviewed application releases use the `Render Deploy Recovery` workflow as an
 R2 action. It runs only after successful `CI` for a same-repository push to
 `main`, requires the latest successful SHA reachable from current `main`,
-deploys that exact SHA through Render's API, waits for API, MCP, and worker to
-reach terminal `live`, and verifies API/MCP revision headers.
+deploys that exact SHA through Render's API, waits for API, MCP, the legacy
+indexer, and the versioned Open Competition indexer to reach terminal `live`,
+and verifies API/MCP revision headers. The sole provisioning recovery is an
+absent allowlisted Open Competition indexer: the controller verifies the exact
+repository Blueprint identity, synchronizes it, and revalidates all bindings
+before deployment. Other missing or ambiguous services fail closed.
 Native provider commit triggers are disabled so two independent deploy
 authorities cannot race. The Render credential is isolated to this workflow;
 the scheduled observer and application containers never receive it. This

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -19,6 +19,11 @@ from typing import Any, Callable
 SCHEMA = "agent-bounties/render-deploy-evidence-v1"
 REPOSITORY = "github.com/nspg13/agent-bounties"
 PROTOCOL = "agent-bounties/autonomous-v1"
+BLUEPRINT_PATH = "render.yaml"
+BLUEPRINT_RECOVERABLE_SERVICE_NAMES = frozenset(
+    {"agent-bounties-open-competition-v1-indexer"}
+)
+BLUEPRINT_STATUSES = {"created", "paused", "in_sync", "syncing", "error"}
 HEALTH_STABILITY_PROBES = 8
 DEPLOY_MODES = {"build_and_deploy", "deploy_only"}
 ACTIVE_STATUSES = {
@@ -67,6 +72,12 @@ CLOUD_AGENT_RUNTIME_ENVIRONMENT = {
 
 class RecoveryError(RuntimeError):
     pass
+
+
+class RenderServiceMissing(RecoveryError):
+    def __init__(self, service_name: str) -> None:
+        self.service_name = service_name
+        super().__init__(f"expected exactly one Render service named {service_name}; found 0")
 
 
 class RenderHttpError(RecoveryError):
@@ -277,6 +288,8 @@ def select_service(spec: ServiceSpec, payload: object) -> dict[str, Any]:
         for service in unwrap_service_entries(payload)
         if service.get("name") == spec.name
     ]
+    if not matches:
+        raise RenderServiceMissing(spec.name)
     if len(matches) != 1:
         raise RecoveryError(
             f"expected exactly one Render service named {spec.name}; found {len(matches)}"
@@ -292,6 +305,80 @@ def select_service(spec: ServiceSpec, payload: object) -> dict[str, Any]:
     if not isinstance(service_id, str) or not re.fullmatch(r"srv-[0-9a-z]+", service_id):
         raise RecoveryError(f"{spec.name} has an invalid Render service id")
     return service
+
+
+def unwrap_blueprint_entries(payload: object) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise RecoveryError("Render Blueprint-list response must be an array")
+    blueprints: list[dict[str, Any]] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        blueprint = entry.get("blueprint", entry)
+        if isinstance(blueprint, dict):
+            blueprints.append(blueprint)
+    return blueprints
+
+
+def validate_blueprint(blueprint: object) -> dict[str, Any]:
+    if not isinstance(blueprint, dict):
+        raise RecoveryError("Render Blueprint response must be an object")
+    blueprint = blueprint.get("blueprint", blueprint)
+    if not isinstance(blueprint, dict):
+        raise RecoveryError("Render Blueprint response is missing metadata")
+    blueprint_id = blueprint.get("id")
+    if not isinstance(blueprint_id, str) or not re.fullmatch(
+        r"exs-[0-9a-z]{20}", blueprint_id
+    ):
+        raise RecoveryError("Render Blueprint has an invalid id")
+    if normalize_repo(blueprint.get("repo")) != REPOSITORY:
+        raise RecoveryError("Render Blueprint is connected to an unexpected repository")
+    if blueprint.get("branch") != "main":
+        raise RecoveryError("Render Blueprint is not connected to the main branch")
+    if blueprint.get("path") != BLUEPRINT_PATH:
+        raise RecoveryError("Render Blueprint uses an unexpected file path")
+    status = blueprint.get("status")
+    if status not in BLUEPRINT_STATUSES:
+        raise RecoveryError("Render Blueprint has an unknown status")
+    if not isinstance(blueprint.get("autoSync"), bool):
+        raise RecoveryError("Render Blueprint is missing its Auto Sync state")
+    resources = blueprint.get("resources", [])
+    if not isinstance(resources, list):
+        raise RecoveryError("Render Blueprint resources must be an array")
+    return blueprint
+
+
+def select_blueprint(payload: object) -> dict[str, Any]:
+    candidates = [
+        blueprint
+        for blueprint in unwrap_blueprint_entries(payload)
+        if normalize_repo(blueprint.get("repo")) == REPOSITORY
+        and blueprint.get("branch") == "main"
+        and blueprint.get("path") == BLUEPRINT_PATH
+    ]
+    if len(candidates) != 1:
+        raise RecoveryError(
+            "expected exactly one Render Blueprint for the repository main branch and "
+            f"{BLUEPRINT_PATH}; found {len(candidates)}"
+        )
+    return validate_blueprint(candidates[0])
+
+
+def blueprint_has_service(
+    blueprint: dict[str, Any], spec: ServiceSpec
+) -> bool:
+    matches = [
+        resource
+        for resource in blueprint.get("resources", [])
+        if isinstance(resource, dict) and resource.get("name") == spec.name
+    ]
+    if len(matches) > 1:
+        raise RecoveryError(f"Render Blueprint has duplicate resources named {spec.name}")
+    if not matches:
+        return False
+    if matches[0].get("type") != spec.service_type:
+        raise RecoveryError(f"Render Blueprint has an unexpected type for {spec.name}")
+    return True
 
 
 def unwrap_deploy(payload: object) -> dict[str, Any]:
@@ -522,11 +609,109 @@ class RenderClient:
             self._sleep(float(attempt * 2))
         raise AssertionError("unreachable")
 
+    def _write_with_retry(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any],
+        attempts: int = 3,
+    ) -> Any:
+        for attempt in range(1, attempts + 1):
+            try:
+                return self._request_json(method, path, payload)
+            except RenderHttpError as error:
+                if error.status not in TRANSIENT_HTTP_STATUSES or attempt == attempts:
+                    raise
+            except RenderTransportError:
+                if attempt == attempts:
+                    raise
+            self._sleep(float(attempt * 2))
+        raise AssertionError("unreachable")
+
     def resolve_service(self, spec: ServiceSpec) -> dict[str, Any]:
         query = urllib.parse.urlencode(
             {"name": spec.name, "includePreviews": "false", "limit": "20"}
         )
         return select_service(spec, self._read_with_retry(f"/services?{query}"))
+
+    def ensure_blueprint_service(
+        self,
+        spec: ServiceSpec,
+        *,
+        attempts: int = 60,
+        poll_seconds: float = 5,
+    ) -> dict[str, Any]:
+        if spec.name not in BLUEPRINT_RECOVERABLE_SERVICE_NAMES:
+            raise RecoveryError(f"Blueprint recovery is not authorized for {spec.name}")
+        if attempts < 1 or poll_seconds < 0:
+            raise RecoveryError("Blueprint recovery polling configuration is invalid")
+
+        blueprint = select_blueprint(self._read_with_retry("/blueprints?limit=100"))
+        blueprint_id = blueprint["id"]
+        if not blueprint_has_service(blueprint, spec):
+            disabled_for_recovery = False
+            try:
+                if blueprint["autoSync"]:
+                    disabled = validate_blueprint(
+                        self._write_with_retry(
+                            "PATCH",
+                            f"/blueprints/{blueprint_id}",
+                            {"autoSync": False},
+                        )
+                    )
+                    if disabled["autoSync"]:
+                        raise RecoveryError("Render did not disable Blueprint Auto Sync")
+                    disabled_for_recovery = True
+                enabled = validate_blueprint(
+                    self._write_with_retry(
+                        "PATCH",
+                        f"/blueprints/{blueprint_id}",
+                        {"autoSync": True, "path": BLUEPRINT_PATH},
+                    )
+                )
+                if not enabled["autoSync"]:
+                    raise RecoveryError("Render did not enable Blueprint Auto Sync")
+            except RecoveryError as error:
+                if disabled_for_recovery:
+                    try:
+                        restored = validate_blueprint(
+                            self._write_with_retry(
+                                "PATCH",
+                                f"/blueprints/{blueprint_id}",
+                                {"autoSync": True, "path": BLUEPRINT_PATH},
+                            )
+                        )
+                    except RecoveryError as restore_error:
+                        raise RecoveryError(
+                            "Blueprint recovery failed and Render Auto Sync could not be "
+                            "restored"
+                        ) from restore_error
+                    if not restored["autoSync"]:
+                        raise RecoveryError(
+                            "Blueprint recovery failed and Render Auto Sync remains disabled"
+                        ) from error
+                raise
+
+        last_status = blueprint.get("status")
+        for attempt in range(1, attempts + 1):
+            current = validate_blueprint(
+                self._read_with_retry(f"/blueprints/{blueprint_id}")
+            )
+            last_status = current["status"]
+            if blueprint_has_service(current, spec):
+                try:
+                    return self.resolve_service(spec)
+                except RenderServiceMissing:
+                    pass
+            if current["status"] == "error":
+                raise RecoveryError(
+                    f"Render Blueprint entered error state before creating {spec.name}"
+                )
+            if attempt < attempts:
+                self._sleep(poll_seconds)
+        raise RecoveryError(
+            f"Render Blueprint did not create {spec.name}; last status {last_status}"
+        )
 
     def disable_native_auto_deploy(self, service: dict[str, Any]) -> None:
         if auto_deploy_disabled(service.get("autoDeploy")):
@@ -1316,8 +1501,24 @@ def deploy(
     initial: dict[str, dict[str, Any]] = {}
     preexisting_live: dict[str, dict[str, Any]] = {}
 
+    resolved: dict[str, dict[str, Any]] = {}
+    missing: list[ServiceSpec] = []
     for spec in specs:
-        services.append((spec, client.resolve_service(spec)))
+        try:
+            resolved[spec.name] = client.resolve_service(spec)
+        except RenderServiceMissing:
+            if spec.name not in BLUEPRINT_RECOVERABLE_SERVICE_NAMES:
+                raise
+            missing.append(spec)
+
+    for spec in missing:
+        resolved[spec.name] = client.ensure_blueprint_service(spec)
+
+    # Revalidate every binding after a Blueprint sync and before changing any
+    # service configuration or triggering a deployment.
+    if missing:
+        resolved = {spec.name: client.resolve_service(spec) for spec in specs}
+    services = [(spec, resolved[spec.name]) for spec in specs]
 
     if deploy_mode == "deploy_only":
         for spec, service in services:

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -79,6 +79,21 @@ class EnvironmentClient:
         return {"key": key, "value": value, "changed": self.changed}
 
 
+def blueprint_record(**overrides):
+    record = {
+        "id": "exs-" + "a" * 20,
+        "name": "agent-bounties-production",
+        "status": "in_sync",
+        "autoSync": True,
+        "repo": "https://github.com/NSPG13/agent-bounties.git",
+        "branch": "main",
+        "path": "render.yaml",
+        "resources": [],
+    }
+    record.update(overrides)
+    return record
+
+
 class ResolutionFailureClient:
     def __init__(self) -> None:
         self.resolved = []
@@ -161,6 +176,117 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             recovery.select_service(spec, [{"service": wrong}])
         with self.assertRaisesRegex(recovery.RecoveryError, "exactly one"):
             recovery.select_service(spec, [{"service": service}, {"service": service}])
+
+    def test_missing_service_has_a_typed_fail_closed_error(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        with self.assertRaises(recovery.RenderServiceMissing) as raised:
+            recovery.select_service(spec, [])
+        self.assertEqual(raised.exception.service_name, spec.name)
+
+    def test_blueprint_selection_is_exact_and_repository_bound(self) -> None:
+        selected = recovery.select_blueprint(
+            [{"blueprint": blueprint_record()}, {"blueprint": blueprint_record(
+                id="exs-" + "b" * 20,
+                branch="staging",
+            )}]
+        )
+        self.assertEqual(selected["id"], "exs-" + "a" * 20)
+
+        with self.assertRaisesRegex(recovery.RecoveryError, "exactly one"):
+            recovery.select_blueprint(
+                [
+                    {"blueprint": blueprint_record()},
+                    {"blueprint": blueprint_record(id="exs-" + "b" * 20)},
+                ]
+            )
+        with self.assertRaisesRegex(recovery.RecoveryError, "exactly one"):
+            recovery.select_blueprint(
+                [{"blueprint": blueprint_record(repo="https://github.com/attacker/fork")}]
+            )
+
+    def test_blueprint_recovery_materializes_only_the_pinned_worker(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        resource = {"id": "srv-" + "c" * 20, "name": spec.name, "type": spec.service_type}
+        service = {
+            "id": resource["id"],
+            "name": spec.name,
+            "type": spec.service_type,
+            "branch": "main",
+            "repo": "https://github.com/NSPG13/agent-bounties.git",
+        }
+        client = RecordingClient()
+        sleeps = []
+        client._sleep = sleeps.append
+        responses = [
+            [{"blueprint": blueprint_record()}],
+            blueprint_record(autoSync=False),
+            blueprint_record(autoSync=True),
+            blueprint_record(status="syncing"),
+            blueprint_record(resources=[resource]),
+            [{"service": service}],
+        ]
+        with mock.patch.object(client, "_request_json", side_effect=responses) as request:
+            self.assertEqual(
+                client.ensure_blueprint_service(spec, attempts=3, poll_seconds=0.25),
+                service,
+            )
+
+        blueprint_id = "exs-" + "a" * 20
+        self.assertEqual(
+            request.call_args_list,
+            [
+                mock.call("GET", "/blueprints?limit=100"),
+                mock.call("PATCH", f"/blueprints/{blueprint_id}", {"autoSync": False}),
+                mock.call(
+                    "PATCH",
+                    f"/blueprints/{blueprint_id}",
+                    {"autoSync": True, "path": "render.yaml"},
+                ),
+                mock.call("GET", f"/blueprints/{blueprint_id}"),
+                mock.call("GET", f"/blueprints/{blueprint_id}"),
+                mock.call(
+                    "GET",
+                    "/services?name=agent-bounties-open-competition-v1-indexer&includePreviews=false&limit=20",
+                ),
+            ],
+        )
+        self.assertEqual(sleeps, [0.25])
+
+    def test_blueprint_recovery_refuses_other_missing_services(self) -> None:
+        client = RecordingClient()
+        with self.assertRaisesRegex(recovery.RecoveryError, "not authorized"):
+            client.ensure_blueprint_service(recovery.SERVICE_SPECS[0])
+        self.assertEqual(client.requests, [])
+
+    def test_blueprint_recovery_restores_auto_sync_after_enable_failure(self) -> None:
+        client = RecordingClient()
+        responses = [
+            [{"blueprint": blueprint_record()}],
+            blueprint_record(autoSync=False),
+            recovery.RenderHttpError(400, "invalid update"),
+            blueprint_record(autoSync=True),
+        ]
+        with mock.patch.object(client, "_request_json", side_effect=responses) as request:
+            with self.assertRaises(recovery.RenderHttpError):
+                client.ensure_blueprint_service(recovery.SERVICE_SPECS[-1])
+
+        blueprint_id = "exs-" + "a" * 20
+        self.assertEqual(
+            request.call_args_list[-1],
+            mock.call(
+                "PATCH",
+                f"/blueprints/{blueprint_id}",
+                {"autoSync": True, "path": "render.yaml"},
+            ),
+        )
+
+    def test_blueprint_resource_type_mismatch_fails_closed(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        blueprint = blueprint_record(
+            resources=[{"name": spec.name, "type": "web_service"}]
+        )
+        with self.assertRaisesRegex(recovery.RecoveryError, "unexpected type"):
+            recovery.blueprint_has_service(blueprint, spec)
 
     def test_existing_deploy_reuses_only_active_exact_revision(self) -> None:
         revision = "a" * 40


### PR DESCRIPTION
## Outcome\n\nAllows the exact-SHA Render release controller to recover one narrowly allowlisted missing resource: gent-bounties-open-competition-v1-indexer.\n\n## Safety boundary\n\n- Validates exactly one Blueprint bound to NSPG13/agent-bounties, main, and repository-root ender.yaml.\n- Uses Render's supported Blueprint Auto Sync API and restores Auto Sync if the enable operation fails.\n- Waits for the exact worker name and ackground_worker type, then revalidates all four service bindings before normal configuration or deployment mutation.\n- Any missing legacy service, duplicate, wrong repository, wrong branch, wrong path, wrong type, or Blueprint error fails closed.\n- Does not change contract bytecode, factory addresses, historical rows, active bounties, contributors, claims, or payouts. Public Open Competition creation/commitments/inventory remain disabled.\n\n## Evidence\n\n- python scripts/test_render_deploy_recovery.py — 60 passed\n- python scripts/check-render-blueprint.py — passed\n- Python compilation — passed\n- scripts/preflight.ps1 -Mode core — passed\n- git diff --check — passed\n\nFollow-up to #796 and failed-closed deployment run 31198370032.