### PR TITLE
fix: include compiled assets in production images

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -8,14 +8,19 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "Dockerfile"
+      - "contracts/**"
+      - "crates/**"
       - "docker-compose.production.yml"
       - "docs/deployment.md"
+      - "fixtures/**"
       - "migrations/**"
+      - "schemas/**"
       - "scripts/check-containers.ps1"
       - "scripts/check-containers.sh"
       - "scripts/check-production-compose.ps1"
       - "scripts/check-production-compose.sh"
       - "scripts/check-production-smoke.sh"
+      - "site/**"
   push:
     branches: [main]
     paths:
@@ -24,14 +29,19 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "Dockerfile"
+      - "contracts/**"
+      - "crates/**"
       - "docker-compose.production.yml"
       - "docs/deployment.md"
+      - "fixtures/**"
       - "migrations/**"
+      - "schemas/**"
       - "scripts/check-containers.ps1"
       - "scripts/check-containers.sh"
       - "scripts/check-production-compose.ps1"
       - "scripts/check-production-compose.sh"
       - "scripts/check-production-smoke.sh"
+      - "site/**"
   workflow_dispatch:
 
 permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /workspace
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY contracts ./contracts
+COPY fixtures ./fixtures
 COPY migrations ./migrations
 COPY schemas ./schemas
 COPY site ./site

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -202,6 +202,11 @@ For an all-404 result, repair in this order:
    repository root as Docker context, and use `/health` as the health check.
 3. Confirm the service variables are `APP_PACKAGE=api` and `APP_BINARY=api`.
    A worker or MCP binary on this hostname does not expose the funding routes.
+   The repository-root Docker context must also copy every root-level asset
+   compiled into a Rust binary. `scripts/check-render-blueprint.py` verifies
+   those `include_str!` and `include_bytes!` dependencies, and the Containers
+   workflow monitors every copied source directory so an application or asset
+   change cannot bypass a production-image build.
 4. Copy the service's current `onrender.com` URL from **Settings** and rerun the
    diagnostic against it. Do not infer the hostname from the service name.
 5. If the Render URL passes, attach and verify `api.bountyboard.global`, set

--- a/scripts/check-render-blueprint.py
+++ b/scripts/check-render-blueprint.py
@@ -140,6 +140,61 @@ def require_address(value: object, label: str) -> str:
     return value
 
 
+def require_docker_compile_time_assets(repo_root: Path) -> None:
+    dockerfile_path = repo_root / "Dockerfile"
+    if not dockerfile_path.exists():
+        fail("missing Dockerfile")
+    dockerfile = dockerfile_path.read_text(encoding="utf-8")
+    copied_roots: set[str] = set()
+    for line in dockerfile.splitlines():
+        if "--from=" in line:
+            continue
+        match = re.match(r"^\s*COPY\s+(?:--\S+\s+)*(?P<sources>.+?)\s+\S+\s*$", line)
+        if not match:
+            continue
+        for source in match.group("sources").split():
+            if source.startswith("/"):
+                continue
+            copied_roots.add(source.rstrip("/").split("/", 1)[0])
+
+    include_pattern = re.compile(r'include_(?:str|bytes)!\(\s*"([^"]+)"\s*\)')
+    for rust_source in repo_root.glob("crates/**/*.rs"):
+        contents = rust_source.read_text(encoding="utf-8")
+        production_contents = contents.split("#[cfg(test)]", 1)[0]
+        for relative_asset in include_pattern.findall(production_contents):
+            resolved_asset = (rust_source.parent / relative_asset).resolve()
+            try:
+                repository_asset = resolved_asset.relative_to(repo_root.resolve())
+            except ValueError:
+                fail(
+                    f"{rust_source.relative_to(repo_root)} includes an asset outside the repository: "
+                    f"{relative_asset}"
+                )
+            if not resolved_asset.is_file():
+                fail(
+                    f"{rust_source.relative_to(repo_root)} includes missing asset "
+                    f"{repository_asset.as_posix()}"
+                )
+            root = repository_asset.parts[0]
+            if root not in copied_roots:
+                fail(
+                    f"Dockerfile must copy {root}/ because {rust_source.relative_to(repo_root)} "
+                    f"compiles {repository_asset.as_posix()} into a production binary"
+                )
+
+    workflow = (repo_root / ".github" / "workflows" / "containers.yml").read_text(
+        encoding="utf-8"
+    )
+    for root in sorted(copied_roots):
+        if root == "." or not (repo_root / root).is_dir():
+            continue
+        path_filter = f'- "{root}/**"'
+        if workflow.count(path_filter) != 2:
+            fail(
+                f"containers workflow must monitor {root}/** for pull_request and main push builds"
+            )
+
+
 def load_mainnet_deployment(repo_root: Path) -> dict[str, object]:
     path = repo_root / "deployments" / "base-mainnet.json"
     if not path.exists():
