### PR TITLE
Validate signed-quorum bounded-wallet creations

### DIFF
--- a/scripts/relay_autonomous_action.py
+++ b/scripts/relay_autonomous_action.py
@@ -551,7 +551,14 @@ def read_state(client: CastClient, contract: str, block: str | None = None) -> B
     )
 
 
-def validate_common(state: BountyState, *, require_funded: bool = True) -> None:
+def validate_common(
+    state: BountyState,
+    *,
+    require_funded: bool = True,
+    verification_mode: int = 0,
+    threshold: int = 1,
+    expected_verifier_module: str | None = None,
+) -> None:
     expected = {
         "chain_id": CHAIN_ID,
         "codehash": CLONE_CODEHASH,
@@ -559,8 +566,8 @@ def validate_common(state: BountyState, *, require_funded: bool = True) -> None:
         "factory_implementation": IMPLEMENTATION,
         "factory": FACTORY,
         "settlement_token": USDC,
-        "verification_mode": 0,
-        "threshold": 1,
+        "verification_mode": verification_mode,
+        "threshold": threshold,
     }
     for field, wanted in expected.items():
         observed = getattr(state, field)
@@ -568,7 +575,12 @@ def validate_common(state: BountyState, *, require_funded: bool = True) -> None:
             raise RelayError(
                 f"fail-closed canonical-state mismatch for {field}: expected {wanted}, got {observed}"
             )
-    if state.verifier_module not in ALLOWED_VERIFIER_MODULES:
+    allowed_verifier_modules = (
+        ALLOWED_VERIFIER_MODULES
+        if expected_verifier_module is None
+        else (expected_verifier_module,)
+    )
+    if state.verifier_module not in allowed_verifier_modules:
         raise RelayError(
             f"verifier module is not allowlisted for the bounded relay: {state.verifier_module}"
         )

--- a/scripts/relay_bounded_wallet_action.py
+++ b/scripts/relay_bounded_wallet_action.py
@@ -448,7 +448,13 @@ def validate_created_bounty(
     params = decoded["params"]
     assert isinstance(params, dict)
     bounty = read_state(client, predicted, block=block)
-    validate_common(bounty, require_funded=False)
+    validate_common(
+        bounty,
+        require_funded=False,
+        verification_mode=int(params["verification_mode"]),
+        threshold=int(params["threshold"]),
+        expected_verifier_module=str(params["verifier_module"]),
+    )
     expected_status = 1 if prepared["initial_funding"] == prepared["target"] else 0
     expected = {
         "bounty_id": prepared["bounty_id"],

--- a/scripts/test_relay_bounded_wallet_action.py
+++ b/scripts/test_relay_bounded_wallet_action.py
@@ -191,6 +191,32 @@ class BoundedWalletRelayTests(unittest.TestCase):
         encoded = encode(f"f({POLICY_TYPE})", policy_tuple(policy))
         self.assertEqual(keccak_hex(encoded), relay.POLICY_HASH)
 
+    def test_common_identity_accepts_an_exact_signed_quorum_profile(self) -> None:
+        common = relay.validate_common.__globals__
+        state = mock.Mock(
+            chain_id=common["CHAIN_ID"],
+            codehash=common["CLONE_CODEHASH"],
+            canonical=True,
+            factory_implementation=common["IMPLEMENTATION"],
+            factory=common["FACTORY"],
+            settlement_token=common["USDC"],
+            verification_mode=1,
+            threshold=2,
+            verifier_module=relay.ZERO_ADDRESS,
+            solver_reward=100_000,
+            verifier_reward=10_000,
+            target_amount=110_000,
+            funded_amount=110_000,
+        )
+        relay.validate_common(
+            state,
+            verification_mode=1,
+            threshold=2,
+            expected_verifier_module=relay.ZERO_ADDRESS,
+        )
+        with self.assertRaisesRegex(relay.RelayError, "verifier module is not allowlisted"):
+            relay.validate_common(state, verification_mode=1, threshold=2)
+
     def test_comment_requires_exact_command_and_schema(self) -> None:
         body = relay.COMMAND + "\n```json\n" + json.dumps(envelope()) + "\n```"
         self.assertEqual(relay.parse_comment(body)["issue_number"], 249)


### PR DESCRIPTION
## Outcome
Fixes the bounded-wallet sponsor's post-creation check so it validates the exact verification mode, threshold, and verifier-module identity already authorized by the signed payload. Deterministic relay callers retain their existing defaults.

The prior attempts failed before broadcast; no USDC moved.

## Verification
- bounded-wallet relay tests: 9 passed
- autonomous relay regression tests: 20 passed
- new regression proves signed-quorum identity passes only with the exact zero verifier-module profile