### PR TITLE
Add bounded Render worker provisioning fallback

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,8 +74,12 @@ succeeds on a push to `main`, the workflow:
    branch, and service type;
 4. if and only if the additive Open Competition V1 indexer is absent, validates
    exactly one Blueprint bound to this repository, `main`, and `render.yaml`,
-   cycles its supported Auto Sync setting, waits for the exact typed worker,
-   and then revalidates every service binding;
+   cycles its supported Auto Sync setting, and waits for the exact typed worker;
+   if an otherwise healthy Blueprint remains in sync without materializing that
+   worker, provisions only that allowlisted worker through Render's service API
+   by copying the validated legacy worker's workspace, project environment, and
+   database binding, attaches the exact existing environment group, verifies
+   every nonsecret value by readback, and then revalidates all four bindings;
 5. disables any drifted native auto-deploy setting;
 6. reconciles `PUBLIC_BASE_URL`, `MCP_BASE_URL`, and `WEBSITE_BASE_URL` on
    both public services;

--- a/docs/self-healing-operations.md
+++ b/docs/self-healing-operations.md
@@ -50,8 +50,12 @@ disables native commit-trigger deploys, polls all four Render deploy records,
 and writes redacted evidence. If only the allowlisted additive Open Competition
 indexer is missing, it first verifies the exact repository Blueprint identity,
 cycles Auto Sync through Render's supported API, waits for the typed resource,
-and revalidates all bindings. Any other missing or ambiguous service fails
-closed. A newer failed main commit cannot suppress the
+and revalidates all bindings. If the Blueprint remains healthy but does not
+materialize that one worker, the controller may create only the allowlisted
+worker through Render's service API. It derives workspace, project environment,
+database, and environment-group identity from already validated resources and
+read-verifies the resulting service before deployment. Any other missing or
+ambiguous service fails closed. A newer failed main commit cannot suppress the
 last known-good release, and an older successful run skips after a newer
 successful run exists. It cannot deploy an unrelated branch, contract, wallet,
 or payment action. A missing credential, ambiguous service, failed build,

--- a/docs/software-development-lifecycle.md
+++ b/docs/software-development-lifecycle.md
@@ -189,7 +189,11 @@ deploys that exact SHA through Render's API, waits for API, MCP, the legacy
 indexer, and the versioned Open Competition indexer to reach terminal `live`,
 and verifies API/MCP revision headers. The sole provisioning recovery is an
 absent allowlisted Open Competition indexer: the controller verifies the exact
-repository Blueprint identity, synchronizes it, and revalidates all bindings
+repository Blueprint identity and synchronizes it. If Render reports the
+Blueprint healthy without materializing the worker, the controller may create
+only that worker through the service API using the validated legacy worker's
+workspace, project environment, database binding, and exact existing
+environment group. It read-verifies the new worker and revalidates all bindings
 before deployment. Other missing or ambiguous services fail closed.
 Native provider commit triggers are disabled so two independent deploy
 authorities cannot race. The Render credential is isolated to this workflow;

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -5,6 +5,8 @@ import re
 import sys
 from pathlib import Path
 
