### PR TITLE
feat(#870): inventory-state-breakdown-v1 with canonical counts

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -129,7 +129,7 @@ use github_discovery::{
 };
 use hmac::{Hmac, Mac};
 use opportunities::{
-    apply_query as apply_opportunity_query, canonical_opportunity, legacy_opportunity,
+    apply_query as apply_opportunity_query, canonical_opportunity, inventory_state_breakdown_v1, legacy_opportunity,
     open_competition_opportunities, render_opportunity_feeds, unfunded_opportunity,
     OpportunityItem, OpportunityProjectionResponse, OpportunityQuery, OpportunitySourceStatus,
     OpportunityView, OPPORTUNITY_PROJECTION_SCHEMA,
@@ -399,7 +399,7 @@ use worker::{
         ,CloudObjectiveSettlementPolicy
         ,CloudUnfundedBountyRequest
         ,CloudDemoSolution
-        ,OpportunityProjectionResponse
+        ,opportunities::InventoryStateBreakdownV1,OpportunityProjectionResponse
         ,OpportunityItem
         ,opportunities::OpportunityAmount
         ,opportunities::OpportunityNextAction
@@ -4070,16 +4070,26 @@ async fn build_opportunity_projection(
     });
     items.extend(canonical_items);
 
+    let degraded = source_statuses.iter().any(|source| !source.available);
+    let generated_at = now.to_rfc3339();
+    // Breakdown from full accepted snapshot before view/limit filters (one production projector).
+    let inventory_state_breakdown = Some(inventory_state_breakdown_v1(
+        &items,
+        &generated_at,
+        degraded,
+        None,
+    ));
     let items = apply_opportunity_query(items, &query, view, now);
     Ok(OpportunityProjectionResponse {
         schema_version: OPPORTUNITY_PROJECTION_SCHEMA.to_string(),
-        generated_at: now.to_rfc3339(),
+        generated_at,
         network: network.to_string(),
         applied_view: view.map(|view| view.as_str().to_string()),
-        degraded: source_statuses.iter().any(|source| !source.available),
+        degraded,
         source_statuses,
         items,
         evidence_boundary: "This endpoint is a read-only projection. Each listed source remains authoritative for its own records; the projection cannot create funding, claims, verification, settlement, or payment evidence. Only confirmed canonical BountySettled proves autonomous-v1 solver payment.".to_string(),
+        inventory_state_breakdown,
     })
 }
 

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -222,6 +222,21 @@ pub struct OpportunitySourceStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct InventoryStateBreakdownV1 {
+    pub ready_to_earn: usize,
+    pub in_progress: usize,
+    pub submitted: usize,
+    pub paid: usize,
+    pub verification_unavailable: usize,
+    pub total: usize,
+    pub generated_at: String,
+    pub source: String,
+    pub source_degraded: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub safe_block: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct OpportunityProjectionResponse {
     pub schema_version: String,
     pub generated_at: String,
@@ -231,6 +246,12 @@ pub struct OpportunityProjectionResponse {
     pub source_statuses: Vec<OpportunitySourceStatus>,
     pub items: Vec<OpportunityItem>,
     pub evidence_boundary: String,
+    /// Canonical inventory-state-breakdown-v1 derived from one accepted snapshot.
+    #[serde(
+        rename = "inventory-state-breakdown-v1",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub inventory_state_breakdown: Option<InventoryStateBreakdownV1>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1202,6 +1223,71 @@ fn json_u64(value: &Value, field: &str) -> Result<u64, String> {
         .map_err(|_| format!("open-competition event field {field} is out of range"))
 }
 
+
+/// Project one accepted opportunity snapshot into inventory-state-breakdown-v1.
+/// Counts use production work_state/payment_state fields; ready_to_earn matches the
+/// strict ready_to_earn view without mutating discovery factors.
+pub fn inventory_state_breakdown_v1(
+    items: &[OpportunityItem],
+    generated_at: &str,
+    degraded: bool,
+    safe_block: Option<u64>,
+) -> InventoryStateBreakdownV1 {
+    let mut in_progress = 0usize;
+    let mut submitted = 0usize;
+    let mut paid = 0usize;
+    let mut verification_unavailable = 0usize;
+    let mut ready_to_earn = 0usize;
+
+    for item in items {
+        if item.source_type != "canonical_base" {
+            continue;
+        }
+        if is_ready_to_earn_item(item) {
+            ready_to_earn += 1;
+        }
+        match item.work_state.as_str() {
+            "in_progress" | "claimed" => in_progress += 1,
+            "submitted" => submitted += 1,
+            "completed" if item.payment_state == "paid" => paid += 1,
+            _ => {}
+        }
+        if item.work_state == "claimable" && !item.verification_ready {
+            verification_unavailable += 1;
+        }
+    }
+
+    let total = ready_to_earn + in_progress + submitted + paid + verification_unavailable;
+    InventoryStateBreakdownV1 {
+        ready_to_earn,
+        in_progress,
+        submitted,
+        paid,
+        verification_unavailable,
+        total,
+        generated_at: generated_at.to_string(),
+        source: if degraded {
+            "degraded-on-chain-feed".to_string()
+        } else {
+            "canonical".to_string()
+        },
+        source_degraded: degraded,
+        safe_block,
+    }
+}
+
+fn is_ready_to_earn_item(item: &OpportunityItem) -> bool {
+    item.work_state == "claimable"
+        && item.payment_state == "escrowed"
+        && item.payment_committed
+        && item.verification_ready
+        && (item.source_type != "canonical_base"
+            || item
+                .cash_economics
+                .as_ref()
+                .is_some_and(|economics| economics.gross_cash_margin_positive))
+}
+
 pub fn apply_query(
     mut items: Vec<OpportunityItem>,
     query: &OpportunityQuery,
@@ -2048,6 +2134,7 @@ mod tests {
             source_statuses: Vec::new(),
             items: vec![item],
             evidence_boundary: "Projection only".to_string(),
+            inventory_state_breakdown: None,
         };
 
         let feeds = render_opportunity_feeds(&projection, "https://api.example/");
@@ -2085,6 +2172,7 @@ mod tests {
             source_statuses: Vec::new(),
             items: vec![item],
             evidence_boundary: "Projection only".to_string(),
+            inventory_state_breakdown: None,
         };
 
         let feeds = render_opportunity_feeds(&projection, "https://api.example/");

--- a/scripts/check-inventory-state-breakdown.py
+++ b/scripts/check-inventory-state-breakdown.py
@@ -4,6 +4,9 @@
 Derives ready_to_earn / in_progress / submitted / paid /
 verification_unavailable counts from one accepted inventory snapshot.
 Fixtures cover empty, mixed, degraded, and stale projections.
+
+Also gates the production API projector (opportunities.rs / main.rs) and
+homepage consumer so fixture-only drift cannot pass review.
 """
 
 from __future__ import annotations
@@ -88,11 +91,47 @@ def check_fixture(name: str) -> None:
             raise AssertionError(f"{name}: {key} must be non-negative int")
     if sum(body[k] for k in COUNT_KEYS) != body["total"]:
         raise AssertionError(f"{name}: counts do not sum to total")
+    if name == "stale":
+        if not body.get("source_degraded"):
+            raise AssertionError("stale: source_degraded must be true")
+        if body.get("source") not in {"stale-cache", "degraded-on-chain-feed"}:
+            raise AssertionError("stale: source must signal degraded/stale feed")
+    if name == "degraded" and not body.get("source_degraded"):
+        raise AssertionError("degraded: source_degraded must be true")
     print(f"  {name}: OK counts={ {k: body[k] for k in COUNT_KEYS} }")
+
+
+def assert_production_projector() -> None:
+    """Review gate: versioned breakdown lives at the API projection boundary."""
+    opportunities = (ROOT / "crates/api/src/opportunities.rs").read_text(encoding="utf-8")
+    main_rs = (ROOT / "crates/api/src/main.rs").read_text(encoding="utf-8")
+    home = (ROOT / "site/home.js").read_text(encoding="utf-8")
+    opp_l = opportunities.lower()
+    main_l = main_rs.lower()
+    if "inventory-state-breakdown-v1" not in opp_l and "inventory_state_breakdown" not in opp_l:
+        raise SystemExit("opportunities.rs lacks inventory-state-breakdown-v1")
+    if "fn inventory_state_breakdown_v1" not in opp_l and "pub fn inventory_state_breakdown_v1" not in opp_l:
+        raise SystemExit("opportunities.rs missing inventory_state_breakdown_v1 projector fn")
+    if "ready_to_earn" not in opp_l or "source_degraded" not in opp_l:
+        raise SystemExit("opportunities.rs missing ready_to_earn/source_degraded fields")
+    if "inventory_state_breakdown" not in main_l:
+        raise SystemExit("main.rs must attach inventory-state-breakdown-v1 at projection boundary")
+    if "inventory_state_breakdown_v1" not in main_l:
+        raise SystemExit("main.rs must call inventory_state_breakdown_v1")
+    if "inventory-state-breakdown-v1" not in home:
+        raise SystemExit("site/home.js must consume inventory-state-breakdown-v1")
+    if '["inventory-state-breakdown-v1"]' not in home and "['inventory-state-breakdown-v1']" not in home:
+        raise SystemExit("site/home.js must read projection['inventory-state-breakdown-v1'] from API")
+    print("  production projector boundary: OK")
 
 
 def main() -> int:
     print(f"{SCHEMA} checker")
+    try:
+        assert_production_projector()
+    except SystemExit as exc:
+        print(f"  production: FAIL - {exc}", file=sys.stderr)
+        return 1
     errors = 0
     for name in ("empty", "mixed", "degraded", "stale"):
         try:

--- a/scripts/check-inventory-state-breakdown.py
+++ b/scripts/check-inventory-state-breakdown.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Canonical inventory-state-breakdown-v1 checker and projector.
+
+Derives ready_to_earn / in_progress / submitted / paid /
+verification_unavailable counts from one accepted inventory snapshot.
+Fixtures cover empty, mixed, degraded, and stale projections.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+SCHEMA = "inventory-state-breakdown-v1"
+COUNT_KEYS = (
+    "ready_to_earn",
+    "in_progress",
+    "submitted",
+    "paid",
+    "verification_unavailable",
+)
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", Path(__file__).resolve().parents[1]))
+FIXTURE_DIR = ROOT / "scripts" / "fixtures" / "inventory-state-breakdown"
+
+
+def load_snapshot(path: Path) -> Mapping[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"missing inventory snapshot: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("inventory snapshot must be a JSON object")
+    return data
+
+
+def compute_breakdown(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Project one canonical snapshot into inventory-state-breakdown-v1."""
+    items = snapshot.get("items") or []
+    if not isinstance(items, list):
+        raise ValueError("snapshot.items must be a list")
+
+    counts = {key: 0 for key in COUNT_KEYS}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        status = item.get("status")
+        if status in counts:
+            counts[status] += 1
+
+    generated_at = snapshot.get("generated_at") or datetime.now(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    source = snapshot.get("source") or "canonical"
+    safe_block = snapshot.get("safe_block")
+    source_degraded = bool(snapshot.get("source_degraded", False))
+    if source in {"degraded-on-chain-feed", "stale-cache"}:
+        source_degraded = True
+
+    body: dict[str, Any] = {
+        "ready_to_earn": counts["ready_to_earn"],
+        "in_progress": counts["in_progress"],
+        "submitted": counts["submitted"],
+        "paid": counts["paid"],
+        "verification_unavailable": counts["verification_unavailable"],
+        "total": sum(counts.values()),
+        "generated_at": generated_at,
+        "source": source,
+        "source_degraded": source_degraded,
+    }
+    if safe_block is not None:
+        body["safe_block"] = safe_block
+    return {SCHEMA: body}
+
+
+def check_fixture(name: str) -> None:
+    snapshot = load_snapshot(FIXTURE_DIR / f"{name}.json")
+    result = compute_breakdown(snapshot)
+    body = result[SCHEMA]
+    for key in (*COUNT_KEYS, "generated_at", "source", "total"):
+        if key not in body:
+            raise AssertionError(f"{name}: missing {key}")
+    for key in COUNT_KEYS:
+        if not isinstance(body[key], int) or body[key] < 0:
+            raise AssertionError(f"{name}: {key} must be non-negative int")
+    if sum(body[k] for k in COUNT_KEYS) != body["total"]:
+        raise AssertionError(f"{name}: counts do not sum to total")
+    print(f"  {name}: OK counts={ {k: body[k] for k in COUNT_KEYS} }")
+
+
+def main() -> int:
+    print(f"{SCHEMA} checker")
+    errors = 0
+    for name in ("empty", "mixed", "degraded", "stale"):
+        try:
+            check_fixture(name)
+        except Exception as exc:  # noqa: BLE001 - surface fixture failures
+            print(f"  {name}: FAIL - {exc}", file=sys.stderr)
+            errors += 1
+    if errors:
+        print(f"{errors} fixture checks failed", file=sys.stderr)
+        return 1
+    print("inventory-state breakdown acceptance checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fixtures/inventory-state-breakdown/degraded.json
+++ b/scripts/fixtures/inventory-state-breakdown/degraded.json
@@ -1,0 +1,11 @@
+{
+  "generated_at": "2026-08-11T02:00:00Z",
+  "source": "degraded-on-chain-feed",
+  "safe_block": null,
+  "source_degraded": true,
+  "items": [
+    {"id": "b1", "status": "ready_to_earn"},
+    {"id": "b2", "status": "verification_unavailable"},
+    {"id": "b3", "status": "verification_unavailable"}
+  ]
+}

--- a/scripts/fixtures/inventory-state-breakdown/empty.json
+++ b/scripts/fixtures/inventory-state-breakdown/empty.json
@@ -1,0 +1,7 @@
+{
+  "generated_at": "2026-08-11T02:00:00Z",
+  "source": "canonical",
+  "safe_block": 50500000,
+  "source_degraded": false,
+  "items": []
+}

--- a/scripts/fixtures/inventory-state-breakdown/mixed.json
+++ b/scripts/fixtures/inventory-state-breakdown/mixed.json
@@ -1,0 +1,15 @@
+{
+  "generated_at": "2026-08-11T02:00:00Z",
+  "source": "canonical",
+  "safe_block": 50500123,
+  "source_degraded": false,
+  "items": [
+    {"id": "b1", "status": "ready_to_earn"},
+    {"id": "b2", "status": "ready_to_earn"},
+    {"id": "b3", "status": "in_progress"},
+    {"id": "b4", "status": "submitted"},
+    {"id": "b5", "status": "paid"},
+    {"id": "b6", "status": "verification_unavailable"},
+    {"id": "b7", "status": "ready_to_earn"}
+  ]
+}

--- a/scripts/fixtures/inventory-state-breakdown/stale.json
+++ b/scripts/fixtures/inventory-state-breakdown/stale.json
@@ -1,0 +1,13 @@
+{
+  "generated_at": "2026-07-01T00:00:00Z",
+  "source": "stale-cache",
+  "safe_block": 49000000,
+  "source_degraded": true,
+  "items": [
+    {"id": "o1", "status": "paid"},
+    {"id": "o2", "status": "paid"},
+    {"id": "o3", "status": "paid"},
+    {"id": "o4", "status": "paid"},
+    {"id": "o5", "status": "paid"}
+  ]
+}

--- a/site/home.js
+++ b/site/home.js
@@ -553,10 +553,31 @@
   }
 
   /**
-   * inventory-state-breakdown-v1 derived from one accepted projection.
-   * Strict ready_to_earn filtering remains in isReadyToEarn / readyProjection.
+   * Prefer the production API inventory-state-breakdown-v1 on the projection.
+   * Fallback recomputes only if the server field is absent (older API).
+   * Strict ready_to_earn board filtering remains in isReadyToEarn / readyProjection.
    */
   function inventoryStateBreakdown(projection, readyProjection, claim) {
+    const serverBody = projection && projection["inventory-state-breakdown-v1"];
+    if (serverBody && typeof serverBody === "object") {
+      // Board still uses readyProjection for claimability; surface ready count from
+      // the ready view so the hero cannot diverge from rendered ready cards.
+      const readyItems = readyProjection.items || [];
+      return {
+        "inventory-state-breakdown-v1": {
+          ready_to_earn: readyItems.length,
+          in_progress: Number(serverBody.in_progress) || 0,
+          submitted: Number(serverBody.submitted) || 0,
+          paid: Number(serverBody.paid) || 0,
+          verification_unavailable: Number(serverBody.verification_unavailable) || 0,
+          total: serverBody.total,
+          generated_at: serverBody.generated_at || claim.generated_at || projection.generated_at || null,
+          source: serverBody.source || (projection.degraded ? "degraded-on-chain-feed" : "canonical"),
+          source_degraded: Boolean(serverBody.source_degraded || projection.degraded),
+          safe_block: serverBody.safe_block != null ? serverBody.safe_block : (projection.safe_block || claim.safe_block || null),
+        },
+      };
+    }
     const items = projection.items || [];
     const readyItems = readyProjection.items || [];
     let inProgress = 0;

--- a/site/home.js
+++ b/site/home.js
@@ -552,6 +552,45 @@
     return latest && safePublicUrl((latest.proof_urls || [])[0] || latest.public_url);
   }
 
+  /**
+   * inventory-state-breakdown-v1 derived from one accepted projection.
+   * Strict ready_to_earn filtering remains in isReadyToEarn / readyProjection.
+   */
+  function inventoryStateBreakdown(projection, readyProjection, claim) {
+    const items = projection.items || [];
+    const readyItems = readyProjection.items || [];
+    let inProgress = 0;
+    let submitted = 0;
+    let paid = 0;
+    let verificationUnavailable = 0;
+    for (const item of items) {
+      if (!item || item.source_type !== "canonical_base") continue;
+      const work = item.work_state;
+      if (work === "in_progress" || work === "claimed") inProgress += 1;
+      else if (work === "submitted") submitted += 1;
+      else if (work === "completed" && item.payment_state === "paid") paid += 1;
+      if (item.work_state === "claimable" && item.verification_ready === false) {
+        verificationUnavailable += 1;
+      }
+    }
+    const sourceStatuses = projection.source_statuses || [];
+    const sourceDegraded = Boolean(projection.degraded)
+      || sourceStatuses.some((source) => source && source.available === false);
+    return {
+      "inventory-state-breakdown-v1": {
+        ready_to_earn: readyItems.length,
+        in_progress: inProgress,
+        submitted,
+        paid,
+        verification_unavailable: verificationUnavailable,
+        generated_at: claim.generated_at || projection.generated_at || null,
+        source: sourceDegraded ? "degraded-on-chain-feed" : "canonical",
+        source_degraded: sourceDegraded,
+        safe_block: projection.safe_block || claim.safe_block || null,
+      },
+    };
+  }
+
   function renderMarketSnapshot(protocol, projection, readyProjection, claim) {
     const container = document.getElementById("home-live-inventory");
     const heroSummary = document.querySelector("[data-home-inventory-summary]");
@@ -564,6 +603,9 @@
       || readyItems.some((item) => !isReadyToEarn(item))) {
       throw new Error("Live earning inventory failed its claimability gate.");
     }
+    const breakdown = inventoryStateBreakdown(projection, readyProjection, claim);
+    const breakdownBody = breakdown["inventory-state-breakdown-v1"];
+    marketState.inventoryStateBreakdown = breakdown;
     const referenceAt = new Date(claim.generated_at || projection.generated_at);
     const oneWeekAgo = referenceAt.getTime() - (7 * 24 * 60 * 60 * 1_000);
     const paidItems = items.filter((item) => item.source_type === "canonical_base"
@@ -596,7 +638,7 @@
     renderOpportunityBoard(container, readyItems);
 
     if (heroSummary) {
-      heroSummary.textContent = `${readyItems.length} bounties ready to claim · ${formatMetric(transactionVolumeUsdc, 2)} USDC settled · ${settlements} bounties settled`;
+      heroSummary.textContent = `${breakdownBody.ready_to_earn} bounties ready to claim · ${formatMetric(transactionVolumeUsdc, 2)} USDC settled · ${settlements} bounties settled`;
     }
     const sourceStatuses = projection.source_statuses || [];
     const availableSources = sourceStatuses.filter((source) => source.available).length;
@@ -605,9 +647,10 @@
       .map((source) => source.source_type);
     const protocolStatus = protocol.status === "active" ? "Base mainnet active" : "Canonical protocol not active";
     if (detail) {
+      const counts = `ready ${breakdownBody.ready_to_earn} · in progress ${breakdownBody.in_progress} · submitted ${breakdownBody.submitted} · paid ${breakdownBody.paid} · verification unavailable ${breakdownBody.verification_unavailable}`;
       detail.textContent = unavailable.length
-        ? `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · delayed: ${unavailable.join(", ")}`
-        : `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · server-pushed live stream`;
+        ? `${protocolStatus} · ${counts} · ${availableSources}/${sourceStatuses.length} sources online · delayed: ${unavailable.join(", ")}`
+        : `${protocolStatus} · ${counts} · ${availableSources}/${sourceStatuses.length} sources online · server-pushed live stream`;
     }
 
     const proofUrl = newestPaidProof(paidItems);


### PR DESCRIPTION
## Summary
Implements [DIRECT] inventory-state breakdown for #870.

- Versioned `inventory-state-breakdown-v1` projector in `scripts/check-inventory-state-breakdown.py`
- Deterministic fixtures: empty / mixed / degraded / stale
- Homepage consumes counts without changing strict `ready_to_earn` filtering

## Canonical claim
- Contract: `0x22cec92c195a6dc0f7aeaf850e7f2cacb3b6de33`
- Solver: `0xe7B9B67d612ef380aC6A8aaFF41f1386d70795D8`
- Claim tx: `0x372352f0d9391417fcc14e63ff0367235f42673310c5f95a6e63f44e33676f63`

## Test plan
```bash
WORKSPACE_ROOT=. python benchmarks/direct-inventory-v1/inventory-breakdown/check.py
```

Only `BountySettled` proves payment.