### PR TITLE
Fix claim wallet UI and Brave connection errors

### DIFF
--- a/scripts/test-autonomous-wallet-flow.js
+++ b/scripts/test-autonomous-wallet-flow.js
@@ -148,7 +148,14 @@ assert(postHtml.includes('name="solverReward" type="number" min="0.01" step="0.0
 assert(postHtml.includes('name="verifierReward" type="number" min="0.01" step="0.01" value="0.01"'));
 
 const earnHtml = fs.readFileSync(path.join(repoRoot, "site", "earn.html"), "utf8");
+const sharedCss = fs.readFileSync(path.join(repoRoot, "site", "styles.css"), "utf8");
+const simpleUxCss = fs.readFileSync(path.join(repoRoot, "site", "simple-ux.css"), "utf8");
 assert(earnHtml.includes("Sign once. Start after BountyClaimed"));
+assert(earnHtml.includes('class="claim-wallet-stack"'));
+assert(earnHtml.includes('styles.css?v=20260813-1'));
+assert(earnHtml.includes('simple-ux.css?v=2'));
+assert(sharedCss.includes(".sr-only"));
+assert(simpleUxCss.includes(".claim-wallet-stack"));
 assert(earnHtml.includes("Gas is sponsored for this funding action"));
 assert(earnHtml.includes('data-wallet-requires="direct-transactions"'));
 assert(earnHtml.includes('src="wallet-adapter-registry.js?v=1"'));
@@ -160,6 +167,8 @@ assert(
 assert(source.includes('params.get("bountyContract")'));
 assert(source.includes("Sign once to claim"));
 assert(source.includes("Sponsored refundable bond"));
+assert(source.includes('walletRequest("eth_accounts")'));
+assert(source.includes("already has a request open"));
 assert(!source.includes("/v1/base/autonomous-bounties/authorized-claim-plan"));
 const fundingStart = source.indexOf("async function fundBounty(event)");
 const submissionStart = source.indexOf("async function submitBounty(event)", fundingStart);
@@ -412,7 +421,120 @@ async function testDeterministicPostingDefaults() {
   );
 }
 
-testDeterministicPostingDefaults()
+function walletHarness(provider) {
+  const selector = {
+    dataset: {},
+    disabled: false,
+    value: "0",
+    replaceChildren(...options) {
+      this.options = options;
+      const selected = options.find((option) => option.selected) || options[0];
+      this.value = selected ? selected.value : "";
+    },
+    addEventListener() {},
+  };
+  const document = {
+    addEventListener() {},
+    createElement() {
+      return { value: "", textContent: "", selected: false };
+    },
+    getElementById() {
+      return null;
+    },
+    querySelector(value) {
+      return value === "[data-wallet-provider]" ? selector : null;
+    },
+    querySelectorAll(value) {
+      return value === "[data-wallet-provider]" ? [selector] : [];
+    },
+  };
+  const window = {
+    addEventListener() {},
+    dispatchEvent() {},
+    ethereum: provider,
+  };
+  const context = vm.createContext({
+    console,
+    crypto: webcrypto,
+    document,
+    window,
+    Event,
+    URLSearchParams,
+    location: { search: "" },
+    fetch: async () => ({ ok: true, json: async () => protocol }),
+    setTimeout: (callback) => {
+      callback();
+      return 1;
+    },
+  });
+  const instrumentedSource = source.replace(
+    /\}\)\(\);\s*$/,
+    "globalThis.__agentBountiesTest = { connectWallet }; })();",
+  );
+  new vm.Script(evmSource, { filename: "site/evm.js" }).runInContext(context);
+  new vm.Script(instrumentedSource, { filename: "site/autonomous.js" }).runInContext(context);
+  return context.__agentBountiesTest;
+}
+
+async function testWalletConnectionReuseAndErrors() {
+  const account = "0x2222222222222222222222222222222222222222";
+  const authorizedCalls = [];
+  const authorized = walletHarness({
+    isBraveWallet: true,
+    async request({ method }) {
+      authorizedCalls.push(method);
+      if (method === "eth_accounts") return [account];
+      if (method === "eth_requestAccounts") throw new Error("should not request an authorized account again");
+      if (method === "eth_chainId") return protocol.chain_id_hex;
+      throw new Error(`Unexpected wallet method: ${method}`);
+    },
+  });
+  assert.strictEqual(await authorized.connectWallet(), account);
+  assert.deepStrictEqual(authorizedCalls, ["eth_accounts", "eth_chainId"]);
+
+  let resolveAccounts;
+  let requestCount = 0;
+  const pendingAccounts = new Promise((resolve) => {
+    resolveAccounts = resolve;
+  });
+  const concurrent = walletHarness({
+    isBraveWallet: true,
+    async request({ method }) {
+      if (method === "eth_accounts") return [];
+      if (method === "eth_requestAccounts") {
+        requestCount += 1;
+        return pendingAccounts;
+      }
+      if (method === "eth_chainId") return protocol.chain_id_hex;
+      throw new Error(`Unexpected wallet method: ${method}`);
+    },
+  });
+  const first = concurrent.connectWallet();
+  const second = concurrent.connectWallet();
+  resolveAccounts([account]);
+  assert.deepStrictEqual(await Promise.all([first, second]), [account, account]);
+  assert.strictEqual(requestCount, 1, "concurrent connects must share one wallet permission request");
+
+  const failing = walletHarness({
+    isBraveWallet: true,
+    async request({ method }) {
+      if (method === "eth_accounts") return [];
+      if (method === "eth_requestAccounts") {
+        throw Object.assign(new Error("An internal error has occurred"), { code: -32603 });
+      }
+      throw new Error(`Unexpected wallet method: ${method}`);
+    },
+  });
+  await assert.rejects(
+    failing.connectWallet(),
+    /Brave Wallet could not complete the connection\. Open it, finish setup or unlock it, close any pending request, then try again\./,
+  );
+}
+
+Promise.all([
+  testDeterministicPostingDefaults(),
+  testWalletConnectionReuseAndErrors(),
+])
   .then(() => console.log("autonomous wallet flow contract passed"))
   .catch((error) => {
     console.error(error);

--- a/site/autonomous.js
+++ b/site/autonomous.js
@@ -14,6 +14,7 @@
     providers: [],
     legalAction: null,
     legalScope: null,
+    walletConnection: null,
   };
 
   const announcedProviders = [];
@@ -72,6 +73,43 @@
     if (provider.isCoinbaseWallet) return "Coinbase Wallet";
     if (provider.isBraveWallet) return "Brave Wallet";
     return "Browser wallet";
+  }
+
+  function selectedProviderName(provider = state.provider) {
+    const selected = state.providers.find((item) => item.provider === provider);
+    return providerName(provider || {}, selected ? selected.info : {});
+  }
+
+  function walletErrorCode(error) {
+    const values = [
+      error && error.code,
+      error && error.data && error.data.code,
+      error && error.data && error.data.originalError && error.data.originalError.code,
+    ];
+    for (const value of values) {
+      const parsed = Number(value);
+      if (Number.isInteger(parsed)) return parsed;
+    }
+    return null;
+  }
+
+  function walletConnectionErrorMessage(error, action = "connect") {
+    const name = selectedProviderName();
+    const message = error && error.message ? error.message : String(error || "");
+    const code = walletErrorCode(error);
+    if (code === 4001 || /user (rejected|denied)|request rejected|cancelled/i.test(message)) {
+      return `${name} connection was cancelled. No wallet action was taken.`;
+    }
+    if (code === -32002 || /already processing|already pending|request.*pending/i.test(message)) {
+      return `${name} already has a request open. Approve or reject it from the wallet icon, then try again.`;
+    }
+    if (code === -32603 || /internal error/i.test(message)) {
+      const task = action === "switch"
+        ? "switch to Base"
+        : "complete the connection";
+      return `${name} could not ${task}. Open it, finish setup or unlock it, close any pending request, then try again.`;
+    }
+    return message || `${name} could not ${action === "switch" ? "switch to Base" : "connect"}. Try again from the wallet icon.`;
   }
 
   function rememberProvider(event) {
@@ -627,11 +665,23 @@
     return JSON.stringify(canonicalJsonValue(value));
   }
 
