### PR TITLE
Use a valid bounty discovery schedule variable

### DIFF
--- a/.github/workflows/bounty-inventory-guard.yml
+++ b/.github/workflows/bounty-inventory-guard.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Reconcile GitHub state from canonical Base evidence
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCOVERY_EXECUTE: ${{ (github.event_name == 'workflow_dispatch' && inputs.execute_github_discovery) || (github.event_name == 'schedule' && vars.GITHUB_BOUNTY_DISCOVERY_EXECUTE == 'true') }}
+          DISCOVERY_EXECUTE: ${{ (github.event_name == 'workflow_dispatch' && inputs.execute_github_discovery) || (github.event_name == 'schedule' && vars.BOUNTY_DISCOVERY_EXECUTE == 'true') }}
         run: |
           EXECUTE_ARGS=()
           if [[ "$DISCOVERY_EXECUTE" == "true" ]]; then

--- a/scripts/test_reconcile_github_bounty_labels.py
+++ b/scripts/test_reconcile_github_bounty_labels.py
@@ -276,7 +276,8 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
         self.assertIn("group: canonical-github-bounty-reconciliation", workflow)
         self.assertIn("cancel-in-progress: false", workflow)
         self.assertIn("default: false", workflow)
-        self.assertIn("vars.GITHUB_BOUNTY_DISCOVERY_EXECUTE == 'true'", workflow)
+        self.assertIn("vars.BOUNTY_DISCOVERY_EXECUTE == 'true'", workflow)
+        self.assertNotIn("vars.GITHUB_", workflow)
         self.assertIn("bounty-label-reconciliation.log", workflow)
         self.assertIn("if: always()", workflow)
 


### PR DESCRIPTION
## Summary
- replace the GitHub-reserved GITHUB_BOUNTY_DISCOVERY_EXECUTE repository variable with BOUNTY_DISCOVERY_EXECUTE
- assert the workflow never references a repository variable beginning with the reserved GITHUB_ prefix

## Validation
- python scripts/test_reconcile_github_bounty_labels.py
- workflow YAML parse
- controlled execute already completed with 100% coverage, zero duplicates, and a zero-write idempotency pass; schedule remains disabled until this merges