### PR TITLE
Reconcile Open Competition hosted release gates

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -219,6 +219,7 @@ jobs:
               f"- Services live: `{sum(item['status'] == 'live' for item in evidence['services'])}/4`",
               f"- Exact health attestations: `{len(evidence['health'])}/2`",
               f"- Public runtime variables reconciled: `{len(evidence.get('public_environment', []))}`",
+              f"- Open Competition shared variables reconciled: `{len(evidence.get('open_competition_environment', []))}`",
               f"- Cloud runtime variables: `{len(evidence.get('cloud_environment', []))}/10`",
               f"- Cloud model credential supplied: `{bool(evidence.get('secret_environment'))}`",
               f"- Cloud drafting ready: `{bool(evidence.get('cloud_readiness', {}).get('available'))}`",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -80,21 +80,25 @@ succeeds on a push to `main`, the workflow:
    by copying the validated legacy worker's workspace, project environment, and
    database binding, attaches the exact existing environment group, verifies
    every nonsecret value by readback, and then revalidates all four bindings;
-5. disables any drifted native auto-deploy setting;
-6. reconciles `PUBLIC_BASE_URL`, `MCP_BASE_URL`, and `WEBSITE_BASE_URL` on
+5. verifies that the exact shared Base environment group is linked to all four
+   services, derives the Open Competition manifest, verifier catalog, and
+   disabled activation gates from the checked-in mainnet release evidence, and
+   reconciles each nonsecret value through Render with exact readback;
+6. disables any drifted native auto-deploy setting;
+7. reconciles `PUBLIC_BASE_URL`, `MCP_BASE_URL`, and `WEBSITE_BASE_URL` on
    both public services;
-7. reconciles all nonsecret cloud-agent settings on API and copies the optional
+8. reconciles all nonsecret cloud-agent settings on API and copies the optional
    GitHub-held model key without including its value in evidence;
-8. creates or updates the optional FID-filtered Neynar provider webhook and
+9. creates or updates the optional FID-filtered Neynar provider webhook and
    reconciles its bot identity, reply signer, and generated signing secret on
    API without including their values in evidence;
-9. calls Render's deploy API with the exact commit for API, MCP, and both workers;
-10. waits for all four deploys to reach `live` and fails on terminal errors;
-11. verifies exact revision and protocol headers from API and MCP `/health`;
-12. attests cloud readiness and fails if a supplied model credential did not
+10. calls Render's deploy API with the exact commit for API, MCP, and both workers;
+11. waits for all four deploys to reach `live` and fails on terminal errors;
+12. verifies exact revision and protocol headers from API and MCP `/health`;
+13. attests cloud readiness and fails if a supplied model credential did not
     become usable;
-13. attests social mention readiness when provider values were supplied;
-14. stores a redacted 30-day deployment evidence artifact.
+14. attests social mention readiness when provider values were supplied;
+15. stores a redacted 30-day deployment evidence artifact.
 
 Configure the GitHub Actions secret `RENDER_API_KEY`. Create it in the
 Render Dashboard for the workspace that owns these four services, then store

--- a/docs/self-healing-operations.md
+++ b/docs/self-healing-operations.md
@@ -54,8 +54,11 @@ and revalidates all bindings. If the Blueprint remains healthy but does not
 materialize that one worker, the controller may create only the allowlisted
 worker through Render's service API. It derives workspace, project environment,
 database, and environment-group identity from already validated resources and
-read-verifies the resulting service before deployment. Any other missing or
-ambiguous service fails closed. A newer failed main commit cannot suppress the
+read-verifies the resulting service before deployment. Before every deployment
+it also requires that shared group on all four services and reconciles the
+hidden-canary manifest, verifier catalog, and false activation gates from the
+checked-in release evidence. Any other missing or ambiguous service fails
+closed. A newer failed main commit cannot suppress the
 last known-good release, and an older successful run skips after a newer
 successful run exists. It cannot deploy an unrelated branch, contract, wallet,
 or payment action. A missing credential, ambiguous service, failed build,

