### PR TITLE
Prepare ClawHub skill publication

### DIFF
--- a/docs/openclaw-distribution.md
+++ b/docs/openclaw-distribution.md
@@ -93,21 +93,31 @@ state before work.
 
 Validate the bundle without publishing:
 
-```bash
-clawhub skill publish skills/agent-bounties `
+```powershell
+node scripts/prepare-clawhub-skill.mjs --output target/clawhub-agent-bounties
+clawhub skill publish target/clawhub-agent-bounties `
   --slug agent-bounties `
   --name "Agent Bounties" `
+  --version 1.4.5 `
   --dry-run `
   --json
 ```
 
+The staging command copies an explicit allowlist from the canonical portable
+skill and excludes `.claude-plugin`. Current ClawHub releases classify a folder
+containing `.claude-plugin/plugin.json` as a plugin before applying skill-file
+ignore rules, so publishing `skills/agent-bounties` directly fails closed. Use
+a new empty output path for every validation or publication attempt; the helper
+never overwrites an existing directory.
+
 Publishing requires a human-authenticated ClawHub owner:
 
-```bash
+```powershell
 clawhub login
-clawhub skill publish skills/agent-bounties `
+clawhub skill publish target/clawhub-agent-bounties `
   --slug agent-bounties `
   --name "Agent Bounties" `
+  --version 1.4.5 `
   --source-repo NSPG13/agent-bounties `
   --source-commit <merged-commit-sha> `
   --source-ref main `

--- a/scripts/prepare-clawhub-skill.mjs
+++ b/scripts/prepare-clawhub-skill.mjs
@@ -1,0 +1,120 @@
+import { access, cp, lstat, mkdir, readdir } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const CLAWHUB_SKILL_SOURCE_ENTRIES = Object.freeze([
+  "SKILL.md",
+  "README.md",
+  "LICENSE",
+  "fixtures",
+  "references",
+  "scripts",
+]);
+
+const defaultSourceDir = fileURLToPath(
+  new URL("../skills/agent-bounties/", import.meta.url),
+);
+
+function isInside(parent, candidate) {
+  const path = relative(parent, candidate);
+  return path !== "" && !path.startsWith("..") && !isAbsolute(path);
+}
+
+async function inventoryRegularFiles(root) {
+  const files = [];
+
+  async function walk(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const absolutePath = join(directory, entry.name);
+      const relativePath = relative(root, absolutePath).replaceAll("\\", "/");
+      if (entry.isSymbolicLink()) {
+        throw new Error(`ClawHub staging refuses symbolic link: ${relativePath}`);
+      }
+      if (entry.isDirectory()) {
+        await walk(absolutePath);
+      } else if (entry.isFile()) {
+        const fileStat = await lstat(absolutePath);
+        files.push({ path: relativePath, size: fileStat.size });
+      }
+    }
+  }
+
+  await walk(root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export async function prepareClawHubSkill({
+  sourceDir = defaultSourceDir,
+  outputDir,
+} = {}) {
+  if (!outputDir) throw new Error("--output is required");
+
+  const source = resolve(sourceDir);
+  const output = resolve(outputDir);
+  if (source === output || isInside(source, output)) {
+    throw new Error("ClawHub staging output must be outside the canonical skill directory");
+  }
+
+  await access(join(source, "SKILL.md"));
+  try {
+    await access(output);
+    throw new Error(`ClawHub staging output already exists: ${output}`);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+
+  await mkdir(dirname(output), { recursive: true });
+  await mkdir(output, { recursive: false });
+  for (const entry of CLAWHUB_SKILL_SOURCE_ENTRIES) {
+    await cp(join(source, entry), join(output, entry), {
+      recursive: true,
+      errorOnExist: true,
+      force: false,
+    });
+  }
+
+  const files = await inventoryRegularFiles(output);
+  if (!files.some((file) => file.path === "SKILL.md")) {
+    throw new Error("ClawHub staging output is missing SKILL.md");
+  }
+
+  return {
+    schema_version: "agent-bounties/clawhub-skill-stage-v1",
+    source,
+    output,
+    source_entries: [...CLAWHUB_SKILL_SOURCE_ENTRIES],
+    excluded_source_entries: [".claude-plugin"],
+    file_count: files.length,
+    total_bytes: files.reduce((total, file) => total + file.size, 0),
+    files,
+  };
+}
+
+function parseArguments(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--output") {
+      parsed.outputDir = argv[index + 1];
+      index += 1;
+    } else if (argument === "--source") {
+      parsed.sourceDir = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  return parsed;
+}
+
+async function main() {
+  const result = await prepareClawHubSkill(parseArguments(process.argv.slice(2)));
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { access, readFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import {
@@ -13,6 +15,10 @@ import {
   verifyClaimableItem,
   verifyDirectChainInventory,
 } from "../skills/agent-bounties/scripts/check-in.mjs";
+import {
+  CLAWHUB_SKILL_SOURCE_ENTRIES,
+  prepareClawHubSkill,
+} from "./prepare-clawhub-skill.mjs";
 
 async function fixture(name) {
   return JSON.parse(
@@ -409,6 +415,33 @@ test("portable skill metadata and install contracts remain publishable", async (
   ];
   for (const path of bundleFiles) {
     await access(new URL(`../skills/agent-bounties/${path}`, import.meta.url));
+  }
+});
+
+test("ClawHub staging preserves the portable skill and excludes plugin markers", async () => {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), "agent-bounties-clawhub-"));
+  const outputDir = join(temporaryRoot, "agent-bounties");
+  try {
+    const result = await prepareClawHubSkill({ outputDir });
+    assert.equal(result.schema_version, "agent-bounties/clawhub-skill-stage-v1");
+    assert.deepEqual(result.source_entries, [...CLAWHUB_SKILL_SOURCE_ENTRIES]);
+    assert.deepEqual(result.excluded_source_entries, [".claude-plugin"]);
+    assert.ok(result.file_count > 0);
+    assert.ok(result.total_bytes > 0);
+    await access(join(outputDir, "SKILL.md"));
+    assert.match(
+      await readFile(join(outputDir, "LICENSE"), "utf8"),
+      /^MIT No Attribution\r?\n/,
+    );
+    await access(join(outputDir, "scripts", "check-in.mjs"));
+    await assert.rejects(access(join(outputDir, ".claude-plugin", "plugin.json")));
+    await assert.rejects(access(join(outputDir, "openclaw.plugin.json")));
+    await assert.rejects(
+      prepareClawHubSkill({ outputDir }),
+      /staging output already exists/,
+    );
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## What changed

- add an explicit-allowlist staging helper for the portable Agent Bounties skill
- exclude `.claude-plugin` from the staged skill bundle
- document the versioned ClawHub validation and owner-publication workflow
- test the staged bundle, license, required files, exclusions, and overwrite refusal

## Why

ClawHub CLI v0.23.3 classifies `skills/agent-bounties` as a plugin when it sees `.claude-plugin/plugin.json`, before skill ignore rules apply. Direct `clawhub skill publish` therefore fails even though the repository contains a valid portable `SKILL.md` bundle.

The helper keeps the canonical source unchanged and generates a fresh, reviewable publication artifact containing only the portable skill files.

## Impact

This PR does not publish anything externally and does not change bounty, payment, or runtime behavior. After merge, a maintainer can generate a source-backed artifact and run the documented ClawHub dry run before separately authorizing publication.

Public-work notice: #907.

## Validation

- `./scripts/preflight.ps1 -Mode core`
- `./scripts/check.ps1`
- `node --test scripts/test_agent_bounties_openclaw_skill.mjs` (27 passed)
- `cargo run -p cli -- docs-contract-check`
- ClawHub dry run: `would-publish`, version `1.4.5`, 16 files, fingerprint `12352ba34d0018e9d3f30a079c48370b6058b3fbec6588634de137eb01c95e3b`

The repository-wide gate exited 0. The branch was rebased onto production revision `455e1b9` as head `180588f`; the focused 27-test suite, core preflight, diff check, Claude plugin, Dependency Review, Code Size Report, and CI passed again. ClawHub v0.23.3 again returned `would-publish` for the 16-file artifact with the same fingerprint; nothing was published. Existing Foundry timestamp/typecast lints and the existing Rust future-compatibility warning remain non-blocking and are outside this change. Independent review remains required; no admin bypass is requested.
