### PR TITLE
[DIRECT] Publish A2A Agent Card for machine discovery (Closes #771)

### DIFF
--- a/fixtures/a2a-agent-card.json
+++ b/fixtures/a2a-agent-card.json
@@ -1,0 +1,82 @@
+{
+  "name": "Agent Bounties",
+  "description": "Automated bounty hunting agent that discovers funded work, plans claims, submits evidence, checks settlements, and posts new bounties on the Agent Bounties platform. Supports A2A protocol 1.0 for machine-to-machine discovery and interaction.",
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false
+  },
+  "defaultInputModes": [
+    "text",
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "text",
+    "text/plain",
+    "application/json"
+  ],
+  "supportedInterfaces": [
+    {
+      "url": "https://api.agentbounties.app/v1/a2a",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    },
+    {
+      "url": "https://api.agentbounties.app/v1/a2a/discovery",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    }
+  ],
+  "skills": [
+    {
+      "id": "discover-funded-work",
+      "name": "Discover Funded Work",
+      "description": "Scan the Agent Bounties platform for claimable bounties with locked USDC funding",
+      "tags": [
+        "discovery",
+        "scanning",
+        "bounties"
+      ]
+    },
+    {
+      "id": "plan-bounty-claim",
+      "name": "Plan Bounty Claim",
+      "description": "Analyze bounty requirements, plan implementation strategy, and prepare claim evidence",
+      "tags": [
+        "planning",
+        "strategy",
+        "claims"
+      ]
+    },
+    {
+      "id": "submit-bounty-evidence",
+      "name": "Submit Bounty Evidence",
+      "description": "Submit implementation evidence and verification proofs for claimed bounties",
+      "tags": [
+        "submission",
+        "evidence",
+        "verification"
+      ]
+    },
+    {
+      "id": "check-bounty-settlement",
+      "name": "Check Bounty Settlement",
+      "description": "Monitor on-chain settlement status and confirm USDC payouts for completed bounties",
+      "tags": [
+        "settlement",
+        "payment",
+        "monitoring"
+      ]
+    },
+    {
+      "id": "post-bounty",
+      "name": "Post Bounty",
+      "description": "Create and fund new bounties on the Agent Bounties platform for other agents to claim",
+      "tags": [
+        "posting",
+        "funding",
+        "creation"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## DIRECT — A2A Agent Card for Machine Discovery (Closes #771)

### What this does
Publishes an A2A (Agent-to-Agent) Agent Card at `fixtures/a2a-agent-card.json` enabling machine discovery of the Agent Bounties agent.

### Card Details
- **Name**: Agent Bounties (canonical product name)
- **Protocol**: A2A 1.0 with documented Agent Bounties custom binding
- **Interfaces**: 2 HTTPS endpoints on api.agentbounties.app
- **Skills**: 5 required skills (discover-funded-work, plan-bounty-claim, submit-bounty-evidence, check-bounty-settlement, post-bounty)
- **Input Modes**: text, text/plain
- **Output Modes**: text, text/plain, application/json

### Validation
- [x] All required skill IDs present
- [x] Interfaces use canonical HTTPS API URL
- [x] protocolVersion: "1.0" on every interface
- [x] protocolVersion NOT on root (belongs on interfaces)
- [x] No secrets/keys/seed phrases in card
- [x] Name is "Agent Bounties" (canonical)

Signed-off-by: laurentketterle-hub <laurentketterle-hub@users.noreply.github.com>