@@ -298,6 +353,7 @@ def load_open_competition_mainnet_release(repo_root: Path) -> dict[str, object]:
 
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
+    require_docker_compile_time_assets(repo_root)
     deployment = load_mainnet_deployment(repo_root)
     open_competition_release = load_open_competition_mainnet_release(repo_root)
     rpc_url = str(deployment["rpc_url"])

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -97,6 +97,7 @@ def compile_python(platform: str) -> None:
         "scripts/standing_meta_v4_rehearsal_audit.py", "scripts/test_standing_meta_v4_rehearsal_audit.py",
         "scripts/check-site.py", "scripts/check-coinbase-embedded-wallet.py", "scripts/configure-wallet-providers.py",
         "scripts/check-moonpay-onramp.py", "scripts/check-migration-history.py", "scripts/check-render-blueprint.py",
+        "scripts/test_check_render_blueprint.py",
         "scripts/review_external_pr.py", "scripts/test_review_external_pr.py",
         "scripts/stage_review_contract_root.py", "scripts/test_stage_review_contract_root.py",
         "scripts/validate_real_funding_rehearsal.py", "scripts/rehearse_autonomous_activation.py",
@@ -259,6 +260,7 @@ def main() -> int:
     )])
     py("-m", "pip", "install", "-r", "scripts/requirements-attest.txt")
     py("scripts/test_shared_evm.py", "-v")
+    py("scripts/test_check_render_blueprint.py", "-v")
     py("scripts/check-render-blueprint.py")
     py("scripts/test_mcp_tool_registry.py", "-v")
     py("scripts/test_review_external_pr.py", "-v")

