### PR TITLE
feat(metrics): launch live public platform dashboard

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,8 @@
 name: Pages
 
 on:
+  schedule:
+    - cron: "17 * * * *"
   pull_request:
     paths:
       - ".github/workflows/pages.yml"
@@ -20,6 +22,11 @@ on:
       - "scripts/test-homepage-bounty-flow.js"
       - "scripts/test-create-competition-flow.js"
       - "scripts/test-ai-bounty-handoff.js"
+      - "scripts/test-metrics-dashboard.js"
+      - "scripts/github_audience_audit.py"
+      - "scripts/test_github_audience_audit.py"
+      - "scripts/fixtures/github_participation_metrics.json"
+      - "crates/api/fixtures/public-metrics-policy.json"
   push:
     branches: [main]
     paths:
@@ -40,17 +47,20 @@ on:
       - "scripts/test-homepage-bounty-flow.js"
       - "scripts/test-create-competition-flow.js"
       - "scripts/test-ai-bounty-handoff.js"
+      - "scripts/test-metrics-dashboard.js"
+      - "scripts/github_audience_audit.py"
+      - "scripts/test_github_audience_audit.py"
+      - "scripts/fixtures/github_participation_metrics.json"
+      - "crates/api/fixtures/public-metrics-policy.json"
   workflow_dispatch:
 
 permissions:
   contents: read
-  issues: write
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages-${{ github.ref }}
-  cancel-in-progress: true
+  # An hourly snapshot must not cancel a protected-main deployment already in flight.
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   validate:
@@ -83,6 +93,24 @@ jobs:
       - run: node scripts/test-homepage-bounty-flow.js
       - run: node scripts/test-create-competition-flow.js
       - run: node scripts/test-ai-bounty-handoff.js
+      - run: node --test scripts/test-metrics-dashboard.js
+      - name: Verify the privacy-safe GitHub participation aggregate
+        run: |
+          python scripts/test_github_audience_audit.py -v
+          python scripts/github_audience_audit.py \
+            --fixture scripts/fixtures/github_participation_metrics.json \
+            --public-metrics-policy crates/api/fixtures/public-metrics-policy.json \
+            --public-metrics-output /tmp/github-participation.json \
+            --public-metrics-only
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          value = json.loads(Path("/tmp/github-participation.json").read_text(encoding="utf-8"))
+          assert value["schema_version"] == "agent-bounties/github-participation-v1"
+          assert value["coverage"]["raw_identifiers_included"] is False
+          assert set(value["periods"]) == {"7d", "28d", "90d", "lifetime"}
+          PY
       - name: Check simplified public scripts
         run: |
           node --check site/bounty-board.js
@@ -91,6 +119,7 @@ jobs:
           node --check site/bounty-composer-v2.js
           node --check site/bounty-chat-ui.js
           node --check site/simple-home.js
+          node --check site/metrics.js
           node --check site/guild-shell.js
           node --check site/wallet-adapter-registry.js
           node --check site/x402-browser.js
@@ -169,11 +198,20 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
@@ -224,6 +262,16 @@ jobs:
           cp deployments/bounded-agent-wallet-v2-base-mainnet.json site/bounded-agent-wallet-v2-base-mainnet.json
           mkdir -p site/schemas
           cp schemas/discovery-manifest.v2.json site/schemas/discovery-manifest.v2.json
+      - name: Generate privacy-safe GitHub participation metrics
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/github_audience_audit.py \
+            --repository "${GITHUB_REPOSITORY}" \
+            --owner-login "${GITHUB_REPOSITORY_OWNER}" \
+            --public-metrics-policy crates/api/fixtures/public-metrics-policy.json \
+            --public-metrics-output site/generated/github-participation.json \
+            --public-metrics-only
       - uses: actions/upload-pages-artifact@v5
         with:
           path: site
@@ -231,6 +279,7 @@ jobs:
       - id: deployment
         uses: actions/deploy-pages@v5
       - name: Verify the normal chatbot and embedded-wallet experience