-  async function connectWallet(context = document) {
+  async function connectWalletOnce(context) {
     await discoverProviders();
     selectProvider(context);
     const protocol = await loadProtocol();
-    const accounts = await walletRequest("eth_requestAccounts");
+    let accounts = [];
+    try {
+      accounts = await walletRequest("eth_accounts");
+    } catch (_error) {
+      // Some injected providers reject passive account reads while locked.
+    }
+    if (!accounts || !accounts[0]) {
+      try {
+        accounts = await walletRequest("eth_requestAccounts");
+      } catch (error) {
+        throw new Error(walletConnectionErrorMessage(error));
+      }
+    }
     if (!accounts || !accounts[0]) throw new Error("No wallet account was returned.");
     state.account = accounts[0];
     configurePostVerification(
@@ -641,27 +691,47 @@
       protocol,
       state.account,
     );
-    const current = await walletRequest("eth_chainId");
+    let current;
+    try {
+      current = await walletRequest("eth_chainId");
+    } catch (error) {
+      throw new Error(walletConnectionErrorMessage(error, "switch"));
+    }
     if (String(current).toLowerCase() !== protocol.chain_id_hex.toLowerCase()) {
       try {
         await walletRequest("wallet_switchEthereumChain", [{ chainId: protocol.chain_id_hex }]);
       } catch (error) {
         if (error && error.code === 4902) {
-          await walletRequest("wallet_addEthereumChain", [
-            {
-              chainId: protocol.chain_id_hex,
-              chainName: "Base",
-              nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
-              rpcUrls: ["https://mainnet.base.org"],
-              blockExplorerUrls: [protocol.explorer_url],
-            },
-          ]);
+          try {
+            await walletRequest("wallet_addEthereumChain", [
+              {
+                chainId: protocol.chain_id_hex,
+                chainName: "Base",
+                nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+                rpcUrls: ["https://mainnet.base.org"],
+                blockExplorerUrls: [protocol.explorer_url],
+              },
+            ]);
+          } catch (addError) {
+            throw new Error(walletConnectionErrorMessage(addError, "switch"));
+          }
         } else {
-          throw error;
+          throw new Error(walletConnectionErrorMessage(error, "switch"));
         }
       }
     }
     return state.account;
+  }
+
+  async function connectWallet(context = document) {
+    if (state.walletConnection) return state.walletConnection;
+    const connection = connectWalletOnce(context);
+    state.walletConnection = connection;
+    try {
+      return await connection;
+    } finally {
+      if (state.walletConnection === connection) state.walletConnection = null;
+    }
   }
 
   async function isContractAccount(account) {
@@ -2103,12 +2173,21 @@
     if (creatorRefundButton) creatorRefundButton.addEventListener("click", withdrawCreatorRefund);
     document.querySelectorAll("[data-connect-wallet]").forEach((button) => {
       button.addEventListener("click", async () => {
+        if (button.getAttribute("aria-busy") === "true") return;
         const target = byId(button.dataset.output);
+        const label = button.textContent;
+        button.setAttribute("aria-busy", "true");
+        button.disabled = true;
+        button.textContent = "Connecting...";
         try {
           const account = await connectWallet(button.closest("form") || document);
           output(target, `Connected: ${account}`, "success");
         } catch (error) {
           output(target, error.message || String(error), "error");
+        } finally {
+          button.removeAttribute("aria-busy");
+          button.disabled = false;
+          button.textContent = label;
         }
       });
     });

--- a/site/earn.html
+++ b/site/earn.html
@@ -8,9 +8,9 @@
     <title>Earn Money With AI | Funded Agent Bounties</title>
     <meta name="description" content="Find funded AI, coding, research, and writing bounties with explicit rewards and acceptance criteria. Use ChatGPT, Claude, or Gemini Spark to help claim, complete, and submit work.">
     <link rel="canonical" href="https://agentbounties.app/earn.html">
-    <link rel="stylesheet" href="styles.css?v=20260722-1">
+    <link rel="stylesheet" href="styles.css?v=20260813-1">
     <link rel="stylesheet" href="guild-pages.css?v=20260722-1">
-    <link rel="stylesheet" href="simple-ux.css?v=1">
+    <link rel="stylesheet" href="simple-ux.css?v=2">
     <link rel="stylesheet" href="onramp.css?v=1">
     <link rel="stylesheet" href="wallet-adapters.css?v=1">
     <link rel="stylesheet" href="coinbase-embedded-wallet.bundle.css?v=1">
@@ -106,15 +106,17 @@
             <p class="eyebrow">Claim this task</p>
             <h2 id="claim-title">Review it, connect your wallet, and claim it.</h2>
             <p class="fine">Start work only after the claim is confirmed.</p>
-            <label class="wallet-picker">
-              Wallet
-              <select data-wallet-provider aria-label="Wallet provider">
-                <option>Detecting wallets</option>
-              </select>
-            </label>
-            <button class="button secondary" type="button" data-connect-wallet data-output="claim-feed-output">Connect wallet</button>
-            <output id="claim-feed-output" class="output compact-output" aria-live="polite">Review the selected task before signing.</output>
-            <div data-legal-consent data-consent-actions="claim_bounty"></div>
+            <div class="claim-wallet-stack">
+              <label class="wallet-picker">
+                Wallet
+                <select data-wallet-provider aria-label="Wallet provider">
+                  <option>Detecting wallets</option>
+                </select>
+              </label>
+              <button class="button secondary" type="button" data-connect-wallet data-output="claim-feed-output">Connect wallet</button>
+              <output id="claim-feed-output" class="output compact-output" aria-live="polite">Review the selected task before signing.</output>
+              <div data-legal-consent data-consent-actions="claim_bounty"></div>
+            </div>
           </div>
           <div id="claimable-feed" class="bounty-feed" aria-live="polite">Loading the selected task…</div>
         </div>

--- a/site/simple-ux.css
+++ b/site/simple-ux.css
@@ -211,6 +211,29 @@ body.guild-interior .cancel-hero h1 {
   display: none !important;
 }
 
+.claim-wallet-stack {
+  display: grid;
+  align-items: start;
+  gap: 14px;
+  margin-top: 28px;
+}
+
+.claim-wallet-stack .wallet-picker {
+  width: 100%;
+  max-width: none;
+}
+
+.claim-wallet-stack > .button {
+  justify-self: start;
+  margin: 0;
+}
+
+.claim-wallet-stack .compact-output,
+.claim-wallet-stack .legal-consent {
+  width: 100%;
+  margin: 0;
+}
+
 .post-workflow {
   max-width: 1120px;
   margin: 0 auto;

--- a/site/styles.css
+++ b/site/styles.css
@@ -21,6 +21,18 @@
   display: none !important;
 }
 
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 body {
   margin: 0;
   background: var(--paper);


### PR DESCRIPTION
## Outcome
- gives the claim wallet controls a stable vertical layout with full-width status/consent surfaces
- restores the canonical visually-hidden utility so screen-reader-only copy does not render visibly
- reuses authorized Brave accounts, coalesces concurrent connection requests, and turns `-32603` into actionable unlock/setup/pending-request guidance
- preserves the existing chain-switch and claim transaction behavior

## Scope and contributor impact
- Site-only UI/client wallet change; no contracts, escrow, verification, funding, settlement, or payment evidence changed.
- Public maintainer notice: #935
- Open PRs #880, #718, #687, #724, and #729 were inspected; none overlap these production files.
- No migration and no collaboration branch are required.

## Verification
- `scripts/preflight.ps1 -Mode core`
- `node scripts/test-autonomous-wallet-flow.js`
- `node scripts/test-wallet-adapter-registry.js`
- `python scripts/check-site.py`
- `python scripts/check-coinbase-embedded-wallet.py`
- `python scripts/check-moonpay-onramp.py`
- `git diff --check`
- Playwright desktop and narrow-viewport layout checks: no overlap or horizontal overflow
- Playwright simulated Brave `-32603`: actionable error displayed

## Release
Merge to `main` triggers the repository's GitHub Pages validation/deployment workflow. The maintainer has explicitly authorized an admin-bypass merge for this urgent repair.