+from render_deploy_recovery import OPEN_COMPETITION_WORKER_ENVIRONMENT
+
 
 SERVICE_NAMES = [
     "agent-bounties-api",
@@ -360,15 +362,9 @@ def main() -> int:
             if active:
                 require_env_value(block, "BASE_INDEXER_FACTORY_CONTRACT", str(factory["contract"]))
         if service == "agent-bounties-open-competition-v1-indexer":
-            require_env_value(block, "BASE_INDEXER_PROTOCOL", "open-competition-v1")
-            require_env_value(block, "OPEN_COMPETITION_INDEXER_NETWORK", "base-mainnet")
-            require_env_value(
-                block,
-                "OPEN_COMPETITION_V1_FACTORY_CONTRACT",
-                "0x9e9382beb8b1a45b737d484b5eafa7b8779d4ca5",
-            )
-            require_env_value(block, "OPEN_COMPETITION_V1_DEPLOYMENT_BLOCK", '"49663931"')
-            require_env_value(block, "OPEN_COMPETITION_INDEXER_RPC_URL", rpc_url)
+            for key, value in OPEN_COMPETITION_WORKER_ENVIRONMENT.items():
+                rendered_value = f'"{value}"' if value.isdecimal() else value
+                require_env_value(block, key, rendered_value)
 
     database = section(text, "databases")
     for required in (

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -24,6 +24,35 @@ BLUEPRINT_RECOVERABLE_SERVICE_NAMES = frozenset(
     {"agent-bounties-open-competition-v1-indexer"}
 )
 BLUEPRINT_STATUSES = {"created", "paused", "in_sync", "syncing", "error"}
+ENV_GROUP_SERVICE_TYPES = {
+    "static_site": "static",
+    "web_service": "web",
+    "private_service": "pserv",
+    "background_worker": "worker",
+    "cron_job": "cron",
+}
+OPEN_COMPETITION_WORKER_NAME = "agent-bounties-open-competition-v1-indexer"
+OPEN_COMPETITION_REFERENCE_SERVICE_NAME = "agent-bounties-base-indexer"
+OPEN_COMPETITION_ENV_GROUP_NAME = "agent-bounties-base"
+OPEN_COMPETITION_WORKER_ENVIRONMENT = {
+    "APP_PACKAGE": "worker",
+    "APP_BINARY": "worker",
+    "RUST_LOG": "info",
+    "PUBLIC_BASE_URL": "https://api.agentbounties.app",
+    "BASE_INDEXER_PROTOCOL": "open-competition-v1",
+    "OPEN_COMPETITION_INDEXER_NETWORK": "base-mainnet",
+    "OPEN_COMPETITION_V1_FACTORY_CONTRACT": (
+        "0x9e9382beb8b1a45b737d484b5eafa7b8779d4ca5"
+    ),
+    "OPEN_COMPETITION_V1_DEPLOYMENT_BLOCK": "49663931",
+    "OPEN_COMPETITION_INDEXER_RPC_URL": "https://mainnet.base.org",
+    "OPEN_COMPETITION_INDEXER_POLL_SECONDS": "15",
+    "OPEN_COMPETITION_INDEXER_CONFIRMATIONS": "2",
+    "OPEN_COMPETITION_INDEXER_MAX_BLOCKS_PER_QUERY": "2000",
+    "BASE_INDEXER_RETRY_INITIAL_SECONDS": "5",
+    "BASE_INDEXER_RETRY_MAX_SECONDS": "120",
+    "BASE_INDEXER_EXIT_AFTER_FAILURES": "8",
+}
 HEALTH_STABILITY_PROBES = 8
 DEPLOY_MODES = {"build_and_deploy", "deploy_only"}
 ACTIVE_STATUSES = {
@@ -183,6 +212,7 @@ def redact(value: str) -> str:
     value = re.sub(r"(?i)(authorization:\s*bearer\s+)[^\s]+", r"\1[redacted]", value)
     value = re.sub(r"(?i)([?&](?:key|token)=)[^&\s]+", r"\1[redacted]", value)
     value = re.sub(r"(?i)(render_api_key\s*[=:]\s*)[^\s,;]+", r"\1[redacted]", value)
+    value = re.sub(r"(?i)postgres(?:ql)?://[^\s\"']+", "[database-url-redacted]", value)
     return value[:1000]
 
 
@@ -416,6 +446,101 @@ def unwrap_env_var(payload: object) -> dict[str, str]:
     return {"key": key, "value": value}
 
 
+def validate_owner_id(value: object) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[a-z]+-[0-9a-z]+", value):
+        raise RecoveryError("Render service is missing its workspace id")
+    return value
+
+
+def validate_environment_id(value: object) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[a-z]+-[0-9a-z]+", value):
+        raise RecoveryError("Render service has an invalid project environment id")
+    return value
+
+
+def validate_database_url(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise RecoveryError("reference Render worker has no DATABASE_URL")
+    try:
+        parsed = urllib.parse.urlsplit(value)
+    except ValueError:
+        raise RecoveryError("reference Render worker has an invalid DATABASE_URL") from None
+    if parsed.scheme not in {"postgres", "postgresql"} or not parsed.hostname:
+        raise RecoveryError("reference Render worker has an invalid DATABASE_URL")
+    return value
+
+
+def unwrap_env_group_entries(payload: object) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise RecoveryError("Render environment-group list response must be an array")
+    groups: list[dict[str, Any]] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        group = entry.get("envGroup", entry)
+        if isinstance(group, dict):
+            groups.append(group)
+    return groups
+
+
+def select_env_group(payload: object, owner_id: str) -> dict[str, Any]:
+    matches = [
+        group
+        for group in unwrap_env_group_entries(payload)
+        if group.get("name") == OPEN_COMPETITION_ENV_GROUP_NAME
+        and group.get("ownerId") == owner_id
+    ]
+    if len(matches) != 1:
+        raise RecoveryError(
+            "expected exactly one Render environment group named "
+            f"{OPEN_COMPETITION_ENV_GROUP_NAME} in the reference workspace; "
+            f"found {len(matches)}"
+        )
+    group = matches[0]
+    group_id = group.get("id")
+    if not isinstance(group_id, str) or not re.fullmatch(r"evg-[0-9a-z]+", group_id):
+        raise RecoveryError("Render environment group has an invalid id")
+    return group
+
+
+def unwrap_env_group(payload: object) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RecoveryError("Render environment-group response must be an object")
+    group = payload.get("envGroup", payload)
+    if not isinstance(group, dict):
+        raise RecoveryError("Render environment-group response is missing metadata")
+    return group
+
+
+def env_group_has_service(
+    payload: object,
+    spec: ServiceSpec,
+    service_id: str,
+) -> bool:
+    group = unwrap_env_group(payload)
+    links = group.get("serviceLinks")
+    if not isinstance(links, list):
+        raise RecoveryError("Render environment group is missing service links")
+    matches: list[dict[str, Any]] = []
+    for link in links:
+        if not isinstance(link, dict):
+            continue
+        service = link.get("service", link)
+        if isinstance(service, dict) and service.get("id") == service_id:
+            matches.append(service)
+    if len(matches) > 1:
+        raise RecoveryError("Render environment group has duplicate worker links")
+    if not matches:
+        return False
+    service = matches[0]
+    if (
+        service.get("name") != spec.name
+        or service.get("type") != ENV_GROUP_SERVICE_TYPES.get(spec.service_type)
+    ):
+        raise RecoveryError("Render environment group linked an unexpected service")
+    return True
+
+
 def normalize_public_base_url(name: str, value: str) -> str:
     candidate = value.strip().rstrip("/")
     try:
@@ -613,7 +738,7 @@ class RenderClient:
         self,
         method: str,
         path: str,
-        payload: dict[str, Any],
+        payload: dict[str, Any] | None,
         attempts: int = 3,
     ) -> Any:
         for attempt in range(1, attempts + 1):
@@ -634,11 +759,149 @@ class RenderClient:
         )
         return select_service(spec, self._read_with_retry(f"/services?{query}"))
 
+    def resolve_env_group(self, owner_id: str) -> dict[str, Any]:
+        owner_id = validate_owner_id(owner_id)
+        query = urllib.parse.urlencode(
+            {
+                "name": OPEN_COMPETITION_ENV_GROUP_NAME,
+                "ownerId": owner_id,
+                "limit": "20",
+            }
+        )
+        return select_env_group(
+            self._read_with_retry(f"/env-groups?{query}"), owner_id
+        )
+
+    def get_env_var(self, service: dict[str, Any], key: str) -> dict[str, str]:
+        service_id = service.get("id")
+        if not isinstance(service_id, str) or not service_id.startswith("srv-"):
+            raise RecoveryError("Render service is missing its id")
+        encoded_key = urllib.parse.quote(key, safe="")
+        return unwrap_env_var(
+            self._read_with_retry(f"/services/{service_id}/env-vars/{encoded_key}")
+        )
+
+    def provision_open_competition_service(
+        self,
+        spec: ServiceSpec,
+        reference_service: dict[str, Any],
+    ) -> dict[str, Any]:
+        if spec.name != OPEN_COMPETITION_WORKER_NAME:
+            raise RecoveryError(f"direct Render provisioning is not authorized for {spec.name}")
+        if (
+            reference_service.get("name") != OPEN_COMPETITION_REFERENCE_SERVICE_NAME
+            or reference_service.get("type") != "background_worker"
+            or reference_service.get("branch") != "main"
+            or normalize_repo(reference_service.get("repo")) != REPOSITORY
+        ):
+            raise RecoveryError("direct Render provisioning reference service is invalid")
+
+        owner_id = validate_owner_id(reference_service.get("ownerId"))
+        environment_id = reference_service.get("environmentId")
+        if environment_id is not None:
+            environment_id = validate_environment_id(environment_id)
+        env_group = self.resolve_env_group(owner_id)
+        group_environment_id = env_group.get("environmentId")
+        if group_environment_id is not None:
+            group_environment_id = validate_environment_id(group_environment_id)
+        if (
+            environment_id is not None
+            and group_environment_id is not None
+            and group_environment_id != environment_id
+        ):
+            raise RecoveryError(
+                "reference Render worker and environment group are in different projects"
+            )
+        if environment_id is None:
+            environment_id = group_environment_id
+        database_url = validate_database_url(
+            self.get_env_var(reference_service, "DATABASE_URL").get("value")
+        )
+
+        env_vars = [
+            {"key": key, "value": value}
+            for key, value in OPEN_COMPETITION_WORKER_ENVIRONMENT.items()
+        ]
+        env_vars.append({"key": "DATABASE_URL", "value": database_url})
+        payload: dict[str, Any] = {
+            "type": "background_worker",
+            "name": OPEN_COMPETITION_WORKER_NAME,
+            "ownerId": owner_id,
+            "repo": "https://github.com/NSPG13/agent-bounties",
+            "branch": "main",
+            "autoDeploy": "no",
+            "envVars": env_vars,
+            "serviceDetails": {
+                "runtime": "docker",
+                "envSpecificDetails": {
+                    "dockerContext": ".",
+                    "dockerfilePath": "./Dockerfile",
+                },
+                "plan": "starter",
+                "region": "oregon",
+                "maxShutdownDelaySeconds": 60,
+            },
+        }
+        if environment_id is not None:
+            payload["environmentId"] = environment_id
+
+        try:
+            created = select_service(
+                spec,
+                [self._write_with_retry("POST", "/services", payload)],
+            )
+        except RenderHttpError as error:
+            if error.status != 409:
+                raise
+            # A concurrent Blueprint sync is acceptable only if it created the
+            # exact service identity that this controller was about to create.
+            created = self.resolve_service(spec)
+
+        if created.get("ownerId") != owner_id:
+            raise RecoveryError("new Render worker is in an unexpected workspace")
+        if environment_id is not None and created.get("environmentId") != environment_id:
+            raise RecoveryError("new Render worker is in an unexpected project environment")
+
+        group_id = env_group["id"]
+        linked_group = self._read_with_retry(f"/env-groups/{group_id}")
+        if not env_group_has_service(linked_group, spec, created["id"]):
+            try:
+                self._write_with_retry(
+                    "POST",
+                    f"/env-groups/{group_id}/services/{created['id']}",
+                    None,
+                )
+            except RenderHttpError as error:
+                if error.status != 409:
+                    raise
+            linked_group = self._read_with_retry(f"/env-groups/{group_id}")
+        if not env_group_has_service(linked_group, spec, created["id"]):
+            raise RecoveryError("Render did not attach the required environment group")
+
+        verified = self.resolve_service(spec)
+        if verified.get("ownerId") != owner_id:
+            raise RecoveryError("provisioned Render worker changed workspaces")
+        if environment_id is not None and verified.get("environmentId") != environment_id:
+            raise RecoveryError("provisioned Render worker changed project environments")
+        for key, expected in OPEN_COMPETITION_WORKER_ENVIRONMENT.items():
+            actual = self.get_env_var(verified, key)
+            if actual != {"key": key, "value": expected}:
+                raise RecoveryError(
+                    f"provisioned Render worker did not retain required {key}"
+                )
+        retained_database_url = validate_database_url(
+            self.get_env_var(verified, "DATABASE_URL").get("value")
+        )
+        if retained_database_url != database_url:
+            raise RecoveryError("provisioned Render worker changed its DATABASE_URL")
+        return verified
+
     def ensure_blueprint_service(
         self,
         spec: ServiceSpec,
         *,
-        attempts: int = 60,
+        reference_service: dict[str, Any] | None = None,
+        attempts: int = 12,
         poll_seconds: float = 5,
     ) -> dict[str, Any]:
         if spec.name not in BLUEPRINT_RECOVERABLE_SERVICE_NAMES:
@@ -709,6 +972,8 @@ class RenderClient:
                 )
             if attempt < attempts:
                 self._sleep(poll_seconds)
+        if reference_service is not None:
+            return self.provision_open_competition_service(spec, reference_service)
         raise RecoveryError(
             f"Render Blueprint did not create {spec.name}; last status {last_status}"
         )
@@ -1512,7 +1777,10 @@ def deploy(
             missing.append(spec)
 
     for spec in missing:
-        resolved[spec.name] = client.ensure_blueprint_service(spec)
+        resolved[spec.name] = client.ensure_blueprint_service(
+            spec,
+            reference_service=resolved.get(OPEN_COMPETITION_REFERENCE_SERVICE_NAME),
+        )
 
     # Revalidate every binding after a Blueprint sync and before changing any
     # service configuration or triggering a deployment.

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -94,6 +94,36 @@ def blueprint_record(**overrides):
     return record
 
 
+def worker_service_record(name=None, **overrides):
+    record = {
+        "id": "srv-" + "c" * 20,
+        "name": name or recovery.OPEN_COMPETITION_WORKER_NAME,
+        "type": "background_worker",
+        "branch": "main",
+        "repo": "https://github.com/NSPG13/agent-bounties.git",
+        "ownerId": "tea-owner123",
+        "environmentId": "evm-project123",
+        "autoDeploy": "no",
+    }
+    record.update(overrides)
+    return record
+
+
+def env_group_record(service=None, **overrides):
+    linked_service = None
+    if service is not None:
+        linked_service = dict(service)
+        linked_service["type"] = "worker"
+    record = {
+        "id": "evg-" + "d" * 20,
+        "name": recovery.OPEN_COMPETITION_ENV_GROUP_NAME,
+        "ownerId": "tea-owner123",
+        "serviceLinks": [] if linked_service is None else [linked_service],
+    }
+    record.update(overrides)
+    return record
+
+
 class ResolutionFailureClient:
     def __init__(self) -> None:
         self.resolved = []
@@ -287,6 +317,184 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(recovery.RecoveryError, "unexpected type"):
             recovery.blueprint_has_service(blueprint, spec)
+
+    def test_direct_worker_provisioning_is_exact_and_secret_free_in_result(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        reference = worker_service_record(
+            recovery.OPEN_COMPETITION_REFERENCE_SERVICE_NAME,
+            id="srv-" + "b" * 20,
+        )
+        created = worker_service_record()
+        database_url = "postgresql://worker:private-value@database.internal/bounties"
+        env_responses = [
+            {"envVar": {"key": key, "value": value}}
+            for key, value in recovery.OPEN_COMPETITION_WORKER_ENVIRONMENT.items()
+        ]
+        responses = [
+            [{"envGroup": env_group_record()}],
+            {"envVar": {"key": "DATABASE_URL", "value": database_url}},
+            {"service": created},
+            {"envGroup": env_group_record()},
+            {},
+            {"envGroup": env_group_record(created)},
+            [{"service": created}],
+            *env_responses,
+            {"envVar": {"key": "DATABASE_URL", "value": database_url}},
+        ]
+        client = RecordingClient()
+        with mock.patch.object(client, "_request_json", side_effect=responses) as request:
+            result = client.provision_open_competition_service(spec, reference)
+
+        self.assertEqual(result, created)
+        create_call = request.call_args_list[2]
+        self.assertEqual(create_call.args[:2], ("POST", "/services"))
+        create_payload = create_call.args[2]
+        self.assertEqual(create_payload["type"], "background_worker")
+        self.assertEqual(create_payload["ownerId"], reference["ownerId"])
+        self.assertEqual(create_payload["environmentId"], reference["environmentId"])
+        self.assertEqual(create_payload["autoDeploy"], "no")
+        self.assertEqual(
+            create_payload["serviceDetails"],
+            {
+                "runtime": "docker",
+                "envSpecificDetails": {
+                    "dockerContext": ".",
+                    "dockerfilePath": "./Dockerfile",
+                },
+                "plan": "starter",
+                "region": "oregon",
+                "maxShutdownDelaySeconds": 60,
+            },
+        )
+        self.assertEqual(
+            {item["key"]: item["value"] for item in create_payload["envVars"]},
+            {
+                **recovery.OPEN_COMPETITION_WORKER_ENVIRONMENT,
+                "DATABASE_URL": database_url,
+            },
+        )
+        self.assertNotIn("private-value", recovery.json.dumps(result))
+
+    def test_direct_worker_provisioning_refuses_any_other_service(self) -> None:
+        client = RecordingClient()
+        with self.assertRaisesRegex(recovery.RecoveryError, "not authorized"):
+            client.provision_open_competition_service(
+                recovery.SERVICE_SPECS[0],
+                worker_service_record(recovery.OPEN_COMPETITION_REFERENCE_SERVICE_NAME),
+            )
+        self.assertEqual(client.requests, [])
+
+    def test_direct_worker_provisioning_requires_one_matching_env_group(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        reference = worker_service_record(
+            recovery.OPEN_COMPETITION_REFERENCE_SERVICE_NAME
+        )
+        client = RecordingClient()
+        with mock.patch.object(client, "_request_json", return_value=[]):
+            with self.assertRaisesRegex(recovery.RecoveryError, "exactly one"):
+                client.provision_open_competition_service(spec, reference)
+        self.assertEqual(
+            client.requests,
+            [],
+        )
+
+    def test_direct_worker_provisioning_accepts_only_an_exact_409_race(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        reference = worker_service_record(
+            recovery.OPEN_COMPETITION_REFERENCE_SERVICE_NAME,
+            id="srv-" + "b" * 20,
+        )
+        created = worker_service_record()
+        database_url = "postgres://worker:private-value@database.internal/bounties"
+        responses = [
+            [{"envGroup": env_group_record()}],
+            {"envVar": {"key": "DATABASE_URL", "value": database_url}},
+            recovery.RenderHttpError(409, "service name already exists"),
+            [{"service": created}],
+            {"envGroup": env_group_record()},
+            {},
+            {"envGroup": env_group_record(created)},
+            [{"service": created}],
+            *[
+                {"envVar": {"key": key, "value": value}}
+                for key, value in recovery.OPEN_COMPETITION_WORKER_ENVIRONMENT.items()
+            ],
+            {"envVar": {"key": "DATABASE_URL", "value": database_url}},
+        ]
+        client = RecordingClient()
+        with mock.patch.object(client, "_request_json", side_effect=responses):
+            self.assertEqual(
+                client.provision_open_competition_service(spec, reference),
+                created,
+            )
+
+    def test_direct_worker_provisioning_rejects_created_owner_mismatch(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        reference = worker_service_record(
+            recovery.OPEN_COMPETITION_REFERENCE_SERVICE_NAME
+        )
+        responses = [
+            [{"envGroup": env_group_record()}],
+            {
+                "envVar": {
+                    "key": "DATABASE_URL",
+                    "value": "postgres://worker:private-value@db/app",
+                }
+            },
+            {"service": worker_service_record(ownerId="tea-attacker123")},
+        ]
+        client = RecordingClient()
+        with mock.patch.object(client, "_request_json", side_effect=responses):
+            with self.assertRaisesRegex(recovery.RecoveryError, "workspace"):
+                client.provision_open_competition_service(spec, reference)
+
+    def test_direct_worker_provisioning_requires_verified_group_link(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        reference = worker_service_record(
+            recovery.OPEN_COMPETITION_REFERENCE_SERVICE_NAME
+        )
+        created = worker_service_record()
+        responses = [
+            [{"envGroup": env_group_record()}],
+            {
+                "envVar": {
+                    "key": "DATABASE_URL",
+                    "value": "postgres://worker:private-value@db/app",
+                }
+            },
+            {"service": created},
+            {"envGroup": env_group_record()},
+            {},
+            {"envGroup": env_group_record()},
+        ]
+        client = RecordingClient()
+        with mock.patch.object(client, "_request_json", side_effect=responses):
+            with self.assertRaisesRegex(recovery.RecoveryError, "attach"):
+                client.provision_open_competition_service(spec, reference)
+
+    def test_blueprint_error_never_invokes_direct_provisioning(self) -> None:
+        spec = recovery.SERVICE_SPECS[-1]
+        reference = worker_service_record(
+            recovery.OPEN_COMPETITION_REFERENCE_SERVICE_NAME
+        )
+        client = RecordingClient()
+        responses = [
+            [{"blueprint": blueprint_record(autoSync=False)}],
+            blueprint_record(status="syncing", autoSync=True),
+            blueprint_record(status="error", autoSync=False),
+        ]
+        with mock.patch.object(client, "_request_json", side_effect=responses):
+            with mock.patch.object(
+                client, "provision_open_competition_service"
+            ) as provision:
+                with self.assertRaisesRegex(recovery.RecoveryError, "error state"):
+                    client.ensure_blueprint_service(
+                        spec,
+                        reference_service=reference,
+                        attempts=1,
+                        poll_seconds=0,
+                    )
+                provision.assert_not_called()
 
     def test_existing_deploy_reuses_only_active_exact_revision(self) -> None:
         revision = "a" * 40
@@ -1307,6 +1515,12 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         self.assertEqual(
             recovery.redact("RENDER_API_KEY is required"),
             "RENDER_API_KEY is required",
+        )
+        self.assertNotIn(
+            "private-value",
+            recovery.redact(
+                'bad payload {"value":"postgresql://worker:private-value@db/app"}'
+            ),
         )
 
 


### PR DESCRIPTION
## Summary
- add a direct Render service-creation fallback only for the missing Open Competition V1 indexer when the validated Blueprint remains healthy but does not materialize it
- derive workspace, project environment, database binding, and environment group from already validated production resources
- read-verify exact service identity and every nonsecret worker value before any deployment proceeds
- keep all other missing/ambiguous services fail-closed and redact database URLs from errors

## Safety
- no contract, wallet, bounty, contributor, or payment state changes
- no public Open Competition activation flags are changed
- the fallback cannot provision any service except `agent-bounties-open-competition-v1-indexer`
- Blueprint `error` remains a hard stop

## Checks
- `python scripts/test_render_deploy_recovery.py -v` (67 passed)
- `python scripts/check-render-blueprint.py`
- `python -m py_compile scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py scripts/check-render-blueprint.py`
- `scripts/preflight.ps1 -Mode core`
- `git diff --check`