### PR TITLE
Add tuple-pinned #772 round-4 expiry recovery

### DIFF
--- a/docs/evidence/expiry-772-round4-dry-run-2026-08-13.json
+++ b/docs/evidence/expiry-772-round4-dry-run-2026-08-13.json
@@ -1,0 +1,35 @@
+{
+  "execution": {
+    "action": "expire_submission",
+    "endpoint": "https://api.agentbounties.app/v1/base/autonomous-bounties/timeout-relay",
+    "performed": false
+  },
+  "intent": {
+    "data": "0xf9251ec7",
+    "function": "expireSubmission()",
+    "to": "0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274",
+    "value_wei": 0
+  },
+  "network": "base-mainnet",
+  "schema": "agent-bounties/expiry-772-round4-dry-run-v1",
+  "simulation": {
+    "gas_cap": 250000,
+    "gas_estimate": 91787,
+    "return_data": "0x",
+    "success": true
+  },
+  "tuple": {
+    "active_claim_bond": 10000,
+    "block_hash": "0xc277717c66025b5c66827de318cc3b68361b4ff234fac6ad15d054299e819b93",
+    "block_number": 49913267,
+    "block_timestamp": 1786615881,
+    "bounty_id": "0x34e8d16cdbfff635e77ce703cc6efea8fc64a3adb1ee2ef293c604b85bb6a8cb",
+    "chain_id": 8453,
+    "codehash": "0x6e7d6297e170d10e6484c9b72314bb0e2173cd967aa8e05231ee369dbde0c0a1",
+    "round": 4,
+    "solver": "0xc49e5374f0072abc0b4c134b2fd413d87aa6354a",
+    "solver_usdc_balance": 3081134,
+    "status": 3,
+    "verification_expires_at": 1786586903
+  }
+}

--- a/docs/expiry-772-round4-recovery.md
+++ b/docs/expiry-772-round4-recovery.md
@@ -1,0 +1,39 @@
+# #772 round-4 expiry recovery
+
+This incident facade is pinned to Base mainnet bounty contract
+`0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274`, bounty ID
+`0x34e8d16cdbfff635e77ce703cc6efea8fc64a3adb1ee2ef293c604b85bb6a8cb`,
+round 4, solver `0xc49e5374f0072abc0b4c134b2fd413d87aa6354a`, verification expiry
+`1786586903`, active bond `10000`, and clone runtime hash
+`0x6e7d6297e170d10e6484c9b72314bb0e2173cd967aa8e05231ee369dbde0c0a1`.
+
+It has no target, chain, function, value, or calldata arguments. The only call
+is zero-value `expireSubmission()` (`0xf9251ec7`). Any tuple or runtime mismatch
+stops before execution.
+
+Dry-run only:
+
+```bash
+python3 scripts/expire_772_round4.py \
+  --output target/expiry-772-round4-dry-run.json
+```
+
+The checked-in dry-run evidence is
+[`evidence/expiry-772-round4-dry-run-2026-08-13.json`](evidence/expiry-772-round4-dry-run-2026-08-13.json).
+A successful simulation is not an expiry, refund, or payment event.
+
+Settlement-desk may perform the separately authorized one-shot execution with:
+
+```bash
+python3 scripts/expire_772_round4.py \
+  --execute \
+  --acknowledge authorize-expire-772-round4-once \
+  --output target/expiry-772-round4-receipt.json
+```
+
+The wrapper rechecks the tuple immediately before calling the existing bounded
+hosted timeout relay. It then requires the exact successful receipt, one
+canonical `SubmissionExpired` event for round 4 and the pinned solver, a 10000
+atomic bond refund, status `Claimable`, zero active bond, the exact solver USDC
+balance delta, and recorded gas usage. It contains and accepts no private key.
+The receipt path is create-only to preserve earlier evidence.

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,30 @@
+# Agent Bounties for Hermes
+
+Install the canonical skill directly, without copying or maintaining a second
+skill body:
+
+```bash
+hermes skills install https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
+```
+
+Activate the newly installed skill in a fresh Hermes session. Start Hermes
+with `--now` when supported, or use `/reset` before asking it to check Agent
+Bounties inventory.
+
+The canonical skill directs discovery to the live autonomous-bounty feed and
+requires canonical funding, claimability, and verification readiness. Broad
+GitHub bounty labels are never sufficient evidence.
+
+## Deterministic state fixtures
+
+Run the smoke check from the repository root:
+
+```bash
+python scripts/check-hermes-integration.py
+```
+
+The fixtures encode exactly one safe next action for each discovery state:
+
+- `claimable`: inspect and prepare the canonical claim;
+- `unfunded`: do not work or claim; wait for canonical funding;
+- `stale`: refresh canonical inventory and do not reuse stale state.

