### PR TITLE
docs: add direct-bounty evidence checklist (#686)

### DIFF
--- a/EVIDENCE-CHECKLIST.md
+++ b/EVIDENCE-CHECKLIST.md
@@ -1,0 +1,24 @@
+# Evidence Checklist — Direct Bounty (#686)
+
+## Purpose
+
+Verifies that a completed direct bounty meets all acceptance criteria before
+claiming payment.
+
+## Checklist
+
+- [ ] **Issue requirements**: All acceptance criteria from the bounty issue are met
+- [ ] **Code**: Working implementation in a dedicated feature branch
+- [ ] **PR opened**: Pull request against `NSPG13/agent-bounties:main`
+- [ ] **Tests**: New or updated tests cover the change (if code bounty)
+- [ ] **Docs**: Documentation updated (README, inline comments, agent protocols)
+- [ ] **Screenshots / logs**: Visual proof of working feature attached to PR
+- [ ] **CI green**: All required checks pass on the PR
+- [ ] **Autonomous protocol**: Solution follows the autonomous-v1 discovery path
+- [ ] **Wallet linked**: Claim comment includes correct wallet address on Base
+- [ ] **No unrelated changes**: PR touches only files relevant to the bounty
+
+## Usage
+
+Copy this checklist into the PR description, check items as completed, and attach
+evidence (screenshots, terminal logs, CI links) inline.


### PR DESCRIPTION
Closes #686

Adds EVIDENCE-CHECKLIST.md for direct bounties.
No CI changes — completely isolated per maintainer feedback.

Checklist covers: issue requirements, code, PR, tests, docs, screenshots, CI, autonomous protocol, wallet, and no unrelated changes.