### PR TITLE
Add bounded Render operator token rotation

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -39,6 +39,11 @@ on:
         required: false
         default: false
         type: boolean
+      rotate_operator_api_token:
+        description: "Rotate the hosted operator token without returning its value"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -88,6 +93,7 @@ jobs:
       PRODUCTION_WEBSITE_BASE_URL: ${{ vars.PRODUCTION_WEBSITE_BASE_URL || 'https://agentbounties.app' }}
       RENDER_DEPLOY_PAUSE_REASON: ${{ vars.RENDER_DEPLOY_PAUSE_REASON }}
       OPEN_COMPETITION_ENTRANT_RELAY_CANARY: ${{ inputs.open_competition_entrant_relay_canary || false }}
+      ROTATE_OPERATOR_API_TOKEN: ${{ inputs.rotate_operator_api_token || false }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -187,10 +193,21 @@ jobs:
           BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT: ${{ vars.BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT }}
         run: |
           entrant_canary_args=()
+          operator_rotation_args=()
           if [[ "${OPEN_COMPETITION_ENTRANT_RELAY_CANARY}" == "true" ]]; then
             entrant_canary_args+=(--enable-open-competition-entrant-relay-canary)
           elif [[ "${OPEN_COMPETITION_ENTRANT_RELAY_CANARY}" != "false" ]]; then
             echo "Invalid entrant relay canary input" >&2
+            exit 1
+          fi
+          if [[ "${ROTATE_OPERATOR_API_TOKEN}" == "true" ]]; then
+            if [[ "${REQUESTED_DEPLOY_MODE}" != "deploy_only" ]]; then
+              echo "Operator token rotation requires deploy_only" >&2
+              exit 1
+            fi
+            operator_rotation_args+=(--rotate-operator-api-token)
+          elif [[ "${ROTATE_OPERATOR_API_TOKEN}" != "false" ]]; then
+            echo "Invalid operator token rotation input" >&2
             exit 1
           fi
           python scripts/render_deploy_recovery.py \
@@ -204,6 +221,7 @@ jobs:
             --base-mainnet-leaderboard-reward-contract "$BASE_MAINNET_LEADERBOARD_REWARD_CONTRACT" \
             --base-sepolia-leaderboard-reward-contract "$BASE_SEPOLIA_LEADERBOARD_REWARD_CONTRACT" \
             "${entrant_canary_args[@]}" \
+            "${operator_rotation_args[@]}" \
             --output target/operations/render-deploy.json
 
       - name: Publish deployment evidence summary
@@ -234,6 +252,7 @@ jobs:
               f"- Exact health attestations: `{len(evidence['health'])}/2`",
               f"- Public runtime variables reconciled: `{len(evidence.get('public_environment', []))}`",
               f"- Open Competition shared variables reconciled: `{len(evidence.get('open_competition_environment', []))}`",
+              f"- Operator token rotated: `{bool(evidence.get('operator_token_rotation', {}).get('performed'))}`",
               f"- Cloud runtime variables: `{len(evidence.get('cloud_environment', []))}/10`",
               f"- Cloud model credential supplied: `{bool(evidence.get('secret_environment'))}`",
               f"- Cloud drafting ready: `{bool(evidence.get('cloud_readiness', {}).get('available'))}`",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -156,11 +156,19 @@ Use `deploy_only` for runtime-only configuration after capacity is available:
 
 `deploy_only` rejects a service whose current live artifact does not match the
 supplied SHA. It reuses that artifact, applies saved environment values, and
-does not build new code. It restarts only API, then requires the supplied SHA
-from `/health` and the exact leaderboard contracts from the live API. Render's
+does not build new code. It restarts only API unless a shared environment
+change requires another linked service, then requires the supplied SHA from
+`/health` and the exact leaderboard contracts from the live API. Render's
 branch label is recorded but is not artifact evidence. Render currently applies
 the workspace pipeline quota before both deployment modes, so `deploy_only` is
 not a quota bypass.
+
+If the hosted operator credential may have been disclosed, dispatch this same
+exact-revision recovery workflow in `deploy_only` mode with
+`rotate_operator_api_token=true`. The replacement is generated only inside the
+runner, installed in the existing Render operator environment group, and never
+returned in logs or evidence. The API and MCP are both redeployed and attested;
+the evidence records only that rotation occurred.
 
 The API and MCP services need the same `DATABASE_URL`, public URLs, factory,
 implementation, and Base RPC configuration. Canonical planners fail closed

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import sys
 import time
 import urllib.error
@@ -34,6 +35,11 @@ ENV_GROUP_SERVICE_TYPES = {
 OPEN_COMPETITION_WORKER_NAME = "agent-bounties-open-competition-v1-indexer"
 OPEN_COMPETITION_REFERENCE_SERVICE_NAME = "agent-bounties-base-indexer"
 OPEN_COMPETITION_ENV_GROUP_NAME = "agent-bounties-base"
+OPERATOR_ENV_GROUP_NAME = "agent-bounties-operator"
+OPERATOR_TOKEN_KEY = "OPERATOR_API_TOKEN"
+OPERATOR_TOKEN_SERVICE_NAMES = frozenset(
+    {"agent-bounties-api", "agent-bounties-mcp"}
+)
 OPEN_COMPETITION_RELEASE_MANIFEST_PATH = Path(
     "deployments/open-competition-v1-base-mainnet.json"
 )
@@ -481,6 +487,21 @@ def validate_owner_id(value: object) -> str:
     return value
 
 
+def deploy_only_can_reuse_current(
+    service_name: str,
+    *,
+    open_competition_environment_changed: bool,
+    operator_token_changed: bool,
+) -> bool:
+    if service_name == CLOUD_AGENT_API_SERVICE_NAME:
+        return False
+    if open_competition_environment_changed:
+        return False
+    return not (
+        operator_token_changed and service_name in OPERATOR_TOKEN_SERVICE_NAMES
+    )
+
+
 def validate_environment_id(value: object) -> str:
     if not isinstance(value, str) or not re.fullmatch(r"[a-z]+-[0-9a-z]+", value):
         raise RecoveryError("Render service has an invalid project environment id")
@@ -529,6 +550,26 @@ def select_env_group(payload: object, owner_id: str) -> dict[str, Any]:
     group_id = group.get("id")
     if not isinstance(group_id, str) or not re.fullmatch(r"evg-[0-9a-z]+", group_id):
         raise RecoveryError("Render environment group has an invalid id")
+    return group
+
+
+def select_operator_env_group(payload: object, owner_id: str) -> dict[str, Any]:
+    matches = [
+        group
+        for group in unwrap_env_group_entries(payload)
+        if group.get("name") == OPERATOR_ENV_GROUP_NAME
+        and group.get("ownerId") == owner_id
+    ]
+    if len(matches) != 1:
+        raise RecoveryError(
+            "expected exactly one Render environment group named "
+            f"{OPERATOR_ENV_GROUP_NAME} in the reference workspace; "
+            f"found {len(matches)}"
+        )
+    group = matches[0]
+    group_id = group.get("id")
+    if not isinstance(group_id, str) or not re.fullmatch(r"evg-[0-9a-z]+", group_id):
+        raise RecoveryError("Render operator environment group has an invalid id")
     return group
 
 
@@ -992,6 +1033,19 @@ class RenderClient:
             }
         )
         return select_env_group(
+            self._read_with_retry(f"/env-groups?{query}"), owner_id
+        )
+
+    def resolve_operator_env_group(self, owner_id: str) -> dict[str, Any]:
+        owner_id = validate_owner_id(owner_id)
+        query = urllib.parse.urlencode(
+            {
+                "name": OPERATOR_ENV_GROUP_NAME,
+                "ownerId": owner_id,
+                "limit": "20",
+            }
+        )
+        return select_operator_env_group(
             self._read_with_retry(f"/env-groups?{query}"), owner_id
         )
 
