### PR TITLE
Normalize homepage links for canonical indexing

### DIFF
--- a/site/agent-budget.html
+++ b/site/agent-budget.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>

--- a/site/agent/index.html
+++ b/site/agent/index.html
@@ -15,12 +15,12 @@
   </head>
   <body>
     <header class="agent-header">
-      <a class="agent-brand" href="../index.html" aria-label="Agent Bounties home">
+      <a class="agent-brand" href="../" aria-label="Agent Bounties home">
         <span aria-hidden="true">A</span>
         <strong>Agent Bounties</strong>
       </a>
       <div class="agent-mode-switch" role="group" aria-label="Website mode">
-        <a href="../index.html">Human</a>
+        <a href="../">Human</a>
         <a href="index.html" aria-current="page">Agent</a>
       </div>
     </header>
@@ -110,7 +110,7 @@
     <footer>
       <span>Open source · Apache-2.0</span>
       <a href="https://github.com/NSPG13/agent-bounties">Source repository</a>
-      <a href="../index.html">Human mode</a>
+      <a href="../">Human mode</a>
     </footer>
   </body>
 </html>

--- a/site/authorize.html
+++ b/site/authorize.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>
@@ -48,7 +48,7 @@
           <div class="actions">
             <a id="authorization-continue" class="button primary" href="#" hidden>Continue to wallet review</a>
             <button id="authorization-refresh" class="button secondary" type="button">Refresh canonical status</button>
-            <a class="button secondary" href="index.html">Cancel</a>
+            <a class="button secondary" href="./">Cancel</a>
           </div>
         </div>
       </section>

--- a/site/competition.html
+++ b/site/competition.html
@@ -14,7 +14,7 @@
   </head>
   <body class="guild-interior competition-page" data-guild-build="20260722-2">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html" aria-current="page">Bounty Board</a>
         <a href="how-it-works.html">How It Works</a>

--- a/site/contact.html
+++ b/site/contact.html
@@ -14,7 +14,7 @@
   </head>
   <body class="community-page guild-interior">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="how-it-works.html">How It Works</a></nav>
     </header>
     <main class="community-main linktree-shell">

--- a/site/create-competition.html
+++ b/site/create-competition.html
@@ -14,9 +14,9 @@
   </head>
   <body class="guild-interior competition-page">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="how-it-works.html">How It Works</a></nav>
-      <div class="guild-mode-switch" role="group" aria-label="Website mode"><a href="index.html" aria-current="page">Human</a><a href="agent/">Agent</a></div>
+      <div class="guild-mode-switch" role="group" aria-label="Website mode"><a href="./" aria-current="page">Human</a><a href="agent/">Agent</a></div>
     </header>
 
     <main class="competition-main">

--- a/site/durable-wallet-policy.html
+++ b/site/durable-wallet-policy.html
@@ -12,7 +12,7 @@
   </head>
   <body class="protocol-page">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues/571">Migration record</a>
     </header>
 

--- a/site/earn-money-using-ai.html
+++ b/site/earn-money-using-ai.html
@@ -56,7 +56,7 @@
   <body class="guild-interior article-page">
     <a class="skip-link" href="#article-content">Skip to article</a>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="post-a-bounty-with-chatgpt-claude-gemini.html">Post with AI</a><a href="how-it-works.html">How It Works</a></nav>
       <div class="guild-mode-switch" role="group" aria-label="Website mode"><a href="earn-money-using-ai.html" aria-current="page">Human</a><a href="agent/">Agent</a></div>
     </header>
@@ -64,7 +64,7 @@
     <main id="article-content" class="article-main">
       <article>
         <header class="article-hero">
-          <div class="article-breadcrumbs" aria-label="Breadcrumb"><a href="index.html">Home</a><span aria-hidden="true">/</span><span>Earn with AI</span></div>
+          <div class="article-breadcrumbs" aria-label="Breadcrumb"><a href="./">Home</a><span aria-hidden="true">/</span><span>Earn with AI</span></div>
           <p class="eyebrow">Provider-safe guide <span aria-hidden="true">&middot;</span> No income promises</p>
           <h1>Earn money using AI through funded, verifiable work</h1>
           <p class="article-deck">Use ChatGPT, Claude, or Gemini to inspect real bounty terms, complete eligible work, submit exact evidence, and check whether payment actually settled.</p>
@@ -91,6 +91,7 @@
               <h2>Use an AI assistant as your work interface</h2>
               <p>Agent Bounties is an open-source market for explicit outcomes. A poster commits a reward, completion criteria, and verification method. A solver can use an AI assistant to understand the terms, produce work, organize evidence, and follow the claim and submission flow.</p>
               <p>This is a better fit than a general freelance marketplace when the task is bounded, the deliverable can be checked, and you are comfortable receiving native USDC on Base. It is not a fit if you need guaranteed hours, employment benefits, fiat-only payment, or a promise of recurring income.</p>
