### PR TITLE
fix: resume partial inventory activation

### DIFF
--- a/scripts/activate_direct_growth_v2.py
+++ b/scripts/activate_direct_growth_v2.py
@@ -636,6 +636,57 @@ Public
 """
 
 
+def execute_creation_plan(
+    args: argparse.Namespace,
+    cast: Cast,
+    manifest: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    plan_path: Path,
+    action_path: Path,
+    private_key: str,
+) -> tuple[str, str, str | None, bool]:
+    predicted = address(plan.get("predicted_bounty_contract"), "predicted bounty")
+    bounty_id = bytes32(plan.get("bounty_id"), "bounty id")
+    if is_canonical(cast, manifest["canonical_factory"], predicted):
+        return predicted, bounty_id, None, False
+
+    run(
+        [
+            args.python,
+            "scripts/plan_bounded_agent_action.py",
+            "create",
+            "--wallet",
+            manifest["wallet"],
+            "--creation-plan",
+            str(plan_path),
+            "--manifest",
+            str(contract_manifest_path(manifest)),
+            "--rpc-url",
+            args.rpc_url,
+            "--expect-owner",
+            manifest["owner"],
+            "--expect-delegate",
+            manifest["delegate"],
+            "--expect-policy-hash",
+            manifest["wallet_policy_hash"],
+            "--output",
+            str(action_path),
+        ]
+    )
+    action = json.loads(action_path.read_text(encoding="utf-8"))
+    direct = action["direct_transaction"]
+    tx_hash, created_now = create_if_missing(
+        cast,
+        manifest["canonical_factory"],
+        predicted,
+        address(direct.get("to"), "direct transaction target"),
+        str(direct.get("data")),
+        private_key,
+        args.broadcast_recovery_timeout,
+    )
+    return predicted, bounty_id, tx_hash, created_now
+
+
 def activate(args: argparse.Namespace) -> dict[str, Any]:
     manifest = load_manifest(args.manifest)
     commit = args.commit.strip().lower()
@@ -687,41 +738,14 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
             json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
         action_path = args.output_dir / f"issue-{issue}-bounded-action.json"
-        run(
-            [
-                args.python,
-                "scripts/plan_bounded_agent_action.py",
-                "create",
-                "--wallet",
-                manifest["wallet"],
-                "--creation-plan",
-                str(plan_path),
-                "--manifest",
-                str(contract_manifest_path(manifest)),
-                "--rpc-url",
-                args.rpc_url,
-                "--expect-owner",
-                manifest["owner"],
-                "--expect-delegate",
-                manifest["delegate"],
-                "--expect-policy-hash",
-                manifest["wallet_policy_hash"],
-                "--output",
-                str(action_path),
-            ]
-        )
-        action = json.loads(action_path.read_text(encoding="utf-8"))
-        direct = action["direct_transaction"]
-        predicted = address(plan.get("predicted_bounty_contract"), "predicted bounty")
-        bounty_id = bytes32(plan.get("bounty_id"), "bounty id")
-        tx_hash, created_now = create_if_missing(
+        predicted, bounty_id, tx_hash, created_now = execute_creation_plan(
+            args,
             cast,
-            manifest["canonical_factory"],
-            predicted,
-            address(direct.get("to"), "direct transaction target"),
-            str(direct.get("data")),
+            manifest,
+            plan,
+            plan_path,
+            action_path,
             private_key,
-            args.broadcast_recovery_timeout,
         )
         if created_now:
             new_spend += int(manifest["initial_funding"])

--- a/scripts/test_activate_direct_growth_v2.py
+++ b/scripts/test_activate_direct_growth_v2.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 import tempfile
 import unittest
 from unittest import mock
@@ -162,6 +163,35 @@ class DirectGrowthActivationTests(unittest.TestCase):
                 "secret",
                 0,
             )
+
+    def test_resume_skips_action_planning_for_existing_canonical_contract(self) -> None:
+        cast = mock.Mock()
+        cast.call.return_value = "true"
+        manifest = activation.load_manifest()
+        plan = {
+            "predicted_bounty_contract": "0x" + "22" * 20,
+            "bounty_id": "0x" + "33" * 32,
+        }
+        args = SimpleNamespace(
+            python="python",
+            rpc_url="https://rpc.example",
+            broadcast_recovery_timeout=0,
+        )
+        with mock.patch.object(activation, "run") as planner:
+            result = activation.execute_creation_plan(
+                args,
+                cast,
+                manifest,
+                plan,
+                Path("unused-plan.json"),
+                Path("unused-action.json"),
+                "secret",
+            )
+        self.assertEqual(
+            result,
+            (plan["predicted_bounty_contract"], plan["bounty_id"], None, False),
+        )
+        planner.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Incident continuation

The mainnet activation partially succeeded: #869 and #870 are canonically funded and ready, then the provider rate-limited the run before #871. Retrying correctly failed closed because the action planner rejects already-occupied deterministic addresses.

## Fix

Validate the predicted contract and bounty ID immediately after receiving the canonical creation plan. If the deterministic contract is already registered by the canonical factory, skip bounded action planning and broadcasting, then reconcile existing events. New addresses still pass through the exact existing planner and broadcast path.

## Verification

- `python -m unittest scripts.test_activate_direct_growth_v2 scripts.test_activate_direct_inventory_v1 -v` (18 passed)
- `python -m py_compile scripts/activate_direct_growth_v2.py scripts/test_activate_direct_growth_v2.py`
- `git diff --check`

The new regression asserts that a canonical existing address never invokes the action planner.

## Financial boundary

This PR moves no funds. Current canonical state is two funded tasks and 4.59 USDC bounded-wallet liquidity. After merge, the idempotent workflow should reconcile those two, create only the remaining three for 3.30 USDC, and leave 1.29 USDC. Only canonical events establish those results.

Incident: #868