### PR TITLE
feat(#869): retry-safe Base RPC failover with chain-id validation

### DIFF
--- a/scripts/_shared/rpc.py
+++ b/scripts/_shared/rpc.py
@@ -1,14 +1,44 @@
-"""JSON-RPC transport shared by local fork rehearsal scripts."""
+"""JSON-RPC transport with retry-safe Base RPC failover and chain-id validation."""
 
 from __future__ import annotations
 
 import json
-from typing import Any
+import time
+from typing import Any, Sequence
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
+# Ordered Base mainnet HTTPS endpoints
+BASE_RPC_ENDPOINTS: Sequence[str] = (
+    "https://mainnet.base.org",
+    "https://base.llamarpc.com",
+    "https://base-rpc.publicnode.com",
+    "https://1rpc.io/base",
+    "https://base.drpc.org",
+)
 
-def rpc(url: str, method: str, params: list[Any], request_id: int = 1) -> Any:
+BASE_CHAIN_ID = 8453
+MAX_RETRIES = 3
+INITIAL_BACKOFF_SECONDS = 1.0
+
+
+def _backoff(attempt: int) -> float:
+    """Deterministic backoff: 1s, 2s, 4s."""
+    return INITIAL_BACKOFF_SECONDS * (2 ** (attempt - 1))
+
+
+def _retryable_status(code: int) -> bool:
+    """HTTP 429 (rate-limit) and 5xx are retryable."""
+    return code == 429 or 500 <= code < 600
+
+
+def rpc(
+    url: str,
+    method: str,
+    params: list[Any],
+    request_id: int = 1,
+) -> Any:
+    """Single-endpoint JSON-RPC call (preserved for backward compat)."""
     payload = json.dumps(
         {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
     ).encode("utf-8")
@@ -19,5 +49,101 @@ def rpc(url: str, method: str, params: list[Any], request_id: int = 1) -> Any:
     except URLError as error:
         raise RuntimeError(f"RPC transport failed for {method}: {error}") from error
     if body.get("error"):
-        raise RuntimeError(f"RPC {method} failed: {json.dumps(body['error'], sort_keys=True)}")
+        raise RuntimeError(
+            f"RPC {method} failed: {json.dumps(body['error'], sort_keys=True)}"
+        )
+    return body.get("result")
+
+
+def rpc_failover(
+    method: str,
+    params: list[Any],
+    request_id: int = 1,
+    endpoints: Sequence[str] | None = None,
+    max_retries: int = MAX_RETRIES,
+) -> Any:
+    """JSON-RPC call with ordered HTTPS endpoint failover and retry.
+
+    Validates Base chain ID 8453 before reads. Retries only bounded
+    transport errors, HTTP 429, and HTTP 5xx with deterministic backoff.
+    Preserves JSON-RPC execution errors and never exposes credentials.
+    """
+    if endpoints is None:
+        endpoints = BASE_RPC_ENDPOINTS
+
+    last_error: Exception | None = None
+
+    for endpoint in endpoints:
+        chain_id = _validate_chain(endpoint)
+        if chain_id is None:
+            continue  # skip endpoints that don't validate
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                return _rpc_call(endpoint, method, params, request_id)
+            except _TransportError as e:
+                last_error = e
+                if e.retryable:
+                    if attempt < max_retries:
+                        time.sleep(_backoff(attempt))
+                        continue
+                break  # non-retryable or exhausted retries for this endpoint
+            except _RpcError:
+                raise  # JSON-RPC execution errors: do NOT retry
+
+    raise RuntimeError(
+        f"RPC failover exhausted for {method} across {len(endpoints)} endpoints"
+    ) from last_error
+
+
+class _TransportError(Exception):
+    def __init__(self, message: str, retryable: bool = True):
+        super().__init__(message)
+        self.retryable = retryable
+
+
+class _RpcError(Exception):
+    pass
+
+
+def _validate_chain(endpoint: str) -> int | None:
+    """Call eth_chainId and verify Base chain ID 8453. Returns chain_id or None."""
+    try:
+        result = _rpc_call(endpoint, "eth_chainId", [], 1)
+        chain_id = int(result, 16) if isinstance(result, str) else result
+        if chain_id == BASE_CHAIN_ID:
+            return chain_id
+    except Exception:
+        pass
+    return None
+
+
+def _rpc_call(endpoint: str, method: str, params: list[Any], request_id: int) -> Any:
+    """Low-level call: transport errors become _TransportError, RPC errors become _RpcError."""
+    payload = json.dumps(
+        {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+    ).encode("utf-8")
+    request = Request(
+        endpoint, data=payload, headers={"content-type": "application/json"}
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            status = response.getcode()
+            body = json.load(response)
+    except URLError as error:
+        raise _TransportError(
+            f"RPC transport failed for {method}: {error}", retryable=True
+        ) from error
+
+    # HTTP status check before parsing RPC result
+    if _retryable_status(status):
+        raise _TransportError(
+            f"HTTP {status} from {endpoint}", retryable=True
+        )
+
+    if body.get("error"):
+        raise _RpcError(
+            f"RPC {method} failed: {json.dumps(body['error'], sort_keys=True)}"
+        )
+
     return body.get("result")

--- a/scripts/test_shared_rpc.py
+++ b/scripts/test_shared_rpc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Characterization tests for the shared JSON-RPC transport."""
+"""Characterization tests for retry-safe Base RPC failover transport."""
 
 from __future__ import annotations
 
@@ -8,29 +8,170 @@ import unittest
 from unittest.mock import patch
 from urllib.error import URLError
 
-from _shared.rpc import rpc
+from _shared.rpc import (
+    rpc,
+    rpc_failover,
+    _TransportError,
+    _RpcError,
+    _validate_chain,
+    BASE_CHAIN_ID,
+    BASE_RPC_ENDPOINTS,
+)
 
 
 class RpcTest(unittest.TestCase):
     def test_result_and_rpc_error_contracts(self) -> None:
         for body, expected, message in (
             (b'{"result":"0x2105"}', "0x2105", None),
-            (b'{"error":{"code":-1,"message":"bad"}}', None, 'RPC eth_chainId failed: {"code": -1, "message": "bad"}'),
-            (b'{}', None, None),
+            (
+                b'{"error":{"code":-1,"message":"bad"}}',
+                None,
+                'RPC eth_chainId failed: {"code": -1, "message": "bad"}',
+            ),
+            (b"{}", None, None),
         ):
-            with self.subTest(body=body), patch("_shared.rpc.urlopen", return_value=io.BytesIO(body)):
+            with self.subTest(body=body), patch(
+                "_shared.rpc.urlopen", return_value=io.BytesIO(body)
+            ):
                 if message:
                     with self.assertRaises(RuntimeError) as raised:
                         rpc("http://localhost", "eth_chainId", [], 7)
                     self.assertEqual(str(raised.exception), message)
                 else:
-                    self.assertEqual(rpc("http://localhost", "eth_chainId", [], 7), expected)
+                    self.assertEqual(
+                        rpc("http://localhost", "eth_chainId", [], 7), expected
+                    )
 
     def test_transport_error_contract(self) -> None:
-        with patch("_shared.rpc.urlopen", side_effect=URLError("offline")), self.assertRaisesRegex(
+        with patch(
+            "_shared.rpc.urlopen", side_effect=URLError("offline")
+        ), self.assertRaisesRegex(
             RuntimeError, "^RPC transport failed for eth_call:"
         ):
             rpc("http://localhost", "eth_call", [])
+
+    # ── RPC failover tests ──
+
+    def test_chain_validation_accepts_8453(self) -> None:
+        """eth_chainId returns 0x2105 (8453) → validation passes."""
+        with patch(
+            "_shared.rpc.urlopen",
+            return_value=io.BytesIO(b'{"result":"0x2105"}'),
+        ):
+            chain_id = _validate_chain("https://mainnet.base.org")
+        self.assertEqual(chain_id, 8453)
+
+    def test_chain_validation_rejects_wrong_chain(self) -> None:
+        """eth_chainId returns 0x1 (Ethereum mainnet) → validation fails (wrong chain)."""
+        with patch(
+            "_shared.rpc.urlopen",
+            return_value=io.BytesIO(b'{"result":"0x1"}'),
+        ):
+            chain_id = _validate_chain("https://wrong.chain")
+        self.assertIsNone(chain_id)
+
+    def test_chain_validation_transport_failure_returns_none(self) -> None:
+        """Transport error during chain validation → skip endpoint."""
+        with patch("_shared.rpc.urlopen", side_effect=URLError("offline")):
+            chain_id = _validate_chain("https://dead.endpoint")
+        self.assertIsNone(chain_id)
+
+    def test_rpc_error_not_retried(self) -> None:
+        """JSON-RPC execution errors are NOT retried — they propagate immediately."""
+        call_count = [0]
+
+        def mock_open(*args, **kwargs):
+            call_count[0] += 1
+            return io.BytesIO(
+                b'{"error":{"code":-32000,"message":"execution reverted"}}'
+            )
+
+        with patch("_shared.rpc.urlopen", side_effect=mock_open):
+            with self.assertRaises(_RpcError):
+                rpc_failover("eth_call", [{"to": "0x00"}], endpoints=["https://base.local"])
+        # Only 1 call — RPC errors are never retried
+        self.assertEqual(call_count[0], 1)
+
+    def test_http_429_retried_then_exhaust(self) -> None:
+        """HTTP 429 is retried, then exhaust after max_retries."""
+        call_count = [0]
+
+        class MockResponse:
+            def getcode(self):
+                return 429
+
+            def read(self):
+                return b"{}"
+
+            def close(self):
+                pass
+
+        with patch("_shared.rpc.urlopen", side_effect=lambda *a, **kw: MockResponse()):
+            with self.assertRaises(RuntimeError) as ctx:
+                rpc_failover(
+                    "eth_chainId",
+                    [],
+                    endpoints=["https://base.local"],
+                    max_retries=3,
+                )
+        self.assertIn("RPC failover exhausted", str(ctx.exception))
+
+    def test_http_500_retried_and_recovered(self) -> None:
+        """HTTP 500 on attempt 1 → retry → gets valid chain ID on attempt 2."""
+        call_count = [0]
+
+        def mock_fn(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # 500 error
+                resp = type("Resp", (), {
+                    "getcode": lambda s: 500,
+                    "read": lambda s: b"{}",
+                    "close": lambda s: None,
+                })()
+                return resp
+            else:
+                # Recover: valid chain ID
+                return io.BytesIO(b'{"result":"0x2105"}')
+
+        with patch("_shared.rpc.urlopen", side_effect=mock_fn), patch(
+            "_shared.rpc.time.sleep"
+        ):
+            result = rpc_failover(
+                "eth_blockNumber",
+                [],
+                endpoints=["https://base.local"],
+                max_retries=3,
+            )
+        self.assertEqual(result, "0x2105")
+
+    def test_https_endpoints_used(self) -> None:
+        """All configured endpoints use HTTPS scheme."""
+        for endpoint in BASE_RPC_ENDPOINTS:
+            self.assertTrue(
+                endpoint.startswith("https://"),
+                f"Endpoint {endpoint} must use HTTPS",
+            )
+
+    def test_failover_skips_invalid_chain(self) -> None:
+        """If first endpoint is wrong chain, failover tries next endpoint."""
+        call_order = []
+
+        def mock_fn(req, **kwargs):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            call_order.append(url)
+            if "wrong" in url:
+                return io.BytesIO(b'{"result":"0x1"}')  # wrong chain
+            return io.BytesIO(b'{"result":"0x2105"}')  # correct chain
+
+        with patch("_shared.rpc.urlopen", side_effect=mock_fn):
+            result = rpc_failover(
+                "eth_blockNumber",
+                [],
+                endpoints=["https://wrong.chain", "https://base.local"],
+                max_retries=1,
+            )
+        self.assertEqual(result, "0x2105")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #869