### PR TITLE
Cache-bust the claim wallet script

### DIFF
--- a/scripts/test-autonomous-wallet-flow.js
+++ b/scripts/test-autonomous-wallet-flow.js
@@ -154,6 +154,7 @@ assert(earnHtml.includes("Sign once. Start after BountyClaimed"));
 assert(earnHtml.includes('class="claim-wallet-stack"'));
 assert(earnHtml.includes('styles.css?v=20260813-1'));
 assert(earnHtml.includes('simple-ux.css?v=2'));
+assert(earnHtml.includes('autonomous.js?v=20260813-1'));
 assert(sharedCss.includes(".sr-only"));
 assert(simpleUxCss.includes(".claim-wallet-stack"));
 assert(earnHtml.includes("Gas is sponsored for this funding action"));
@@ -161,7 +162,7 @@ assert(earnHtml.includes('data-wallet-requires="direct-transactions"'));
 assert(earnHtml.includes('src="wallet-adapter-registry.js?v=1"'));
 assert(earnHtml.includes('src="x402-browser.js?v=1"'));
 assert(
-  earnHtml.indexOf('src="x402-browser.js?v=1"') < earnHtml.indexOf('src="autonomous.js"'),
+  earnHtml.indexOf('src="x402-browser.js?v=1"') < earnHtml.indexOf('src="autonomous.js?v=20260813-1"'),
   "the sponsored x402 client must load before the autonomous funding flow",
 );
 assert(source.includes('params.get("bountyContract")'));

--- a/site/earn.html
+++ b/site/earn.html
@@ -195,7 +195,7 @@
     <script src="wallet-adapter-registry.js?v=1"></script>
     <script src="coinbase-embedded-wallet.bundle.js?v=1"></script>
     <script src="x402-browser.js?v=1"></script>
-    <script src="autonomous.js"></script>
+    <script src="autonomous.js?v=20260813-1"></script>
     <script src="bounty-board.js?v=2"></script>
   </body>
 </html>


### PR DESCRIPTION
## Outcome
Cache-bust the deployed `autonomous.js` reference on the claim page so existing Brave sessions load the wallet error fix immediately instead of retaining an older edge/browser-cached script.

## Verification
- `node scripts/test-autonomous-wallet-flow.js`
- `python scripts/check-site.py`
- `git diff --check`

Follow-up to #936 within maintainer notice #935. No contract, escrow, funding, verification, settlement, or payment-evidence behavior changes.