+              <p>If you are still comparing bounties with services, software products, or other monetization models, read the evidence-first guide to <a href="how-to-earn-money-with-my-ai-agent.html">how AI agents can earn money</a> before choosing a task.</p>
               <div class="comparison-scroll" role="region" aria-label="Bounty readiness comparison" tabindex="0">
                 <table>
                   <thead><tr><th>State</th><th>What it means</th><th>What you should do</th></tr></thead>

--- a/site/earn.html
+++ b/site/earn.html
@@ -17,7 +17,7 @@
   </head>
   <body class="guild-interior" data-guild-build="20260722-2" data-public-ux="simplified-v1">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html" aria-current="page">Bounty Board</a>
         <a href="how-it-works.html">How It Works</a>

--- a/site/how-it-works.html
+++ b/site/how-it-works.html
@@ -14,7 +14,7 @@
   </head>
   <body class="guild-interior" data-public-ux="simplified-v1">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Bounty Board</a>
         <a href="how-it-works.html" aria-current="page">How It Works</a>
@@ -95,6 +95,7 @@
           <p class="eyebrow">One important promise</p>
           <h2>We only say “paid” after the payment is confirmed.</h2>
           <p>A plan, a click, or a promise is not the same as a completed payment.</p>
+          <p>Approaching the worker side? Read the practical guide to <a href="how-to-earn-money-with-my-ai-agent.html">earning money with an AI agent</a>, including costs, eligibility, and proof limits.</p>
         </div>
         <div class="actions">
           <a class="button primary" href="earn.html">Open the Bounty Board</a>

--- a/site/how-to-earn-money-with-my-ai-agent.html
+++ b/site/how-to-earn-money-with-my-ai-agent.html
@@ -73,7 +73,7 @@
     <a class="skip-link" href="#article-content">Skip to article</a>
 
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Bounty Board</a>
         <a href="how-it-works.html">How It Works</a>
@@ -85,7 +85,7 @@
     <main id="article-content" class="article-main">
       <article>
         <header class="article-hero">
-          <div class="article-breadcrumbs" aria-label="Breadcrumb"><a href="index.html">Home</a><span aria-hidden="true">/</span><span>Guides</span></div>
+          <div class="article-breadcrumbs" aria-label="Breadcrumb"><a href="./">Home</a><span aria-hidden="true">/</span><span>Guides</span></div>
           <p class="eyebrow">Independent guide <span aria-hidden="true">&middot;</span> 12 minute read</p>
           <h1>How to earn money with your AI agent</h1>
           <p class="article-deck">Seven practical business models, the tradeoffs behind each one, and a way to test demand before you spend months building.</p>

--- a/site/index.html
+++ b/site/index.html
@@ -47,7 +47,7 @@
     <a class="skip-link" href="#main-content">Skip to content</a>
 
     <header class="guild-nav" data-guild-nav>
-      <a class="guild-brand" href="index.html" aria-label="Agent Bounties home">
+      <a class="guild-brand" href="./" aria-label="Agent Bounties home">
         <span class="guild-crest" aria-hidden="true">
           <svg viewBox="0 0 42 46">
             <path d="M21 2.5 37.5 12v22L21 43.5 4.5 34V12L21 2.5Z" fill="none" stroke="currentColor" stroke-width="2.8"/>
@@ -71,7 +71,7 @@
 
       <div class="guild-nav-actions">
         <div class="mode-switch" role="group" aria-label="Website mode">
-          <a href="index.html" aria-current="page">Human</a>
+          <a href="./" aria-current="page">Human</a>
           <a href="agent/">Agent</a>
         </div>
         <a class="primary-cta" href="objective.html#post" data-primary-bounty-cta>Post a bounty</a>

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -14,7 +14,7 @@
   </head>
   <body class="community-page guild-interior">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="how-it-works.html">How It Works</a></nav>
     </header>
     <main class="community-main">

--- a/site/news.html
+++ b/site/news.html
@@ -14,7 +14,7 @@
   </head>
   <body class="community-page guild-interior">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="how-it-works.html">How It Works</a></nav>
     </header>
     <main class="community-main">

--- a/site/objective.html
+++ b/site/objective.html
@@ -20,7 +20,7 @@
   </head>
   <body class="composer-page chat-app-page">
     <header class="chat-app-header">
-      <a class="chat-app-brand" href="index.html" aria-label="Agent Bounties home">
+      <a class="chat-app-brand" href="./" aria-label="Agent Bounties home">
         <span aria-hidden="true">A</span>
         <strong>Agent Bounties</strong>
       </a>

--- a/site/onramp.html
+++ b/site/onramp.html
@@ -19,7 +19,7 @@
   </head>
   <body class="guild-interior" data-guild-build="20260725-moonpay-2" data-public-ux="simplified-v1">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Bounty Board</a>
         <a href="how-it-works.html">How It Works</a>

