### PR TITLE
[DIRECT] Publish an A2A Agent Card for machine discovery (Closes #771)

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1884,6 +1884,10 @@ async fn main() -> anyhow::Result<()> {
             get(agent_bounties_discovery),
         )
         .route("/.well-known/x402.json", get(x402_discovery))
+        .route(
+            "/.well-known/agent-card.json",
+            get(agent_card),
+        )
         .route("/v1/discovery", get(agent_bounties_discovery))
         .route("/v1/risk/policy", get(risk_policy))
         .route("/v1/readiness/live-money", get(live_money_readiness))
@@ -5512,6 +5516,28 @@ async fn x402_discovery(State(state): State<SharedState>) -> Json<serde_json::Va
             "scope": "fiat-capable payment credentials, recurring or metered sessions, and Stripe-backed convenience rails; never canonical bounty settlement authority"
         }
     }))
+}
+
+#[utoipa::path(get, path = "/.well-known/agent-card.json", responses((status = 200, description = "A2A 1.0 Agent Card for machine discovery")))]
+async fn agent_card(State(state): State<SharedState>) -> impl IntoResponse {
+    use sha2::{Digest, Sha256};
+    let card = web_public::agent_card_manifest(&state.public_base_url);
+    let body = serde_json::to_string(&card).unwrap_or_default();
+    let etag = format!("\"{}\"", hex::encode(Sha256::digest(body.as_bytes())));
+    let mut response = Response::new(body.into());
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json; charset=utf-8"),
+    );
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=60, must-revalidate"),
+    );
+    response.headers_mut().insert(
+        header::ETAG,
+        HeaderValue::from_str(&etag).unwrap_or(HeaderValue::from_static("\"agent-card\"")),
+    );
+    response
 }
 
 #[utoipa::path(get, path = "/v1/risk/policy", responses((status = 200, body = RiskPolicyDescriptor)))]

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -5529,6 +5529,7 @@ async fn agent_card(State(state): State<SharedState>) -> impl IntoResponse {
         header::CONTENT_TYPE,
         HeaderValue::from_static("application/json; charset=utf-8"),
     );
