### PR TITLE
feat: inventory-state breakdown response with canonical counts (#870)

### DIFF
--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "a386a6dc2e408ef7cf58fd77e9d28560c87dc8f01e98cce955e346c8ba6e3efb"
+  "normalized_sha256": "36a40b159749e77d2039d364dfc410cbe418926d4fc3fa4e1443a5062d71332a"
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -469,6 +469,8 @@ use worker::{
         ,SubmitUnfundedBountySolutionRequest
         ,AutonomousBountyInventorySummary
         ,AutonomousBountyInventoryItem
+        ,InventoryBreakdown
+        ,InventoryBreakdownCounts
         ,SolverLeaderboardResponse
         ,SolverLeaderboardPeriodResponse
         ,SolverLeaderboardRanking
@@ -2024,6 +2026,24 @@ impl PlatformCanonicalSourceFreshness {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct InventoryBreakdownCounts {
+    ready_to_earn: u64,
+    claimed_in_progress: u64,
+    submitted: u64,
+    paid: u64,
+    verification_unavailable: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+struct InventoryBreakdown {
+    schema: String,
+    safe_block: Option<u64>,
+    generated_at: String,
+    source_available: bool,
+    counts: InventoryBreakdownCounts,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct AutonomousVerificationJobsQuery {
     network: Option<String>,
@@ -2535,6 +2555,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/v1/base/autonomous-bounties/feed",
             get(autonomous_bounty_feed),
+        )
+        .route(
+            "/v1/base/autonomous-bounties/inventory-breakdown",
+            get(inventory_breakdown),
         )
         .route(
             "/v1/base/autonomous-bounties/leaderboard",
@@ -14046,6 +14070,72 @@ async fn build_open_competition_inventory_summary(
         verifier_reward_usdc_base_units: sum(|item| &item.verifier_reward_usdc_base_units)?
             .to_string(),
     })
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/base/autonomous-bounties/inventory-breakdown",
+    params(("network" = Option<String>, Query, description = "Base network; defaults to base-mainnet")),
+    responses((status = 200, body = InventoryBreakdown))
+)]
+async fn inventory_breakdown(
+    State(state): State<SharedState>,
+    Query(query): Query<AutonomousBountyFeedQuery>,
+) -> Result<Json<InventoryBreakdown>, StatusCode> {
+    let network = query.network.as_deref().unwrap_or("base-mainnet");
+    let feed = load_autonomous_bounty_feed(&state, network, false).await?;
+    let generated_at = Utc::now().to_rfc3339();
+
+    let (safe_block, source_available) = match (
+        state.store.as_ref(),
+        state
+            .base_rpc_urls
+            .resolve(network)
+            .ok()
+            .and_then(|(descriptor, _)| autonomous_factory_for_chain(descriptor.chain_id)),
+    ) {
+        (Some(store), Some(factory)) => {
+            match store.get_base_indexer_heartbeat(network, &factory).await {
+                Ok(Some(heartbeat)) => (heartbeat.persisted_cursor_block, true),
+                _ => (None, false),
+            }
+        }
+        _ => (None, false),
+    };
+
+    let mut ready_to_earn: u64 = 0;
+    let mut claimed_in_progress: u64 = 0;
+    let mut submitted: u64 = 0;
+    let mut paid: u64 = 0;
+    let mut verification_unavailable: u64 = 0;
+
+    for item in &feed {
+        if item.status == "claimable" && item.terms_valid && item.verification_ready {
+            ready_to_earn += 1;
+        } else if item.status == "claimed" {
+            claimed_in_progress += 1;
+        } else if item.status == "submitted" {
+            submitted += 1;
+        } else if item.status == "paid" {
+            paid += 1;
+        } else {
+            verification_unavailable += 1;
+        }
+    }
+
+    Ok(Json(InventoryBreakdown {
+        schema: "agent-bounties/inventory-breakdown-v1".to_string(),
+        safe_block,
+        generated_at,
+        source_available,
+        counts: InventoryBreakdownCounts {
+            ready_to_earn,
+            claimed_in_progress,
+            submitted,
+            paid,
+            verification_unavailable,
+        },
+    }))
 }
 
 fn format_usdc_base_units(amount: u128) -> String {

--- a/crates/domain/src/claim_readiness.rs
+++ b/crates/domain/src/claim_readiness.rs
@@ -1,0 +1,124 @@
+use serde::{Deserialize, Serialize};
+
+/// A solver-facing claim-readiness diagnostic response.
+/// Exposes reward, refundable bond, external spend, gross cash margin, and an actionable blocker.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClaimReadinessDiagnostic {
+    pub scenario: String,
+    pub reward: String,
+    pub refundable_bond: String,
+    pub external_spend: String,
+    pub gross_cash_margin: String,
+    /// Gross cash margin is clearly distinguished from guaranteed net profit.
+    pub is_guaranteed_net_profit: bool,
+    pub next_action: String,
+    pub blocker: Option<String>,
+}
+
+impl ClaimReadinessDiagnostic {
+    /// Validates the diagnostic against security requirements.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        // Never request private keys or seed phrases.
+        let json = serde_json::to_string(self).unwrap_or_default().to_lowercase();
+        if json.contains("private key") || json.contains("seed phrase") {
+            return Err("Diagnostic must never request a private key or seed phrase");
+        }
+        
+        // Reject any result that describes a plan, signature, transaction hash, or hosted row as payment.
+        for forbidden in &["payment: plan", "payment: signature", "payment: transaction hash", "payment: hosted row", "as payment"] {
+            if json.contains(forbidden) {
+                return Err("Diagnostic must not describe a plan, signature, tx hash, or hosted row as payment");
+            }
+        }
+        
+        // Gross cash margin MUST NOT be misrepresented as guaranteed net profit.
+        if self.is_guaranteed_net_profit {
+            return Err("Gross cash margin cannot be represented as guaranteed net profit");
+        }
+        
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE_JSON: &str = include_str!("../../../fixtures/claim-readiness-diagnostics.json");
+
+    #[test]
+    fn parses_and_validates_committed_fixture() {
+        let diagnostics: Vec<ClaimReadinessDiagnostic> = serde_json::from_str(FIXTURE_JSON)
+            .expect("Fixture must be valid JSON");
+            
+        assert_eq!(diagnostics.len(), 4, "Fixture must cover 4 specific scenarios");
+        
+        let healthy = diagnostics.iter().find(|d| d.scenario == "ready-to-earn").unwrap();
+        assert_eq!(healthy.next_action, "sign_claim_transaction");
+        assert!(healthy.blocker.is_none());
+        assert!(healthy.validate().is_ok());
+
+        let stale = diagnostics.iter().find(|d| d.scenario == "stale").unwrap();
+        assert_eq!(stale.next_action, "abort_claim");
+        assert!(stale.blocker.as_ref().unwrap().contains("stale"));
+        assert!(stale.validate().is_ok());
+
+        let malformed = diagnostics.iter().find(|d| d.scenario == "malformed").unwrap();
+        assert_eq!(malformed.next_action, "abort_claim");
+        assert!(malformed.blocker.as_ref().unwrap().contains("malformed"));
+        assert!(malformed.validate().is_ok());
+
+        let unfunded = diagnostics.iter().find(|d| d.scenario == "unfunded").unwrap();
+        assert_eq!(unfunded.next_action, "abort_claim");
+        assert!(unfunded.blocker.as_ref().unwrap().contains("unfunded"));
+        assert!(unfunded.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_private_key_requests() {
+        let mut diag = ClaimReadinessDiagnostic {
+            scenario: "malicious".to_string(),
+            reward: "0".to_string(),
+            refundable_bond: "0".to_string(),
+            external_spend: "0".to_string(),
+            gross_cash_margin: "0".to_string(),
+            is_guaranteed_net_profit: false,
+            next_action: "Provide your private key to claim".to_string(),
+            blocker: None,
+        };
+        assert!(diag.validate().is_err());
+        
+        diag.next_action = "Enter seed phrase".to_string();
+        assert!(diag.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_misrepresented_payment() {
+        let diag = ClaimReadinessDiagnostic {
+            scenario: "misrepresented".to_string(),
+            reward: "0".to_string(),
+            refundable_bond: "0".to_string(),
+            external_spend: "0".to_string(),
+            gross_cash_margin: "0".to_string(),
+            is_guaranteed_net_profit: false,
+            next_action: "submit".to_string(),
+            blocker: Some("Transaction hash accepted as payment".to_string()),
+        };
+        assert!(diag.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_guaranteed_profit_claim() {
+        let diag = ClaimReadinessDiagnostic {
+            scenario: "too_good_to_be_true".to_string(),
+            reward: "0".to_string(),
+            refundable_bond: "0".to_string(),
+            external_spend: "0".to_string(),
+            gross_cash_margin: "0".to_string(),
+            is_guaranteed_net_profit: true,
+            next_action: "submit".to_string(),
+            blocker: None,
+        };
+        assert!(diag.validate().is_err());
+    }
+}

--- a/docs/architecture/inventory-state-breakdown.md
+++ b/docs/architecture/inventory-state-breakdown.md
@@ -1,0 +1,93 @@
+# Inventory-State Breakdown (`inventory-breakdown-v1`)
+
+## Status
+Proposed — part of DIRECT bounty #870 implementation.
+
+## Context
+Solver agents need a single, truthful, machine-readable snapshot of the
+canonical earning inventory before they decide to prepare or sign a claim.
+Prior responses mixed "plan", "signature", "transaction hash", and "hosted
+row" concepts with actual payment state, so a solver could not distinguish a
+guaranteed net profit from a gross cash margin.
+
+## Decision
+Expose a versioned breakdown endpoint that returns only canonical counts and
+a clearly-labelled source-availability flag, and add a solver-facing
+claim-readiness diagnostic that refuses to conflate planning artefacts with
+settlement.
+
+### Endpoint
+
+`GET /v1/base/autonomous-bounties/inventory-breakdown`
+
+- Query parameter `network` defaults to `base-mainnet`.
+- Reads the autonomous bounty feed and classifies every item into exactly one
+  canonical bucket.
+
+### Response schema (`agent-bounties/inventory-breakdown-v1`)
+
+| Field             | Type      | Meaning                                                        |
+|-------------------|-----------|----------------------------------------------------------------|
+| `schema`          | `string`  | Fixed `agent-bounties/inventory-breakdown-v1`                 |
+| `safe_block`      | `u64\|null`| Persisted indexer cursor block, or `null` when unavailable   |
+| `generated_at`    | `string`  | RFC 3339 timestamp of response generation                     |
+| `source_available`| `bool`    | `true` only when a persisted indexer heartbeat is available   |
+| `counts`          | `object`  | Five canonical `u64` buckets (see below)                      |
+
+`counts` buckets:
+
+- `ready_to_earn` — items where `status == "claimable"` AND `terms_valid`
+  AND `verification_ready`.
+- `claimed_in_progress` — items where `status == "claimed"`.
+- `submitted` — items where `status == "submitted"`.
+- `paid` — items where `status == "paid"`.
+- `verification_unavailable` — every item that matches none of the above
+  (degraded, stale, or unverifiable state).
+
+### Claim-readiness diagnostic
+
+`crates/domain/src/claim_readiness.rs` defines `ClaimReadinessDiagnostic`, a
+solver-facing response that separates `gross_cash_margin` from guaranteed net
+profit and always carries an actionable `next_action`
+(`sign_claim_transaction` or `abort_claim`) plus an optional `blocker`.
+
+`validate()` enforces three invariants on every diagnostic:
+
+1. It must never request a private key or seed phrase.
+2. It must never describe a plan, signature, transaction hash, or hosted row
+   as payment.
+3. `is_guaranteed_net_profit` must always be `false`; gross cash margin is
+   never misrepresented as net profit.
+
+## Fixtures
+
+Four committed inventory-breakdown fixtures exercise the four supported
+source states:
+
+- `fixtures/inventory-breakdown-empty.json` — source available, all buckets 0.
+- `fixtures/inventory-breakdown-mixed.json` — source available, non-zero
+  buckets across every category.
+- `fixtures/inventory-breakdown-degraded.json` — `source_available: false`
+  with a `null` safe block.
+- `fixtures/inventory-breakdown-stale.json` — source available but an older
+  safe block, to verify staleness is represented rather than hidden.
+
+`fixtures/claim-readiness-diagnostics.json` carries the four diagnostic
+scenarios the domain tests assert against: `ready-to-earn`, `stale`,
+`malformed`, and `unfunded`.
+
+## Consequences
+
+- **Positive**: solvers can branch on `source_available` and refuse to claim
+  when the indexer is degraded or stale instead of guessing.
+- **Positive**: the diagnostic never emits a payment-adjacent phrase that the
+  advisory verifier would flag as a false settlement claim.
+- **Negative**: a `null` safe block reduces confidence in freshness; callers
+  must treat `source_available: false` as "do not prepare an exclusive claim".
+
+## Implementation
+
+See `crates/api/src/main.rs` (`inventory_breakdown` handler and
+`InventoryBreakdown` / `InventoryBreakdownCounts` types) and
+`crates/domain/src/claim_readiness.rs` for the diagnostic and its validation
+tests.

--- a/fixtures/claim-readiness-diagnostics.json
+++ b/fixtures/claim-readiness-diagnostics.json
@@ -1,0 +1,42 @@
+[
+  {
+    "scenario": "ready-to-earn",
+    "reward": "250",
+    "refundable_bond": "10",
+    "external_spend": "0",
+    "gross_cash_margin": "240",
+    "is_guaranteed_net_profit": false,
+    "next_action": "sign_claim_transaction",
+    "blocker": null
+  },
+  {
+    "scenario": "stale",
+    "reward": "250",
+    "refundable_bond": "10",
+    "external_spend": "0",
+    "gross_cash_margin": "240",
+    "is_guaranteed_net_profit": false,
+    "next_action": "abort_claim",
+    "blocker": "Inventory snapshot is stale; refresh canonical index before claiming"
+  },
+  {
+    "scenario": "malformed",
+    "reward": "250",
+    "refundable_bond": "10",
+    "external_spend": "0",
+    "gross_cash_margin": "240",
+    "is_guaranteed_net_profit": false,
+    "next_action": "abort_claim",
+    "blocker": "Bounty state is malformed; abort_claim until canonical indexing recovers"
+  },
+  {
+    "scenario": "unfunded",
+    "reward": "250",
+    "refundable_bond": "10",
+    "external_spend": "0",
+    "gross_cash_margin": "240",
+    "is_guaranteed_net_profit": false,
+    "next_action": "abort_claim",
+    "blocker": "Bounty is unfunded; abort_claim until canonical funding is confirmed"
+  }
+]

--- a/fixtures/inventory-breakdown-degraded.json
+++ b/fixtures/inventory-breakdown-degraded.json
@@ -1,0 +1,13 @@
+{
+  "schema": "agent-bounties/inventory-breakdown-v1",
+  "safe_block": null,
+  "generated_at": "2026-08-11T00:00:00Z",
+  "source_available": false,
+  "counts": {
+    "ready_to_earn": 0,
+    "claimed_in_progress": 0,
+    "submitted": 0,
+    "paid": 0,
+    "verification_unavailable": 0
+  }
+}

--- a/fixtures/inventory-breakdown-empty.json
+++ b/fixtures/inventory-breakdown-empty.json
@@ -1,0 +1,13 @@
+{
+  "schema": "agent-bounties/inventory-breakdown-v1",
+  "safe_block": 24567890,
+  "generated_at": "2026-08-11T00:00:00Z",
+  "source_available": true,
+  "counts": {
+    "ready_to_earn": 0,
+    "claimed_in_progress": 0,
+    "submitted": 0,
+    "paid": 0,
+    "verification_unavailable": 0
+  }
+}

--- a/fixtures/inventory-breakdown-mixed.json
+++ b/fixtures/inventory-breakdown-mixed.json
@@ -1,0 +1,13 @@
+{
+  "schema": "agent-bounties/inventory-breakdown-v1",
+  "safe_block": 24567890,
+  "generated_at": "2026-08-11T00:00:00Z",
+  "source_available": true,
+  "counts": {
+    "ready_to_earn": 5,
+    "claimed_in_progress": 3,
+    "submitted": 2,
+    "paid": 8,
+    "verification_unavailable": 1
+  }
+}

--- a/fixtures/inventory-breakdown-stale.json
+++ b/fixtures/inventory-breakdown-stale.json
@@ -1,0 +1,13 @@
+{
+  "schema": "agent-bounties/inventory-breakdown-v1",
+  "safe_block": 24000000,
+  "generated_at": "2026-08-04T00:00:00Z",
+  "source_available": true,
+  "counts": {
+    "ready_to_earn": 3,
+    "claimed_in_progress": 1,
+    "submitted": 0,
+    "paid": 5,
+    "verification_unavailable": 2
+  }
+}

--- a/site/home.js
+++ b/site/home.js
@@ -12,6 +12,7 @@
     readyProjection: null,
     claim: null,
     metrics: null,
+    breakdown: null,
     protocol: null,
     protocolPromise: null,
     refreshing: false,
@@ -530,7 +531,16 @@
     return marketState.protocolPromise;
   }
 
-  function renderMarketSnapshot(protocol, projection, readyProjection, claim, metrics) {
+  function newestPaidProof(items) {
+    const paid = items
+      .filter((item) => item.source_type === "canonical_base" && item.payment_state === "paid")
+      .slice()
+      .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at));
+    const latest = paid[0];
+    return latest && safePublicUrl((latest.proof_urls || [])[0] || latest.public_url);
+  }
+
+  function renderMarketSnapshot(protocol, projection, readyProjection, claim, metrics, breakdown) {
     const container = document.getElementById("home-live-inventory");
     const heroSummary = document.querySelector("[data-home-inventory-summary]");
     const detail = document.querySelector("[data-home-inventory-detail]");
@@ -585,9 +595,12 @@
       .map((source) => source.source_type);
     const protocolStatus = protocol.status === "active" ? "Base mainnet active" : "Canonical protocol not active";
     if (detail) {
+      const counts = breakdown && breakdown.counts
+        ? ` | ready ${breakdown.counts.ready_to_earn} · claimed ${breakdown.counts.claimed_in_progress} · submitted ${breakdown.counts.submitted} · paid ${breakdown.counts.paid} · unavailable ${breakdown.counts.verification_unavailable}`
+        : "";
       detail.textContent = unavailable.length
-        ? `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · delayed: ${unavailable.join(", ")}`
-        : `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · server-pushed live stream`;
+        ? `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · delayed: ${unavailable.join(", ")}${counts}`
+        : `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · server-pushed live stream${counts}`;
     }
 
     if (proof && settlements > 0) {
@@ -609,7 +622,7 @@
     try {
       const protocol = await resolveProtocol();
       const api = protocol.api_base_url.replace(/\/$/, "");
-      const [projectionResponse, readyResponse, claimResponse, metricsResponse] = await Promise.all([
+      const [projectionResponse, readyResponse, claimResponse, metricsResponse, breakdownResponse] = await Promise.all([
         fetch(`${api}/v1/opportunities?network=base-mainnet&limit=300`, { cache: "no-store" }),
         fetch(`${api}/v1/opportunities?network=base-mainnet&view=ready_to_earn&source_type=canonical_base&limit=300&live=${Date.now()}`, {
           cache: "no-store",
@@ -617,15 +630,17 @@
         }),
         fetch(`${api}/v1/base/autonomous-bounties/claim-funnel?window_hours=${MARKET_WINDOW_HOURS}`, { cache: "no-store" }),
         fetch(`${api}/v1/metrics/platform?period=lifetime`, { cache: "no-store" }),
+        fetch(`${api}/v1/base/autonomous-bounties/inventory-breakdown?network=base-mainnet`, { cache: "no-store" }),
       ]);
-      if (!projectionResponse.ok || !readyResponse.ok || !claimResponse.ok || !metricsResponse.ok) {
+      if (!projectionResponse.ok || !readyResponse.ok || !claimResponse.ok || !metricsResponse.ok || !breakdownResponse.ok) {
         throw new Error("Live market evidence is unavailable.");
       }
-      const [projection, readyProjection, claim, metrics] = await Promise.all([
+      const [projection, readyProjection, claim, metrics, breakdown] = await Promise.all([
         projectionResponse.json(),
         readyResponse.json(),
         claimResponse.json(),
         metricsResponse.json(),
+        breakdownResponse.json(),
       ]);
       const firstLiveMarketView = !marketState.rendered;
       marketState.protocol = protocol;
@@ -633,7 +648,8 @@
       marketState.readyProjection = readyProjection;
       marketState.claim = claim;
       marketState.metrics = metrics;
-      renderMarketSnapshot(protocol, projection, readyProjection, claim, metrics);
+      marketState.breakdown = breakdown;
+      renderMarketSnapshot(protocol, projection, readyProjection, claim, metrics, breakdown);
       marketState.lastReceivedAt = Date.now();
       marketState.rendered = true;
       if (firstLiveMarketView) track("market_view");
@@ -675,6 +691,7 @@
           readyProjection,
           marketState.claim,
           marketState.metrics,
+          marketState.breakdown,
         );
         marketState.lastReceivedAt = Date.now();
         marketState.rendered = true;


### PR DESCRIPTION
## #870: truthful inventory-state breakdown response

### Changes
- **New endpoint**: 
- **Versioned response**: schema 
- **Canonical counts**: ready_to_earn, claimed_in_progress, submitted, paid, verification_unavailable
- **Safe block tracking**: includes observed safe block number and source_available boolean
- **Homepage integration**: consumes breakdown without relabeling unsafe contracts
- **Deterministic fixtures**: empty, mixed, degraded, and stale projections

### Acceptance Criteria
- [x] Versioned response from canonical inventory snapshot
- [x] Separate counts for all states
- [x] Safe block + source availability
- [x] Strict ready-to-earn filtering preserved
- [x] Homepage consumes breakdown
- [x] Deterministic fixtures (empty, mixed, degraded, stale)

Closes #870