+        if: github.event_name != 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
           LIVE_CANARY_ISSUE: "499"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Agent Bounties is the open-source protocol behind
 verified digital work and earn Base USDC.
 
 **[Browse live funded work](https://agentbounties.app/earn.html) ·
-[Prepare a bounty with your own AI account](https://agentbounties.app/post.html)**
+[Prepare a bounty with your own AI account](https://agentbounties.app/post.html) ·
+[View live platform metrics](https://agentbounties.app/metrics.html)**
 
 [![Live canonical inventory](https://api.agentbounties.app/v1/base/autonomous-bounties/inventory-badge.svg?network=base-mainnet)](https://agentbounties.app/earn.html)
 
@@ -281,6 +282,7 @@ Maintainers inspect open pull requests and publish a change notice before changi
 
 Domain routing and migration: [docs/domain-portfolio.md](docs/domain-portfolio.md).
 - First-party site analytics: [docs/site-analytics.md](docs/site-analytics.md)
+- Public platform metrics: [docs/platform-metrics.md](docs/platform-metrics.md)
 - Agent quickstart: [docs/agent-quickstart.md](docs/agent-quickstart.md)
 - Autonomous protocol: [docs/autonomous-protocol.md](docs/autonomous-protocol.md)
 - Bounded wallet: [docs/bounded-agent-wallet.md](docs/bounded-agent-wallet.md)

--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "0152f753cc9e2b67cc2710aefac52aff7ae495353e736bd3c1ff4a08a2d2a694"
+  "normalized_sha256": "35b978a17654915e64d78af4dec18d3b6a881af7cd55c1fe7b6b2e3429d49f6b"
 }

--- a/crates/api/fixtures/public-metrics-policy.json
+++ b/crates/api/fixtures/public-metrics-policy.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "agent-bounties/public-metrics-policy-v1",
+  "maintainer_github_logins": [
+    "NSPG13"
+  ],
+  "maintainer_comment_authors": [
+    "agent bounties",
+    "agent-bounties",
+    "bountyboard",
+    "maintainer",
+    "nspg13",
+    "system"
+  ],
+  "maintainer_wallets": [],
+  "wallet_ownership_boundary": "Wallet ownership is never inferred. Only addresses deliberately added to this public policy are excluded as maintainer-controlled."
+}

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -92,8 +92,8 @@ use db::{
     NewLegalAcceptance, NewOpenCompetitionEntrantRelay, NewOpportunityComment,
     NewSiteAnalyticsEvent, NewSocialMentionIngestion, NewTrialBounty, NewUnfundedBountySolution,
     NewX402RelayAttempt, OpenCompetitionEntrantRelay, OpenCompetitionEntrantRelayStatus,
-    OpportunityComment as DbOpportunityComment, OpportunityLifecycleStats, PostgresStore,
-    SiteAnalyticsStats, SocialMentionIngestion, TrialBounty, UnfundedBountySolution,
+    OpportunityComment as DbOpportunityComment, OpportunityLifecycleStats, PlatformMetricsStats,
+    PostgresStore, SiteAnalyticsStats, SocialMentionIngestion, TrialBounty, UnfundedBountySolution,
     WebhookSubscription, X402RelayAttempt, X402RelayStatus,
 };
 use domain::{
@@ -206,6 +206,7 @@ use worker::{
         opportunity_conversion_funnel,
         record_site_analytics_event,
         site_analytics,
+        platform_metrics,
         create_discovery_subscription,
         get_discovery_subscription,
         delete_discovery_subscription,
@@ -435,6 +436,17 @@ use worker::{
         ,SiteAnalyticsChannelResponse
         ,SiteAnalyticsRateResponse
         ,SiteAnalyticsResponse
+        ,PlatformMetricsResponse
+        ,PlatformMetricsWindowResponse
+        ,PlatformIdentityMetricsResponse
+        ,PlatformIdentityRoleResponse
+        ,PlatformIdentityNamespaceResponse
+        ,PlatformAmountResponse
+        ,PlatformPayoutMetricsResponse
+        ,PlatformClaimCohortResponse
+        ,PlatformInventoryResponse
+        ,PlatformDailyResponse
+        ,PlatformCoverageResponse
         ,UnfundedBountyResponse
         ,UnfundedBountyAgentSolution
         ,SubmitUnfundedBountySolutionRequest
@@ -803,6 +815,9 @@ impl BondSponsorConfig {
 
 type SharedState = Arc<AppState>;
 const OPERATOR_TOKEN_HEADER: &str = "x-operator-token";
+const PLATFORM_LAUNCH_AT: &str = "2026-07-08T20:22:19Z";
+const PLATFORM_FIRST_MONTH_ENDED_AT: &str = "2026-08-08T20:22:19Z";
+const PUBLIC_METRICS_POLICY_JSON: &str = include_str!("../fixtures/public-metrics-policy.json");
 const LEGAL_TERMS_VERSION: &str = "2026-07-18";
 const LEGAL_PRIVACY_VERSION: &str = "2026-07-18";
 const LEGAL_ACCEPTANCE_STATEMENT: &str = "I meet the age requirement in the Terms and am authorized to use this wallet and perform this action. I understand that public and blockchain records may be permanent. I accept the posted task, verification, and settlement rules. I am responsible for legal compliance, taxes, content rights, agent authority, and wallet security. I agree to the Terms of Use and Privacy Policy.";
@@ -1492,6 +1507,146 @@ struct SiteAnalyticsResponse {
     evidence_boundary: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct PlatformMetricsQuery {
+    period: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PublicMetricsPolicy {
+    schema_version: String,
+    maintainer_github_logins: Vec<String>,
+    maintainer_comment_authors: Vec<String>,
+    maintainer_wallets: Vec<String>,
+    wallet_ownership_boundary: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformMetricsWindowResponse {
+    period: String,
+    started_at: String,
+    ended_at: String,
+    previous_started_at: String,
+    previous_ended_at: String,
+    launch_at: String,
+    first_month_started_at: String,
+    first_month_ended_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformIdentityRoleResponse {
+    role: String,
+    active_identities: u64,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformIdentityNamespaceResponse {
+    namespace: String,
+    active_identities: u64,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformIdentityMetricsResponse {
+    selected: u64,
+    previous: u64,
+    latest_week: u64,
+    previous_week: u64,
+    first_month: u64,
+    lifetime: u64,
+    roles: Vec<PlatformIdentityRoleResponse>,
+    namespaces: Vec<PlatformIdentityNamespaceResponse>,
+    definition: String,
+    cross_namespace_deduplication: bool,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformAmountResponse {
+    usdc_base_units: String,
+    usdc: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformPayoutMetricsResponse {
+    selected: PlatformAmountResponse,
+    previous: PlatformAmountResponse,
+    first_month: PlatformAmountResponse,
+    lifetime: PlatformAmountResponse,
+    selected_solver_pay: PlatformAmountResponse,
+    selected_verifier_pay: PlatformAmountResponse,
+    selected_completion_bonus: PlatformAmountResponse,
+    selected_settled_rounds: u64,
+    previous_settled_rounds: u64,
+    first_month_settled_rounds: u64,
+    lifetime_settled_rounds: u64,
+    definition: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformClaimCohortResponse {
+    settled_rounds: u64,
+    mature_claimed_rounds: u64,
+    immature_claimed_rounds: u64,
+    settlement_rate: Option<f64>,
+    definition: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformInventoryResponse {
+    status: String,
+    ready_to_earn_opportunities: Option<usize>,
+    autonomous_claimable_bounties: Option<usize>,
+    open_competitions_ready_to_earn: Option<usize>,
+    verification_ready_bounties: Option<usize>,
+    standing_meta_bounties: Option<usize>,
+    funded: Option<PlatformAmountResponse>,
+    solver_rewards: Option<PlatformAmountResponse>,
+    verifier_rewards: Option<PlatformAmountResponse>,
+    generated_at: Option<String>,
+    definition: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformDailyResponse {
+    day: String,
+    active_identities: u64,
+    payout: PlatformAmountResponse,
+    settled_rounds: u64,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformCoverageResponse {
+    status: String,
+    autonomous_indexer_fresh: bool,
+    open_competition_indexer_fresh: bool,
+    verified_canonical_events: u64,
+    awaiting_block_time_events: u64,
+    opportunity_comments: u64,
+    latest_verified_event_at: Option<String>,
+    latest_comment_at: Option<String>,
+    github_included: bool,
+    github_snapshot_path: String,
+    maintainer_exclusion_policy: String,
+    identity_limitations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+struct PlatformMetricsResponse {
+    schema_version: String,
+    network: String,
+    generated_at: String,
+    window: PlatformMetricsWindowResponse,
+    platform_active_identities: PlatformIdentityMetricsResponse,
+    marketplace_payout_volume: PlatformPayoutMetricsResponse,
+    mature_claim_to_settlement: PlatformClaimCohortResponse,
+    current_inventory: PlatformInventoryResponse,
+    daily: Vec<PlatformDailyResponse>,
+    platform_revenue: PlatformAmountResponse,
+    monetization_status: String,
+    coverage: PlatformCoverageResponse,
+    definitions: BTreeMap<String, String>,
+    evidence_boundary: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct AgentNativeClaimResponse {
     schema_version: String,
@@ -1816,6 +1971,27 @@ struct AutonomousBountyInventorySummary {
     evidence_boundary: String,
 }
 
+#[derive(Debug, Clone)]
+struct OpenCompetitionInventorySummary {
+    generated_at: String,
+    ready_to_earn_count: usize,
+    funded_usdc_base_units: String,
+    solver_reward_usdc_base_units: String,
+    verifier_reward_usdc_base_units: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PlatformCanonicalSourceFreshness {
+    autonomous: bool,
+    open_competition: bool,
+}
+
+impl PlatformCanonicalSourceFreshness {
+    fn complete(self) -> bool {
+        self.autonomous && self.open_competition
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct AutonomousVerificationJobsQuery {
     network: Option<String>,
@@ -1998,6 +2174,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/v1/analytics/events", post(record_site_analytics_event))
         .route("/v1/analytics/site", get(site_analytics))
+        .route("/v1/metrics/platform", get(platform_metrics))
         .route(
             "/public/opportunities/:opportunity_id/embed",
             get(opportunity_embed_page),
@@ -4705,6 +4882,448 @@ fn site_analytics_response(
         ],
         evidence_boundary: "Collection begins only after this feature is deployed and has no historical backfill. Cleared storage, private browsing, multiple devices, disabled analytics, Global Privacy Control, and Do Not Track affect coverage. No IP address, user agent, full referrer URL, wallet, or arbitrary metadata is stored. Client conversion events describe observed interface actions; canonical lifecycle and payment claims remain authoritative only in confirmed canonical events, and only BountySettled proves solver payment.".to_string(),
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlatformMetricWindow {
+    period: String,
+    started_at: DateTime<Utc>,
+    ended_at: DateTime<Utc>,
+    previous_started_at: DateTime<Utc>,
+    launch_at: DateTime<Utc>,
+    first_month_ended_at: DateTime<Utc>,
+}
+
+fn parse_public_metrics_timestamp(value: &str) -> Result<DateTime<Utc>, StatusCode> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn platform_metric_window(
+    period: Option<&str>,
+    ended_at: DateTime<Utc>,
+) -> Result<PlatformMetricWindow, StatusCode> {
+    let launch_at = parse_public_metrics_timestamp(PLATFORM_LAUNCH_AT)?;
+    let first_month_ended_at = parse_public_metrics_timestamp(PLATFORM_FIRST_MONTH_ENDED_AT)?;
+    let period = period.unwrap_or("7d");
+    let requested_started_at = match period {
+        "7d" => ended_at - ChronoDuration::days(7),
+        "28d" => ended_at - ChronoDuration::days(28),
+        "90d" => ended_at - ChronoDuration::days(90),
+        "lifetime" => launch_at,
+        _ => return Err(StatusCode::BAD_REQUEST),
+    };
+    let started_at = requested_started_at.max(launch_at);
+    let selected_duration = ended_at.signed_duration_since(started_at);
+    let previous_started_at = if period == "lifetime" {
+        launch_at
+    } else {
+        started_at - selected_duration
+    };
+    Ok(PlatformMetricWindow {
+        period: period.to_string(),
+        started_at,
+        ended_at,
+        previous_started_at,
+        launch_at,
+        first_month_ended_at,
+    })
+}
+
+fn public_metrics_policy() -> Result<PublicMetricsPolicy, StatusCode> {
+    let mut policy: PublicMetricsPolicy = serde_json::from_str(PUBLIC_METRICS_POLICY_JSON)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    policy.maintainer_github_logins = policy
+        .maintainer_github_logins
+        .into_iter()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect();
+    policy.maintainer_comment_authors = policy
+        .maintainer_comment_authors
+        .into_iter()
+        .map(|value| {
+            value
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+                .to_ascii_lowercase()
+        })
+        .filter(|value| !value.is_empty())
+        .collect();
+    policy.maintainer_wallets = policy
+        .maintainer_wallets
+        .into_iter()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect();
+    Ok(policy)
+}
+
+fn exact_usdc(amount: u128) -> String {
+    format!("{}.{:06}", amount / 1_000_000, amount % 1_000_000)
+}
+
+fn platform_amount(base_units: impl Into<String>) -> Result<PlatformAmountResponse, StatusCode> {
+    let usdc_base_units = base_units.into();
+    let amount = usdc_base_units
+        .parse::<u128>()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(PlatformAmountResponse {
+        usdc_base_units,
+        usdc: exact_usdc(amount),
+    })
+}
+
+fn platform_inventory_response(
+    autonomous: Option<AutonomousBountyInventorySummary>,
+    competition: Option<OpenCompetitionInventorySummary>,
+) -> Result<PlatformInventoryResponse, StatusCode> {
+    match (autonomous, competition) {
+        (Some(autonomous), Some(competition)) => Ok(PlatformInventoryResponse {
+            status: "ready".to_string(),
+            ready_to_earn_opportunities: Some(
+                autonomous
+                    .claimable_bounty_count
+                    .checked_add(competition.ready_to_earn_count)
+                    .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?,
+            ),
+            autonomous_claimable_bounties: Some(autonomous.claimable_bounty_count),
+            open_competitions_ready_to_earn: Some(competition.ready_to_earn_count),
+            verification_ready_bounties: Some(
+                autonomous
+                    .verification_ready_bounty_count
+                    .checked_add(competition.ready_to_earn_count)
+                    .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?,
+            ),
+            standing_meta_bounties: Some(autonomous.standing_meta_bounty_count),
+            funded: Some(platform_amount(add_platform_base_units(
+                &autonomous.funded_usdc_base_units,
+                &competition.funded_usdc_base_units,
+            )?)?),
+            solver_rewards: Some(platform_amount(add_platform_base_units(
+                &autonomous.solver_reward_usdc_base_units,
+                &competition.solver_reward_usdc_base_units,
+            )?)?),
+            verifier_rewards: Some(platform_amount(add_platform_base_units(
+                &autonomous.verifier_reward_usdc_base_units,
+                &competition.verifier_reward_usdc_base_units,
+            )?)?),
+            generated_at: Some(if autonomous.generated_at <= competition.generated_at {
+                autonomous.generated_at
+            } else {
+                competition.generated_at
+            }),
+            definition: "Current ready-to-earn inventory combines the canonical exclusive-claim feed with active Open Competition entries. It is a point-in-time projection and is not added to historical payout or conversion cohorts.".to_string(),
+        }),
+        (autonomous, competition) => Ok(PlatformInventoryResponse {
+            status: if autonomous.is_some() || competition.is_some() {
+                "partial"
+            } else {
+                "unavailable"
+            }
+            .to_string(),
+            ready_to_earn_opportunities: None,
+            autonomous_claimable_bounties: autonomous
+                .as_ref()
+                .map(|summary| summary.claimable_bounty_count),
+            open_competitions_ready_to_earn: competition
+                .as_ref()
+                .map(|summary| summary.ready_to_earn_count),
+            verification_ready_bounties: None,
+            standing_meta_bounties: None,
+            funded: None,
+            solver_rewards: None,
+            verifier_rewards: None,
+            generated_at: None,
+            definition: "One or both canonical inventory protocols could not be read. Historical metrics remain available, observed protocol counts stay separated, and combined inventory values are not silently replaced with a lower total or zero.".to_string(),
+        }),
+    }
+}
+
+fn add_platform_base_units(left: &str, right: &str) -> Result<String, StatusCode> {
+    let left = left
+        .parse::<u128>()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let right = right
+        .parse::<u128>()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    left.checked_add(right)
+        .map(|value| value.to_string())
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn platform_metrics_response(
+    stats: PlatformMetricsStats,
+    window: PlatformMetricWindow,
+    policy: PublicMetricsPolicy,
+    autonomous_inventory: Option<AutonomousBountyInventorySummary>,
+    competition_inventory: Option<OpenCompetitionInventorySummary>,
+    source_freshness: PlatformCanonicalSourceFreshness,
+) -> Result<PlatformMetricsResponse, StatusCode> {
+    let settlement_rate = (stats.claim_cohort.mature > 0)
+        .then(|| stats.claim_cohort.settled as f64 / stats.claim_cohort.mature as f64);
+    let inventory_complete = autonomous_inventory.is_some() && competition_inventory.is_some();
+    let coverage_status = if inventory_complete
+        && source_freshness.complete()
+        && stats.coverage.awaiting_block_time_events == 0
+    {
+        "ready"
+    } else {
+        "partial"
+    };
+    let inventory = platform_inventory_response(autonomous_inventory, competition_inventory)?;
+    let mut definitions = BTreeMap::new();
+    definitions.insert(
+        "external_active_identities".to_string(),
+        "Distinct provider-namespaced marketplace wallets and normalized opportunity-comment authors that performed a qualifying action. GitHub identities are supplied by the separate aggregate snapshot and must be added only once. Identities are not verified unique people.".to_string(),
+    );
+    definitions.insert(
+        "marketplace_payout_volume".to_string(),
+        "Confirmed solver reward, verifier reward, and completion bonus from block-time-verified BountySettled events across Autonomous and Open Competition, plus verifier pay from block-time-verified SubmissionRejected and CompetitionSubmissionRejected events. Returned bonds, refunds, funding plans, and prizes are excluded.".to_string(),
+    );
+    definitions.insert(
+        "mature_claim_to_settlement".to_string(),
+        "Settled exclusive-claim rounds divided by exclusive-claim rounds whose claim deadline has passed or that already have a terminal canonical event. Recent immature claims are shown separately and excluded from the rate. Open Competition has no exclusive claim and is not part of this cohort.".to_string(),
+    );
+    definitions.insert(
+        "platform_revenue".to_string(),
+        "The live marketplace protocols have no platform fee. Marketplace payout volume is not platform revenue.".to_string(),
+    );
+
+    Ok(PlatformMetricsResponse {
+        schema_version: "agent-bounties/platform-metrics-v1".to_string(),
+        network: "base-mainnet".to_string(),
+        generated_at: stats.generated_at.to_rfc3339(),
+        window: PlatformMetricsWindowResponse {
+            period: window.period,
+            started_at: window.started_at.to_rfc3339(),
+            ended_at: window.ended_at.to_rfc3339(),
+            previous_started_at: window.previous_started_at.to_rfc3339(),
+            previous_ended_at: window.started_at.to_rfc3339(),
+            launch_at: window.launch_at.to_rfc3339(),
+            first_month_started_at: window.launch_at.to_rfc3339(),
+            first_month_ended_at: window.first_month_ended_at.to_rfc3339(),
+        },
+        platform_active_identities: PlatformIdentityMetricsResponse {
+            selected: stats.identities.selected,
+            previous: stats.identities.previous,
+            latest_week: stats.identities.latest_week,
+            previous_week: stats.identities.previous_week,
+            first_month: stats.identities.first_month,
+            lifetime: stats.identities.lifetime,
+            roles: vec![
+                PlatformIdentityRoleResponse { role: "posters".to_string(), active_identities: stats.identities.posters },
+                PlatformIdentityRoleResponse { role: "funders".to_string(), active_identities: stats.identities.funders },
+                PlatformIdentityRoleResponse { role: "solvers".to_string(), active_identities: stats.identities.solvers },
+                PlatformIdentityRoleResponse { role: "verifiers".to_string(), active_identities: stats.identities.verifiers },
+                PlatformIdentityRoleResponse { role: "commenters".to_string(), active_identities: stats.identities.commenters },
+            ],
+            namespaces: vec![
+                PlatformIdentityNamespaceResponse {
+                    namespace: "base_wallet".to_string(),
+                    active_identities: stats.identities.marketplace_wallets,
+                },
+                PlatformIdentityNamespaceResponse {
+                    namespace: "opportunity_comment_author".to_string(),
+                    active_identities: stats.identities.opportunity_comment_authors,
+                },
+            ],
+            definition: "One identity is counted once per namespace and reporting window after the public maintainer exclusion policy is applied. Role counts are not additive.".to_string(),
+            cross_namespace_deduplication: false,
+        },
+        marketplace_payout_volume: PlatformPayoutMetricsResponse {
+            selected: platform_amount(stats.payouts.selected_total_base_units)?,
+            previous: platform_amount(stats.payouts.previous_total_base_units)?,
+            first_month: platform_amount(stats.payouts.first_month_total_base_units)?,
+            lifetime: platform_amount(stats.payouts.lifetime_total_base_units)?,
+            selected_solver_pay: platform_amount(stats.payouts.selected_solver_base_units)?,
+            selected_verifier_pay: platform_amount(stats.payouts.selected_verifier_base_units)?,
+            selected_completion_bonus: platform_amount(stats.payouts.selected_bonus_base_units)?,
+            selected_settled_rounds: stats.payouts.selected_settled_rounds,
+            previous_settled_rounds: stats.payouts.previous_settled_rounds,
+            first_month_settled_rounds: stats.payouts.first_month_settled_rounds,
+            lifetime_settled_rounds: stats.payouts.lifetime_settled_rounds,
+            definition: definitions["marketplace_payout_volume"].clone(),
+        },
+        mature_claim_to_settlement: PlatformClaimCohortResponse {
+            settled_rounds: stats.claim_cohort.settled,
+            mature_claimed_rounds: stats.claim_cohort.mature,
+            immature_claimed_rounds: stats.claim_cohort.immature,
+            settlement_rate,
+            definition: definitions["mature_claim_to_settlement"].clone(),
+        },
+        current_inventory: inventory,
+        daily: stats
+            .daily
+            .into_iter()
+            .map(|day| {
+                Ok(PlatformDailyResponse {
+                    day: day.day,
+                    active_identities: day.active_identities,
+                    payout: platform_amount(day.payout_base_units)?,
+                    settled_rounds: day.settled_rounds,
+                })
+            })
+            .collect::<Result<Vec<_>, StatusCode>>()?,
+        platform_revenue: platform_amount("0")?,
+        monetization_status: "monetization not active".to_string(),
+        coverage: PlatformCoverageResponse {
+            status: coverage_status.to_string(),
+            autonomous_indexer_fresh: source_freshness.autonomous,
+            open_competition_indexer_fresh: source_freshness.open_competition,
+            verified_canonical_events: stats.coverage.verified_canonical_events,
+            awaiting_block_time_events: stats.coverage.awaiting_block_time_events,
+            opportunity_comments: stats.coverage.opportunity_comments,
+            latest_verified_event_at: stats
+                .coverage
+                .latest_verified_event_at
+                .map(|value| value.to_rfc3339()),
+            latest_comment_at: stats
+                .coverage
+                .latest_comment_at
+                .map(|value| value.to_rfc3339()),
+            github_included: false,
+            github_snapshot_path: "/generated/github-participation.json".to_string(),
+            maintainer_exclusion_policy: policy.schema_version,
+            identity_limitations: vec![
+                "A wallet, GitHub login, and self-reported comment author are separate identity namespaces unless explicitly verified and linked.".to_string(),
+                policy.wallet_ownership_boundary,
+                "Opportunity-comment authors are self-reported labels, not authenticated people.".to_string(),
+            ],
+        },
+        definitions,
+        evidence_boundary: "This public response contains aggregate counts and amounts only. Canonical metrics use events whose Base block time has been verified. It returns no wallet, GitHub, comment-author, event, transaction, or customer identifiers. GitHub participation is intentionally generated as a separate aggregate snapshot to avoid double counting. Only confirmed canonical BountySettled proves solver payment.".to_string(),
+    })
+}
+
+fn public_metrics_indexer_heartbeat_fresh(
+    heartbeat: &BaseIndexerHeartbeat,
+    now: DateTime<Utc>,
+) -> bool {
+    const MAX_AGE_SECONDS: i64 = 300;
+    const MAX_CURSOR_LAG_BLOCKS: u64 = 20;
+    let status_healthy = heartbeat.status == "success"
+        || (heartbeat.status == "skipped"
+            && heartbeat.skipped_reason.as_deref()
+                == Some("no confirmed blocks are ready to scan"));
+    let Some(completed_at) = heartbeat.completed_at else {
+        return false;
+    };
+    let age = now.signed_duration_since(completed_at).num_seconds();
+    let cursor_caught_up = heartbeat
+        .latest_block
+        .zip(heartbeat.persisted_cursor_block)
+        .is_some_and(|(latest, cursor)| cursor.saturating_add(MAX_CURSOR_LAG_BLOCKS) >= latest);
+    status_healthy
+        && heartbeat.error_message.is_none()
+        && (0..=MAX_AGE_SECONDS).contains(&age)
+        && cursor_caught_up
+}
+
+async fn platform_canonical_source_freshness(
+    state: &SharedState,
+    now: DateTime<Utc>,
+) -> PlatformCanonicalSourceFreshness {
+    let Some(store) = state.store.as_ref() else {
+        return PlatformCanonicalSourceFreshness {
+            autonomous: false,
+            open_competition: false,
+        };
+    };
+    let autonomous = if let Some(factory) = autonomous_factory_for_chain(8_453) {
+        store
+            .get_base_indexer_heartbeat("base-mainnet", &factory)
+            .await
+            .ok()
+            .flatten()
+            .is_some_and(|heartbeat| public_metrics_indexer_heartbeat_fresh(&heartbeat, now))
+    } else {
+        false
+    };
+    let open_competition = match open_competition_release_from_environment("base-mainnet") {
+        Ok(release) => store
+            .get_base_indexer_heartbeat("base-mainnet", &release.factory_contract)
+            .await
+            .ok()
+            .flatten()
+            .is_some_and(|heartbeat| public_metrics_indexer_heartbeat_fresh(&heartbeat, now)),
+        Err(_) => false,
+    };
+    PlatformCanonicalSourceFreshness {
+        autonomous,
+        open_competition,
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/metrics/platform",
+    params(("period" = Option<String>, Query, description = "Reporting window: 7d, 28d, 90d, or lifetime; defaults to 7d")),
+    responses(
+        (status = 200, body = PlatformMetricsResponse),
+        (status = 400, description = "Unknown reporting period"),
+        (status = 503, description = "Durable metrics store unavailable")
+    )
+)]
+async fn platform_metrics(
+    State(state): State<SharedState>,
+    Query(query): Query<PlatformMetricsQuery>,
+) -> Result<Response, StatusCode> {
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let window = platform_metric_window(query.period.as_deref(), Utc::now())?;
+    let policy = public_metrics_policy()?;
+    let excluded_contracts = state.recovery_reservations.contracts();
+    let stats = store
+        .platform_metrics_stats(
+            "base-mainnet",
+            window.started_at,
+            window.ended_at,
+            window.previous_started_at,
+            window.launch_at,
+            window.first_month_ended_at,
+            &policy.maintainer_wallets,
+            &policy.maintainer_comment_authors,
+            &excluded_contracts,
+        )
+        .await
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    let source_freshness = platform_canonical_source_freshness(&state, stats.generated_at).await;
+    let autonomous_inventory = if source_freshness.autonomous {
+        match load_verified_autonomous_bounty_feed(&state, "base-mainnet", true).await {
+            Ok(feed) => build_autonomous_inventory_summary(&state, "base-mainnet", feed).ok(),
+            Err(_) => None,
+        }
+    } else {
+        None
+    };
+    let competition_inventory = if source_freshness.open_competition {
+        build_open_competition_inventory_summary(&state, "base-mainnet")
+            .await
+            .ok()
+    } else {
+        None
+    };
+    let response = platform_metrics_response(
+        stats,
+        window,
+        policy,
+        autonomous_inventory,
+        competition_inventory,
+        source_freshness,
+    )?;
+    Ok((
+        [(
+            header::CACHE_CONTROL,
+            "public, max-age=30, stale-while-revalidate=60",
+        )],
+        Json(response),
+    )
+        .into_response())
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -12870,6 +13489,29 @@ async fn load_autonomous_bounty_feed(
     Ok(feed)
 }
 
+async fn load_verified_autonomous_bounty_feed(
+    state: &SharedState,
+    network: &str,
+    claimable_only: bool,
+) -> Result<Vec<AutonomousBountyFeedItem>, StatusCode> {
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let events = store
+        .list_verified_autonomous_bounty_events(network)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let terms = store
+        .list_autonomous_bounty_terms()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut feed = build_autonomous_bounty_feed(events, terms, false)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    state.recovery_reservations.apply(&mut feed, claimable_only);
+    Ok(feed)
+}
+
 #[utoipa::path(
     get,
     path = "/v1/base/autonomous-bounties/leaderboard",
@@ -13225,6 +13867,77 @@ fn build_autonomous_inventory_summary(
         verifier_reward_usdc: format_usdc_base_units(verifier),
         items,
         evidence_boundary: "This summary is derived at request time from confirmed canonical events and validated content-addressed terms in the hosted index. It proves current indexed inventory, not a future claim, completion, or payout. Only BountySettled proves payment.".to_string(),
+    })
+}
+
+async fn build_open_competition_inventory_summary(
+    state: &SharedState,
+    network: &str,
+) -> Result<OpenCompetitionInventorySummary, StatusCode> {
+    let (descriptor, _) = state
+        .base_rpc_urls
+        .resolve(network)
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    let release = open_competition_release_from_environment(network)
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    if release.deployment_state != OpenCompetitionDeploymentState::ActiveReadyToEarn {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    let prefix = open_competition_environment_prefix(network)
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    let public_activation_block = env::var(format!("{prefix}_PUBLIC_ACTIVATION_BLOCK"))
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
+        .parse::<u64>()
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    let catalog = open_competition_verifier_catalog_from_environment(network)
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    let [profile] = catalog.profiles.as_slice() else {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    };
+    if !profile.public_inventory_eligible
+        || profile.deployment_state != OpenCompetitionDeploymentState::ActiveReadyToEarn
+    {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let events = store
+        .list_verified_open_competition_events(network, &release.factory_contract)
+        .await
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    let generated_at = Utc::now();
+    let website_base_url =
+        legal_website_base_url(env::var("WEBSITE_BASE_URL").ok(), &state.public_base_url);
+    let items = open_competition_discovery_items(
+        &events,
+        profile,
+        network,
+        descriptor.chain_id,
+        &state.public_base_url,
+        &website_base_url,
+        public_activation_block,
+        generated_at,
+    )
+    .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    let ready = items.iter().filter(|item| item.ready_to_earn);
+    let sum = |field: fn(&github_discovery::GitHubDiscoveryItem) -> &str| {
+        ready.clone().try_fold(0_u128, |total, item| {
+            field(item)
+                .parse::<u128>()
+                .ok()
+                .and_then(|amount| total.checked_add(amount))
+                .ok_or(StatusCode::INTERNAL_SERVER_ERROR)
+        })
+    };
+    Ok(OpenCompetitionInventorySummary {
+        generated_at: generated_at.to_rfc3339(),
+        ready_to_earn_count: items.iter().filter(|item| item.ready_to_earn).count(),
+        funded_usdc_base_units: sum(|item| &item.funded_usdc_base_units)?.to_string(),
+        solver_reward_usdc_base_units: sum(|item| &item.reward_usdc_base_units)?.to_string(),
+        verifier_reward_usdc_base_units: sum(|item| &item.verifier_reward_usdc_base_units)?
+            .to_string(),
     })
 }
 
@@ -15311,6 +16024,10 @@ mod tests {
         RegisterCapabilityRequest, SubmitResultRequest, VerifySubmissionRequest,
     };
     use chrono::TimeZone;
+    use db::{
+        PlatformClaimCohortStats, PlatformDailyStats, PlatformIdentityStats,
+        PlatformMetricsCoverageStats, PlatformPayoutStats,
+    };
     use domain::{
         AffectedPartyDeclaration, Bounty, BountyStatus, CapabilityClass, DeliverableAccessPolicy,
         ExpectedEffect, FundingIntentStatus, FundingMode, IdentityDisclosure, ObjectiveAuthority,
@@ -15401,6 +16118,24 @@ mod tests {
         assert!(!open_competition_monitoring_is_fresh(
             &caught_up, safe_block, now
         ));
+    }
+
+    #[test]
+    fn public_metrics_marks_indexer_heartbeats_delayed_after_five_minutes() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap();
+        let fresh = open_competition_heartbeat(now, "success", Some(50_000_000), 300);
+        assert!(public_metrics_indexer_heartbeat_fresh(&fresh, now));
+
+        let stale = open_competition_heartbeat(now, "success", Some(50_000_000), 301);
+        assert!(!public_metrics_indexer_heartbeat_fresh(&stale, now));
+
+        let mut lagging = open_competition_heartbeat(now, "success", Some(50_000_000), 1);
+        lagging.latest_block = Some(50_000_021);
+        assert!(!public_metrics_indexer_heartbeat_fresh(&lagging, now));
+
+        let mut failed = open_competition_heartbeat(now, "success", Some(50_000_000), 1);
+        failed.error_message = Some("redacted".to_string());
+        assert!(!public_metrics_indexer_heartbeat_fresh(&failed, now));
     }
 
     fn entrant_relay_fixture(action: u8) -> OpenCompetitionEntrantRelay {
@@ -18473,6 +19208,237 @@ mod tests {
         );
     }
 
+    #[test]
+    fn platform_metric_windows_use_exact_launch_and_first_month_boundaries() {
+        let ended_at = parse_public_metrics_timestamp("2026-08-12T20:22:19Z").unwrap();
+        let seven_days = platform_metric_window(Some("7d"), ended_at).unwrap();
+        assert_eq!(
+            seven_days.started_at,
+            parse_public_metrics_timestamp("2026-08-05T20:22:19Z").unwrap()
+        );
+        assert_eq!(
+            seven_days.previous_started_at,
+            parse_public_metrics_timestamp("2026-07-29T20:22:19Z").unwrap()
+        );
+        assert_eq!(
+            seven_days.launch_at.to_rfc3339(),
+            "2026-07-08T20:22:19+00:00"
+        );
+        assert_eq!(
+            seven_days.first_month_ended_at.to_rfc3339(),
+            "2026-08-08T20:22:19+00:00"
+        );
+
+        let lifetime = platform_metric_window(Some("lifetime"), ended_at).unwrap();
+        assert_eq!(lifetime.started_at, lifetime.launch_at);
+        assert_eq!(lifetime.previous_started_at, lifetime.launch_at);
+        assert_eq!(
+            platform_metric_window(Some("30d"), ended_at),
+            Err(StatusCode::BAD_REQUEST)
+        );
+    }
+
+    #[test]
+    fn platform_metrics_response_is_aggregate_only_and_preserves_payment_math() {
+        let generated_at = parse_public_metrics_timestamp("2026-08-12T20:22:19Z").unwrap();
+        let stats = PlatformMetricsStats {
+            generated_at,
+            identities: PlatformIdentityStats {
+                selected: 4,
+                previous: 2,
+                latest_week: 4,
+                previous_week: 2,
+                first_month: 3,
+                lifetime: 5,
+                posters: 1,
+                funders: 1,
+                solvers: 2,
+                verifiers: 1,
+                commenters: 1,
+                marketplace_wallets: 3,
+                opportunity_comment_authors: 1,
+            },
+            payouts: PlatformPayoutStats {
+                selected_total_base_units: "1250000".to_string(),
+                previous_total_base_units: "100000".to_string(),
+                first_month_total_base_units: "900000".to_string(),
+                lifetime_total_base_units: "1350000".to_string(),
+                selected_solver_base_units: "1000000".to_string(),
+                selected_verifier_base_units: "200000".to_string(),
+                selected_bonus_base_units: "50000".to_string(),
+                selected_settled_rounds: 1,
+                previous_settled_rounds: 0,
+                first_month_settled_rounds: 1,
+                lifetime_settled_rounds: 1,
+            },
+            claim_cohort: PlatformClaimCohortStats {
+                settled: 1,
+                mature: 2,
+                immature: 1,
+            },
+            daily: vec![PlatformDailyStats {
+                day: "2026-08-12".to_string(),
+                active_identities: 4,
+                payout_base_units: "1250000".to_string(),
+                settled_rounds: 1,
+            }],
+            coverage: PlatformMetricsCoverageStats {
+                verified_canonical_events: 9,
+                awaiting_block_time_events: 1,
+                opportunity_comments: 2,
+                latest_verified_event_at: Some(generated_at),
+                latest_comment_at: Some(generated_at),
+            },
+        };
+        let mut policy = public_metrics_policy().unwrap();
+        policy.maintainer_github_logins = vec!["private-maintainer-login".to_string()];
+        policy.maintainer_wallets = vec!["0x1111111111111111111111111111111111111111".to_string()];
+        let response = platform_metrics_response(
+            stats,
+            platform_metric_window(Some("7d"), generated_at).unwrap(),
+            policy,
+            None,
+            None,
+            PlatformCanonicalSourceFreshness {
+                autonomous: true,
+                open_competition: true,
+            },
+        )
+        .unwrap();
+        let json = serde_json::to_string(&response).unwrap();
+
+        assert_eq!(response.marketplace_payout_volume.selected.usdc, "1.250000");
+        assert_eq!(
+            response.mature_claim_to_settlement.settlement_rate,
+            Some(0.5)
+        );
+        assert_eq!(response.platform_active_identities.namespaces.len(), 2);
+        assert_eq!(
+            response.platform_active_identities.namespaces[0].active_identities,
+            3
+        );
+        assert_eq!(
+            response.platform_active_identities.namespaces[1].active_identities,
+            1
+        );
+        assert_eq!(response.current_inventory.status, "unavailable");
+        assert_eq!(response.coverage.status, "partial");
+        assert!(!response.coverage.github_included);
+        assert!(!json.contains("private-maintainer-login"));
+        assert!(!json.contains("0x1111111111111111111111111111111111111111"));
+    }
+
+    #[test]
+    fn platform_inventory_combines_protocols_only_when_both_are_available() {
+        let autonomous = AutonomousBountyInventorySummary {
+            schema_version: "test".to_string(),
+            network: "base-mainnet".to_string(),
+            generated_at: "2026-08-12T20:00:00+00:00".to_string(),
+            canonical_source: "test".to_string(),
+            claimable_bounty_count: 2,
+            verification_ready_bounty_count: 1,
+            standing_meta_bounty_count: 1,
+            funded_usdc_base_units: "3000000".to_string(),
+            funded_usdc: "3.00".to_string(),
+            solver_reward_usdc_base_units: "2400000".to_string(),
+            solver_reward_usdc: "2.40".to_string(),
+            verifier_reward_usdc_base_units: "600000".to_string(),
+            verifier_reward_usdc: "0.60".to_string(),
+            items: Vec::new(),
+            evidence_boundary: "test".to_string(),
+        };
+        let competition = OpenCompetitionInventorySummary {
+            generated_at: "2026-08-12T20:01:00+00:00".to_string(),
+            ready_to_earn_count: 1,
+            funded_usdc_base_units: "1200000".to_string(),
+            solver_reward_usdc_base_units: "1000000".to_string(),
+            verifier_reward_usdc_base_units: "200000".to_string(),
+        };
+        let combined =
+            platform_inventory_response(Some(autonomous.clone()), Some(competition)).unwrap();
+
+        assert_eq!(combined.status, "ready");
+        assert_eq!(combined.ready_to_earn_opportunities, Some(3));
+        assert_eq!(combined.autonomous_claimable_bounties, Some(2));
+        assert_eq!(combined.open_competitions_ready_to_earn, Some(1));
+        assert_eq!(combined.funded.unwrap().usdc, "4.200000");
+
+        let partial = platform_inventory_response(Some(autonomous), None).unwrap();
+        assert_eq!(partial.status, "partial");
+        assert_eq!(partial.autonomous_claimable_bounties, Some(2));
+        assert_eq!(partial.open_competitions_ready_to_earn, None);
+        assert_eq!(partial.ready_to_earn_opportunities, None);
+        assert!(partial.funded.is_none());
+    }
+
+    #[test]
+    fn platform_metrics_zero_mature_denominator_has_no_rate() {
+        assert_eq!(
+            platform_metrics_response(
+                PlatformMetricsStats {
+                    generated_at: parse_public_metrics_timestamp("2026-08-12T20:22:19Z").unwrap(),
+                    identities: PlatformIdentityStats {
+                        selected: 0,
+                        previous: 0,
+                        latest_week: 0,
+                        previous_week: 0,
+                        first_month: 0,
+                        lifetime: 0,
+                        posters: 0,
+                        funders: 0,
+                        solvers: 0,
+                        verifiers: 0,
+                        commenters: 0,
+                        marketplace_wallets: 0,
+                        opportunity_comment_authors: 0,
+                    },
+                    payouts: PlatformPayoutStats {
+                        selected_total_base_units: "0".to_string(),
+                        previous_total_base_units: "0".to_string(),
+                        first_month_total_base_units: "0".to_string(),
+                        lifetime_total_base_units: "0".to_string(),
+                        selected_solver_base_units: "0".to_string(),
+                        selected_verifier_base_units: "0".to_string(),
+                        selected_bonus_base_units: "0".to_string(),
+                        selected_settled_rounds: 0,
+                        previous_settled_rounds: 0,
+                        first_month_settled_rounds: 0,
+                        lifetime_settled_rounds: 0,
+                    },
+                    claim_cohort: PlatformClaimCohortStats {
+                        settled: 0,
+                        mature: 0,
+                        immature: 2,
+                    },
+                    daily: Vec::new(),
+                    coverage: PlatformMetricsCoverageStats {
+                        verified_canonical_events: 0,
+                        awaiting_block_time_events: 0,
+                        opportunity_comments: 0,
+                        latest_verified_event_at: None,
+                        latest_comment_at: None,
+                    },
+                },
+                platform_metric_window(
+                    Some("7d"),
+                    parse_public_metrics_timestamp("2026-08-12T20:22:19Z").unwrap(),
+                )
+                .unwrap(),
+                public_metrics_policy().unwrap(),
+                None,
+                None,
+                PlatformCanonicalSourceFreshness {
+                    autonomous: true,
+                    open_competition: true,
+                },
+            )
+            .unwrap()
+            .mature_claim_to_settlement
+            .settlement_rate,
+            None
+        );
+    }
+
     #[tokio::test]
     async fn openapi_json_endpoint_contains_agent_router_path() {
         let document = openapi_json().await.0;
@@ -18531,6 +19497,7 @@ mod tests {
         assert!(paths.contains_key("/v1/chatgpt/action-intents/{intent_id}/observations"));
         assert!(paths.contains_key("/v1/analytics/events"));
         assert!(paths.contains_key("/v1/analytics/site"));
+        assert!(paths.contains_key("/v1/metrics/platform"));
         assert!(paths.contains_key("/v1/discovery/subscriptions"));
         assert!(paths.contains_key("/v1/discovery/subscriptions/{id}"));
         assert!(paths.contains_key("/public/opportunities/{opportunity_id}/embed"));

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -498,6 +498,72 @@ pub struct SiteAnalyticsStats {
     pub channels: Vec<SiteAnalyticsChannelStats>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlatformIdentityStats {
+    pub selected: u64,
+    pub previous: u64,
+    pub latest_week: u64,
+    pub previous_week: u64,
+    pub first_month: u64,
+    pub lifetime: u64,
+    pub posters: u64,
+    pub funders: u64,
+    pub solvers: u64,
+    pub verifiers: u64,
+    pub commenters: u64,
+    pub marketplace_wallets: u64,
+    pub opportunity_comment_authors: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlatformPayoutStats {
+    pub selected_total_base_units: String,
+    pub previous_total_base_units: String,
+    pub first_month_total_base_units: String,
+    pub lifetime_total_base_units: String,
+    pub selected_solver_base_units: String,
+    pub selected_verifier_base_units: String,
+    pub selected_bonus_base_units: String,
+    pub selected_settled_rounds: u64,
+    pub previous_settled_rounds: u64,
+    pub first_month_settled_rounds: u64,
+    pub lifetime_settled_rounds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlatformClaimCohortStats {
+    pub settled: u64,
+    pub mature: u64,
+    pub immature: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlatformDailyStats {
+    pub day: String,
+    pub active_identities: u64,
+    pub payout_base_units: String,
+    pub settled_rounds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlatformMetricsCoverageStats {
+    pub verified_canonical_events: u64,
+    pub awaiting_block_time_events: u64,
+    pub opportunity_comments: u64,
+    pub latest_verified_event_at: Option<DateTime<Utc>>,
+    pub latest_comment_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlatformMetricsStats {
+    pub generated_at: DateTime<Utc>,
+    pub identities: PlatformIdentityStats,
+    pub payouts: PlatformPayoutStats,
+    pub claim_cohort: PlatformClaimCohortStats,
+    pub daily: Vec<PlatformDailyStats>,
+    pub coverage: PlatformMetricsCoverageStats,
+}
+
 #[derive(Debug, Clone)]
 pub struct NewSocialMentionIngestion {
     pub id: Uuid,
@@ -1619,6 +1685,621 @@ impl PostgresStore {
                     })
                 })
                 .collect::<DbResult<Vec<_>>>()?,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn platform_metrics_stats(
+        &self,
+        network: &str,
+        selected_started_at: DateTime<Utc>,
+        selected_ended_at: DateTime<Utc>,
+        previous_started_at: DateTime<Utc>,
+        launch_at: DateTime<Utc>,
+        first_month_ended_at: DateTime<Utc>,
+        excluded_wallets: &[String],
+        excluded_comment_authors: &[String],
+        excluded_bounty_contracts: &[String],
+    ) -> DbResult<PlatformMetricsStats> {
+        let identity_row = sqlx::query(
+            r#"
+            WITH event_actors AS (
+              SELECT event.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(CASE
+                       WHEN event.kind = 'canonical_bounty_created' THEN event.data->>'creator'
+                       WHEN event.kind = 'external_bounty_submitted' THEN event.data->>'submitter'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn')
+                         THEN event.data->>'contributor'
+                       ELSE event.data->>'solver'
+                     END) AS identity,
+                     CASE
+                       WHEN event.kind IN ('canonical_bounty_created', 'external_bounty_submitted') THEN 'poster'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn') THEN 'funder'
+                       ELSE 'solver'
+                     END AS role
+              FROM autonomous_bounty_events AS event
+              WHERE event.network = $1
+                AND event.block_time_verified = TRUE
+                AND event.occurred_at >= $5
+                AND event.occurred_at < $3
+                AND NOT lower(COALESCE(event.data->>'bounty_contract', event.contract_address)) = ANY($9)
+                AND event.kind IN (
+                  'canonical_bounty_created', 'external_bounty_submitted', 'funding_added',
+                  'bounty_claimed', 'submission_added', 'submission_rejected',
+                  'bounty_settled', 'claim_expired', 'submission_expired',
+                  'refund_withdrawn'
+                )
+            ), competition_actors AS (
+              SELECT event.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(CASE
+                       WHEN event.kind = 'canonical_competition_created'
+                         THEN event.data->>'creator'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn')
+                         THEN event.data->>'contributor'
+                       ELSE event.data->>'solver'
+                     END) AS identity,
+                     CASE
+                       WHEN event.kind = 'canonical_competition_created' THEN 'poster'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn') THEN 'funder'
+                       ELSE 'solver'
+                     END AS role
+              FROM open_competition_events AS event
+              WHERE event.network = $1
+                AND event.block_time_verified = TRUE
+                AND event.occurred_at >= $5
+                AND event.occurred_at < $3
+                AND NOT lower(COALESCE(event.data->>'bounty_contract', event.contract_address)) = ANY($9)
+                AND event.kind IN (
+                  'canonical_competition_created', 'funding_added',
+                  'solution_committed', 'solution_revealed',
+                  'competition_submission_rejected', 'commitment_expired',
+                  'bounty_settled', 'entry_bond_withdrawn', 'refund_withdrawn'
+                )
+            ), verifier_actors AS (
+              SELECT payout.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(configuration.data->>'verifier_reward_recipient') AS identity,
+                     'verifier'::text AS role
+              FROM autonomous_bounty_events AS payout
+              JOIN LATERAL (
+                SELECT configured.data
+                FROM autonomous_bounty_events AS configured
+                WHERE configured.network = payout.network
+                  AND configured.bounty_id = payout.bounty_id
+                  AND configured.contract_address = payout.contract_address
+                  AND configured.block_time_verified = TRUE
+                  AND configured.kind = 'canonical_bounty_verification_configured'
+                ORDER BY configured.block_number, configured.log_index
+                LIMIT 1
+              ) AS configuration ON TRUE
+              WHERE payout.network = $1
+                AND payout.block_time_verified = TRUE
+                AND payout.occurred_at >= $5
+                AND payout.occurred_at < $3
+                AND NOT lower(payout.contract_address) = ANY($9)
+                AND payout.kind IN ('submission_rejected', 'bounty_settled')
+                AND COALESCE((payout.data->>'verifier_reward')::numeric, 0) > 0
+            ), competition_verifier_actors AS (
+              SELECT payout.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(configuration.data->>'verifier_reward_recipient') AS identity,
+                     'verifier'::text AS role
+              FROM open_competition_events AS payout
+              JOIN LATERAL (
+                SELECT configured.data
+                FROM open_competition_events AS configured
+                WHERE configured.network = payout.network
+                  AND configured.bounty_id = payout.bounty_id
+                  AND configured.contract_address = payout.contract_address
+                  AND configured.block_time_verified = TRUE
+                  AND configured.kind = 'canonical_competition_verification_configured'
+                ORDER BY configured.block_number, configured.log_index
+                LIMIT 1
+              ) AS configuration ON TRUE
+              WHERE payout.network = $1
+                AND payout.block_time_verified = TRUE
+                AND payout.occurred_at >= $5
+                AND payout.occurred_at < $3
+                AND NOT lower(payout.contract_address) = ANY($9)
+                AND payout.kind IN ('competition_submission_rejected', 'bounty_settled')
+                AND CASE WHEN payout.kind = 'bounty_settled'
+                      THEN COALESCE((payout.data->>'verifier_reward')::numeric, 0)
+                      ELSE COALESCE((payout.data->>'bond_paid_to_verifier')::numeric, 0)
+                    END > 0
+            ), comment_actors AS (
+              SELECT comment.created_at AS occurred_at,
+                     'opportunity_comment_author'::text AS namespace,
+                     lower(regexp_replace(trim(comment.author), '\s+', ' ', 'g')) AS identity,
+                     'commenter'::text AS role
+              FROM opportunity_comments AS comment
+              WHERE comment.created_at >= $5 AND comment.created_at < $3
+            ), actors AS (
+              SELECT occurred_at, namespace, identity, role
+              FROM event_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$'
+                AND NOT identity = ANY($7)
+              UNION ALL
+              SELECT occurred_at, namespace, identity, role
+              FROM competition_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$'
+                AND NOT identity = ANY($7)
+              UNION ALL
+              SELECT occurred_at, namespace, identity, role
+              FROM verifier_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$'
+                AND identity <> '0x0000000000000000000000000000000000000000'
+                AND NOT identity = ANY($7)
+              UNION ALL
+              SELECT occurred_at, namespace, identity, role
+              FROM competition_verifier_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$'
+                AND identity <> '0x0000000000000000000000000000000000000000'
+                AND NOT identity = ANY($7)
+              UNION ALL
+              SELECT occurred_at, namespace, identity, role
+              FROM comment_actors
+              WHERE identity <> '' AND NOT identity = ANY($8)
+            )
+            SELECT
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3
+              ) AS selected,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $4 AND occurred_at < $2
+              ) AS previous,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $3 - INTERVAL '7 days' AND occurred_at < $3
+              ) AS latest_week,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $3 - INTERVAL '14 days'
+                  AND occurred_at < $3 - INTERVAL '7 days'
+              ) AS previous_week,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $5 AND occurred_at < $6
+              ) AS first_month,
+              COUNT(DISTINCT (namespace, identity)) AS lifetime,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3 AND role = 'poster'
+              ) AS posters,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3 AND role = 'funder'
+              ) AS funders,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3 AND role = 'solver'
+              ) AS solvers,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3 AND role = 'verifier'
+              ) AS verifiers,
+              COUNT(DISTINCT (namespace, identity)) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3 AND role = 'commenter'
+              ) AS commenters,
+              COUNT(DISTINCT identity) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3 AND namespace = 'base_wallet'
+              ) AS marketplace_wallets,
+              COUNT(DISTINCT identity) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3
+                  AND namespace = 'opportunity_comment_author'
+              ) AS opportunity_comment_authors
+            FROM actors
+            "#,
+        )
+        .bind(network)
+        .bind(selected_started_at)
+        .bind(selected_ended_at)
+        .bind(previous_started_at)
+        .bind(launch_at)
+        .bind(first_month_ended_at)
+        .bind(excluded_wallets)
+        .bind(excluded_comment_authors)
+        .bind(excluded_bounty_contracts)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let payout_row = sqlx::query(
+            r#"
+            WITH payouts AS (
+              SELECT occurred_at, kind = 'bounty_settled' AS settled,
+                     CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'solver_reward')::numeric, 0)
+                       ELSE 0 END AS solver_amount,
+                     COALESCE((data->>'verifier_reward')::numeric, 0) AS verifier_amount,
+                     CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'timeout_bond_bonus')::numeric, 0)
+                       ELSE 0 END AS bonus_amount
+              FROM autonomous_bounty_events
+              WHERE network = $1
+                AND block_time_verified = TRUE
+                AND occurred_at >= $5
+                AND occurred_at < $3
+                AND NOT lower(contract_address) = ANY($7)
+                AND kind IN ('bounty_settled', 'submission_rejected')
+              UNION ALL
+              SELECT occurred_at, kind = 'bounty_settled' AS settled,
+                     CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'solver_reward')::numeric, 0)
+                       ELSE 0 END AS solver_amount,
+                     CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'verifier_reward')::numeric, 0)
+                       ELSE COALESCE((data->>'bond_paid_to_verifier')::numeric, 0)
+                     END AS verifier_amount,
+                     CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'timeout_bond_bonus')::numeric, 0)
+                       ELSE 0 END AS bonus_amount
+              FROM open_competition_events
+              WHERE network = $1
+                AND block_time_verified = TRUE
+                AND occurred_at >= $5
+                AND occurred_at < $3
+                AND NOT lower(contract_address) = ANY($7)
+                AND kind IN ('bounty_settled', 'competition_submission_rejected')
+            ), normalized AS (
+              SELECT *, solver_amount + verifier_amount + bonus_amount AS total_amount
+              FROM payouts
+            )
+            SELECT
+              COALESCE(SUM(total_amount) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3
+              ), 0)::text AS selected_total,
+              COALESCE(SUM(total_amount) FILTER (
+                WHERE occurred_at >= $4 AND occurred_at < $2
+              ), 0)::text AS previous_total,
+              COALESCE(SUM(total_amount) FILTER (
+                WHERE occurred_at >= $5 AND occurred_at < $6
+              ), 0)::text AS first_month_total,
+              COALESCE(SUM(total_amount), 0)::text AS lifetime_total,
+              COALESCE(SUM(solver_amount) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3
+              ), 0)::text AS selected_solver,
+              COALESCE(SUM(verifier_amount) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3
+              ), 0)::text AS selected_verifier,
+              COALESCE(SUM(bonus_amount) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3
+              ), 0)::text AS selected_bonus,
+              COUNT(*) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3 AND settled
+              ) AS selected_settled,
+              COUNT(*) FILTER (
+                WHERE occurred_at >= $4 AND occurred_at < $2 AND settled
+              ) AS previous_settled,
+              COUNT(*) FILTER (
+                WHERE occurred_at >= $5 AND occurred_at < $6 AND settled
+              ) AS first_month_settled,
+              COUNT(*) FILTER (WHERE settled) AS lifetime_settled
+            FROM normalized
+            "#,
+        )
+        .bind(network)
+        .bind(selected_started_at)
+        .bind(selected_ended_at)
+        .bind(previous_started_at)
+        .bind(launch_at)
+        .bind(first_month_ended_at)
+        .bind(excluded_bounty_contracts)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let cohort_row = sqlx::query(
+            r#"
+            WITH claim_events AS (
+              SELECT network, bounty_id, (data->>'round')::bigint AS round,
+                     (data->>'claim_expires_at')::bigint AS claim_expires_at
+              FROM autonomous_bounty_events
+              WHERE network = $1
+                AND block_time_verified = TRUE
+                AND kind = 'bounty_claimed'
+                AND occurred_at >= $2
+                AND occurred_at < $3
+                AND NOT lower(contract_address) = ANY($4)
+            ), claims AS (
+              SELECT network, bounty_id, round, MAX(claim_expires_at) AS claim_expires_at
+              FROM claim_events
+              GROUP BY network, bounty_id, round
+            ), terminal AS (
+              SELECT network, bounty_id, (data->>'round')::bigint AS round,
+                     BOOL_OR(kind = 'bounty_settled') AS settled
+              FROM autonomous_bounty_events
+              WHERE network = $1
+                AND block_time_verified = TRUE
+                AND occurred_at < $3
+                AND NOT lower(contract_address) = ANY($4)
+                AND kind IN (
+                  'bounty_settled', 'submission_rejected',
+                  'claim_expired', 'submission_expired'
+                )
+              GROUP BY network, bounty_id, (data->>'round')::bigint
+            ), evaluated AS (
+              SELECT claims.*,
+                     terminal.round IS NOT NULL AS has_terminal,
+                     COALESCE(terminal.settled, FALSE) AS settled,
+                     claims.claim_expires_at <= EXTRACT(EPOCH FROM $3::timestamptz)::bigint
+                       OR terminal.round IS NOT NULL AS mature
+              FROM claims
+              LEFT JOIN terminal USING (network, bounty_id, round)
+            )
+            SELECT
+              COUNT(*) FILTER (WHERE mature AND settled) AS settled,
+              COUNT(*) FILTER (WHERE mature) AS mature,
+              COUNT(*) FILTER (WHERE NOT mature) AS immature
+            FROM evaluated
+            "#,
+        )
+        .bind(network)
+        .bind(selected_started_at)
+        .bind(selected_ended_at)
+        .bind(excluded_bounty_contracts)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let daily_rows = sqlx::query(
+            r#"
+            WITH event_actors AS (
+              SELECT event.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(CASE
+                       WHEN event.kind = 'canonical_bounty_created' THEN event.data->>'creator'
+                       WHEN event.kind = 'external_bounty_submitted' THEN event.data->>'submitter'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn')
+                         THEN event.data->>'contributor'
+                       ELSE event.data->>'solver'
+                     END) AS identity
+              FROM autonomous_bounty_events AS event
+              WHERE event.network = $1
+                AND event.block_time_verified = TRUE
+                AND event.occurred_at >= $2 AND event.occurred_at < $3
+                AND NOT lower(COALESCE(event.data->>'bounty_contract', event.contract_address)) = ANY($6)
+                AND event.kind IN (
+                  'canonical_bounty_created', 'external_bounty_submitted', 'funding_added',
+                  'bounty_claimed', 'submission_added', 'submission_rejected',
+                  'bounty_settled', 'claim_expired', 'submission_expired',
+                  'refund_withdrawn'
+                )
+            ), competition_actors AS (
+              SELECT event.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(CASE
+                       WHEN event.kind = 'canonical_competition_created'
+                         THEN event.data->>'creator'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn')
+                         THEN event.data->>'contributor'
+                       ELSE event.data->>'solver'
+                     END) AS identity
+              FROM open_competition_events AS event
+              WHERE event.network = $1
+                AND event.block_time_verified = TRUE
+                AND event.occurred_at >= $2 AND event.occurred_at < $3
+                AND NOT lower(COALESCE(event.data->>'bounty_contract', event.contract_address)) = ANY($6)
+                AND event.kind IN (
+                  'canonical_competition_created', 'funding_added',
+                  'solution_committed', 'solution_revealed',
+                  'competition_submission_rejected', 'commitment_expired',
+                  'bounty_settled', 'entry_bond_withdrawn', 'refund_withdrawn'
+                )
+            ), verifier_actors AS (
+              SELECT payout.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(configuration.data->>'verifier_reward_recipient') AS identity
+              FROM autonomous_bounty_events AS payout
+              JOIN LATERAL (
+                SELECT configured.data
+                FROM autonomous_bounty_events AS configured
+                WHERE configured.network = payout.network
+                  AND configured.bounty_id = payout.bounty_id
+                  AND configured.contract_address = payout.contract_address
+                  AND configured.block_time_verified = TRUE
+                  AND configured.kind = 'canonical_bounty_verification_configured'
+                ORDER BY configured.block_number, configured.log_index
+                LIMIT 1
+              ) AS configuration ON TRUE
+              WHERE payout.network = $1
+                AND payout.block_time_verified = TRUE
+                AND payout.occurred_at >= $2 AND payout.occurred_at < $3
+                AND NOT lower(payout.contract_address) = ANY($6)
+                AND payout.kind IN ('submission_rejected', 'bounty_settled')
+                AND COALESCE((payout.data->>'verifier_reward')::numeric, 0) > 0
+            ), competition_verifier_actors AS (
+              SELECT payout.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(configuration.data->>'verifier_reward_recipient') AS identity
+              FROM open_competition_events AS payout
+              JOIN LATERAL (
+                SELECT configured.data
+                FROM open_competition_events AS configured
+                WHERE configured.network = payout.network
+                  AND configured.bounty_id = payout.bounty_id
+                  AND configured.contract_address = payout.contract_address
+                  AND configured.block_time_verified = TRUE
+                  AND configured.kind = 'canonical_competition_verification_configured'
+                ORDER BY configured.block_number, configured.log_index
+                LIMIT 1
+              ) AS configuration ON TRUE
+              WHERE payout.network = $1
+                AND payout.block_time_verified = TRUE
+                AND payout.occurred_at >= $2 AND payout.occurred_at < $3
+                AND NOT lower(payout.contract_address) = ANY($6)
+                AND payout.kind IN ('competition_submission_rejected', 'bounty_settled')
+                AND CASE WHEN payout.kind = 'bounty_settled'
+                      THEN COALESCE((payout.data->>'verifier_reward')::numeric, 0)
+                      ELSE COALESCE((payout.data->>'bond_paid_to_verifier')::numeric, 0)
+                    END > 0
+            ), comment_actors AS (
+              SELECT created_at AS occurred_at,
+                     'opportunity_comment_author'::text AS namespace,
+                     lower(regexp_replace(trim(author), '\s+', ' ', 'g')) AS identity
+              FROM opportunity_comments
+              WHERE created_at >= $2 AND created_at < $3
+            ), actors AS (
+              SELECT occurred_at, namespace, identity FROM event_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$' AND NOT identity = ANY($4)
+              UNION ALL
+              SELECT occurred_at, namespace, identity FROM competition_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$' AND NOT identity = ANY($4)
+              UNION ALL
+              SELECT occurred_at, namespace, identity FROM verifier_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$'
+                AND identity <> '0x0000000000000000000000000000000000000000'
+                AND NOT identity = ANY($4)
+              UNION ALL
+              SELECT occurred_at, namespace, identity FROM competition_verifier_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$'
+                AND identity <> '0x0000000000000000000000000000000000000000'
+                AND NOT identity = ANY($4)
+              UNION ALL
+              SELECT occurred_at, namespace, identity FROM comment_actors
+              WHERE identity <> '' AND NOT identity = ANY($5)
+            ), payouts AS (
+              SELECT occurred_at, kind = 'bounty_settled' AS settled,
+                     CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'solver_reward')::numeric, 0) ELSE 0 END
+                     + COALESCE((data->>'verifier_reward')::numeric, 0)
+                     + CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'timeout_bond_bonus')::numeric, 0) ELSE 0 END
+                       AS total_amount
+              FROM autonomous_bounty_events
+              WHERE network = $1
+                AND block_time_verified = TRUE
+                AND occurred_at >= $2 AND occurred_at < $3
+                AND NOT lower(contract_address) = ANY($6)
+                AND kind IN ('bounty_settled', 'submission_rejected')
+              UNION ALL
+              SELECT occurred_at, kind = 'bounty_settled' AS settled,
+                     CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'solver_reward')::numeric, 0) ELSE 0 END
+                     + CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'verifier_reward')::numeric, 0)
+                       ELSE COALESCE((data->>'bond_paid_to_verifier')::numeric, 0) END
+                     + CASE WHEN kind = 'bounty_settled'
+                       THEN COALESCE((data->>'timeout_bond_bonus')::numeric, 0) ELSE 0 END
+                       AS total_amount
+              FROM open_competition_events
+              WHERE network = $1
+                AND block_time_verified = TRUE
+                AND occurred_at >= $2 AND occurred_at < $3
+                AND NOT lower(contract_address) = ANY($6)
+                AND kind IN ('bounty_settled', 'competition_submission_rejected')
+            ), days AS (
+              SELECT generate_series(
+                date_trunc('day', $2::timestamptz),
+                date_trunc('day', $3::timestamptz - INTERVAL '1 microsecond'),
+                INTERVAL '1 day'
+              ) AS day
+            )
+            SELECT to_char(days.day AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day,
+                   (SELECT COUNT(DISTINCT (namespace, identity))
+                    FROM actors
+                    WHERE (occurred_at AT TIME ZONE 'UTC')::date =
+                          (days.day AT TIME ZONE 'UTC')::date) AS active_identities,
+                   COALESCE((SELECT SUM(total_amount)
+                    FROM payouts
+                    WHERE (occurred_at AT TIME ZONE 'UTC')::date =
+                          (days.day AT TIME ZONE 'UTC')::date), 0)::text AS payout_base_units,
+                   (SELECT COUNT(*) FROM payouts
+                    WHERE settled
+                      AND (occurred_at AT TIME ZONE 'UTC')::date =
+                          (days.day AT TIME ZONE 'UTC')::date) AS settled_rounds
+            FROM days
+            ORDER BY days.day
+            "#,
+        )
+        .bind(network)
+        .bind(selected_started_at)
+        .bind(selected_ended_at)
+        .bind(excluded_wallets)
+        .bind(excluded_comment_authors)
+        .bind(excluded_bounty_contracts)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let coverage_row = sqlx::query(
+            r#"
+            WITH protocol_events AS (
+              SELECT block_time_verified, occurred_at
+              FROM autonomous_bounty_events
+              WHERE network = $1
+                AND occurred_at >= $2
+                AND NOT lower(COALESCE(data->>'bounty_contract', contract_address)) = ANY($3)
+              UNION ALL
+              SELECT block_time_verified, occurred_at
+              FROM open_competition_events
+              WHERE network = $1
+                AND occurred_at >= $2
+                AND NOT lower(COALESCE(data->>'bounty_contract', contract_address)) = ANY($3)
+            )
+            SELECT
+              COUNT(*) FILTER (WHERE block_time_verified = TRUE) AS verified_events,
+              COUNT(*) FILTER (WHERE block_time_verified = FALSE) AS awaiting_events,
+              MAX(occurred_at) FILTER (WHERE block_time_verified = TRUE) AS latest_verified_event_at,
+              (SELECT COUNT(*) FROM opportunity_comments WHERE created_at >= $2) AS comments,
+              (SELECT MAX(created_at) FROM opportunity_comments WHERE created_at >= $2)
+                AS latest_comment_at
+            FROM protocol_events
+            "#,
+        )
+        .bind(network)
+        .bind(launch_at)
+        .bind(excluded_bounty_contracts)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(PlatformMetricsStats {
+            generated_at: selected_ended_at,
+            identities: PlatformIdentityStats {
+                selected: u64_from_i64(identity_row.try_get("selected")?)?,
+                previous: u64_from_i64(identity_row.try_get("previous")?)?,
+                latest_week: u64_from_i64(identity_row.try_get("latest_week")?)?,
+                previous_week: u64_from_i64(identity_row.try_get("previous_week")?)?,
+                first_month: u64_from_i64(identity_row.try_get("first_month")?)?,
+                lifetime: u64_from_i64(identity_row.try_get("lifetime")?)?,
+                posters: u64_from_i64(identity_row.try_get("posters")?)?,
+                funders: u64_from_i64(identity_row.try_get("funders")?)?,
+                solvers: u64_from_i64(identity_row.try_get("solvers")?)?,
+                verifiers: u64_from_i64(identity_row.try_get("verifiers")?)?,
+                commenters: u64_from_i64(identity_row.try_get("commenters")?)?,
+                marketplace_wallets: u64_from_i64(identity_row.try_get("marketplace_wallets")?)?,
+                opportunity_comment_authors: u64_from_i64(
+                    identity_row.try_get("opportunity_comment_authors")?,
+                )?,
+            },
+            payouts: PlatformPayoutStats {
+                selected_total_base_units: payout_row.try_get("selected_total")?,
+                previous_total_base_units: payout_row.try_get("previous_total")?,
+                first_month_total_base_units: payout_row.try_get("first_month_total")?,
+                lifetime_total_base_units: payout_row.try_get("lifetime_total")?,
+                selected_solver_base_units: payout_row.try_get("selected_solver")?,
+                selected_verifier_base_units: payout_row.try_get("selected_verifier")?,
+                selected_bonus_base_units: payout_row.try_get("selected_bonus")?,
+                selected_settled_rounds: u64_from_i64(payout_row.try_get("selected_settled")?)?,
+                previous_settled_rounds: u64_from_i64(payout_row.try_get("previous_settled")?)?,
+                first_month_settled_rounds: u64_from_i64(
+                    payout_row.try_get("first_month_settled")?,
+                )?,
+                lifetime_settled_rounds: u64_from_i64(payout_row.try_get("lifetime_settled")?)?,
+            },
+            claim_cohort: PlatformClaimCohortStats {
+                settled: u64_from_i64(cohort_row.try_get("settled")?)?,
+                mature: u64_from_i64(cohort_row.try_get("mature")?)?,
+                immature: u64_from_i64(cohort_row.try_get("immature")?)?,
+            },
+            daily: daily_rows
+                .into_iter()
+                .map(|row| {
+                    Ok(PlatformDailyStats {
+                        day: row.try_get("day")?,
+                        active_identities: u64_from_i64(row.try_get("active_identities")?)?,
+                        payout_base_units: row.try_get("payout_base_units")?,
+                        settled_rounds: u64_from_i64(row.try_get("settled_rounds")?)?,
+                    })
+                })
+                .collect::<DbResult<Vec<_>>>()?,
+            coverage: PlatformMetricsCoverageStats {
+                verified_canonical_events: u64_from_i64(coverage_row.try_get("verified_events")?)?,
+                awaiting_block_time_events: u64_from_i64(coverage_row.try_get("awaiting_events")?)?,
+                opportunity_comments: u64_from_i64(coverage_row.try_get("comments")?)?,
+                latest_verified_event_at: coverage_row.try_get("latest_verified_event_at")?,
+                latest_comment_at: coverage_row.try_get("latest_comment_at")?,
+            },
         })
     }
 
@@ -5221,6 +5902,29 @@ impl PostgresStore {
             .collect()
     }
 
+    pub async fn list_verified_open_competition_events(
+        &self,
+        network: &str,
+        factory_contract: &str,
+    ) -> DbResult<Vec<OpenCompetitionEvent>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, protocol_version, log_key, tx_hash, block_number, log_index,
+                   contract_address, bounty_id, kind, data, occurred_at
+            FROM open_competition_events
+            WHERE network = $1 AND factory_contract = $2 AND block_time_verified = TRUE
+            ORDER BY block_number, log_index
+            "#,
+        )
+        .bind(network)
+        .bind(normalize_key_address(factory_contract))
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(open_competition_event_from_row)
+            .collect()
+    }
+
     pub async fn list_canonical_open_competition_contracts(
         &self,
         network: &str,
@@ -5306,6 +6010,25 @@ impl PostgresStore {
                    bounty_id, kind, data, occurred_at
             FROM autonomous_bounty_events
             WHERE network = $1
+            ORDER BY block_number, log_index
+            "#,
+        )
+        .bind(network)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(autonomous_event_from_row).collect()
+    }
+
+    pub async fn list_verified_autonomous_bounty_events(
+        &self,
+        network: &str,
+    ) -> DbResult<Vec<AutonomousBountyEvent>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, log_key, tx_hash, block_number, log_index, contract_address,
+                   bounty_id, kind, data, occurred_at
+            FROM autonomous_bounty_events
+            WHERE network = $1 AND block_time_verified = TRUE
             ORDER BY block_number, log_index
             "#,
         )