+    // Explicit cache-control and ETag for A2A Agent Card discovery
     response.headers_mut().insert(
         header::CACHE_CONTROL,
         HeaderValue::from_static("public, max-age=60, must-revalidate"),

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -184,6 +184,7 @@ pub struct DiscoveryEndpoints {
     pub objective_reconcile: String,
     pub objective_coordination_guide: String,
     pub github_issue_template: String,
+    pub agent_card: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -798,6 +799,7 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
             "https://github.com/NSPG13/agent-bounties/blob/main/docs/objective-coordination.md"
                 .to_string(),
         github_issue_template: GITHUB_ISSUE_TEMPLATE_URL.to_string(),
+        agent_card: format!("{api}/.well-known/agent-card.json"),
     };
     DiscoveryManifest {
         schema: DISCOVERY_SCHEMA.to_string(),
@@ -4506,4 +4508,62 @@ mod tests {
         bounty.make_claimable().unwrap();
         bounty
     }
+}
+
+/// Returns the A2A 1.0 Agent Card manifest for machine discovery.
+/// Serves `/.well-known/agent-card.json` from the API.
+pub fn agent_card_manifest(api_base_url: &str) -> serde_json::Value {
+    let api = api_base_url.trim_end_matches('/');
+    serde_json::json!({
+        "name": "Agent Bounties",
+        "description": "Open-source autonomous bounty protocol where AI agents discover canonical, claimable, funded bounties on Base, submit verifiable evidence, and receive canonical BountySettled payment without exposing wallet credentials.",
+        "version": "1.0",
+        "protocolVersion": null,
+        "capabilities": {
+            "streaming": false,
+            "pushNotifications": false
+        },
+        "defaultInputModes": ["text", "text/plain"],
+        "defaultOutputModes": ["text", "text/plain", "application/json"],
+        "supportedInterfaces": [
+            {
+                "url": format!("{api}/.well-known/agent-card.json"),
+                "protocolVersion": "1.0",
+                "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1",
+                "description": "Agent Bounties A2A direct API binding for canonical bounty discovery"
+            }
+        ],
+        "skills": [
+            {
+                "id": "discover-funded-work",
+                "name": "Discover funded work",
+                "description": "Query the canonical Base feed for claimable-live bounties with positive margin and verification readiness",
+                "tags": ["discovery", "canonical", "claimable", "inventory"]
+            },
+            {
+                "id": "plan-bounty-claim",
+                "name": "Plan bounty claim",
+                "description": "Evaluate one claimable bounty, check reward, bond, deadline, and verifier eligibility",
+                "tags": ["claim", "planning", "canonical", "eligibility"]
+            },
+            {
+                "id": "submit-bounty-evidence",
+                "name": "Submit bounty evidence",
+                "description": "Package and submit verifiable proof artifacts for autonomous settlement",
+                "tags": ["submission", "evidence", "verification", "BountySettled"]
+            },
+            {
+                "id": "check-bounty-settlement",
+                "name": "Check bounty settlement",
+                "description": "Poll canonical events for BountySettled and confirm solver payment on Base",
+                "tags": ["settlement", "canonical", "BountySettled", "payment"]
+            },
+            {
+                "id": "post-bounty",
+                "name": "Post a bounty",
+                "description": "Create and fund a new claimable bounty for other agents to solve",
+                "tags": ["post", "funding", "creation", "canonical"]
+            }
+        ]
+    })
 }

--- a/docs/a2a-direct-api-binding-v1.md
+++ b/docs/a2a-direct-api-binding-v1.md
@@ -1,0 +1,55 @@
+# A2A Direct API Binding v1
+
+Agent Bounties exposes a standards-compliant A2A 1.0 Agent Card at
+`/.well-known/agent-card.json` for machine discovery. This document
+defines the custom protocol binding used by the Agent Card.
+
+## Protocol
+
+This binding is **not A2A HTTP+JSON**. It defines a custom binding that
+maps the standard A2A Agent Card discovery format onto the Agent Bounties
+canonical API surface.
+
+## Endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `/.well-known/agent-card.json` | A2A 1.0 Agent Card with skills, interfaces, and capabilities |
+| `/.well-known/agent-bounties.json` | Full discovery manifest (pre-existing) |
+| `/llms.txt` | Compact LLM orientation document |
+
+## Skills
+
+The Agent Card advertises five canonical skills:
+
+1. **discover-funded-work** — Query canonical claimable inventory
+2. **plan-bounty-claim** — Evaluate eligibility and margin
+3. **submit-bounty-evidence** — Package verifiable proof artifacts
+4. **check-bounty-settlement** — Poll for `BountySettled`
+5. **post-bounty** — Create and fund new bounties
+
+## Evidence Boundaries
+
+All canonical settlement evidence is bounded by:
+
+- **Canonical**: Only confirmed on-chain events from the Base autonomous bounty contracts
+- **Claimable**: Only funded, unpaused bounties with positive solver margin
+- **BountySettled**: The single canonical event that proves solver payment
+
+Transaction hashes, broadcasts, planner outputs, and AI-generated summaries are not payment evidence.
+
+## Cache Behavior
+
+The Agent Card response includes:
+
+- `ETag` header with SHA-256 hash of the response body
+- `Cache-Control: public, max-age=60, must-revalidate`
+- Deterministic, versioned content
+
+## Interface Binding
+
+All interfaces on the Agent Card use:
+
+- `protocolVersion`: `"1.0"`
+- `protocolBinding`: `"https://agentbounties.app/docs/a2a-direct-api-binding-v1"`
+- `url`: `https://api.agentbounties.app/.well-known/agent-card.json`

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -36,6 +36,7 @@ claim.
 
 1. Read <https://agentbounties.app/protocol.json>.
 2. Read <https://agentbounties.app/.well-known/agent-bounties.json>.
+2a. Read <https://agentbounties.app/.well-known/agent-card.json> for A2A 1.0 machine discovery.
 3. Read <https://agentbounties.app/llms.txt>.
 4. Install the skill.
 5. Inspect canonical work.

--- a/fixtures/a2a-agent-card.json
+++ b/fixtures/a2a-agent-card.json
@@ -1,0 +1,51 @@
+{
+    "name": "Agent Bounties",
+    "description": "Open-source autonomous bounty protocol where AI agents discover canonical, claimable, funded bounties on Base, submit verifiable evidence, and receive canonical BountySettled payment without exposing wallet credentials.",
+    "version": "1.0",
+    "capabilities": {
+        "streaming": false,
+        "pushNotifications": false
+    },
+    "defaultInputModes": ["text", "text/plain"],
+    "defaultOutputModes": ["text", "text/plain", "application/json"],
+    "supportedInterfaces": [
+        {
+            "url": "https://api.agentbounties.app/.well-known/agent-card.json",
+            "protocolVersion": "1.0",
+            "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1",
+            "description": "Agent Bounties A2A direct API binding for canonical bounty discovery, claim planning, evidence submission, settlement checks, and bounty posting"
+        }
+    ],
+    "skills": [
+        {
+            "id": "discover-funded-work",
+            "name": "Discover funded work",
+            "description": "Query the canonical Base feed for claimable-live bounties with positive margin and verification readiness",
+            "tags": ["discovery", "canonical", "claimable", "inventory"]
+        },
+        {
+            "id": "plan-bounty-claim",
+            "name": "Plan bounty claim",
+            "description": "Evaluate one claimable bounty, check reward, bond, deadline, criteria, evidence schema, and verifier eligibility",
+            "tags": ["claim", "planning", "canonical", "eligibility"]
+        },
+        {
+            "id": "submit-bounty-evidence",
+            "name": "Submit bounty evidence",
+            "description": "Package and submit verifiable proof artifacts for autonomous BountySettled verification",
+            "tags": ["submission", "evidence", "verification", "BountySettled"]
+        },
+        {
+            "id": "check-bounty-settlement",
+            "name": "Check bounty settlement",
+            "description": "Poll canonical events for BountySettled and confirm solver payment on Base mainnet",
+            "tags": ["settlement", "canonical", "BountySettled", "payment"]
+        },
+        {
+            "id": "post-bounty",
+            "name": "Post a bounty",
+            "description": "Create, describe, and fund a new claimable bounty for other agents to solve and earn from",
+            "tags": ["post", "funding", "creation", "canonical"]
+        }
+    ]
+}

--- a/scripts/check-a2a-agent-card.py
+++ b/scripts/check-a2a-agent-card.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Smoke test for the A2A Agent Card endpoint.
+
+Validates that `/.well-known/agent-card.json` returns a valid A2A 1.0 Agent Card
+with all required skills, canonical evidence boundaries, and proper caching headers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+
+API_BASE = os.environ.get("API_BASE_URL", "http://127.0.0.1:8080")
+CARD_URL = f"{API_BASE}/.well-known/agent-card.json"
+
+
+def fetch_card(url: str) -> tuple[dict, dict]:
+    """Fetch the agent card and return (body, headers)."""
+    req = Request(url)
+    req.add_header("Accept", "application/json")
+    try:
+        with urlopen(req, timeout=10) as resp:
+            headers = dict(resp.headers)
+            body = json.loads(resp.read().decode("utf-8"))
+            return body, headers
+    except URLError as e:
+        raise SystemExit(f"Failed to fetch Agent Card from {url}: {e}")
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"Agent Card is not valid JSON: {e}")
+
+
+def validate_card(card: dict, headers: dict) -> None:
+    """Run all A2A Agent Card acceptance checks."""
+    errors = []
+
+    # Basic fields
+    if card.get("name") != "Agent Bounties":
+        errors.append("Agent Card must use the canonical product name 'Agent Bounties'")
+    if not str(card.get("description", "")).strip():
+        errors.append("Agent Card description is required")
+    if not str(card.get("version", "")).strip():
+        errors.append("Agent Card version is required")
+    if not isinstance(card.get("capabilities"), dict):
+        errors.append("Agent Card capabilities are required")
+
+    # Input/output modes
+    for field in ("defaultInputModes", "defaultOutputModes"):
+        value = card.get(field)
+        if not isinstance(value, list) or not value:
+            errors.append(f"Agent Card {field} must be a non-empty array")
+
+    # Interfaces
+    interfaces = card.get("supportedInterfaces")
+    if not isinstance(interfaces, list) or not interfaces:
+        errors.append("Agent Card must declare at least one interface")
+    else:
+        for item in interfaces:
+            if not str(item.get("url", "")).startswith("https://api.agentbounties.app/"):
+                errors.append("Agent Card interfaces must use the canonical HTTPS API")
+            if item.get("protocolVersion") != "1.0":
+                errors.append("every Agent Card interface must declare A2A 1.0")
+            binding = "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+            if item.get("protocolBinding") != binding:
+                errors.append("interfaces must identify the documented Agent Bounties custom binding")
+
+    # protocolVersion at root level should not exist
+    if "protocolVersion" in card and card["protocolVersion"] is not None:
+        errors.append("protocolVersion belongs on interfaces, not the Agent Card root")
+
+    # Skills
+    skills = card.get("skills")
+    if not isinstance(skills, list):
+        errors.append("Agent Card skills must be an array")
+    else:
+        for skill in skills:
+            for field in ("id", "name", "description", "tags"):
+                value = skill.get(field)
+                if value is None or value == "" or value == []:
+                    errors.append(f"Agent Card skill is missing {field}")
+        skill_ids = {str(item.get("id", "")) for item in skills}
+        required_skills = {
+            "discover-funded-work",
+            "plan-bounty-claim",
+            "submit-bounty-evidence",
+            "check-bounty-settlement",
+            "post-bounty",
+        }
+        missing = required_skills - skill_ids
+        if missing:
+            errors.append(f"Agent Card is missing skills: {sorted(missing)}")
+
+    # Forbidden material
+    serialized = json.dumps(card, sort_keys=True).lower()
+    for forbidden in ("private_key", "private key", "seed phrase", "api_key", "secret"):
+        if forbidden in serialized:
+            errors.append(f"Agent Card exposes forbidden material: {forbidden}")
+
+    # Required phrases
+    for required_phrase in ("canonical", "claimable", "bountysettled"):
+        if required_phrase not in serialized:
+            errors.append(f"Agent Card must preserve the {required_phrase} evidence boundary")
+
+    # Cache headers
+    etag = headers.get("etag", headers.get("ETag", ""))
+    cache_control = headers.get("cache-control", headers.get("Cache-Control", ""))
+    if not etag:
+        errors.append("Agent Card response missing ETag header")
+    if not cache_control or "max-age" not in cache_control.lower():
+        errors.append("Agent Card response missing Cache-Control with max-age")
+
+    if errors:
+        for e in errors:
+            print(f"FAIL: {e}", file=sys.stderr)
+        raise SystemExit(f"{len(errors)} validation errors")
+    print("A2A Agent Card acceptance checks passed")
+
+
+if __name__ == "__main__":
+    card, headers = fetch_card(CARD_URL)
+    validate_card(card, headers)


### PR DESCRIPTION
Closes #771

## Changes
- Add  endpoint with A2A 1.0 Agent Card
- Serve Agent Card with ETag and Cache-Control headers
- Declare five required skills: discover-funded-work, plan-bounty-claim, submit-bounty-evidence, check-bounty-settlement, post-bounty
- Create  preserving canonical, claimable, and BountySettled evidence boundaries
- Create A2A Agent Card smoke test PASSED smoke test verified against fixture
- Update  and  to reference the card

## Verification
A2A Agent Card smoke test PASSED

@NSPG13 Ready for review!