### PR TITLE
Open Competition V1: bounded gas-sponsored entrant wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ __pycache__/
 .tools/
 contracts/**/out/
 contracts/**/cache/
+/out/
+/cache/
 broadcast/
 /tools/coinbase-embedded-wallet/.build-check

--- a/contracts/base-escrow/src/OpenCompetitionEntrantWalletFactoryV1.sol
+++ b/contracts/base-escrow/src/OpenCompetitionEntrantWalletFactoryV1.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./OpenCompetitionEntrantWalletV1.sol";
+
+/// @notice Deterministically deploys policy-bound entrant wallets for one frozen competition factory.
+/// @dev This contract has no owner, upgrade path, arbitrary-call authority, or gas reimbursement path.
+contract OpenCompetitionEntrantWalletFactoryV1 {
+    using SafeBountyToken for address;
+
+    enum FundingMode {
+        None,
+        Allowance,
+        Eip3009
+    }
+
+    OpenCompetitionBountyFactoryV1 public immutable competitionFactory;
+    address public immutable settlementToken;
+    address public immutable implementation;
+    mapping(address => bool) public isFactoryWallet;
+    uint256 private _reentrancy = 1;
+
+    event OpenCompetitionEntrantWalletCreated(
+        address indexed wallet,
+        address indexed owner,
+        address indexed delegate,
+        bytes32 userSalt,
+        bytes32 effectiveSalt,
+        bytes32 policyHash,
+        FundingMode fundingMode,
+        uint256 initialFunding
+    );
+
+    modifier nonReentrant() {
+        require(_reentrancy == 1, "reentrant");
+        _reentrancy = 2;
+        _;
+        _reentrancy = 1;
+    }
+
+    constructor(address competitionFactory_) {
+        require(competitionFactory_.code.length > 0, "factory has no code");
+        competitionFactory = OpenCompetitionBountyFactoryV1(competitionFactory_);
+        settlementToken = OpenCompetitionBountyFactoryV1(competitionFactory_).settlementToken();
+        require(settlementToken.code.length > 0, "token has no code");
+        implementation = address(new OpenCompetitionEntrantWalletV1(competitionFactory_));
+    }
+
+    function createWallet(
+        address owner,
+        OpenCompetitionEntrantWalletV1.Policy calldata policy,
+        bytes32 userSalt
+    ) external nonReentrant returns (address wallet) {
+        wallet = _deploy(owner, policy, userSalt, FundingMode.None, 0);
+    }
+
+    function createWalletAndFund(
+        OpenCompetitionEntrantWalletV1.Policy calldata policy,
+        bytes32 userSalt,
+        uint256 initialFunding
+    ) external nonReentrant returns (address wallet) {
+        require(initialFunding > 0, "funding zero");
+        wallet = _deploy(msg.sender, policy, userSalt, FundingMode.Allowance, initialFunding);
+        uint256 balanceBefore = IERC20BountyToken(settlementToken).balanceOf(wallet);
+        settlementToken.safeTransferFrom(msg.sender, wallet, initialFunding);
+        require(
+            IERC20BountyToken(settlementToken).balanceOf(wallet) == balanceBefore + initialFunding,
+            "funding not received"
+        );
+    }
+
+    /// @notice Any keeper may deploy and fund the exact wallet named by a Circle USDC authorization.
+    function createWalletWithAuthorization(
+        address owner,
+        OpenCompetitionEntrantWalletV1.Policy calldata policy,
+        bytes32 userSalt,
+        uint256 initialFunding,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 authorizationNonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external nonReentrant returns (address wallet) {
+        require(initialFunding > 0, "funding zero");
+        wallet = _deploy(owner, policy, userSalt, FundingMode.Eip3009, initialFunding);
+        uint256 balanceBefore = IERC20BountyToken(settlementToken).balanceOf(wallet);
+        settlementToken.safeTransferWithAuthorization(
+            owner, wallet, initialFunding, validAfter, validBefore, authorizationNonce, v, r, s
+        );
+        require(
+            IERC20BountyToken(settlementToken).balanceOf(wallet) == balanceBefore + initialFunding,
+            "funding not received"
+        );
+    }
+
+    function predictWallet(
+        address owner,
+        OpenCompetitionEntrantWalletV1.Policy calldata policy,
+        bytes32 userSalt
+    ) external view returns (address) {
+        return _predictWallet(owner, userSalt, keccak256(abi.encode(policy)));
+    }
+
+    function walletInitCodeHash() public view returns (bytes32) {
+        return keccak256(
+            abi.encodePacked(
+                hex"3d602d80600a3d3981f3",
+                hex"363d3d373d3d3d363d73",
+                bytes20(implementation),
+                hex"5af43d82803e903d91602b57fd5bf3"
+            )
+        );
+    }
+
+    function effectiveSalt(address owner, bytes32 userSalt, bytes32 policyHash_) public pure returns (bytes32) {
+        return keccak256(abi.encode(owner, userSalt, policyHash_));
+    }
+
+    function _deploy(
+        address owner,
+        OpenCompetitionEntrantWalletV1.Policy calldata policy,
+        bytes32 userSalt,
+        FundingMode fundingMode,
+        uint256 initialFunding
+    ) private returns (address wallet) {
+        require(owner != address(0), "owner zero");
+        require(userSalt != bytes32(0), "user salt zero");
+        bytes32 policyHash_ = keccak256(abi.encode(policy));
+        bytes32 salt = effectiveSalt(owner, userSalt, policyHash_);
+        wallet = _predictWallet(owner, userSalt, policyHash_);
+        if (wallet.code.length > 0) {
+            require(isFactoryWallet[wallet], "wallet address occupied");
+            OpenCompetitionEntrantWalletV1 existing = OpenCompetitionEntrantWalletV1(payable(wallet));
+            require(existing.owner() == owner, "wallet owner changed");
+            require(existing.policyHash() == policyHash_, "wallet policy changed");
+            return wallet;
+        }
+        wallet = _cloneDeterministic(implementation, salt);
+        isFactoryWallet[wallet] = true;
+        OpenCompetitionEntrantWalletV1(payable(wallet)).initialize(owner, policy);
+        emit OpenCompetitionEntrantWalletCreated(
+            wallet, owner, policy.delegate, userSalt, salt, policyHash_, fundingMode, initialFunding
+        );
+    }
+
+    function _predictWallet(address owner, bytes32 userSalt, bytes32 policyHash_) private view returns (address) {
+        return address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            bytes1(0xff),
+                            address(this),
+                            effectiveSalt(owner, userSalt, policyHash_),
+                            walletInitCodeHash()
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    function _cloneDeterministic(address target, bytes32 salt) private returns (address instance) {
+        bytes20 targetBytes = bytes20(target);
+        bytes memory creationCode = abi.encodePacked(
+            hex"3d602d80600a3d3981f3", hex"363d3d373d3d3d363d73", targetBytes, hex"5af43d82803e903d91602b57fd5bf3"
+        );
+        assembly ("memory-safe") {
+            instance := create2(0, add(creationCode, 0x20), mload(creationCode), salt)
+        }
+        require(instance != address(0), "wallet deployment failed");
+    }
+}

--- a/contracts/base-escrow/src/OpenCompetitionEntrantWalletV1.sol
+++ b/contracts/base-escrow/src/OpenCompetitionEntrantWalletV1.sol
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "./OpenCompetitionBountyFactoryV1.sol";
+
+/// @notice A policy-capped entrant account for canonical Open Competition V1 bounties.
+/// @dev A keeper may pay gas for exact EIP-712-authorized actions, but cannot choose
+/// a bounty, proof, commitment, recipient, or token transfer on the wallet's behalf.
+contract OpenCompetitionEntrantWalletV1 {
+    using SafeBountyToken for address;
+
+    enum Action {
+        Commit,
+        Reveal,
+        WithdrawBond
+    }
+
+    enum ErrorCode {
+        Unauthorized,
+        Reentrant,
+        InvalidInitialization,
+        InvalidAddress,
+        AlreadyRevoked,
+        InvalidOwnershipTransfer,
+        SignatureExpired,
+        NonceMismatch,
+        InvalidSignature,
+        InvalidAmount,
+        TransferFailed,
+        InvalidPolicy,
+        InactivePolicy,
+        ActionNotAllowed,
+        InvalidCompetition,
+        CreatorControlled,
+        VerifierProfileMismatch,
+        SpendLimitExceeded,
+        TokenOperationFailed
+    }
+
+    error WalletError(ErrorCode code);
+
+    struct Policy {
+        address delegate;
+        uint64 validAfter;
+        uint64 validUntil;
+        uint64 periodSeconds;
+        uint256 maxPerAction;
+        uint256 maxPerPeriod;
+        uint256 maxLifetimeSpend;
+        uint256 maxBountyTarget;
+        uint8 allowedActions;
+        address verifierModule;
+        bytes32 verifierRuntimeCodeHash;
+        bytes32 verifierPolicyHash;
+        bytes32 acceptanceCriteriaHash;
+        bytes32 benchmarkHash;
+        bytes32 evidenceSchemaHash;
+    }
+
+    uint8 public constant ACTION_COMMIT = uint8(1) << uint8(Action.Commit);
+    uint8 public constant ACTION_REVEAL = uint8(1) << uint8(Action.Reveal);
+    uint8 public constant ACTION_WITHDRAW_BOND = uint8(1) << uint8(Action.WithdrawBond);
+    uint8 public constant ALL_ACTIONS = ACTION_COMMIT | ACTION_REVEAL | ACTION_WITHDRAW_BOND;
+
+    bytes4 private constant ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    uint256 private constant ERC1271_GAS_LIMIT = 200_000;
+    uint256 private constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant NAME_HASH = keccak256("Agent Bounties Open Competition Entrant Wallet");
+    bytes32 private constant VERSION_HASH = keccak256("1");
+    bytes32 private constant ACTION_TYPEHASH = keccak256(
+        "OpenCompetitionEntrantAction(address wallet,uint8 action,bytes32 payloadHash,uint256 nonce,uint256 deadline,uint64 policyVersion)"
+    );
+
+    OpenCompetitionBountyFactoryV1 public immutable factory;
+    address public immutable settlementToken;
+    address public immutable deploymentFactory;
+    address public owner;
+    address public pendingOwner;
+    Policy private _policy;
+    uint64 public policyVersion;
+    uint256 public delegateNonce;
+    uint256 public periodBucket;
+    uint256 public periodSpent;
+    uint256 public lifetimeSpent;
+    bool public revoked;
+    uint256 private _reentrancy = 1;
+    bool private _initialized;
+
+    event PolicyConfigured(
+        uint64 indexed version, address indexed delegate, uint8 allowedActions, bytes32 indexed policyHash
+    );
+    event PolicyRevoked(uint64 indexed version, address indexed delegate);
+    event SpendCharged(uint256 amount, uint256 periodSpent, uint256 lifetimeSpent, uint256 periodBucket);
+    event EntrantActionExecuted(
+        Action indexed action, address indexed delegate, address indexed relayer, uint256 nonce, bytes32 payloadHash
+    );
+    event OwnershipTransferStarted(address indexed owner, address indexed pendingOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event TokenWithdrawn(address indexed token, address indexed to, uint256 amount);
+    event EthWithdrawn(address indexed to, uint256 amount);
+    event BondRecovered(address indexed bounty, address indexed owner);
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert WalletError(ErrorCode.Unauthorized);
+        _;
+    }
+
+    modifier nonReentrant() {
+        if (_reentrancy != 1) revert WalletError(ErrorCode.Reentrant);
+        _reentrancy = 2;
+        _;
+        _reentrancy = 1;
+    }
+
+    /// @dev Locks the implementation while clones retain independent storage.
+    constructor(address factory_) {
+        if (factory_.code.length == 0) revert WalletError(ErrorCode.InvalidAddress);
+        deploymentFactory = msg.sender;
+        factory = OpenCompetitionBountyFactoryV1(factory_);
+        settlementToken = OpenCompetitionBountyFactoryV1(factory_).settlementToken();
+        if (settlementToken.code.length == 0) revert WalletError(ErrorCode.InvalidAddress);
+        _initialized = true;
+    }
+
+    function initialize(address owner_, Policy calldata initialPolicy) external {
+        if (msg.sender != deploymentFactory) revert WalletError(ErrorCode.Unauthorized);
+        if (_initialized) revert WalletError(ErrorCode.InvalidInitialization);
+        if (owner_ == address(0)) revert WalletError(ErrorCode.InvalidAddress);
+        _initialized = true;
+        _reentrancy = 1;
+        owner = owner_;
+        emit OwnershipTransferred(address(0), owner_);
+        _configurePolicy(initialPolicy);
+    }
+
+    receive() external payable {}
+
+    function configurePolicy(Policy calldata nextPolicy) external onlyOwner {
+        _configurePolicy(nextPolicy);
+    }
+
+    function revokePolicy() external onlyOwner {
+        if (revoked) revert WalletError(ErrorCode.AlreadyRevoked);
+        revoked = true;
+        emit PolicyRevoked(policyVersion, _policy.delegate);
+    }
+
+    function transferOwnership(address nextOwner) external onlyOwner {
+        if (nextOwner == address(0)) revert WalletError(ErrorCode.InvalidAddress);
+        pendingOwner = nextOwner;
+        emit OwnershipTransferStarted(owner, nextOwner);
+    }
+
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert WalletError(ErrorCode.InvalidOwnershipTransfer);
+        address previousOwner = owner;
+        owner = msg.sender;
+        pendingOwner = address(0);
+        emit OwnershipTransferred(previousOwner, msg.sender);
+    }
+
+    function commitSolution(address bountyAddress, bytes32 commitment) external nonReentrant {
+        _requireDirectDelegate(Action.Commit);
+        bytes memory payload = abi.encode(bountyAddress, commitment);
+        uint256 nonce = _consumeDirectNonce();
+        _commitSolution(bountyAddress, commitment);
+        emit EntrantActionExecuted(Action.Commit, _policy.delegate, msg.sender, nonce, keccak256(payload));
+    }
+
+    function revealSolution(
+        address bountyAddress,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 salt,
+        bytes calldata proof
+    ) external nonReentrant {
+        _requireDirectDelegate(Action.Reveal);
+        bytes memory payload = abi.encode(bountyAddress, submissionHash, evidenceHash, salt, proof);
+        uint256 nonce = _consumeDirectNonce();
+        _revealSolution(bountyAddress, submissionHash, evidenceHash, salt, proof);
+        emit EntrantActionExecuted(Action.Reveal, _policy.delegate, msg.sender, nonce, keccak256(payload));
+    }
+
+    function withdrawEntryBond(address bountyAddress) external nonReentrant {
+        _requireDirectDelegate(Action.WithdrawBond);
+        bytes memory payload = abi.encode(bountyAddress);
+        uint256 nonce = _consumeDirectNonce();
+        _withdrawEntryBond(bountyAddress);
+        emit EntrantActionExecuted(Action.WithdrawBond, _policy.delegate, msg.sender, nonce, keccak256(payload));
+    }
+
+    /// @notice Any keeper may relay one exact action signed by the active delegate.
+    function executeWithSignature(
+        Action action,
+        bytes calldata payload,
+        uint256 nonce,
+        uint256 deadline,
+        bytes calldata signature
+    ) external nonReentrant returns (bytes memory result) {
+        _requireActivePolicy(action);
+        if (block.timestamp > deadline) revert WalletError(ErrorCode.SignatureExpired);
+        if (nonce != delegateNonce) revert WalletError(ErrorCode.NonceMismatch);
+        bytes32 payloadHash = keccak256(payload);
+        bytes32 digest = actionDigest(action, payloadHash, nonce, deadline);
+        if (!_isValidSignatureNow(_policy.delegate, digest, signature)) {
+            revert WalletError(ErrorCode.InvalidSignature);
+        }
+        delegateNonce = nonce + 1;
+        result = _dispatch(action, payload);
+        emit EntrantActionExecuted(action, _policy.delegate, msg.sender, nonce, payloadHash);
+    }
+
+    function actionDigest(Action action, bytes32 payloadHash, uint256 nonce, uint256 deadline)
+        public
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(
+            abi.encode(ACTION_TYPEHASH, address(this), uint8(action), payloadHash, nonce, deadline, policyVersion)
+        );
+        bytes32 domainSeparator =
+            keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, address(this)));
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function policy() external view returns (Policy memory) {
+        return _policy;
+    }
+
+    function policyHash() public view returns (bytes32) {
+        return keccak256(abi.encode(_policy));
+    }
+
+    /// @notice Owner recovery does not depend on an active delegate policy.
+    function recoverEntryBond(address bountyAddress) external onlyOwner nonReentrant {
+        _withdrawEntryBond(bountyAddress);
+        emit BondRecovered(bountyAddress, msg.sender);
+    }
+
+    function withdrawToken(address token, address to, uint256 amount) external onlyOwner nonReentrant {
+        if (token.code.length == 0 || to == address(0)) revert WalletError(ErrorCode.InvalidAddress);
+        if (amount == 0) revert WalletError(ErrorCode.InvalidAmount);
+        token.safeTransfer(to, amount);
+        emit TokenWithdrawn(token, to, amount);
+    }
+
+    function withdrawEth(address payable to, uint256 amount) external onlyOwner nonReentrant {
+        if (to == address(0)) revert WalletError(ErrorCode.InvalidAddress);
+        if (amount == 0 || amount > address(this).balance) revert WalletError(ErrorCode.InvalidAmount);
+        (bool ok,) = to.call{value: amount}("");
+        if (!ok) revert WalletError(ErrorCode.TransferFailed);
+        emit EthWithdrawn(to, amount);
+    }
+
+    function _configurePolicy(Policy memory nextPolicy) private {
+        if (
+            nextPolicy.delegate == address(0) || nextPolicy.validUntil <= nextPolicy.validAfter
+                || nextPolicy.validUntil <= block.timestamp || nextPolicy.allowedActions == 0
+                || (nextPolicy.allowedActions & ~ALL_ACTIONS) != 0 || nextPolicy.maxBountyTarget == 0
+                || nextPolicy.verifierModule.code.length == 0 || nextPolicy.verifierRuntimeCodeHash == bytes32(0)
+                || nextPolicy.verifierModule.codehash != nextPolicy.verifierRuntimeCodeHash
+                || nextPolicy.verifierPolicyHash == bytes32(0) || nextPolicy.acceptanceCriteriaHash == bytes32(0)
+                || nextPolicy.benchmarkHash == bytes32(0) || nextPolicy.evidenceSchemaHash == bytes32(0)
+        ) revert WalletError(ErrorCode.InvalidPolicy);
+        if ((nextPolicy.allowedActions & ACTION_COMMIT) != 0) {
+            if (
+                nextPolicy.periodSeconds == 0 || nextPolicy.maxPerAction == 0 || nextPolicy.maxPerPeriod == 0
+                    || nextPolicy.maxLifetimeSpend < lifetimeSpent || nextPolicy.maxLifetimeSpend == 0
+            ) revert WalletError(ErrorCode.InvalidPolicy);
+        }
+        _policy = nextPolicy;
+        policyVersion += 1;
+        revoked = false;
+        if (nextPolicy.periodSeconds > 0) {
+            periodBucket = block.timestamp / nextPolicy.periodSeconds;
+            periodSpent = 0;
+        }
+        emit PolicyConfigured(policyVersion, nextPolicy.delegate, nextPolicy.allowedActions, keccak256(abi.encode(nextPolicy)));
+    }
+
+    function _requireDirectDelegate(Action action) private view {
+        if (msg.sender != _policy.delegate) revert WalletError(ErrorCode.Unauthorized);
+        _requireActivePolicy(action);
+    }
+
+    function _consumeDirectNonce() private returns (uint256 nonce) {
+        nonce = delegateNonce;
+        delegateNonce = nonce + 1;
+    }
+
+    function _requireActivePolicy(Action action) private view {
+        if (revoked || block.timestamp < _policy.validAfter || block.timestamp > _policy.validUntil) {
+            revert WalletError(ErrorCode.InactivePolicy);
+        }
+        if ((_policy.allowedActions & (uint8(1) << uint8(action))) == 0) {
+            revert WalletError(ErrorCode.ActionNotAllowed);
+        }
+    }
+
+    function _dispatch(Action action, bytes calldata payload) private returns (bytes memory) {
+        if (action == Action.Commit) {
+            (address commitBountyAddress, bytes32 commitment) = abi.decode(payload, (address, bytes32));
+            _commitSolution(commitBountyAddress, commitment);
+            return bytes("");
+        }
+        if (action == Action.Reveal) {
+            (
+                address revealBountyAddress,
+                bytes32 submissionHash,
+                bytes32 evidenceHash,
+                bytes32 salt,
+                bytes memory proof
+            ) = abi.decode(payload, (address, bytes32, bytes32, bytes32, bytes));
+            _revealSolution(revealBountyAddress, submissionHash, evidenceHash, salt, proof);
+            return bytes("");
+        }
+        address withdrawBountyAddress = abi.decode(payload, (address));
+        _withdrawEntryBond(withdrawBountyAddress);
+        return bytes("");
+    }
+
+    function _commitSolution(address bountyAddress, bytes32 commitment) private {
+        OpenCompetitionBountyV1 bounty = _canonicalCompetition(bountyAddress);
+        _requireBountyPolicy(bounty);
+        if (bounty.creator() == owner || bounty.creator() == _policy.delegate) {
+            revert WalletError(ErrorCode.CreatorControlled);
+        }
+        uint256 bond = bounty.verifierReward();
+        _chargeSpend(bond);
+        _approveExact(bountyAddress, bond);
+        bounty.commitSolution(commitment);
+        _approveExact(bountyAddress, 0);
+    }
+
+    function _revealSolution(
+        address bountyAddress,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 salt,
+        bytes memory proof
+    ) private {
+        OpenCompetitionBountyV1 bounty = _canonicalCompetition(bountyAddress);
+        _requireBountyPolicy(bounty);
+        if (bounty.creator() == owner || bounty.creator() == _policy.delegate) {
+            revert WalletError(ErrorCode.CreatorControlled);
+        }
+        bounty.revealSolution(submissionHash, evidenceHash, salt, proof);
+    }
+
+    function _withdrawEntryBond(address bountyAddress) private {
+        OpenCompetitionBountyV1 bounty = _canonicalCompetition(bountyAddress);
+        bounty.withdrawEntryBond();
+    }
+
+    function _canonicalCompetition(address bountyAddress) private view returns (OpenCompetitionBountyV1 bounty) {
+        if (!factory.isCanonicalCompetition(bountyAddress)) revert WalletError(ErrorCode.InvalidCompetition);
+        bounty = OpenCompetitionBountyV1(bountyAddress);
+        if (
+            bounty.factory() != address(factory) || bounty.settlementToken() != settlementToken
+                || bounty.protocolVersion() != factory.SUPPORTED_PROTOCOL_VERSION()
+        ) revert WalletError(ErrorCode.InvalidCompetition);
+    }
+
+    function _requireBountyPolicy(OpenCompetitionBountyV1 bounty) private view {
+        if (bounty.targetAmount() > _policy.maxBountyTarget) revert WalletError(ErrorCode.SpendLimitExceeded);
+        if (
+            bounty.verifierModule() != _policy.verifierModule
+                || _policy.verifierModule.codehash != _policy.verifierRuntimeCodeHash
+                || bounty.policyHash() != _policy.verifierPolicyHash
+                || bounty.acceptanceCriteriaHash() != _policy.acceptanceCriteriaHash
+                || bounty.benchmarkHash() != _policy.benchmarkHash
+                || bounty.evidenceSchemaHash() != _policy.evidenceSchemaHash
+        ) revert WalletError(ErrorCode.VerifierProfileMismatch);
+    }
+
+    function _chargeSpend(uint256 amount) private {
+        if (amount == 0) revert WalletError(ErrorCode.InvalidAmount);
+        if (amount > _policy.maxPerAction) revert WalletError(ErrorCode.SpendLimitExceeded);
+        uint256 bucket = block.timestamp / _policy.periodSeconds;
+        if (bucket != periodBucket) {
+            periodBucket = bucket;
+            periodSpent = 0;
+        }
+        if (
+            periodSpent + amount > _policy.maxPerPeriod || lifetimeSpent + amount > _policy.maxLifetimeSpend
+        ) revert WalletError(ErrorCode.SpendLimitExceeded);
+        periodSpent += amount;
+        lifetimeSpent += amount;
+        emit SpendCharged(amount, periodSpent, lifetimeSpent, bucket);
+    }
+
+    function _approveExact(address spender, uint256 amount) private {
+        (bool zeroOk, bytes memory zeroResult) =
+            settlementToken.call(abi.encodeWithSignature("approve(address,uint256)", spender, 0));
+        if (!zeroOk || (zeroResult.length != 0 && !abi.decode(zeroResult, (bool)))) {
+            revert WalletError(ErrorCode.TokenOperationFailed);
+        }
+        if (amount == 0) return;
+        (bool ok, bytes memory result) =
+            settlementToken.call(abi.encodeWithSignature("approve(address,uint256)", spender, amount));
+        if (!ok || (result.length != 0 && !abi.decode(result, (bool)))) {
+            revert WalletError(ErrorCode.TokenOperationFailed);
+        }
+    }
+
+    function _isValidSignatureNow(address signer, bytes32 digest, bytes memory signature) private view returns (bool) {
+        if (signer.code.length > 0) {
+            bytes memory callData = abi.encodeCall(IERC1271.isValidSignature, (digest, signature));
+            bool ok;
+            bytes4 result;
+            uint256 gasLimit = ERC1271_GAS_LIMIT;
+            assembly ("memory-safe") {
+                let output := mload(0x40)
+                mstore(output, 0)
+                ok := staticcall(gasLimit, signer, add(callData, 0x20), mload(callData), output, 0x20)
+                result := mload(output)
+            }
+            return ok && result == ERC1271_MAGIC_VALUE;
+        }
+        return _recover(digest, signature) == signer;
+    }
+
+    function _recover(bytes32 digest, bytes memory signature) private pure returns (address recovered) {
+        if (signature.length != 65) return address(0);
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+        if (uint256(s) > SECP256K1N_DIV_2 || (v != 27 && v != 28)) return address(0);
+        recovered = ecrecover(digest, v, r, s);
+    }
+}

