### PR TITLE
Handle Render env-group update responses

### DIFF
--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -515,6 +515,26 @@ def unwrap_env_group(payload: object) -> dict[str, Any]:
     return group
 
 
+def env_group_env_var(payload: object, key: str) -> dict[str, str]:
+    group = unwrap_env_group(payload)
+    env_vars = group.get("envVars")
+    if not isinstance(env_vars, list):
+        raise RecoveryError("Render environment group is missing environment variables")
+    matches = [
+        item
+        for item in env_vars
+        if isinstance(item, dict) and item.get("key") == key
+    ]
+    if len(matches) != 1:
+        raise RecoveryError(
+            f"Render environment group returned {len(matches)} values for {key}"
+        )
+    value = matches[0].get("value")
+    if not isinstance(value, str):
+        raise RecoveryError(f"Render environment group returned an invalid value for {key}")
+    return {"key": key, "value": value}
+
+
 def env_group_has_service(
     payload: object,
     spec: ServiceSpec,
@@ -905,8 +925,8 @@ class RenderClient:
             if error.status != 404:
                 raise
         if changed:
-            updated = unwrap_env_var(
-                self._write_with_retry("PUT", path, {"value": value})
+            updated = env_group_env_var(
+                self._write_with_retry("PUT", path, {"value": value}), key
             )
             if updated != {"key": key, "value": value}:
                 raise RecoveryError(

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -809,7 +809,16 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         client = RecordingClient()
         group = env_group_record()
         expected = {"envVar": {"key": "SAFE_GATE", "value": "false"}}
-        responses = [recovery.RenderHttpError(404, "missing"), expected, expected]
+        updated_group = {
+            "envGroup": env_group_record(
+                envVars=[{"key": "SAFE_GATE", "value": "false"}]
+            )
+        }
+        responses = [
+            recovery.RenderHttpError(404, "missing"),
+            updated_group,
+            expected,
+        ]
         with mock.patch.object(
             client, "_request_json", side_effect=responses
         ) as request:


### PR DESCRIPTION
## Summary
- parse Render environment-group `PUT` responses as the documented full environment-group object
- continue to verify the updated key inside that response and by a separate exact `GET` readback

## Production finding
Render run 31204024647 failed closed before any service deployment with `Render environment-variable response is incomplete`. The first env-group update succeeded at the provider, but Render returns an environment group from this endpoint rather than the single env-var shape used by service updates. No contracts, bounties, contributors, payments, or public gates were changed.

## Checks
- `python scripts/test_render_deploy_recovery.py -v` (71 passed)
- `python scripts/check-render-blueprint.py`
- `python -m py_compile scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py`
- `scripts/preflight.ps1 -Mode core`
- `git diff --check`