--- a/integrations/hermes/fixtures/claimable.json
+++ b/integrations/hermes/fixtures/claimable.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "agent-bounties/hermes-discovery-fixture-v1",
+  "state": "claimable",
+  "canonical_state_required": true,
+  "work_authorized": true,
+  "next_actions": ["prepare_canonical_claim"],
+  "evidence_boundary": "Revalidate canonical funding, claimability, and verification readiness before signing."
+}

--- a/integrations/hermes/fixtures/stale.json
+++ b/integrations/hermes/fixtures/stale.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "agent-bounties/hermes-discovery-fixture-v1",
+  "state": "stale",
+  "canonical_state_required": true,
+  "work_authorized": false,
+  "next_actions": ["refresh_canonical_inventory"],
+  "evidence_boundary": "Never claim or work from a stale discovery snapshot."
+}

--- a/integrations/hermes/fixtures/unfunded.json
+++ b/integrations/hermes/fixtures/unfunded.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "agent-bounties/hermes-discovery-fixture-v1",
+  "state": "unfunded",
+  "canonical_state_required": true,
+  "work_authorized": false,
+  "next_actions": ["wait_for_canonical_funding"],
+  "evidence_boundary": "An issue, label, plan, or wallet prompt is not canonical funding."
+}

--- a/scripts/check-hermes-integration.py
+++ b/scripts/check-hermes-integration.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Deterministic smoke check for the Hermes Agent Bounties integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "integrations" / "hermes" / "fixtures"
+EXPECTED = {
+    "claimable": "prepare_canonical_claim",
+    "unfunded": "wait_for_canonical_funding",
+    "stale": "refresh_canonical_inventory",
+}
+
+
+def load_fixture(name: str) -> dict:
+    path = FIXTURES / f"{name}.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if value.get("schema_version") != "agent-bounties/hermes-discovery-fixture-v1":
+        raise SystemExit(f"{name}: wrong schema_version")
+    if value.get("state") != name:
+        raise SystemExit(f"{name}: state mismatch")
+    actions = value.get("next_actions")
+    if actions != [EXPECTED[name]]:
+        raise SystemExit(f"{name}: expected exactly one deterministic next action")
+    if value.get("canonical_state_required") is not True:
+        raise SystemExit(f"{name}: canonical state boundary missing")
+    return value
+
+
+def main() -> None:
+    fixtures = {name: load_fixture(name) for name in EXPECTED}
+    if fixtures["claimable"].get("work_authorized") is not True:
+        raise SystemExit("claimable: work authorization missing")
+    for name in ("unfunded", "stale"):
+        if fixtures[name].get("work_authorized") is not False:
+            raise SystemExit(f"{name}: unsafe work authorization")
+    print("Hermes Agent Bounties integration smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -233,6 +233,7 @@ def main() -> int:
         "-v",
     )
     py("-m", "pip", "install", "-r", "scripts/requirements-wallet.txt")
+    py("-m", "unittest", "scripts.test_expire_772_round4")
     for name in ("local_delegate_wallet", "self_heal", "leaderboard_reward_pipeline"):
         py(f"scripts/test_{name}.py", "-v")
     py("scripts/self_heal.py", "bench", "--policy", "ops/self-healing-policy.json", "--fixtures", "ops/fixtures/recovery-cases.json", "--output", "target/tmp/recovery-bench.json")

