### PR TITLE
feat: derive Open Competition monitoring from live heartbeat

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -77,7 +77,7 @@ use cloud_agent::{
     CloudObjectiveVerifierDraft, CloudUnfundedBountyRequest,
 };
 use db::{
-    ChatgptActionIntent as DbChatgptActionIntent, ChatgptActionObservation,
+    BaseIndexerHeartbeat, ChatgptActionIntent as DbChatgptActionIntent, ChatgptActionObservation,
     ClaimCandidateReservation, ClaimFunnelStats, DbError, GitHubIssueSyncBountyUpsert,
     NewBondSponsorship, NewChatgptActionIntent, NewClaimCandidate, NewDiscoveryWebhookSubscription,
     NewLegalAcceptance, NewOpportunityComment, NewSiteAnalyticsEvent, NewSocialMentionIngestion,
@@ -5523,11 +5523,11 @@ async fn get_open_competition_readiness(
     State(state): State<SharedState>,
     Query(query): Query<OpenCompetitionReadinessQuery>,
 ) -> Result<Json<OpenCompetitionReadinessReport>, StatusCode> {
-    let network = query.network.as_deref().unwrap_or("base-mainnet");
     let safe_state = observe_open_competition_state_for_api(&state, &query).await?;
+    let offchain_gates = open_competition_offchain_gates(&state, &safe_state).await?;
     Ok(Json(open_competition_readiness_from_state(
         &safe_state,
-        &open_competition_offchain_gates(network)?,
+        &offchain_gates,
     )))
 }
 
@@ -5593,10 +5593,8 @@ async fn prepare_open_competition_reveal(
     {
         return Err(StatusCode::CONFLICT);
     }
-    let readiness = open_competition_readiness_from_state(
-        &safe_state,
-        &open_competition_offchain_gates(network)?,
-    );
+    let offchain_gates = open_competition_offchain_gates(&state, &safe_state).await?;
+    let readiness = open_competition_readiness_from_state(&safe_state, &offchain_gates);
     let mut plan = plan_open_competition_action(
         OpenCompetitionOperation::PrepareOpenCompetitionReveal,
         &readiness,
@@ -5709,10 +5707,8 @@ async fn open_competition_action_from_safe_state(
         },
     )
     .await?;
-    let readiness = open_competition_readiness_from_state(
-        &safe_state,
-        &open_competition_offchain_gates(network)?,
-    );
+    let offchain_gates = open_competition_offchain_gates(state, &safe_state).await?;
+    let readiness = open_competition_readiness_from_state(&safe_state, &offchain_gates);
     let mut plan = plan_open_competition_action(
         operation,
         &readiness,
@@ -5829,16 +5825,67 @@ fn select_open_competition_verifier(
     }
 }
 
-fn open_competition_offchain_gates(
-    network: &str,
+async fn open_competition_offchain_gates(
+    state: &AppState,
+    safe_state: &OpenCompetitionSafeState,
 ) -> Result<OpenCompetitionOffchainGates, StatusCode> {
-    let prefix = open_competition_environment_prefix(network)?;
+    let prefix = open_competition_environment_prefix(&safe_state.network)?;
+    let monitoring_configured = env_flag(&format!("{prefix}_MONITORING_ACTIVE"));
+    let monitoring_active = if monitoring_configured {
+        match &state.store {
+            Some(store) => store
+                .get_base_indexer_heartbeat(&safe_state.network, &safe_state.factory_contract)
+                .await
+                .ok()
+                .flatten()
+                .is_some_and(|heartbeat| {
+                    open_competition_monitoring_is_fresh(
+                        &heartbeat,
+                        safe_state.safe_block_number,
+                        Utc::now(),
+                    )
+                }),
+            None => false,
+        }
+    } else {
+        false
+    };
     Ok(OpenCompetitionOffchainGates {
         gas_sponsorship_available: env_flag(&format!("{prefix}_GAS_SPONSORSHIP_AVAILABLE")),
         relay_support_available: env_flag(&format!("{prefix}_RELAY_SUPPORT_AVAILABLE")),
         r4_release_evidence_complete: env_flag(&format!("{prefix}_R4_EVIDENCE_COMPLETE")),
-        monitoring_active: env_flag(&format!("{prefix}_MONITORING_ACTIVE")),
+        monitoring_active,
     })
+}
+
+fn open_competition_monitoring_is_fresh(
+    heartbeat: &BaseIndexerHeartbeat,
+    safe_block_number: u64,
+    now: DateTime<Utc>,
+) -> bool {
+    const MAX_HEARTBEAT_AGE_SECONDS: i64 = 90;
+    const MAX_CURSOR_LAG_BLOCKS: u64 = 20;
+
+    let status_healthy = heartbeat.status == "success"
+        || (heartbeat.status == "skipped"
+            && heartbeat.skipped_reason.as_deref()
+                == Some("no confirmed blocks are ready to scan"));
+    let Some(completed_at) = heartbeat.completed_at else {
+        return false;
+    };
+    let age = now.signed_duration_since(completed_at).num_seconds();
+    let latest_block_healthy = heartbeat
+        .latest_block
+        .is_some_and(|latest| latest.saturating_add(MAX_CURSOR_LAG_BLOCKS) >= safe_block_number);
+    let cursor_healthy = heartbeat
+        .persisted_cursor_block
+        .is_some_and(|cursor| cursor.saturating_add(MAX_CURSOR_LAG_BLOCKS) >= safe_block_number);
+
+    status_healthy
+        && heartbeat.error_message.is_none()
+        && (0..=MAX_HEARTBEAT_AGE_SECONDS).contains(&age)
+        && latest_block_healthy
+        && cursor_healthy
 }
 
 fn open_competition_hosted_operation_enabled(
@@ -13662,6 +13709,78 @@ mod tests {
     };
 
     type TestHmacSha256 = Hmac<Sha256>;
+
+    fn open_competition_heartbeat(
+        now: DateTime<Utc>,
+        status: &str,
+        cursor: Option<u64>,
+        age_seconds: i64,
+    ) -> BaseIndexerHeartbeat {
+        BaseIndexerHeartbeat {
+            network: "base-mainnet".to_string(),
+            escrow_contract: "0x9e9382beb8b1a45b737d484b5eafa7b8779d4ca5".to_string(),
+            status: status.to_string(),
+            started_at: now - ChronoDuration::seconds(age_seconds + 1),
+            completed_at: Some(now - ChronoDuration::seconds(age_seconds)),
+            latest_block: cursor.map(|block| block.saturating_add(2)),
+            confirmed_to_block: cursor,
+            from_block: cursor,
+            to_block: cursor,
+            fetched_logs: 0,
+            persisted_cursor_block: cursor,
+            skipped_reason: None,
+            error_message: None,
+            updated_at: now - ChronoDuration::seconds(age_seconds),
+        }
+    }
+
+    #[test]
+    fn open_competition_monitoring_requires_fresh_healthy_cursor_evidence() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap();
+        let safe_block = 50_000_000;
+        let healthy = open_competition_heartbeat(now, "success", Some(safe_block), 15);
+        assert!(open_competition_monitoring_is_fresh(
+            &healthy, safe_block, now
+        ));
+
+        let stale = open_competition_heartbeat(now, "success", Some(safe_block), 91);
+        assert!(!open_competition_monitoring_is_fresh(
+            &stale, safe_block, now
+        ));
+
+        let lagging = open_competition_heartbeat(now, "success", Some(safe_block - 21), 15);
+        assert!(!open_competition_monitoring_is_fresh(
+            &lagging, safe_block, now
+        ));
+
+        let failed = open_competition_heartbeat(now, "failed", Some(safe_block), 15);
+        assert!(!open_competition_monitoring_is_fresh(
+            &failed, safe_block, now
+        ));
+    }
+
+    #[test]
+    fn open_competition_monitoring_accepts_only_the_caught_up_skip_reason() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap();
+        let safe_block = 50_000_000;
+        let mut caught_up = open_competition_heartbeat(now, "skipped", Some(safe_block), 15);
+        caught_up.skipped_reason = Some("no confirmed blocks are ready to scan".to_string());
+        assert!(open_competition_monitoring_is_fresh(
+            &caught_up, safe_block, now
+        ));
+
+        caught_up.skipped_reason =
+            Some("latest block is below configured confirmations".to_string());
+        assert!(!open_competition_monitoring_is_fresh(
+            &caught_up, safe_block, now
+        ));
+
+        caught_up.skipped_reason = Some("no confirmed blocks are ready to scan".to_string());
+        caught_up.error_message = Some("redacted failure".to_string());
+        assert!(!open_competition_monitoring_is_fresh(
+            &caught_up, safe_block, now
+        ));
+    }
 
     #[tokio::test]
     async fn objective_api_requires_signed_creation_and_preserves_role_boundaries() {

--- a/deployments/open-competition-v1-base-mainnet.json
+++ b/deployments/open-competition-v1-base-mainnet.json
@@ -91,6 +91,7 @@
     "public_creation_enabled": false,
     "public_commitments_enabled": false,
     "public_inventory_eligible": false,
+    "monitoring_gate_configured": true,
     "monitoring_active": false,
     "relay_support_available": false,
     "gas_sponsorship_available": false,

--- a/docs/open-competition-v1-release-runbook.md
+++ b/docs/open-competition-v1-release-runbook.md
@@ -165,5 +165,8 @@ The current Base mainnet release evidence is published in
 `deployments/open-competition-v1-base-mainnet.json`. Its hidden canary settled
 canonically and conserved escrow at a safe block. The hosted manifest remains
 `mainnet_canary_not_ready_to_earn`; public creation, commitments, and inventory
-stay disabled while monitoring, relay, gas-sponsorship, and final release
-evidence gates are false.
+stay disabled. The monitoring gate is configured but becomes ready only when
+the version-specific indexer's database heartbeat is successful or caught up,
+no more than 90 seconds old, error-free, and within 20 blocks of the API's safe
+block. A feature flag by itself cannot satisfy it. Relay, gas-sponsorship, and
+final R4 release-evidence gates remain false.

--- a/docs/open-competition-v1.md
+++ b/docs/open-competition-v1.md
@@ -156,6 +156,9 @@ Versioned HTTP interfaces are:
 Canonical identity, funding, timing, capacity, wallet-entry, and deadline facts
 come from one safe-block RPC snapshot. Hosted monitoring, relay support, gas
 sponsorship, and completed release evidence remain explicit offchain gates.
+Monitoring requires both operator configuration and a fresh, successful,
+version-specific indexer heartbeat whose persisted cursor is within 20 safe
+blocks; stale, failed, missing, or error-bearing heartbeats fail closed.
 Creation and new commitments have independent default-off kill switches;
 reveal, expiry, cancellation refund, and bond withdrawal recovery remain
 available when entry is disabled.

--- a/render.yaml
+++ b/render.yaml
@@ -58,7 +58,7 @@ envVarGroups:
       - key: BASE_MAINNET_OPEN_COMPETITION_V1_R4_EVIDENCE_COMPLETE
         value: "false"
       - key: BASE_MAINNET_OPEN_COMPETITION_V1_MONITORING_ACTIVE
-        value: "false"
+        value: "true"
       - key: BASE_MAINNET_OPEN_COMPETITION_V1_CREATION_ENABLED
         value: "false"
       - key: BASE_MAINNET_OPEN_COMPETITION_V1_COMMITMENTS_ENABLED

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -212,8 +212,21 @@ def load_open_competition_mainnet_release(repo_root: Path) -> dict[str, object]:
     if release.get("deployment_state") != "mainnet_canary_not_ready_to_earn":
         fail("Open Competition V1 hosted release must remain in hidden-canary state")
     hosted = release.get("hosted_activation")
-    if not isinstance(hosted, dict) or any(hosted.values()):
-        fail("Open Competition V1 hosted activation gates must remain false")
+    if not isinstance(hosted, dict):
+        fail("Open Competition V1 hosted activation evidence is missing")
+    if hosted.get("monitoring_gate_configured") is not True:
+        fail("Open Competition V1 monitoring gate must be configured")
+    for field in (
+        "public_creation_enabled",
+        "public_commitments_enabled",
+        "public_inventory_eligible",
+        "monitoring_active",
+        "relay_support_available",
+        "gas_sponsorship_available",
+        "r4_release_evidence_complete",
+    ):
+        if hosted.get(field) is not False:
+            fail(f"Open Competition V1 hidden-canary gate {field} must remain false")
     if not isinstance(release.get("release_manifest"), dict):
         fail("Open Competition V1 release_manifest is missing")
     catalog = release.get("verifier_catalog")
@@ -343,11 +356,13 @@ def main() -> int:
         "BASE_MAINNET_OPEN_COMPETITION_V1_GAS_SPONSORSHIP_AVAILABLE",
         "BASE_MAINNET_OPEN_COMPETITION_V1_RELAY_SUPPORT_AVAILABLE",
         "BASE_MAINNET_OPEN_COMPETITION_V1_R4_EVIDENCE_COMPLETE",
-        "BASE_MAINNET_OPEN_COMPETITION_V1_MONITORING_ACTIVE",
         "BASE_MAINNET_OPEN_COMPETITION_V1_CREATION_ENABLED",
         "BASE_MAINNET_OPEN_COMPETITION_V1_COMMITMENTS_ENABLED",
     ):
         require_env_value(base_group, key, '"false"')
+    require_env_value(
+        base_group, "BASE_MAINNET_OPEN_COMPETITION_V1_MONITORING_ACTIVE", '"true"'
+    )
     relayer_group = require_group(
         text,
         "agent-bounties-x402-relayer",

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -670,7 +670,6 @@ def open_competition_shared_environment(
         "BASE_MAINNET_OPEN_COMPETITION_V1_R4_EVIDENCE_COMPLETE": (
             "r4_release_evidence_complete"
         ),
-        "BASE_MAINNET_OPEN_COMPETITION_V1_MONITORING_ACTIVE": "monitoring_active",
         "BASE_MAINNET_OPEN_COMPETITION_V1_CREATION_ENABLED": (
             "public_creation_enabled"
         ),
@@ -680,6 +679,10 @@ def open_competition_shared_environment(
     }
     if activation.get("public_inventory_eligible") is not False:
         raise RecoveryError("Open Competition public inventory must remain disabled")
+    if activation.get("monitoring_gate_configured") is not True:
+        raise RecoveryError("Open Competition monitoring gate must be configured")
+    if activation.get("monitoring_active") is not False:
+        raise RecoveryError("Open Competition runtime monitoring cannot be pre-attested")
     for field in activation_fields.values():
         if activation.get(field) is not False:
             raise RecoveryError(f"Open Competition hosted activation requires {field}=false")
@@ -694,6 +697,7 @@ def open_competition_shared_environment(
         ),
     }
     values.update({key: "false" for key in activation_fields})
+    values["BASE_MAINNET_OPEN_COMPETITION_V1_MONITORING_ACTIVE"] = "true"
     return values
 
 

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -776,7 +776,12 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         for key, value in values.items():
             if key.endswith("_JSON") or key == "BASE_MAINNET_RPC_URL":
                 continue
-            self.assertEqual(value, "false")
+            expected = (
+                "true"
+                if key == "BASE_MAINNET_OPEN_COMPETITION_V1_MONITORING_ACTIVE"
+                else "false"
+            )
+            self.assertEqual(value, expected)
 
     def test_open_competition_shared_environment_rejects_activation(self) -> None:
         source = recovery.json.loads(
@@ -789,6 +794,36 @@ class RenderDeployRecoveryTests(unittest.TestCase):
             path = Path(directory) / "release.json"
             path.write_text(recovery.json.dumps(source), encoding="utf-8")
             with self.assertRaisesRegex(recovery.RecoveryError, "requires.*false"):
+                recovery.open_competition_shared_environment(path)
+
+    def test_open_competition_shared_environment_rejects_unconfigured_monitoring(
+        self,
+    ) -> None:
+        source = recovery.json.loads(
+            recovery.OPEN_COMPETITION_RELEASE_MANIFEST_PATH.read_text(
+                encoding="utf-8"
+            )
+        )
+        source["hosted_activation"]["monitoring_gate_configured"] = False
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "release.json"
+            path.write_text(recovery.json.dumps(source), encoding="utf-8")
+            with self.assertRaisesRegex(recovery.RecoveryError, "must be configured"):
+                recovery.open_competition_shared_environment(path)
+
+    def test_open_competition_shared_environment_rejects_pre_attested_monitoring(
+        self,
+    ) -> None:
+        source = recovery.json.loads(
+            recovery.OPEN_COMPETITION_RELEASE_MANIFEST_PATH.read_text(
+                encoding="utf-8"
+            )
+        )
+        source["hosted_activation"]["monitoring_active"] = True
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "release.json"
+            path.write_text(recovery.json.dumps(source), encoding="utf-8")
+            with self.assertRaisesRegex(recovery.RecoveryError, "cannot be pre-attested"):
                 recovery.open_competition_shared_environment(path)
 
     def test_shared_environment_variable_is_read_verified(self) -> None:


### PR DESCRIPTION
## Outcome

Makes the Open Competition V1 dependency-monitoring gate depend on the version-specific durable indexer heartbeat instead of an environment flag alone.

- requires the operator gate plus a successful/caught-up heartbeat
- fails closed after 90 seconds, over 20 blocks of cursor lag, any worker error, missing DB, or missing heartbeat
- configures monitoring for the hidden canary without enabling public creation, commitments, inventory, relay, gas sponsorship, or R4 evidence
- preserves reveal and withdrawal recovery behavior

## Risk boundary

This is an additive read/readiness change. It does not deploy contracts, submit transactions, migrate historical rows, or modify any bounty, contribution, claim, or payout state.

## Checks

- powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Mode core
- cargo test -p api open_competition_monitoring -- --nocapture
- cargo fmt --check
- python scripts/check-render-blueprint.py
- python -m unittest scripts.test_render_deploy_recovery
- git diff --check
