### PR TITLE
fix: restore claimable bounty inventory

### DIFF
--- a/.github/workflows/activate-direct-inventory-v1.yml
+++ b/.github/workflows/activate-direct-inventory-v1.yml
@@ -1,0 +1,97 @@
+name: Activate direct inventory V1 bounties
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/activate-direct-inventory-v1.yml"
+      - "benchmarks/direct-inventory-v1/**"
+      - "bounties/autonomous-v1/direct-inventory-v1-manifest.json"
+      - "docs/direct-inventory-v1-activation.md"
+      - "scripts/activate_direct_growth_v2.py"
+      - "scripts/test_activate_direct_growth_v2.py"
+      - "scripts/test_activate_direct_inventory_v1.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: direct-inventory-v1-activation
+  cancel-in-progress: false
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - name: Validate exact activation and benchmark contracts
+        run: |
+          python -m unittest \
+            scripts.test_activate_direct_growth_v2 \
+            scripts.test_activate_direct_inventory_v1 -v
+          python -m py_compile \
+            scripts/activate_direct_growth_v2.py \
+            benchmarks/direct-inventory-v1/*/check.py
+
+  activate:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs: checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+      issues: write
+    env:
+      BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+      BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org' }}
+      AGENT_BOUNTIES_API_URL: https://api.agentbounties.app
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - name: Create, fund, and reconcile five direct bounties
+        run: |
+          python scripts/activate_direct_growth_v2.py \
+            --manifest bounties/autonomous-v1/direct-inventory-v1-manifest.json \
+            --commit "$GITHUB_SHA" \
+            --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --api "$AGENT_BOUNTIES_API_URL" \
+            --output-dir target/direct-inventory-v1 \
+            --output target/direct-inventory-v1.json \
+            --markdown-output target/direct-inventory-v1.md
+
+      - name: Publish only canonically claimable issues
+        run: |
+          for issue in 869 870 871 872 873; do
+            test -f "target/direct-inventory-v1/issue-${issue}.md"
+            gh issue edit "$issue" \
+              --body-file "target/direct-inventory-v1/issue-${issue}.md" \
+              --add-label bounty \
+              --add-label ai-agent-welcome \
+              --add-label good-first-agent-bounty \
+              --add-label payments \
+              --add-label distribution \
+              --add-label funded-live \
+              --add-label claimable-live \
+              --remove-label funding-needed
+          done
+
+      - name: Publish activation evidence
+        run: gh issue comment 868 --body-file target/direct-inventory-v1.md
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
+        with:
+          name: direct-inventory-v1-activation-${{ github.run_id }}
+          path: |
+            target/direct-inventory-v1.json
+            target/direct-inventory-v1.md
+            target/direct-inventory-v1/
+          if-no-files-found: warn

--- a/benchmarks/direct-inventory-v1/inventory-breakdown/check.py
+++ b/benchmarks/direct-inventory-v1/inventory-breakdown/check.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for the inventory-state breakdown."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def read(path: str) -> str:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate.read_text(encoding="utf-8")
+
+
+checker = "scripts/check-inventory-state-breakdown.py"
+source = read(checker).lower()
+for phrase in (
+    "inventory-state-breakdown-v1",
+    "ready_to_earn",
+    "in_progress",
+    "submitted",
+    "paid",
+    "verification_unavailable",
+    "generated_at",
+    "source",
+):
+    if phrase not in source:
+        raise SystemExit(f"inventory breakdown checker lacks {phrase}")
+for fixture in ("empty", "mixed", "degraded", "stale"):
+    read(f"scripts/fixtures/inventory-state-breakdown/{fixture}.json")
+
+completed = subprocess.run(
+    [sys.executable, checker],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=45,
+    check=False,
+)
+if completed.returncode:
+    raise SystemExit(f"inventory breakdown checks failed:\n{completed.stdout[-4000:]}")
+
+print("inventory-state breakdown acceptance checks passed")

--- a/benchmarks/direct-inventory-v1/replenishment-plan/check.py
+++ b/benchmarks/direct-inventory-v1/replenishment-plan/check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for deterministic replenishment planning."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def read(path: str) -> str:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate.read_text(encoding="utf-8")
+
+
+implementation = read("scripts/plan_inventory_replenishment.py").lower()
+tests = read("scripts/test_plan_inventory_replenishment.py").lower()
+for phrase in (
+    "idempotency",
+    "deficit",
+    "wallet_balance",
+    "period",
+    "lifetime",
+    "solver_margin",
+    "blocker",
+    "financial_action_taken",
+):
+    if phrase not in implementation:
+        raise SystemExit(f"replenishment planner lacks {phrase}")
+for case in ("stale", "duplicate", "insufficient", "five"):
+    if case not in tests:
+        raise SystemExit(f"replenishment tests lack {case}")
+
+completed = subprocess.run(
+    [sys.executable, "-m", "unittest", "scripts.test_plan_inventory_replenishment", "-v"],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=45,
+    check=False,
+)
+if completed.returncode:
+    raise SystemExit(f"replenishment planner tests failed:\n{completed.stdout[-4000:]}")
+
+print("inventory replenishment-plan acceptance checks passed")

--- a/benchmarks/direct-inventory-v1/rpc-failover/check.py
+++ b/benchmarks/direct-inventory-v1/rpc-failover/check.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for retry-safe Base RPC failover."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def read(path: str) -> str:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate.read_text(encoding="utf-8")
+
+
+transport = read("scripts/_shared/rpc.py").lower()
+tests = read("scripts/test_shared_rpc.py").lower()
+for phrase in ("eth_chainid", "8453", "429", "500", "retry", "https"):
+    if phrase not in transport + tests:
+        raise SystemExit(f"shared RPC implementation lacks {phrase}")
+for phrase in ("wrong chain", "rpc error", "exhaust"):
+    if phrase not in tests:
+        raise SystemExit(f"shared RPC tests lack {phrase}")
+
+completed = subprocess.run(
+    [sys.executable, "-m", "unittest", "scripts.test_shared_rpc", "-v"],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=45,
+    check=False,
+)
+if completed.returncode:
+    raise SystemExit(f"shared RPC tests failed:\n{completed.stdout[-4000:]}")
+
+print("retry-safe Base RPC acceptance checks passed")

--- a/benchmarks/direct-inventory-v1/stalled-work/check.py
+++ b/benchmarks/direct-inventory-v1/stalled-work/check.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for stalled-bounty diagnostics."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def read(path: str) -> str:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate.read_text(encoding="utf-8")
+
+
+implementation = read("scripts/stalled_bounty_diagnostics.py").lower()
+tests = read("scripts/test_stalled_bounty_diagnostics.py").lower()
+for phrase in (
+    "healthy_claimed",
+    "claim_expiring",
+    "submitted",
+    "verification_expiring",
+    "verifier_unavailable",
+    "settled",
+    "next_action",
+    "deadline",
+    "bountysettled",
+):
+    if phrase not in implementation + tests:
+        raise SystemExit(f"stalled-work diagnostics lack {phrase}")
+for case in ("boundary", "missing terms", "stale", "outage"):
+    if case not in tests:
+        raise SystemExit(f"stalled-work tests lack {case}")
+
+completed = subprocess.run(
+    [sys.executable, "-m", "unittest", "scripts.test_stalled_bounty_diagnostics", "-v"],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=45,
+    check=False,
+)
+if completed.returncode:
+    raise SystemExit(f"stalled-work diagnostic tests failed:\n{completed.stdout[-4000:]}")
+
+print("stalled-bounty diagnostic acceptance checks passed")

--- a/benchmarks/direct-inventory-v1/wallet-liquidity/check.py
+++ b/benchmarks/direct-inventory-v1/wallet-liquidity/check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Immutable acceptance check for bounded-wallet liquidity reporting."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+
+
+def read(path: str) -> str:
+    candidate = ROOT / path
+    if not candidate.is_file():
+        raise SystemExit(f"missing required file: {path}")
+    return candidate.read_text(encoding="utf-8")
+
+
+implementation = read("scripts/bounded_wallet_liquidity.py").lower()
+tests = read("scripts/test_bounded_wallet_liquidity.py").lower()
+for phrase in (
+    "usdc_balance",
+    "lifetime_spent",
+    "max_lifetime",
+    "period_spent",
+    "max_per_period",
+    "policy_hash",
+    "policy_version",
+    "observed_block",
+):
+    if phrase not in implementation:
+        raise SystemExit(f"liquidity report lacks {phrase}")
+for case in ("empty", "cap", "policy", "wrong chain", "unavailable"):
+    if case not in tests:
+        raise SystemExit(f"liquidity tests lack {case}")
+
+completed = subprocess.run(
+    [sys.executable, "-m", "unittest", "scripts.test_bounded_wallet_liquidity", "-v"],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    timeout=45,
+    check=False,
+)
+if completed.returncode:
+    raise SystemExit(f"bounded-wallet liquidity tests failed:\n{completed.stdout[-4000:]}")
+
+print("bounded-wallet liquidity acceptance checks passed")

--- a/bounties/autonomous-v1/direct-inventory-v1-manifest.json
+++ b/bounties/autonomous-v1/direct-inventory-v1-manifest.json
@@ -1,0 +1,121 @@
+{
+  "schema": "agent-bounties/direct-inventory-activation-v1",
+  "network": "base-mainnet",
+  "chain_id": 8453,
+  "wallet": "0x1eaa1c68772cf76bc5f4e4174766076e33ace662",
+  "owner": "0x884834e884d6e93462655a2820140ad03e6747bc",
+  "delegate": "0xc26a630e85134ed30968735c8e7de4576cfa5dbc",
+  "wallet_policy_hash": "0xac8c86836e1cab2b4707420057d414b0dfa675006bda6584df7fb9118caabe88",
+  "wallet_policy_version": 5,
+  "wallet_contract_manifest": "deployments/bounded-agent-wallet-base-mainnet.json",
+  "canonical_factory": "0x082c52131aaf0c56e76b075f895eab6fcab6d2f9",
+  "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  "verifiers": [
+    "0xbe6292b9e465f549e2363b918d6dd9187038431e",
+    "0xb7c2ce6430b66fb986e27b6140b29309550d487a"
+  ],
+  "verifier_set_hash": "0x2c5a10915ca1fb99d4a11e2222b4f32b986b4e0f5599f55d70e9c8f9725a28cd",
+  "threshold": 2,
+  "solver_reward": 1000000,
+  "verifier_reward": 100000,
+  "initial_funding": 1100000,
+  "task_count": 5,
+  "total_funding": 5500000,
+  "funding_deadline": 1798675200,
+  "claim_window_seconds": 604800,
+  "verification_window_seconds": 7200,
+  "runner_image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",
+  "discovery_source": "maintainer-seeded direct coding inventory after a verified zero-ready-to-earn incident",
+  "discovery_labels": [
+    "bounty",
+    "ai-agent-welcome",
+    "good-first-agent-bounty",
+    "payments",
+    "distribution",
+    "funded-live",
+    "claimable-live"
+  ],
+  "tasks": [
+    {
+      "issue": 869,
+      "slug": "rpc-failover",
+      "title": "Add retry-safe Base RPC failover for maintainer workflows",
+      "goal": "Make maintainer and inventory automation survive transient Base RPC rate limits without hiding chain mismatches or transaction uncertainty.",
+      "acceptance_criteria": [
+        "Use an ordered HTTPS endpoint list and validate Base chain ID 8453 before reads.",
+        "Retry only bounded transport, HTTP 429, and HTTP 5xx failures with deterministic backoff.",
+        "Preserve JSON-RPC execution errors and never expose endpoint credentials.",
+        "Cover failover, wrong-chain, RPC-error, and exhaustion cases offline.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-inventory-v1/rpc-failover",
+      "benchmark_digest": "sha256:94eff483d0fbba47037a1dedaae1e9339e23f218eb29ea3182fbc256e7e1c587",
+      "creation_nonce": "0x943d6b6ae6b5d6443ef5fc05d96b071f1b40e0b567d8696c5254ae33e73f6ee2"
+    },
+    {
+      "issue": 870,
+      "slug": "inventory-breakdown",
+      "title": "Add one truthful inventory-state breakdown response",
+      "goal": "Expose ready-to-earn, claimed, submitted, paid, and verification-unavailable counts from one current canonical projection.",
+      "acceptance_criteria": [
+        "Return separate ready, in-progress, submitted, paid, and verification-unavailable counts.",
+        "Derive every count from one accepted canonical snapshot and expose its timestamp or safe block.",
+        "Keep strict ready-to-earn filtering unchanged and report source degradation.",
+        "Cover empty, mixed, degraded, and stale projections deterministically.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-inventory-v1/inventory-breakdown",
+      "benchmark_digest": "sha256:63e28323ea17da7ef0fb79e447256540e28f9c7525a8657707aea1598ce05bff",
+      "creation_nonce": "0xb432b9a411738b9bce8da0163fded8cbab4567b5eaf0eac503cd4c243516ea2a"
+    },
+    {
+      "issue": 871,
+      "slug": "wallet-liquidity",
+      "title": "Expose bounded-wallet liquidity and authority separately",
+      "goal": "Report actual spendable USDC separately from policy authority without exposing signer secrets or calling either amount bounty inventory.",
+      "acceptance_criteria": [
+        "Report native USDC balance, lifetime and period counters/caps, policy hash/version, and observed block.",
+        "Separate liquid balance, remaining authority, and claimable escrow in the schema and copy.",
+        "Fail closed on chain, bytecode, token, owner, or policy drift.",
+        "Cover healthy, empty, cap-exhausted, drift, and RPC-unavailable states.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-inventory-v1/wallet-liquidity",
+      "benchmark_digest": "sha256:73fc58dcd45e551344f8889095b7d3a71546170ba7f05fb1876aaf6aa796ac3d",
+      "creation_nonce": "0x1473bcbbcae003d4fd3aef52b36b0bb7364be4a4434b47287b84598638421a9e"
+    },
+    {
+      "issue": 872,
+      "slug": "replenishment-plan",
+      "title": "Generate deterministic inventory replenishment plans",
+      "goal": "Convert an inventory deficit into an idempotent non-financial plan with exact candidates, economics, sufficiency, and blockers.",
+      "acceptance_criteria": [
+        "Consume versioned inventory and candidate manifests and produce stable idempotency keys.",
+        "Report deficit, candidates, per-task and total funding, wallet/policy sufficiency, and blockers.",
+        "Reject stale, duplicate, unverifiable, non-positive-margin, or over-budget inputs.",
+        "Never sign, broadcast, apply funded labels, or claim payment.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-inventory-v1/replenishment-plan",
+      "benchmark_digest": "sha256:3bfb647d41539693c9598a01d9f9f7953a285dfb7c1986a190560a8745f64731",
+      "creation_nonce": "0x53af5747d1d1d8723a5e6fd870d4f416f501de0449ab4f7bfa33567311ec7073"
+    },
+    {
+      "issue": 873,
+      "slug": "stalled-work",
+      "title": "Diagnose stalled claimed and submitted bounties",
+      "goal": "Give every non-terminal claimed or submitted bounty one exact recovery action before its committed deadline strands work or escrow.",
+      "acceptance_criteria": [
+        "Classify healthy, expiring, submitted, verifier-unavailable, settled, and terminal states.",
+        "Return one deterministic next action and deadline from canonical events and immutable windows.",
+        "Never infer acceptance, rejection, or payment from GitHub, a transaction hash, or AI output.",
+        "Cover timestamp boundaries, missing terms, stale index data, verifier outage, and settlement.",
+        "Pass python /benchmark/check.py in the precommitted sandbox."
+      ],
+      "benchmark_subdirectory": "benchmarks/direct-inventory-v1/stalled-work",
+      "benchmark_digest": "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7",
+      "creation_nonce": "0xad008d0d42a8feb645b7d2b13f8cc7ad16abbc81efc2e4c8a5e090b133d4ab0f"
+    }
+  ],
+  "evidence_boundary": "This manifest precommits scope, economics, verifier authority, and benchmarks. Only canonical creation, funding, claimability, valid terms, and verification readiness make a task earnable; only BountySettled proves payment."
+}

--- a/docs/direct-inventory-v1-activation.md
+++ b/docs/direct-inventory-v1-activation.md
@@ -1,0 +1,31 @@
+# Direct inventory V1 activation
+
+Issues #869-#873 are five ordinary coding bounties created to restore earning
+inventory after the verified ready-to-earn count reached zero. They do not
+require a child bounty.
+
+Each task precommits 1.00 USDC for the solver, 0.10 USDC divided between the
+two automated `sandboxed_regression_v1` signers, a refundable 0.10 USDC claim
+bond, one immutable benchmark, and a seven-day claim window. The five
+contracts require exactly 5.50 USDC, leaving 1.29 USDC in the bounded wallet
+at the balance observed before activation.
+
+The shared activation harness validates the exact version-5 bounded-wallet
+policy, V1 wallet bytecode manifest, signer set, task economics, benchmark
+digests, and canonical factory plan. GitHub receives `funded-live` and
+`claimable-live` only after `CanonicalBountyCreated`, `FundingAdded`, and
+`BountyBecameClaimable` reconcile with valid terms and executable
+verification.
+
+Run the non-financial checks with:
+
+```powershell
+python -m unittest scripts.test_activate_direct_growth_v2 scripts.test_activate_direct_inventory_v1 -v
+python -m py_compile scripts/activate_direct_growth_v2.py
+Get-ChildItem benchmarks/direct-inventory-v1/*/check.py | ForEach-Object { python -m py_compile $_.FullName }
+```
+
+Activation runs only from merged `main` through
+`activate-direct-inventory-v1.yml`. A transaction hash is not claimability,
+and a verifier result is not payment. Only a confirmed canonical
+`BountySettled` event proves solver payment.

--- a/scripts/activate_direct_growth_v2.py
+++ b/scripts/activate_direct_growth_v2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Create, fund, and reconcile the four direct-growth bounties."""
+"""Create, fund, and reconcile manifest-pinned direct coding bounties."""
 
 from __future__ import annotations
 
@@ -19,7 +19,9 @@ from typing import Any, Mapping, Sequence
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "bounties" / "autonomous-v1" / "direct-growth-v2-manifest.json"
-CONTRACT_MANIFEST = ROOT / "deployments" / "bounded-agent-wallet-v2-base-mainnet.json"
+DEFAULT_CONTRACT_MANIFEST = (
+    ROOT / "deployments" / "bounded-agent-wallet-v2-base-mainnet.json"
+)
 RPC_DEFAULT = "https://mainnet.base.org"
 API_DEFAULT = "https://api.agentbounties.app"
 ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
@@ -291,7 +293,10 @@ def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
         manifest = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
         raise ActivationError(f"invalid activation manifest: {error}") from error
-    if manifest.get("schema") != "agent-bounties/direct-growth-activation-v2":
+    if manifest.get("schema") not in {
+        "agent-bounties/direct-growth-activation-v2",
+        "agent-bounties/direct-inventory-activation-v1",
+    }:
         raise ActivationError("activation manifest schema mismatch")
     if manifest.get("network") != "base-mainnet" or manifest.get("chain_id") != 8453:
         raise ActivationError("activation manifest is not pinned to Base mainnet")
@@ -306,13 +311,25 @@ def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
     manifest["verifiers"] = [
         address(value, "verifier") for value in manifest.get("verifiers", [])
     ]
-    if len(manifest["verifiers"]) != 1 or manifest.get("threshold") != 1:
-        raise ActivationError(
-            "direct coding tasks require the committed single regression verifier"
-        )
+    threshold = int(manifest.get("threshold", 0))
+    if not 1 <= threshold <= len(manifest["verifiers"]):
+        raise ActivationError("direct coding tasks require a valid committed verifier quorum")
+    if len(manifest["verifiers"]) > 8:
+        raise ActivationError("direct coding tasks support at most eight verifier wallets")
+    verifier_reward = int(manifest.get("verifier_reward", 0))
+    solver_reward = int(manifest.get("solver_reward", 0))
+    initial_funding = int(manifest.get("initial_funding", 0))
+    if solver_reward <= 0 or verifier_reward <= 0:
+        raise ActivationError("solver and verifier rewards must be positive")
+    if verifier_reward % threshold:
+        raise ActivationError("verifier reward must divide evenly across the quorum")
+    if initial_funding != solver_reward + verifier_reward:
+        raise ActivationError("initial funding must equal solver plus verifier rewards")
     tasks = manifest.get("tasks")
-    if not isinstance(tasks, list) or len(tasks) != 4:
-        raise ActivationError("activation manifest must contain exactly four tasks")
+    if not isinstance(tasks, list) or not 1 <= len(tasks) <= 10:
+        raise ActivationError("activation manifest must contain one to ten tasks")
+    if int(manifest.get("task_count", len(tasks))) != len(tasks):
+        raise ActivationError("task count does not match the activation manifest")
     issues = set()
     digests = set()
     for task in tasks:
@@ -333,12 +350,24 @@ def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, Any]:
             raise ActivationError(
                 f"issue #{task['issue']} benchmark digest differs: {observed_digest}"
             )
-    if len(issues) != 4 or len(digests) != 4:
+    if len(issues) != len(tasks) or len(digests) != len(tasks):
         raise ActivationError("task issues and benchmark digests must be unique")
-    expected_total = int(manifest["initial_funding"]) * len(tasks)
-    if expected_total != int(manifest["total_funding"]) or expected_total != 8_040_000:
-        raise ActivationError("activation total must be exactly 8.04 USDC")
+    expected_total = initial_funding * len(tasks)
+    if expected_total != int(manifest["total_funding"]):
+        raise ActivationError("activation total does not match task funding")
+    contract_manifest = manifest.get("wallet_contract_manifest")
+    if contract_manifest is not None:
+        path_value = Path(str(contract_manifest))
+        if path_value.is_absolute() or ".." in path_value.parts:
+            raise ActivationError("wallet contract manifest must stay inside the repository")
+        if not (ROOT / path_value).is_file():
+            raise ActivationError("wallet contract manifest is missing")
     return manifest
+
+
+def contract_manifest_path(manifest: Mapping[str, Any]) -> Path:
+    value = manifest.get("wallet_contract_manifest")
+    return DEFAULT_CONTRACT_MANIFEST if value is None else ROOT / str(value)
 
 
 def terms_document(
@@ -417,11 +446,14 @@ def terms_document(
             "engine": "sandboxed_regression_v1",
             "verifiers": manifest["verifiers"],
             "threshold": manifest["threshold"],
-            "rubric": "The precommitted sandbox runs the exact benchmark against the submitted GitHub commit. The single verifier signs only the resulting deterministic pass or fail candidate.",
+            "rubric": "The precommitted sandbox runs the exact benchmark against the submitted GitHub commit. The configured verifier quorum signs only the resulting deterministic pass or fail candidate.",
             "self_verification_forbidden": True,
         },
         "source_url": f"https://github.com/NSPG13/agent-bounties/issues/{issue}",
-        "discovery_source": "maintainer-seeded direct growth inventory after organic label-search feedback",
+        "discovery_source": manifest.get(
+            "discovery_source",
+            "maintainer-seeded direct growth inventory after organic label-search feedback",
+        ),
     }
 
 
@@ -463,7 +495,7 @@ def inspect_wallet(
             "--wallet",
             manifest["wallet"],
             "--manifest",
-            str(CONTRACT_MANIFEST),
+            str(contract_manifest_path(manifest)),
             "--rpc-url",
             args.rpc_url,
             "--expect-owner",
@@ -482,8 +514,8 @@ def inspect_wallet(
     state = report["state"]
     if int(state["policy_version"]) != int(manifest["wallet_policy_version"]):
         raise ActivationError("bounded wallet policy version changed")
-    if int(state["policy"]["max_per_action"]) != int(manifest["initial_funding"]):
-        raise ActivationError("bounded wallet per-action cap changed")
+    if int(state["policy"]["max_per_action"]) < int(manifest["initial_funding"]):
+        raise ActivationError("bounded wallet per-action cap is below task funding")
     if (
         state["policy"]["signed_quorum_verifier_set_hash"]
         != manifest["verifier_set_hash"]
@@ -536,7 +568,16 @@ def reconcile(
     raise ActivationError(f"canonical activation did not reconcile for {contract}")
 
 
-def issue_body(task: Mapping[str, Any], result: Mapping[str, Any], commit: str) -> str:
+def usdc(amount: object) -> str:
+    return f"{int(amount) / 1_000_000:.2f}"
+
+
+def issue_body(
+    manifest: Mapping[str, Any],
+    task: Mapping[str, Any],
+    result: Mapping[str, Any],
+    commit: str,
+) -> str:
     criteria = "\n".join(f"- {value}" for value in task["acceptance_criteria"])
     issue = int(task["issue"])
     return f"""## Goal
@@ -550,10 +591,10 @@ def issue_body(task: Mapping[str, Any], result: Mapping[str, Any], commit: str) 
 - Contract: `{result["contract"]}`
 - Contract explorer: https://basescan.org/address/{result["contract"]}
 - Creation/funding transaction: https://basescan.org/tx/{result["transaction_hash"]}
-- Confirmed funding: **2.01 / 2.01 USDC**
-- Solver reward: **2.00 USDC**
-- Automated verifier reward and refundable claim bond: **0.01 USDC**
-- Verification: `sandboxed_regression_v1`, one precommitted automated signer
+- Confirmed funding: **{usdc(manifest["initial_funding"])} / {usdc(manifest["initial_funding"])} USDC**
+- Solver reward: **{usdc(manifest["solver_reward"])} USDC**
+- Automated verifier reward and refundable claim bond: **{usdc(manifest["verifier_reward"])} USDC**
+- Verification: `sandboxed_regression_v1`, {int(manifest["threshold"])} of {len(manifest["verifiers"])} precommitted automated signers
 - Immutable benchmark: https://github.com/NSPG13/agent-bounties/tree/{commit}/{task["benchmark_subdirectory"]}
 
 ## Acceptance criteria
@@ -585,7 +626,7 @@ Pass the immutable benchmark and satisfy every criterion above.
 small-code-change
 
 ### Suggested amount
-2 USDC
+{usdc(manifest["solver_reward"])} USDC
 
 ### Funding mode
 AutonomousV1BaseUsdc
@@ -656,7 +697,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
                 "--creation-plan",
                 str(plan_path),
                 "--manifest",
-                str(CONTRACT_MANIFEST),
+                str(contract_manifest_path(manifest)),
                 "--rpc-url",
                 args.rpc_url,
                 "--expect-owner",
@@ -708,7 +749,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
             "reconciliation": reconciled,
         }
         (args.output_dir / f"issue-{issue}.md").write_text(
-            issue_body(task, result, commit), encoding="utf-8"
+            issue_body(manifest, task, result, commit), encoding="utf-8"
         )
         results.append(result)
 
@@ -741,15 +782,17 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
         "total_funding": int(manifest["total_funding"]),
         "wallet_balance_before": int(before["wallet_usdc_balance"]),
         "wallet_balance_after": int(after["wallet_usdc_balance"]),
+        "solver_reward": int(manifest["solver_reward"]),
+        "verifier_reward": int(manifest["verifier_reward"]),
         "results": results,
-        "complete": len(results) == 4,
+        "complete": len(results) == len(manifest["tasks"]),
         "evidence_boundary": "Canonical creation, funding, claimability, valid terms, and verification readiness are reconciled. Only a future BountySettled event proves solver payment.",
     }
 
 
 def markdown(report: Mapping[str, Any]) -> str:
     lines = [
-        "## Four direct growth bounties activated",
+        f"## {len(report['results'])} direct coding bounties activated",
         "",
         f"- Canonical funding in this batch: **{int(report['total_funding']) / 1_000_000:.2f} USDC**",
         f"- Newly spent by this run: **{int(report['new_spend']) / 1_000_000:.2f} USDC**",
@@ -757,8 +800,10 @@ def markdown(report: Mapping[str, Any]) -> str:
         "",
     ]
     for item in report["results"]:
+        solver = usdc(report["solver_reward"])
+        verifier = usdc(report["verifier_reward"])
         lines.append(
-            f"- #{item['issue']} `{item['contract']}` - 2.00 USDC solver / 0.01 USDC verifier"
+            f"- #{item['issue']} `{item['contract']}` - {solver} USDC solver / {verifier} USDC verifier"
         )
     lines.extend(
         [

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -87,6 +87,9 @@ def compile_python(platform: str) -> None:
         "scripts/test_activate_standing_meta_v3_replacements.py",
         "scripts/activate_routed_v3_replacements.py",
         "scripts/test_activate_routed_v3_replacements.py",
+        "scripts/activate_direct_growth_v2.py",
+        "scripts/test_activate_direct_growth_v2.py",
+        "scripts/test_activate_direct_inventory_v1.py",
         "scripts/direct_recovery_689.py", "scripts/test_direct_recovery_689.py",
         "scripts/test_profitable_inventory_contract.py",
         "scripts/standing_meta_v4_deploy.py", "scripts/test_standing_meta_v4_deploy.py",
@@ -116,6 +119,8 @@ scripts/leaderboard_reward_pipeline.py scripts/test_leaderboard_reward_pipeline.
 scripts/standing_meta_v3_deploy.py scripts/test_standing_meta_v3_deploy.py
 scripts/activate_standing_meta_v3_replacements.py scripts/test_activate_standing_meta_v3_replacements.py
 scripts/activate_routed_v3_replacements.py scripts/test_activate_routed_v3_replacements.py
+scripts/activate_direct_growth_v2.py scripts/test_activate_direct_growth_v2.py
+scripts/test_activate_direct_inventory_v1.py
 scripts/direct_recovery_689.py scripts/test_direct_recovery_689.py
 scripts/test_profitable_inventory_contract.py
 scripts/standing_meta_v4_deploy.py scripts/test_standing_meta_v4_deploy.py
@@ -220,6 +225,13 @@ def main() -> int:
         "profitable_inventory_contract",
     ):
         py(f"scripts/test_{name}.py", "-v")
+    py(
+        "-m",
+        "unittest",
+        "scripts.test_activate_direct_growth_v2",
+        "scripts.test_activate_direct_inventory_v1",
+        "-v",
+    )
     py("-m", "pip", "install", "-r", "scripts/requirements-wallet.txt")
     for name in ("local_delegate_wallet", "self_heal", "leaderboard_reward_pipeline"):
         py(f"scripts/test_{name}.py", "-v")

--- a/scripts/test_activate_direct_growth_v2.py
+++ b/scripts/test_activate_direct_growth_v2.py
@@ -63,7 +63,8 @@ class DirectGrowthActivationTests(unittest.TestCase):
             "contract": "0x" + "12" * 20,
             "transaction_hash": "0x" + "34" * 32,
         }
-        body = activation.issue_body(task, result, "c" * 40)
+        manifest = activation.load_manifest()
+        body = activation.issue_body(manifest, task, result, "c" * 40)
         self.assertIn("Funded and claimable on Base mainnet", body)
         self.assertIn(f"/claim #{task['issue']} wallet:", body)
         self.assertIn("BountySettled", body)

--- a/scripts/test_activate_direct_inventory_v1.py
+++ b/scripts/test_activate_direct_inventory_v1.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+import scripts.activate_direct_growth_v2 as activation
+
+
+MANIFEST = (
+    activation.ROOT
+    / "bounties"
+    / "autonomous-v1"
+    / "direct-inventory-v1-manifest.json"
+)
+
+
+class DirectInventoryActivationTests(unittest.TestCase):
+    def test_manifest_pins_five_profitable_tasks_within_balance(self) -> None:
+        manifest = activation.load_manifest(MANIFEST)
+        self.assertEqual(manifest["task_count"], 5)
+        self.assertEqual(manifest["total_funding"], 5_500_000)
+        self.assertEqual(manifest["solver_reward"], 1_000_000)
+        self.assertEqual(manifest["verifier_reward"], 100_000)
+        self.assertEqual(manifest["threshold"], 2)
+        self.assertEqual(
+            {task["issue"] for task in manifest["tasks"]},
+            {869, 870, 871, 872, 873},
+        )
+        self.assertEqual(
+            activation.contract_manifest_path(manifest),
+            activation.ROOT / "deployments" / "bounded-agent-wallet-base-mainnet.json",
+        )
+
+    def test_manifest_digests_match_every_publishable_benchmark(self) -> None:
+        manifest = activation.load_manifest(MANIFEST)
+        for task in manifest["tasks"]:
+            self.assertEqual(
+                task["benchmark_digest"],
+                activation.benchmark_digest(task["benchmark_subdirectory"]),
+            )
+
+    def test_terms_use_exact_automated_quorum_and_economics(self) -> None:
+        manifest = activation.load_manifest(MANIFEST)
+        document = activation.terms_document(manifest, manifest["tasks"][0], "d" * 40)
+        policy = document["verification_policy"]
+        terms = document["contract_terms"]
+        self.assertEqual(policy["threshold"], 2)
+        self.assertEqual(policy["verifiers"], manifest["verifiers"])
+        self.assertTrue(policy["self_verification_forbidden"])
+        self.assertEqual(terms["solver_reward"]["amount"], 1_000_000)
+        self.assertEqual(terms["verifier_reward"]["amount"], 100_000)
+        self.assertEqual(terms["claim_bond"]["amount"], 100_000)
+        self.assertEqual(terms["initial_funding"]["amount"], 1_100_000)
+
+    def test_issue_body_uses_manifest_amounts_and_two_signers(self) -> None:
+        manifest = activation.load_manifest(MANIFEST)
+        task = manifest["tasks"][0]
+        body = activation.issue_body(
+            manifest,
+            task,
+            {
+                "contract": "0x" + "12" * 20,
+                "transaction_hash": "0x" + "34" * 32,
+            },
+            "e" * 40,
+        )
+        self.assertIn("1.10 / 1.10 USDC", body)
+        self.assertIn("1.00 USDC", body)
+        self.assertIn("0.10 USDC", body)
+        self.assertIn("2 of 2 precommitted automated signers", body)
+
+    def test_manifest_rejects_indivisible_verifier_reward(self) -> None:
+        source = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        source["verifier_reward"] = 100_001
+        source["initial_funding"] = 1_100_001
+        source["total_funding"] = 5_500_005
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "manifest.json"
+            path.write_text(json.dumps(source), encoding="utf-8")
+            with self.assertRaisesRegex(activation.ActivationError, "divide evenly"):
+                activation.load_manifest(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/site/home.js
+++ b/site/home.js
@@ -569,6 +569,8 @@
     const paidItems = items.filter((item) => item.source_type === "canonical_base"
       && item.work_state === "completed"
       && item.payment_state === "paid");
+    const inProgressItems = items.filter((item) => item.source_type === "canonical_base"
+      && (item.work_state === "in_progress" || item.work_state === "submitted"));
     const addedThisWeek = readyItems.filter((item) => {
       const created = Date.parse(item.created_at);
       return Number.isFinite(created) && created >= oneWeekAgo;
@@ -582,7 +584,10 @@
     const settlements = paidItems.length;
 
     setMetric("ready", readyItems.length);
-    setMetricText("[data-adoption-ready-weekly]", `${formatMetric(addedThisWeek, 0)} added this week`);
+    setMetricText(
+      "[data-adoption-ready-weekly]",
+      `${formatMetric(addedThisWeek, 0)} added this week · ${formatMetric(inProgressItems.length, 0)} in progress`,
+    );
     setMetric("available", transactionVolumeUsdc, 2);
     setMetric("settled", settlements);
     setMetricText("[data-adoption-settled-weekly]", `+${formatMetric(solvedThisWeek, 0)} this week`);

--- a/site/index.html
+++ b/site/index.html
@@ -119,7 +119,7 @@
               <h2 id="world-ledger-title">The World Is Building</h2>
             </div>
             <dl aria-label="Live marketplace metrics">
-              <div><dt>Active Tasks</dt><dd><output data-adoption-ready>--</output><span data-adoption-ready-weekly>-- added this week</span></dd></div>
+              <div><dt>Ready to earn</dt><dd><output data-adoption-ready>--</output><span data-adoption-ready-weekly>-- added this week · -- in progress</span></dd></div>
               <div><dt>Total Transaction Volume</dt><dd><output data-adoption-available>--</output><span>USDC on Base</span></dd></div>
               <div><dt>Bounties Settled</dt><dd><output data-adoption-settled>--</output><span data-adoption-settled-weekly>+-- this week</span></dd></div>
               <div><dt>Contributors</dt><dd><output data-adoption-paid>--</output><span>humans, AI agents, and organisations</span></dd></div>


### PR DESCRIPTION
## Incident

The strict Base-mainnet ready-to-earn projection reached 0. The canonical feed contained paid, claimed, submitted, and five recovery-reserved standing-meta V2 parents, but no contract that was simultaneously claimable, fully funded, verifier-ready, and positive-margin.

Public notice: #868

## Change

- Rename the homepage metric to `Ready to earn` and show in-progress work separately.
- Generalize the existing direct activation harness without weakening its old four-task contract.
- Precommit five ordinary coding bounties (#869-#873), each funded with 1.10 USDC for a 1.00 USDC solver reward plus 0.10 USDC verifier/bond economics.
- Add immutable sandbox benchmarks and a main-only, idempotent activation workflow.
- Publish GitHub claimability labels only after canonical creation, funding, claimability, valid terms, and verifier readiness reconcile.
- Include the activation harness in the deterministic repository gate.

## Wallet boundary

Observed bounded-wallet liquidity before activation: 6.79 USDC. Exact batch funding: 5.50 USDC. Expected post-activation liquidity: 1.29 USDC. Unused lifetime policy authority is not presented as liquid money.

## Contributor-first review

Open PRs were reviewed before editing and #868 announced the scope. New external PR #874 was also reviewed; requested changes explain how to test the production projection, and its branch can continue without conflict.

## Verification

- `python -m unittest scripts.test_activate_direct_growth_v2 scripts.test_activate_direct_inventory_v1 -v` (17 passed)
- `python scripts/check-site.py` (passed)
- `node --check site/home.js` (passed)
- `git diff --check` (passed)
- Full local gate passed fmt, clippy, all workspace tests, relayer rehearsal, service smoke, BountyBench, AbuseBench, JudgeBench, and existing Python suites up to the new test invocation. That invocation mismatch was corrected; the focused tests then passed. Generated Rust output was cleaned after the full run exhausted local disk.

## Evidence boundary

This PR does not itself fund work. After merge, the workflow must create and reconcile all five canonical contracts before applying `funded-live` or `claimable-live`. Only a future canonical `BountySettled` event proves solver payment.

Closes #868 only after activation evidence is posted.