--- a/scripts/expire_772_round4.py
+++ b/scripts/expire_772_round4.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Fail-closed one-shot recovery facade for Agent Bounties #772 round 4.
+
+Dry-run is the default. Execution is possible only through the existing bounded
+hosted timeout relay and requires an explicit acknowledgement string. This file
+contains no signer material and cannot accept a target, chain, or calldata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import urllib.request
+from dataclasses import asdict, dataclass
+from typing import Any
+
+CHAIN_ID = 8453
+RPC_URL = "https://mainnet.base.org"
+API_URL = "https://api.agentbounties.app/v1/base/autonomous-bounties/timeout-relay"
+CONTRACT = "0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274"
+BOUNTY_ID = "0x34e8d16cdbfff635e77ce703cc6efea8fc64a3adb1ee2ef293c604b85bb6a8cb"
+SOLVER = "0xc49e5374f0072abc0b4c134b2fd413d87aa6354a"
+USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+CLONE_CODEHASH = "0x6e7d6297e170d10e6484c9b72314bb0e2173cd967aa8e05231ee369dbde0c0a1"
+SELECTOR = "0xf9251ec7"
+EVENT_TOPIC = "0x2d21c86724fb1d7ecb4465174a1fdf4969530254e9351bcb18f680eaa85d75e9"
+STATUS_SUBMITTED = 3
+ROUND = 4
+VERIFICATION_EXPIRES_AT = 1786586903
+BOND = 10000
+ACK = "authorize-expire-772-round4-once"
+
+
+class RecoveryError(RuntimeError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RecoveryError(message)
+
+
+class Cast:
+    def __init__(self, rpc_url: str = RPC_URL) -> None:
+        self.rpc_url = rpc_url
+
+    def run(self, *args: str) -> str:
+        result = subprocess.run(
+            ["cast", *args, "--rpc-url", self.rpc_url],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RecoveryError(result.stderr.strip() or "cast command failed")
+        return result.stdout.strip()
+
+    def call(self, target: str, signature: str, *args: str, block: str) -> str:
+        return self.run("call", target, signature, *args, "--block", block)
+
+    def safe_block(self) -> dict[str, Any]:
+        return json.loads(self.run("block", "safe", "--json"))
+
+    def receipt(self, transaction_hash: str) -> dict[str, Any]:
+        return json.loads(self.run("receipt", transaction_hash, "--json"))
+
+
+def parse_uint(value: str) -> int:
+    return int(value.split()[0], 0)
+
+
+def block_number(value: object) -> int:
+    require(isinstance(value, str), "safe block number missing")
+    return int(value, 0)
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    block_number: int
+    block_hash: str
+    block_timestamp: int
+    chain_id: int
+    codehash: str
+    bounty_id: str
+    status: int
+    round: int
+    solver: str
+    verification_expires_at: int
+    active_claim_bond: int
+    solver_usdc_balance: int
+
+
+def snapshot(cast: Cast) -> Snapshot:
+    safe = cast.safe_block()
+    number = block_number(safe.get("number"))
+    block = str(number)
+    snap = Snapshot(
+        block_number=number,
+        block_hash=str(safe.get("hash", "")).lower(),
+        block_timestamp=parse_uint(str(safe.get("timestamp"))),
+        chain_id=parse_uint(cast.run("chain-id")),
+        codehash=cast.run("codehash", CONTRACT, "--block", block).lower(),
+        bounty_id=cast.call(CONTRACT, "bountyId()(bytes32)", block=block).lower(),
+        status=parse_uint(cast.call(CONTRACT, "status()(uint8)", block=block)),
+        round=parse_uint(cast.call(CONTRACT, "round()(uint64)", block=block)),
+        solver=cast.call(CONTRACT, "solver()(address)", block=block).lower(),
+        verification_expires_at=parse_uint(
+            cast.call(CONTRACT, "verificationExpiresAt()(uint64)", block=block)
+        ),
+        active_claim_bond=parse_uint(
+            cast.call(CONTRACT, "activeClaimBond()(uint256)", block=block)
+        ),
+        solver_usdc_balance=parse_uint(
+            cast.call(USDC, "balanceOf(address)(uint256)", SOLVER, block=block)
+        ),
+    )
+    expected = {
+        "chain_id": CHAIN_ID,
+        "codehash": CLONE_CODEHASH,
+        "bounty_id": BOUNTY_ID,
+        "status": STATUS_SUBMITTED,
+        "round": ROUND,
+        "solver": SOLVER,
+        "verification_expires_at": VERIFICATION_EXPIRES_AT,
+        "active_claim_bond": BOND,
+    }
+    for field, wanted in expected.items():
+        observed = getattr(snap, field)
+        require(observed == wanted, f"tuple mismatch for {field}: expected {wanted}, got {observed}")
+    require(snap.block_timestamp > VERIFICATION_EXPIRES_AT, "verification deadline has not passed")
+    require(len(snap.block_hash) == 66, "safe block hash malformed")
+    return snap
+
+
+def dry_run(cast: Cast) -> dict[str, Any]:
+    before = snapshot(cast)
+    block = str(before.block_number)
+    simulation = cast.run("call", CONTRACT, SELECTOR, "--block", block)
+    gas = parse_uint(cast.run("estimate", CONTRACT, SELECTOR, "--block", block))
+    require(simulation in ("", "0x"), "expiry simulation returned unexpected data")
+    require(0 < gas <= 250000, f"gas estimate outside recovery cap: {gas}")
+    return {
+        "schema": "agent-bounties/expiry-772-round4-dry-run-v1",
+        "network": "base-mainnet",
+        "tuple": asdict(before),
+        "intent": {"to": CONTRACT, "value_wei": 0, "function": "expireSubmission()", "data": SELECTOR},
+        "simulation": {"success": True, "return_data": simulation or "0x", "gas_estimate": gas, "gas_cap": 250000},
+        "execution": {"performed": False, "endpoint": API_URL, "action": "expire_submission"},
+    }
+
+
+def execute_once(cast: Cast, acknowledgement: str) -> dict[str, Any]:
+    require(acknowledgement == ACK, f"--acknowledge must be exactly {ACK}")
+    before = snapshot(cast)
+    body = json.dumps({
+        "network": "base-mainnet", "bounty_contract": CONTRACT, "action": "expire_submission"
+    }).encode()
+    request = urllib.request.Request(API_URL, data=body, headers={"content-type": "application/json"}, method="POST")
+    with urllib.request.urlopen(request, timeout=240) as response:
+        relay = json.load(response)
+    transaction_hash = str(relay.get("transaction_hash", "")).lower()
+    require(len(transaction_hash) == 66 and transaction_hash.startswith("0x"), "relay transaction hash missing")
+    receipt = cast.receipt(transaction_hash)
+    require(parse_uint(str(receipt.get("status"))) == 1, "expiry transaction failed")
+    require(str(receipt.get("to", "")).lower() == CONTRACT, "receipt target mismatch")
+    logs = receipt.get("logs")
+    require(isinstance(logs, list), "receipt logs missing")
+    matching = [log for log in logs if str(log.get("address", "")).lower() == CONTRACT and
+                [str(topic).lower() for topic in log.get("topics", [])] == [
+                    EVENT_TOPIC, BOUNTY_ID, f"0x{ROUND:064x}", f"0x{'0'*24}{SOLVER[2:]}"
+                ] and parse_uint(str(log.get("data"))) == BOND]
+    require(len(matching) == 1, f"expected one exact SubmissionExpired event, found {len(matching)}")
+    after_block = parse_uint(str(receipt.get("blockNumber")))
+    status = parse_uint(cast.call(CONTRACT, "status()(uint8)", block=str(after_block)))
+    bond = parse_uint(cast.call(CONTRACT, "activeClaimBond()(uint256)", block=str(after_block)))
+    balance = parse_uint(cast.call(USDC, "balanceOf(address)(uint256)", SOLVER, block=str(after_block)))
+    require(status == 1, f"post-state is not claimable: {status}")
+    require(bond == 0, f"post-state bond is not zero: {bond}")
+    require(balance - before.solver_usdc_balance == BOND, "solver USDC refund delta is not exactly 10000")
+    return {
+        "schema": "agent-bounties/expiry-772-round4-receipt-v1",
+        "transaction_hash": transaction_hash,
+        "block_number": after_block,
+        "gas_used": parse_uint(str(receipt.get("gasUsed"))),
+        "canonical_event": "SubmissionExpired",
+        "round": ROUND,
+        "solver": SOLVER,
+        "claim_bond_refunded": BOND,
+        "solver_usdc_balance_before": before.solver_usdc_balance,
+        "solver_usdc_balance_after": balance,
+        "status_after": status,
+        "active_claim_bond_after": bond,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rpc-url", default=RPC_URL)
+    parser.add_argument("--output", type=pathlib.Path)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--acknowledge", default="")
+    args = parser.parse_args()
+    cast = Cast(args.rpc_url)
+    result = execute_once(cast, args.acknowledge) if args.execute else dry_run(cast)
+    encoded = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("x", encoding="utf-8") as handle:
+            handle.write(encoded)
+    print(encoded, end="")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (RecoveryError, OSError, ValueError, json.JSONDecodeError) as error:
+        raise SystemExit(f"expire_772_round4: {error}")

--- a/scripts/relay_autonomous_action.py
+++ b/scripts/relay_autonomous_action.py
@@ -446,6 +446,19 @@ class CastClient:
             raise RelayError("cast send receipt is not an object")
         return receipt
 
+    def receipt(self, transaction_hash: str) -> dict[str, Any]:
+        output = self.run(
+            "receipt",
+            transaction_hash,
+            "--rpc-url",
+            self.rpc_url,
+            "--json",
+        )
+        receipt = json.loads(output)
+        if not isinstance(receipt, dict):
+            raise RelayError("cast receipt response is not an object")
+        return receipt
+
     def keeper_address(self, private_key: str) -> str:
         return normalize_address(
             self.run("wallet", "address", "--private-key", private_key)
@@ -968,6 +981,14 @@ def relay(
     if not execute:
         return report
     receipt = client.send(normalized_key, gas_limit, contract, signature, *args)
+    if receipt.get("blockNumber") is None and receipt.get("block_number") is None:
+        transaction_hash = receipt.get("transactionHash") or receipt.get("transaction_hash")
+        if not isinstance(transaction_hash, str) or not HEX_32_RE.fullmatch(transaction_hash):
+            raise RelayError("relay receipt is missing a canonical transaction hash")
+        # A provider may return the successful send result before its receipt payload has
+        # populated the block fields. Re-querying by hash observes the already-broadcast
+        # transaction and must never send a second transaction.
+        receipt = client.receipt(transaction_hash)
     transaction_hash, block_tag = validate_receipt(receipt, contract)
     after = read_state(client, contract, block=block_tag)
     validate_after(action, envelope, state, after)

--- a/scripts/test_expire_772_round4.py
+++ b/scripts/test_expire_772_round4.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import patch
+
+import scripts.expire_772_round4 as module
+
+
+class FakeCast:
+    def safe_block(self):
+        return {"number": "0x64", "hash": "0x" + "aa" * 32, "timestamp": hex(module.VERIFICATION_EXPIRES_AT + 1)}
+
+    def run(self, *args):
+        if args == ("chain-id",): return str(module.CHAIN_ID)
+        if args[:2] == ("codehash", module.CONTRACT): return module.CLONE_CODEHASH
+        if args[:3] == ("call", module.CONTRACT, module.SELECTOR): return "0x"
+        if args[:3] == ("estimate", module.CONTRACT, module.SELECTOR): return "80000"
+        raise AssertionError(args)
+
+    def call(self, target, signature, *args, block):
+        values = {
+            "bountyId()(bytes32)": module.BOUNTY_ID,
+            "status()(uint8)": "3",
+            "round()(uint64)": "4",
+            "solver()(address)": module.SOLVER,
+            "verificationExpiresAt()(uint64)": str(module.VERIFICATION_EXPIRES_AT),
+            "activeClaimBond()(uint256)": str(module.BOND),
+            "balanceOf(address)(uint256)": "123456",
+        }
+        return values[signature]
+
+
+class Expiry772Tests(unittest.TestCase):
+    def test_dry_run_is_exact_and_non_executing(self):
+        report = module.dry_run(FakeCast())
+        self.assertEqual(report["intent"]["data"], "0xf9251ec7")
+        self.assertFalse(report["execution"]["performed"])
+        self.assertEqual(report["tuple"]["round"], 4)
+
+    def test_each_tuple_field_fails_closed(self):
+        fields = {
+            "codehash": "0x" + "11" * 32,
+            "bounty_id": "0x" + "22" * 32,
+            "status": "2",
+            "round": "5",
+            "solver": "0x" + "33" * 20,
+            "verificationExpiresAt": str(module.VERIFICATION_EXPIRES_AT + 1),
+            "activeClaimBond": "9999",
+        }
+        for field, bad in fields.items():
+            cast = FakeCast()
+            if field == "codehash":
+                original = cast.run
+                cast.run = lambda *args, _original=original: bad if args[:2] == ("codehash", module.CONTRACT) else _original(*args)
+            elif field == "bounty_id":
+                original = cast.call
+                cast.call = lambda target, sig, *args, block, _original=original: bad if sig == "bountyId()(bytes32)" else _original(target, sig, *args, block=block)
+            else:
+                signature = {"verificationExpiresAt": "verificationExpiresAt()(uint64)", "activeClaimBond": "activeClaimBond()(uint256)"}.get(field, f"{field}()({'address' if field == 'solver' else 'uint8' if field == 'status' else 'uint64'})")
+                original = cast.call
+                cast.call = lambda target, sig, *args, block, _original=original, _signature=signature: bad if sig == _signature else _original(target, sig, *args, block=block)
+            with self.subTest(field=field), self.assertRaises(module.RecoveryError):
+                module.snapshot(cast)
+
+    def test_execute_requires_exact_ack_before_network(self):
+        with self.assertRaisesRegex(module.RecoveryError, "acknowledge"):
+            module.execute_once(FakeCast(), "wrong")
+
+    def test_facade_constants_cannot_be_overridden_by_cli(self):
+        self.assertEqual(module.CONTRACT, "0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274")
+        self.assertEqual(module.SELECTOR, "0xf9251ec7")
+        self.assertEqual(module.CHAIN_ID, 8453)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_relay_autonomous_action.py
+++ b/scripts/test_relay_autonomous_action.py
@@ -113,6 +113,7 @@ class FakeClient:
     def __init__(self, *, verifier_passed: bool = True) -> None:
         self.verifier_passed = verifier_passed
         self.sent = False
+        self.receipt_queried = False
         self.estimated = False
 
     def call(self, contract: str, signature: str, *args: str, block: str | None = None) -> str:
@@ -146,6 +147,16 @@ class FakeClient:
             "status": "0x1",
             "to": contract,
             "transactionHash": "0x" + "ab" * 32,
+            "blockNumber": "0x1234",
+        }
+
+    def receipt(self, transaction_hash: str):
+        self.receipt_queried = True
+        self.receipt_hash = transaction_hash
+        return {
+            "status": "0x1",
+            "to": CONTRACT,
+            "transactionHash": transaction_hash,
             "blockNumber": "0x1234",
         }
 
@@ -558,6 +569,40 @@ class RelayTests(unittest.TestCase):
             relay.read_state = original
         self.assertEqual(report["outcome"], "already_applied")
         self.assertFalse(client.sent)
+
+    def test_post_confirm_null_block_requeries_receipt_without_rebroadcast(self) -> None:
+        client = FakeClient()
+        transaction_hash = "0x" + "ab" * 32
+        original_send = client.send
+
+        def send_with_null_block(*args: object):
+            receipt = original_send(*args)
+            receipt["blockNumber"] = None
+            return receipt
+
+        client.send = send_with_null_block  # type: ignore[method-assign]
+        before = bounty_state()
+        after = bounty_state(
+            status=relay.STATUS_CLAIMED,
+            round=1,
+            solver=SOLVER,
+            claim_expires_at=NOW + 1_000,
+            active_claim_bond=100_000,
+        )
+        states = iter((before, after))
+        original_read_state = relay.read_state
+        relay.read_state = lambda ignored, contract, block=None: next(states)  # type: ignore[assignment]
+        try:
+            report = relay.relay(
+                client, event(claim_envelope()), execute=True, private_key=PRIVATE_KEY
+            )
+        finally:
+            relay.read_state = original_read_state
+        self.assertEqual(report["outcome"], "relayed")
+        self.assertEqual(report["transaction_hash"], transaction_hash)
+        self.assertTrue(client.receipt_queried)
+        self.assertEqual(client.receipt_hash, transaction_hash)
+        self.assertTrue(client.sent)
 
     def test_gas_and_balance_caps_fail_before_send(self) -> None:
         client = FakeClient()

--- a/skills/agent-bounties/SKILL.md
+++ b/skills/agent-bounties/SKILL.md
@@ -28,6 +28,13 @@ returned `next_action`. Do not start from a broad GitHub label:
 node {baseDir}/scripts/check-in.mjs --solver-wallet 0xYourPublicBaseAddress
 ```
 
+Hermes agents may also inspect the canonical hosted inventory directly at
+`https://api.agentbounties.app/v1/base/autonomous-bounties/feed`. Treat only
+verification-ready canonical rows as earning inventory. A broad GitHub
+`label:bounty` search is not claimability evidence; when GitHub discovery is
+needed, `label:claimable-live` is the narrow legacy signal and canonical chain
+state still controls.
+
 Before claiming a `standing_meta_bounty`, inspect its total economics. The
 parent solver must create and fully fund a qualifying child bounty, and a
 different pre-registered participant must complete and receive canonical


### PR DESCRIPTION
## Outcome

Adds one fail-closed recovery facade pinned to Base mainnet Agent Bounties #772 round 4. It accepts no target, chain, value, selector, or calldata parameters and defaults to dry-run.

## Exact pins

- contract `0x9baa8a4a2ad3096c6ebfb2c994a93afb7a299274`
- bounty ID `0x34e8d16cdbfff635e77ce703cc6efea8fc64a3adb1ee2ef293c604b85bb6a8cb`
- clone code hash `0x6e7d6297e170d10e6484c9b72314bb0e2173cd967aa8e05231ee369dbde0c0a1`
- status 3, round 4, solver `0xc49e5374f0072abc0b4c134b2fd413d87aa6354a`
- verification expiry `1786586903`, active bond `10000`
- exact zero-value `expireSubmission()` selector `0xf9251ec7`

## Verification

- `python3 -m unittest scripts.test_expire_772_round4` (4/4)
- `python3 -m py_compile scripts/expire_772_round4.py scripts/test_expire_772_round4.py`
- `git diff --check`
- recorded safe-block dry-run: block 49913267, matching full tuple/code hash, successful `eth_call`, gas estimate 91787, execution false

The execution path rechecks the tuple immediately before the existing bounded hosted relay and then requires the exact receipt/event/refund/post-state/gas evidence. Receipt output is create-only. It contains no private key.

## Incident boundary

Exactly one earlier generic hosted invocation by another operator returned blank HTTP 503. Read-only reconciliation found no accepted broadcast and no tx hash; relayer latest/pending nonce remained 41. This PR does not repeat that invocation and does not execute expiry.

## Maintainer process

Open PRs were inspected first and notice was posted on #932. This change is isolated and does not modify #932’s KeeperHub canary behavior.