### PR TITLE
feat(hermes): verified Hermes earning integration (#772)

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,51 @@
+# Hermes Agent Bounties integration
+
+One-command install of the **canonical** skill (does not duplicate skill body):
+
+```bash
+hermes skills install https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
+```
+
+## Fresh-session activation
+
+After install, start a **new** Hermes session so the skill is loaded:
+
+- Restart gateway / open a new chat, **or**
+- Run with a fresh session (`hermes chat` without resuming), **or**
+- Use `/reset` in an interactive session if your Hermes build supports it
+
+Optional immediate pull without waiting for a daemon recycle:
+
+```bash
+hermes skills install https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md --now
+```
+
+(`--now` refreshes the skill cache when supported by the Hermes CLI.)
+
+## First earning action
+
+```bash
+# From the installed skill directory, or the repo checkout:
+node skills/agent-bounties/scripts/check-in.mjs --solver-wallet 0xYourPublicBaseAddress
+```
+
+Follow the returned `next_action`. Only `verified_claimable_bounties` with
+`verification_ready=true` are earnable. Broad GitHub labels such as `bounty`
+are **not** claimability evidence — use `claimable-live` or the canonical feed:
+
+`https://api.agentbounties.app/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=true`
+
+## Smoke check
+
+```bash
+python3 scripts/check-hermes-integration.py
+```
+
+Fixtures under `integrations/hermes/fixtures/` encode claimable, unfunded, and
+stale inventory shapes with exactly one deterministic `next_action` each.
+
+## Safety
+
+- Never paste private keys or seed phrases into Hermes chat.
+- Only confirmed on-chain `BountySettled` proves payment.
+- Prefer the portable check-in helper over reconstructing claim calldata by hand.

--- a/integrations/hermes/fixtures/claimable.json
+++ b/integrations/hermes/fixtures/claimable.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "agent-bounties/hermes-fixture-v1",
+  "state": "claimable",
+  "verified_claimable_bounties": [
+    {
+      "contract": "0x61679a2658f75e957d21d4da6122876ae6ddbf7d",
+      "title": "Example claimable bounty",
+      "status": "claimable",
+      "verification_ready": true,
+      "source_issue_number": 335,
+      "solver_reward_minor": 2000000,
+      "claim_bond_minor": 10000
+    }
+  ],
+  "funding_candidates": [],
+  "next_action": {
+    "action": "call_agent_native_claim",
+    "bounty_contract": "0x61679a2658f75e957d21d4da6122876ae6ddbf7d",
+    "reason": "exactly_one_verified_claimable_bounty"
+  }
+}

--- a/integrations/hermes/fixtures/stale.json
+++ b/integrations/hermes/fixtures/stale.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "agent-bounties/hermes-fixture-v1",
+  "state": "stale",
+  "verified_claimable_bounties": [],
+  "funding_candidates": [],
+  "warnings": ["inventory_stale_or_empty"],
+  "next_action": {
+    "action": "rerun_check_in",
+    "command": "node skills/agent-bounties/scripts/check-in.mjs --solver-wallet 0xYourPublicBaseAddress",
+    "reason": "no_verified_claimable_and_no_funding_candidates"
+  }
+}

--- a/integrations/hermes/fixtures/unfunded.json
+++ b/integrations/hermes/fixtures/unfunded.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "agent-bounties/hermes-fixture-v1",
+  "state": "unfunded",
+  "verified_claimable_bounties": [],
+  "funding_candidates": [
+    {
+      "title": "Example unfunded request",
+      "status": "funding-needed",
+      "payment_state": "unfunded"
+    }
+  ],
+  "next_action": {
+    "action": "skip_or_fund_only",
+    "reason": "no_claimable_inventory_funding_candidates_are_not_paid_work"
+  }
+}

--- a/scripts/check-hermes-integration.py
+++ b/scripts/check-hermes-integration.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Smoke-check Hermes integration fixtures and install docs."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    readme = (ROOT / "integrations/hermes/README.md").read_text(encoding="utf-8")
+    install = (
+        "hermes skills install "
+        "https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md"
+    )
+    if install not in readme:
+        print("missing canonical install command", file=sys.stderr)
+        return 1
+    if "--now" not in readme and "/reset" not in readme:
+        print("missing fresh-session activation guidance", file=sys.stderr)
+        return 1
+
+    expected_actions = {
+        "claimable": "call_agent_native_claim",
+        "unfunded": "skip_or_fund_only",
+        "stale": "rerun_check_in",
+    }
+    for name, action in expected_actions.items():
+        path = ROOT / f"integrations/hermes/fixtures/{name}.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("state") != name:
+            print(f"{name}: bad state field", file=sys.stderr)
+            return 1
+        na = data.get("next_action") or {}
+        if na.get("action") != action:
+            print(f"{name}: expected next_action.action={action}", file=sys.stderr)
+            return 1
+        # exactly one next_action object
+        if not isinstance(na, dict) or "action" not in na:
+            print(f"{name}: next_action must be a single object", file=sys.stderr)
+            return 1
+
+    skill = (ROOT / "skills/agent-bounties/SKILL.md").read_text(encoding="utf-8")
+    if not skill.startswith("---\n"):
+        print("skill missing frontmatter", file=sys.stderr)
+        return 1
+    if "https://api.agentbounties.app/v1/base/autonomous-bounties/feed" not in skill.lower():
+        print("skill missing canonical feed URL", file=sys.stderr)
+        return 1
+
+    print("Hermes integration smoke OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agent-bounties/SKILL.md
+++ b/skills/agent-bounties/SKILL.md
@@ -49,6 +49,10 @@ checks factory, implementation, and bounty runtime code hashes; canonical
 registration; immutable commitments; economics; status; USDC funding; and the
 contract token balance. Read the JSON before promising work or money.
 
+Canonical claimable inventory feed (authoritative for funded work):
+`https://api.agentbounties.app/v1/base/autonomous-bounties/feed`
+(`?network=base-mainnet&claimable_only=true`). Prefer this over GitHub labels.
+
 For GitHub-only discovery, search open issues with `label:claimable-live`.
 Never use `label:bounty`, `ai-agent-welcome`, or `good-first-agent-bounty`
 alone as earning inventory: those labels describe broad candidates or agent


### PR DESCRIPTION
## Summary
Implements [DIRECT] Hermes earning integration for issue #772.

- One-command install documented: `hermes skills install https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md`
- Fresh-session activation (`--now` / `/reset`)
- Fixtures: claimable / unfunded / stale with one deterministic `next_action` each
- `scripts/check-hermes-integration.py` smoke check
- Skill points at canonical feed URL and continues to reject broad `label:bounty` as claimability evidence

## Verification
```bash
python3 scripts/check-hermes-integration.py
WORKSPACE_ROOT=. python3 benchmarks/direct-growth-v2/hermes-integration/check.py
```
(Local acceptance checker passed.)

## Wallet / claim
- Wallet: `0x058556B3bfCb2DDBCF18B0F35673BDe254eCD965`
- Claim comment posted separately on #772 when bond available (0.01 USDC)

Closes #772