### PR TITLE
[codex] Add live repository acquisition metrics

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -110,6 +110,10 @@ jobs:
           assert value["schema_version"] == "agent-bounties/github-participation-v1"
           assert value["coverage"]["raw_identifiers_included"] is False
           assert set(value["periods"]) == {"7d", "28d", "90d", "lifetime"}
+          acquisition = value["repository_acquisition"]
+          assert acquisition["window_kind"] == "rolling_14_days"
+          assert acquisition["coverage"]["status"] == "unavailable"
+          assert len(acquisition["historical_snapshots"]) == 2
           PY
       - name: Check simplified public scripts
         run: |
@@ -264,7 +268,7 @@ jobs:
           cp schemas/discovery-manifest.v2.json site/schemas/discovery-manifest.v2.json
       - name: Generate privacy-safe GitHub participation metrics
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPOSITORY_TRAFFIC_TOKEN || github.token }}
         run: |
           python scripts/github_audience_audit.py \
             --repository "${GITHUB_REPOSITORY}" \

--- a/docs/platform-metrics.md
+++ b/docs/platform-metrics.md
@@ -10,6 +10,7 @@ and raw identities are outside this surface.
 - Production launch: `2026-07-08T20:22:19Z`.
 - First month: `[2026-07-08T20:22:19Z, 2026-08-08T20:22:19Z)`.
 - Periods: rolling 7, 28, or 90 days, plus lifetime since launch.
+- The dashboard opens on lifetime and orders controls from longest to most recent.
 - All boundaries and daily series use UTC.
 
 ## Headline metrics
@@ -79,9 +80,27 @@ transaction IDs.
 
 `/generated/github-participation.json`
 
-GitHub Pages regenerates this aggregate-only file hourly at minute 17 with the
-workflow `GITHUB_TOKEN`. It never needs an operator API secret. The dashboard
-adds this distinct `github` namespace to the platform aggregates once.
+GitHub Pages regenerates this aggregate-only file hourly at minute 17. Public
+participation uses the workflow `GITHUB_TOKEN`; the administration-read traffic
+endpoint uses the encrypted `REPOSITORY_TRAFFIC_TOKEN` only inside this
+read-only aggregate generator when configured and otherwise fails closed. It
+never needs an operator API secret.
+The dashboard adds the distinct `github` participation namespace to platform
+aggregates once.
+
+The same aggregate-only file includes GitHub repository acquisition for the
+rolling 14-day window exposed by the GitHub Traffic API:
+
+- clone events and unique cloners;
+- page views and unique visitors.
+
+Unique cloners and unique visitors are presented as GitHub-measured repository
+users. They remain separate because GitHub does not expose their identities or
+overlap, and they are not added to external active identities because they
+cannot be deduplicated against GitHub participants, wallets, or comment authors.
+The dashboard also shows dated 9 July and 11 July public snapshots for context.
+Those overlapping rolling snapshots are never summed or described as lifetime
+traffic.
 
 `GET /v1/analytics/site?window_hours=<hours>`
 
@@ -96,6 +115,8 @@ and is never added to active identities.
   an error, or lagging its observed chain head by more than 20 blocks makes the
   platform source partial and withholds combined point-in-time inventory.
 - GitHub aggregate data older than two hours is delayed.
+- Missing GitHub repository traffic is shown as unavailable; dated historical
+  snapshots are not substituted for live traffic.
 - Missing required identity sources make identity totals partial.
 - Missing inventory stays unavailable instead of becoming zero.
 - Missing historical browser analytics is disclosed and never estimated.

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -316,10 +316,14 @@ def main() -> int:
             "Mature claim-to-settlement",
             "Role counts are not additive",
             "Browser/device IDs",
+            "Thousands of repository actions",
+            "Unique cloners",
+            "Unique visitors",
+            "Unique repository users measured by GitHub",
             "Monetization not active",
             "Only a confirmed canonical <code>BountySettled</code> event proves solver payment",
