### PR TITLE
Fix bounty discovery evidence rendering

### DIFF
--- a/scripts/reconcile_github_bounty_labels.py
+++ b/scripts/reconcile_github_bounty_labels.py
@@ -1381,6 +1381,7 @@ def main(argv: list[str] | None = None, request: HttpRequest = default_http_requ
             plan.issue_number is not None for plan in eligible
         ),
         "planned_create_count": sum(plan.issue_number is None for plan in eligible),
+        "covered_record_count": len(eligible),
         "covered_record_count_after_successful_reconciliation": len(eligible),
         "excluded_historical_terminal_count": len(excluded),
         "coverage_percent": 100.0,

--- a/scripts/test_reconcile_github_bounty_labels.py
+++ b/scripts/test_reconcile_github_bounty_labels.py
@@ -460,15 +460,29 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
             fixture = root / "fixture.json"
             policy_path = root / "policy.json"
             report = root / "report.json"
+            markdown = root / "report.md"
             fixture.write_text(json.dumps({"projection": projection(record), "issues": []}), encoding="utf-8")
             policy_path.write_text(json.dumps(policy()), encoding="utf-8")
             self.assertEqual(
-                main(["--fixture", str(fixture), "--policy", str(policy_path), "--json-out", str(report)]),
+                main(
+                    [
+                        "--fixture",
+                        str(fixture),
+                        "--policy",
+                        str(policy_path),
+                        "--json-out",
+                        str(report),
+                        "--md-out",
+                        str(markdown),
+                    ]
+                ),
                 0,
             )
             payload = json.loads(report.read_text(encoding="utf-8"))
             self.assertEqual(payload["mode"], "dry-run")
             self.assertEqual(payload["coverage_percent"], 100.0)
+            self.assertEqual(payload["covered_record_count"], 1)
+            self.assertIn("Covered records: `1`", markdown.read_text(encoding="utf-8"))
             with self.assertRaisesRegex(LabelReconciliationError, "fixture mode"):
                 with patch.dict(os.environ, {"GITHUB_TOKEN": "token"}):
                     main(


### PR DESCRIPTION
## Summary
- include the covered record count in reconciliation reports
- exercise JSON and Markdown report writing in the dry-run fixture test

## Why
The first production dry-run correctly computed 100% projected coverage and made no writes, but the Markdown artifact writer referenced a success field that the JSON report did not expose. This fix keeps the fail-closed dry-run evidence path usable before controlled backfill.

## Validation
- python scripts/test_reconcile_github_bounty_labels.py
- python -m py_compile scripts/reconcile_github_bounty_labels.py scripts/test_reconcile_github_bounty_labels.py
- live production dry-run: 59 projected, 45 eligible, 8 planned creates, 14 historical-terminal exclusions, 100% projected coverage, 0 duplicate mappings