--- a/docs/software-development-lifecycle.md
+++ b/docs/software-development-lifecycle.md
@@ -194,7 +194,9 @@ Blueprint healthy without materializing the worker, the controller may create
 only that worker through the service API using the validated legacy worker's
 workspace, project environment, database binding, and exact existing
 environment group. It read-verifies the new worker and revalidates all bindings
-before deployment. Other missing or ambiguous services fail closed.
+before deployment. The controller then reconciles only the checked-in
+hidden-canary manifest, verifier catalog, and explicit false activation gates
+on the exact shared environment group. Other missing or ambiguous services fail closed.
 Native provider commit triggers are disabled so two independent deploy
 authorities cannot race. The Render credential is isolated to this workflow;
 the scheduled observer and application containers never receive it. This

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -34,6 +34,9 @@ ENV_GROUP_SERVICE_TYPES = {
 OPEN_COMPETITION_WORKER_NAME = "agent-bounties-open-competition-v1-indexer"
 OPEN_COMPETITION_REFERENCE_SERVICE_NAME = "agent-bounties-base-indexer"
 OPEN_COMPETITION_ENV_GROUP_NAME = "agent-bounties-base"
+OPEN_COMPETITION_RELEASE_MANIFEST_PATH = Path(
+    "deployments/open-competition-v1-base-mainnet.json"
+)
 OPEN_COMPETITION_WORKER_ENVIRONMENT = {
     "APP_PACKAGE": "worker",
     "APP_BINARY": "worker",
@@ -578,6 +581,100 @@ def public_environment_values(
     }
 
 
+def open_competition_shared_environment(
+    manifest_path: Path = OPEN_COMPETITION_RELEASE_MANIFEST_PATH,
+) -> dict[str, str]:
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RecoveryError(
+            f"Open Competition release manifest is unavailable: {redact(str(error))}"
+        ) from None
+    if not isinstance(manifest, dict):
+        raise RecoveryError("Open Competition release manifest must be an object")
+    if (
+        manifest.get("schema_version")
+        != "agent-bounties/open-competition-v1-base-mainnet-release-v1"
+        or manifest.get("protocol_version")
+        != "agent-bounties/open-competition-v1"
+        or manifest.get("network") != "base-mainnet"
+        or manifest.get("chain_id") != 8453
+        or manifest.get("deployment_state")
+        != "mainnet_canary_not_ready_to_earn"
+    ):
+        raise RecoveryError("Open Competition release manifest identity is invalid")
+
+    release = manifest.get("release_manifest")
+    catalog = manifest.get("verifier_catalog")
+    activation = manifest.get("hosted_activation")
+    if not isinstance(release, dict) or not isinstance(catalog, dict):
+        raise RecoveryError("Open Competition release manifest is incomplete")
+    if not isinstance(activation, dict):
+        raise RecoveryError("Open Competition hosted activation evidence is missing")
+    if (
+        release.get("protocol_version") != "agent-bounties/open-competition-v1"
+        or release.get("network") != "base-mainnet"
+        or release.get("chain_id") != 8453
+        or release.get("deployment_state")
+        != "mainnet_canary_not_ready_to_earn"
+    ):
+        raise RecoveryError("Open Competition hosted release identity is invalid")
+    profiles = catalog.get("profiles")
+    if (
+        catalog.get("schema_version")
+        != "agent-bounties/open-competition-v1-verifier-catalog-v1"
+        or catalog.get("protocol_version")
+        != "agent-bounties/open-competition-v1"
+        or catalog.get("network") != "base-mainnet"
+        or not isinstance(profiles, list)
+        or not profiles
+    ):
+        raise RecoveryError("Open Competition verifier catalog identity is invalid")
+    for profile in profiles:
+        if (
+            not isinstance(profile, dict)
+            or profile.get("deployment_state")
+            != "mainnet_canary_not_ready_to_earn"
+            or profile.get("public_inventory_eligible") is not False
+        ):
+            raise RecoveryError("Open Competition verifier profile is not hidden-canary safe")
+
+    activation_fields = {
+        "BASE_MAINNET_OPEN_COMPETITION_V1_GAS_SPONSORSHIP_AVAILABLE": (
+            "gas_sponsorship_available"
+        ),
+        "BASE_MAINNET_OPEN_COMPETITION_V1_RELAY_SUPPORT_AVAILABLE": (
+            "relay_support_available"
+        ),
+        "BASE_MAINNET_OPEN_COMPETITION_V1_R4_EVIDENCE_COMPLETE": (
+            "r4_release_evidence_complete"
+        ),
+        "BASE_MAINNET_OPEN_COMPETITION_V1_MONITORING_ACTIVE": "monitoring_active",
+        "BASE_MAINNET_OPEN_COMPETITION_V1_CREATION_ENABLED": (
+            "public_creation_enabled"
+        ),
+        "BASE_MAINNET_OPEN_COMPETITION_V1_COMMITMENTS_ENABLED": (
+            "public_commitments_enabled"
+        ),
+    }
+    if activation.get("public_inventory_eligible") is not False:
+        raise RecoveryError("Open Competition public inventory must remain disabled")
+    for field in activation_fields.values():
+        if activation.get(field) is not False:
+            raise RecoveryError(f"Open Competition hosted activation requires {field}=false")
+
+    values = {
+        "BASE_MAINNET_OPEN_COMPETITION_V1_RELEASE_MANIFEST_JSON": json.dumps(
+            release, ensure_ascii=False, separators=(",", ":")
+        ),
+        "BASE_MAINNET_OPEN_COMPETITION_V1_VERIFIER_CATALOG_JSON": json.dumps(
+            catalog, ensure_ascii=False, separators=(",", ":")
+        ),
+    }
+    values.update({key: "false" for key in activation_fields})
+    return values
+
+
 def normalize_evm_address(name: str, value: str) -> str:
     normalized = value.strip().lower()
     if not re.fullmatch(r"0x[0-9a-f]{40}", normalized):
@@ -772,6 +869,11 @@ class RenderClient:
             self._read_with_retry(f"/env-groups?{query}"), owner_id
         )
 
+    def get_env_group(self, group_id: str) -> dict[str, Any]:
+        if not re.fullmatch(r"evg-[0-9a-z]+", group_id):
+            raise RecoveryError("Render environment group has an invalid id")
+        return unwrap_env_group(self._read_with_retry(f"/env-groups/{group_id}"))
+
     def get_env_var(self, service: dict[str, Any], key: str) -> dict[str, str]:
         service_id = service.get("id")
         if not isinstance(service_id, str) or not service_id.startswith("srv-"):
@@ -780,6 +882,42 @@ class RenderClient:
         return unwrap_env_var(
             self._read_with_retry(f"/services/{service_id}/env-vars/{encoded_key}")
         )
+
+    def ensure_env_group_env_var(
+        self,
+        group: dict[str, Any],
+        key: str,
+        value: str,
+    ) -> dict[str, Any]:
+        group_id = group.get("id")
+        if not isinstance(group_id, str) or not re.fullmatch(
+            r"evg-[0-9a-z]+", group_id
+        ):
+            raise RecoveryError("Render environment group has an invalid id")
+        encoded_key = urllib.parse.quote(key, safe="")
+        path = f"/env-groups/{group_id}/env-vars/{encoded_key}"
+        changed = True
+        try:
+            current = unwrap_env_var(self._read_with_retry(path))
+            if current == {"key": key, "value": value}:
+                changed = False
+        except RenderHttpError as error:
+            if error.status != 404:
+                raise
+        if changed:
+            updated = unwrap_env_var(
+                self._write_with_retry("PUT", path, {"value": value})
+            )
+            if updated != {"key": key, "value": value}:
+                raise RecoveryError(
+                    f"Render did not update shared Open Competition variable {key}"
+                )
+        verified = unwrap_env_var(self._read_with_retry(path))
+        if verified != {"key": key, "value": value}:
+            raise RecoveryError(
+                f"Render did not retain shared Open Competition variable {key}"
+            )
+        return {"key": key, "value": value, "changed": changed}
 
     def provision_open_competition_service(
         self,
@@ -863,7 +1001,7 @@ class RenderClient:
             raise RecoveryError("new Render worker is in an unexpected project environment")
 
         group_id = env_group["id"]
-        linked_group = self._read_with_retry(f"/env-groups/{group_id}")
+        linked_group = self.get_env_group(group_id)
         if not env_group_has_service(linked_group, spec, created["id"]):
             try:
                 self._write_with_retry(
@@ -874,7 +1012,7 @@ class RenderClient:
             except RenderHttpError as error:
                 if error.status != 409:
                     raise
-            linked_group = self._read_with_retry(f"/env-groups/{group_id}")
+            linked_group = self.get_env_group(group_id)
         if not env_group_has_service(linked_group, spec, created["id"]):
             raise RecoveryError("Render did not attach the required environment group")
 
@@ -1802,6 +1940,26 @@ def deploy(
                 )
             preexisting_live[spec.name] = current
 
+    reference_service = resolved.get(OPEN_COMPETITION_REFERENCE_SERVICE_NAME)
+    if reference_service is None:
+        raise RecoveryError("validated reference Render worker is unavailable")
+    shared_group = client.resolve_env_group(
+        validate_owner_id(reference_service.get("ownerId"))
+    )
+    shared_group = client.get_env_group(shared_group["id"])
+    for spec, service in services:
+        if not env_group_has_service(shared_group, spec, service["id"]):
+            raise RecoveryError(
+                f"required Render environment group is not linked to {spec.name}"
+            )
+    desired_open_competition_environment = open_competition_shared_environment()
+    reconciled_open_competition_environment = []
+    open_competition_environment_changed = False
+    for key, value in desired_open_competition_environment.items():
+        record = client.ensure_env_group_env_var(shared_group, key, value)
+        open_competition_environment_changed |= record["changed"]
+        reconciled_open_competition_environment.append(record)
+
     neynar_inputs = normalize_neynar_social_inputs(
         api_key=neynar_api_key,
         signer_uuid=neynar_signer_uuid,
@@ -1910,7 +2068,11 @@ def deploy(
         else frozenset()
     )
     for spec, service in services:
-        if deploy_mode == "deploy_only" and spec.name != CLOUD_AGENT_API_SERVICE_NAME:
+        if (
+            deploy_mode == "deploy_only"
+            and spec.name != CLOUD_AGENT_API_SERVICE_NAME
+            and not open_competition_environment_changed
+        ):
             created = preexisting_live[spec.name]
         else:
             created = client.ensure_deploy(
@@ -1919,7 +2081,10 @@ def deploy(
                 force=(
                     True
                     if deploy_mode == "deploy_only"
-                    else public_environment_changed.get(spec.name, False)
+                    else (
+                        public_environment_changed.get(spec.name, False)
+                        or open_competition_environment_changed
+                    )
                 ),
                 deploy_mode=deploy_mode,
             )
@@ -2033,6 +2198,7 @@ def deploy(
         "health": health,
         "custom_domains": custom_domains,
         "public_environment": reconciled_public_environment,
+        "open_competition_environment": reconciled_open_competition_environment,
         "cloud_environment": cloud_environment,
         "secret_environment": secret_environment,
         "social_environment": social_environment,

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -754,6 +755,76 @@ class RenderDeployRecoveryTests(unittest.TestCase):
                 "MCP_BASE_URL": "https://mcp.agentbounties.app",
                 "WEBSITE_BASE_URL": "https://agentbounties.app",
             },
+        )
+
+    def test_open_competition_shared_environment_is_hidden_canary_only(self) -> None:
+        values = recovery.open_competition_shared_environment()
+        self.assertEqual(len(values), 8)
+        release = recovery.json.loads(
+            values["BASE_MAINNET_OPEN_COMPETITION_V1_RELEASE_MANIFEST_JSON"]
+        )
+        catalog = recovery.json.loads(
+            values["BASE_MAINNET_OPEN_COMPETITION_V1_VERIFIER_CATALOG_JSON"]
+        )
+        self.assertEqual(
+            release["deployment_state"], "mainnet_canary_not_ready_to_earn"
+        )
+        self.assertFalse(catalog["profiles"][0]["public_inventory_eligible"])
+        for key, value in values.items():
+            if key.endswith("_JSON"):
+                continue
+            self.assertEqual(value, "false")
+
+    def test_open_competition_shared_environment_rejects_activation(self) -> None:
+        source = recovery.json.loads(
+            recovery.OPEN_COMPETITION_RELEASE_MANIFEST_PATH.read_text(
+                encoding="utf-8"
+            )
+        )
+        source["hosted_activation"]["public_creation_enabled"] = True
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "release.json"
+            path.write_text(recovery.json.dumps(source), encoding="utf-8")
+            with self.assertRaisesRegex(recovery.RecoveryError, "requires.*false"):
+                recovery.open_competition_shared_environment(path)
+
+    def test_shared_environment_variable_is_read_verified(self) -> None:
+        client = RecordingClient()
+        group = env_group_record()
+        expected = {"envVar": {"key": "SAFE_GATE", "value": "false"}}
+        with mock.patch.object(
+            client, "_request_json", side_effect=[expected, expected]
+        ) as request:
+            self.assertEqual(
+                client.ensure_env_group_env_var(group, "SAFE_GATE", "false"),
+                {"key": "SAFE_GATE", "value": "false", "changed": False},
+            )
+        path = f"/env-groups/{group['id']}/env-vars/SAFE_GATE"
+        self.assertEqual(
+            request.call_args_list,
+            [mock.call("GET", path), mock.call("GET", path)],
+        )
+
+    def test_shared_environment_variable_update_requires_exact_readback(self) -> None:
+        client = RecordingClient()
+        group = env_group_record()
+        expected = {"envVar": {"key": "SAFE_GATE", "value": "false"}}
+        responses = [recovery.RenderHttpError(404, "missing"), expected, expected]
+        with mock.patch.object(
+            client, "_request_json", side_effect=responses
+        ) as request:
+            self.assertEqual(
+                client.ensure_env_group_env_var(group, "SAFE_GATE", "false"),
+                {"key": "SAFE_GATE", "value": "false", "changed": True},
+            )
+        path = f"/env-groups/{group['id']}/env-vars/SAFE_GATE"
+        self.assertEqual(
+            request.call_args_list,
+            [
+                mock.call("GET", path),
+                mock.call("PUT", path, {"value": "false"}),
+                mock.call("GET", path),
+            ],
         )
 
     def test_api_runtime_environment_enables_social_mention_drafts(self) -> None:


### PR DESCRIPTION
## Summary
- reconcile the hosted Open Competition mainnet release manifest and verifier catalog from the checked-in frozen release evidence
- require the exact shared Base environment group to be linked to all four validated services
- keep public inventory, creation, commitments, monitoring, relay, gas sponsorship, and R4 evidence gates explicitly false
- read-verify every Render environment-group update and force all linked services to redeploy when shared state changes

## Production finding
The exact-SHA deployment in run 31202064520 succeeded with 4/4 services live and 8 stable health probes per public service. A post-deploy probe then correctly returned 503 for state/readiness because Render still exposed the previous `source_only_not_ready_to_earn` catalog. This change repairs only that nonsecret hosted configuration drift; it does not activate public earning.

## Safety
- no contract, wallet, bounty, contributor, or payment state changes
- a checked-in manifest with any activation flag or public inventory eligibility set true is rejected
- missing or incorrect service/group links fail before configuration mutation

## Checks
- `python scripts/test_render_deploy_recovery.py -v` (71 passed)
- `python scripts/check-render-blueprint.py`
- `python -m py_compile scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py scripts/check-render-blueprint.py`
- `scripts/preflight.ps1 -Mode core`
- `git diff --check`