--- a/contracts/base-escrow/test/OpenCompetitionEntrantWalletV1.t.sol
+++ b/contracts/base-escrow/test/OpenCompetitionEntrantWalletV1.t.sol
@@ -1,0 +1,661 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+import "../src/OpenCompetitionEntrantWalletFactoryV1.sol";
+
+interface EntrantWalletVm {
+    function warp(uint256) external;
+    function roll(uint256) external;
+    function prank(address) external;
+    function addr(uint256 privateKey) external returns (address);
+    function sign(uint256 privateKey, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+    function etch(address target, bytes calldata code) external;
+}
+
+contract EntrantWalletToken {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(address => mapping(bytes32 => bool)) public authorizationUsed;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balanceOf[from] >= amount, "balance");
+        require(allowance[from][msg.sender] >= amount, "allowance");
+        allowance[from][msg.sender] -= amount;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferWithAuthorization(
+        address from,
+        address to,
+        uint256 amount,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8,
+        bytes32,
+        bytes32
+    ) external {
+        require(block.timestamp > validAfter && block.timestamp < validBefore, "authorization timing");
+        require(!authorizationUsed[from][nonce], "authorization used");
+        require(balanceOf[from] >= amount, "balance");
+        authorizationUsed[from][nonce] = true;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+    }
+}
+
+contract EntrantWalletNonTransferringToken {
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function approve(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transfer(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function transferWithAuthorization(address, address, uint256, uint256, uint256, bytes32, uint8, bytes32, bytes32)
+        external
+        pure
+    {}
+}
+
+contract EntrantWalletVerifier is IAgentBountyVerifier {
+    bytes32 public immutable passingProofHash;
+
+    constructor(bytes32 passingProofHash_) {
+        passingProofHash = passingProofHash_;
+    }
+
+    function verify(bytes32, uint64 round, address, bytes32, bytes32, bytes32, bytes calldata proof)
+        external
+        view
+        returns (bool passed, bytes32 responseHash)
+    {
+        responseHash = keccak256(proof);
+        passed = round == 1 && responseHash == passingProofHash;
+    }
+}
+
+contract EntrantWalletCreator {
+    function approve(EntrantWalletToken token, address spender, uint256 amount) external {
+        token.approve(spender, amount);
+    }
+
+    function create(
+        OpenCompetitionBountyFactoryV1 factory,
+        OpenCompetitionBountyFactoryV1.CreateCompetitionParams calldata params,
+        uint256 initialFunding,
+        bytes32 creationNonce
+    ) external returns (address bounty, bytes32 bountyId) {
+        return factory.createCompetition(params, initialFunding, creationNonce);
+    }
+}
+
+contract EntrantWalletOtherSolver {
+    function approve(EntrantWalletToken token, address spender, uint256 amount) external {
+        token.approve(spender, amount);
+    }
+
+    function commit(OpenCompetitionBountyV1 bounty, bytes32 commitment) external {
+        bounty.commitSolution(commitment);
+    }
+
+    function reveal(
+        OpenCompetitionBountyV1 bounty,
+        bytes32 submissionHash,
+        bytes32 evidenceHash,
+        bytes32 salt,
+        bytes calldata proof
+    ) external {
+        bounty.revealSolution(submissionHash, evidenceHash, salt, proof);
+    }
+}
+
+contract EntrantWallet1271Delegate is IERC1271 {
+    bytes32 private approvedDigest;
+    bytes32 private approvedSignatureHash;
+
+    function approve(bytes32 digest, bytes calldata signature) external {
+        approvedDigest = digest;
+        approvedSignatureHash = keccak256(signature);
+    }
+
+    function isValidSignature(bytes32 digest, bytes calldata signature) external view returns (bytes4) {
+        return digest == approvedDigest && keccak256(signature) == approvedSignatureHash ? bytes4(0x1626ba7e) : bytes4(0);
+    }
+}
+
+contract OpenCompetitionEntrantWalletV1Test {
+    EntrantWalletVm private constant vm =
+        EntrantWalletVm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    uint256 private constant DELEGATE_KEY = 0xA11CE;
+    uint256 private constant WRONG_KEY = 0xB0B;
+    uint256 private constant SECP256K1_N =
+        0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141;
+    bytes32 private constant TERMS_HASH = keccak256("entrant-wallet-terms");
+    bytes32 private constant VERIFIER_POLICY_HASH = keccak256("entrant-wallet-verifier-policy");
+    bytes32 private constant CRITERIA_HASH = keccak256("entrant-wallet-criteria");
+    bytes32 private constant BENCHMARK_HASH = keccak256("entrant-wallet-benchmark");
+    bytes32 private constant EVIDENCE_SCHEMA_HASH = keccak256("entrant-wallet-evidence-schema");
+    bytes32 private constant SUBMISSION_HASH = keccak256("entrant-wallet-submission");
+    bytes32 private constant OTHER_SUBMISSION_HASH = keccak256("entrant-wallet-other-submission");
+    bytes32 private constant EVIDENCE_HASH = keccak256("entrant-wallet-evidence");
+    bytes32 private constant OTHER_EVIDENCE_HASH = keccak256("entrant-wallet-other-evidence");
+    bytes32 private constant SALT = keccak256("entrant-wallet-private-salt");
+    bytes32 private constant OTHER_SALT = keccak256("entrant-wallet-other-private-salt");
+    bytes private constant PASSING_PROOF = bytes("entrant-wallet-passing-proof");
+
+    EntrantWalletToken private token;
+    OpenCompetitionBountyFactoryV1 private competitionFactory;
+    OpenCompetitionEntrantWalletFactoryV1 private walletFactory;
+    EntrantWalletVerifier private verifier;
+    EntrantWalletCreator private creator;
+    OpenCompetitionEntrantWalletV1 private wallet;
+    address private delegate;
+    uint256 private creationNonce;
+
+    function setUp() public {
+        vm.warp(1_800_000_000);
+        token = new EntrantWalletToken();
+        competitionFactory = new OpenCompetitionBountyFactoryV1(address(token));
+        walletFactory = new OpenCompetitionEntrantWalletFactoryV1(address(competitionFactory));
+        verifier = new EntrantWalletVerifier(keccak256(PASSING_PROOF));
+        creator = new EntrantWalletCreator();
+        delegate = vm.addr(DELEGATE_KEY);
+        wallet = OpenCompetitionEntrantWalletV1(
+            payable(walletFactory.createWallet(address(this), _policy(delegate, 100, 200, 500), keccak256("wallet")))
+        );
+        token.mint(address(wallet), 1_000);
+        token.mint(address(creator), 10_000);
+        creator.approve(token, address(competitionFactory), type(uint256).max);
+        token.mint(address(this), 10_000);
+        token.approve(address(competitionFactory), type(uint256).max);
+    }
+
+    function testKeeperRelaysCommitAndRevealWhileWalletIsCanonicalSolver() public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+
+        _executeSigned(OpenCompetitionEntrantWalletV1.Action.Commit, abi.encode(address(bounty), commitment), DELEGATE_KEY);
+        require(bounty.hasEntered(address(wallet)), "wallet did not enter");
+        require(token.balanceOf(address(wallet)) == 900, "bond not charged");
+        require(wallet.lifetimeSpent() == 100, "lifetime spend mismatch");
+        require(token.allowance(address(wallet), address(bounty)) == 0, "bounty allowance remains");
+        vm.roll(block.number + 1);
+
+        _executeSigned(
+            OpenCompetitionEntrantWalletV1.Action.Reveal,
+            abi.encode(address(bounty), SUBMISSION_HASH, EVIDENCE_HASH, SALT, PASSING_PROOF),
+            DELEGATE_KEY
+        );
+
+        require(bounty.winner() == address(wallet), "wallet is not winner");
+        require(token.balanceOf(address(wallet)) == 1_900, "wallet payout mismatch");
+        require(token.balanceOf(bounty.verifierRewardRecipient()) == 100, "verifier payout mismatch");
+        require(wallet.delegateNonce() == 2, "nonce mismatch");
+    }
+
+    function testRelayerCannotMutateSignedPayloadOrReplayIt() public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        bytes memory payload = abi.encode(address(bounty), commitment);
+        uint256 deadline = block.timestamp + 300;
+        bytes memory signature = _sign(wallet, OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, DELEGATE_KEY);
+
+        bytes memory mutated = abi.encode(address(bounty), bytes32(uint256(commitment) + 1));
+        (bool mutatedOk,) = address(wallet).call(
+            abi.encodeCall(
+                wallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, mutated, 0, deadline, signature)
+            )
+        );
+        require(!mutatedOk && wallet.delegateNonce() == 0, "mutated payload accepted");
+
+        wallet.executeWithSignature(OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, signature);
+        (bool replayOk,) = address(wallet).call(
+            abi.encodeCall(
+                wallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, signature)
+            )
+        );
+        require(!replayOk && wallet.delegateNonce() == 1, "signature replayed");
+    }
+
+    function testWrongAndMalleableSignaturesFailClosed() public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        bytes memory payload = abi.encode(address(bounty), commitment);
+        uint256 deadline = block.timestamp + 300;
+        bytes memory wrongSignature =
+            _sign(wallet, OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, WRONG_KEY);
+        (bool wrongOk,) = address(wallet).call(
+            abi.encodeCall(
+                wallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, wrongSignature)
+            )
+        );
+        require(!wrongOk, "wrong signer accepted");
+
+        bytes32 digest = wallet.actionDigest(OpenCompetitionEntrantWalletV1.Action.Commit, keccak256(payload), 0, deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(DELEGATE_KEY, digest);
+        bytes memory highS = abi.encodePacked(r, bytes32(SECP256K1_N - uint256(s)), v == 27 ? uint8(28) : uint8(27));
+        (bool highSOk,) = address(wallet).call(
+            abi.encodeCall(
+                wallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, highS)
+            )
+        );
+        require(!highSOk && wallet.delegateNonce() == 0, "malleable signature accepted");
+    }
+
+    function testPolicyRotationInvalidatesQueuedSignature() public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        bytes memory payload = abi.encode(address(bounty), commitment);
+        uint256 deadline = block.timestamp + 300;
+        bytes memory signature = _sign(wallet, OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, DELEGATE_KEY);
+
+        wallet.configurePolicy(_policy(delegate, 100, 200, 500));
+        (bool ok,) = address(wallet).call(
+            abi.encodeCall(
+                wallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, signature)
+            )
+        );
+        require(!ok && wallet.policyVersion() == 2 && wallet.delegateNonce() == 0, "old policy signature accepted");
+    }
+
+    function testDirectDelegateUsesSameNonceAndCaps() public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        vm.prank(delegate);
+        wallet.commitSolution(address(bounty), commitment);
+        require(wallet.delegateNonce() == 1, "direct nonce mismatch");
+        require(wallet.periodSpent() == 100 && wallet.lifetimeSpent() == 100, "direct spend not charged");
+    }
+
+    function testPerActionCapRejectsBondWithoutConsumingNonce() public {
+        OpenCompetitionEntrantWalletV1 cappedWallet = OpenCompetitionEntrantWalletV1(
+            payable(walletFactory.createWallet(address(this), _policy(delegate, 99, 200, 500), keccak256("capped")))
+        );
+        token.mint(address(cappedWallet), 1_000);
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(cappedWallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        bytes memory payload = abi.encode(address(bounty), commitment);
+        uint256 deadline = block.timestamp + 300;
+        bytes memory signature =
+            _sign(cappedWallet, OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, DELEGATE_KEY);
+        (bool ok,) = address(cappedWallet).call(
+            abi.encodeCall(
+                cappedWallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, signature)
+            )
+        );
+        require(!ok && cappedWallet.delegateNonce() == 0, "oversized bond accepted");
+        require(token.balanceOf(address(cappedWallet)) == 1_000, "failed action moved funds");
+    }
+
+    function testUnknownFactoryAndVerifierProfileAreRejected() public {
+        EntrantWalletVerifier otherVerifier = new EntrantWalletVerifier(keccak256(PASSING_PROOF));
+        OpenCompetitionBountyV1 wrongVerifier = _createCompetition(creator, _params(address(otherVerifier)), 1_000);
+        bytes32 wrongCommitment =
+            wrongVerifier.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        _assertSignedCallFails(
+            wallet,
+            OpenCompetitionEntrantWalletV1.Action.Commit,
+            abi.encode(address(wrongVerifier), wrongCommitment),
+            DELEGATE_KEY
+        );
+
+        OpenCompetitionBountyFactoryV1 otherFactory = new OpenCompetitionBountyFactoryV1(address(token));
+        creator.approve(token, address(otherFactory), type(uint256).max);
+        (address otherBounty,) = creator.create(otherFactory, _params(address(verifier)), 1_000, keccak256("other-factory"));
+        bytes32 otherCommitment = OpenCompetitionBountyV1(otherBounty).solutionCommitment(
+            address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT
+        );
+        _assertSignedCallFails(
+            wallet,
+            OpenCompetitionEntrantWalletV1.Action.Commit,
+            abi.encode(otherBounty, otherCommitment),
+            DELEGATE_KEY
+        );
+        require(wallet.delegateNonce() == 0, "rejected bounty consumed nonce");
+    }
+
+    function testVerifierRuntimeMismatchFailsClosed() public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        vm.etch(address(verifier), hex"00");
+        _assertSignedCallFails(
+            wallet,
+            OpenCompetitionEntrantWalletV1.Action.Commit,
+            abi.encode(address(bounty), commitment),
+            DELEGATE_KEY
+        );
+        require(token.balanceOf(address(wallet)) == 1_000, "runtime mismatch moved funds");
+    }
+
+    function testCreatorControlledWalletCannotEnter() public {
+        OpenCompetitionBountyV1 bounty = _createCompetitionFromOwner(_params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        _assertSignedCallFails(
+            wallet,
+            OpenCompetitionEntrantWalletV1.Action.Commit,
+            abi.encode(address(bounty), commitment),
+            DELEGATE_KEY
+        );
+        require(!bounty.hasEntered(address(wallet)), "creator-controlled wallet entered");
+    }
+
+    function testPostCommitOwnershipTransferToCreatorCannotReveal() public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        _executeSigned(OpenCompetitionEntrantWalletV1.Action.Commit, abi.encode(address(bounty), commitment), DELEGATE_KEY);
+        vm.roll(block.number + 1);
+
+        wallet.transferOwnership(address(creator));
+        vm.prank(address(creator));
+        wallet.acceptOwnership();
+        bytes memory payload = abi.encode(address(bounty), SUBMISSION_HASH, EVIDENCE_HASH, SALT, PASSING_PROOF);
+        _assertSignedCallFails(wallet, OpenCompetitionEntrantWalletV1.Action.Reveal, payload, DELEGATE_KEY);
+        (,,,, OpenCompetitionBountyV1.EntryState entryState) = bounty.entries(address(wallet));
+        require(entryState == OpenCompetitionBountyV1.EntryState.Committed, "creator consumed committed entry");
+        require(bounty.winner() == address(0), "creator-controlled wallet won");
+    }
+
+    function testOwnerRecoversLosingBondAfterPolicyExpiry() public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        _executeSigned(OpenCompetitionEntrantWalletV1.Action.Commit, abi.encode(address(bounty), commitment), DELEGATE_KEY);
+
+        EntrantWalletOtherSolver other = new EntrantWalletOtherSolver();
+        token.mint(address(other), 100);
+        other.approve(token, address(bounty), 100);
+        bytes32 otherCommitment =
+            bounty.solutionCommitment(address(other), OTHER_SUBMISSION_HASH, OTHER_EVIDENCE_HASH, OTHER_SALT);
+        other.commit(bounty, otherCommitment);
+        vm.roll(block.number + 1);
+        other.reveal(bounty, OTHER_SUBMISSION_HASH, OTHER_EVIDENCE_HASH, OTHER_SALT, PASSING_PROOF);
+        require(bounty.winner() == address(other), "other solver did not win");
+
+        OpenCompetitionEntrantWalletV1.Policy memory currentPolicy = wallet.policy();
+        vm.warp(uint256(currentPolicy.validUntil) + 1);
+        wallet.recoverEntryBond(address(bounty));
+        require(token.balanceOf(address(wallet)) == 1_000, "owner recovery did not return bond");
+    }
+
+    function testNonOwnerCannotWithdrawOrRecover() public {
+        (bool withdrawOk,) = address(wallet).call(
+            abi.encodeCall(wallet.withdrawToken, (address(token), address(this), 1))
+        );
+        require(withdrawOk, "owner withdrawal setup failed");
+        token.mint(address(wallet), 1);
+        vm.prank(delegate);
+        (bool nonOwnerOk,) = address(wallet).call(
+            abi.encodeCall(wallet.withdrawToken, (address(token), delegate, 1))
+        );
+        require(!nonOwnerOk, "delegate withdrew token");
+    }
+
+    function testFactoryPredictionIsPolicyBoundAndIdempotent() public {
+        OpenCompetitionEntrantWalletV1.Policy memory first = _policy(delegate, 100, 200, 500);
+        bytes32 salt = keccak256("prediction");
+        address predicted = walletFactory.predictWallet(address(this), first, salt);
+        address deployed = walletFactory.createWallet(address(this), first, salt);
+        require(predicted == deployed && walletFactory.isFactoryWallet(deployed), "prediction mismatch");
+        require(walletFactory.createWallet(address(this), first, salt) == deployed, "deployment not idempotent");
+
+        OpenCompetitionEntrantWalletV1.Policy memory changed = _policy(delegate, 100, 200, 501);
+        require(walletFactory.predictWallet(address(this), changed, salt) != predicted, "policy did not bind address");
+    }
+
+    function testFactoryRejectsNonTransferringFundingToken() public {
+        EntrantWalletNonTransferringToken badToken = new EntrantWalletNonTransferringToken();
+        OpenCompetitionBountyFactoryV1 badCompetitionFactory =
+            new OpenCompetitionBountyFactoryV1(address(badToken));
+        OpenCompetitionEntrantWalletFactoryV1 badWalletFactory =
+            new OpenCompetitionEntrantWalletFactoryV1(address(badCompetitionFactory));
+        EntrantWalletVerifier badVerifier = new EntrantWalletVerifier(keccak256(PASSING_PROOF));
+        OpenCompetitionEntrantWalletV1.Policy memory badPolicy = OpenCompetitionEntrantWalletV1.Policy({
+            delegate: delegate,
+            validAfter: uint64(block.timestamp),
+            validUntil: uint64(block.timestamp + 30 days),
+            periodSeconds: 1 days,
+            maxPerAction: 100,
+            maxPerPeriod: 200,
+            maxLifetimeSpend: 500,
+            maxBountyTarget: 1_000,
+            allowedActions: type(uint8).max >> 5,
+            verifierModule: address(badVerifier),
+            verifierRuntimeCodeHash: address(badVerifier).codehash,
+            verifierPolicyHash: VERIFIER_POLICY_HASH,
+            acceptanceCriteriaHash: CRITERIA_HASH,
+            benchmarkHash: BENCHMARK_HASH,
+            evidenceSchemaHash: EVIDENCE_SCHEMA_HASH
+        });
+        (bool ok,) = address(badWalletFactory).call(
+            abi.encodeCall(badWalletFactory.createWalletAndFund, (badPolicy, keccak256("bad-token"), 100))
+        );
+        require(!ok, "non-transferring token funded wallet");
+    }
+
+    function testContractDelegateSignatureIsSupported() public {
+        EntrantWallet1271Delegate smartDelegate = new EntrantWallet1271Delegate();
+        OpenCompetitionEntrantWalletV1 smartWallet = OpenCompetitionEntrantWalletV1(
+            payable(
+                walletFactory.createWallet(
+                    address(this), _policy(address(smartDelegate), 100, 200, 500), keccak256("smart-delegate")
+                )
+            )
+        );
+        token.mint(address(smartWallet), 1_000);
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(smartWallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        bytes memory payload = abi.encode(address(bounty), commitment);
+        uint256 deadline = block.timestamp + 300;
+        bytes memory signature = hex"1234";
+        bytes32 digest =
+            smartWallet.actionDigest(OpenCompetitionEntrantWalletV1.Action.Commit, keccak256(payload), 0, deadline);
+        smartDelegate.approve(digest, signature);
+        smartWallet.executeWithSignature(
+            OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, signature
+        );
+        require(bounty.hasEntered(address(smartWallet)), "contract delegate commit failed");
+    }
+
+    function testFuzzSignedCommitmentMutationCannotConsumeNonce(bytes32 mutation) public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        bytes memory payload = abi.encode(address(bounty), commitment);
+        uint256 deadline = block.timestamp + 300;
+        bytes memory signature =
+            _sign(wallet, OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, DELEGATE_KEY);
+        bytes32 mutatedCommitment = bytes32(uint256(commitment) ^ (uint256(mutation) | 1));
+        bytes memory mutatedPayload = abi.encode(address(bounty), mutatedCommitment);
+        (bool ok,) = address(wallet).call(
+            abi.encodeCall(
+                wallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, mutatedPayload, 0, deadline, signature)
+            )
+        );
+        require(!ok && wallet.delegateNonce() == 0, "fuzzed commitment mutation accepted");
+        require(token.balanceOf(address(wallet)) == 1_000, "fuzzed mutation moved funds");
+    }
+
+    function testFuzzSubBondPerActionCapConservesFunds(uint96 rawCap) public {
+        uint256 cap = 1 + uint256(rawCap) % 99;
+        OpenCompetitionEntrantWalletV1 cappedWallet = OpenCompetitionEntrantWalletV1(
+            payable(
+                walletFactory.createWallet(
+                    address(this), _policy(delegate, cap, 200, 500), keccak256(abi.encode("fuzz-cap", cap))
+                )
+            )
+        );
+        token.mint(address(cappedWallet), 1_000);
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(cappedWallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        bytes memory payload = abi.encode(address(bounty), commitment);
+        uint256 deadline = block.timestamp + 300;
+        bytes memory signature =
+            _sign(cappedWallet, OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, DELEGATE_KEY);
+        (bool ok,) = address(cappedWallet).call(
+            abi.encodeCall(
+                cappedWallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, signature)
+            )
+        );
+        require(!ok && cappedWallet.delegateNonce() == 0, "fuzzed sub-bond cap accepted");
+        require(token.balanceOf(address(cappedWallet)) == 1_000, "fuzzed cap moved funds");
+        require(token.balanceOf(address(bounty)) == 1_000, "fuzzed cap changed escrow");
+    }
+
+    function testFuzzExpiredSignatureCannotConsumeNonce(uint32 delay) public {
+        OpenCompetitionBountyV1 bounty = _createCompetition(creator, _params(address(verifier)), 1_000);
+        bytes32 commitment = bounty.solutionCommitment(address(wallet), SUBMISSION_HASH, EVIDENCE_HASH, SALT);
+        bytes memory payload = abi.encode(address(bounty), commitment);
+        uint256 deadline = block.timestamp + 60;
+        bytes memory signature =
+            _sign(wallet, OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, DELEGATE_KEY);
+        vm.warp(deadline + 1 + uint256(delay) % 1 days);
+        (bool ok,) = address(wallet).call(
+            abi.encodeCall(
+                wallet.executeWithSignature,
+                (OpenCompetitionEntrantWalletV1.Action.Commit, payload, 0, deadline, signature)
+            )
+        );
+        require(!ok && wallet.delegateNonce() == 0, "expired fuzzed signature accepted");
+        require(token.balanceOf(address(wallet)) == 1_000, "expired signature moved funds");
+    }
+
+    function _policy(address delegate_, uint256 maxPerAction, uint256 maxPerPeriod, uint256 maxLifetime)
+        private
+        view
+        returns (OpenCompetitionEntrantWalletV1.Policy memory)
+    {
+        return OpenCompetitionEntrantWalletV1.Policy({
+            delegate: delegate_,
+            validAfter: uint64(block.timestamp),
+            validUntil: uint64(block.timestamp + 30 days),
+            periodSeconds: 1 days,
+            maxPerAction: maxPerAction,
+            maxPerPeriod: maxPerPeriod,
+            maxLifetimeSpend: maxLifetime,
+            maxBountyTarget: 1_000,
+            allowedActions: 7,
+            verifierModule: address(verifier),
+            verifierRuntimeCodeHash: address(verifier).codehash,
+            verifierPolicyHash: VERIFIER_POLICY_HASH,
+            acceptanceCriteriaHash: CRITERIA_HASH,
+            benchmarkHash: BENCHMARK_HASH,
+            evidenceSchemaHash: EVIDENCE_SCHEMA_HASH
+        });
+    }
+
+    function _params(address verifierAddress)
+        private
+        view
+        returns (OpenCompetitionBountyFactoryV1.CreateCompetitionParams memory)
+    {
+        return OpenCompetitionBountyFactoryV1.CreateCompetitionParams({
+            solverReward: 900,
+            verifierReward: 100,
+            termsHash: TERMS_HASH,
+            policyHash: VERIFIER_POLICY_HASH,
+            acceptanceCriteriaHash: CRITERIA_HASH,
+            benchmarkHash: BENCHMARK_HASH,
+            evidenceSchemaHash: EVIDENCE_SCHEMA_HASH,
+            fundingDeadline: uint64(block.timestamp + 1 days),
+            competitionWindowSeconds: 1 days,
+            revealWindowSeconds: 1 hours,
+            maxEntries: 4,
+            verifierModule: verifierAddress,
+            verifierRewardRecipient: address(0xBEEF)
+        });
+    }
+
+    function _createCompetition(
+        EntrantWalletCreator creator_,
+        OpenCompetitionBountyFactoryV1.CreateCompetitionParams memory params,
+        uint256 initialFunding
+    ) private returns (OpenCompetitionBountyV1 bounty) {
+        creationNonce += 1;
+        (address bountyAddress,) =
+            creator_.create(competitionFactory, params, initialFunding, bytes32(creationNonce));
+        return OpenCompetitionBountyV1(bountyAddress);
+    }
+
+    function _createCompetitionFromOwner(
+        OpenCompetitionBountyFactoryV1.CreateCompetitionParams memory params,
+        uint256 initialFunding
+    ) private returns (OpenCompetitionBountyV1 bounty) {
+        creationNonce += 1;
+        (address bountyAddress,) =
+            competitionFactory.createCompetition(params, initialFunding, bytes32(creationNonce));
+        return OpenCompetitionBountyV1(bountyAddress);
+    }
+
+    function _executeSigned(
+        OpenCompetitionEntrantWalletV1.Action action,
+        bytes memory payload,
+        uint256 signerKey
+    ) private {
+        uint256 nonce = wallet.delegateNonce();
+        uint256 deadline = block.timestamp + 300;
+        bytes memory signature = _sign(wallet, action, payload, nonce, deadline, signerKey);
+        wallet.executeWithSignature(action, payload, nonce, deadline, signature);
+    }
+
+    function _assertSignedCallFails(
+        OpenCompetitionEntrantWalletV1 targetWallet,
+        OpenCompetitionEntrantWalletV1.Action action,
+        bytes memory payload,
+        uint256 signerKey
+    ) private {
+        uint256 nonce = targetWallet.delegateNonce();
+        uint256 deadline = block.timestamp + 300;
+        bytes memory signature = _sign(targetWallet, action, payload, nonce, deadline, signerKey);
+        (bool ok,) = address(targetWallet).call(
+            abi.encodeCall(targetWallet.executeWithSignature, (action, payload, nonce, deadline, signature))
+        );
+        require(!ok, "signed call unexpectedly succeeded");
+    }
+
+    function _sign(
+        OpenCompetitionEntrantWalletV1 targetWallet,
+        OpenCompetitionEntrantWalletV1.Action action,
+        bytes memory payload,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 signerKey
+    ) private returns (bytes memory) {
+        bytes32 digest = targetWallet.actionDigest(action, keccak256(payload), nonce, deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+}

--- a/crates/chain-base/src/open_competition.rs
+++ b/crates/chain-base/src/open_competition.rs
@@ -3,8 +3,9 @@ use super::{
     eip3009_typed_data, encode_address, encode_call, encode_uint256, event_topic, log_key,
     normalize_address, normalize_evm_address, normalize_hash, normalize_topic, parse_bytes32,
     parse_rpc_quantity, predict_minimal_proxy_address, rpc_result, selector, topic_u64, topic_word,
-    word_hex, word_to_u128, word_to_u64, ChainBaseError, Eip3009AuthorizationTypedData, EvmLog,
-    EvmTransactionIntent, JsonRpcTransport, ReqwestJsonRpcTransport,
+    word_hex, word_to_u128, word_to_u64, ChainBaseError, Eip3009AuthorizationTypedData,
+    Eip712DomainData, Eip712TypeField, EvmLog, EvmTransactionIntent, JsonRpcTransport,
+    ReqwestJsonRpcTransport,
 };
 use chrono::{DateTime, Utc};
 use domain::Id;
@@ -23,6 +24,8 @@ pub const OPEN_COMPETITION_VERIFIER_CATALOG_SCHEMA: &str =
 pub const OPEN_COMPETITION_CREATION_SCHEMA: &str =
     "agent-bounties/open-competition-v1-creation-preparation-v1";
 pub const OPEN_COMPETITION_STATE_SCHEMA: &str = "agent-bounties/open-competition-v1-state-v1";
+pub const OPEN_COMPETITION_ENTRANT_ACTION_SCHEMA: &str =
+    "agent-bounties/open-competition-entrant-wallet-action-v1";
 pub const OPEN_COMPETITION_PROTOCOL_VERSION: &str = "agent-bounties/open-competition-v1";
 pub const OPEN_COMPETITION_MAX_ENTRIES: u8 = 64;
 pub const OPEN_COMPETITION_MAX_COMPETITION_WINDOW_SECONDS: u64 = 30 * 24 * 60 * 60;
@@ -575,6 +578,64 @@ pub struct OpenCompetitionCommitmentEnvelope {
     pub evidence_boundary: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenCompetitionEntrantAction {
+    Commit,
+    Reveal,
+    WithdrawBond,
+}
+
+impl OpenCompetitionEntrantAction {
+    pub fn code(self) -> u8 {
+        match self {
+            Self::Commit => 0,
+            Self::Reveal => 1,
+            Self::WithdrawBond => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenCompetitionEntrantActionMessage {
+    pub wallet: String,
+    pub action: u8,
+    pub payload_hash: String,
+    pub nonce: String,
+    pub deadline: String,
+    pub policy_version: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenCompetitionEntrantActionTypedData {
+    pub types: BTreeMap<String, Vec<Eip712TypeField>>,
+    pub domain: Eip712DomainData,
+    pub primary_type: String,
+    pub message: OpenCompetitionEntrantActionMessage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenCompetitionEntrantActionPlan {
+    pub schema_version: String,
+    pub network: String,
+    pub chain_id: u64,
+    pub wallet: String,
+    pub delegate: String,
+    pub policy_hash: String,
+    pub policy_version: u64,
+    pub action: OpenCompetitionEntrantAction,
+    pub action_code: u8,
+    pub nonce: u64,
+    pub deadline: u64,
+    pub payload: String,
+    pub payload_hash: String,
+    pub signing_payload: OpenCompetitionEntrantActionTypedData,
+    pub relay_call: Value,
+    pub evidence_boundary: String,
+}
+
 pub fn generate_open_competition_commitment_envelope(
     input: OpenCompetitionCommitmentInput,
 ) -> Result<OpenCompetitionCommitmentEnvelope, ChainBaseError> {
@@ -691,6 +752,203 @@ pub fn open_competition_solution_commitment(
         parse_bytes32(salt)?,
     ];
     Ok(format!("0x{}", hex::encode(keccak_words(&words))))
+}
+
+pub fn encode_open_competition_entrant_commit_payload(
+    bounty_contract: &str,
+    commitment: &str,
+) -> Result<String, ChainBaseError> {
+    let words = [
+        encode_address(&normalize_evm_address(bounty_contract)?)?,
+        parse_bytes32(commitment)?,
+    ];
+    Ok(format!("0x{}", hex::encode(words.concat())))
+}
+
+pub fn encode_open_competition_entrant_reveal_payload(
+    bounty_contract: &str,
+    submission_hash: &str,
+    evidence_hash: &str,
+    salt: &str,
+    proof: &str,
+) -> Result<String, ChainBaseError> {
+    let proof = decode_prefixed_hex(proof, "proof")?;
+    let mut bytes = Vec::with_capacity(32 * 6 + proof.len().next_multiple_of(32));
+    bytes.extend_from_slice(&encode_address(&normalize_evm_address(bounty_contract)?)?);
+    bytes.extend_from_slice(&parse_bytes32(submission_hash)?);
+    bytes.extend_from_slice(&parse_bytes32(evidence_hash)?);
+    bytes.extend_from_slice(&parse_bytes32(salt)?);
+    bytes.extend_from_slice(&encode_uint256(160)?);
+    bytes.extend_from_slice(&encode_uint256(proof.len() as u128)?);
+    bytes.extend_from_slice(&proof);
+    let padding = (32 - proof.len() % 32) % 32;
+    bytes.resize(bytes.len() + padding, 0);
+    Ok(format!("0x{}", hex::encode(bytes)))
+}
+
+pub fn encode_open_competition_entrant_withdraw_payload(
+    bounty_contract: &str,
+) -> Result<String, ChainBaseError> {
+    Ok(format!(
+        "0x{}",
+        hex::encode(encode_address(&normalize_evm_address(bounty_contract)?)?)
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn plan_open_competition_entrant_action(
+    network: &str,
+    wallet: &str,
+    delegate: &str,
+    policy_hash: &str,
+    policy_version: u64,
+    action: OpenCompetitionEntrantAction,
+    nonce: u64,
+    deadline: u64,
+    payload: &str,
+) -> Result<OpenCompetitionEntrantActionPlan, ChainBaseError> {
+    let descriptor = base_network_descriptor(network)?;
+    let wallet = normalize_evm_address(wallet)?;
+    let delegate = normalize_evm_address(delegate)?;
+    let policy_hash = normalized_nonzero_bytes32(policy_hash, "entrant wallet policy hash")?;
+    if deadline == 0 {
+        return Err(ChainBaseError::InvalidVerificationConfiguration(
+            "entrant wallet action deadline must be positive".to_string(),
+        ));
+    }
+    let payload_bytes = decode_prefixed_hex(payload, "entrant wallet payload")?;
+    if payload_bytes.is_empty() {
+        return Err(ChainBaseError::InvalidVerificationConfiguration(
+            "entrant wallet payload must not be empty".to_string(),
+        ));
+    }
+    let payload = format!("0x{}", hex::encode(&payload_bytes));
+    let payload_hash = format!("0x{}", hex::encode(Keccak256::digest(&payload_bytes)));
+    let mut types = BTreeMap::new();
+    types.insert(
+        "EIP712Domain".to_string(),
+        vec![
+            eip712_type_field("name", "string"),
+            eip712_type_field("version", "string"),
+            eip712_type_field("chainId", "uint256"),
+            eip712_type_field("verifyingContract", "address"),
+        ],
+    );
+    types.insert(
+        "OpenCompetitionEntrantAction".to_string(),
+        vec![
+            eip712_type_field("wallet", "address"),
+            eip712_type_field("action", "uint8"),
+            eip712_type_field("payloadHash", "bytes32"),
+            eip712_type_field("nonce", "uint256"),
+            eip712_type_field("deadline", "uint256"),
+            eip712_type_field("policyVersion", "uint64"),
+        ],
+    );
+    let action_code = action.code();
+    Ok(OpenCompetitionEntrantActionPlan {
+        schema_version: OPEN_COMPETITION_ENTRANT_ACTION_SCHEMA.to_string(),
+        network: network.to_string(),
+        chain_id: descriptor.chain_id,
+        wallet: wallet.clone(),
+        delegate,
+        policy_hash,
+        policy_version,
+        action,
+        action_code,
+        nonce,
+        deadline,
+        payload: payload.clone(),
+        payload_hash: payload_hash.clone(),
+        signing_payload: OpenCompetitionEntrantActionTypedData {
+            types,
+            domain: Eip712DomainData {
+                name: "Agent Bounties Open Competition Entrant Wallet".to_string(),
+                version: "1".to_string(),
+                chain_id: descriptor.chain_id,
+                verifying_contract: wallet.clone(),
+            },
+            primary_type: "OpenCompetitionEntrantAction".to_string(),
+            message: OpenCompetitionEntrantActionMessage {
+                wallet: wallet.clone(),
+                action: action_code,
+                payload_hash,
+                nonce: nonce.to_string(),
+                deadline: deadline.to_string(),
+                policy_version,
+            },
+        },
+        relay_call: json!({
+            "to": wallet,
+            "function": "executeWithSignature(uint8,bytes,uint256,uint256,bytes)",
+            "arguments_before_signature": [action_code, payload, nonce, deadline],
+            "signature_tail": ["delegate_signature"]
+        }),
+        evidence_boundary: "This plan authorizes one exact policy-bound entrant-wallet action. It moves no value until a keeper simulates and broadcasts it. Only canonical competition events prove entry, reveal, bond recovery, or settlement; only BountySettled proves payout.".to_string(),
+    })
+}
+
+pub fn attach_open_competition_entrant_relay_signature(
+    plan: &OpenCompetitionEntrantActionPlan,
+    relayer: &str,
+    signature: &str,
+) -> Result<EvmTransactionIntent, ChainBaseError> {
+    let relayer = normalize_evm_address(relayer)?;
+    let signature_bytes = decode_prefixed_hex(signature, "delegate signature")?;
+    if signature_bytes.len() != 65 {
+        return Err(ChainBaseError::InvalidVerificationConfiguration(
+            "entrant wallet delegate signature must contain 65 bytes".to_string(),
+        ));
+    }
+    let payload = decode_prefixed_hex(&plan.payload, "entrant wallet payload")?;
+    let data = encode_open_competition_entrant_execute_call(
+        plan.action_code,
+        &payload,
+        plan.nonce,
+        plan.deadline,
+        &signature_bytes,
+    )?;
+    Ok(EvmTransactionIntent {
+        from: Some(relayer),
+        to: plan.wallet.clone(),
+        value_wei: 0,
+        data,
+        function: "executeWithSignature(uint8,bytes,uint256,uint256,bytes)".to_string(),
+    })
+}
+
+fn eip712_type_field(name: &str, field_type: &str) -> Eip712TypeField {
+    Eip712TypeField {
+        name: name.to_string(),
+        field_type: field_type.to_string(),
+    }
+}
+
+fn encode_open_competition_entrant_execute_call(
+    action: u8,
+    payload: &[u8],
+    nonce: u64,
+    deadline: u64,
+    signature: &[u8],
+) -> Result<String, ChainBaseError> {
+    let payload_tail_length = 32 + payload.len().next_multiple_of(32);
+    let mut bytes = selector("executeWithSignature(uint8,bytes,uint256,uint256,bytes)").to_vec();
+    bytes.extend_from_slice(&encode_uint256(action.into())?);
+    bytes.extend_from_slice(&encode_uint256(160)?);
+    bytes.extend_from_slice(&encode_uint256(nonce.into())?);
+    bytes.extend_from_slice(&encode_uint256(deadline.into())?);
+    bytes.extend_from_slice(&encode_uint256((160 + payload_tail_length) as u128)?);
+    append_dynamic_bytes(&mut bytes, payload)?;
+    append_dynamic_bytes(&mut bytes, signature)?;
+    Ok(format!("0x{}", hex::encode(bytes)))
+}
+
+fn append_dynamic_bytes(output: &mut Vec<u8>, value: &[u8]) -> Result<(), ChainBaseError> {
+    output.extend_from_slice(&encode_uint256(value.len() as u128)?);
+    output.extend_from_slice(value);
+    let padding = (32 - value.len() % 32) % 32;
+    output.resize(output.len() + padding, 0);
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1980,7 +2238,7 @@ pub fn plan_open_competition_action(
 mod tests {
     use super::*;
     use alloy::{
-        primitives::{keccak256, Address, B256, U256},
+        primitives::{keccak256, Address, Bytes, B256, U256},
         sol_types::SolValue,
     };
     use std::sync::Mutex;
@@ -2592,6 +2850,98 @@ mod tests {
             profile.evidence_schema,
             "agent-bounties/leading-zero-work-evidence-v1"
         );
+    }
+
+    #[test]
+    fn entrant_wallet_payloads_match_solidity_abi_encoding() {
+        let bounty = "0x1111111111111111111111111111111111111111";
+        let commitment = format!("0x{}", "22".repeat(32));
+        let commit = encode_open_competition_entrant_commit_payload(bounty, &commitment).unwrap();
+        let expected_commit =
+            (bounty.parse::<Address>().unwrap(), B256::from([0x22; 32])).abi_encode();
+        assert_eq!(commit, format!("0x{}", hex::encode(expected_commit)));
+
+        let reveal = encode_open_competition_entrant_reveal_payload(
+            bounty,
+            &format!("0x{}", "33".repeat(32)),
+            &format!("0x{}", "44".repeat(32)),
+            &format!("0x{}", "55".repeat(32)),
+            "0xaabbcc",
+        )
+        .unwrap();
+        let expected_reveal = (
+            bounty.parse::<Address>().unwrap(),
+            B256::from([0x33; 32]),
+            B256::from([0x44; 32]),
+            B256::from([0x55; 32]),
+            Bytes::from(vec![0xaa, 0xbb, 0xcc]),
+        )
+            .abi_encode_params();
+        assert_eq!(reveal, format!("0x{}", hex::encode(expected_reveal)));
+    }
+
+    #[test]
+    fn entrant_wallet_typed_action_and_relay_call_are_exact() {
+        let wallet = "0x1111111111111111111111111111111111111111";
+        let relayer = "0x2222222222222222222222222222222222222222";
+        let payload = encode_open_competition_entrant_commit_payload(
+            "0x3333333333333333333333333333333333333333",
+            &format!("0x{}", "44".repeat(32)),
+        )
+        .unwrap();
+        let plan = plan_open_competition_entrant_action(
+            "base-sepolia",
+            wallet,
+            "0x5555555555555555555555555555555555555555",
+            &format!("0x{}", "66".repeat(32)),
+            7,
+            OpenCompetitionEntrantAction::Commit,
+            9,
+            2_000_000_000,
+            &payload,
+        )
+        .unwrap();
+        assert_eq!(plan.schema_version, OPEN_COMPETITION_ENTRANT_ACTION_SCHEMA);
+        assert_eq!(plan.chain_id, 84_532);
+        assert_eq!(plan.action_code, 0);
+        assert_eq!(
+            plan.signing_payload.primary_type,
+            "OpenCompetitionEntrantAction"
+        );
+        assert_eq!(
+            plan.signing_payload.domain.name,
+            "Agent Bounties Open Competition Entrant Wallet"
+        );
+        assert_eq!(plan.signing_payload.message.nonce, "9");
+        assert_eq!(
+            plan.payload_hash,
+            format!(
+                "0x{}",
+                hex::encode(keccak256(
+                    hex::decode(payload.trim_start_matches("0x")).unwrap()
+                ))
+            )
+        );
+
+        let signature = format!("0x{}", "77".repeat(65));
+        let intent =
+            attach_open_competition_entrant_relay_signature(&plan, relayer, &signature).unwrap();
+        let mut expected =
+            selector("executeWithSignature(uint8,bytes,uint256,uint256,bytes)").to_vec();
+        expected.extend_from_slice(
+            &(
+                U256::ZERO,
+                Bytes::from(hex::decode(payload.trim_start_matches("0x")).unwrap()),
+                U256::from(9_u64),
+                U256::from(2_000_000_000_u64),
+                Bytes::from(vec![0x77_u8; 65]),
+            )
+                .abi_encode_params(),
+        );
+        assert_eq!(intent.from.as_deref(), Some(relayer));
+        assert_eq!(intent.to, wallet);
+        assert_eq!(intent.value_wei, 0);
+        assert_eq!(intent.data, format!("0x{}", hex::encode(expected)));
     }
 }
 

--- a/docs/open-competition-v1-release-runbook.md
+++ b/docs/open-competition-v1-release-runbook.md
@@ -170,3 +170,36 @@ the version-specific indexer's database heartbeat is successful or caught up,
 no more than 90 seconds old, error-free, and within 20 blocks of the API's safe
 block. A feature flag by itself cannot satisfy it. Relay, gas-sponsorship, and
 final R4 release-evidence gates remain false.
+
+## Entrant-Wallet Relay Gate
+
+Gas sponsorship for multiple competitors uses the additive
+`OpenCompetitionEntrantWalletV1`; a generic keeper cannot relay for arbitrary
+EOAs because the frozen bounty records `msg.sender` as solver. This path does
+not change or redeploy the existing bounty factory.
+
+Freeze and review the entrant wallet and its deterministic factory separately:
+
+```text
+python scripts/build_open_competition_entrant_wallet_bundle.py \
+  --network base-sepolia \
+  --output target/open-competition-entrant-wallet/base-sepolia-deployment.json
+
+forge test --root contracts/base-escrow \
+  --match-contract OpenCompetitionEntrantWalletV1Test --fuzz-runs 1000
+```
+
+The manifest must pin the existing competition factory and native USDC, the
+entrant implementation/factory/clone runtimes, deterministic deployer runtime,
+compiler settings, clean git tree, and default-off activation fields. Rehearse
+with separate ephemeral owner, delegate, keeper, creator, and competitor
+actors. Commit and reveal must be relayed by the keeper while the entrant
+wallet holds zero ETH; the commit transport must contain no reveal secret.
+Record a passing settlement and a losing-bond recovery, exact event topics,
+safe-block receipt hashes, gas payer and cost, wallet and escrow USDC deltas,
+nonces, policy hash/version, verifier runtime/profile hashes, and source tree.
+
+Any entrant wallet, factory, planner, typed-data schema, or relay-byte change
+invalidates that rehearsal. Do not set hosted relay or gas-sponsorship gates
+true until the secret-free evidence is published, audited, replayed on an
+exact mainnet fork, and covered by the required independent contract review.

--- a/docs/open-competition-v1.md
+++ b/docs/open-competition-v1.md
@@ -171,6 +171,54 @@ relay support all pass.
 Only confirmed canonical `BountySettled`, including the winner and
 `submission_sequence`, proves payment.
 
+## Gas-Sponsored Entrant Accounts
+
+An additive entrant account lets an agent compete without holding ETH and
+without changing `OpenCompetitionBountyV1` bytecode. The account itself is the
+canonical solver. Its owner installs one time-bounded policy containing the
+delegate, exact competition factory and native-USDC binding, approved verifier
+address and runtime hash, verifier configuration hashes, permitted actions,
+and per-action, period, lifetime, and bounty-value caps.
+
+The delegate may act directly or sign
+`OpenCompetitionEntrantAction(address wallet,uint8 action,bytes32 payloadHash,uint256 nonce,uint256 deadline,uint64 policyVersion)`.
+A keeper pays gas only for the exact signed payload. Commit relay material
+contains the commitment but never the salt, submission hash, evidence hash, or
+proof. Reveal relay material contains those values only when the agent is ready
+to reveal. Direct and relayed actions share one nonce, so signatures cannot be
+replayed across paths. The wallet exposes no delegate-controlled arbitrary
+call, token withdrawal, gas reimbursement, or destination selection.
+
+Creator-address exclusion is checked at both commit and reveal, including
+after ownership or delegate rotation. This blocks direct creator control of the
+entrant account; it does not prove unrelated beneficial ownership. The owner
+can rotate or revoke policy, withdraw wallet assets, and recover a losing bond
+when the bounty permits withdrawal. Agents must therefore treat the owner as a
+custody authority and the delegate policy as bounded action authority, not as
+an ownership firewall.
+
+The factory deploys policy-bound deterministic clones and supports exact
+allowance funding or native-USDC EIP-3009 funding. Factory provenance still
+does not approve a verifier. Hosted use remains disabled until the entrant
+factory runtime, implementation runtime, clone runtime, policy, verifier
+runtime, and complete verifier profile match a reviewed deployment manifest.
+
+Local fail-closed tools are:
+
+```text
+python scripts/build_open_competition_entrant_wallet_bundle.py --network base-sepolia --output target/open-competition-entrant-wallet/base-sepolia-deployment.json
+python scripts/plan_open_competition_entrant_action.py commit --manifest <deployment-manifest> --wallet 0x... --bounty 0x... --commitment-envelope <local-envelope>
+python scripts/relay_open_competition_entrant_action.py --manifest <deployment-manifest> --plan <action-plan> --signature-file <signature> --keeper 0x...
+```
+
+The commit planner validates the complete local recovery envelope, but its
+output intentionally omits all reveal secrets. The relay refuses a plaintext
+commitment envelope for a commit. At action time it re-reads canonical safe
+state, reproduces every signed field, simulates the exact call, caps gas, and
+after execution requires the exact wallet and competition events at a safe
+block. A relayed reveal reports payment only when that same canonical receipt
+contains `BountySettled` and the USDC delta reconciles.
+
 ## Release States
 
 The hosted release advances in one direction through:

--- a/docs/security/open-competition-entrant-wallet-v1-static-analysis.md
+++ b/docs/security/open-competition-entrant-wallet-v1-static-analysis.md
@@ -1,0 +1,28 @@
+# Open Competition Entrant Wallet V1 Static Analysis
+
+Slither `0.11.5` analyzed the complete `contracts/base-escrow` Foundry project
+with tests, scripts, and dependency findings filtered from the release review.
+The machine-readable result is generated at
+`target/open-competition-entrant-wallet-slither.json` and is not committed.
+
+The new entrant wallet and factory produced 13 findings. No untriaged finding
+is accepted for release:
+
+| Detector | Count | Classification |
+| --- | ---: | --- |
+| `reentrancy-balance` | 2 | False positive for the two factory funding paths. Both external entry points hold the factory's storage reentrancy lock across deployment, pre-balance, native-USDC transfer, and post-balance. The deployment manifest pins native Base USDC, which has no receiver callback. Tests reject a non-transferring token. |
+| `incorrect-equality` | 2 | Intentional exact balance-delta invariant. Fee-on-transfer, rebasing, mint-on-transfer, and malformed tokens are unsupported and must fail rather than underfund or overfund a policy-bound wallet. |
+| `timestamp` | 4 | Intended policy validity, signature-expiry, and spend-period boundaries. Deadlines are short and checked again in action-time simulation; they do not provide randomness or select a winner. |
+| `assembly` | 3 | Minimal-proxy CREATE2, bounded-gas ERC-1271 static call, and low-s ECDSA decoding. Exact runtime hashes and signature adversarial tests cover these paths. |
+| `low-level-calls` | 2 | Owner-only ETH recovery and exact native-USDC allowance reset/set with return-value validation. The delegate and keeper cannot invoke withdrawals. |
+
+The apparent factory reentrancy findings do not make arbitrary tokens safe.
+Hosted deployment is permitted only when the exact competition factory binds
+the manifest's native-USDC address and action-time balance-delta checks pass.
+Any deployment with another token requires a new threat
+model, static-analysis triage, and tests.
+
+Static analysis is one R4 input, not release approval. Base Sepolia rehearsal,
+exact mainnet-fork replay, independent review, bytecode/manifest audit, and
+safe-block receipt reconciliation remain required before hosted relay or gas
+sponsorship can be enabled.

--- a/docs/security/open-competition-v1-threat-model.md
+++ b/docs/security/open-competition-v1-threat-model.md
@@ -33,6 +33,11 @@ bounty is advertised as ready.
 | Unbounded payout/refund loops | pull payments and bounded scalar accounting | gas cost remains for each claimant |
 | Reentrancy or false token return | non-reentrant state transitions and checked low-level token calls | nonstandard rebasing/fee tokens are unsupported; deployments pin native USDC |
 | False payment claims | canonical settlement event and safe-block confirmation | RPC/indexer compromise must be caught by independent chain validation |
+| Keeper mutates an entrant action | EIP-712 signature binds wallet, action, payload hash, shared nonce, short deadline, and policy version; action-time simulation and safe-block receipt reconciliation | a keeper can censor or delay, and Base ordering still applies |
+| Keeper or delegate drains the entrant account | delegate has only commit, reveal, and bond-withdraw actions; no arbitrary call, recipient choice, reimbursement, or withdrawal; gas is paid by the keeper | the wallet owner retains custody and can withdraw assets or revoke/rotate policy |
+| Creator takes control after commitment | creator-address exclusion is rechecked at reveal after any owner/delegate rotation | an unrelated address does not prove an unrelated beneficial owner |
+| Stale or substituted verifier profile | wallet pins verifier address, runtime hash, policy, criteria, benchmark, and evidence schema; planner and relay re-read them at a safe block | a reviewed deterministic verifier can still implement a poor predicate |
+| Commitment secret leaks through sponsorship | commit plans and relay envelopes carry only the commitment; reveal material is supplied only at reveal time | the local recovery envelope, delegate host, or reveal transport can still leak secrets |
 
 ## Explicit Non-Claims
 
@@ -44,6 +49,10 @@ bounty is advertised as ready.
 - Commit/reveal does not make Base ordering censorship-resistant.
 - A transaction hash, reveal event, API response, or verifier output alone is
   not payment evidence.
+- A factory-created entrant account proves one protocol account, not one
+  independent agent, human, or organization.
+- Creator-address exclusion does not detect common control through unrelated
+  wallets, contract owners, delegates, custodians, or private keys.
 
 ## Containment And Release Gates
 
@@ -56,3 +65,9 @@ Mainnet activation requires the repository R4 gates: Foundry unit/fuzz/
 invariant tests, static analysis, independent contract review, full Base
 Sepolia rehearsal, exact mainnet-fork replay, exact bytecode/configuration
 evidence, bounded-wallet policy review, and action-time signing approval.
+
+The entrant wallet and entrant factory are a separate release boundary from
+the already deployed bounty factory. Their deployment, relay, and gas gates
+remain false until their own bytecode is frozen, reviewed, rehearsed, replayed,
+and reconciled. Earlier bounty-factory canary evidence cannot be reused as
+entrant-wallet evidence.

--- a/scripts/build_open_competition_entrant_wallet_bundle.py
+++ b/scripts/build_open_competition_entrant_wallet_bundle.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Build exact deterministic deployment bundles for the Open Competition entrant wallet."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACTS = ROOT / "contracts" / "base-escrow"
+CREATE2_DEPLOYER = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+CREATE2_DEPLOYER_CODE_HASH = "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989"
+FACTORY_CONTRACT = "OpenCompetitionEntrantWalletFactoryV1"
+WALLET_CONTRACT = "OpenCompetitionEntrantWalletV1"
+NETWORKS = {
+    "base-sepolia": {
+        "chain_id": 84532,
+        "rpc_url": "https://sepolia.base.org",
+        "competition_factory": "0x7231f1312448fa60078fb56cdb6e2c392bd1269b",
+        "settlement_token": "0x036cbd53842c5426634e7929541ec2318f3dcf7e",
+    },
+    "base-mainnet": {
+        "chain_id": 8453,
+        "rpc_url": "https://mainnet.base.org",
+        "competition_factory": "0x9e9382beb8b1a45b737d484b5eafa7b8779d4ca5",
+        "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+    },
+}
+SOURCE_INPUTS = ("contracts/base-escrow",)
+
+
+def executable(name: str) -> str:
+    found = shutil.which(name)
+    if found:
+        return found
+    candidate = ROOT / ".tools" / "foundry" / f"{name}.exe"
+    if candidate.exists():
+        return str(candidate)
+    raise SystemExit(f"{name} is required; install Foundry or use .tools/foundry")
+
+
+CAST = executable("cast")
+FORGE = executable("forge")
+
+
+def run(command: list[str], cwd: Path = ROOT, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        input=input_text,
+    )
+    return result.stdout.strip()
+
+
+def cast(*args: str) -> str:
+    return run([CAST, *args])
+
+
+def keccak(value: str) -> str:
+    return run([CAST, "keccak"], input_text=value).lower()
+
+
+def artifact(contract: str) -> dict:
+    path = CONTRACTS / "out" / f"{contract}.sol" / f"{contract}.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def bytecode(contract: str) -> str:
+    value = artifact(contract)["bytecode"]["object"]
+    if not value.startswith("0x") or "__$" in value:
+        raise SystemExit(f"{contract} creation bytecode is unavailable or unlinked")
+    return value.lower()
+
+
+def immutable_names(contract: str) -> dict[str, str]:
+    value = artifact(contract)
+    identifiers = set(value["deployedBytecode"]["immutableReferences"])
+    names: dict[str, str] = {}
+
+    def visit(node: object) -> None:
+        if isinstance(node, dict):
+            identifier = str(node.get("id"))
+            if identifier in identifiers and node.get("nodeType") == "VariableDeclaration":
+                names[identifier] = str(node["name"])
+            for child in node.values():
+                visit(child)
+        elif isinstance(node, list):
+            for child in node:
+                visit(child)
+
+    visit(value.get("ast", {}))
+    if set(names) != identifiers:
+        for path in (CONTRACTS / "out").glob("*/*.json"):
+            visit(json.loads(path.read_text(encoding="utf-8")).get("ast", {}))
+            if set(names) == identifiers:
+                break
+    if set(names) != identifiers:
+        raise SystemExit(f"{contract} immutable metadata is incomplete")
+    return names
+
+
+def immutable_word(value: str | int) -> str:
+    encoded = f"{value:x}" if isinstance(value, int) else value.lower().removeprefix("0x")
+    if len(encoded) > 64 or any(character not in "0123456789abcdef" for character in encoded):
+        raise SystemExit(f"invalid immutable value: {value}")
+    return encoded.rjust(64, "0")
+
+
+def exact_runtime(contract: str, immutables: dict[str, str | int]) -> str:
+    value = artifact(contract)
+    runtime = value["deployedBytecode"]["object"].lower().removeprefix("0x")
+    references = value["deployedBytecode"]["immutableReferences"]
+    names = immutable_names(contract)
+    if set(immutables) != set(names.values()):
+        raise SystemExit(
+            f"{contract} immutable mismatch: expected {sorted(names.values())}, got {sorted(immutables)}"
+        )
+    for identifier, locations in references.items():
+        word = immutable_word(immutables[names[identifier]])
+        for location in locations:
+            if location["length"] != 32:
+                raise SystemExit(f"{contract} has a non-word immutable")
+            start = location["start"] * 2
+            runtime = f"{runtime[:start]}{word}{runtime[start + 64:]}"
+    return f"0x{runtime}"
+
+
+def append_constructor(code: str, signature: str, *args: str) -> str:
+    encoded = cast("abi-encode", signature, *args)
+    return f"{code}{encoded[2:]}".lower()
+
+
+def create_address(deployer: str, nonce: int) -> str:
+    return cast("compute-address", "--nonce", str(nonce), deployer).split(":", 1)[-1].strip().lower()
+
+
+def source_sha256(name: str) -> str:
+    return f"0x{hashlib.sha256((CONTRACTS / 'src' / f'{name}.sol').read_bytes()).hexdigest()}"
+
+
+def build_bundle(network: str, *, compile_contracts: bool = True) -> dict:
+    config = NETWORKS[network]
+    if compile_contracts:
+        run([FORGE, "build", "--force", "--ast"], cwd=CONTRACTS)
+    init_code = append_constructor(
+        bytecode(FACTORY_CONTRACT), "constructor(address)", config["competition_factory"]
+    )
+    salt_label = f"agent-bounties/{network}/open-competition-entrant-wallet-factory/v1"
+    salt = cast("keccak", salt_label).lower()
+    init_code_hash = keccak(init_code)
+    wallet_factory = cast(
+        "create2",
+        "--deployer",
+        CREATE2_DEPLOYER,
+        "--salt",
+        salt,
+        "--init-code-hash",
+        init_code_hash,
+    ).splitlines()[0].lower()
+    implementation = create_address(wallet_factory, 1)
+    factory_runtime = exact_runtime(
+        FACTORY_CONTRACT,
+        {
+            "competitionFactory": config["competition_factory"],
+            "settlementToken": config["settlement_token"],
+            "implementation": implementation,
+        },
+    )
+    implementation_runtime = exact_runtime(
+        WALLET_CONTRACT,
+        {
+            "deploymentFactory": wallet_factory,
+            "factory": config["competition_factory"],
+            "settlementToken": config["settlement_token"],
+        },
+    )
+    clone_runtime = f"0x363d3d373d3d3d363d73{implementation[2:]}5af43d82803e903d91602b57fd5bf3"
+    source_revision = run(["git", "rev-parse", "HEAD:contracts/base-escrow"])
+    source_dirty = bool(run(["git", "status", "--short", "--", *SOURCE_INPUTS]))
+    return {
+        "schema_version": "agent-bounties/open-competition-entrant-wallet-deployment-v1",
+        "network": network,
+        "chain_id": config["chain_id"],
+        "deployment_state": "source_only_not_ready_to_earn",
+        "contract_source_revision": source_revision,
+        "contract_source_revision_kind": "git-tree",
+        "contract_source_dirty": source_dirty,
+        "compiler": {"solc": "0.8.26", "optimizer": True, "optimizer_runs": 200, "evm": "cancun"},
+        "rpc_url": config["rpc_url"],
+        "canonical": {
+            "competition_factory": config["competition_factory"],
+            "settlement_token": config["settlement_token"],
+        },
+        "deterministic_deployer": {
+            "address": CREATE2_DEPLOYER,
+            "runtime_code_hash": CREATE2_DEPLOYER_CODE_HASH,
+        },
+        "entrant_wallet_factory": {
+            "address": wallet_factory,
+            "implementation": implementation,
+            "salt_label": salt_label,
+            "salt": salt,
+            "init_code_hash": init_code_hash,
+            "deployment_transaction": f"0x{salt[2:]}{init_code[2:]}",
+            "runtime_code_hash": keccak(factory_runtime),
+            "runtime_code_bytes": (len(factory_runtime) - 2) // 2,
+            "implementation_runtime_code_hash": keccak(implementation_runtime),
+            "implementation_runtime_code_bytes": (len(implementation_runtime) - 2) // 2,
+            "clone_runtime_code_hash": keccak(clone_runtime),
+        },
+        "contracts": {
+            FACTORY_CONTRACT: {"source_sha256": source_sha256(FACTORY_CONTRACT)},
+            WALLET_CONTRACT: {"source_sha256": source_sha256(WALLET_CONTRACT)},
+        },
+        "activation_gates": {
+            "base_sepolia_rehearsal_passed": False,
+            "exact_mainnet_fork_replay_passed": False,
+            "static_analysis_passed": False,
+            "independent_review_complete": False,
+            "keeper_relay_rehearsed": False,
+            "keeper_gas_reserve_verified": False,
+            "relay_support_available": False,
+            "gas_sponsorship_available": False,
+        },
+        "evidence_boundary": (
+            "This bundle derives exact addresses, bytecode, runtime hashes, and unsigned CREATE2 deployment "
+            "calldata. It is not deployment, policy approval, relay availability, gas sponsorship, competition "
+            "entry, settlement, or payment evidence."
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--network", choices=sorted(NETWORKS), required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    output = args.output or ROOT / "deployments" / f"open-competition-entrant-wallet-v1-{args.network}.json"
+    bundle = build_bundle(args.network)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(bundle, indent=2) + "\n", encoding="utf-8")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plan_open_competition_entrant_action.py
+++ b/scripts/plan_open_competition_entrant_action.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Plan one exact signed action for an Open Competition entrant wallet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+from inspect_bounded_agent_wallet import call, code_hash, rpc, word_address, word_uint, words
+from plan_bounded_agent_budget import ROOT, require_address, require_bytes32
+
+
+SCHEMA = "agent-bounties/open-competition-entrant-wallet-action-v1"
+COMMITMENT_SCHEMA = "agent-bounties/open-competition-v1-commitment-v1"
+MANIFEST_SCHEMA = "agent-bounties/open-competition-entrant-wallet-deployment-v1"
+POLICY_SIGNATURE = (
+    "policy()(address,uint64,uint64,uint64,uint256,uint256,uint256,uint256,uint8,address,"
+    "bytes32,bytes32,bytes32,bytes32,bytes32)"
+)
+POLICY_FIELDS = (
+    "delegate",
+    "valid_after",
+    "valid_until",
+    "period_seconds",
+    "max_per_action",
+    "max_per_period",
+    "max_lifetime_spend",
+    "max_bounty_target",
+    "allowed_actions",
+    "verifier_module",
+    "verifier_runtime_code_hash",
+    "verifier_policy_hash",
+    "acceptance_criteria_hash",
+    "benchmark_hash",
+    "evidence_schema_hash",
+)
+ACTIONS = {"commit": 0, "reveal": 1, "withdraw_bond": 2}
+ZERO_HASH = "0x" + "00" * 32
+HEX_BYTES = re.compile(r"^0x(?:[0-9a-f]{2})*$")
+
+
+def run_cast(*args: str, input_text: str | None = None) -> str:
+    cast_bin = ROOT / ".tools" / "foundry" / "cast.exe"
+    command = [str(cast_bin) if cast_bin.exists() else "cast", *args]
+    completed = subprocess.run(
+        command,
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        input=input_text,
+    )
+    return completed.stdout.strip().lower()
+
+
+def one_word(rpc_url: str, target: str, signature: str, block: str, arguments: tuple[str, ...] = ()) -> str:
+    result = words(call(rpc_url, target, signature, block, arguments))
+    if len(result) != 1:
+        raise SystemExit(f"{signature} returned an unexpected shape")
+    return result[0]
+
+
+def exact_hex_bytes(value: str, label: str, maximum_bytes: int = 16_384) -> str:
+    normalized = value.strip().lower()
+    if not HEX_BYTES.fullmatch(normalized):
+        raise SystemExit(f"{label} must be complete 0x-prefixed bytes")
+    if (len(normalized) - 2) // 2 > maximum_bytes:
+        raise SystemExit(f"{label} exceeds {maximum_bytes} bytes")
+    return normalized
+
+
+def validate_manifest(value: dict) -> dict:
+    if value.get("schema_version") != MANIFEST_SCHEMA:
+        raise SystemExit("entrant-wallet manifest schema is unsupported")
+    if value.get("network") not in {"base-mainnet", "base-sepolia"}:
+        raise SystemExit("entrant-wallet manifest network is unsupported")
+    expected_chain = 8453 if value["network"] == "base-mainnet" else 84532
+    if value.get("chain_id") != expected_chain:
+        raise SystemExit("entrant-wallet manifest chain id does not match its network")
+    if value.get("contract_source_dirty") is not False:
+        raise SystemExit("entrant-wallet manifest was generated from dirty contract sources")
+    if value.get("contract_source_revision_kind") != "git-tree":
+        raise SystemExit("entrant-wallet manifest must pin a git tree")
+    source_revision = str(value.get("contract_source_revision", ""))
+    if not re.fullmatch(r"[0-9a-f]{40}", source_revision):
+        raise SystemExit("entrant-wallet manifest source revision is invalid")
+    canonical = value.get("canonical") or {}
+    require_address(str(canonical.get("competition_factory", "")), "competition factory")
+    require_address(str(canonical.get("settlement_token", "")), "settlement token")
+    deployer = value.get("deterministic_deployer") or {}
+    require_address(str(deployer.get("address", "")), "deterministic deployer")
+    require_bytes32(str(deployer.get("runtime_code_hash", "")), "deterministic deployer runtime")
+    wallet_factory = value.get("entrant_wallet_factory") or {}
+    for name in ("address", "implementation"):
+        require_address(str(wallet_factory.get(name, "")), name.replace("_", " "))
+    for name in (
+        "runtime_code_hash",
+        "implementation_runtime_code_hash",
+        "clone_runtime_code_hash",
+    ):
+        require_bytes32(str(wallet_factory.get(name, "")), name.replace("_", " "))
+    return value
+
+
+def policy_from_result(result: str) -> tuple[dict, str]:
+    raw_words = words(result)
+    if len(raw_words) != len(POLICY_FIELDS):
+        raise SystemExit("entrant-wallet policy returned an unexpected shape")
+    policy = dict(zip(POLICY_FIELDS, raw_words, strict=True))
+    for name in ("delegate", "verifier_module"):
+        policy[name] = word_address(str(policy[name]))
+    for name in POLICY_FIELDS[1:9]:
+        policy[name] = word_uint(str(policy[name]))
+    for name in POLICY_FIELDS[10:]:
+        policy[name] = f"0x{policy[name]}"
+    return policy, run_cast("keccak", result)
+
+
+def inspect_state(rpc_url: str, manifest: dict, wallet_value: str, bounty_value: str) -> dict:
+    wallet = require_address(wallet_value, "entrant wallet")
+    bounty = require_address(bounty_value, "competition bounty")
+    safe = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False], 1)
+    if not isinstance(safe, dict) or not safe.get("number") or not safe.get("hash"):
+        raise SystemExit("Base safe block is unavailable")
+    block = str(safe["number"])
+    safe_number = int(block, 16)
+    timestamp = int(str(safe["timestamp"]), 16)
+    observed_chain = int(str(rpc(rpc_url, "eth_chainId", [], 2)), 16)
+    if observed_chain != int(manifest["chain_id"]):
+        raise SystemExit("Base RPC chain does not match the entrant-wallet manifest")
+
+    canonical = manifest["canonical"]
+    wallet_manifest = manifest["entrant_wallet_factory"]
+    wallet_factory = require_address(wallet_manifest["address"], "wallet factory")
+    implementation = require_address(wallet_manifest["implementation"], "wallet implementation")
+    competition_factory = require_address(canonical["competition_factory"], "competition factory")
+    settlement_token = require_address(canonical["settlement_token"], "settlement token")
+    addresses = (wallet_factory, implementation, wallet)
+    hashes = {}
+    for index, address in enumerate(addresses):
+        code = str(rpc(rpc_url, "eth_getCode", [address, block], 10 + index)).lower()
+        hashes[address] = code_hash(code)
+    expected_hashes = (
+        wallet_manifest["runtime_code_hash"],
+        wallet_manifest["implementation_runtime_code_hash"],
+        wallet_manifest["clone_runtime_code_hash"],
+    )
+    if tuple(hashes[address] for address in addresses) != expected_hashes:
+        raise SystemExit("entrant-wallet factory, implementation, or clone runtime does not match the manifest")
+    if word_address(one_word(rpc_url, wallet_factory, "implementation()(address)", block)) != implementation:
+        raise SystemExit("entrant-wallet factory implementation binding changed")
+    if (
+        word_address(one_word(rpc_url, wallet_factory, "competitionFactory()(address)", block))
+        != competition_factory
+    ):
+        raise SystemExit("entrant-wallet factory competition binding changed")
+    if word_address(one_word(rpc_url, wallet_factory, "settlementToken()(address)", block)) != settlement_token:
+        raise SystemExit("entrant-wallet factory token binding changed")
+    if not bool(
+        word_uint(one_word(rpc_url, wallet_factory, "isFactoryWallet(address)(bool)", block, (wallet,)))
+    ):
+        raise SystemExit("entrant wallet is not registered by the frozen factory")
+
+    owner = word_address(one_word(rpc_url, wallet, "owner()(address)", block))
+    policy_result = call(rpc_url, wallet, POLICY_SIGNATURE, block)
+    policy, computed_policy_hash = policy_from_result(policy_result)
+    onchain_policy_hash = f"0x{one_word(rpc_url, wallet, 'policyHash()(bytes32)', block)}"
+    if computed_policy_hash != onchain_policy_hash:
+        raise SystemExit("entrant-wallet policy hash does not match its canonical ABI encoding")
+    wallet_state = {
+        "owner": owner,
+        "policy": policy,
+        "policy_hash": onchain_policy_hash,
+        "policy_version": word_uint(one_word(rpc_url, wallet, "policyVersion()(uint64)", block)),
+        "delegate_nonce": word_uint(one_word(rpc_url, wallet, "delegateNonce()(uint256)", block)),
+        "period_bucket": word_uint(one_word(rpc_url, wallet, "periodBucket()(uint256)", block)),
+        "period_spent": word_uint(one_word(rpc_url, wallet, "periodSpent()(uint256)", block)),
+        "lifetime_spent": word_uint(one_word(rpc_url, wallet, "lifetimeSpent()(uint256)", block)),
+        "revoked": bool(word_uint(one_word(rpc_url, wallet, "revoked()(bool)", block))),
+        "token_balance": word_uint(
+            one_word(rpc_url, settlement_token, "balanceOf(address)(uint256)", block, (wallet,))
+        ),
+    }
+    if wallet_state["revoked"] or not policy["valid_after"] <= timestamp <= policy["valid_until"]:
+        raise SystemExit("entrant-wallet policy is revoked, pending, or expired")
+    verifier_code = str(rpc(rpc_url, "eth_getCode", [policy["verifier_module"], block], 20)).lower()
+    if code_hash(verifier_code) != policy["verifier_runtime_code_hash"]:
+        raise SystemExit("entrant-wallet verifier runtime changed")
+
+    if not bool(
+        word_uint(
+            one_word(
+                rpc_url,
+                competition_factory,
+                "isCanonicalCompetition(address)(bool)",
+                block,
+                (bounty,),
+            )
+        )
+    ):
+        raise SystemExit("target is not a canonical Open Competition V1 bounty")
+    entry_words = words(
+        call(
+            rpc_url,
+            bounty,
+            "entries(address)(bytes32,uint64,uint64,uint256,uint8)",
+            block,
+            (wallet,),
+        )
+    )
+    if len(entry_words) != 5:
+        raise SystemExit("competition entry returned an unexpected shape")
+    entry = {
+        "commitment": f"0x{entry_words[0]}",
+        "committed_block": word_uint(entry_words[1]),
+        "reveal_deadline": word_uint(entry_words[2]),
+        "bond": word_uint(entry_words[3]),
+        "state": word_uint(entry_words[4]),
+    }
+    bounty_state = {
+        "factory": word_address(one_word(rpc_url, bounty, "factory()(address)", block)),
+        "settlement_token": word_address(one_word(rpc_url, bounty, "settlementToken()(address)", block)),
+        "creator": word_address(one_word(rpc_url, bounty, "creator()(address)", block)),
+        "target_amount": word_uint(one_word(rpc_url, bounty, "targetAmount()(uint256)", block)),
+        "verifier_reward": word_uint(one_word(rpc_url, bounty, "verifierReward()(uint256)", block)),
+        "status": word_uint(one_word(rpc_url, bounty, "status()(uint8)", block)),
+        "competition_ends_at": word_uint(one_word(rpc_url, bounty, "competitionEndsAt()(uint64)", block)),
+        "entry_count": word_uint(one_word(rpc_url, bounty, "entryCount()(uint8)", block)),
+        "max_entries": word_uint(one_word(rpc_url, bounty, "maxEntries()(uint8)", block)),
+        "verifier_module": word_address(one_word(rpc_url, bounty, "verifierModule()(address)", block)),
+        "policy_hash": f"0x{one_word(rpc_url, bounty, 'policyHash()(bytes32)', block)}",
+        "acceptance_criteria_hash": f"0x{one_word(rpc_url, bounty, 'acceptanceCriteriaHash()(bytes32)', block)}",
+        "benchmark_hash": f"0x{one_word(rpc_url, bounty, 'benchmarkHash()(bytes32)', block)}",
+        "evidence_schema_hash": f"0x{one_word(rpc_url, bounty, 'evidenceSchemaHash()(bytes32)', block)}",
+        "has_entered": bool(
+            word_uint(one_word(rpc_url, bounty, "hasEntered(address)(bool)", block, (wallet,)))
+        ),
+        "entry": entry,
+    }
+    if bounty_state["factory"] != competition_factory or bounty_state["settlement_token"] != settlement_token:
+        raise SystemExit("competition factory or settlement-token binding changed")
+    expected_profile = {
+        "verifier_module": policy["verifier_module"],
+        "policy_hash": policy["verifier_policy_hash"],
+        "acceptance_criteria_hash": policy["acceptance_criteria_hash"],
+        "benchmark_hash": policy["benchmark_hash"],
+        "evidence_schema_hash": policy["evidence_schema_hash"],
+    }
+    if any(bounty_state[name] != expected for name, expected in expected_profile.items()):
+        raise SystemExit("competition does not match the wallet's pinned verifier profile")
+    if bounty_state["target_amount"] > policy["max_bounty_target"]:
+        raise SystemExit("competition target exceeds the entrant-wallet policy")
+    return {
+        "network": manifest["network"],
+        "chain_id": observed_chain,
+        "safe_block": {"number": safe_number, "hash": safe["hash"], "timestamp": timestamp},
+        "wallet": wallet,
+        "bounty": bounty,
+        "wallet_state": wallet_state,
+        "bounty_state": bounty_state,
+    }
+
+
+def validate_commitment_envelope(value: dict, report: dict) -> dict:
+    required = {
+        "schema_version",
+        "network",
+        "chain_id",
+        "bounty",
+        "solver",
+        "submission_hash",
+        "evidence_hash",
+        "salt",
+        "commitment",
+        "committed_block",
+        "reveal_deadline",
+        "evidence_boundary",
+    }
+    if set(value) != required:
+        raise SystemExit("commitment envelope keys are incomplete or unexpected")
+    if value["schema_version"] != COMMITMENT_SCHEMA:
+        raise SystemExit("commitment envelope schema is unsupported")
+    if value["network"] != report["network"] or value["chain_id"] != report["chain_id"]:
+        raise SystemExit("commitment envelope network or chain does not match")
+    if require_address(str(value["bounty"]), "envelope bounty") != report["bounty"]:
+        raise SystemExit("commitment envelope bounty does not match")
+    if require_address(str(value["solver"]), "envelope solver") != report["wallet"]:
+        raise SystemExit("commitment envelope solver must be the entrant wallet")
+    for field in ("submission_hash", "evidence_hash", "salt", "commitment"):
+        value[field] = require_bytes32(str(value[field]), field)
+        if value[field] == ZERO_HASH:
+            raise SystemExit(f"commitment envelope {field} cannot be zero")
+    domain = run_cast("keccak", input_text="agent-bounties/open-competition-v1-solution")
+    encoded = run_cast(
+        "abi-encode",
+        "f(bytes32,uint256,address,address,bytes32,bytes32,bytes32)",
+        domain,
+        str(report["chain_id"]),
+        report["bounty"],
+        report["wallet"],
+        value["submission_hash"],
+        value["evidence_hash"],
+        value["salt"],
+    )
+    if run_cast("keccak", encoded) != value["commitment"]:
+        raise SystemExit("commitment envelope does not reconstruct its commitment")
+    return value
+
+
+def build_plan(
+    report: dict,
+    action: str,
+    envelope: dict | None,
+    proof: str | None,
+    deadline_seconds: int,
+    *,
+    exact_deadline: int | None = None,
+) -> dict:
+    if action not in ACTIONS:
+        raise SystemExit("unsupported entrant-wallet action")
+    if deadline_seconds < 60 or deadline_seconds > 900:
+        raise SystemExit("deadline-seconds must be between 60 and 900")
+    action_code = ACTIONS[action]
+    policy = report["wallet_state"]["policy"]
+    bounty = report["bounty_state"]
+    entry = bounty["entry"]
+    timestamp = report["safe_block"]["timestamp"]
+    if not policy["allowed_actions"] & (1 << action_code):
+        raise SystemExit("action is disabled by the entrant-wallet policy")
+    if action == "commit":
+        if envelope is None:
+            raise SystemExit("commit requires a local commitment envelope")
+        if bounty["status"] != 1 or timestamp >= bounty["competition_ends_at"]:
+            raise SystemExit("competition is not open for a new commitment")
+        if bounty["has_entered"] or bounty["entry_count"] >= bounty["max_entries"]:
+            raise SystemExit("wallet already entered or competition capacity is full")
+        if bounty["creator"] in {report["wallet_state"]["owner"], policy["delegate"]}:
+            raise SystemExit("creator-controlled entrant wallet is ineligible")
+        bond = bounty["verifier_reward"]
+        bucket = timestamp // policy["period_seconds"]
+        period_spent = (
+            report["wallet_state"]["period_spent"]
+            if bucket == report["wallet_state"]["period_bucket"]
+            else 0
+        )
+        if (
+            bond == 0
+            or bond > policy["max_per_action"]
+            or period_spent + bond > policy["max_per_period"]
+            or report["wallet_state"]["lifetime_spent"] + bond > policy["max_lifetime_spend"]
+            or report["wallet_state"]["token_balance"] < bond
+        ):
+            raise SystemExit("entry bond exceeds the wallet's remaining bounded budget")
+        payload = run_cast("abi-encode", "f(address,bytes32)", report["bounty"], envelope["commitment"])
+        direct_data = run_cast(
+            "calldata", "commitSolution(address,bytes32)", report["bounty"], envelope["commitment"]
+        )
+        summary = {"commitment": envelope["commitment"], "maximum_gross_spend": str(bond)}
+    elif action == "reveal":
+        if envelope is None or proof is None:
+            raise SystemExit("reveal requires a local commitment envelope and proof")
+        if bounty["creator"] in {report["wallet_state"]["owner"], policy["delegate"]}:
+            raise SystemExit("creator-controlled entrant wallet is ineligible")
+        if bounty["status"] != 1 or entry["state"] != 1:
+            raise SystemExit("wallet has no live committed entry")
+        if entry["commitment"] != envelope["commitment"]:
+            raise SystemExit("onchain commitment differs from the recovery envelope")
+        if report["safe_block"]["number"] <= entry["committed_block"]:
+            raise SystemExit("reveal requires a later safe block")
+        if timestamp > entry["reveal_deadline"] or timestamp > bounty["competition_ends_at"]:
+            raise SystemExit("reveal deadline has elapsed")
+        payload = run_cast(
+            "abi-encode",
+            "f(address,bytes32,bytes32,bytes32,bytes)",
+            report["bounty"],
+            envelope["submission_hash"],
+            envelope["evidence_hash"],
+            envelope["salt"],
+            proof,
+        )
+        direct_data = run_cast(
+            "calldata",
+            "revealSolution(address,bytes32,bytes32,bytes32,bytes)",
+            report["bounty"],
+            envelope["submission_hash"],
+            envelope["evidence_hash"],
+            envelope["salt"],
+            proof,
+        )
+        summary = {
+            "submission_hash": envelope["submission_hash"],
+            "evidence_hash": envelope["evidence_hash"],
+            "salt": envelope["salt"],
+            "proof_hash": run_cast("keccak", proof),
+            "maximum_gross_spend": "0",
+        }
+    else:
+        if envelope is not None or proof is not None:
+            raise SystemExit("withdraw_bond does not accept an envelope or proof")
+        if bounty["status"] != 2 or entry["state"] != 1 or entry["bond"] == 0:
+            raise SystemExit("wallet has no losing bond available for withdrawal")
+        payload = run_cast("abi-encode", "f(address)", report["bounty"])
+        direct_data = run_cast("calldata", "withdrawEntryBond(address)", report["bounty"])
+        summary = {"recoverable_bond": str(entry["bond"]), "maximum_gross_spend": "0"}
+    payload_hash = run_cast("keccak", payload)
+    nonce = report["wallet_state"]["delegate_nonce"]
+    deadline = (
+        min(timestamp + deadline_seconds, policy["valid_until"])
+        if exact_deadline is None
+        else exact_deadline
+    )
+    if isinstance(deadline, bool) or not isinstance(deadline, int):
+        raise SystemExit("entrant-wallet action deadline must be an integer")
+    if deadline > timestamp + 900:
+        raise SystemExit("entrant-wallet action deadline exceeds the 15-minute relay window")
+    if deadline > policy["valid_until"]:
+        raise SystemExit("entrant-wallet action deadline exceeds the policy validity window")
+    if deadline <= timestamp:
+        raise SystemExit("entrant-wallet policy expires too soon")
+    wallet = report["wallet"]
+    typed = {
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "OpenCompetitionEntrantAction": [
+                {"name": "wallet", "type": "address"},
+                {"name": "action", "type": "uint8"},
+                {"name": "payloadHash", "type": "bytes32"},
+                {"name": "nonce", "type": "uint256"},
+                {"name": "deadline", "type": "uint256"},
+                {"name": "policyVersion", "type": "uint64"},
+            ],
+        },
+        "primaryType": "OpenCompetitionEntrantAction",
+        "domain": {
+            "name": "Agent Bounties Open Competition Entrant Wallet",
+            "version": "1",
+            "chainId": report["chain_id"],
+            "verifyingContract": wallet,
+        },
+        "message": {
+            "wallet": wallet,
+            "action": action_code,
+            "payloadHash": payload_hash,
+            "nonce": str(nonce),
+            "deadline": str(deadline),
+            "policyVersion": report["wallet_state"]["policy_version"],
+        },
+    }
+    return {
+        "schema_version": SCHEMA,
+        "network": report["network"],
+        "chain_id": report["chain_id"],
+        "safe_block": report["safe_block"],
+        "wallet": wallet,
+        "delegate": policy["delegate"],
+        "policy_hash": report["wallet_state"]["policy_hash"],
+        "policy_version": report["wallet_state"]["policy_version"],
+        "action": action,
+        "action_code": action_code,
+        "bounty": report["bounty"],
+        "action_summary": summary,
+        "nonce": nonce,
+        "deadline": deadline,
+        "payload": payload,
+        "payload_hash": payload_hash,
+        "direct_transaction": {
+            "from": policy["delegate"],
+            "to": wallet,
+            "data": direct_data,
+            "value": "0x0",
+        },
+        "signing_payload": typed,
+        "relay_call": {
+            "to": wallet,
+            "function": "executeWithSignature(uint8,bytes,uint256,uint256,bytes)",
+            "arguments_before_signature": [action_code, payload, nonce, deadline],
+            "signature_tail": ["delegate_signature"],
+        },
+        "evidence_boundary": (
+            "This safe-block plan is unsigned. A keeper may pay gas only for the exact signed action. "
+            "Canonical competition events prove entry, reveal, or bond recovery; only BountySettled proves payout."
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=sorted(ACTIONS))
+    parser.add_argument("--wallet", required=True)
+    parser.add_argument("--bounty", required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--rpc-url")
+    parser.add_argument("--commitment-envelope", type=Path)
+    parser.add_argument("--proof")
+    parser.add_argument("--deadline-seconds", type=int, default=300)
+    parser.add_argument(
+        "--output", type=Path, default=ROOT / "target" / "open-competition-entrant-action-plan.json"
+    )
+    args = parser.parse_args()
+    manifest = validate_manifest(json.loads(args.manifest.read_text(encoding="utf-8")))
+    rpc_url = args.rpc_url or str(manifest["rpc_url"])
+    report = inspect_state(rpc_url, manifest, args.wallet, args.bounty)
+    envelope = None
+    if args.commitment_envelope:
+        value = json.loads(args.commitment_envelope.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise SystemExit("commitment envelope must contain one JSON object")
+        envelope = validate_commitment_envelope(value, report)
+    proof = exact_hex_bytes(args.proof, "proof") if args.proof is not None else None
+    plan = build_plan(report, args.action, envelope, proof, args.deadline_seconds)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/relay_open_competition_entrant_action.py
+++ b/scripts/relay_open_competition_entrant_action.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Relay one exact signed Open Competition entrant-wallet action with bounded gas."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+from inspect_bounded_agent_wallet import word_address, word_uint, words
+from plan_bounded_agent_budget import ROOT, require_address, require_bytes32
+from plan_open_competition_entrant_action import (
+    ACTIONS,
+    SCHEMA as PLAN_SCHEMA,
+    build_plan,
+    exact_hex_bytes,
+    inspect_state,
+    rpc,
+    run_cast,
+    validate_commitment_envelope,
+    validate_manifest,
+)
+from relay_autonomous_action import CastClient, RelayError, normalize_private_key, validate_receipt
+
+
+SCHEMA = "agent-bounties/open-competition-entrant-wallet-relay-v1"
+SIGNATURE = "executeWithSignature(uint8,bytes,uint256,uint256,bytes)"
+SIGNATURE_RE = re.compile(r"^0x[0-9a-f]{130}$")
+MAX_GAS_LIMIT = 1_000_000
+MAX_GAS_PRICE_WEI = 2_000_000_000
+MAX_GAS_COST_WEI = 2_000_000_000_000_000
+SAFE_WAIT_SECONDS = 120
+PLAN_KEYS = {
+    "schema_version",
+    "network",
+    "chain_id",
+    "safe_block",
+    "wallet",
+    "delegate",
+    "policy_hash",
+    "policy_version",
+    "action",
+    "action_code",
+    "bounty",
+    "action_summary",
+    "nonce",
+    "deadline",
+    "payload",
+    "payload_hash",
+    "direct_transaction",
+    "signing_payload",
+    "relay_call",
+    "evidence_boundary",
+}
+REVALIDATED_FIELDS = PLAN_KEYS - {"safe_block", "evidence_boundary"}
+
+
+def load_json(path: Path, label: str) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise RelayError(f"{label} must contain one JSON object")
+    return value
+
+
+def validate_plan(value: dict) -> dict:
+    if set(value) != PLAN_KEYS:
+        raise RelayError("entrant action plan keys are incomplete or unexpected")
+    if value.get("schema_version") != PLAN_SCHEMA:
+        raise RelayError("entrant action plan schema is unsupported")
+    if value.get("network") not in {"base-mainnet", "base-sepolia"}:
+        raise RelayError("entrant action plan network is unsupported")
+    expected_chain = 8453 if value["network"] == "base-mainnet" else 84532
+    if value.get("chain_id") != expected_chain:
+        raise RelayError("entrant action plan chain does not match its network")
+    action = value.get("action")
+    if action not in ACTIONS or value.get("action_code") != ACTIONS[action]:
+        raise RelayError("entrant action name and code do not match")
+    value["wallet"] = require_address(str(value.get("wallet", "")), "entrant wallet")
+    value["delegate"] = require_address(str(value.get("delegate", "")), "delegate")
+    value["bounty"] = require_address(str(value.get("bounty", "")), "competition bounty")
+    value["policy_hash"] = require_bytes32(str(value.get("policy_hash", "")), "policy hash")
+    value["payload_hash"] = require_bytes32(str(value.get("payload_hash", "")), "payload hash")
+    value["payload"] = exact_hex_bytes(str(value.get("payload", "")), "payload")
+    for field in ("policy_version", "nonce", "deadline"):
+        item = value.get(field)
+        if isinstance(item, bool) or not isinstance(item, int) or item < 0:
+            raise RelayError(f"entrant action {field} must be a nonnegative integer")
+    if value["policy_version"] == 0 or value["deadline"] == 0:
+        raise RelayError("entrant action policy version and deadline must be positive")
+    safe = value.get("safe_block")
+    if not isinstance(safe, dict) or set(safe) != {"number", "hash", "timestamp"}:
+        raise RelayError("entrant action safe block is malformed")
+    if any(isinstance(safe.get(field), bool) or not isinstance(safe.get(field), int) for field in ("number", "timestamp")):
+        raise RelayError("entrant action safe block number and timestamp must be integers")
+    safe["hash"] = require_bytes32(str(safe.get("hash", "")), "safe block hash")
+    if run_cast("keccak", value["payload"]) != value["payload_hash"]:
+        raise RelayError("entrant action payload hash does not match the signed payload")
+    return value
+
+
+def proof_from_file(path: Path | None) -> str | None:
+    if path is None:
+        return None
+    raw = path.read_text(encoding="utf-8").strip()
+    if raw.startswith("{"):
+        value = json.loads(raw)
+        if not isinstance(value, dict) or set(value) != {"proof"}:
+            raise RelayError("proof JSON must contain only the proof field")
+        raw = str(value["proof"])
+    return exact_hex_bytes(raw, "proof")
+
+
+def assert_original_safe_block_is_canonical(rpc_url: str, plan: dict, current: dict) -> None:
+    original = plan["safe_block"]
+    if current["safe_block"]["number"] < original["number"]:
+        raise RelayError("current safe head is behind the action plan")
+    observed = rpc(rpc_url, "eth_getBlockByNumber", [hex(original["number"]), False], 70)
+    if not isinstance(observed, dict) or str(observed.get("hash", "")).lower() != original["hash"]:
+        raise RelayError("the action plan's original safe block is no longer canonical")
+
+
+def revalidate_plan(
+    rpc_url: str,
+    manifest: dict,
+    plan: dict,
+    envelope: dict | None,
+    proof: str | None,
+) -> tuple[dict, dict]:
+    action = plan["action"]
+    if action == "commit":
+        if envelope is not None or proof is not None:
+            raise RelayError("commit relay accepts no plaintext commitment envelope or proof")
+        summary = plan.get("action_summary")
+        if not isinstance(summary, dict) or set(summary) != {"commitment", "maximum_gross_spend"}:
+            raise RelayError("commit action summary is malformed")
+        commitment = require_bytes32(str(summary["commitment"]), "commitment")
+        planning_envelope = {"commitment": commitment}
+    elif action == "reveal":
+        if envelope is None or proof is None:
+            raise RelayError("reveal relay requires the local commitment envelope and proof file")
+        planning_envelope = envelope
+    else:
+        if envelope is not None or proof is not None:
+            raise RelayError("withdraw_bond relay accepts no commitment envelope or proof")
+        planning_envelope = None
+    current = inspect_state(rpc_url, manifest, plan["wallet"], plan["bounty"])
+    assert_original_safe_block_is_canonical(rpc_url, plan, current)
+    if action == "reveal":
+        assert envelope is not None
+        planning_envelope = validate_commitment_envelope(envelope, current)
+    regenerated = build_plan(
+        current,
+        action,
+        planning_envelope,
+        proof,
+        300,
+        exact_deadline=plan["deadline"],
+    )
+    for field in sorted(REVALIDATED_FIELDS):
+        if regenerated[field] != plan[field]:
+            raise RelayError(f"live safe-state revalidation changed signed field {field}")
+    return current, regenerated
+
+
+def topic_address(value: str) -> str:
+    return "0x" + "00" * 12 + require_address(value, "topic address")[2:]
+
+
+def topic_uint(value: int) -> str:
+    return "0x" + value.to_bytes(32, "big").hex()
+
+
+def canonical_receipt(rpc_url: str, tx_hash: str, receipt_block: int, receipt_hash: str) -> tuple[dict, dict]:
+    deadline = time.monotonic() + SAFE_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        safe = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False], 80)
+        receipt = rpc(rpc_url, "eth_getTransactionReceipt", [tx_hash], 81)
+        block = rpc(rpc_url, "eth_getBlockByNumber", [hex(receipt_block), False], 82)
+        if (
+            isinstance(safe, dict)
+            and int(str(safe.get("number", "0x0")), 16) >= receipt_block
+            and isinstance(receipt, dict)
+            and str(receipt.get("status", "")).lower() == "0x1"
+            and str(receipt.get("blockHash", "")).lower() == receipt_hash
+            and isinstance(block, dict)
+            and str(block.get("hash", "")).lower() == receipt_hash
+        ):
+            return receipt, safe
+        time.sleep(2)
+    raise RelayError("relay receipt did not become canonical at a Base safe block")
+
+
+def matching_logs(receipt: dict, address: str, event_signature: str) -> list[dict]:
+    topic0 = run_cast("keccak", input_text=event_signature)
+    result = []
+    for log in receipt.get("logs", []):
+        if not isinstance(log, dict) or str(log.get("address", "")).lower() != address:
+            continue
+        topics = log.get("topics")
+        if isinstance(topics, list) and topics and str(topics[0]).lower() == topic0:
+            result.append(log)
+    return result
+
+
+def require_wallet_action_event(receipt: dict, plan: dict, keeper: str) -> None:
+    logs = matching_logs(
+        receipt,
+        plan["wallet"],
+        "EntrantActionExecuted(uint8,address,address,uint256,bytes32)",
+    )
+    expected_topics = [topic_uint(plan["action_code"]), topic_address(plan["delegate"]), topic_address(keeper)]
+    for log in logs:
+        topics = [str(value).lower() for value in log.get("topics", [])[1:]]
+        data = words(str(log.get("data", "")))
+        if (
+            topics == expected_topics
+            and len(data) == 2
+            and word_uint(data[0]) == plan["nonce"]
+            and f"0x{data[1]}" == plan["payload_hash"]
+        ):
+            return
+    raise RelayError("canonical receipt lacks the exact entrant-wallet action event")
+
+
+def validate_action_events_and_balances(receipt: dict, plan: dict, before: dict, after: dict) -> dict:
+    action = plan["action"]
+    bounty = plan["bounty"]
+    wallet = plan["wallet"]
+    before_wallet = before["wallet_state"]
+    after_wallet = after["wallet_state"]
+    before_bounty = before["bounty_state"]
+    after_bounty = after["bounty_state"]
+    if after_wallet["delegate_nonce"] != plan["nonce"] + 1:
+        raise RelayError("entrant wallet nonce did not advance exactly once")
+    if (
+        after_wallet["policy_hash"] != before_wallet["policy_hash"]
+        or after_wallet["policy_version"] != before_wallet["policy_version"]
+    ):
+        raise RelayError("entrant wallet policy changed during the relayed action")
+    result: dict = {"payment_proven": False}
+    if action == "commit":
+        logs = matching_logs(
+            receipt,
+            bounty,
+            "SolutionCommitted(bytes32,address,uint8,bytes32,uint64,uint64,uint256)",
+        )
+        if len(logs) != 1 or topic_address(wallet) not in [str(t).lower() for t in logs[0].get("topics", [])]:
+            raise RelayError("canonical receipt lacks the entrant's SolutionCommitted event")
+        committed_data = words(str(logs[0].get("data", "")))
+        if len(committed_data) != 4 or f"0x{committed_data[0]}" != plan["action_summary"]["commitment"]:
+            raise RelayError("SolutionCommitted event does not contain the signed commitment")
+        bond = before_bounty["verifier_reward"]
+        entry = after_bounty["entry"]
+        if entry["state"] != 1 or entry["commitment"] != plan["action_summary"]["commitment"] or entry["bond"] != bond:
+            raise RelayError("committed entry state does not match the signed commitment")
+        if after_wallet["token_balance"] != before_wallet["token_balance"] - bond:
+            raise RelayError("entrant wallet token balance does not reconcile with the entry bond")
+        if after_wallet["lifetime_spent"] != before_wallet["lifetime_spent"] + bond:
+            raise RelayError("entrant wallet lifetime spend does not reconcile with the entry bond")
+        result["entry_bond_minor"] = bond
+    elif action == "reveal":
+        entry = after_bounty["entry"]
+        settled = matching_logs(
+            receipt,
+            bounty,
+            "BountySettled(bytes32,uint64,address,uint256,uint256,uint256,uint256,bytes32,bytes32,bytes32,bytes32)",
+        )
+        rejected = matching_logs(
+            receipt,
+            bounty,
+            "CompetitionSubmissionRejected(bytes32,uint64,address,uint256,bytes32)",
+        )
+        if len(settled) + len(rejected) != 1:
+            raise RelayError("canonical reveal receipt must contain exactly one settlement or rejection event")
+        if settled:
+            if topic_address(wallet) not in [str(t).lower() for t in settled[0].get("topics", [])]:
+                raise RelayError("BountySettled does not identify the entrant wallet as solver")
+            if after_bounty["status"] != 2 or entry["state"] != 4:
+                raise RelayError("settled reveal state does not identify the entrant wallet as winner")
+            data = words(str(settled[0].get("data", "")))
+            if len(data) != 8:
+                raise RelayError("BountySettled event data is malformed")
+            if (
+                f"0x{data[4]}" != plan["action_summary"]["submission_hash"]
+                or f"0x{data[5]}" != plan["action_summary"]["evidence_hash"]
+            ):
+                raise RelayError("BountySettled hashes do not match the signed reveal")
+            solver_reward, returned_bond, timeout_bonus, verifier_reward = map(word_uint, data[:4])
+            expected_delta = solver_reward + returned_bond + timeout_bonus
+            if after_wallet["token_balance"] != before_wallet["token_balance"] + expected_delta:
+                raise RelayError("winner token balance does not reconcile with BountySettled")
+            result.update(
+                {
+                    "payment_proven": True,
+                    "solver_reward_minor": solver_reward,
+                    "entry_bond_returned_minor": returned_bond,
+                    "timeout_bonus_minor": timeout_bonus,
+                    "verifier_reward_minor": verifier_reward,
+                }
+            )
+        else:
+            if topic_address(wallet) not in [str(t).lower() for t in rejected[0].get("topics", [])]:
+                raise RelayError("CompetitionSubmissionRejected does not identify the entrant wallet")
+            if entry["state"] != 2 or entry["bond"] != 0:
+                raise RelayError("rejected reveal state does not match CompetitionSubmissionRejected")
+            if after_wallet["token_balance"] != before_wallet["token_balance"]:
+                raise RelayError("rejected reveal unexpectedly changed the entrant wallet token balance")
+            result["reveal_rejected"] = True
+    else:
+        logs = matching_logs(receipt, bounty, "EntryBondWithdrawn(bytes32,address,uint256)")
+        if len(logs) != 1 or topic_address(wallet) not in [str(t).lower() for t in logs[0].get("topics", [])]:
+            raise RelayError("canonical receipt lacks the entrant's EntryBondWithdrawn event")
+        amount_words = words(str(logs[0].get("data", "")))
+        if len(amount_words) != 1:
+            raise RelayError("EntryBondWithdrawn event data is malformed")
+        amount = word_uint(amount_words[0])
+        if after_bounty["entry"]["state"] != 5 or after_bounty["entry"]["bond"] != 0:
+            raise RelayError("withdrawn entry-bond state is not final")
+        if after_wallet["token_balance"] != before_wallet["token_balance"] + amount:
+            raise RelayError("entrant wallet token balance does not reconcile with bond withdrawal")
+        result["entry_bond_withdrawn_minor"] = amount
+    return result
+
+
+def execute_or_validate(
+    *,
+    rpc_url: str,
+    cast_bin: str,
+    manifest: dict,
+    plan: dict,
+    envelope: dict | None,
+    proof: str | None,
+    signature: str,
+    execute: bool,
+    keeper_value: str | None,
+    private_key: str | None,
+) -> dict:
+    before, _ = revalidate_plan(rpc_url, manifest, plan, envelope, proof)
+    client = CastClient(cast_bin, rpc_url, "latest")
+    if private_key:
+        normalized_key = normalize_private_key(private_key)
+        keeper = client.keeper_address(normalized_key)
+    else:
+        normalized_key = None
+        if execute:
+            raise RelayError("BASE_KEEPER_PRIVATE_KEY is required with --execute")
+        if keeper_value is None:
+            raise RelayError("--keeper is required for dry-run validation")
+        keeper = require_address(keeper_value, "keeper")
+    if client.chain_id() != plan["chain_id"]:
+        raise RelayError("keeper RPC chain does not match the signed entrant action")
+    digest = client.call(
+        plan["wallet"],
+        "actionDigest(uint8,bytes32,uint256,uint256)(bytes32)",
+        str(plan["action_code"]),
+        plan["payload_hash"],
+        str(plan["nonce"]),
+        str(plan["deadline"]),
+        block="latest",
+    ).strip().lower()
+    require_bytes32(digest, "entrant action digest")
+    args = (
+        str(plan["action_code"]),
+        plan["payload"],
+        str(plan["nonce"]),
+        str(plan["deadline"]),
+        signature,
+    )
+    gas_estimate = client.estimate(keeper, plan["wallet"], SIGNATURE, *args)
+    gas_limit = gas_estimate * 125 // 100 + 10_000
+    gas_price = client.gas_price()
+    max_gas_cost = gas_limit * gas_price
+    if gas_limit > MAX_GAS_LIMIT:
+        raise RelayError("entrant action gas exceeds the keeper limit")
+    if gas_price > MAX_GAS_PRICE_WEI or max_gas_cost > MAX_GAS_COST_WEI:
+        raise RelayError("entrant action gas price or maximum total cost exceeds the keeper ceiling")
+    keeper_balance = client.balance(keeper)
+    if keeper_balance < max_gas_cost:
+        raise RelayError("keeper balance is below the bounded relay cost", retryable=True)
+    report = {
+        "schema_version": SCHEMA,
+        "outcome": "validated",
+        "network": plan["network"],
+        "chain_id": plan["chain_id"],
+        "wallet": plan["wallet"],
+        "bounty": plan["bounty"],
+        "action": plan["action"],
+        "nonce": plan["nonce"],
+        "deadline": plan["deadline"],
+        "payload_hash": plan["payload_hash"],
+        "signature_hash": run_cast("keccak", signature),
+        "action_digest": digest,
+        "keeper": keeper,
+        "keeper_balance_before_wei": keeper_balance,
+        "gas_estimate": gas_estimate,
+        "gas_limit": gas_limit,
+        "gas_price_wei": gas_price,
+        "maximum_gas_cost_wei": max_gas_cost,
+        "entrant_wallet_eth_required_wei": 0,
+        "safe_block_before": before["safe_block"],
+        "payment_proven": False,
+        "evidence_boundary": (
+            "Validation and a signature are not entry or payment evidence. A canonical safe-block action event "
+            "proves the relay; only canonical BountySettled proves solver payment."
+        ),
+    }
+    if not execute:
+        return report
+    assert normalized_key is not None
+    sent = client.send(normalized_key, gas_limit, plan["wallet"], SIGNATURE, *args)
+    tx_hash, block_tag = validate_receipt(sent, plan["wallet"])
+    receipt_block = int(block_tag, 0)
+    receipt_hash = require_bytes32(
+        str(sent.get("blockHash") or sent.get("block_hash") or ""), "receipt block hash"
+    )
+    receipt, safe = canonical_receipt(rpc_url, tx_hash, receipt_block, receipt_hash)
+    require_wallet_action_event(receipt, plan, keeper)
+    after = inspect_state(rpc_url, manifest, plan["wallet"], plan["bounty"])
+    if after["safe_block"]["number"] < receipt_block:
+        raise RelayError("post-action inspection did not reach the canonical receipt block")
+    action_result = validate_action_events_and_balances(receipt, plan, before, after)
+    report.update(
+        {
+            "outcome": "relayed",
+            "transaction_hash": tx_hash,
+            "receipt_block": receipt_block,
+            "receipt_block_hash": receipt_hash,
+            "canonical_safe_block": {
+                "number": int(str(safe["number"]), 16),
+                "hash": str(safe["hash"]).lower(),
+                "timestamp": int(str(safe["timestamp"]), 16),
+            },
+            "safe_block_after": after["safe_block"],
+            "keeper_balance_after_wei": client.balance(keeper),
+            "gas_payer": keeper,
+            "entrant_wallet_eth_spent_wei": 0,
+            **action_result,
+        }
+    )
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--signature-file", type=Path, required=True)
+    parser.add_argument("--commitment-envelope", type=Path)
+    parser.add_argument("--proof-file", type=Path)
+    parser.add_argument("--rpc-url")
+    parser.add_argument("--cast-bin", default=str(ROOT / ".tools" / "foundry" / "cast.exe"))
+    parser.add_argument("--keeper")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument(
+        "--report", type=Path, default=ROOT / "target" / "open-competition-entrant-relay.json"
+    )
+    args = parser.parse_args()
+    manifest = validate_manifest(load_json(args.manifest, "entrant-wallet manifest"))
+    plan = validate_plan(load_json(args.plan, "entrant action plan"))
+    if plan["network"] != manifest["network"] or plan["chain_id"] != manifest["chain_id"]:
+        raise SystemExit("entrant action plan and deployment manifest disagree")
+    signature = args.signature_file.read_text(encoding="utf-8").strip().lower()
+    if not SIGNATURE_RE.fullmatch(signature):
+        raise SystemExit("signature file must contain exactly one 65-byte signature")
+    envelope = load_json(args.commitment_envelope, "commitment envelope") if args.commitment_envelope else None
+    proof = proof_from_file(args.proof_file)
+    rpc_url = args.rpc_url or str(manifest["rpc_url"])
+    report = execute_or_validate(
+        rpc_url=rpc_url,
+        cast_bin=args.cast_bin,
+        manifest=manifest,
+        plan=plan,
+        envelope=envelope,
+        proof=proof,
+        signature=signature,
+        execute=args.execute,
+        keeper_value=args.keeper,
+        private_key=os.environ.get("BASE_KEEPER_PRIVATE_KEY"),
+    )
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(args.report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_build_open_competition_entrant_wallet_bundle.py
+++ b/scripts/test_build_open_competition_entrant_wallet_bundle.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATH = ROOT / "scripts" / "build_open_competition_entrant_wallet_bundle.py"
+SPEC = importlib.util.spec_from_file_location("build_open_competition_entrant_wallet_bundle", PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class OpenCompetitionEntrantWalletBundleTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.sepolia = MODULE.build_bundle("base-sepolia")
+        cls.mainnet = MODULE.build_bundle("base-mainnet", compile_contracts=False)
+
+    def test_networks_bind_distinct_frozen_factories(self) -> None:
+        self.assertEqual(self.sepolia["chain_id"], 84532)
+        self.assertEqual(self.mainnet["chain_id"], 8453)
+        self.assertNotEqual(
+            self.sepolia["canonical"]["competition_factory"],
+            self.mainnet["canonical"]["competition_factory"],
+        )
+        self.assertNotEqual(
+            self.sepolia["entrant_wallet_factory"]["address"],
+            self.mainnet["entrant_wallet_factory"]["address"],
+        )
+
+    def test_bundle_is_deterministic_and_under_code_limits(self) -> None:
+        rebuilt = MODULE.build_bundle("base-sepolia", compile_contracts=False)
+        self.assertEqual(
+            rebuilt["entrant_wallet_factory"]["address"],
+            self.sepolia["entrant_wallet_factory"]["address"],
+        )
+        self.assertLess(self.sepolia["entrant_wallet_factory"]["implementation_runtime_code_bytes"], 24_576)
+        self.assertLess(self.sepolia["entrant_wallet_factory"]["runtime_code_bytes"], 24_576)
+
+    def test_activation_defaults_fail_closed(self) -> None:
+        self.assertTrue(all(value is False for value in self.mainnet["activation_gates"].values()))
+        self.assertEqual(self.mainnet["deployment_state"], "source_only_not_ready_to_earn")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_plan_open_competition_entrant_action.py
+++ b/scripts/test_plan_open_competition_entrant_action.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import plan_open_competition_entrant_action as planner  # noqa: E402
+
+
+WALLET = "0x1111111111111111111111111111111111111111"
+OWNER = "0x2222222222222222222222222222222222222222"
+DELEGATE = "0x3333333333333333333333333333333333333333"
+CREATOR = "0x4444444444444444444444444444444444444444"
+BOUNTY = "0x5555555555555555555555555555555555555555"
+COMMITMENT = "0x" + "66" * 32
+SUBMISSION = "0x" + "77" * 32
+EVIDENCE = "0x" + "88" * 32
+SALT = "0x" + "99" * 32
+
+
+def report(*, entered: bool = False, entry_state: int = 0, wallet_balance: int = 1_000_000) -> dict:
+    return {
+        "network": "base-sepolia",
+        "chain_id": 84_532,
+        "safe_block": {"number": 100, "hash": "0x" + "aa" * 32, "timestamp": 1_000_000},
+        "wallet": WALLET,
+        "bounty": BOUNTY,
+        "wallet_state": {
+            "owner": OWNER,
+            "policy": {
+                "delegate": DELEGATE,
+                "valid_after": 900_000,
+                "valid_until": 2_000_000,
+                "period_seconds": 3_600,
+                "max_per_action": 100_000,
+                "max_per_period": 200_000,
+                "max_lifetime_spend": 300_000,
+                "max_bounty_target": 2_000_000,
+                "allowed_actions": 7,
+                "verifier_module": "0x6666666666666666666666666666666666666666",
+                "verifier_runtime_code_hash": "0x" + "ab" * 32,
+                "verifier_policy_hash": "0x" + "bc" * 32,
+                "acceptance_criteria_hash": "0x" + "cd" * 32,
+                "benchmark_hash": "0x" + "de" * 32,
+                "evidence_schema_hash": "0x" + "ef" * 32,
+            },
+            "policy_hash": "0x" + "12" * 32,
+            "policy_version": 3,
+            "delegate_nonce": 5,
+            "period_bucket": 277,
+            "period_spent": 50_000,
+            "lifetime_spent": 100_000,
+            "revoked": False,
+            "token_balance": wallet_balance,
+        },
+        "bounty_state": {
+            "factory": "0x7777777777777777777777777777777777777777",
+            "settlement_token": "0x8888888888888888888888888888888888888888",
+            "creator": CREATOR,
+            "target_amount": 1_100_000,
+            "verifier_reward": 100_000,
+            "status": 1,
+            "competition_ends_at": 1_500_000,
+            "entry_count": 1 if entered else 0,
+            "max_entries": 4,
+            "verifier_module": "0x6666666666666666666666666666666666666666",
+            "policy_hash": "0x" + "bc" * 32,
+            "acceptance_criteria_hash": "0x" + "cd" * 32,
+            "benchmark_hash": "0x" + "de" * 32,
+            "evidence_schema_hash": "0x" + "ef" * 32,
+            "has_entered": entered,
+            "entry": {
+                "commitment": COMMITMENT if entered else planner.ZERO_HASH,
+                "committed_block": 99 if entered else 0,
+                "reveal_deadline": 1_200_000 if entered else 0,
+                "bond": 100_000 if entered else 0,
+                "state": entry_state,
+            },
+        },
+    }
+
+
+def envelope() -> dict:
+    return {
+        "schema_version": planner.COMMITMENT_SCHEMA,
+        "network": "base-sepolia",
+        "chain_id": 84_532,
+        "bounty": BOUNTY,
+        "solver": WALLET,
+        "submission_hash": SUBMISSION,
+        "evidence_hash": EVIDENCE,
+        "salt": SALT,
+        "commitment": COMMITMENT,
+        "committed_block": 0,
+        "reveal_deadline": 0,
+        "evidence_boundary": "local recovery material",
+    }
+
+
+class EntrantActionPlannerTests(unittest.TestCase):
+    def test_commit_never_serializes_salt_or_reveal_material(self) -> None:
+        plan = planner.build_plan(report(), "commit", envelope(), None, 300)
+        serialized = json.dumps(plan).lower()
+        self.assertNotIn(SALT[2:], serialized)
+        self.assertNotIn(SUBMISSION[2:], serialized)
+        self.assertNotIn(EVIDENCE[2:], serialized)
+        self.assertEqual(plan["action_summary"]["commitment"], COMMITMENT)
+        self.assertEqual(plan["nonce"], 5)
+        self.assertEqual(plan["deadline"], 1_000_300)
+
+    def test_reveal_requires_exact_live_commitment_and_later_safe_block(self) -> None:
+        current = report(entered=True, entry_state=1)
+        plan = planner.build_plan(current, "reveal", envelope(), "0xaabb", 300)
+        self.assertEqual(plan["action_summary"]["salt"], SALT)
+        self.assertEqual(plan["action_summary"]["proof_hash"], planner.run_cast("keccak", "0xaabb"))
+        current["bounty_state"]["entry"]["commitment"] = "0x" + "01" * 32
+        with self.assertRaisesRegex(SystemExit, "onchain commitment differs"):
+            planner.build_plan(current, "reveal", envelope(), "0xaabb", 300)
+
+    def test_reveal_rechecks_creator_control_after_commit(self) -> None:
+        current = report(entered=True, entry_state=1)
+        current["wallet_state"]["owner"] = CREATOR
+        with self.assertRaisesRegex(SystemExit, "creator-controlled"):
+            planner.build_plan(current, "reveal", envelope(), "0xaabb", 300)
+
+    def test_commit_fails_closed_when_remaining_budget_is_insufficient(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "bounded budget"):
+            planner.build_plan(report(wallet_balance=99_999), "commit", envelope(), None, 300)
+
+    def test_relay_revalidation_preserves_the_original_deadline(self) -> None:
+        current = report()
+        plan = planner.build_plan(current, "commit", envelope(), None, 300)
+        current["safe_block"]["timestamp"] += 10
+        regenerated = planner.build_plan(
+            current,
+            "commit",
+            envelope(),
+            None,
+            300,
+            exact_deadline=plan["deadline"],
+        )
+        self.assertEqual(regenerated["deadline"], plan["deadline"])
+        current["safe_block"]["timestamp"] = plan["deadline"]
+        with self.assertRaisesRegex(SystemExit, "expires too soon"):
+            planner.build_plan(
+                current,
+                "commit",
+                envelope(),
+                None,
+                300,
+                exact_deadline=plan["deadline"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_relay_open_competition_entrant_action.py
+++ b/scripts/test_relay_open_competition_entrant_action.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import plan_open_competition_entrant_action as planner  # noqa: E402
+import relay_open_competition_entrant_action as relay  # noqa: E402
+from test_plan_open_competition_entrant_action import envelope, report  # noqa: E402
+
+
+class EntrantActionRelayTests(unittest.TestCase):
+    def test_plan_validation_rejects_unknown_fields_and_payload_mutation(self) -> None:
+        plan = planner.build_plan(report(), "commit", envelope(), None, 300)
+        plan["unexpected"] = True
+        with self.assertRaisesRegex(Exception, "keys are incomplete or unexpected"):
+            relay.validate_plan(plan)
+        plan.pop("unexpected")
+        plan["payload"] = plan["payload"][:-2] + "00"
+        with self.assertRaisesRegex(Exception, "payload hash"):
+            relay.validate_plan(plan)
+
+    def test_commit_revalidation_requires_no_plaintext_envelope(self) -> None:
+        plan = planner.build_plan(report(), "commit", envelope(), None, 300)
+        with self.assertRaisesRegex(Exception, "accepts no plaintext"):
+            relay.revalidate_plan("unused", {}, plan, envelope(), None)
+
+    def test_revalidated_fields_cover_every_signed_and_executable_field(self) -> None:
+        self.assertIn("payload", relay.REVALIDATED_FIELDS)
+        self.assertIn("payload_hash", relay.REVALIDATED_FIELDS)
+        self.assertIn("signing_payload", relay.REVALIDATED_FIELDS)
+        self.assertIn("relay_call", relay.REVALIDATED_FIELDS)
+        self.assertIn("nonce", relay.REVALIDATED_FIELDS)
+        self.assertIn("deadline", relay.REVALIDATED_FIELDS)
+        self.assertNotIn("safe_block", relay.REVALIDATED_FIELDS)
+
+    def test_validate_action_events_rejects_nonce_that_did_not_advance(self) -> None:
+        before = report()
+        plan = planner.build_plan(before, "commit", envelope(), None, 300)
+        after = copy.deepcopy(before)
+        with self.assertRaisesRegex(Exception, "nonce did not advance"):
+            relay.validate_action_events_and_balances({"logs": []}, plan, before, after)
+
+    def test_wallet_action_event_layout_matches_the_solidity_event(self) -> None:
+        plan = planner.build_plan(report(), "commit", envelope(), None, 300)
+        keeper = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        receipt = {
+            "logs": [
+                {
+                    "address": plan["wallet"],
+                    "topics": [
+                        planner.run_cast(
+                            "keccak",
+                            input_text="EntrantActionExecuted(uint8,address,address,uint256,bytes32)",
+                        ),
+                        relay.topic_uint(plan["action_code"]),
+                        relay.topic_address(plan["delegate"]),
+                        relay.topic_address(keeper),
+                    ],
+                    "data": relay.topic_uint(plan["nonce"]) + plan["payload_hash"][2:],
+                }
+            ]
+        }
+        relay.require_wallet_action_event(receipt, plan, keeper)
+        receipt["logs"][0]["topics"][3] = relay.topic_address(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        )
+        with self.assertRaisesRegex(Exception, "exact entrant-wallet action event"):
+            relay.require_wallet_action_event(receipt, plan, keeper)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome
Adds a bounded smart-account entrant path so a keeper can pay gas for exact EIP-712-authorized Open Competition V1 commit, reveal, and losing-bond withdrawal actions. Existing bounty/factory bytecode, rows, bounties, contributors, claims, and payouts are unchanged.

## Safety boundary
- policy-bound deterministic clone; no upgrade, arbitrary delegate call, gas reimbursement, or delegate withdrawal
- exact competition factory, native USDC, verifier address/runtime, policy/criteria/benchmark/evidence hashes
- one shared direct/relay nonce and short action deadline
- creator-address control checked at commit and reveal, including after owner/delegate rotation
- commit relay contains commitment only; no salt, submission/evidence hash, or proof
- live safe-block revalidation, exact-call simulation, gas ceilings, canonical receipt/event and USDC reconciliation
- all hosted relay, gas, inventory, and public-creation gates remain false

## Verification
- full Foundry suite: 177 passed, 0 failed, 11 fork-only skipped; fuzz runs 1,000
- entrant wallet suite: 18 passed, including three 1,000-run fuzz tests
- Python bundle/planner/relay suite: 13 passed
- Rust Solidity-ABI parity tests: 2 passed
- Slither 0.11.5: new findings triaged in `docs/security/open-competition-entrant-wallet-v1-static-analysis.md`; no untriaged release finding
- `cargo fmt --all -- --check`
- `python scripts/check-site.py`
- `scripts/preflight.ps1 -Mode core`

## Release sequence
This PR freezes source only. After merge: build the clean git-tree bundle, deploy/rehearse on Base Sepolia with ephemeral owner/delegate/keeper/creator actors, publish secret-free receipts and balance deltas, run exact mainnet-fork replay, and obtain the required independent review before any hosted relay or gas-sponsorship gate is enabled.

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/795#issuecomment-5221408632