-            'data-period="7d" aria-pressed="true"',
-            'data-period="lifetime"',
+            'data-period="lifetime" aria-pressed="true"',
+            'data-period="7d" aria-pressed="false"',
         ],
     )
     require_phrases(

--- a/scripts/github_audience_audit.py
+++ b/scripts/github_audience_audit.py
@@ -42,6 +42,22 @@ MENTION_RE = re.compile(r"(?<![A-Za-z0-9-])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))"
 PLATFORM_LAUNCH_AT = "2026-07-08T20:22:19Z"
 PLATFORM_FIRST_MONTH_ENDED_AT = "2026-08-08T20:22:19Z"
 PUBLIC_METRICS_PERIOD_DAYS = {"7d": 7, "28d": 28, "90d": 90}
+PUBLIC_REPOSITORY_TRAFFIC_SNAPSHOTS = (
+    {
+        "observed_at": "2026-07-09T23:09:23Z",
+        "clone_events": 1260,
+        "unique_cloners": 222,
+        "page_views": 98,
+        "unique_visitors": 28,
+    },
+    {
+        "observed_at": "2026-07-11T06:58:04Z",
+        "clone_events": 2448,
+        "unique_cloners": 310,
+        "page_views": 280,
+        "unique_visitors": 58,
+    },
+)
 
 
 def utc_now() -> str:
@@ -77,11 +93,37 @@ def gh_api(repository: str, suffix: str, *, accept: str | None = None) -> list[d
     return flatten_pages(json.loads(completed.stdout))
 
 
+def gh_api_json(repository: str, suffix: str) -> Any:
+    completed = subprocess.run(
+        ["gh", "api", f"repos/{repository}/{suffix.lstrip('/')}"],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="strict",
+    )
+    return json.loads(completed.stdout)
+
+
+def collect_repository_traffic(repository: str) -> dict[str, Any]:
+    """Collect GitHub's aggregate rolling traffic without paths or identities."""
+
+    try:
+        clones = gh_api_json(repository, "traffic/clones?per=day")
+        views = gh_api_json(repository, "traffic/views?per=day")
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return {"status": "unavailable"}
+    if not isinstance(clones, dict) or not isinstance(views, dict):
+        return {"status": "unavailable"}
+    return {"status": "ready", "clones": clones, "views": views}
+
+
 def collect_snapshot(
     repository: str,
     *,
     include_enrichment: bool = True,
     activity_since: str | None = None,
+    include_repository_traffic: bool = False,
 ) -> dict[str, Any]:
     issues = gh_api(repository, "issues?state=all&per_page=100")
     pulls = gh_api(repository, "pulls?state=all&per_page=100")
@@ -147,6 +189,11 @@ def collect_snapshot(
         "reviews": reviews,
         "reactions": reactions,
         "stargazers": stargazers,
+        "repository_traffic": (
+            collect_repository_traffic(repository)
+            if include_repository_traffic
+            else {"status": "unavailable"}
+        ),
     }
 
 
@@ -489,6 +536,87 @@ def public_metrics_policy(path: Path | None) -> dict[str, Any]:
     return value
 
 
+def build_public_repository_acquisition(
+    snapshot: dict[str, Any], generated_at: datetime
+) -> dict[str, Any]:
+    traffic = snapshot.get("repository_traffic")
+    base: dict[str, Any] = {
+        "source": "github_repository_traffic",
+        "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
+        "window_kind": "rolling_14_days",
+        "window_days": 14,
+        "historical_snapshots": [
+            dict(value) for value in PUBLIC_REPOSITORY_TRAFFIC_SNAPSHOTS
+        ],
+        "coverage": {"status": "unavailable"},
+        "definitions": {
+            "clone_events": "Repository clone operations in GitHub's rolling 14-day traffic window.",
+            "unique_cloners": "Unique repository users measured by GitHub as cloners in the rolling window.",
+            "page_views": "Repository page views in GitHub's rolling 14-day traffic window.",
+            "unique_visitors": "Unique repository users measured by GitHub as visitors in the rolling window.",
+            "overlap": "GitHub does not expose overlap between unique cloners and unique visitors, so they are not summed or added to active platform identities.",
+        },
+    }
+    if not isinstance(traffic, dict) or traffic.get("status") != "ready":
+        return base
+    clones = traffic.get("clones")
+    views = traffic.get("views")
+    if not isinstance(clones, dict) or not isinstance(views, dict):
+        return base
+
+    def count(value: Any) -> int | None:
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+        return None
+
+    clone_events = count(clones.get("count"))
+    unique_cloners = count(clones.get("uniques"))
+    page_views = count(views.get("count"))
+    unique_visitors = count(views.get("uniques"))
+    if None in (clone_events, unique_cloners, page_views, unique_visitors):
+        return base
+    if unique_cloners > clone_events or unique_visitors > page_views:
+        return base
+
+    timestamps = []
+    for series_name, payload in (("clones", clones), ("views", views)):
+        series = payload.get(series_name)
+        if not isinstance(series, list):
+            return base
+        for point in series:
+            if not isinstance(point, dict):
+                return base
+            timestamp = parse_utc_timestamp(point.get("timestamp"))
+            if (
+                timestamp is None
+                or count(point.get("count")) is None
+                or count(point.get("uniques")) is None
+            ):
+                return base
+            timestamps.append(timestamp)
+    if not timestamps:
+        return base
+
+    base.update(
+        {
+            "started_at": min(timestamps).isoformat().replace("+00:00", "Z"),
+            "ended_at": (max(timestamps) + timedelta(days=1))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "clone_events": clone_events,
+            "unique_cloners": unique_cloners,
+            "page_views": page_views,
+            "unique_visitors": unique_visitors,
+            "coverage": {
+                "status": "ready",
+                "raw_identifiers_included": False,
+                "unique_audiences_are_additive": False,
+            },
+        }
+    )
+    return base
+
+
 def build_public_participation_metrics(
     snapshot: dict[str, Any],
     owner_login: str,
@@ -657,6 +785,7 @@ def build_public_participation_metrics(
     first_month = aggregate(launch_at, first_month_ended_at)
     latest_week = periods["7d"]["active_identities"]
     previous_week = periods["7d"]["previous_active_identities"]
+    repository_acquisition = build_public_repository_acquisition(snapshot, generated_at)
 
     return {
         "schema_version": "agent-bounties/github-participation-v1",
@@ -672,6 +801,7 @@ def build_public_participation_metrics(
             "previous_active_identities": previous_week,
         },
         "first_month": first_month,
+        "repository_acquisition": repository_acquisition,
         "coverage": {
             "status": "partial" if missing_timestamp_records else "ready",
             "qualifying_records": len(activity),
@@ -783,6 +913,7 @@ def main() -> int:
             args.repository,
             include_enrichment=not args.public_metrics_only,
             activity_since=PLATFORM_LAUNCH_AT if args.public_metrics_only else None,
+            include_repository_traffic=args.public_metrics_only,
         )
     snapshot.setdefault("repository", args.repository)
     if args.snapshot_output:

--- a/scripts/test-metrics-dashboard.js
+++ b/scripts/test-metrics-dashboard.js
@@ -51,6 +51,14 @@ function github(overrides = {}) {
     weekly: { latest_active_identities: 4, previous_active_identities: 1 },
     first_month: { active_identities: 7 },
     coverage: { status: "ready" },
+    repository_acquisition: {
+      generated_at: "2026-08-12T20:00:00Z",
+      clone_events: 9654,
+      unique_cloners: 446,
+      page_views: 883,
+      unique_visitors: 218,
+      coverage: { status: "ready", unique_audiences_are_additive: false },
+    },
     ...overrides,
   };
 }
@@ -131,4 +139,13 @@ test("lifetime acquisition lookback is bounded to the public API contract", () =
   assert.equal(metrics.acquisitionWindowHours("7d", NOW), 168);
   assert.ok(metrics.acquisitionWindowHours("lifetime", NOW) >= 1);
   assert.ok(metrics.acquisitionWindowHours("lifetime", Date.parse("2028-08-12T00:00:00Z")) <= 8760);
+});
+
+test("repository traffic has an independent honest status and comparable baseline", () => {
+  assert.equal(metrics.dashboardStatus("ready", "ready"), "ready");
+  assert.equal(metrics.dashboardStatus("ready", "unavailable"), "partial");
+  assert.equal(metrics.dashboardStatus("ready", "delayed"), "delayed");
+  assert.equal(metrics.dashboardStatus("unavailable", "ready"), "unavailable");
+  assert.equal(metrics.ratioMultiple(9654, 2448).toFixed(1), "3.9");
+  assert.equal(metrics.ratioMultiple(9654, 0), null);
 });

--- a/scripts/test_github_audience_audit.py
+++ b/scripts/test_github_audience_audit.py
@@ -131,6 +131,74 @@ class GitHubAudienceAuditTests(unittest.TestCase):
         self.assertEqual(snapshot["reactions"], [])
         self.assertEqual(snapshot["stargazers"], [])
 
+    def test_repository_traffic_is_aggregate_only_and_preserves_window_scope(self) -> None:
+        snapshot = {
+            "fetched_at": "2026-08-12T20:22:19Z",
+            "repository_traffic": {
+                "status": "ready",
+                "clones": {
+                    "count": 9654,
+                    "uniques": 446,
+                    "clones": [
+                        {"timestamp": "2026-07-30T00:00:00Z", "count": 4000, "uniques": 250},
+                        {"timestamp": "2026-08-12T00:00:00Z", "count": 5654, "uniques": 300},
+                    ],
+                },
+                "views": {
+                    "count": 883,
+                    "uniques": 218,
+                    "views": [
+                        {"timestamp": "2026-07-30T00:00:00Z", "count": 300, "uniques": 100},
+                        {"timestamp": "2026-08-12T00:00:00Z", "count": 583, "uniques": 140},
+                    ],
+                },
+            },
+        }
+
+        acquisition = MODULE.build_public_repository_acquisition(
+            snapshot, MODULE.parse_utc_timestamp(snapshot["fetched_at"])
+        )
+        serialized = json.dumps(acquisition).lower()
+
+        self.assertEqual(acquisition["coverage"]["status"], "ready")
+        self.assertEqual(acquisition["clone_events"], 9654)
+        self.assertEqual(acquisition["unique_cloners"], 446)
+        self.assertEqual(acquisition["page_views"], 883)
+        self.assertEqual(acquisition["unique_visitors"], 218)
+        self.assertEqual(acquisition["started_at"], "2026-07-30T00:00:00Z")
+        self.assertEqual(acquisition["ended_at"], "2026-08-13T00:00:00Z")
+        self.assertFalse(acquisition["coverage"]["unique_audiences_are_additive"])
+        self.assertNotIn("login", serialized)
+        self.assertNotIn("github.com/", serialized)
+
+    def test_repository_traffic_fails_closed_when_counts_are_invalid(self) -> None:
+        generated_at = MODULE.parse_utc_timestamp("2026-08-12T20:22:19Z")
+        acquisition = MODULE.build_public_repository_acquisition(
+            {
+                "repository_traffic": {
+                    "status": "ready",
+                    "clones": {"count": 2, "uniques": 3, "clones": []},
+                    "views": {"count": 1, "uniques": 1, "views": []},
+                }
+            },
+            generated_at,
+        )
+        self.assertEqual(acquisition["coverage"]["status"], "unavailable")
+        self.assertNotIn("clone_events", acquisition)
+
+    def test_repository_traffic_collection_uses_only_aggregate_endpoints(self) -> None:
+        payloads = {
+            "traffic/clones?per=day": {"count": 9, "uniques": 4, "clones": []},
+            "traffic/views?per=day": {"count": 8, "uniques": 3, "views": []},
+        }
+        with patch.object(
+            MODULE, "gh_api_json", side_effect=lambda _repo, suffix: payloads[suffix]
+        ) as api:
+            traffic = MODULE.collect_repository_traffic("NSPG13/agent-bounties")
+
+        self.assertEqual(traffic["status"], "ready")
+        self.assertEqual(api.call_count, 2)
+
     def test_public_activity_is_deduplicated_and_bots_are_excluded(self) -> None:
         handles = [participant["handle"] for participant in self.audit["participants"]]
         self.assertEqual(handles, ["alice-agent", "bob-human"])

--- a/site/generated/github-participation.json
+++ b/site/generated/github-participation.json
@@ -14,6 +14,24 @@
   },
   "weekly": {"latest_active_identities": 0, "previous_active_identities": 0},
   "first_month": {"started_at": "2026-07-08T20:22:19Z", "ended_at": "2026-08-08T20:22:19Z", "active_identities": 0, "qualifying_actions": 0, "roles": [], "roles_are_additive": false, "daily": []},
+  "repository_acquisition": {
+    "source": "github_repository_traffic",
+    "generated_at": "2026-07-08T20:22:19Z",
+    "window_kind": "rolling_14_days",
+    "window_days": 14,
+    "historical_snapshots": [
+      {"observed_at": "2026-07-09T23:09:23Z", "clone_events": 1260, "unique_cloners": 222, "page_views": 98, "unique_visitors": 28},
+      {"observed_at": "2026-07-11T06:58:04Z", "clone_events": 2448, "unique_cloners": 310, "page_views": 280, "unique_visitors": 58}
+    ],
+    "coverage": {"status": "unavailable"},
+    "definitions": {
+      "clone_events": "Repository clone operations in GitHub's rolling 14-day traffic window.",
+      "unique_cloners": "Unique repository users measured by GitHub as cloners in the rolling window.",
+      "page_views": "Repository page views in GitHub's rolling 14-day traffic window.",
+      "unique_visitors": "Unique repository users measured by GitHub as visitors in the rolling window.",
+      "overlap": "GitHub does not expose overlap between unique cloners and unique visitors, so they are not summed or added to active platform identities."
+    }
+  },
   "coverage": {"status": "unavailable", "qualifying_records": 0, "excluded_records": 0, "missing_timestamp_records": 0, "maintainer_exclusion_policy": "agent-bounties/public-metrics-policy-v1", "raw_identifiers_included": false},
   "definitions": {
     "active_identity": "One external GitHub login with a qualifying action. It is a participating identity, not a verified unique person.",

--- a/site/metrics.css
+++ b/site/metrics.css
@@ -262,12 +262,96 @@ body.metrics-page {
 }
 
 .trend-section,
+.repository-section,
 .composition-section,
 .inventory-section,
 .comparison-section,
 .supporting-section,
 .evidence-section {
   padding: clamp(70px, 9vw, 132px) 0 0;
+}
+
+.repository-status-line {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 18px 0;
+  color: var(--metrics-muted);
+  font-size: 12px;
+}
+
+.repository-metrics {
+  display: grid;
+  grid-template-columns: 1.2fr repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--metrics-line);
+}
+
+.repository-metric {
+  min-width: 0;
+  padding: clamp(24px, 3vw, 42px);
+  background: #030c08;
+}
+
+.repository-metric > span {
+  color: var(--metrics-muted);
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.repository-metric output {
+  display: block;
+  margin: 28px 0 18px;
+  color: var(--metrics-paper);
+  font: 500 clamp(42px, 5vw, 72px) / 0.9 Georgia, "Times New Roman", serif;
+  letter-spacing: -0.06em;
+}
+
+.repository-metric-primary output {
+  color: var(--metrics-accent);
+}
+
+.repository-metric p,
+.repository-comparison {
+  margin: 0;
+  color: var(--metrics-muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.repository-history {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 1px;
+  background: var(--metrics-line);
+}
+
+.repository-history p {
+  margin: 0;
+  padding: 22px clamp(24px, 3vw, 42px);
+  background: rgba(3, 12, 8, 0.72);
+  color: #cbd3cb;
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.repository-history strong {
+  color: var(--metrics-paper);
+}
+
+.repository-history span {
+  display: block;
+  color: #7f8d84;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.repository-comparison {
+  margin-top: 18px;
 }
 
 .section-heading {
@@ -533,7 +617,7 @@ body.metrics-page {
 
 .source-ledger {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1px;
   margin-top: 32px;
   background: var(--metrics-line);
@@ -652,6 +736,7 @@ body.metrics-page {
 
 @media (max-width: 980px) {
   .headline-metrics,
+  .repository-metrics,
   .inventory-ledger,
   .source-ledger {
     grid-template-columns: 1fr;
@@ -668,6 +753,10 @@ body.metrics-page {
   }
 
   .trend-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .repository-history {
     grid-template-columns: 1fr;
   }
 }

--- a/site/metrics.html
+++ b/site/metrics.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://agentbounties.app/metrics.html">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="guild-pages.css?v=20260721">
-    <link rel="stylesheet" href="metrics.css?v=1">
+    <link rel="stylesheet" href="metrics.css?v=2">
   </head>
   <body class="metrics-page guild-interior">
     <a class="skip-link" href="#main-content">Skip to metrics</a>
@@ -39,10 +39,10 @@
 
       <div class="period-control" role="group" aria-label="Reporting period">
         <span>Reporting period</span>
-        <button type="button" data-period="7d" aria-pressed="true">7 days</button>
-        <button type="button" data-period="28d" aria-pressed="false">28 days</button>
+        <button type="button" data-period="lifetime" aria-pressed="true">Lifetime</button>
         <button type="button" data-period="90d" aria-pressed="false">90 days</button>
-        <button type="button" data-period="lifetime" aria-pressed="false">Lifetime</button>
+        <button type="button" data-period="28d" aria-pressed="false">28 days</button>
+        <button type="button" data-period="7d" aria-pressed="false">7 days</button>
       </div>
 
       <p class="metrics-notice" data-dashboard-notice aria-live="polite">Loading source-backed metrics…</p>
@@ -66,6 +66,44 @@
           <p class="metric-change"><strong data-mature-cohort>—</strong> mature claimed rounds</p>
           <p data-immature-context>Recent claims stay outside the rate until they mature or reach a terminal event.</p>
         </article>
+      </section>
+
+      <section class="repository-section" aria-labelledby="repository-title">
+        <div class="section-heading">
+          <div><p class="metrics-kicker">Repository acquisition · rolling 14 days</p><h2 id="repository-title">Thousands of repository actions</h2></div>
+          <p>GitHub measures unique repository users separately as cloners and visitors. Their overlap is unknown, so these groups are not added together or to active platform identities.</p>
+        </div>
+        <div class="repository-status-line">
+          <span class="source-state" data-repository-status data-status="loading">loading</span>
+          <span data-repository-window>Loading GitHub's aggregate traffic window.</span>
+        </div>
+        <div class="repository-metrics" aria-label="GitHub repository acquisition">
+          <article class="repository-metric repository-metric-primary">
+            <span>Clone events</span>
+            <output data-clone-events>—</output>
+            <p>Repository clone operations. Repeat cloning can create multiple events.</p>
+          </article>
+          <article class="repository-metric">
+            <span>Unique cloners</span>
+            <output data-unique-cloners>—</output>
+            <p>Unique repository users measured by GitHub as cloners.</p>
+          </article>
+          <article class="repository-metric">
+            <span>Page views</span>
+            <output data-page-views>—</output>
+            <p>Views of repository pages during the same rolling window.</p>
+          </article>
+          <article class="repository-metric">
+            <span>Unique visitors</span>
+            <output data-unique-visitors>—</output>
+            <p>Unique repository users measured by GitHub as visitors.</p>
+          </article>
+        </div>
+        <div class="repository-history" aria-label="Early repository acquisition snapshots">
+          <p><strong>1,260</strong> clone events · <strong>222</strong> unique cloners · <strong>98</strong> views · <strong>28</strong> unique visitors <span>9 July public snapshot</span></p>
+          <p><strong>2,448</strong> clone events · <strong>310</strong> unique cloners · <strong>280</strong> views · <strong>58</strong> unique visitors <span>11 July public snapshot</span></p>
+        </div>
+        <p class="repository-comparison" data-repository-comparison>Historical snapshots are overlapping rolling windows and are not summed.</p>
       </section>
 
       <section class="trend-section" aria-labelledby="trend-title">
@@ -160,7 +198,8 @@
           <details open><summary>What is an external active identity?</summary><p>One namespaced GitHub login, Base wallet, or normalized self-reported comment author with a qualifying action in the period. Namespaces are not merged, so this is participation—not verified unique people.</p></details>
           <details><summary>What counts as payout volume?</summary><p>Solver reward, verifier reward, and timeout completion bonus from confirmed, block-time-verified <code>BountySettled</code> events across both live protocols, plus verifier pay from confirmed rejected-submission events.</p></details>
           <details><summary>What is a mature claimed round?</summary><p>An exclusive-claim <code>(network, bounty_id, round)</code> whose deadline has passed or that already has a terminal canonical event. Immature claims are shown separately. Open Competition has no exclusive claim and stays outside this cohort.</p></details>
-          <details><summary>What is deliberately excluded?</summary><p>Bots, maintainers in the public policy, browser visitors, stars, returned claim bonds, refunds, funding intentions, unconfirmed transactions, leaderboard prizes, and private operational analytics.</p></details>
+          <details><summary>How are repository users counted?</summary><p>GitHub reports unique cloners and unique visitors for a rolling 14-day window. Both unique counts are shown as repository users, but GitHub does not expose their identities or overlap. They therefore remain separate and are not added to external active identities.</p></details>
+          <details><summary>What is deliberately excluded?</summary><p>Bots, maintainers in the public policy, browser visitors, stars, repository traffic from active platform identity totals, returned claim bonds, refunds, funding intentions, unconfirmed transactions, leaderboard prizes, and private operational analytics.</p></details>
         </div>
         <p class="payment-boundary">Only a confirmed canonical <code>BountySettled</code> event proves solver payment.</p>
       </section>
@@ -169,6 +208,6 @@
     <footer class="guild-shell-footer"><span>Public aggregate evidence. No handles or wallet addresses are exposed.</span><a href="privacy.html">Privacy</a><a href="https://api.agentbounties.app/api-docs/openapi.json">API</a></footer>
     <script src="analytics-config.js"></script>
     <script src="analytics.js"></script>
-    <script src="metrics.js?v=1"></script>
+    <script src="metrics.js?v=2"></script>
   </body>
 </html>

--- a/site/metrics.js
+++ b/site/metrics.js
@@ -65,6 +65,19 @@
     return "ready";
   }
 
+  function dashboardStatus(coreStatus, repositoryStatus) {
+    if (coreStatus === "unavailable") return "unavailable";
+    if (coreStatus === "partial" || repositoryStatus === "partial" || repositoryStatus === "unavailable") return "partial";
+    if (coreStatus === "delayed" || repositoryStatus === "delayed") return "delayed";
+    return "ready";
+  }
+
+  function ratioMultiple(current, baseline) {
+    const denominator = Math.max(0, finiteNumber(baseline));
+    if (!denominator) return null;
+    return Math.max(0, finiteNumber(current)) / denominator;
+  }
+
   function roleMap(roles) {
     return new Map(
       (Array.isArray(roles) ? roles : []).map((item) => [
@@ -197,7 +210,7 @@
 
   function start(win, doc) {
     const state = {
-      period: "7d",
+      period: "lifetime",
       platform: null,
       github: null,
       acquisition: null,
@@ -257,13 +270,14 @@
       });
     }
 
-    function renderSourceLedger(merged, acquisitionStatus) {
+    function renderSourceLedger(merged, acquisitionStatus, repositoryStatus) {
       const target = one("[data-source-ledger]");
       if (!target) return;
       target.replaceChildren();
       const sources = [
         ["Marketplace events", merged.platform_status, state.platform?.generated_at, "Confirmed canonical Base events with verified block time."],
         ["GitHub participation", merged.github_status, state.github?.generated_at, "Hourly aggregate of external issues, pull requests, comments, and reviews."],
+        ["Repository acquisition", repositoryStatus, state.github?.repository_acquisition?.generated_at, "GitHub clone and page-view aggregates for its rolling 14-day traffic window."],
         ["Browser acquisition", acquisitionStatus, state.acquisition?.generated_at, "First-party browser/device IDs; never counted as users or identities."],
       ];
       sources.forEach(([name, status, generatedAt, description]) => {
@@ -297,10 +311,19 @@
         now,
         ACQUISITION_DELAY_MS,
       );
+      const repositoryAcquisition = state.github?.repository_acquisition;
+      const repositoryStatus = sourceStatus(
+        repositoryAcquisition
+          ? { generated_at: repositoryAcquisition.generated_at, status: repositoryAcquisition.coverage?.status }
+          : null,
+        now,
+        GITHUB_DELAY_MS,
+      );
+      const overallStatus = dashboardStatus(merged.status, repositoryStatus);
       const status = one("[data-overall-status]");
       if (status) {
-        status.dataset.status = merged.status;
-        status.lastChild.textContent = merged.status === "ready" ? "Live data" : merged.status[0].toUpperCase() + merged.status.slice(1);
+        status.dataset.status = overallStatus;
+        status.lastChild.textContent = overallStatus === "ready" ? "Live data" : overallStatus[0].toUpperCase() + overallStatus.slice(1);
       }
       const timestamps = [platform?.generated_at, state.github?.generated_at]
         .map((value) => Date.parse(value || ""))
@@ -345,18 +368,43 @@
       setText("[data-first-month-settled]", payout ? formatInteger(payout.first_month_settled_rounds) : "—");
       setText("[data-lifetime-settled]", payout ? formatInteger(payout.lifetime_settled_rounds) : "—");
 
+      const repositoryReady = repositoryStatus === "ready" || repositoryStatus === "delayed";
+      const repositoryStatusNode = one("[data-repository-status]");
+      if (repositoryStatusNode) {
+        repositoryStatusNode.dataset.status = repositoryStatus;
+        repositoryStatusNode.textContent = repositoryStatus;
+      }
+      setText("[data-clone-events]", repositoryReady ? formatInteger(repositoryAcquisition.clone_events) : "—");
+      setText("[data-unique-cloners]", repositoryReady ? formatInteger(repositoryAcquisition.unique_cloners) : "—");
+      setText("[data-page-views]", repositoryReady ? formatInteger(repositoryAcquisition.page_views) : "—");
+      setText("[data-unique-visitors]", repositoryReady ? formatInteger(repositoryAcquisition.unique_visitors) : "—");
+      if (repositoryReady) {
+        const started = new Date(repositoryAcquisition.started_at);
+        const ended = new Date(Date.parse(repositoryAcquisition.ended_at) - 1);
+        const dateOptions = { day: "numeric", month: "short", year: "numeric", timeZone: "UTC" };
+        setText("[data-repository-window]", `${started.toLocaleDateString("en-US", dateOptions)} – ${ended.toLocaleDateString("en-US", dateOptions)} · GitHub rolling 14-day window`);
+        const multiple = ratioMultiple(repositoryAcquisition.clone_events, 2448);
+        setText("[data-repository-comparison]", multiple == null
+          ? "Historical snapshots are overlapping rolling windows and are not summed."
+          : `Current clone activity is ${multiple.toLocaleString("en-US", { maximumFractionDigits: 1 })}× the 11 July public snapshot. Historical snapshots are overlapping rolling windows and are not summed.`);
+      } else {
+        setText("[data-repository-window]", "GitHub repository traffic is unavailable; no lower value is substituted.");
+        setText("[data-repository-comparison]", "The dated July snapshots remain visible, but they are not substituted for missing live traffic.");
+      }
+
       setText("[data-browser-identities]", state.acquisition ? formatInteger(state.acquisition.overview?.unique_visitors) : "—");
       setText("[data-browser-context]", state.acquisition
         ? `${formatInteger(state.acquisition.overview?.sessions)} browser sessions in the matching lookback. Device/browser IDs are not people.`
         : "Acquisition source unavailable. Browser IDs are never estimated or counted as active identities.");
       setText("[data-platform-revenue]", platform ? amount(platform.platform_revenue) : "0 USDC");
-      renderSourceLedger(merged, acquisitionStatus);
+      renderSourceLedger(merged, acquisitionStatus, repositoryStatus);
 
       const notices = [];
       if (merged.status === "partial") notices.push("Identity totals are partial because a required participation source is unavailable or incomplete.");
       if (merged.status === "delayed") notices.push("One or more required sources are delayed; values remain visible with their source timestamps.");
       if (merged.status === "unavailable") notices.push("Marketplace metrics are temporarily unavailable; no missing value has been replaced with zero.");
-      if (merged.status === "ready") notices.push(`Live aggregate for ${state.period === "lifetime" ? "lifetime since launch" : state.period}. Roles are not additive.`);
+      if (["partial", "unavailable"].includes(repositoryStatus)) notices.push("Repository acquisition is unavailable or incomplete; historical snapshots remain labeled and are not substituted as live data.");
+      if (overallStatus === "ready") notices.push(`Live aggregate for ${state.period === "lifetime" ? "lifetime since launch" : state.period}. Roles are not additive.`);
       setText("[data-dashboard-notice]", notices.join(" "));
     }
 
@@ -431,10 +479,12 @@
     acquisitionWindowHours,
     chartSvg,
     combinedStatus,
+    dashboardStatus,
     mergeDaily,
     mergeMetrics,
     sourceStatus,
     start,
+    ratioMultiple,
     weeklyGrowth,
   };
 });


### PR DESCRIPTION
## Outcome

Adds the source-backed repository-acquisition figures requested after the first production dashboard launch and makes Lifetime the first dashboard view.

The early “thousands” figure was GitHub repository traffic: 1,260 clone events from 222 unique cloners on the 9 July public snapshot and 2,448 clone events from 310 unique cloners by the 11 July snapshot. The current live GitHub Traffic API read is 9,654 clone events from 446 unique cloners, plus 883 page views from 218 unique visitors, in GitHub's rolling 14-day window.

## User impact

- The dashboard opens on Lifetime and orders filters Lifetime → 90 days → 28 days → 7 days.
- A prominent visual section shows clone events, unique cloners, page views, and unique visitors.
- Unique cloners and unique visitors are described as GitHub-measured repository users.
- The two unique audiences are not summed because GitHub does not expose overlap, and they are not added to active platform identities because they cannot be deduplicated against contributors, wallets, or comment authors.
- Dated July snapshots remain visible as comparison points and are never summed or substituted for unavailable live traffic.

## Implementation

- Extends the hourly aggregate-only GitHub snapshot with the two GitHub Traffic API summaries.
- Validates non-negative counts, unique ≤ total invariants, exact UTC coverage bounds, and aggregate-only privacy fields.
- Fails closed to `unavailable` when permissions, shape, or counts are invalid.
- Uses encrypted `REPOSITORY_TRAFFIC_TOKEN` only in the read-only aggregate generation step, falling back to the workflow token and never requiring an operator API secret.
- Adds independent freshness/status rendering and source-ledger coverage.

## Verification

- `scripts/preflight.ps1 -Mode core` — pass
- `python scripts/test_github_audience_audit.py -v` — 13 pass
- fixture generator contract — pass
- fresh live generator read — ready, aggregate-only, 9,654 / 446 / 883 / 218
- `node --test scripts/test-metrics-dashboard.js` — 7 pass
- `python scripts/check-site.py` — pass
- `python -m py_compile scripts/github_audience_audit.py scripts/test_github_audience_audit.py` — pass
- `node --check site/metrics.js` — pass
- `git diff --check` — pass
- Playwright desktop/mobile — Lifetime initial, 7-day switch works, no horizontal overflow, reduced motion disables animation, zero console errors

Full local preflight remains unavailable because `forge` is not installed. Protected `full-check`, `postgres-sync`, and `sdlc-recovery` remain required before merge.

Public maintainer notice: #924.
