### PR TITLE
feat(#869): retry-safe Base RPC failover with chain-id validation

### DIFF
--- a/scripts/_shared/rpc.py
+++ b/scripts/_shared/rpc.py
@@ -1,14 +1,75 @@
-"""JSON-RPC transport shared by local fork rehearsal scripts."""
+"""JSON-RPC transport shared by local fork rehearsal scripts, with retry-safe
+Base RPC failover and chain-id validation.
+
+The transport accepts an ordered HTTPS Base endpoint list, validates chain ID
+8453 before using an endpoint, and retries only bounded transport failures,
+HTTP 429, and HTTP 5xx responses with deterministic exponential backoff.
+Confirmed JSON-RPC execution errors are never retried, and endpoint
+credentials are never surfaced in errors.
+"""
 
 from __future__ import annotations
 
 import json
-from typing import Any
-from urllib.error import URLError
+import time
+from typing import Any, Sequence
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+
+# Ordered Base mainnet HTTPS endpoints. Credentials must never appear here.
+BASE_RPC_ENDPOINTS: Sequence[str] = (
+    "https://mainnet.base.org",
+    "https://base.llamarpc.com",
+    "https://base-rpc.publicnode.com",
+    "https://1rpc.io/base",
+    "https://base.drpc.org",
+)
+
+BASE_CHAIN_ID = 8453
+MAX_RETRIES = 3
+INITIAL_BACKOFF_SECONDS = 1.0
+
+
+class TransportError(RuntimeError):
+    """Transport-level failure (network, HTTP 429, or HTTP 5xx).
+
+    ``retryable`` is True for bounded transport failures that may succeed on
+    retry, and False for confirmed non-retryable HTTP errors.
+    """
+
+    def __init__(self, message: str, *, retryable: bool = True) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+class RpcError(RuntimeError):
+    """Confirmed JSON-RPC execution error. Never retried."""
+
+
+def _backoff(attempt: int) -> float:
+    """Deterministic exponential backoff: 1s, 2s, 4s, ..."""
+    return INITIAL_BACKOFF_SECONDS * (2 ** max(attempt - 1, 0))
+
+
+def _retryable_status(code: int) -> bool:
+    """HTTP 429 and 5xx responses are retryable; everything else is not."""
+    return code == 429 or 500 <= code < 600
+
+
+def _redact_endpoint(endpoint: str) -> str:
+    """Strip any credentials an endpoint URL might carry before logging."""
+    if "@" not in endpoint:
+        return endpoint
+    try:
+        scheme, rest = endpoint.split("://", 1)
+        host = rest.split("@", 1)[-1]
+        return f"{scheme}://{host}"
+    except Exception:  # noqa: BLE001 - never crash on malformed endpoints
+        return "<redacted-endpoint>"
 
 
 def rpc(url: str, method: str, params: list[Any], request_id: int = 1) -> Any:
+    """Single-endpoint JSON-RPC call (preserved for backward compatibility)."""
     payload = json.dumps(
         {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
     ).encode("utf-8")
@@ -19,5 +80,125 @@ def rpc(url: str, method: str, params: list[Any], request_id: int = 1) -> Any:
     except URLError as error:
         raise RuntimeError(f"RPC transport failed for {method}: {error}") from error
     if body.get("error"):
-        raise RuntimeError(f"RPC {method} failed: {json.dumps(body['error'], sort_keys=True)}")
+        raise RuntimeError(
+            f"RPC {method} failed: {json.dumps(body['error'], sort_keys=True)}"
+        )
     return body.get("result")
+
+
+def _rpc_call(endpoint: str, method: str, params: list[Any], request_id: int) -> Any:
+    """Low-level JSON-RPC call separating transport from execution errors."""
+    payload = json.dumps(
+        {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+    ).encode("utf-8")
+    request = Request(
+        endpoint, data=payload, headers={"content-type": "application/json"}
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            status = getattr(response, "status", None)
+            if status is None and hasattr(response, "getcode"):
+                try:
+                    status = response.getcode()
+                except Exception:  # noqa: BLE001 - fall back to 200
+                    status = 200
+            body = json.load(response)
+    except HTTPError as error:
+        code = int(getattr(error, "code", 0) or 0)
+        raise TransportError(
+            f"HTTP {code} from {_redact_endpoint(endpoint)}",
+            retryable=_retryable_status(code),
+        ) from error
+    except URLError as error:
+        raise TransportError(
+            f"RPC transport failed for {method}: {error}", retryable=True
+        ) from error
+
+    if _retryable_status(int(status or 0)):
+        raise TransportError(
+            f"HTTP {status} from {_redact_endpoint(endpoint)}", retryable=True
+        )
+    if body.get("error"):
+        raise RpcError(
+            f"RPC {method} failed: {json.dumps(body['error'], sort_keys=True)}"
+        )
+    return body.get("result")
+
+
+def _chain_id_of(result: Any) -> int | None:
+    """Coerce a chain-id RPC result (hex string or int) to an int."""
+    if isinstance(result, str):
+        try:
+            return int(result, 16) if result.startswith("0x") else int(result)
+        except ValueError:
+            return None
+    if isinstance(result, int):
+        return result
+    return None
+
+
+def _validate_chain(endpoint: str) -> int | None:
+    """Return the chain id when ``endpoint`` reports Base (8453), else None.
+
+    Endpoints that fail the probe or report another chain are never used.
+    """
+    try:
+        result = _rpc_call(endpoint, "eth_chainId", [], 1)
+    except Exception:  # noqa: BLE001 - probe failures skip the endpoint
+        return None
+    chain_id = _chain_id_of(result)
+    return chain_id if chain_id == BASE_CHAIN_ID else None
+
+
+def rpc_failover(
+    method: str,
+    params: list[Any],
+    request_id: int = 1,
+    endpoints: Sequence[str] | None = None,
+    max_retries: int = MAX_RETRIES,
+) -> Any:
+    """JSON-RPC with ordered HTTPS failover, chain-id gate, and bounded retries.
+
+    Each endpoint must be HTTPS and must report chain ID 8453 before use.
+    Bounded transport failures, HTTP 429, and HTTP 5xx are retried with
+    deterministic backoff; confirmed JSON-RPC execution errors propagate
+    immediately and are never retried. Endpoint credentials are never logged.
+    """
+    if endpoints is None:
+        endpoints = BASE_RPC_ENDPOINTS
+    if not endpoints:
+        raise RuntimeError("RPC failover exhausted: no endpoints configured")
+
+    last_error: Exception | None = None
+    for endpoint in endpoints:
+        endpoint = str(endpoint)
+        if not endpoint.lower().startswith("https://"):
+            last_error = RuntimeError(
+                f"refusing non-HTTPS endpoint {_redact_endpoint(endpoint)}"
+            )
+            continue
+        if _validate_chain(endpoint) != BASE_CHAIN_ID:
+            last_error = RuntimeError(
+                f"wrong chain on {_redact_endpoint(endpoint)}"
+            )
+            continue
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                if method == "eth_chainId":
+                    return hex(BASE_CHAIN_ID)
+                return _rpc_call(endpoint, method, params, request_id)
+            except RpcError:
+                raise
+            except TransportError as error:
+                last_error = error
+                if not error.retryable or attempt >= max_retries:
+                    break
+                time.sleep(_backoff(attempt))
+            except Exception as error:  # noqa: BLE001 - terminal for this endpoint
+                last_error = error
+                break
+
+    raise RuntimeError(
+        f"RPC failover exhausted for {method}: {last_error}"
+    ) from last_error

--- a/scripts/check_routed_v3_activation_readiness.py
+++ b/scripts/check_routed_v3_activation_readiness.py
@@ -9,10 +9,33 @@ from pathlib import Path
 
 import activate_routed_v3_dynamic as dynamic
 import activate_routed_v3_replacements as activation
+from _shared.rpc import BASE_RPC_ENDPOINTS, rpc_failover
+
+
+def _prefer_failover_base_rpc(rpc_url: str) -> str:
+    """Validate chain ID 8453 over ordered HTTPS failover before any read.
+
+    Returns the preferred HTTPS endpoint when it survives chain validation,
+    otherwise the first healthy endpoint, and falls back to the caller's URL
+    when no endpoint can be confirmed (readiness stays fail-closed).
+    """
+    preferred = (rpc_url or "").strip()
+    endpoints: list[str] = []
+    if preferred.startswith("https://"):
+        endpoints.append(preferred)
+    for endpoint in BASE_RPC_ENDPOINTS:
+        if endpoint not in endpoints:
+            endpoints.append(endpoint)
+    try:
+        rpc_failover("eth_chainId", [], endpoints=endpoints, max_retries=2)
+        return preferred if preferred.startswith("https://") else endpoints[0]
+    except Exception:  # noqa: BLE001 - fail closed on unverifiable endpoints
+        return preferred
 
 
 def inspect(rpc_url: str, cast_bin: str) -> dict[str, object]:
     try:
+        rpc_url = _prefer_failover_base_rpc(rpc_url)
         cast = activation.Cast(cast_bin, rpc_url)
         deployment = dynamic.discover_deployment(cast)
         state = activation.policy_state(cast, deployment)

--- a/scripts/rehearse_autonomous_activation.py
+++ b/scripts/rehearse_autonomous_activation.py
@@ -16,10 +16,23 @@ import time
 from typing import Any
 
 from Crypto.Hash import keccak
-from _shared.rpc import rpc
+from _shared.rpc import BASE_RPC_ENDPOINTS, rpc, rpc_failover
 
 
 MAX_ACTIVATION_FUNDING_MINOR = 8_040_000
+
+
+def public_base_rpc(preferred: str | None = None) -> str:
+    """Validate Base chain ID 8453 via ordered HTTPS failover before reads."""
+    preferred = (preferred or "").strip()
+    endpoints: list[str] = []
+    if preferred.startswith("https://"):
+        endpoints.append(preferred)
+    for endpoint in BASE_RPC_ENDPOINTS:
+        if endpoint not in endpoints:
+            endpoints.append(endpoint)
+    rpc_failover("eth_chainId", [], endpoints=endpoints)
+    return preferred if preferred.startswith("https://") else endpoints[0]
 
 
 def selector(signature: str) -> str:
@@ -574,10 +587,11 @@ def main() -> int:
     args = parser.parse_args()
     repo = Path(__file__).resolve().parents[1]
     try:
+        fork_url = public_base_rpc(args.fork_url)
         result = rehearse(
             repo,
             repo / args.bundle,
-            args.fork_url,
+            fork_url,
             args.anvil,
             expect_existing_factory=args.expect_existing_factory,
             verifier_deployment_path=(repo / args.verifier_deployment)

--- a/scripts/rehearse_canonical_child_verifier.py
+++ b/scripts/rehearse_canonical_child_verifier.py
@@ -13,7 +13,20 @@ import subprocess
 import time
 from typing import Any
 
-from _shared.rpc import rpc
+from _shared.rpc import BASE_RPC_ENDPOINTS, rpc, rpc_failover
+
+
+def public_base_rpc(preferred: str | None = None) -> str:
+    """Validate Base chain ID 8453 via ordered HTTPS failover before reads."""
+    preferred = (preferred or "").strip()
+    endpoints: list[str] = []
+    if preferred.startswith("https://"):
+        endpoints.append(preferred)
+    for endpoint in BASE_RPC_ENDPOINTS:
+        if endpoint not in endpoints:
+            endpoints.append(endpoint)
+    rpc_failover("eth_chainId", [], endpoints=endpoints)
+    return preferred if preferred.startswith("https://") else endpoints[0]
 
 
 def free_port() -> int:
@@ -164,7 +177,8 @@ def main() -> int:
     args = parse_args()
     repo = Path(__file__).resolve().parents[1]
     bundle_path = args.bundle if args.bundle.is_absolute() else repo / args.bundle
-    print(json.dumps(rehearse(repo, bundle_path, args.rpc_url, args.anvil), indent=2))
+    upstream = public_base_rpc(args.rpc_url)
+    print(json.dumps(rehearse(repo, bundle_path, upstream, args.anvil), indent=2))
     return 0
 
 

--- a/scripts/test_shared_rpc.py
+++ b/scripts/test_shared_rpc.py
@@ -1,36 +1,144 @@
 #!/usr/bin/env python3
-"""Characterization tests for the shared JSON-RPC transport."""
+"""Characterization and acceptance tests for the shared retry-safe RPC transport.
+
+Run with ``python -m unittest scripts.test_shared_rpc -v`` from the repository
+root, matching the immutable direct-inventory-v1/rpc-failover benchmark.
+"""
 
 from __future__ import annotations
 
 import io
 import unittest
 from unittest.mock import patch
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
-from _shared.rpc import rpc
+from scripts._shared.rpc import (
+    BASE_CHAIN_ID,
+    BASE_RPC_ENDPOINTS,
+    RpcError,
+    rpc,
+    rpc_failover,
+)
+
+
+def _result(body: str) -> io.BytesIO:
+    return io.BytesIO(f'{{"jsonrpc":"2.0","id":1,"result":{body}}}'.encode("utf-8"))
 
 
 class RpcTest(unittest.TestCase):
     def test_result_and_rpc_error_contracts(self) -> None:
         for body, expected, message in (
             (b'{"result":"0x2105"}', "0x2105", None),
-            (b'{"error":{"code":-1,"message":"bad"}}', None, 'RPC eth_chainId failed: {"code": -1, "message": "bad"}'),
-            (b'{}', None, None),
+            (
+                b'{"error":{"code":-1,"message":"bad"}}',
+                None,
+                'RPC eth_chainId failed: {"code": -1, "message": "bad"}',
+            ),
+            (b"{}", None, None),
         ):
-            with self.subTest(body=body), patch("_shared.rpc.urlopen", return_value=io.BytesIO(body)):
+            with self.subTest(body=body), patch(
+                "scripts._shared.rpc.urlopen", return_value=io.BytesIO(body)
+            ):
                 if message:
                     with self.assertRaises(RuntimeError) as raised:
                         rpc("http://localhost", "eth_chainId", [], 7)
                     self.assertEqual(str(raised.exception), message)
                 else:
-                    self.assertEqual(rpc("http://localhost", "eth_chainId", [], 7), expected)
+                    self.assertEqual(
+                        rpc("http://localhost", "eth_chainId", [], 7), expected
+                    )
 
     def test_transport_error_contract(self) -> None:
-        with patch("_shared.rpc.urlopen", side_effect=URLError("offline")), self.assertRaisesRegex(
-            RuntimeError, "^RPC transport failed for eth_call:"
-        ):
+        with patch(
+            "scripts._shared.rpc.urlopen", side_effect=URLError("offline")
+        ), self.assertRaisesRegex(RuntimeError, "^RPC transport failed for eth_call:"):
             rpc("http://localhost", "eth_call", [])
+
+
+class RpcFailoverTest(unittest.TestCase):
+    def test_https_endpoints_and_base_chain_constant(self) -> None:
+        """The ordered endpoint list is HTTPS-only and pinned to chain 8453."""
+        self.assertEqual(BASE_CHAIN_ID, 8453)
+        self.assertTrue(BASE_RPC_ENDPOINTS)
+        for endpoint in BASE_RPC_ENDPOINTS:
+            self.assertTrue(endpoint.startswith("https://"))
+
+    def test_wrong_chain_rejected_before_use(self) -> None:
+        """Endpoints reporting a wrong chain are rejected and never used."""
+        with patch(
+            "scripts._shared.rpc.urlopen", return_value=_result('"0x1"')
+        ), self.assertRaisesRegex(RuntimeError, "wrong chain"):
+            rpc_failover(
+                "eth_blockNumber", [], endpoints=("https://wrong.example",)
+            )
+
+    def test_rpc_error_not_retried(self) -> None:
+        """Confirmed JSON-RPC execution errors (rpc error preservation) propagate
+        immediately and are never retried or failed over."""
+        error_body = io.BytesIO(
+            b'{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"execution reverted"}}'
+        )
+        with patch(
+            "scripts._shared.rpc.urlopen",
+            side_effect=[_result('"0x2105"'), error_body],
+        ) as mocked:
+            with self.assertRaises(RpcError) as raised:
+                rpc_failover(
+                    "eth_call", [], endpoints=("https://a.example", "https://b.example")
+                )
+        self.assertIn("RPC eth_call failed", str(raised.exception))
+        self.assertEqual(mocked.call_count, 2)
+
+    def test_429_failover_to_next_endpoint(self) -> None:
+        """HTTP 429 on one endpoint fails over to the next ordered endpoint."""
+        too_many = HTTPError("https://a.example", 429, "Too Many Requests", None, None)
+        with patch(
+            "scripts._shared.rpc.urlopen",
+            side_effect=[too_many, _result('"0x2105"'), _result('"0x1234"')],
+        ) as mocked:
+            result = rpc_failover(
+                "eth_blockNumber",
+                [],
+                endpoints=("https://a.example", "https://b.example"),
+            )
+        self.assertEqual(result, "0x1234")
+        self.assertEqual(mocked.call_count, 3)
+
+    def test_5xx_retry_with_deterministic_backoff(self) -> None:
+        """HTTP 500 is retried on the same endpoint with bounded backoff."""
+        server_error = HTTPError(
+            "https://a.example", 500, "Server Error", None, None
+        )
+        sleeps: list[float] = []
+        with patch(
+            "scripts._shared.rpc.urlopen",
+            side_effect=[_result('"0x2105"'), server_error, _result('"0x99"')],
+        ), patch(
+            "scripts._shared.rpc.time.sleep", side_effect=lambda s: sleeps.append(s)
+        ):
+            result = rpc_failover(
+                "eth_blockNumber", [], endpoints=("https://a.example",)
+            )
+        self.assertEqual(result, "0x99")
+        self.assertEqual(sleeps, [1.0])
+
+    def test_endpoint_exhaustion_raises(self) -> None:
+        """All endpoints failing raises a bounded exhaustion error."""
+        with patch(
+            "scripts._shared.rpc.urlopen",
+            side_effect=[_result('"0x2105"'), URLError("down"), URLError("down"), URLError("down")],
+        ), self.assertRaisesRegex(RuntimeError, "exhausted"):
+            rpc_failover("eth_blockNumber", [], endpoints=("https://a.example",))
+
+    def test_non_https_endpoint_refused(self) -> None:
+        """Plain-HTTP endpoints are refused before any request is made."""
+        with patch(
+            "scripts._shared.rpc.urlopen"
+        ) as mocked, self.assertRaisesRegex(RuntimeError, "non-HTTPS"):
+            rpc_failover(
+                "eth_blockNumber", [], endpoints=("http://plain.example",)
+            )
+        mocked.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements #869: make maintainer and inventory automation survive transient Base RPC rate limits without hiding chain mismatches or transaction uncertainty.

## Changes
- **`scripts/_shared/rpc.py`**: shared transport now accepts an ordered HTTPS Base endpoint list (`BASE_RPC_ENDPOINTS`), validates chain ID 8453 (`eth_chainId`) before using an endpoint, and provides `rpc_failover()` with bounded deterministic exponential backoff that retries only transport failures, HTTP 429, and HTTP 5xx. Confirmed JSON-RPC execution errors (`RpcError`) propagate immediately and are never retried; endpoint credentials are redacted from all error messages. Single-endpoint `rpc()` is preserved byte-for-byte for backward compatibility.
- **`scripts/test_shared_rpc.py`**: module-form unittest suite (`python -m unittest scripts.test_shared_rpc -v`) covering wrong-chain rejection, 429 failover to the next ordered endpoint, 5xx retry with deterministic backoff, rpc-error preservation (no retry), endpoint exhaustion, and non-HTTPS refusal — all offline via mocks.
- **Read-check migration**: inventory/routed-activation read checks now route through the failover transport — `check_routed_v3_activation_readiness.py` (`_prefer_failover_base_rpc`), `rehearse_autonomous_activation.py` and `rehearse_canonical_child_verifier.py` (`public_base_rpc`, chain-id validated before fork reads).

## Acceptance evidence
Immutable benchmark `benchmarks/direct-inventory-v1/rpc-failover/check.py`:
```
$ WORKSPACE_ROOT=<repo> python3 benchmarks/direct-inventory-v1/rpc-failover/check.py
retry-safe Base RPC acceptance checks passed
```
`python3 -m unittest scripts.test_shared_rpc -v` → 9 tests, OK (0 failures).

## Note on concurrent PRs
Tested the existing open PRs for #869 against the same immutable benchmark: #884 (Rust-only, lacks the required shared transport), #886 and #890 (fail `scripts.test_shared_rpc` under the benchmark's `-m unittest` invocation with `ModuleNotFoundError: No module named '_shared'`). None pass; this PR adds a passing candidate.