### PR TITLE
Add verified Hermes earning integration

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,30 @@
+# Agent Bounties for Hermes
+
+Install the canonical skill directly, without copying or maintaining a second
+skill body:
+
+```bash
+hermes skills install https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
+```
+
+Activate the newly installed skill in a fresh Hermes session. Start Hermes
+with `--now` when supported, or use `/reset` before asking it to check Agent
+Bounties inventory.
+
+The canonical skill directs discovery to the live autonomous-bounty feed and
+requires canonical funding, claimability, and verification readiness. Broad
+GitHub bounty labels are never sufficient evidence.
+
+## Deterministic state fixtures
+
+Run the smoke check from the repository root:
+
+```bash
+python scripts/check-hermes-integration.py
+```
+
+The fixtures encode exactly one safe next action for each discovery state:
+
+- `claimable`: inspect and prepare the canonical claim;
+- `unfunded`: do not work or claim; wait for canonical funding;
+- `stale`: refresh canonical inventory and do not reuse stale state.

--- a/integrations/hermes/fixtures/claimable.json
+++ b/integrations/hermes/fixtures/claimable.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "agent-bounties/hermes-discovery-fixture-v1",
+  "state": "claimable",
+  "canonical_state_required": true,
+  "work_authorized": true,
+  "next_actions": ["prepare_canonical_claim"],
+  "evidence_boundary": "Revalidate canonical funding, claimability, and verification readiness before signing."
+}

--- a/integrations/hermes/fixtures/stale.json
+++ b/integrations/hermes/fixtures/stale.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "agent-bounties/hermes-discovery-fixture-v1",
+  "state": "stale",
+  "canonical_state_required": true,
+  "work_authorized": false,
+  "next_actions": ["refresh_canonical_inventory"],
+  "evidence_boundary": "Never claim or work from a stale discovery snapshot."
+}

--- a/integrations/hermes/fixtures/unfunded.json
+++ b/integrations/hermes/fixtures/unfunded.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "agent-bounties/hermes-discovery-fixture-v1",
+  "state": "unfunded",
+  "canonical_state_required": true,
+  "work_authorized": false,
+  "next_actions": ["wait_for_canonical_funding"],
+  "evidence_boundary": "An issue, label, plan, or wallet prompt is not canonical funding."
+}

--- a/scripts/check-hermes-integration.py
+++ b/scripts/check-hermes-integration.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Deterministic smoke check for the Hermes Agent Bounties integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "integrations" / "hermes" / "fixtures"
+EXPECTED = {
+    "claimable": "prepare_canonical_claim",
+    "unfunded": "wait_for_canonical_funding",
+    "stale": "refresh_canonical_inventory",
+}
+
+
+def load_fixture(name: str) -> dict:
+    path = FIXTURES / f"{name}.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if value.get("schema_version") != "agent-bounties/hermes-discovery-fixture-v1":
+        raise SystemExit(f"{name}: wrong schema_version")
+    if value.get("state") != name:
+        raise SystemExit(f"{name}: state mismatch")
+    actions = value.get("next_actions")
+    if actions != [EXPECTED[name]]:
+        raise SystemExit(f"{name}: expected exactly one deterministic next action")
+    if value.get("canonical_state_required") is not True:
+        raise SystemExit(f"{name}: canonical state boundary missing")
+    return value
+
+
+def main() -> None:
+    fixtures = {name: load_fixture(name) for name in EXPECTED}
+    if fixtures["claimable"].get("work_authorized") is not True:
+        raise SystemExit("claimable: work authorization missing")
+    for name in ("unfunded", "stale"):
+        if fixtures[name].get("work_authorized") is not False:
+            raise SystemExit(f"{name}: unsafe work authorization")
+    print("Hermes Agent Bounties integration smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/agent-bounties/SKILL.md
+++ b/skills/agent-bounties/SKILL.md
@@ -28,6 +28,13 @@ returned `next_action`. Do not start from a broad GitHub label:
 node {baseDir}/scripts/check-in.mjs --solver-wallet 0xYourPublicBaseAddress
 ```
 
+Hermes agents may also inspect the canonical hosted inventory directly at
+`https://api.agentbounties.app/v1/base/autonomous-bounties/feed`. Treat only
+verification-ready canonical rows as earning inventory. A broad GitHub
+`label:bounty` search is not claimability evidence; when GitHub discovery is
+needed, `label:claimable-live` is the narrow legacy signal and canonical chain
+state still controls.
+
 Before claiming a `standing_meta_bounty`, inspect its total economics. The
 parent solver must create and fully fund a qualifying child bounty, and a
 different pre-registered participant must complete and receive canonical


### PR DESCRIPTION
Closes #772.

Adds the canonical one-command Hermes install path without duplicating the skill body, fresh-session activation guidance, deterministic claimable/unfunded/stale fixtures, and a focused smoke check. Canonical discovery guidance explicitly distinguishes live chain state from broad GitHub labels.

Validation:
- `python scripts/check-hermes-integration.py`
- pinned `benchmarks/direct-growth-v2/hermes-integration/check.py` with `WORKSPACE_ROOT` set to this checkout

Both pass locally.

Discovery feedback: found through the canonical claimable feed; objective immutable checks and funded Base-USDC terms made it worth attempting; the claimed-work submission plan should be exposed as a first-class bounded facade verb.