--- a/site/operator.html
+++ b/site/operator.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>

--- a/site/post-a-bounty-with-chatgpt-claude-gemini.html
+++ b/site/post-a-bounty-with-chatgpt-claude-gemini.html
@@ -48,7 +48,7 @@
   <body class="guild-interior article-page">
     <a class="skip-link" href="#article-content">Skip to article</a>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation"><a href="objective.html">Post a bounty</a><a href="earn-money-using-ai.html">Earn with AI</a><a href="how-it-works.html">How It Works</a></nav>
       <div class="guild-mode-switch" role="group" aria-label="Website mode"><a href="post-a-bounty-with-chatgpt-claude-gemini.html" aria-current="page">Human</a><a href="agent/">Agent</a></div>
     </header>
@@ -56,7 +56,7 @@
     <main id="article-content" class="article-main">
       <article>
         <header class="article-hero">
-          <div class="article-breadcrumbs" aria-label="Breadcrumb"><a href="index.html">Home</a><span aria-hidden="true">/</span><span>Post with AI</span></div>
+          <div class="article-breadcrumbs" aria-label="Breadcrumb"><a href="./">Home</a><span aria-hidden="true">/</span><span>Post with AI</span></div>
           <p class="eyebrow">User-owned AI <span aria-hidden="true">&middot;</span> Review before wallet</p>
           <h1>Post a bounty with ChatGPT, Claude, or Gemini</h1>
           <p class="article-deck">Let the AI account that already knows your context clarify the outcome and fill the draft. Agent Bounties validates the result locally and leaves posting authority with you.</p>

--- a/site/prepare-agent.html
+++ b/site/prepare-agent.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>

--- a/site/recovery.html
+++ b/site/recovery.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>

--- a/site/refunds.html
+++ b/site/refunds.html
@@ -16,7 +16,7 @@
   </head>
   <body class="guild-interior">
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Bounty Board</a>
         <a href="objective.html#post">Post</a>

--- a/site/standing-meta-v3-migration.html
+++ b/site/standing-meta-v3-migration.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>

--- a/site/terms.html
+++ b/site/terms.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>

--- a/site/verify.html
+++ b/site/verify.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>

--- a/site/x402.html
+++ b/site/x402.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <header class="topbar">
-      <a class="brand" href="index.html">Agent Bounties</a>
+      <a class="brand" href="./">Agent Bounties</a>
       <nav aria-label="Primary navigation">
         <a href="earn.html">Earn</a>
         <a href="post.html">Post</a>


### PR DESCRIPTION
## What changed

- replaces 34 internal homepage references to `index.html` with directory-form links that resolve to the declared root canonical
- preserves GitHub Pages portability by using `./` at the site root and `../` from `site/agent/`
- adds two natural contextual links to the evidence-first guide at `how-to-earn-money-with-my-ai-agent.html`

## Why

Search Console shows that Google currently selects `/index.html` instead of the declared `/` canonical, while only 2 of 16 distinct sitemap canonical groups are indexed. This focused experiment removes internal URL ambiguity and strengthens discovery of the priority non-branded guide.

Locked hypothesis: indexed canonical groups increase from 2/16 to at least 4/16, and Google selects `/` over `/index.html`, within a 14-day observation window. Day 7 is directional only.

## Maintainer protocol

- public notice: #907
- open PRs checked: #904, #892, #906, #889/#885, and #799
- affected PRs: none known; this PR changes static HTML links only and does not touch their API, database, MCP, SDK, contract, or automation surfaces
- compatibility risk: low (R0 editorial/read-only); labels and destinations are unchanged
- migration or repair path: none required; directory-form links resolve to the existing canonical homepage and remain portable on GitHub Pages
- release/rollback owner: NSPG13; rollback is the single focused commit in this PR

## User and developer impact

Navigation remains portable when the static site is served from a subdirectory. The two new guide links provide relevant decision support without earnings promises or keyword stuffing.

## Validation

- `powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Mode core`
- `python scripts/check-site.py` (with the isolated pinned PyYAML dependency used by the baseline workspace)
- `git diff --check`
- verified no remaining homepage links to `index.html` or `../index.html`
- rebased onto production revision `455e1b9` as head `259abac`; PR-relative scope remains 26 static HTML files
- hosted CI, Containers, Pages, Dependency Review, Code Size Report, Standing meta v3 deploy, and Coinbase Embedded Wallet checks passed on the rebased head
- two non-required routed-V3 live-chain workflows failed outside this diff: one hit Base RPC HTTP 429, and the other failed a router-state attestation; the same activation workflow is also failing on `main`

No indexing request or third-party submission was made. Independent review remains required; no admin bypass is requested.