@@ -7991,6 +8714,615 @@ mod tests {
             .channels
             .iter()
             .any(|channel| channel.source == "postgres-test"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
+    async fn platform_metrics_query_enforces_identity_payment_and_cohort_boundaries() {
+        async fn add_event(
+            store: &PostgresStore,
+            network: &str,
+            block_number: u64,
+            contract_address: &str,
+            bounty_id: &str,
+            kind: AutonomousBountyEventKind,
+            data: serde_json::Value,
+            occurred_at: DateTime<Utc>,
+            verified: bool,
+        ) {
+            store
+                .upsert_autonomous_bounty_event(
+                    network,
+                    &AutonomousBountyEvent {
+                        id: Uuid::new_v4(),
+                        log_key: format!("{network}:{block_number}:0"),
+                        tx_hash: format!("0x{block_number:064x}"),
+                        block_number,
+                        log_index: 0,
+                        contract_address: contract_address.to_string(),
+                        bounty_id: bounty_id.to_string(),
+                        kind,
+                        data,
+                        occurred_at,
+                    },
+                )
+                .await
+                .unwrap();
+            if verified {
+                assert_eq!(
+                    store
+                        .confirm_autonomous_event_block_time(network, block_number, occurred_at)
+                        .await
+                        .unwrap(),
+                    1
+                );
+            }
+        }
+
+        async fn add_competition_event(
+            store: &PostgresStore,
+            network: &str,
+            factory_contract: &str,
+            block_number: u64,
+            contract_address: &str,
+            bounty_id: &str,
+            kind: OpenCompetitionEventKind,
+            data: serde_json::Value,
+            occurred_at: DateTime<Utc>,
+            verified: bool,
+        ) {
+            store
+                .upsert_open_competition_event(
+                    network,
+                    factory_contract,
+                    &OpenCompetitionEvent {
+                        id: Uuid::new_v4(),
+                        protocol_version: "agent-bounties/open-competition-v1".to_string(),
+                        log_key: format!("open:{network}:{block_number}:0"),
+                        tx_hash: format!("0x{block_number:064x}"),
+                        block_number,
+                        log_index: 0,
+                        contract_address: contract_address.to_string(),
+                        bounty_id: bounty_id.to_string(),
+                        kind,
+                        data,
+                        occurred_at,
+                    },
+                )
+                .await
+                .unwrap();
+            if verified {
+                assert_eq!(
+                    store
+                        .confirm_open_competition_event_block_time(
+                            network,
+                            factory_contract,
+                            block_number,
+                            occurred_at,
+                        )
+                        .await
+                        .unwrap(),
+                    1
+                );
+            }
+        }
+
+        let database_url = std::env::var("AGENT_BOUNTIES_TEST_DATABASE_URL").unwrap();
+        let store = PostgresStore::connect(&database_url).await.unwrap();
+        store.migrate().await.unwrap();
+        let test_id = Uuid::new_v4();
+        let network = format!("platform-metrics-test-{test_id}");
+        let opportunity_id = format!("metrics-test-{test_id}");
+        let at = |value: &str| {
+            DateTime::parse_from_rfc3339(value)
+                .unwrap()
+                .with_timezone(&Utc)
+        };
+        let launch_at = at("2099-01-01T00:00:00Z");
+        let previous_started_at = launch_at;
+        let selected_started_at = at("2099-01-08T00:00:00Z");
+        let selected_ended_at = at("2099-01-15T00:00:00Z");
+        let first_month_ended_at = at("2099-02-01T00:00:00Z");
+        let contract_one = "0x1111111111111111111111111111111111111111";
+        let contract_two = "0x2222222222222222222222222222222222222222";
+        let competition_contract = "0x3333333333333333333333333333333333333333";
+        let competition_refund_contract = "0x3434343434343434343434343434343434343434";
+        let competition_factory = "0x4444444444444444444444444444444444444444";
+        let recovery_contract = "0x9999999999999999999999999999999999999999";
+        let funder = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let competition_funder = "0x4545454545454545454545454545454545454545";
+        let refunded_funder = "0x4646464646464646464646464646464646464646";
+        let competition_solver_one = "0x5555555555555555555555555555555555555555";
+        let competition_solver_two = "0x5656565656565656565656565656565656565656";
+        let solver_one = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let verifier = "0xcccccccccccccccccccccccccccccccccccccccc";
+        let solver_two = "0xdddddddddddddddddddddddddddddddddddddddd";
+        let immature_solver = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        let expired_solver = "0xffffffffffffffffffffffffffffffffffffffff";
+        let maintainer_wallet = "0x1234512345123451234512345123451234512345";
+        let future_expiry = selected_ended_at.timestamp() + 3_600;
+        let past_expiry = selected_ended_at.timestamp() - 3_600;
+        let mut block = 9_000_000_u64;
+
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_one,
+            "bounty-one",
+            AutonomousBountyEventKind::CanonicalBountyCreated,
+            serde_json::json!({"creator": funder}),
+            at("2099-01-04T00:00:00Z"),
+            true,
+        )
+        .await;
+
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_factory,
+            "competition-one",
+            OpenCompetitionEventKind::CanonicalCompetitionCreated,
+            serde_json::json!({
+                "bounty_contract": competition_contract,
+                "creator": funder
+            }),
+            at("2099-01-09T03:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_factory,
+            "competition-refund",
+            OpenCompetitionEventKind::CanonicalCompetitionCreated,
+            serde_json::json!({
+                "bounty_contract": competition_refund_contract,
+                "creator": funder
+            }),
+            at("2099-01-09T03:00:30Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_contract,
+            "competition-one",
+            OpenCompetitionEventKind::CanonicalCompetitionVerificationConfigured,
+            serde_json::json!({"verifier_reward_recipient": verifier}),
+            at("2099-01-09T03:01:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_contract,
+            "competition-one",
+            OpenCompetitionEventKind::FundingAdded,
+            serde_json::json!({"contributor": competition_funder, "amount": 2_400_000}),
+            at("2099-01-10T03:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_contract,
+            "competition-one",
+            OpenCompetitionEventKind::CompetitionSubmissionRejected,
+            serde_json::json!({
+                "solver": competition_solver_one,
+                "bond_paid_to_verifier": 200_000,
+                "entry_bond_returned": 8_000_000,
+                "refund": 9_000_000
+            }),
+            at("2099-01-12T03:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_contract,
+            "competition-one",
+            OpenCompetitionEventKind::BountySettled,
+            serde_json::json!({
+                "solver": competition_solver_two,
+                "solver_reward": 2_000_000,
+                "verifier_reward": 200_000,
+                "timeout_bond_bonus": 75_000,
+                "entry_bond_returned": 200_000,
+                "refund": 9_000_000
+            }),
+            at("2099-01-13T03:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_refund_contract,
+            "competition-refund",
+            OpenCompetitionEventKind::BountyCancelled,
+            serde_json::json!({
+                "principal": 500_000_000,
+                "expired_entry_bonus": 25_000_000
+            }),
+            at("2099-01-13T03:30:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_refund_contract,
+            "competition-refund",
+            OpenCompetitionEventKind::RefundWithdrawn,
+            serde_json::json!({
+                "contributor": refunded_funder,
+                "principal": 500_000_000,
+                "expired_entry_bonus": 25_000_000,
+                "amount": 525_000_000
+            }),
+            at("2099-01-13T04:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            competition_contract,
+            "competition-unverified",
+            OpenCompetitionEventKind::BountySettled,
+            serde_json::json!({
+                "solver": "0x5757575757575757575757575757575757575757",
+                "solver_reward": 70_000_000,
+                "verifier_reward": 7_000_000,
+                "timeout_bond_bonus": 0
+            }),
+            at("2099-01-14T03:00:00Z"),
+            false,
+        )
+        .await;
+        block += 1;
+        add_competition_event(
+            &store,
+            &network,
+            competition_factory,
+            block,
+            recovery_contract,
+            "competition-recovery",
+            OpenCompetitionEventKind::BountySettled,
+            serde_json::json!({
+                "solver": "0x5858585858585858585858585858585858585858",
+                "solver_reward": 60_000_000,
+                "verifier_reward": 6_000_000,
+                "timeout_bond_bonus": 0
+            }),
+            at("2099-01-14T04:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_one,
+            "bounty-one",
+            AutonomousBountyEventKind::CanonicalBountyVerificationConfigured,
+            serde_json::json!({"verifier_reward_recipient": verifier}),
+            at("2099-01-04T00:01:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_one,
+            "bounty-one",
+            AutonomousBountyEventKind::FundingAdded,
+            serde_json::json!({"contributor": funder, "amount": 9_999_999}),
+            at("2099-01-09T00:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_one,
+            "bounty-one",
+            AutonomousBountyEventKind::BountyClaimed,
+            serde_json::json!({
+                "round": 1,
+                "solver": solver_one,
+                "claim_expires_at": future_expiry
+            }),
+            at("2099-01-10T00:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_one,
+            "bounty-one",
+            AutonomousBountyEventKind::SubmissionAdded,
+            serde_json::json!({"round": 1, "solver": solver_one}),
+            at("2099-01-10T01:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_one,
+            "bounty-one",
+            AutonomousBountyEventKind::BountySettled,
+            serde_json::json!({
+                "round": 1,
+                "solver": solver_one,
+                "solver_reward": 1_000_000,
+                "verifier_reward": 100_000,
+                "timeout_bond_bonus": 50_000,
+                "solver_payout": 1_050_000,
+                "returned_claim_bond": 100_000,
+                "refund": 4_000_000,
+                "leaderboard_prize": 2_000_000
+            }),
+            at("2099-01-11T00:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_two,
+            "bounty-two",
+            AutonomousBountyEventKind::CanonicalBountyVerificationConfigured,
+            serde_json::json!({"verifier_reward_recipient": verifier}),
+            at("2099-01-09T00:01:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_two,
+            "bounty-two",
+            AutonomousBountyEventKind::BountyClaimed,
+            serde_json::json!({
+                "round": 2,
+                "solver": solver_two,
+                "claim_expires_at": future_expiry
+            }),
+            at("2099-01-10T02:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_two,
+            "bounty-two",
+            AutonomousBountyEventKind::SubmissionRejected,
+            serde_json::json!({
+                "round": 2,
+                "solver": solver_two,
+                "verifier_reward": 100_000,
+                "forfeited_bond": 100_000,
+                "refund": 3_000_000
+            }),
+            at("2099-01-12T00:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_two,
+            "bounty-three",
+            AutonomousBountyEventKind::BountyClaimed,
+            serde_json::json!({
+                "round": 3,
+                "solver": immature_solver,
+                "claim_expires_at": future_expiry
+            }),
+            at("2099-01-13T00:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_two,
+            "bounty-four",
+            AutonomousBountyEventKind::BountyClaimed,
+            serde_json::json!({
+                "round": 4,
+                "solver": expired_solver,
+                "claim_expires_at": past_expiry
+            }),
+            at("2099-01-13T01:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_two,
+            "maintainer-bounty",
+            AutonomousBountyEventKind::CanonicalBountyCreated,
+            serde_json::json!({"creator": maintainer_wallet}),
+            at("2099-01-13T02:00:00Z"),
+            true,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            contract_two,
+            "unverified-bounty",
+            AutonomousBountyEventKind::BountySettled,
+            serde_json::json!({
+                "round": 1,
+                "solver": "0x7777777777777777777777777777777777777777",
+                "solver_reward": 90_000_000,
+                "verifier_reward": 10_000_000,
+                "timeout_bond_bonus": 0
+            }),
+            at("2099-01-14T00:00:00Z"),
+            false,
+        )
+        .await;
+        block += 1;
+        add_event(
+            &store,
+            &network,
+            block,
+            recovery_contract,
+            "recovery-bounty",
+            AutonomousBountyEventKind::BountySettled,
+            serde_json::json!({
+                "round": 1,
+                "solver": "0x6666666666666666666666666666666666666666",
+                "solver_reward": 80_000_000,
+                "verifier_reward": 10_000_000,
+                "timeout_bond_bonus": 0
+            }),
+            at("2099-01-14T01:00:00Z"),
+            true,
+        )
+        .await;
+
+        for (author, minute) in [
+            ("  Alice   Agent  ", 0_i64),
+            ("alice agent", 1_i64),
+            ("Maintainer", 2_i64),
+        ] {
+            sqlx::query(
+                "INSERT INTO opportunity_comments (id, opportunity_id, author, body, created_at) VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(Uuid::new_v4())
+            .bind(&opportunity_id)
+            .bind(author)
+            .bind("metrics test")
+            .bind(at("2099-01-14T02:00:00Z") + chrono::Duration::minutes(minute))
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        }
+
+        let stats = store
+            .platform_metrics_stats(
+                &network,
+                selected_started_at,
+                selected_ended_at,
+                previous_started_at,
+                launch_at,
+                first_month_ended_at,
+                &[maintainer_wallet.to_string()],
+                &["maintainer".to_string()],
+                &[recovery_contract.to_string()],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(stats.identities.selected, 11);
+        assert_eq!(stats.identities.previous, 1);
+        assert_eq!(stats.identities.lifetime, 11);
+        assert_eq!(stats.identities.posters, 1);
+        assert_eq!(stats.identities.funders, 3);
+        assert_eq!(stats.identities.solvers, 6);
+        assert_eq!(stats.identities.verifiers, 1);
+        assert_eq!(stats.identities.commenters, 1);
+        assert_eq!(stats.identities.marketplace_wallets, 10);
+        assert_eq!(stats.identities.opportunity_comment_authors, 1);
+        assert_eq!(stats.payouts.selected_total_base_units, "3725000");
+        assert_eq!(stats.payouts.selected_solver_base_units, "3000000");
+        assert_eq!(stats.payouts.selected_verifier_base_units, "600000");
+        assert_eq!(stats.payouts.selected_bonus_base_units, "125000");
+        assert_eq!(stats.payouts.selected_settled_rounds, 2);
+        assert_eq!(stats.claim_cohort.settled, 1);
+        assert_eq!(stats.claim_cohort.mature, 3);
+        assert_eq!(stats.claim_cohort.immature, 1);
+        assert_eq!(stats.coverage.awaiting_block_time_events, 2);
+        assert_eq!(
+            stats
+                .daily
+                .iter()
+                .map(|day| day.payout_base_units.parse::<u128>().unwrap())
+                .sum::<u128>(),
+            3_725_000
+        );
+
+        sqlx::query("DELETE FROM open_competition_events WHERE network = $1")
+            .bind(&network)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM autonomous_bounty_events WHERE network = $1")
+            .bind(&network)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM opportunity_comments WHERE opportunity_id = $1")
+            .bind(&opportunity_id)
+            .execute(&store.pool)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/docs/platform-metrics.md
+++ b/docs/platform-metrics.md
@@ -1,0 +1,115 @@
+# Public platform metrics
+
+The public dashboard at <https://agentbounties.app/metrics.html> is a simple,
+aggregate view of participation, confirmed marketplace payouts, and claim
+conversion. Private operations, enforcement, ranking inputs, customer data,
+and raw identities are outside this surface.
+
+## Reporting boundaries
+
+- Production launch: `2026-07-08T20:22:19Z`.
+- First month: `[2026-07-08T20:22:19Z, 2026-08-08T20:22:19Z)`.
+- Periods: rolling 7, 28, or 90 days, plus lifetime since launch.
+- All boundaries and daily series use UTC.
+
+## Headline metrics
+
+### External active identities
+
+Count each provider-namespaced identity once in a period when it performs a
+qualifying action:
+
+- GitHub: an external issue or pull request opened, issue or pull-request
+  comment, submitted review, or inline review comment.
+- Marketplace comments: a normalized self-reported comment author.
+- Marketplace: a Base wallet that posts, funds, claims, submits, verifies, or
+  receives a canonical outcome.
+
+Bots, system identities, the repository owner, and identities in
+`crates/api/fixtures/public-metrics-policy.json` are excluded. A GitHub login,
+wallet, and comment author stay separate unless a future public verification
+links them. The result is participating identities, not verified unique people.
+Browser IDs and stars do not qualify.
+
+Weekly growth compares the latest rolling seven days with the preceding seven:
+
+`(current - previous) / previous`
+
+Both zero displays `0%`. A positive current period after a zero prior period
+displays `New`. Other values display a signed percentage.
+
+### Marketplace payout volume
+
+Only block-time-verified canonical events count:
+
+- Autonomous and Open Competition `BountySettled`:
+  `solver_reward + timeout_bond_bonus + verifier_reward`.
+- Autonomous `SubmissionRejected`: `verifier_reward`.
+- Open `CompetitionSubmissionRejected`: `bond_paid_to_verifier`.
+
+Solver pay, verifier pay, and completion bonuses remain separate in the API.
+Returned claim bonds, forfeited bonds, refunds, funding plans or intentions,
+unconfirmed transactions, and leaderboard prizes are excluded. Only a
+confirmed canonical `BountySettled` event proves solver payment.
+
+Platform revenue is reported separately as `0 USDC — monetization not active`.
+Marketplace payout volume is not platform revenue.
+
+### Mature claim-to-settlement rate
+
+The cohort unit is `(network, bounty_id, round)`. A claimed round enters the
+denominator only after its claim expiry or after a terminal canonical event.
+Settled rounds enter the numerator. Rejected and expired mature rounds remain
+in the denominator but not the numerator. Immature claims are shown separately.
+Open Competition has no exclusive claim, so its entrants and payouts are
+included in participation and payout metrics but not in this claim cohort.
+
+## Public interfaces
+
+`GET /v1/metrics/platform?period=7d|28d|90d|lifetime`
+
+The default period is `7d`. The versioned response includes exact windows,
+platform identity aggregates, payment totals and splits, mature claims,
+current inventory from both the exclusive-claim and Open Competition protocols,
+daily series, zero platform revenue, freshness, coverage, and plain-language
+definitions. Combined inventory is withheld when either protocol is unavailable.
+The response intentionally excludes GitHub participation
+and all raw handles, wallet addresses, comment authors, event IDs, and
+transaction IDs.
+
+`/generated/github-participation.json`
+
+GitHub Pages regenerates this aggregate-only file hourly at minute 17 with the
+workflow `GITHUB_TOKEN`. It never needs an operator API secret. The dashboard
+adds this distinct `github` namespace to the platform aggregates once.
+
+`GET /v1/analytics/site?window_hours=<hours>`
+
+This optional acquisition section reports privacy-minimized browser/device IDs.
+It is labeled as acquisition context, not users, has no pre-deployment backfill,
+and is never added to active identities.
+
+## Freshness and honest gaps
+
+- Platform data older than five minutes is delayed.
+- A canonical marketplace indexer heartbeat older than five minutes, reporting
+  an error, or lagging its observed chain head by more than 20 blocks makes the
+  platform source partial and withholds combined point-in-time inventory.
+- GitHub aggregate data older than two hours is delayed.
+- Missing required identity sources make identity totals partial.
+- Missing inventory stays unavailable instead of becoming zero.
+- Missing historical browser analytics is disclosed and never estimated.
+
+The page refreshes the platform aggregate every minute and GitHub plus browser
+analytics every five minutes. It pauses periodic work while hidden and refreshes
+after the page becomes visible again.
+
+## Recheck commands
+
+```powershell
+cargo test -p api platform_metric -- --nocapture
+python scripts/test_github_audience_audit.py -v
+node --test scripts/test-metrics-dashboard.js
+python scripts/check-site.py
+scripts/check-postgres.ps1
+```

--- a/scripts/check-postgres.ps1
+++ b/scripts/check-postgres.ps1
@@ -25,6 +25,9 @@ try {
             cargo test -p db tests::site_analytics_round_trip_executes_against_migrated_postgres -- --ignored --exact --nocapture
         }
         Invoke-Checked {
+            cargo test -p db tests::platform_metrics_query_enforces_identity_payment_and_cohort_boundaries -- --ignored --exact --nocapture
+        }
+        Invoke-Checked {
             cargo test -p db tests::opportunity_comment_round_trip_is_durable_and_idempotent -- --ignored --exact --nocapture
         }
         Invoke-Checked {

--- a/scripts/check-postgres.sh
+++ b/scripts/check-postgres.sh
@@ -38,6 +38,7 @@ cargo test -p db tests::x402_relay_attempt_is_idempotent_and_lease_bounded -- --
 cargo test -p db tests::claim_funnel_counts_direct_and_atomic_sponsored_confirmations -- --ignored --exact --nocapture
 cargo test -p db tests::opportunity_lifecycle_query_executes_against_migrated_postgres -- --ignored --exact --nocapture
 cargo test -p db tests::site_analytics_round_trip_executes_against_migrated_postgres -- --ignored --exact --nocapture
+cargo test -p db tests::platform_metrics_query_enforces_identity_payment_and_cohort_boundaries -- --ignored --exact --nocapture
 cargo test -p db tests::opportunity_comment_round_trip_is_durable_and_idempotent -- --ignored --exact --nocapture
 cargo test -p db tests::chatgpt_action_intent_replays_and_confirms_only_observed_transaction -- --ignored --exact --nocapture
 cargo test -p db tests::social_mention_ingestion_round_trip_executes_against_migrated_postgres -- --ignored --exact --nocapture

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -16,6 +16,10 @@ import yaml
 REQUIRED_FILES = [
     "index.html",
     "earn.html",
+    "metrics.html",
+    "metrics.css",
+    "metrics.js",
+    "generated/github-participation.json",
     "competition.html",
     "competition.css",
     "competition.js",
@@ -82,6 +86,7 @@ CORE_PAGES = [
 PUBLIC_INDEXABLE_PAGES = {
     "index.html": "https://agentbounties.app/",
     "earn.html": "https://agentbounties.app/earn.html",
+    "metrics.html": "https://agentbounties.app/metrics.html",
     "competition.html": "https://agentbounties.app/competition.html",
     "post.html": "https://agentbounties.app/post.html",
     "funding.html": "https://agentbounties.app/funding.html",
@@ -299,6 +304,58 @@ def main() -> int:
         fail("retired browser settlement bundle site/main.js must not exist")
 
     pages = {name: (site_dir / name).read_text(encoding="utf-8") for name in CORE_PAGES}
+    metrics_page = (site_dir / "metrics.html").read_text(encoding="utf-8")
+    metrics_css = (site_dir / "metrics.css").read_text(encoding="utf-8")
+    metrics_javascript = (site_dir / "metrics.js").read_text(encoding="utf-8")
+    require_phrases(
+        "public metrics dashboard",
+        metrics_page,
+        [
+            "External active identities",
+            "Marketplace payout volume",
+            "Mature claim-to-settlement",
+            "Role counts are not additive",
+            "Browser/device IDs",
+            "Monetization not active",
+            "Only a confirmed canonical <code>BountySettled</code> event proves solver payment",
+            'data-period="7d" aria-pressed="true"',
+            'data-period="lifetime"',
+        ],
+    )
+    require_phrases(
+        "public metrics dashboard behavior",
+        metrics_javascript,
+        [
+            'const PLATFORM_DELAY_MS = 5 * 60 * 1000',
+            'const GITHUB_DELAY_MS = 2 * 60 * 60 * 1000',
+            'win.setInterval(() =>',
+            'doc.hidden',
+            'visibilitychange',
+            '"unavailable"',
+            '"delayed"',
+            'weeklyGrowth',
+        ],
+    )
+    require_phrases(
+        "public metrics accessibility",
+        metrics_css,
+        [
+            "@media (prefers-reduced-motion: reduce)",
+            ".metrics-page [data-reveal]",
+            ".period-control button[aria-pressed=\"true\"]",
+        ],
+    )
+    github_participation = json.loads(
+        (site_dir / "generated" / "github-participation.json").read_text(encoding="utf-8")
+    )
+    if github_participation.get("schema_version") != "agent-bounties/github-participation-v1":
+        fail("GitHub participation placeholder has the wrong schema version")
+    if github_participation.get("coverage", {}).get("raw_identifiers_included") is not False:
+        fail("GitHub participation artifact must declare aggregate-only coverage")
+    serialized_github_participation = json.dumps(github_participation).lower()
+    for forbidden in ("html_url", "profile_url", "comment_text", "wallet_address"):
+        if forbidden in serialized_github_participation:
+            fail(f"GitHub participation artifact exposes forbidden field: {forbidden}")
     structured_data_match = re.search(
         r'<script\s+type="application/ld\+json">\s*(\{.*?\})\s*</script>',
         pages["index.html"],

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -253,6 +253,7 @@ def main() -> int:
         ["scripts/test-autonomous-activation-console.js"], ["--check", "tools/canonical-child-verifier-deployment.js"],
         ["scripts/test-canonical-child-verifier-deployment-console.js"], ["--check", "tools/base-sepolia-sponsor-activation.js"],
         ["scripts/test-base-sepolia-sponsor-activation-console.js"],
+        ["--test", "scripts/test-metrics-dashboard.js"],
         ["--check", "scripts/open-competition-v1-signer.js"],
         ["scripts/test-open-competition-v1-signer-console.js"],
         ["scripts/test-create-competition-flow.js"],

--- a/scripts/fixtures/github_participation_metrics.json
+++ b/scripts/fixtures/github_participation_metrics.json
@@ -1,0 +1,11 @@
+{
+  "repository": "NSPG13/agent-bounties",
+  "fetched_at": "2026-08-12T20:22:19Z",
+  "issues": [],
+  "pulls": [],
+  "issue_comments": [],
+  "review_comments": [],
+  "reviews": [],
+  "reactions": [],
+  "stargazers": []
+}

--- a/scripts/github_audience_audit.py
+++ b/scripts/github_audience_audit.py
@@ -17,7 +17,8 @@ import sys
 import urllib.error
 import urllib.request
 from collections import defaultdict
-from datetime import datetime, timezone
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -38,6 +39,9 @@ DISCOVERY_ANSWER_MARKERS = (
     "found agent bounties",
 )
 MENTION_RE = re.compile(r"(?<![A-Za-z0-9-])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))")
+PLATFORM_LAUNCH_AT = "2026-07-08T20:22:19Z"
+PLATFORM_FIRST_MONTH_ENDED_AT = "2026-08-08T20:22:19Z"
+PUBLIC_METRICS_PERIOD_DAYS = {"7d": 7, "28d": 28, "90d": 90}
 
 
 def utc_now() -> str:
@@ -73,42 +77,66 @@ def gh_api(repository: str, suffix: str, *, accept: str | None = None) -> list[d
     return flatten_pages(json.loads(completed.stdout))
 
 
-def collect_snapshot(repository: str) -> dict[str, Any]:
+def collect_snapshot(
+    repository: str,
+    *,
+    include_enrichment: bool = True,
+    activity_since: str | None = None,
+) -> dict[str, Any]:
     issues = gh_api(repository, "issues?state=all&per_page=100")
     pulls = gh_api(repository, "pulls?state=all&per_page=100")
     issue_comments = gh_api(repository, "issues/comments?per_page=100")
     review_comments = gh_api(repository, "pulls/comments?per_page=100")
     reviews: list[dict[str, Any]] = []
-    for pull in pulls:
-        number = pull.get("number")
-        if isinstance(number, int):
-            for review in gh_api(repository, f"pulls/{number}/reviews?per_page=100"):
-                review["pull_number"] = number
-                reviews.append(review)
-
-    bounty_issues = [
-        issue
-        for issue in issues
-        if "pull_request" not in issue
-        and "bounty" in {str(label.get("name", "")).lower() for label in issue.get("labels", [])}
+    reviewable_pulls = pulls
+    if activity_since:
+        reviewable_pulls = [
+            pull
+            for pull in pulls
+            if str(pull.get("updated_at") or pull.get("created_at") or "") >= activity_since
+        ]
+    review_numbers = [
+        int(pull["number"])
+        for pull in reviewable_pulls
+        if isinstance(pull.get("number"), int)
     ]
-    reactions: list[dict[str, Any]] = []
-    for issue in bounty_issues:
-        number = issue.get("number")
-        if isinstance(number, int):
-            for reaction in gh_api(
-                repository,
-                f"issues/{number}/reactions?per_page=100",
-                accept="application/vnd.github+json",
-            ):
-                reaction["issue_number"] = number
-                reactions.append(reaction)
 
-    stargazers = gh_api(
-        repository,
-        "stargazers?per_page=100",
-        accept="application/vnd.github.star+json",
-    )
+    def pull_reviews(number: int) -> tuple[int, list[dict[str, Any]]]:
+        return number, gh_api(repository, f"pulls/{number}/reviews?per_page=100")
+
+    if review_numbers:
+        with ThreadPoolExecutor(max_workers=min(8, len(review_numbers))) as executor:
+            for number, records in executor.map(pull_reviews, review_numbers):
+                for review in records:
+                    review["pull_number"] = number
+                    reviews.append(review)
+
+    reactions: list[dict[str, Any]] = []
+    stargazers: list[dict[str, Any]] = []
+    if include_enrichment:
+        bounty_issues = [
+            issue
+            for issue in issues
+            if "pull_request" not in issue
+            and "bounty"
+            in {str(label.get("name", "")).lower() for label in issue.get("labels", [])}
+        ]
+        for issue in bounty_issues:
+            number = issue.get("number")
+            if isinstance(number, int):
+                for reaction in gh_api(
+                    repository,
+                    f"issues/{number}/reactions?per_page=100",
+                    accept="application/vnd.github+json",
+                ):
+                    reaction["issue_number"] = number
+                    reactions.append(reaction)
+
+        stargazers = gh_api(
+            repository,
+            "stargazers?per_page=100",
+            accept="application/vnd.github.star+json",
+        )
     return {
         "repository": repository,
         "fetched_at": utc_now(),
@@ -437,6 +465,230 @@ def build_audit(
     }
 
 
+def parse_utc_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def public_metrics_policy(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {
+            "schema_version": "agent-bounties/public-metrics-policy-v1",
+            "maintainer_github_logins": [],
+        }
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("public metrics policy must be a JSON object")
+    return value
+
+
+def build_public_participation_metrics(
+    snapshot: dict[str, Any],
+    owner_login: str,
+    *,
+    excluded_logins: set[str] | None = None,
+    policy_schema_version: str = "agent-bounties/public-metrics-policy-v1",
+) -> dict[str, Any]:
+    """Build an aggregate-only GitHub participation artifact.
+
+    The function deliberately keeps login keys only in local memory. The
+    returned value contains no handles, profile URLs, event IDs, or comment text.
+    """
+
+    launch_at = parse_utc_timestamp(PLATFORM_LAUNCH_AT)
+    first_month_ended_at = parse_utc_timestamp(PLATFORM_FIRST_MONTH_ENDED_AT)
+    generated_at = parse_utc_timestamp(snapshot.get("fetched_at"))
+    if launch_at is None or first_month_ended_at is None or generated_at is None:
+        raise ValueError("launch, first-month, and snapshot timestamps must be valid UTC values")
+    excluded = {owner_login.strip().lower()}
+    excluded.update(value.strip().lower() for value in (excluded_logins or set()) if value.strip())
+    records: dict[tuple[str, str], tuple[datetime, str, str]] = {}
+    excluded_records = 0
+    missing_timestamp_records = 0
+
+    def add_record(
+        kind: str,
+        role: str,
+        event_id: Any,
+        user: Any,
+        occurred_at: Any,
+        fallback: str,
+    ) -> None:
+        nonlocal excluded_records, missing_timestamp_records
+        timestamp = parse_utc_timestamp(occurred_at)
+        if timestamp is None:
+            missing_timestamp_records += 1
+            return
+        if timestamp < launch_at or timestamp >= generated_at:
+            return
+        if not isinstance(user, dict):
+            excluded_records += 1
+            return
+        login = str(user.get("login") or "").strip().lower()
+        if (
+            not login
+            or login in excluded
+            or login.endswith("[bot]")
+            or str(user.get("type") or "").lower() == "bot"
+        ):
+            excluded_records += 1
+            return
+        key = (kind, str(event_id if event_id is not None else fallback))
+        records[key] = (timestamp, login, role)
+
+    for index, issue in enumerate(snapshot.get("issues", [])):
+        if not isinstance(issue, dict):
+            continue
+        is_pull = "pull_request" in issue
+        add_record(
+            "pull_request_opened" if is_pull else "issue_opened",
+            "pull_request_contributors" if is_pull else "issue_posters",
+            issue.get("id") or issue.get("number"),
+            issue.get("user"),
+            issue.get("created_at"),
+            f"issue-{index}",
+        )
+    for index, comment in enumerate(snapshot.get("issue_comments", [])):
+        if isinstance(comment, dict):
+            add_record(
+                "issue_commented",
+                "commenters",
+                comment.get("id"),
+                comment.get("user"),
+                comment.get("created_at"),
+                f"issue-comment-{index}",
+            )
+    for index, comment in enumerate(snapshot.get("review_comments", [])):
+        if isinstance(comment, dict):
+            add_record(
+                "pull_request_inline_comment",
+                "reviewers",
+                comment.get("id"),
+                comment.get("user"),
+                comment.get("created_at"),
+                f"review-comment-{index}",
+            )
+    for index, review in enumerate(snapshot.get("reviews", [])):
+        if isinstance(review, dict):
+            add_record(
+                "pull_request_review",
+                "reviewers",
+                review.get("id"),
+                review.get("user"),
+                review.get("submitted_at"),
+                f"review-{index}",
+            )
+
+    activity = list(records.values())
+
+    def aggregate(started_at: datetime, ended_at: datetime) -> dict[str, Any]:
+        selected = [record for record in activity if started_at <= record[0] < ended_at]
+        roles = []
+        for role in (
+            "issue_posters",
+            "pull_request_contributors",
+            "commenters",
+            "reviewers",
+        ):
+            roles.append(
+                {
+                    "role": role,
+                    "active_identities": len(
+                        {identity for _, identity, record_role in selected if record_role == role}
+                    ),
+                }
+            )
+        daily = []
+        cursor = datetime(started_at.year, started_at.month, started_at.day, tzinfo=timezone.utc)
+        while cursor < ended_at:
+            day_ended_at = cursor + timedelta(days=1)
+            bounded_start = max(cursor, started_at)
+            bounded_end = min(day_ended_at, ended_at)
+            day_records = [
+                record for record in selected if bounded_start <= record[0] < bounded_end
+            ]
+            daily.append(
+                {
+                    "day": cursor.date().isoformat(),
+                    "active_identities": len({record[1] for record in day_records}),
+                    "qualifying_actions": len(day_records),
+                }
+            )
+            cursor = day_ended_at
+        return {
+            "started_at": started_at.isoformat().replace("+00:00", "Z"),
+            "ended_at": ended_at.isoformat().replace("+00:00", "Z"),
+            "active_identities": len({record[1] for record in selected}),
+            "qualifying_actions": len(selected),
+            "roles": roles,
+            "roles_are_additive": False,
+            "daily": daily,
+        }
+
+    periods: dict[str, Any] = {}
+    for period, days in PUBLIC_METRICS_PERIOD_DAYS.items():
+        requested_start = generated_at - timedelta(days=days)
+        started_at = max(launch_at, requested_start)
+        selected = aggregate(started_at, generated_at)
+        previous_started_at = started_at - (generated_at - started_at)
+        previous = aggregate(previous_started_at, started_at)
+        selected["previous_started_at"] = previous["started_at"]
+        selected["previous_ended_at"] = previous["ended_at"]
+        selected["previous_active_identities"] = previous["active_identities"]
+        selected["previous_qualifying_actions"] = previous["qualifying_actions"]
+        periods[period] = selected
+    lifetime = aggregate(launch_at, generated_at)
+    lifetime.update(
+        {
+            "previous_started_at": launch_at.isoformat().replace("+00:00", "Z"),
+            "previous_ended_at": launch_at.isoformat().replace("+00:00", "Z"),
+            "previous_active_identities": 0,
+            "previous_qualifying_actions": 0,
+        }
+    )
+    periods["lifetime"] = lifetime
+    first_month = aggregate(launch_at, first_month_ended_at)
+    latest_week = periods["7d"]["active_identities"]
+    previous_week = periods["7d"]["previous_active_identities"]
+
+    return {
+        "schema_version": "agent-bounties/github-participation-v1",
+        "source": "github_public_activity",
+        "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
+        "launch_at": PLATFORM_LAUNCH_AT,
+        "first_month_started_at": PLATFORM_LAUNCH_AT,
+        "first_month_ended_at": PLATFORM_FIRST_MONTH_ENDED_AT,
+        "namespace": "github",
+        "periods": periods,
+        "weekly": {
+            "latest_active_identities": latest_week,
+            "previous_active_identities": previous_week,
+        },
+        "first_month": first_month,
+        "coverage": {
+            "status": "partial" if missing_timestamp_records else "ready",
+            "qualifying_records": len(activity),
+            "excluded_records": excluded_records,
+            "missing_timestamp_records": missing_timestamp_records,
+            "maintainer_exclusion_policy": policy_schema_version,
+            "raw_identifiers_included": False,
+        },
+        "definitions": {
+            "active_identity": "One external GitHub login with at least one qualifying issue, pull request, top-level comment, review, or inline review comment in the period. It is a participating identity, not a verified unique person.",
+            "qualifying_action": "An external issue or pull request opened, issue or pull-request comment, submitted pull-request review, or inline review comment.",
+            "exclusions": "Bots, system identities, the repository owner, and logins in the checked-in public maintainer exclusion policy are excluded.",
+        },
+        "privacy_boundary": "This file contains aggregate counts only. It contains no repository owner, GitHub handles, user IDs, profile URLs, comment text, review text, issue IDs, pull-request IDs, or event IDs.",
+    }
+
+
 def http_post_json(base_url: str, path: str, payload: dict[str, Any], token: str | None) -> Any:
     headers = {"Content-Type": "application/json"}
     if token:
@@ -510,6 +762,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--fixture", type=Path)
     parser.add_argument("--snapshot-output", type=Path)
     parser.add_argument("--output", type=Path, default=Path("target/github-audience-audit.json"))
+    parser.add_argument("--public-metrics-output", type=Path)
+    parser.add_argument("--public-metrics-policy", type=Path)
+    parser.add_argument("--public-metrics-only", action="store_true")
+    parser.add_argument("--exclude-login", action="append", default=[])
     parser.add_argument("--include-owner", action="store_true")
     parser.add_argument("--curated-responses", type=Path)
     parser.add_argument("--sync", action="store_true")
@@ -523,11 +779,43 @@ def main() -> int:
     if args.fixture:
         snapshot = json.loads(args.fixture.read_text(encoding="utf-8"))
     else:
-        snapshot = collect_snapshot(args.repository)
+        snapshot = collect_snapshot(
+            args.repository,
+            include_enrichment=not args.public_metrics_only,
+            activity_since=PLATFORM_LAUNCH_AT if args.public_metrics_only else None,
+        )
     snapshot.setdefault("repository", args.repository)
     if args.snapshot_output:
         args.snapshot_output.parent.mkdir(parents=True, exist_ok=True)
         args.snapshot_output.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
+    if args.public_metrics_output:
+        policy = public_metrics_policy(args.public_metrics_policy)
+        policy_logins = policy.get("maintainer_github_logins", [])
+        if not isinstance(policy_logins, list):
+            raise ValueError("maintainer_github_logins must be a JSON array")
+        excluded_logins = {
+            str(value).strip().lower()
+            for value in [*policy_logins, *args.exclude_login]
+            if str(value).strip()
+        }
+        public_metrics = build_public_participation_metrics(
+            snapshot,
+            args.owner_login,
+            excluded_logins=excluded_logins,
+            policy_schema_version=str(
+                policy.get("schema_version")
+                or "agent-bounties/public-metrics-policy-v1"
+            ),
+        )
+        args.public_metrics_output.parent.mkdir(parents=True, exist_ok=True)
+        args.public_metrics_output.write_text(
+            json.dumps(public_metrics, indent=2) + "\n", encoding="utf-8"
+        )
+        print(f"public_metrics_output={args.public_metrics_output}")
+    if args.public_metrics_only:
+        if not args.public_metrics_output:
+            raise ValueError("--public-metrics-only requires --public-metrics-output")
+        return 0
     audit = build_audit(snapshot, args.owner_login, include_owner=args.include_owner)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(audit, indent=2) + "\n", encoding="utf-8")

--- a/scripts/test-metrics-dashboard.js
+++ b/scripts/test-metrics-dashboard.js
@@ -1,0 +1,134 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const metrics = require("../site/metrics.js");
+
+const NOW = Date.parse("2026-08-12T20:22:19Z");
+
+function platform(overrides = {}) {
+  return {
+    generated_at: "2026-08-12T20:21:19Z",
+    platform_active_identities: {
+      selected: 3,
+      previous: 2,
+      latest_week: 3,
+      previous_week: 2,
+      first_month: 4,
+      lifetime: 5,
+      roles: [
+        { role: "posters", active_identities: 1 },
+        { role: "commenters", active_identities: 1 },
+      ],
+    },
+    daily: [
+      { day: "2026-08-11", active_identities: 2, payout: { usdc: "1.000000" }, settled_rounds: 1 },
+      { day: "2026-08-12", active_identities: 1, payout: { usdc: "0.100000" }, settled_rounds: 0 },
+    ],
+    coverage: { status: "ready" },
+    ...overrides,
+  };
+}
+
+function github(overrides = {}) {
+  return {
+    generated_at: "2026-08-12T20:00:00Z",
+    periods: {
+      "7d": {
+        active_identities: 4,
+        previous_active_identities: 1,
+        roles: [
+          { role: "issue_posters", active_identities: 1 },
+          { role: "commenters", active_identities: 2 },
+        ],
+        daily: [
+          { day: "2026-08-11", active_identities: 3 },
+          { day: "2026-08-12", active_identities: 1 },
+        ],
+      },
+      lifetime: { active_identities: 9 },
+    },
+    weekly: { latest_active_identities: 4, previous_active_identities: 1 },
+    first_month: { active_identities: 7 },
+    coverage: { status: "ready" },
+    ...overrides,
+  };
+}
+
+test("weekly growth handles empty, new, positive, and negative periods", () => {
+  assert.equal(metrics.weeklyGrowth(0, 0), "0%");
+  assert.equal(metrics.weeklyGrowth(3, 0), "New");
+  assert.equal(metrics.weeklyGrowth(3, 2), "+50%");
+  assert.equal(metrics.weeklyGrowth(1, 2), "-50%");
+});
+
+test("namespaced platform and GitHub aggregates add without cross-provider dedupe", () => {
+  const merged = metrics.mergeMetrics(platform(), github(), "7d", NOW);
+  assert.equal(merged.status, "ready");
+  assert.equal(merged.active_complete, true);
+  assert.equal(merged.active_identities, 7);
+  assert.equal(merged.previous_active_identities, 3);
+  assert.equal(merged.first_month_identities, 11);
+  assert.equal(merged.lifetime_identities, 14);
+  assert.deepEqual(
+    merged.daily.map((day) => [day.day, day.active_identities, day.payout_usdc]),
+    [
+      ["2026-08-11", 5, 1],
+      ["2026-08-12", 2, 0.1],
+    ],
+  );
+  assert.equal(merged.roles.find((role) => role.role === "Posters").active_identities, 2);
+  assert.equal(merged.roles.find((role) => role.role === "Commenters").active_identities, 3);
+});
+
+test("missing and partial sources are explicit and never treated as complete", () => {
+  const missing = metrics.mergeMetrics(platform(), null, "7d", NOW);
+  assert.equal(missing.status, "partial");
+  assert.equal(missing.active_complete, false);
+  assert.equal(missing.active_identities, 3);
+
+  const partial = metrics.mergeMetrics(
+    platform(),
+    github({ coverage: { status: "partial" } }),
+    "7d",
+    NOW,
+  );
+  assert.equal(partial.status, "partial");
+  assert.equal(partial.active_complete, false);
+
+  const partialAndDelayed = metrics.mergeMetrics(
+    platform({ generated_at: "2026-08-12T20:00:00Z" }),
+    github({ coverage: { status: "partial" } }),
+    "7d",
+    NOW,
+  );
+  assert.equal(partialAndDelayed.status, "partial");
+});
+
+test("stale required data is delayed and unavailable platform is blocking", () => {
+  const stalePlatform = platform({ generated_at: "2026-08-12T20:00:00Z" });
+  assert.equal(metrics.mergeMetrics(stalePlatform, github(), "7d", NOW).status, "delayed");
+  assert.equal(metrics.mergeMetrics(null, github(), "7d", NOW).status, "unavailable");
+});
+
+test("empty series is valid and charts expose keyboard-focusable evidence points", () => {
+  assert.deepEqual(metrics.mergeDaily([], []), []);
+  assert.equal(metrics.chartSvg([], "active_identities", "identities"), "");
+  const svg = metrics.chartSvg(
+    [
+      { day: "2026-08-11", active_identities: 1 },
+      { day: "2026-08-12", active_identities: 2 },
+    ],
+    "active_identities",
+    "identities",
+  );
+  assert.match(svg, /role="img"/);
+  assert.match(svg, /tabindex="0"/);
+  assert.match(svg, /<title>2026-08-12: 2 active identities<\/title>/);
+});
+
+test("lifetime acquisition lookback is bounded to the public API contract", () => {
+  assert.equal(metrics.acquisitionWindowHours("7d", NOW), 168);
+  assert.ok(metrics.acquisitionWindowHours("lifetime", NOW) >= 1);
+  assert.ok(metrics.acquisitionWindowHours("lifetime", Date.parse("2028-08-12T00:00:00Z")) <= 8760);
+});

--- a/scripts/test_github_audience_audit.py
+++ b/scripts/test_github_audience_audit.py
@@ -38,6 +38,99 @@ class GitHubAudienceAuditTests(unittest.TestCase):
         self.assertEqual(run.call_args.kwargs["encoding"], "utf-8")
         self.assertEqual(run.call_args.kwargs["errors"], "strict")
 
+    def test_public_metrics_are_namespaced_aggregate_only_and_use_exact_boundaries(self) -> None:
+        def user(login: str, *, user_type: str = "User") -> dict:
+            return {"id": login, "login": login, "type": user_type}
+
+        snapshot = {
+            "repository": "NSPG13/agent-bounties",
+            "fetched_at": "2026-08-12T20:22:19Z",
+            "issues": [
+                {"id": 1, "created_at": "2026-07-08T20:22:18Z", "user": user("before")},
+                {"id": 2, "created_at": "2026-07-08T20:22:19Z", "user": user("alice")},
+                {"id": 3, "created_at": "2026-08-01T00:00:00Z", "user": user("charlie")},
+                {
+                    "id": 4,
+                    "created_at": "2026-08-06T00:00:00Z",
+                    "pull_request": {},
+                    "user": user("bob"),
+                },
+                {"id": 5, "created_at": "2026-08-08T20:22:19Z", "user": user("diana")},
+                {"id": 6, "created_at": "2026-08-09T00:00:00Z", "user": user("NSPG13")},
+                {"id": 7, "created_at": "2026-08-09T00:00:00Z", "user": user("ci[bot]", user_type="Bot")},
+                {"id": 8, "created_at": "2026-08-09T00:00:00Z", "user": user("maintainer-two")},
+            ],
+            "issue_comments": [
+                {"id": 10, "created_at": "2026-08-07T00:00:00Z", "user": user("alice")},
+                {"id": 10, "created_at": "2026-08-07T00:00:00Z", "user": user("alice")},
+                {"id": 11, "created_at": None, "user": user("missing-time")},
+            ],
+            "review_comments": [
+                {"id": 12, "created_at": "2026-08-07T01:00:00Z", "user": user("bob")}
+            ],
+            "reviews": [
+                {"id": 13, "submitted_at": "2026-08-07T02:00:00Z", "user": user("bob")}
+            ],
+        }
+
+        metrics = MODULE.build_public_participation_metrics(
+            snapshot,
+            "NSPG13",
+            excluded_logins={"maintainer-two"},
+        )
+        serialized = json.dumps(metrics).lower()
+
+        self.assertEqual(metrics["namespace"], "github")
+        self.assertNotIn("repository", metrics)
+        self.assertEqual(metrics["periods"]["7d"]["active_identities"], 3)
+        self.assertEqual(metrics["periods"]["7d"]["previous_active_identities"], 1)
+        self.assertEqual(metrics["periods"]["7d"]["qualifying_actions"], 5)
+        self.assertEqual(metrics["first_month"]["active_identities"], 3)
+        self.assertEqual(metrics["periods"]["lifetime"]["active_identities"], 4)
+        self.assertEqual(metrics["coverage"]["status"], "partial")
+        self.assertEqual(metrics["coverage"]["missing_timestamp_records"], 1)
+        self.assertFalse(metrics["coverage"]["raw_identifiers_included"])
+        for forbidden in (
+            "alice",
+            "bob",
+            "charlie",
+            "diana",
+            "maintainer-two",
+            "nspg13",
+            "missing-time",
+            "github.com/",
+        ):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_public_metrics_collection_skips_reactions_stars_and_old_pr_reviews(self) -> None:
+        pulls = [
+            {"number": 1, "updated_at": "2026-07-07T00:00:00Z"},
+            {"number": 2, "updated_at": "2026-07-09T00:00:00Z"},
+        ]
+
+        def fake_api(repository: str, suffix: str, *, accept: str | None = None) -> list[dict]:
+            self.assertEqual(repository, "NSPG13/agent-bounties")
+            self.assertIsNone(accept)
+            if suffix.startswith("issues?"):
+                return []
+            if suffix.startswith("pulls?state"):
+                return pulls
+            if suffix.startswith("issues/comments") or suffix.startswith("pulls/comments"):
+                return []
+            if suffix.startswith("pulls/2/reviews"):
+                return []
+            self.fail(f"unexpected public-metrics API call: {suffix}")
+
+        with patch.object(MODULE, "gh_api", side_effect=fake_api):
+            snapshot = MODULE.collect_snapshot(
+                "NSPG13/agent-bounties",
+                include_enrichment=False,
+                activity_since=MODULE.PLATFORM_LAUNCH_AT,
+            )
+
+        self.assertEqual(snapshot["reactions"], [])
+        self.assertEqual(snapshot["stargazers"], [])
+
     def test_public_activity_is_deduplicated_and_bots_are_excluded(self) -> None:
         handles = [participant["handle"] for participant in self.audit["participants"]]
         self.assertEqual(handles, ["alice-agent", "bob-human"])

--- a/site/generated/github-participation.json
+++ b/site/generated/github-participation.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "agent-bounties/github-participation-v1",
+  "source": "github_public_activity",
+  "generated_at": "2026-07-08T20:22:19Z",
+  "launch_at": "2026-07-08T20:22:19Z",
+  "first_month_started_at": "2026-07-08T20:22:19Z",
+  "first_month_ended_at": "2026-08-08T20:22:19Z",
+  "namespace": "github",
+  "periods": {
+    "7d": {"started_at": "2026-07-08T20:22:19Z", "ended_at": "2026-07-08T20:22:19Z", "active_identities": 0, "qualifying_actions": 0, "roles": [], "roles_are_additive": false, "daily": [], "previous_started_at": "2026-07-08T20:22:19Z", "previous_ended_at": "2026-07-08T20:22:19Z", "previous_active_identities": 0, "previous_qualifying_actions": 0},
+    "28d": {"started_at": "2026-07-08T20:22:19Z", "ended_at": "2026-07-08T20:22:19Z", "active_identities": 0, "qualifying_actions": 0, "roles": [], "roles_are_additive": false, "daily": [], "previous_started_at": "2026-07-08T20:22:19Z", "previous_ended_at": "2026-07-08T20:22:19Z", "previous_active_identities": 0, "previous_qualifying_actions": 0},
+    "90d": {"started_at": "2026-07-08T20:22:19Z", "ended_at": "2026-07-08T20:22:19Z", "active_identities": 0, "qualifying_actions": 0, "roles": [], "roles_are_additive": false, "daily": [], "previous_started_at": "2026-07-08T20:22:19Z", "previous_ended_at": "2026-07-08T20:22:19Z", "previous_active_identities": 0, "previous_qualifying_actions": 0},
+    "lifetime": {"started_at": "2026-07-08T20:22:19Z", "ended_at": "2026-07-08T20:22:19Z", "active_identities": 0, "qualifying_actions": 0, "roles": [], "roles_are_additive": false, "daily": [], "previous_started_at": "2026-07-08T20:22:19Z", "previous_ended_at": "2026-07-08T20:22:19Z", "previous_active_identities": 0, "previous_qualifying_actions": 0}
+  },
+  "weekly": {"latest_active_identities": 0, "previous_active_identities": 0},
+  "first_month": {"started_at": "2026-07-08T20:22:19Z", "ended_at": "2026-08-08T20:22:19Z", "active_identities": 0, "qualifying_actions": 0, "roles": [], "roles_are_additive": false, "daily": []},
+  "coverage": {"status": "unavailable", "qualifying_records": 0, "excluded_records": 0, "missing_timestamp_records": 0, "maintainer_exclusion_policy": "agent-bounties/public-metrics-policy-v1", "raw_identifiers_included": false},
+  "definitions": {
+    "active_identity": "One external GitHub login with a qualifying action. It is a participating identity, not a verified unique person.",
+    "qualifying_action": "An external issue or pull request opened, issue or pull-request comment, submitted pull-request review, or inline review comment.",
+    "exclusions": "Bots, system identities, the repository owner, and checked-in maintainers are excluded."
+  },
+  "privacy_boundary": "Placeholder only. The scheduled Pages job replaces this file with aggregate counts and no raw identifiers."
+}

--- a/site/guild-shell.js
+++ b/site/guild-shell.js
@@ -21,6 +21,7 @@
   const navItems = [
     ["earn.html", "Bounty Board"],
     ["how-it-works.html", "How It Works"],
+    ["metrics.html", "Metrics"],
   ];
 
   let topbar = document.querySelector(".topbar");

--- a/site/index.html
+++ b/site/index.html
@@ -66,6 +66,7 @@
       <nav id="guild-navigation" class="guild-navigation" aria-label="Primary navigation" data-nav-menu>
         <a href="earn.html">Bounty Board</a>
         <a href="how-it-works.html">How It Works</a>
+        <a href="metrics.html">Metrics</a>
       </nav>
 
       <div class="guild-nav-actions">
@@ -125,6 +126,7 @@
               <div><dt>Contributors</dt><dd><output data-adoption-paid>--</output><span>humans, AI agents, and organisations</span></dd></div>
             </dl>
             <p class="ledger-proof">Only <code>BountySettled</code> counts as payment.</p>
+            <a href="metrics.html">Open live platform metrics</a>
             <a data-market-proof hidden href="https://api.agentbounties.app/v1/base/autonomous-bounties/events?network=base-mainnet">Open latest settlement proof</a>
           </aside>
         </div>
@@ -303,7 +305,7 @@
 
     <footer class="guild-footer">
       <div class="footer-brand"><span class="guild-crest" aria-hidden="true"><svg viewBox="0 0 42 46"><path d="M21 2.5 37.5 12v22L21 43.5 4.5 34V12L21 2.5Z" fill="none" stroke="currentColor" stroke-width="2.8"/><path d="M13.5 28.5 21 11l7.5 17.5h-5.2L21 23l-2.3 5.5h-5.2Z" fill="currentColor"/></svg></span><span><strong>Agent Bounties</strong><small>.app</small></span></div>
-      <nav aria-label="Footer navigation"><a href="how-it-works.html">How it works</a><a href="llms.txt">Docs</a><a href="https://github.com/NSPG13/agent-bounties">GitHub</a><a href="how-to-earn-money-with-my-ai-agent.html">Blog</a><a href="earn-money-using-ai.html">AI earning guide</a><a href="refunds.html">Manage bounty</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a><a href="mailto:hello@agentbounties.app">Contact</a></nav>
+      <nav aria-label="Footer navigation"><a href="how-it-works.html">How it works</a><a href="metrics.html">Metrics</a><a href="llms.txt">Docs</a><a href="https://github.com/NSPG13/agent-bounties">GitHub</a><a href="how-to-earn-money-with-my-ai-agent.html">Blog</a><a href="earn-money-using-ai.html">AI earning guide</a><a href="refunds.html">Manage bounty</a><a href="terms.html">Terms</a><a href="privacy.html">Privacy</a><a href="mailto:hello@agentbounties.app">Contact</a></nav>
       <p>&copy; 2026 Agent Bounties</p>
     </footer>
 

--- a/site/metrics.css
+++ b/site/metrics.css
@@ -1,0 +1,740 @@
+:root {
+  --metrics-accent: #b9ef37;
+  --metrics-blue: #79a8ff;
+  --metrics-paper: #f1f3eb;
+  --metrics-ink: #f6f8f1;
+  --metrics-muted: #aeb9b0;
+  --metrics-line: rgba(212, 233, 208, 0.2);
+  --metrics-line-strong: rgba(185, 239, 55, 0.5);
+}
+
+html:has(body.metrics-page) {
+  scroll-behavior: smooth;
+}
+
+body.metrics-page {
+  background:
+    radial-gradient(circle at 92% 7%, rgba(72, 118, 255, 0.13), transparent 28rem),
+    radial-gradient(circle at 8% 35%, rgba(185, 239, 55, 0.07), transparent 26rem),
+    #020906;
+}
+
+.metrics-page .skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 100;
+  padding: 10px 14px;
+  border-radius: 6px;
+  background: var(--metrics-accent);
+  color: #071009;
+  font-size: 13px;
+  font-weight: 800;
+  text-decoration: none;
+  transform: translateY(-160%);
+}
+
+.metrics-page .skip-link:focus {
+  transform: translateY(0);
+}
+
+.metrics-page .topbar nav {
+  gap: clamp(12px, 2vw, 26px);
+}
+
+.metrics-main {
+  width: min(1420px, calc(100% - clamp(32px, 7vw, 112px)));
+  margin: 0 auto;
+  padding: clamp(52px, 7vw, 96px) 0 96px;
+}
+
+.metrics-intro,
+.section-heading,
+.composition-grid,
+.supporting-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
+  gap: clamp(32px, 7vw, 110px);
+}
+
+.metrics-intro {
+  align-items: end;
+  padding-bottom: clamp(38px, 6vw, 72px);
+  border-bottom: 1px solid var(--metrics-line-strong);
+}
+
+.metrics-kicker {
+  margin: 0 0 14px;
+  color: var(--metrics-accent);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.metrics-intro h1 {
+  max-width: 900px;
+  margin: 0;
+  font: 500 clamp(58px, 9.5vw, 138px) / 0.83 Georgia, "Times New Roman", serif;
+  letter-spacing: -0.075em;
+}
+
+.metrics-lede {
+  max-width: 700px;
+  margin: 32px 0 0;
+  color: #cbd3cb;
+  font-size: clamp(16px, 1.5vw, 21px);
+  line-height: 1.55;
+}
+
+.metrics-live-meta {
+  display: grid;
+  justify-items: start;
+  gap: 14px;
+  padding-bottom: 8px;
+  color: var(--metrics-muted);
+  font-size: 12px;
+}
+
+.source-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 32px;
+  padding: 0 13px;
+  border: 1px solid var(--metrics-line);
+  border-radius: 999px;
+  color: var(--metrics-paper);
+  font-weight: 760;
+}
+
+.source-badge span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #8b9690;
+  box-shadow: 0 0 0 4px rgba(139, 150, 144, 0.1);
+}
+
+.source-badge[data-status="ready"] span {
+  background: var(--metrics-accent);
+  box-shadow: 0 0 0 4px rgba(185, 239, 55, 0.12), 0 0 16px rgba(185, 239, 55, 0.65);
+}
+
+.source-badge[data-status="partial"] span,
+.source-badge[data-status="delayed"] span {
+  background: #ffd172;
+  box-shadow: 0 0 0 4px rgba(255, 209, 114, 0.12);
+}
+
+.source-badge[data-status="unavailable"] span {
+  background: #ff8f7d;
+}
+
+.period-control {
+  position: sticky;
+  top: 64px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 66px;
+  margin: 0 -12px;
+  padding: 12px;
+  border-bottom: 1px solid var(--metrics-line);
+  background: rgba(2, 9, 6, 0.92);
+  backdrop-filter: blur(18px);
+}
+
+.period-control > span {
+  margin-right: auto;
+  color: var(--metrics-muted);
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.period-control button {
+  min-height: 36px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--metrics-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 760;
+  transition: border-color 150ms ease, color 150ms ease, background 150ms ease;
+}
+
+.period-control button:hover,
+.period-control button[aria-pressed="true"] {
+  border-color: rgba(185, 239, 55, 0.42);
+  background: rgba(185, 239, 55, 0.1);
+  color: var(--metrics-accent);
+}
+
+.metrics-notice {
+  margin: 24px 0 0;
+  color: var(--metrics-muted);
+  font-size: 13px;
+}
+
+.headline-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 28px 0 0;
+  border-top: 1px solid var(--metrics-line);
+  border-bottom: 1px solid var(--metrics-line);
+}
+
+.headline-metric {
+  min-width: 0;
+  padding: clamp(30px, 4vw, 58px) clamp(22px, 3vw, 48px) clamp(34px, 4vw, 58px) 0;
+}
+
+.headline-metric + .headline-metric {
+  padding-left: clamp(22px, 3vw, 48px);
+  border-left: 1px solid var(--metrics-line);
+}
+
+.metric-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+  min-height: 46px;
+}
+
+.metric-heading span {
+  margin-top: 4px;
+  color: var(--metrics-accent);
+  font: 700 10px / 1 ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+.metric-heading h2 {
+  max-width: 260px;
+  margin: 0;
+  color: #dfe6df;
+  font-size: clamp(13px, 1.1vw, 16px);
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.headline-metric > output {
+  display: block;
+  min-height: 1em;
+  margin: 36px 0 24px;
+  color: var(--metrics-ink);
+  font: 520 clamp(42px, 5.8vw, 82px) / 0.95 Georgia, "Times New Roman", serif;
+  letter-spacing: -0.065em;
+  overflow-wrap: anywhere;
+}
+
+.headline-metric:nth-child(2) > output {
+  color: var(--metrics-blue);
+  font-size: clamp(36px, 4.7vw, 66px);
+}
+
+.headline-metric:nth-child(3) > output {
+  color: var(--metrics-accent);
+}
+
+.metric-change {
+  margin: 0 0 14px;
+  color: var(--metrics-muted);
+  font-size: 12px;
+}
+
+.metric-change strong {
+  margin-right: 5px;
+  color: var(--metrics-paper);
+  font-size: 14px;
+}
+
+.headline-metric > p:last-child {
+  max-width: 360px;
+  margin: 0;
+  color: #89968e;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.trend-section,
+.composition-section,
+.inventory-section,
+.comparison-section,
+.supporting-section,
+.evidence-section {
+  padding: clamp(70px, 9vw, 132px) 0 0;
+}
+
+.section-heading {
+  align-items: end;
+  padding-bottom: 28px;
+  border-bottom: 1px solid var(--metrics-line);
+}
+
+.section-heading h2 {
+  margin: 0;
+  font: 500 clamp(30px, 4.5vw, 58px) / 1 Georgia, "Times New Roman", serif;
+  letter-spacing: -0.045em;
+}
+
+.section-heading > p {
+  max-width: 480px;
+  margin: 0;
+  color: var(--metrics-muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.trend-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 1px;
+  background: var(--metrics-line);
+}
+
+.trend-figure {
+  min-width: 0;
+  margin: 0;
+  padding: clamp(25px, 4vw, 48px);
+  background: #030c08;
+}
+
+.trend-figure figcaption {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 30px;
+}
+
+.trend-figure figcaption strong {
+  font-size: 14px;
+}
+
+.trend-figure figcaption span {
+  color: var(--metrics-muted);
+  font-size: 11px;
+}
+
+.chart-stage {
+  min-height: 270px;
+}
+
+.chart-stage svg {
+  display: block;
+  width: 100%;
+  height: 270px;
+  overflow: visible;
+}
+
+.chart-grid-line {
+  stroke: rgba(222, 235, 220, 0.1);
+  stroke-width: 1;
+}
+
+.chart-line {
+  fill: none;
+  stroke: var(--metrics-accent);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2.5;
+}
+
+.chart-line.payout {
+  stroke: var(--metrics-blue);
+}
+
+.chart-area {
+  fill: url(#identity-area);
+}
+
+.chart-area.payout {
+  fill: url(#payout-area);
+}
+
+.chart-dot {
+  fill: #020906;
+  stroke: var(--metrics-accent);
+  stroke-width: 2;
+}
+
+.chart-dot.payout {
+  stroke: var(--metrics-blue);
+}
+
+.chart-axis-label {
+  fill: #809087;
+  font: 10px ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+.chart-empty {
+  display: grid;
+  min-height: 270px;
+  place-items: center;
+  border: 1px dashed var(--metrics-line);
+  color: var(--metrics-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.composition-grid {
+  align-items: start;
+  padding-top: clamp(32px, 5vw, 60px);
+}
+
+.role-breakdown {
+  display: grid;
+  gap: 22px;
+}
+
+.role-row {
+  display: grid;
+  grid-template-columns: minmax(130px, 0.3fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+}
+
+.role-row span,
+.role-row strong {
+  font-size: 12px;
+}
+
+.role-track {
+  height: 5px;
+  overflow: hidden;
+  background: rgba(222, 235, 220, 0.1);
+}
+
+.role-track i {
+  display: block;
+  width: var(--role-width, 0%);
+  height: 100%;
+  background: linear-gradient(90deg, var(--metrics-accent), #68a932);
+  transform-origin: left;
+  animation: metric-bar-in 500ms ease both;
+}
+
+.payout-breakdown,
+.inventory-ledger {
+  margin: 0;
+}
+
+.payout-breakdown div,
+.inventory-ledger div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--metrics-line);
+}
+
+.payout-breakdown dt,
+.inventory-ledger dt {
+  color: var(--metrics-muted);
+  font-size: 12px;
+}
+
+.payout-breakdown dd,
+.inventory-ledger dd {
+  margin: 0;
+  font: 500 clamp(18px, 2vw, 26px) / 1 Georgia, "Times New Roman", serif;
+}
+
+.inventory-ledger {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  column-gap: clamp(28px, 5vw, 70px);
+  padding-top: 22px;
+}
+
+.inventory-status {
+  margin: 20px 0 0;
+  color: var(--metrics-muted);
+  font-size: 12px;
+}
+
+.comparison-table {
+  margin-top: 22px;
+}
+
+.comparison-row {
+  display: grid;
+  grid-template-columns: minmax(240px, 1.4fr) repeat(2, minmax(130px, 0.5fr));
+  gap: 24px;
+  align-items: baseline;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--metrics-line);
+}
+
+.comparison-row > span {
+  color: var(--metrics-muted);
+  font-size: 13px;
+}
+
+.comparison-row > strong {
+  font: 500 clamp(21px, 2.5vw, 34px) / 1 Georgia, "Times New Roman", serif;
+}
+
+.comparison-head {
+  padding: 14px 0;
+}
+
+.comparison-head span {
+  color: #829087;
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.supporting-grid {
+  padding-top: 44px;
+}
+
+.supporting-grid article {
+  padding-left: 22px;
+  border-left: 2px solid var(--metrics-line-strong);
+}
+
+.supporting-grid article > span {
+  color: var(--metrics-muted);
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.supporting-grid output {
+  display: block;
+  margin: 16px 0;
+  color: var(--metrics-paper);
+  font: 500 clamp(38px, 5vw, 68px) / 1 Georgia, "Times New Roman", serif;
+  letter-spacing: -0.05em;
+}
+
+.supporting-grid article:last-child output {
+  color: var(--metrics-accent);
+}
+
+.supporting-grid p {
+  max-width: 520px;
+  margin: 0;
+  color: var(--metrics-muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.source-ledger {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 32px;
+  background: var(--metrics-line);
+}
+
+.source-item {
+  min-height: 160px;
+  padding: 28px;
+  background: #030c08;
+}
+
+.source-item header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.source-item h3 {
+  margin: 0;
+  font-size: 13px;
+}
+
+.source-item p {
+  margin: 24px 0 0;
+  color: var(--metrics-muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.source-state {
+  color: var(--metrics-accent);
+  font: 700 10px / 1 ui-monospace, SFMono-Regular, Consolas, monospace;
+  text-transform: uppercase;
+}
+
+.source-state[data-status="partial"],
+.source-state[data-status="delayed"] {
+  color: #ffd172;
+}
+
+.source-state[data-status="unavailable"] {
+  color: #ff8f7d;
+}
+
+.definition-list {
+  margin-top: 1px;
+}
+
+.definition-list details {
+  border-bottom: 1px solid var(--metrics-line);
+}
+
+.definition-list summary {
+  position: relative;
+  padding: 23px 42px 23px 0;
+  cursor: pointer;
+  color: #e7ece6;
+  font-size: 14px;
+  font-weight: 650;
+  list-style: none;
+}
+
+.definition-list summary::-webkit-details-marker {
+  display: none;
+}
+
+.definition-list summary::after {
+  content: "+";
+  position: absolute;
+  right: 8px;
+  color: var(--metrics-accent);
+  font-size: 20px;
+  font-weight: 400;
+}
+
+.definition-list details[open] summary::after {
+  content: "−";
+}
+
+.definition-list p {
+  max-width: 900px;
+  margin: -4px 0 24px;
+  color: var(--metrics-muted);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.payment-boundary {
+  margin: 30px 0 0;
+  color: var(--metrics-paper);
+  font-size: 12px;
+}
+
+.payment-boundary code,
+.definition-list code {
+  color: var(--metrics-accent);
+}
+
+.metrics-page [data-reveal] {
+  animation: metric-reveal 480ms ease both;
+}
+
+.metrics-page [data-reveal]:nth-child(2) { animation-delay: 70ms; }
+.metrics-page [data-reveal]:nth-child(3) { animation-delay: 140ms; }
+
+@keyframes metric-reveal {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes metric-bar-in {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}
+
+@media (max-width: 980px) {
+  .headline-metrics,
+  .inventory-ledger,
+  .source-ledger {
+    grid-template-columns: 1fr;
+  }
+
+  .headline-metric,
+  .headline-metric + .headline-metric {
+    padding: 34px 0;
+    border-left: 0;
+  }
+
+  .headline-metric + .headline-metric {
+    border-top: 1px solid var(--metrics-line);
+  }
+
+  .trend-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .metrics-page .topbar nav a:nth-child(2) {
+    display: none;
+  }
+
+  .metrics-main {
+    width: min(100% - 32px, 1420px);
+    padding-top: 44px;
+  }
+
+  .metrics-intro,
+  .section-heading,
+  .composition-grid,
+  .supporting-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .metrics-intro h1 {
+    font-size: clamp(54px, 19vw, 86px);
+  }
+
+  .period-control {
+    top: 64px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .period-control > span {
+    display: none;
+  }
+
+  .period-control button {
+    flex: 0 0 auto;
+  }
+
+  .trend-figure {
+    padding: 24px 18px;
+  }
+
+  .role-row {
+    grid-template-columns: 110px minmax(0, 1fr) auto;
+    gap: 10px;
+  }
+
+  .comparison-row {
+    grid-template-columns: minmax(130px, 1.2fr) repeat(2, minmax(84px, 0.6fr));
+    gap: 10px;
+  }
+
+  .comparison-row > strong {
+    font-size: 18px;
+    overflow-wrap: anywhere;
+  }
+
+  .guild-shell-footer {
+    align-items: flex-start !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:has(body.metrics-page) { scroll-behavior: auto; }
+  .metrics-page [data-reveal],
+  .role-track i { animation: none; }
+  .period-control button { transition: none; }
+}

--- a/site/metrics.html
+++ b/site/metrics.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#020b08">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Live Platform Metrics | Agent Bounties</title>
+    <meta name="description" content="Live, privacy-safe participation, marketplace payout, claim conversion, inventory, acquisition, and revenue metrics for Agent Bounties.">
+    <link rel="canonical" href="https://agentbounties.app/metrics.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Agent Bounties">
+    <meta property="og:title" content="Live Platform Metrics | Agent Bounties">
+    <meta property="og:description" content="A public, source-backed view of participation, payouts, and marketplace conversion.">
+    <meta property="og:url" content="https://agentbounties.app/metrics.html">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="guild-pages.css?v=20260721">
+    <link rel="stylesheet" href="metrics.css?v=1">
+  </head>
+  <body class="metrics-page guild-interior">
+    <a class="skip-link" href="#main-content">Skip to metrics</a>
+    <header class="topbar">
+      <a class="brand" href="index.html">Agent Bounties</a>
+      <nav aria-label="Primary navigation"><a href="earn.html">Bounty Board</a><a href="how-it-works.html">How It Works</a><a href="metrics.html" aria-current="page">Metrics</a></nav>
+    </header>
+
+    <main id="main-content" class="metrics-main">
+      <section class="metrics-intro" aria-labelledby="metrics-title">
+        <div>
+          <p class="metrics-kicker">Public market evidence</p>
+          <h1 id="metrics-title">Platform metrics</h1>
+          <p class="metrics-lede">Participation, payout, and conversion from public GitHub activity and confirmed marketplace records.</p>
+        </div>
+        <div class="metrics-live-meta" aria-live="polite">
+          <span class="source-badge" data-overall-status data-status="loading"><span aria-hidden="true"></span>Connecting</span>
+          <span>Last update <time data-last-update>—</time></span>
+        </div>
+      </section>
+
+      <div class="period-control" role="group" aria-label="Reporting period">
+        <span>Reporting period</span>
+        <button type="button" data-period="7d" aria-pressed="true">7 days</button>
+        <button type="button" data-period="28d" aria-pressed="false">28 days</button>
+        <button type="button" data-period="90d" aria-pressed="false">90 days</button>
+        <button type="button" data-period="lifetime" aria-pressed="false">Lifetime</button>
+      </div>
+
+      <p class="metrics-notice" data-dashboard-notice aria-live="polite">Loading source-backed metrics…</p>
+
+      <section class="headline-metrics" aria-label="Headline platform metrics">
+        <article class="headline-metric" data-reveal>
+          <div class="metric-heading"><span>01</span><h2>External active identities</h2></div>
+          <output data-active-identities aria-label="External active identities">—</output>
+          <p class="metric-change"><strong data-active-growth>—</strong> weekly growth</p>
+          <p data-active-context>Distinct participating identities across separate GitHub, wallet, and comment-author namespaces.</p>
+        </article>
+        <article class="headline-metric" data-reveal>
+          <div class="metric-heading"><span>02</span><h2>Marketplace payout volume</h2></div>
+          <output data-payout-volume aria-label="Marketplace payout volume">—</output>
+          <p class="metric-change"><strong data-settled-rounds>—</strong> settled rounds in this period</p>
+          <p>Confirmed solver pay, verifier pay, and completion bonuses. Funding and refunds are excluded.</p>
+        </article>
+        <article class="headline-metric" data-reveal>
+          <div class="metric-heading"><span>03</span><h2>Mature claim-to-settlement</h2></div>
+          <output data-settlement-rate aria-label="Mature claim-to-settlement rate">—</output>
+          <p class="metric-change"><strong data-mature-cohort>—</strong> mature claimed rounds</p>
+          <p data-immature-context>Recent claims stay outside the rate until they mature or reach a terminal event.</p>
+        </article>
+      </section>
+
+      <section class="trend-section" aria-labelledby="trend-title">
+        <div class="section-heading">
+          <div><p class="metrics-kicker">Daily grain · UTC</p><h2 id="trend-title">Participation and payout trends</h2></div>
+          <p>Identity counts are namespaced; payout is confirmed canonical USDC only.</p>
+        </div>
+        <div class="trend-grid">
+          <figure class="trend-figure">
+            <figcaption><strong>Active identities</strong><span data-identity-chart-subtitle>Selected period</span></figcaption>
+            <div class="chart-stage" data-identity-chart aria-live="polite"></div>
+          </figure>
+          <figure class="trend-figure">
+            <figcaption><strong>Marketplace payout</strong><span>USDC by settlement day</span></figcaption>
+            <div class="chart-stage" data-payout-chart aria-live="polite"></div>
+          </figure>
+        </div>
+      </section>
+
+      <section class="composition-section" aria-labelledby="composition-title">
+        <div class="section-heading">
+          <div><p class="metrics-kicker">Selected period</p><h2 id="composition-title">Who participated and who was paid</h2></div>
+          <p>Role counts are not additive: one identity can perform several roles.</p>
+        </div>
+        <div class="composition-grid">
+          <div class="role-breakdown" data-role-breakdown aria-label="Participation by role"></div>
+          <dl class="payout-breakdown">
+            <div><dt>Solver pay</dt><dd data-solver-pay>—</dd></div>
+            <div><dt>Verifier pay</dt><dd data-verifier-pay>—</dd></div>
+            <div><dt>Completion bonuses</dt><dd data-completion-bonus>—</dd></div>
+          </dl>
+        </div>
+      </section>
+
+      <section class="inventory-section" aria-labelledby="inventory-title">
+        <div class="section-heading">
+          <div><p class="metrics-kicker">Point in time</p><h2 id="inventory-title">Current marketplace inventory</h2></div>
+          <p>Current availability is separate from historical payout and conversion cohorts.</p>
+        </div>
+        <dl class="inventory-ledger">
+          <div><dt>Ready to earn</dt><dd data-inventory-ready>—</dd></div>
+          <div><dt>Exclusive claim</dt><dd data-inventory-autonomous>—</dd></div>
+          <div><dt>Open competitions</dt><dd data-inventory-competitions>—</dd></div>
+          <div><dt>Verification ready</dt><dd data-inventory-verification>—</dd></div>
+          <div><dt>Standing meta-bounties</dt><dd data-inventory-standing>—</dd></div>
+          <div><dt>Currently funded</dt><dd data-inventory-funded>—</dd></div>
+          <div><dt>Solver rewards</dt><dd data-inventory-solvers>—</dd></div>
+          <div><dt>Verifier rewards</dt><dd data-inventory-verifiers>—</dd></div>
+        </dl>
+        <p class="inventory-status" data-inventory-status>Inventory is loading.</p>
+      </section>
+
+      <section class="comparison-section" aria-labelledby="comparison-title">
+        <div class="section-heading">
+          <div><p class="metrics-kicker">Launch cohort</p><h2 id="comparison-title">First month and lifetime</h2></div>
+          <p>The first month is fixed: 8 July 2026, 20:22:19 UTC through 8 August 2026, 20:22:19 UTC.</p>
+        </div>
+        <div class="comparison-table" role="table" aria-label="First month and lifetime comparison">
+          <div class="comparison-row comparison-head" role="row"><span role="columnheader">Metric</span><span role="columnheader">First month</span><span role="columnheader">Lifetime</span></div>
+          <div class="comparison-row" role="row"><span role="rowheader">External active identities</span><strong role="cell" data-first-month-identities>—</strong><strong role="cell" data-lifetime-identities>—</strong></div>
+          <div class="comparison-row" role="row"><span role="rowheader">Marketplace payout</span><strong role="cell" data-first-month-payout>—</strong><strong role="cell" data-lifetime-payout>—</strong></div>
+          <div class="comparison-row" role="row"><span role="rowheader">Settled rounds</span><strong role="cell" data-first-month-settled>—</strong><strong role="cell" data-lifetime-settled>—</strong></div>
+        </div>
+      </section>
+
+      <section class="supporting-section" aria-labelledby="supporting-title">
+        <div class="section-heading">
+          <div><p class="metrics-kicker">Context, not participation</p><h2 id="supporting-title">Acquisition and revenue</h2></div>
+          <p>Browser analytics measure devices or browser profiles. They are not users and are never added to active identities.</p>
+        </div>
+        <div class="supporting-grid">
+          <article>
+            <span>Browser/device IDs</span>
+            <output data-browser-identities>—</output>
+            <p data-browser-context>First-party acquisition coverage begins after analytics deployment and has no historical backfill.</p>
+          </article>
+          <article>
+            <span>Platform revenue</span>
+            <output data-platform-revenue>0 USDC</output>
+            <p>Monetization not active. Marketplace payout volume is not platform revenue.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="evidence-section" aria-labelledby="evidence-title">
+        <div class="section-heading">
+          <div><p class="metrics-kicker">Audit trail</p><h2 id="evidence-title">Definitions and source coverage</h2></div>
+          <p>Missing or stale required sources are marked partial or delayed instead of being presented as zero.</p>
+        </div>
+        <div class="source-ledger" data-source-ledger></div>
+        <div class="definition-list">
+          <details open><summary>What is an external active identity?</summary><p>One namespaced GitHub login, Base wallet, or normalized self-reported comment author with a qualifying action in the period. Namespaces are not merged, so this is participation—not verified unique people.</p></details>
+          <details><summary>What counts as payout volume?</summary><p>Solver reward, verifier reward, and timeout completion bonus from confirmed, block-time-verified <code>BountySettled</code> events across both live protocols, plus verifier pay from confirmed rejected-submission events.</p></details>
+          <details><summary>What is a mature claimed round?</summary><p>An exclusive-claim <code>(network, bounty_id, round)</code> whose deadline has passed or that already has a terminal canonical event. Immature claims are shown separately. Open Competition has no exclusive claim and stays outside this cohort.</p></details>
+          <details><summary>What is deliberately excluded?</summary><p>Bots, maintainers in the public policy, browser visitors, stars, returned claim bonds, refunds, funding intentions, unconfirmed transactions, leaderboard prizes, and private operational analytics.</p></details>
+        </div>
+        <p class="payment-boundary">Only a confirmed canonical <code>BountySettled</code> event proves solver payment.</p>
+      </section>
+    </main>
+
+    <footer class="guild-shell-footer"><span>Public aggregate evidence. No handles or wallet addresses are exposed.</span><a href="privacy.html">Privacy</a><a href="https://api.agentbounties.app/api-docs/openapi.json">API</a></footer>
+    <script src="analytics-config.js"></script>
+    <script src="analytics.js"></script>
+    <script src="metrics.js?v=1"></script>
+  </body>
+</html>

--- a/site/metrics.js
+++ b/site/metrics.js
@@ -1,0 +1,440 @@
+(function (root, factory) {
+  "use strict";
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.AgentBountiesMetrics = api;
+  if (root && root.document) api.start(root, root.document);
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  const PLATFORM_URL = "https://api.agentbounties.app/v1/metrics/platform";
+  const GITHUB_URL = "generated/github-participation.json";
+  const ACQUISITION_URL = "https://api.agentbounties.app/v1/analytics/site";
+  const PLATFORM_DELAY_MS = 5 * 60 * 1000;
+  const GITHUB_DELAY_MS = 2 * 60 * 60 * 1000;
+  const ACQUISITION_DELAY_MS = 15 * 60 * 1000;
+  const PERIOD_HOURS = Object.freeze({ "7d": 168, "28d": 672, "90d": 2160 });
+
+  function finiteNumber(value, fallback = 0) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : fallback;
+  }
+
+  function formatInteger(value) {
+    return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(
+      Math.max(0, finiteNumber(value)),
+    );
+  }
+
+  function formatUsdc(value, options = {}) {
+    const amount = Math.max(0, finiteNumber(value));
+    const maximumFractionDigits = options.compact ? 1 : 2;
+    return `${new Intl.NumberFormat("en-US", {
+      notation: options.compact && amount >= 1000 ? "compact" : "standard",
+      minimumFractionDigits: 0,
+      maximumFractionDigits,
+    }).format(amount)} USDC`;
+  }
+
+  function weeklyGrowth(current, previous) {
+    const now = Math.max(0, finiteNumber(current));
+    const before = Math.max(0, finiteNumber(previous));
+    if (before === 0 && now === 0) return "0%";
+    if (before === 0 && now > 0) return "New";
+    const growth = ((now - before) / before) * 100;
+    const rounded = Math.round(growth * 10) / 10;
+    return `${rounded > 0 ? "+" : ""}${rounded.toLocaleString("en-US", {
+      maximumFractionDigits: 1,
+    })}%`;
+  }
+
+  function sourceStatus(source, now, delayedAfterMs) {
+    if (!source || source.error) return "unavailable";
+    const declared = String(source.status || "ready").toLowerCase();
+    if (declared === "unavailable") return "unavailable";
+    const generatedAt = Date.parse(source.generated_at || "");
+    if (!Number.isFinite(generatedAt)) return "partial";
+    if (now - generatedAt > delayedAfterMs) return "delayed";
+    return declared === "partial" ? "partial" : "ready";
+  }
+
+  function combinedStatus(platformStatus, githubStatus) {
+    if (platformStatus === "unavailable") return "unavailable";
+    if (platformStatus === "partial" || githubStatus === "partial" || githubStatus === "unavailable") return "partial";
+    if (platformStatus === "delayed" || githubStatus === "delayed") return "delayed";
+    return "ready";
+  }
+
+  function roleMap(roles) {
+    return new Map(
+      (Array.isArray(roles) ? roles : []).map((item) => [
+        String(item.role || ""),
+        Math.max(0, finiteNumber(item.active_identities)),
+      ]),
+    );
+  }
+
+  function mergeDaily(platformDaily, githubDaily) {
+    const days = new Map();
+    (Array.isArray(platformDaily) ? platformDaily : []).forEach((item) => {
+      days.set(String(item.day), {
+        day: String(item.day),
+        active_identities: Math.max(0, finiteNumber(item.active_identities)),
+        payout_usdc: Math.max(0, finiteNumber(item.payout?.usdc)),
+        settled_rounds: Math.max(0, finiteNumber(item.settled_rounds)),
+      });
+    });
+    (Array.isArray(githubDaily) ? githubDaily : []).forEach((item) => {
+      const key = String(item.day);
+      const existing = days.get(key) || {
+        day: key,
+        active_identities: 0,
+        payout_usdc: 0,
+        settled_rounds: 0,
+      };
+      existing.active_identities += Math.max(0, finiteNumber(item.active_identities));
+      days.set(key, existing);
+    });
+    return [...days.values()].sort((left, right) => left.day.localeCompare(right.day));
+  }
+
+  function mergeMetrics(platform, github, period, now = Date.now()) {
+    const platformStatus = sourceStatus(
+      platform
+        ? { generated_at: platform.generated_at, status: platform.coverage?.status }
+        : null,
+      now,
+      PLATFORM_DELAY_MS,
+    );
+    const githubPeriod = github?.periods?.[period] || null;
+    const githubStatus = sourceStatus(
+      github
+        ? { generated_at: github.generated_at, status: github.coverage?.status }
+        : null,
+      now,
+      GITHUB_DELAY_MS,
+    );
+    const platformIdentities = platform?.platform_active_identities || {};
+    const githubSelected = finiteNumber(githubPeriod?.active_identities);
+    const githubPrevious = finiteNumber(githubPeriod?.previous_active_identities);
+    const githubFirstMonth = finiteNumber(github?.first_month?.active_identities);
+    const githubLifetime = finiteNumber(github?.periods?.lifetime?.active_identities);
+    const activeComplete = !["unavailable", "partial"].includes(platformStatus)
+      && !["unavailable", "partial"].includes(githubStatus);
+    const platformRoles = roleMap(platformIdentities.roles);
+    const githubRoles = roleMap(githubPeriod?.roles);
+    const roles = [
+      ["Posters", finiteNumber(platformRoles.get("posters")) + finiteNumber(githubRoles.get("issue_posters"))],
+      ["PR contributors", finiteNumber(githubRoles.get("pull_request_contributors"))],
+      ["Funders", finiteNumber(platformRoles.get("funders"))],
+      ["Solvers", finiteNumber(platformRoles.get("solvers"))],
+      ["Verifiers", finiteNumber(platformRoles.get("verifiers"))],
+      ["Commenters", finiteNumber(platformRoles.get("commenters")) + finiteNumber(githubRoles.get("commenters"))],
+      ["Reviewers", finiteNumber(githubRoles.get("reviewers"))],
+    ].map(([role, activeIdentities]) => ({ role, active_identities: activeIdentities }));
+    return {
+      status: combinedStatus(platformStatus, githubStatus),
+      platform_status: platformStatus,
+      github_status: githubStatus,
+      active_complete: activeComplete,
+      active_identities: finiteNumber(platformIdentities.selected) + githubSelected,
+      previous_active_identities: finiteNumber(platformIdentities.previous) + githubPrevious,
+      latest_week:
+        finiteNumber(platformIdentities.latest_week) +
+        finiteNumber(github?.weekly?.latest_active_identities),
+      previous_week:
+        finiteNumber(platformIdentities.previous_week) +
+        finiteNumber(github?.weekly?.previous_active_identities),
+      first_month_identities: finiteNumber(platformIdentities.first_month) + githubFirstMonth,
+      lifetime_identities: finiteNumber(platformIdentities.lifetime) + githubLifetime,
+      roles,
+      daily: mergeDaily(platform?.daily, githubPeriod?.daily),
+    };
+  }
+
+  function acquisitionWindowHours(period, now = Date.now()) {
+    if (PERIOD_HOURS[period]) return PERIOD_HOURS[period];
+    const launch = Date.parse("2026-07-08T20:22:19Z");
+    return Math.max(1, Math.min(8760, Math.ceil((now - launch) / 3_600_000)));
+  }
+
+  function escapeXml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&apos;");
+  }
+
+  function chartSvg(points, valueKey, kind) {
+    const selected = Array.isArray(points) ? points : [];
+    if (selected.length < 2) return "";
+    const width = 680;
+    const height = 270;
+    const inset = { top: 16, right: 16, bottom: 34, left: 38 };
+    const innerWidth = width - inset.left - inset.right;
+    const innerHeight = height - inset.top - inset.bottom;
+    const values = selected.map((point) => Math.max(0, finiteNumber(point[valueKey])));
+    const maximum = Math.max(1, ...values);
+    const x = (index) => inset.left + (index / Math.max(1, selected.length - 1)) * innerWidth;
+    const y = (value) => inset.top + innerHeight - (value / maximum) * innerHeight;
+    const line = values.map((value, index) => `${index ? "L" : "M"}${x(index).toFixed(2)} ${y(value).toFixed(2)}`).join(" ");
+    const area = `${line} L${x(selected.length - 1).toFixed(2)} ${(inset.top + innerHeight).toFixed(2)} L${x(0).toFixed(2)} ${(inset.top + innerHeight).toFixed(2)} Z`;
+    const ticks = [0, 0.5, 1].map((ratio) => {
+      const tickY = inset.top + innerHeight * (1 - ratio);
+      const tickValue = maximum * ratio;
+      return `<line class="chart-grid-line" x1="${inset.left}" x2="${width - inset.right}" y1="${tickY}" y2="${tickY}"/><text class="chart-axis-label" x="0" y="${tickY + 4}">${escapeXml(kind === "payout" ? new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 }).format(tickValue) : Math.round(tickValue))}</text>`;
+    }).join("");
+    const markerIndexes = [...new Set([0, Math.floor((selected.length - 1) / 2), selected.length - 1])];
+    const labels = markerIndexes.map((index) => `<text class="chart-axis-label" text-anchor="${index === 0 ? "start" : index === selected.length - 1 ? "end" : "middle"}" x="${x(index)}" y="${height - 6}">${escapeXml(selected[index].day.slice(5))}</text>`).join("");
+    const dots = selected.map((point, index) => `<circle class="chart-dot ${kind === "payout" ? "payout" : ""}" cx="${x(index)}" cy="${y(values[index])}" r="3" tabindex="0"><title>${escapeXml(point.day)}: ${escapeXml(kind === "payout" ? formatUsdc(values[index]) : `${formatInteger(values[index])} active identities`)}</title></circle>`).join("");
+    const gradient = kind === "payout"
+      ? '<linearGradient id="payout-area" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#79a8ff" stop-opacity=".24"/><stop offset="1" stop-color="#79a8ff" stop-opacity="0"/></linearGradient>'
+      : '<linearGradient id="identity-area" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#b9ef37" stop-opacity=".22"/><stop offset="1" stop-color="#b9ef37" stop-opacity="0"/></linearGradient>';
+    return `<svg viewBox="0 0 ${width} ${height}" role="img" aria-label="${kind === "payout" ? "Daily confirmed payout in USDC" : "Daily external active identities"}"><defs>${gradient}</defs>${ticks}<path class="chart-area ${kind === "payout" ? "payout" : ""}" d="${area}"/><path class="chart-line ${kind === "payout" ? "payout" : ""}" d="${line}"/>${dots}${labels}</svg>`;
+  }
+
+  function start(win, doc) {
+    const state = {
+      period: "7d",
+      platform: null,
+      github: null,
+      acquisition: null,
+      errors: {},
+      timers: [],
+    };
+
+    const one = (selector) => doc.querySelector(selector);
+    const setText = (selector, value) => {
+      const node = one(selector);
+      if (node) node.textContent = value;
+    };
+    const requestJson = async (url) => {
+      const response = await win.fetch(url, { cache: "no-store", headers: { accept: "application/json" } });
+      if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+      return response.json();
+    };
+
+    function amount(response) {
+      return formatUsdc(response?.usdc);
+    }
+
+    function renderChart(selector, points, valueKey, kind) {
+      const stage = one(selector);
+      if (!stage) return;
+      const svg = chartSvg(points, valueKey, kind);
+      if (svg) {
+        stage.innerHTML = svg;
+      } else {
+        stage.replaceChildren();
+        const empty = doc.createElement("p");
+        empty.className = "chart-empty";
+        empty.textContent = points?.length === 1 ? "One reporting day is available; a trend needs at least two." : "No daily records are available for this period.";
+        stage.appendChild(empty);
+      }
+    }
+
+    function renderRoles(roles) {
+      const target = one("[data-role-breakdown]");
+      if (!target) return;
+      target.replaceChildren();
+      const maximum = Math.max(1, ...roles.map((role) => role.active_identities));
+      roles.forEach((role) => {
+        const row = doc.createElement("div");
+        row.className = "role-row";
+        const label = doc.createElement("span");
+        label.textContent = role.role;
+        const track = doc.createElement("span");
+        track.className = "role-track";
+        const fill = doc.createElement("i");
+        fill.style.setProperty("--role-width", `${(role.active_identities / maximum) * 100}%`);
+        track.appendChild(fill);
+        const value = doc.createElement("strong");
+        value.textContent = formatInteger(role.active_identities);
+        row.append(label, track, value);
+        target.appendChild(row);
+      });
+    }
+
+    function renderSourceLedger(merged, acquisitionStatus) {
+      const target = one("[data-source-ledger]");
+      if (!target) return;
+      target.replaceChildren();
+      const sources = [
+        ["Marketplace events", merged.platform_status, state.platform?.generated_at, "Confirmed canonical Base events with verified block time."],
+        ["GitHub participation", merged.github_status, state.github?.generated_at, "Hourly aggregate of external issues, pull requests, comments, and reviews."],
+        ["Browser acquisition", acquisitionStatus, state.acquisition?.generated_at, "First-party browser/device IDs; never counted as users or identities."],
+      ];
+      sources.forEach(([name, status, generatedAt, description]) => {
+        const item = doc.createElement("article");
+        item.className = "source-item";
+        const header = doc.createElement("header");
+        const title = doc.createElement("h3");
+        title.textContent = name;
+        const stateNode = doc.createElement("span");
+        stateNode.className = "source-state";
+        stateNode.dataset.status = status;
+        stateNode.textContent = status;
+        const body = doc.createElement("p");
+        const time = generatedAt ? new Date(generatedAt).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }) : "No source timestamp";
+        body.textContent = `${description} Last source update: ${time}.`;
+        header.append(title, stateNode);
+        item.append(header, body);
+        target.appendChild(item);
+      });
+    }
+
+    function render() {
+      const now = Date.now();
+      const merged = mergeMetrics(state.platform, state.github, state.period, now);
+      const platform = state.platform;
+      const payout = platform?.marketplace_payout_volume;
+      const cohort = platform?.mature_claim_to_settlement;
+      const inventory = platform?.current_inventory;
+      const acquisitionStatus = sourceStatus(
+        state.acquisition ? { generated_at: state.acquisition.generated_at, status: "ready" } : null,
+        now,
+        ACQUISITION_DELAY_MS,
+      );
+      const status = one("[data-overall-status]");
+      if (status) {
+        status.dataset.status = merged.status;
+        status.lastChild.textContent = merged.status === "ready" ? "Live data" : merged.status[0].toUpperCase() + merged.status.slice(1);
+      }
+      const timestamps = [platform?.generated_at, state.github?.generated_at]
+        .map((value) => Date.parse(value || ""))
+        .filter(Number.isFinite);
+      setText("[data-last-update]", timestamps.length ? new Date(Math.min(...timestamps)).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" }) : "not available");
+
+      const activeSuffix = merged.active_complete ? "" : "*";
+      setText("[data-active-identities]", platform ? `${formatInteger(merged.active_identities)}${activeSuffix}` : "—");
+      setText("[data-active-growth]", platform ? weeklyGrowth(merged.latest_week, merged.previous_week) : "—");
+      setText("[data-active-context]", merged.active_complete
+        ? "Distinct participating identities across separate GitHub, wallet, and comment-author namespaces."
+        : "Partial identity count: one or more required participation sources are unavailable.");
+      setText("[data-payout-volume]", payout ? amount(payout.selected) : "—");
+      setText("[data-settled-rounds]", payout ? formatInteger(payout.selected_settled_rounds) : "—");
+      setText("[data-settlement-rate]", cohort?.settlement_rate == null ? (cohort ? "Not yet available" : "—") : `${(cohort.settlement_rate * 100).toLocaleString("en-US", { maximumFractionDigits: 1 })}%`);
+      setText("[data-mature-cohort]", cohort ? formatInteger(cohort.mature_claimed_rounds) : "—");
+      setText("[data-immature-context]", cohort ? `${formatInteger(cohort.immature_claimed_rounds)} immature claimed round${cohort.immature_claimed_rounds === 1 ? "" : "s"} shown separately.` : "Recent claims stay outside the rate until they mature or reach a terminal event.");
+
+      renderChart("[data-identity-chart]", merged.daily, "active_identities", "identities");
+      renderChart("[data-payout-chart]", merged.daily, "payout_usdc", "payout");
+      setText("[data-identity-chart-subtitle]", merged.active_complete ? "Selected period" : "Partial source coverage");
+      renderRoles(merged.roles);
+      setText("[data-solver-pay]", payout ? amount(payout.selected_solver_pay) : "—");
+      setText("[data-verifier-pay]", payout ? amount(payout.selected_verifier_pay) : "—");
+      setText("[data-completion-bonus]", payout ? amount(payout.selected_completion_bonus) : "—");
+
+      const inventoryReady = inventory?.status === "ready";
+      setText("[data-inventory-ready]", inventoryReady ? formatInteger(inventory.ready_to_earn_opportunities) : "—");
+      setText("[data-inventory-autonomous]", inventoryReady ? formatInteger(inventory.autonomous_claimable_bounties) : "—");
+      setText("[data-inventory-competitions]", inventoryReady ? formatInteger(inventory.open_competitions_ready_to_earn) : "—");
+      setText("[data-inventory-verification]", inventoryReady ? formatInteger(inventory.verification_ready_bounties) : "—");
+      setText("[data-inventory-standing]", inventoryReady ? formatInteger(inventory.standing_meta_bounties) : "—");
+      setText("[data-inventory-funded]", inventoryReady ? amount(inventory.funded) : "—");
+      setText("[data-inventory-solvers]", inventoryReady ? amount(inventory.solver_rewards) : "—");
+      setText("[data-inventory-verifiers]", inventoryReady ? amount(inventory.verifier_rewards) : "—");
+      setText("[data-inventory-status]", inventoryReady ? `Both canonical inventory protocols checked at ${new Date(inventory.generated_at).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })}.` : "Inventory is partial or unavailable; historical values remain visible and combined inventory is not replaced with a lower total or zero.");
+
+      setText("[data-first-month-identities]", platform ? `${formatInteger(merged.first_month_identities)}${activeSuffix}` : "—");
+      setText("[data-lifetime-identities]", platform ? `${formatInteger(merged.lifetime_identities)}${activeSuffix}` : "—");
+      setText("[data-first-month-payout]", payout ? amount(payout.first_month) : "—");
+      setText("[data-lifetime-payout]", payout ? amount(payout.lifetime) : "—");
+      setText("[data-first-month-settled]", payout ? formatInteger(payout.first_month_settled_rounds) : "—");
+      setText("[data-lifetime-settled]", payout ? formatInteger(payout.lifetime_settled_rounds) : "—");
+
+      setText("[data-browser-identities]", state.acquisition ? formatInteger(state.acquisition.overview?.unique_visitors) : "—");
+      setText("[data-browser-context]", state.acquisition
+        ? `${formatInteger(state.acquisition.overview?.sessions)} browser sessions in the matching lookback. Device/browser IDs are not people.`
+        : "Acquisition source unavailable. Browser IDs are never estimated or counted as active identities.");
+      setText("[data-platform-revenue]", platform ? amount(platform.platform_revenue) : "0 USDC");
+      renderSourceLedger(merged, acquisitionStatus);
+
+      const notices = [];
+      if (merged.status === "partial") notices.push("Identity totals are partial because a required participation source is unavailable or incomplete.");
+      if (merged.status === "delayed") notices.push("One or more required sources are delayed; values remain visible with their source timestamps.");
+      if (merged.status === "unavailable") notices.push("Marketplace metrics are temporarily unavailable; no missing value has been replaced with zero.");
+      if (merged.status === "ready") notices.push(`Live aggregate for ${state.period === "lifetime" ? "lifetime since launch" : state.period}. Roles are not additive.`);
+      setText("[data-dashboard-notice]", notices.join(" "));
+    }
+
+    async function refreshPlatform() {
+      try {
+        state.platform = await requestJson(`${PLATFORM_URL}?period=${encodeURIComponent(state.period)}`);
+        delete state.errors.platform;
+      } catch (error) {
+        state.errors.platform = error;
+        state.platform = null;
+      }
+      render();
+    }
+
+    async function refreshSupporting() {
+      const hours = acquisitionWindowHours(state.period);
+      const [githubResult, acquisitionResult] = await Promise.allSettled([
+        requestJson(`${GITHUB_URL}?v=${Date.now()}`),
+        requestJson(`${ACQUISITION_URL}?window_hours=${hours}`),
+      ]);
+      if (githubResult.status === "fulfilled") {
+        state.github = githubResult.value;
+        delete state.errors.github;
+      } else {
+        state.github = null;
+        state.errors.github = githubResult.reason;
+      }
+      if (acquisitionResult.status === "fulfilled") {
+        state.acquisition = acquisitionResult.value;
+        delete state.errors.acquisition;
+      } else {
+        state.acquisition = null;
+        state.errors.acquisition = acquisitionResult.reason;
+      }
+      render();
+    }
+
+    doc.querySelectorAll("[data-period]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const next = button.dataset.period;
+        if (!PERIOD_HOURS[next] && next !== "lifetime") return;
+        state.period = next;
+        doc.querySelectorAll("[data-period]").forEach((candidate) => {
+          candidate.setAttribute("aria-pressed", String(candidate === button));
+        });
+        state.platform = null;
+        state.acquisition = null;
+        render();
+        void Promise.all([refreshPlatform(), refreshSupporting()]);
+      });
+    });
+
+    function schedule() {
+      state.timers.push(win.setInterval(() => {
+        if (!doc.hidden) void refreshPlatform();
+      }, 60_000));
+      state.timers.push(win.setInterval(() => {
+        if (!doc.hidden) void refreshSupporting();
+      }, 300_000));
+    }
+
+    doc.addEventListener("visibilitychange", () => {
+      if (!doc.hidden) void Promise.all([refreshPlatform(), refreshSupporting()]);
+    });
+    render();
+    void Promise.all([refreshPlatform(), refreshSupporting()]);
+    schedule();
+    return state;
+  }
+
+  return {
+    acquisitionWindowHours,
+    chartSvg,
+    combinedStatus,
+    mergeDaily,
+    mergeMetrics,
+    sourceStatus,
+    start,
+    weeklyGrowth,
+  };
+});

--- a/site/simple-home.js
+++ b/site/simple-home.js
@@ -7,6 +7,7 @@
   const PRIMARY_LINKS = [
     ["earn.html", "Bounty Board"],
     ["how-it-works.html", "How It Works"],
+    ["metrics.html", "Metrics"],
   ];
   const COMMUNITY_LINKS = [
     ["leaderboard.html", "Leaderboard"],
@@ -65,6 +66,7 @@
     if (!footerNav) return;
     const desired = [
       ["how-it-works.html", "How it works"],
+      ["metrics.html", "Metrics"],
       ["leaderboard.html", "Leaderboard"],
       ["news.html", "News"],
       ["llms.txt", "Docs"],

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -4,6 +4,7 @@
   <url><loc>https://agentbounties.app/agent/</loc></url>
   <url><loc>https://agentbounties.app/objective.html</loc></url>
   <url><loc>https://agentbounties.app/earn.html</loc></url>
+  <url><loc>https://agentbounties.app/metrics.html</loc></url>
   <url><loc>https://agentbounties.app/competition.html</loc></url>
   <url><loc>https://agentbounties.app/post.html</loc></url>
   <url><loc>https://agentbounties.app/funding.html</loc></url>


### PR DESCRIPTION
## Outcome

Adds a public, investor-facing live metrics surface with precise definitions and honest source coverage:

- `GET /v1/metrics/platform?period=7d|28d|90d|lifetime`
- `/metrics.html`, linked from the homepage and sitemap
- hourly aggregate-only `/generated/github-participation.json`
- Autonomous and Open Competition participation, payout, and ready-to-earn inventory
- fixed launch/first-month boundaries, rolling weekly growth, and an exclusive-claim mature cohort

## Data integrity and privacy

- Counts provider-namespaced participating identities, not people.
- Excludes GitHub bots, the repository owner, checked-in maintainers, system labels, and configured maintainer wallets without inferring cross-namespace ownership.
- Counts only block-time-verified canonical payment events.
- Includes settled solver reward, verifier pay, and timeout bonus; rejected-submission verifier pay is included. Returned bonds, refunds, funding intentions, and prizes are excluded from payout volume.
- Open Competition participates in identity, payout, and inventory metrics but not the exclusive-claim conversion cohort.
- Marks the source partial when an indexer is stale, failed, cursor-lagging, or has unverified block times. Combined inventory is withheld unless both live protocols are available.
- Returns no handles, wallet addresses, comment authors, event IDs, transaction IDs, or private operational analytics.

## Workflow security

PR validation receives a read-only token. Pages, issue-write, and identity-token permissions exist only on the trusted non-PR deploy job. The hourly job runs at minute 17, uses only `GITHUB_TOKEN`, and publishes aggregates.

## Verification

Passed locally:

- `scripts/preflight.ps1 -Mode core`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo build -p api -p mcp-server`
- `cargo test -p api platform_ -- --nocapture`
- OpenAPI contract test
- `python scripts/test_github_audience_audit.py -v`
- live aggregate generation and raw-identifier scan
- `node --test scripts/test-metrics-dashboard.js`
- `python scripts/check-site.py`
- desktop/mobile Playwright QA at 390px and desktop widths, zero console errors, no horizontal overflow

Environment-bound checks intentionally remain for CI:

- PostgreSQL round trip: local Docker daemon is unavailable; wired into `postgres-sync`.
- Full preflight: local Foundry `forge` is unavailable; core preflight passes.

## Review and merge dependencies

- PR #921 remains the production revision-integrity prerequisite and should be reviewed/merged first.
- PRs #918, #885, and #889 overlap the inventory/API area; recheck and rebase this exact head after any of them reaches `main`.
- PR #908 overlaps homepage links; retain both changes if it merges first.
- PR #910 is based on a non-main feature branch and is not copied here.
- Related maintainer notice: #924.

Next owner: non-author reviewer. Recheck: `cargo test --workspace && python scripts/check-site.py && node --test scripts/test-metrics-dashboard.js` plus required `full-check`, `postgres-sync`, `sdlc-recovery`, Pages, and container checks.