@@ -1772,6 +1826,42 @@ def reconcile_cloud_agent_environment(
     return runtime_environment, secret_environment, changed
 
 
+def rotate_operator_token(
+    client: RenderClient,
+    group: dict[str, Any],
+    *,
+    token_factory: Callable[[], str] = lambda: secrets.token_urlsafe(48),
+) -> dict[str, Any]:
+    token_text = token_factory()
+    if (
+        not isinstance(token_text, str)
+        or len(token_text) < 64
+        or any(character.isspace() for character in token_text)
+    ):
+        raise RecoveryError("generated operator token is malformed")
+    token = bytearray(token_text.encode("utf-8"))
+    token_text = ""
+    try:
+        record = client.ensure_env_group_env_var(
+            group,
+            OPERATOR_TOKEN_KEY,
+            token.decode("utf-8"),
+        )
+        if record.get("key") != OPERATOR_TOKEN_KEY or record.get("changed") is not True:
+            raise RecoveryError("Render did not rotate the operator token")
+        evidence = {
+            "performed": True,
+            "key": OPERATOR_TOKEN_KEY,
+            "characters": len(token),
+            "secret_published": False,
+        }
+        setattr(client, "operator_token_rotation_evidence", evidence)
+        return evidence
+    finally:
+        for index in range(len(token)):
+            token[index] = 0
+
+
 def reconcile_neynar_social_environment(
     client: RenderClient,
     service: dict[str, Any],
@@ -2024,8 +2114,11 @@ def deploy(
     base_mainnet_leaderboard_reward_contract: str | None = None,
     base_sepolia_leaderboard_reward_contract: str | None = None,
     open_competition_entrant_relay_canary_enabled: bool = False,
+    rotate_operator_api_token: bool = False,
 ) -> dict[str, Any]:
     deploy_mode = validate_deploy_mode(deploy_mode)
+    if rotate_operator_api_token and deploy_mode != "deploy_only":
+        raise RecoveryError("operator token rotation requires deploy_only")
     services: list[tuple[ServiceSpec, dict[str, Any]]] = []
     pending: dict[str, tuple[dict[str, Any], str]] = {}
     initial: dict[str, dict[str, Any]] = {}
@@ -2079,6 +2172,23 @@ def deploy(
             raise RecoveryError(
                 f"required Render environment group is not linked to {spec.name}"
             )
+
+    operator_token_rotation: dict[str, Any] = {}
+    operator_token_changed = False
+    if rotate_operator_api_token:
+        operator_group = client.resolve_operator_env_group(
+            validate_owner_id(reference_service.get("ownerId"))
+        )
+        operator_group = client.get_env_group(operator_group["id"])
+        for spec, service in services:
+            if spec.name not in OPERATOR_TOKEN_SERVICE_NAMES:
+                continue
+            if not env_group_has_service(operator_group, spec, service["id"]):
+                raise RecoveryError(
+                    f"operator environment group is not linked to {spec.name}"
+                )
+        operator_token_rotation = rotate_operator_token(client, operator_group)
+        operator_token_changed = True
     desired_open_competition_environment = open_competition_shared_environment(
         entrant_relay_canary_enabled=open_competition_entrant_relay_canary_enabled
     )
@@ -2199,8 +2309,13 @@ def deploy(
     for spec, service in services:
         if (
             deploy_mode == "deploy_only"
-            and spec.name != CLOUD_AGENT_API_SERVICE_NAME
-            and not open_competition_environment_changed
+            and deploy_only_can_reuse_current(
+                spec.name,
+                open_competition_environment_changed=(
+                    open_competition_environment_changed
+                ),
+                operator_token_changed=operator_token_changed,
+            )
         ):
             created = preexisting_live[spec.name]
         else:
@@ -2335,6 +2450,7 @@ def deploy(
         "cloud_readiness": cloud_readiness,
         "social_readiness": social_readiness,
         "leaderboard_readiness": leaderboard_readiness,
+        "operator_token_rotation": operator_token_rotation,
     }
 
 
@@ -2375,6 +2491,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Enable only the operator-authenticated entrant relay canary.",
     )
+    parser.add_argument(
+        "--rotate-operator-api-token",
+        action="store_true",
+        help="Rotate the Render-generated operator token without publishing its value.",
+    )
     parser.add_argument("--deploy-timeout-seconds", type=float, default=2400)
     parser.add_argument("--health-timeout-seconds", type=float, default=300)
     parser.add_argument("--poll-seconds", type=float, default=10)
@@ -2388,6 +2509,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    client: RenderClient | None = None
     evidence: dict[str, Any] = {
         "schema": SCHEMA,
         "started_at": utc_now(),
@@ -2406,6 +2528,7 @@ def main() -> int:
         "cloud_readiness": {},
         "social_readiness": {},
         "leaderboard_readiness": [],
+        "operator_token_rotation": {},
         "failure": None,
         "error": None,
     }
@@ -2440,6 +2563,7 @@ def main() -> int:
             open_competition_entrant_relay_canary_enabled=(
                 args.enable_open_competition_entrant_relay_canary
             ),
+            rotate_operator_api_token=args.rotate_operator_api_token,
         )
         evidence.update(result)
         evidence["revision"] = revision
@@ -2449,6 +2573,12 @@ def main() -> int:
         if isinstance(error, RenderDeployFailure):
             evidence["failure"] = error.evidence
     finally:
+        if client is not None:
+            evidence["operator_token_rotation"] = getattr(
+                client,
+                "operator_token_rotation_evidence",
+                evidence["operator_token_rotation"],
+            )
         evidence["completed_at"] = utc_now()
         write_evidence(args.output, evidence)
 

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -80,6 +80,16 @@ class EnvironmentClient:
         return {"key": key, "value": value, "changed": self.changed}
 
 
+class OperatorRotationClient:
+    def __init__(self, changed=True) -> None:
+        self.changed = changed
+        self.values = []
+
+    def ensure_env_group_env_var(self, group, key, value):
+        self.values.append((group["id"], key, value))
+        return {"key": key, "value": value, "changed": self.changed}
+
+
 def blueprint_record(**overrides):
     record = {
         "id": "exs-" + "a" * 20,
@@ -191,6 +201,87 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(recovery.RecoveryError, "deploy mode"):
             recovery.validate_deploy_mode("latest")
+
+    def test_operator_environment_group_selection_is_exact(self) -> None:
+        group = {
+            "id": "evg-" + "e" * 20,
+            "name": recovery.OPERATOR_ENV_GROUP_NAME,
+            "ownerId": "tea-owner123",
+        }
+        self.assertEqual(
+            recovery.select_operator_env_group(
+                [{"envGroup": group}], "tea-owner123"
+            ),
+            group,
+        )
+        with self.assertRaisesRegex(recovery.RecoveryError, "exactly one"):
+            recovery.select_operator_env_group([], "tea-owner123")
+
+    def test_operator_token_rotation_never_returns_the_secret(self) -> None:
+        client = OperatorRotationClient()
+        result = recovery.rotate_operator_token(
+            client,
+            {"id": "evg-" + "e" * 20},
+            token_factory=lambda: "n" * 64,
+        )
+        self.assertEqual(
+            client.values[0][1:],
+            (recovery.OPERATOR_TOKEN_KEY, "n" * 64),
+        )
+        self.assertEqual(
+            result,
+            {
+                "performed": True,
+                "key": recovery.OPERATOR_TOKEN_KEY,
+                "characters": 64,
+                "secret_published": False,
+            },
+        )
+        self.assertEqual(client.operator_token_rotation_evidence, result)
+        self.assertNotIn("n" * 64, recovery.json.dumps(result))
+
+    def test_operator_token_rotation_requires_a_changed_value(self) -> None:
+        with self.assertRaisesRegex(recovery.RecoveryError, "did not rotate"):
+            recovery.rotate_operator_token(
+                OperatorRotationClient(changed=False),
+                {"id": "evg-" + "e" * 20},
+                token_factory=lambda: "n" * 64,
+            )
+
+    def test_operator_token_rotation_requires_deploy_only(self) -> None:
+        with self.assertRaisesRegex(recovery.RecoveryError, "requires deploy_only"):
+            recovery.deploy(
+                ResolutionFailureClient(),
+                "a" * 40,
+                rotate_operator_api_token=True,
+                deploy_timeout_seconds=1,
+                health_timeout_seconds=1,
+                poll_seconds=0,
+            )
+
+    def test_operator_rotation_redeploys_only_linked_runtime_services(self) -> None:
+        decisions = {
+            name: recovery.deploy_only_can_reuse_current(
+                name,
+                open_competition_environment_changed=False,
+                operator_token_changed=True,
+            )
+            for name in (
+                "agent-bounties-api",
+                "agent-bounties-mcp",
+                "agent-bounties-base-indexer",
+                "agent-bounties-open-competition-v1-indexer",
+            )
+        }
+        self.assertEqual(
+            decisions,
+            {
+                "agent-bounties-api": False,
+                "agent-bounties-mcp": False,
+                "agent-bounties-base-indexer": True,
+                "agent-bounties-open-competition-v1-indexer": True,
+            },
+        )
 
     def test_service_resolution_is_exact_and_repository_bound(self) -> None:
         spec = recovery.SERVICE_SPECS[0]


### PR DESCRIPTION
## Outcome

Adds a bounded, auditable emergency rotation path for the hosted operator credential.

- manual `deploy_only` input only
- generates the replacement inside the GitHub runner
- updates the exact existing Render operator environment group
- validates API/MCP group links before mutation
- redeploys and attests API/MCP without rebuilding
- records only that rotation occurred; neither token is returned
- leaves Open Competition public/canary gates unchanged

## Verification

- `python scripts/test_render_deploy_recovery.py -v` (79 passed)
- `python -m py_compile scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py`
- `python scripts/check-render-blueprint.py`
- `scripts/preflight.ps1 -Mode core`
- `git diff --check`

This is operational credential hygiene only. It does not change contracts, bounty rows, contributors, payout records, or public activation.