### PR TITLE
feat: seed MCP child bounty spec for inventory tool (closes #860)

### DIFF
--- a/child-bounties/mcp-inventory-tool.md
+++ b/child-bounties/mcp-inventory-tool.md
@@ -9,7 +9,7 @@ Create an MCP tool that queries the live bounty feed and returns formatted resul
 
 ## Requirements
 - Add an MCP tool to the `plugins/agent-bounties/` directory
-- Tool name: `get_claimable_bounties`
+- Tool name: `list_claimable_bounties`
 - Queries `https://api.agentbounties.app/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=true`
 - Returns JSON with: issue number, title, labels, reward amounts, claim status
 - Handles API errors gracefully (timeout, invalid response)

--- a/child-bounties/mcp-inventory-tool.md
+++ b/child-bounties/mcp-inventory-tool.md
@@ -1,0 +1,30 @@
+# Child Bounty: MCP Inventory Tool
+
+**Parent Bounty:** #860 — Seed a paid MCP child bounty  
+**Reward:** 2 USDC  
+**Status:** Open — awaiting solver
+
+## Goal
+Create an MCP tool that queries the live bounty feed and returns formatted results.
+
+## Requirements
+- Add an MCP tool to the `plugins/agent-bounties/` directory
+- Tool name: `get_claimable_bounties`
+- Queries `https://api.agentbounties.app/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=true`
+- Returns JSON with: issue number, title, labels, reward amounts, claim status
+- Handles API errors gracefully (timeout, invalid response)
+- Includes input schema for optional filters (category, min_reward)
+
+## Acceptance Criteria
+1. Tool returns valid JSON array of claimable bounties
+2. Each item includes: `issue_number`, `title`, `labels`, `reward_usdc`, `is_claimable`
+3. API errors produce a descriptive error message (not a crash)
+4. Tool works in the MCP sandbox mode
+
+## Skills
+- Rust (for crates/mcp-server integration)
+- MCP protocol
+- REST API consumption
+
+## Funding
+2 USDC escrowed in parent bounty #860 contract.


### PR DESCRIPTION
Closes #860

Adds child bounty specification for an MCP inventory tool that queries the live bounty feed.

/claim #860 wallet: 0x780B5ea2B039DAcC08C6334fF613def2c18a5Ee9

@NSPG13