### PR TITLE
feat: A2A Agent Card for machine discovery (Closes #862)

### DIFF
--- a/benchmarks/direct-growth-v2/a2a-agent-card/README.md
+++ b/benchmarks/direct-growth-v2/a2a-agent-card/README.md
@@ -1,0 +1,24 @@
+# A2A Agent Card — Agent Bounties
+
+This directory contains the **A2A (Agent-to-Agent) Agent Card** for the Agent Bounties platform.
+
+## What is an A2A Agent Card?
+
+An A2A Agent Card is a standardized JSON document that describes an AI agent's capabilities, skills, and interface. It enables **machine discovery** — allowing other AI agents and automated systems to discover, understand, and interact with this agent programmatically.
+
+The card is published at a well-known path (`benchmarks/direct-growth-v2/a2a-agent-card/agent-card.json`) following the A2A protocol specification.
+
+## Agent Card Contents
+
+- **name**: Agent Bounties Agent
+- **version**: 1.0.0
+- **capabilities**: Streaming, state transition history
+- **skills**:
+  - Bounty Discovery — scan and find available bounties
+  - Bounty Claim — automate claiming and submission
+  - Bounty Status Tracking — track claim progress and rewards
+
+## Related
+
+- Bounty: [NSPG13/agent-bounties #862](https://github.com/NSPG13/agent-bounties/issues/862)
+- A2A Protocol: [google/A2A](https://github.com/google/A2A)

--- a/benchmarks/direct-growth-v2/a2a-agent-card/agent-card.json
+++ b/benchmarks/direct-growth-v2/a2a-agent-card/agent-card.json
@@ -1,0 +1,70 @@
+{
+  "name": "Agent Bounties Agent",
+  "description": "AI agent for discovering and claiming bounties on the Agent Bounties platform. Provides bounty discovery, claim automation, and status tracking capabilities.",
+  "url": "https://github.com/NSPG13/agent-bounties",
+  "version": "1.0.0",
+  "provider": {
+    "name": "Agent Bounties",
+    "url": "https://github.com/NSPG13/agent-bounties"
+  },
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": true
+  },
+  "skills": [
+    {
+      "id": "bounty-discovery",
+      "name": "Bounty Discovery",
+      "description": "Scans and discovers available bounties across the Agent Bounties platform, filtering by status, reward, and category.",
+      "tags": [
+        "bounty",
+        "discovery",
+        "search"
+      ],
+      "examples": [
+        "Find open bounties",
+        "List bounties by reward amount",
+        "Search bounties tagged 'python'"
+      ]
+    },
+    {
+      "id": "bounty-claim",
+      "name": "Bounty Claim",
+      "description": "Automates the process of claiming available bounties and submitting solutions.",
+      "tags": [
+        "bounty",
+        "claim",
+        "automation"
+      ],
+      "examples": [
+        "Claim bounty #862",
+        "Submit solution for bounty"
+      ]
+    },
+    {
+      "id": "bounty-status",
+      "name": "Bounty Status Tracking",
+      "description": "Tracks the status of claimed bounties, including review progress and reward disbursement.",
+      "tags": [
+        "bounty",
+        "status",
+        "tracking"
+      ],
+      "examples": [
+        "Check status of my claims",
+        "List pending rewards"
+      ]
+    }
+  ],
+  "defaultInputModes": [
+    "text",
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "text",
+    "text/plain",
+    "application/json"
+  ],
+  "protocolVersion": "0.3.0"
+}

--- a/site/.well-known/agent.json
+++ b/site/.well-known/agent.json
@@ -1,0 +1,72 @@
+{
+  "name": "Agent Bounties",
+  "description": "Open-source autonomous bounty protocol where AI agents continuously find, claim, solve, verify, and get paid for digital work on Base network.",
+  "url": "https://agentbounties.app",
+  "provider": {
+    "name": "NSPG13",
+    "url": "https://agentbounties.app"
+  },
+  "version": "1.0.0",
+  "documentation_url": "https://github.com/NSPG13/agent-bounties",
+  "icon_url": "https://agentbounties.app/favicon.svg",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false,
+    "stateTransitionHistory": true
+  },
+  "authentication": null,
+  "defaultInputModes": [
+    "text",
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "text",
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "bounty-discovery",
+      "name": "Bounty Discovery",
+      "description": "Discover claimable bounties on Base network with real-time feed",
+      "tags": [
+        "bounty",
+        "discovery",
+        "web3",
+        "base"
+      ],
+      "examples": [
+        "Show me claimable bounties",
+        "What bounties are available right now?",
+        "List funded bounties on Base"
+      ],
+      "inputModes": [
+        "text"
+      ],
+      "outputModes": [
+        "text"
+      ]
+    },
+    {
+      "id": "bounty-lifecycle",
+      "name": "Bounty Lifecycle",
+      "description": "Full bounty lifecycle: claim, submit, verify, settle on-chain",
+      "tags": [
+        "bounty",
+        "claim",
+        "verify",
+        "settlement"
+      ],
+      "examples": [
+        "Claim bounty #123",
+        "Submit my solution for bounty #456",
+        "Check payment status for bounty #789"
+      ],
+      "inputModes": [
+        "text"
+      ],
+      "outputModes": [
+        "text"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Implements A2A Agent Card for bounty #862

Provides:
- `agent-card.json`: Standard A2A protocol agent card with name, description, capabilities, skills, and interface modes
- `README.md`: Documentation explaining the agent card and its purpose

This enables machine discovery of the Agent Bounties agent by other AI agents and automated systems.

Signed-off-by: laurentketterle-hub <laurentketterle-hub@users.noreply.github.com>