--- a/scripts/test_check_render_blueprint.py
+++ b/scripts/test_check_render_blueprint.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+SCRIPT = SCRIPT_DIR / "check-render-blueprint.py"
+SPEC = importlib.util.spec_from_file_location("check_render_blueprint", SCRIPT)
+assert SPEC and SPEC.loader
+blueprint = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(blueprint)
+
+
+class DockerCompileTimeAssetTests(unittest.TestCase):
+    def create_repository(self, root: Path, *, copy_fixtures: bool) -> None:
+        source = root / "crates" / "api" / "src" / "main.rs"
+        source.parent.mkdir(parents=True)
+        source.write_text(
+            'const CARD: &str = include_str!("../../../fixtures/card.json");\n'
+            '#[cfg(test)]\nmod tests {\n'
+            '    const TEST_ONLY: &str = include_str!("../../../bounties/test.json");\n'
+            '}\n',
+            encoding="utf-8",
+        )
+        fixtures = root / "fixtures"
+        fixtures.mkdir()
+        (fixtures / "card.json").write_text("{}\n", encoding="utf-8")
+        dockerfile = "COPY crates ./crates\n"
+        if copy_fixtures:
+            dockerfile += "COPY fixtures ./fixtures\n"
+        dockerfile += "COPY --from=builder /tmp/service /usr/local/bin/service\n"
+        (root / "Dockerfile").write_text(dockerfile, encoding="utf-8")
+        workflow = root / ".github" / "workflows" / "containers.yml"
+        workflow.parent.mkdir(parents=True)
+        workflow.write_text(
+            'pull_request:\n  paths:\n    - "crates/**"\n'
+            + ('    - "fixtures/**"\n' if copy_fixtures else "")
+            + 'push:\n  paths:\n    - "crates/**"\n'
+            + ('    - "fixtures/**"\n' if copy_fixtures else ""),
+            encoding="utf-8",
+        )
+
+    def test_missing_compile_time_asset_root_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_repository(root, copy_fixtures=False)
+            with self.assertRaisesRegex(
+                SystemExit,
+                r"Dockerfile must copy fixtures/.*compiles fixtures/card.json",
+            ):
+                blueprint.require_docker_compile_time_assets(root)
+
+    def test_copied_asset_and_path_filters_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_repository(root, copy_fixtures=True)
+            blueprint.require_docker_compile_time_assets(root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What Changed

- Copy `fixtures/` into the production Docker build context so the API can compile its A2A Agent Card `include_str!` asset.
- Run the Containers workflow whenever Rust sources or Docker-copied asset roots change.
- Extend the Render blueprint checker with a regression guard that verifies compile-time Rust assets exist, are copied into Docker, and are covered by both PR and `main` path filters.
- Document the compiled-asset deployment invariant.

This is the focused forward repair for the API/MCP revision split reported by Production Smoke. Current `main` serves API revision `40d66406397fbcff5a2a747d2cb111f978714bf5` while MCP serves current revision `9bf75e4062d75817fe9ed532fad47ab6f63c01d3`. The API image build reproduced locally with the exact missing file error for `fixtures/a2a-agent-card.json`; the fixed image and production compose now build and smoke successfully.

## Linked Bounty Or Issue

- #907
- Failed Render recovery evidence: https://github.com/NSPG13/agent-bounties/actions/runs/31458653011
- Revision-parity failure: https://github.com/NSPG13/agent-bounties/actions/runs/31544692551

## Maintainer Change Notice

- Notice issue/comment: https://github.com/NSPG13/agent-bounties/issues/907#issuecomment-5259680408 (issue scope explicitly includes diagnosing the production API deployment failure)
- Open PR queue checked before edits: #892, #908, #909, and #910
- Active PR impact or repair path: #892 overlaps `Dockerfile` and already contains `COPY fixtures ./fixtures` plus a separate `COPY bounties ./bounties`. When #892 rebases after this hotfix, drop only its duplicate fixtures line and retain its independent bounties copy. #908, #909, and #910 do not require repair for this focused change.
- Collaboration branch impact, if any: none

## Discovery Feedback

- How did you find Agent Bounties? Through the repository's scheduled production smoke and discoverability work.
- What made this bounty or project worth participating in? Restoring the current API revision is required before discovery and activation changes can be measured safely.
- If an AI agent helped you find or complete this work, what tool, prompt, link, label, scanner, or workflow led it here? The Production Smoke revision-parity check and Render Deploy Recovery artifact isolated the failing API service; an exact local Docker reproduction identified the missing compile-time fixture.
- What would make the project easier or more trustworthy before you participate again? Keep container path filters aligned with every compiled source and asset root; this PR makes that invariant executable.

Default CTA after value is delivered: **Post your own bounty**.

## Acceptance Criteria

- [x] The PR has a clear verifier or review path.
- [x] Deterministic behavior has tests or a documented manual check.
- [x] Payment, settlement, and payout behavior is unchanged or explicitly covered by tests and docs.

## SDLC And Recovery

- Change class: `R2`
- Authoritative source of truth: root `Dockerfile`, Rust `include_str!`/`include_bytes!` callsites, and `.github/workflows/containers.yml`
- Expected failure modes: missing repository asset, missing Docker `COPY`, or missing PR/main container path filter; the checker fails closed before deployment. The actual three-image build remains authoritative.
- Idempotency or replay key: not applicable; validation is read-only and deterministic
- Rollback or forward-repair path: forward-repair the missing `COPY`/path filter and rerun the full container gate; reverting would restore the known API build failure
- Health/readiness/SLO signal: API and MCP `/health` responses must report the same deployed revision; Production Smoke enforces parity
- Recovery fixture added or reason not applicable: `scripts/test_check_render_blueprint.py` covers the missing-fixture-copy regression and passing invariant
- Release/canary impact: Containers CI now builds API, MCP, and worker images when any copied source/asset root changes; normal review and deployment protections remain required

## Local Checks

```powershell
scripts/preflight.ps1 -Mode core
python scripts/test_check_render_blueprint.py -v
python scripts/check-render-blueprint.py
scripts/check-containers.ps1
scripts/check.ps1
$env:COMPOSE_PROJECT_NAME = 'agent-bounties'; scripts/check-postgres.ps1
scripts/check-production-compose.ps1 -ProjectName agent-bounties-hotfix-smoke -ApiPort 18280 -McpPort 18290
git diff --check
```

Additional reproduction evidence:

- The unmodified current-main API Docker build failed on missing `fixtures/a2a-agent-card.json`.
- Fixed API, MCP, and worker release images all built successfully.
- Production compose smoke passed with API/MCP revision parity and 119 MCP tools.
- Full Foundry gate passed 177 tests with 1,000 fuzz runs; 11 network-dependent fork tests were skipped by design.

## Review Lane

- [x] I believe this is ready for `main`.
- [x] If useful but not main-ready, I am comfortable with maintainers preserving this work on a `collab/pr-<number>-<topic>` branch for follow-up PRs.
- [ ] This touches risky paths and needs manual maintainer security review.

Code review, CI approval, and collaboration-branch preservation do not approve bounty acceptance, payout, or payment settlement.