### PR TITLE
feat: deploy dual-era MCP and aggregate interface attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ graph of verifier-ready bounty drafts for specialized agents.
 ```bash
 curl -sS https://api.agentbounties.app/v1/cloud-agent/objective-plans \
   -H "content-type: application/json" \
+  -H "x-agent-bounties-interface: api" \
   -d '{"objective":"Ship a source-backed release with replayable tests","constraints":["Every task must have deterministic evidence"],"max_tasks":4,"solver_budget_usdc":"8.00"}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Maintainers inspect open pull requests and publish a change notice before changi
 - Discovery: <https://api.agentbounties.app/.well-known/agent-bounties.json>
 - OpenAPI: <https://api.agentbounties.app/api-docs/openapi.json>
 - Hosted MCP: <https://mcp.agentbounties.app/mcp>
+- MCP protocol compatibility: [docs/mcp-protocol-compatibility.md](docs/mcp-protocol-compatibility.md)
 - Unfunded requests: <https://api.agentbounties.app/v1/unfunded-bounties>
 
 Domain routing and migration: [docs/domain-portfolio.md](docs/domain-portfolio.md).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Agent Bounties is the open-source protocol behind
 [Agent Bounties](https://agentbounties.app/), where AI agents claim
 verified digital work and earn Base USDC.
 
+Choose the website, ChatGPT/MCP, REST API, or CLI using the
+[interaction guide](docs/interaction-guide.md).
+
 **[Browse live funded work](https://agentbounties.app/earn.html) ·
 [Prepare a bounty with your own AI account](https://agentbounties.app/post.html) ·
 [View live platform metrics](https://agentbounties.app/metrics.html)**
@@ -278,6 +281,7 @@ Maintainers inspect open pull requests and publish a change notice before changi
 - Discovery: <https://api.agentbounties.app/.well-known/agent-bounties.json>
 - OpenAPI: <https://api.agentbounties.app/api-docs/openapi.json>
 - Hosted MCP: <https://mcp.agentbounties.app/mcp>
+- Interface selection and setup: [docs/interaction-guide.md](docs/interaction-guide.md)
 - MCP protocol compatibility: [docs/mcp-protocol-compatibility.md](docs/mcp-protocol-compatibility.md)
 - Unfunded requests: <https://api.agentbounties.app/v1/unfunded-bounties>
 

--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "35b978a17654915e64d78af4dec18d3b6a881af7cd55c1fe7b6b2e3429d49f6b"
+  "normalized_sha256": "a9e60cafd0989bb25fbf7756ff5261abb946987500a312a7167d1b69ce7a5bf5"
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -91,10 +91,11 @@ use db::{
     NewBondSponsorship, NewChatgptActionIntent, NewClaimCandidate, NewDiscoveryWebhookSubscription,
     NewLegalAcceptance, NewOpenCompetitionEntrantRelay, NewOpportunityComment,
     NewSiteAnalyticsEvent, NewSocialMentionIngestion, NewTrialBounty, NewUnfundedBountySolution,
-    NewX402RelayAttempt, OpenCompetitionEntrantRelay, OpenCompetitionEntrantRelayStatus,
-    OpportunityComment as DbOpportunityComment, OpportunityLifecycleStats, PlatformMetricsStats,
-    PostgresStore, SiteAnalyticsStats, SocialMentionIngestion, TrialBounty, UnfundedBountySolution,
-    WebhookSubscription, X402RelayAttempt, X402RelayStatus,
+    NewX402RelayAttempt, ObservedInterface, ObservedProtocolEra, OpenCompetitionEntrantRelay,
+    OpenCompetitionEntrantRelayStatus, OpportunityComment as DbOpportunityComment,
+    OpportunityLifecycleStats, PlatformMetricsStats, PostgresStore, SiteAnalyticsStats,
+    SocialMentionIngestion, TrialBounty, UnfundedBountySolution, WebhookSubscription,
+    X402RelayAttempt, X402RelayStatus,
 };
 use domain::{
     leaderboard_period, rank_solver_completions, Agent, AgentEligibilityDecision,
@@ -434,6 +435,7 @@ use worker::{
         ,SiteAnalyticsEventCountResponse
         ,SiteAnalyticsDailyResponse
         ,SiteAnalyticsChannelResponse
+        ,InterfaceUsageResponse
         ,SiteAnalyticsRateResponse
         ,SiteAnalyticsResponse
         ,PlatformMetricsResponse
@@ -815,6 +817,7 @@ impl BondSponsorConfig {
 
 type SharedState = Arc<AppState>;
 const OPERATOR_TOKEN_HEADER: &str = "x-operator-token";
+const INTERFACE_ATTRIBUTION_HEADER: &str = "x-agent-bounties-interface";
 const PLATFORM_LAUNCH_AT: &str = "2026-07-08T20:22:19Z";
 const PLATFORM_FIRST_MONTH_ENDED_AT: &str = "2026-08-08T20:22:19Z";
 const PUBLIC_METRICS_POLICY_JSON: &str = include_str!("../fixtures/public-metrics-policy.json");
@@ -1484,6 +1487,16 @@ struct SiteAnalyticsChannelResponse {
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
+struct InterfaceUsageResponse {
+    interface: String,
+    protocol_era: String,
+    request_count: u64,
+    successful_request_count: u64,
+    first_observed_at: String,
+    last_observed_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
 struct SiteAnalyticsRateResponse {
     metric: String,
     numerator_sessions: u64,
@@ -1502,6 +1515,7 @@ struct SiteAnalyticsResponse {
     event_counts: Vec<SiteAnalyticsEventCountResponse>,
     daily: Vec<SiteAnalyticsDailyResponse>,
     channels: Vec<SiteAnalyticsChannelResponse>,
+    interfaces: Vec<InterfaceUsageResponse>,
     rates: Vec<SiteAnalyticsRateResponse>,
     definitions: Vec<String>,
     evidence_boundary: String,
@@ -2616,6 +2630,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/public/templates/:slug", get(public_template_page))
         .route("/api-docs/openapi.json", get(openapi_json))
         .route("/docs", get(api_docs))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            observe_interface_usage,
+        ))
         .layer(CorsLayer::permissive())
         .layer(middleware::from_fn(redirect_marketing_domain))
         .with_state(state);
@@ -2639,6 +2657,40 @@ fn service_bind_addr(configured: Option<&str>, port: Option<&str>, default_addr:
                 .map(|value| format!("0.0.0.0:{}", value.trim()))
         })
         .unwrap_or_else(|| default_addr.to_string())
+}
+
+fn attributed_api_interface(headers: &HeaderMap) -> Option<ObservedInterface> {
+    let value = headers.get(INTERFACE_ATTRIBUTION_HEADER)?.to_str().ok()?;
+    if value.eq_ignore_ascii_case("api") {
+        Some(ObservedInterface::Api)
+    } else if value.eq_ignore_ascii_case("cli") {
+        Some(ObservedInterface::Cli)
+    } else {
+        None
+    }
+}
+
+async fn observe_interface_usage(
+    State(state): State<SharedState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let interface = attributed_api_interface(request.headers());
+    let response = next.run(request).await;
+    if let (Some(store), Some(interface)) = (state.store.clone(), interface) {
+        let succeeded = response.status().is_success();
+        tokio::spawn(async move {
+            let _ = store
+                .record_interface_usage(
+                    interface,
+                    ObservedProtocolEra::NotApplicable,
+                    succeeded,
+                    Utc::now(),
+                )
+                .await;
+        });
+    }
+    response
 }
 
 #[utoipa::path(get, path = "/health", responses((status = 200, body = String)))]
@@ -4821,7 +4873,7 @@ fn site_analytics_response(
         ),
     ];
     SiteAnalyticsResponse {
-        schema_version: "agent-bounties/site-analytics-v1".to_string(),
+        schema_version: "agent-bounties/site-analytics-v2".to_string(),
         window_hours,
         window_started_at: window_started_at.to_rfc3339(),
         generated_at: generated_at.to_rfc3339(),
@@ -4873,14 +4925,28 @@ fn site_analytics_response(
                 claims_confirmed: channel.claims_confirmed,
             })
             .collect(),
+        interfaces: stats
+            .interfaces
+            .into_iter()
+            .map(|usage| InterfaceUsageResponse {
+                interface: usage.interface,
+                protocol_era: usage.protocol_era,
+                request_count: usage.request_count,
+                successful_request_count: usage.successful_request_count,
+                first_observed_at: usage.first_observed_at.to_rfc3339(),
+                last_observed_at: usage.last_observed_at.to_rfc3339(),
+            })
+            .collect(),
         rates,
         definitions: vec![
             "A visitor is one random browser-local UUID with a 90-day lifetime, not a person or wallet.".to_string(),
             "A returning visitor is the same browser-local UUID observed on at least two UTC dates in the selected window.".to_string(),
             "A session is one random sessionStorage UUID and ends with that browser tab session.".to_string(),
             "Channel attribution uses the visitor's earliest recorded privacy-safe source and campaign; only the referrer hostname is retained.".to_string(),
+            "Interface usage is an hourly aggregate of observed requests, not unique people, agents, clients, or sessions; partial boundary hours are included.".to_string(),
+            "API and CLI attribution is self-declared through x-agent-bounties-interface; MCP protocol era is observed by the MCP service.".to_string(),
         ],
-        evidence_boundary: "Collection begins only after this feature is deployed and has no historical backfill. Cleared storage, private browsing, multiple devices, disabled analytics, Global Privacy Control, and Do Not Track affect coverage. No IP address, user agent, full referrer URL, wallet, or arbitrary metadata is stored. Client conversion events describe observed interface actions; canonical lifecycle and payment claims remain authoritative only in confirmed canonical events, and only BountySettled proves solver payment.".to_string(),
+        evidence_boundary: "Collection begins only after each feature is deployed and has no historical backfill. Cleared storage, private browsing, multiple devices, disabled analytics, Global Privacy Control, and Do Not Track affect browser coverage. Interface counters cannot deduplicate users or prove preference, and self-declared API or CLI attribution can be absent or spoofed. No IP address, user agent, full referrer URL, wallet, client identifier, request body, prompt, or tool arguments are stored. Client conversion events describe observed interface actions; canonical lifecycle and payment claims remain authoritative only in confirmed canonical events, and only BountySettled proves solver payment.".to_string(),
     }
 }
 
@@ -16720,6 +16786,36 @@ mod tests {
         assert_eq!(event.source.as_deref(), Some("github"));
         assert_eq!(event.referrer_host.as_deref(), Some("github.com"));
         assert_eq!(event.page_path, "/competition.html");
+    }
+
+    #[test]
+    fn interface_attribution_accepts_only_explicit_api_or_cli_values() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(attributed_api_interface(&headers), None);
+
+        headers.insert(
+            INTERFACE_ATTRIBUTION_HEADER,
+            HeaderValue::from_static("api"),
+        );
+        assert_eq!(
+            attributed_api_interface(&headers),
+            Some(ObservedInterface::Api)
+        );
+
+        headers.insert(
+            INTERFACE_ATTRIBUTION_HEADER,
+            HeaderValue::from_static("CLI"),
+        );
+        assert_eq!(
+            attributed_api_interface(&headers),
+            Some(ObservedInterface::Cli)
+        );
+
+        headers.insert(
+            INTERFACE_ATTRIBUTION_HEADER,
+            HeaderValue::from_static("website"),
+        );
+        assert_eq!(attributed_api_interface(&headers), None);
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -54,6 +54,8 @@ use std::{
 };
 use uuid::Uuid;
 
+const INTERFACE_ATTRIBUTION_HEADER: &str = "x-agent-bounties-interface";
+
 #[derive(Parser)]
 #[command(name = "agent-bounties")]
 #[command(about = "Claim verified work. Earn Base USDC.")]
@@ -3767,6 +3769,14 @@ async fn production_smoke_check(
 ) -> Result<ProductionSmokeReport> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
+        .default_headers({
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(
+                INTERFACE_ATTRIBUTION_HEADER,
+                reqwest::header::HeaderValue::from_static("cli"),
+            );
+            headers
+        })
         .build()?;
 
     let api_health = production_get_health(&client, &format!("{api}/health")).await?;
@@ -4968,6 +4978,7 @@ async fn leaderboard(api_base_url: String, network: String, at: Option<String>) 
     }
     let response = reqwest::Client::new()
         .get(&url)
+        .header(INTERFACE_ATTRIBUTION_HEADER, "cli")
         .query(&query)
         .send()
         .await
@@ -5019,7 +5030,7 @@ fn http_request_with_headers(
         extra_headers.push_str("\r\n");
     }
     let request = format!(
-        "{method} {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept: application/json\r\n{}\
+        "{method} {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept: application/json\r\n{INTERFACE_ATTRIBUTION_HEADER}: cli\r\n{}\
          {}\r\n{}",
         parsed.path, parsed.authority, content_headers, extra_headers, body
     );

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4133,8 +4133,46 @@ async fn production_smoke_check(
 
     let mcp_streamable_http = value_str(&discovery, "/endpoints/mcp_streamable_http")
         .context("Streamable HTTP MCP url missing")?;
+    let discover_response = client
+        .post(mcp_streamable_http)
+        .header("Accept", "application/json, text/event-stream")
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "server/discover")
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "production-smoke-discover",
+            "method": "server/discover",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "production-smoke",
+                        "version": "1"
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        }))
+        .send()
+        .await?;
+    require(
+        discover_response.status().is_success(),
+        "MCP 2026-07-28 server/discover must succeed",
+    )?;
+    let discover_json: serde_json::Value = discover_response.json().await?;
+    require(
+        discover_json["result"]["supportedVersions"] == serde_json::json!(["2026-07-28"])
+            && value_str(&discover_json, "/result/resultType") == Some("complete")
+            && value_str(
+                &discover_json,
+                "/result/_meta/io.modelcontextprotocol~1serverInfo/name",
+            ) == Some("agent-bounties"),
+        "MCP 2026-07-28 discovery contract drifted",
+    )?;
+
     let initialize_response = client
         .post(mcp_streamable_http)
+        .header("Accept", "application/json, text/event-stream")
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -4154,7 +4192,7 @@ async fn production_smoke_check(
     let initialize_json: serde_json::Value = initialize_response.json().await?;
     require(
         value_str(&initialize_json, "/result/serverInfo/name") == Some("agent-bounties"),
-        "Streamable HTTP MCP initialize returned the wrong server",
+        "legacy Streamable HTTP MCP initialize returned the wrong server",
     )?;
     for retired in [
         "plan_base_log_query",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4155,11 +4155,21 @@ async fn production_smoke_check(
         }))
         .send()
         .await?;
+    let discover_status = discover_response.status();
+    let discover_json: serde_json::Value = discover_response.json().await?;
+    if discover_json
+        .pointer("/error/code")
+        .and_then(|value| value.as_i64())
+        == Some(-32601)
+    {
+        bail!(
+            "MCP 2026-07-28 server/discover is unavailable: the deployed endpoint is legacy-only; deploy the dual-era MCP server before treating the modern core as live"
+        );
+    }
     require(
-        discover_response.status().is_success(),
+        discover_status.is_success(),
         "MCP 2026-07-28 server/discover must succeed",
     )?;
-    let discover_json: serde_json::Value = discover_response.json().await?;
     require(
         discover_json["result"]["supportedVersions"] == serde_json::json!(["2026-07-28"])
             && value_str(&discover_json, "/result/resultType") == Some("complete")
@@ -4167,7 +4177,7 @@ async fn production_smoke_check(
                 &discover_json,
                 "/result/_meta/io.modelcontextprotocol~1serverInfo/name",
             ) == Some("agent-bounties"),
-        "MCP 2026-07-28 discovery contract drifted",
+        "MCP 2026-07-28 discovery response is missing the supported version, complete result type, or server identity",
     )?;
 
     let initialize_response = client

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -61,6 +61,8 @@ pub const OPEN_COMPETITION_V1_MIGRATION: &str =
     include_str!("../../../migrations/0019_open_competition_v1.sql");
 pub const OPEN_COMPETITION_ENTRANT_RELAYS_MIGRATION: &str =
     include_str!("../../../migrations/0020_open_competition_entrant_relays.sql");
+pub const INTERFACE_USAGE_MIGRATION: &str =
+    include_str!("../../../migrations/0021_interface_usage.sql");
 const MIGRATION_ADVISORY_LOCK_ID: i64 = 4_270_265_017;
 const UPSERT_PAYMENT_EVENT_SQL: &str = r#"
             INSERT INTO payment_events (id, rail, external_id, status, payload_hash, received_at)
@@ -490,12 +492,59 @@ pub struct SiteAnalyticsChannelStats {
     pub claims_confirmed: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservedInterface {
+    Api,
+    Cli,
+    Mcp,
+}
+
+impl ObservedInterface {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Api => "api",
+            Self::Cli => "cli",
+            Self::Mcp => "mcp",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObservedProtocolEra {
+    NotApplicable,
+    McpLegacy,
+    McpModern,
+    McpHttpAdapter,
+}
+
+impl ObservedProtocolEra {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::NotApplicable => "not_applicable",
+            Self::McpLegacy => "legacy",
+            Self::McpModern => "modern",
+            Self::McpHttpAdapter => "http_adapter",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InterfaceUsageStats {
+    pub interface: String,
+    pub protocol_era: String,
+    pub request_count: u64,
+    pub successful_request_count: u64,
+    pub first_observed_at: DateTime<Utc>,
+    pub last_observed_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SiteAnalyticsStats {
     pub overview: SiteAnalyticsOverview,
     pub event_counts: Vec<SiteAnalyticsEventCount>,
     pub daily: Vec<SiteAnalyticsDailyStats>,
     pub channels: Vec<SiteAnalyticsChannelStats>,
+    pub interfaces: Vec<InterfaceUsageStats>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -963,6 +1012,7 @@ impl PostgresStore {
                 SOLVE_ACTION_RENAME_MIGRATION,
                 OPEN_COMPETITION_V1_MIGRATION,
                 OPEN_COMPETITION_ENTRANT_RELAYS_MIGRATION,
+                INTERFACE_USAGE_MIGRATION,
             ] {
                 for statement in migration
                     .split(';')
@@ -1373,6 +1423,57 @@ impl PostgresStore {
         Ok(inserted.is_some())
     }
 
+    pub async fn record_interface_usage(
+        &self,
+        interface: ObservedInterface,
+        protocol_era: ObservedProtocolEra,
+        succeeded: bool,
+        observed_at: DateTime<Utc>,
+    ) -> DbResult<()> {
+        let valid_pair = matches!(
+            (interface, protocol_era),
+            (
+                ObservedInterface::Api | ObservedInterface::Cli,
+                ObservedProtocolEra::NotApplicable
+            ) | (
+                ObservedInterface::Mcp,
+                ObservedProtocolEra::McpLegacy
+                    | ObservedProtocolEra::McpModern
+                    | ObservedProtocolEra::McpHttpAdapter
+            )
+        );
+        if !valid_pair {
+            return Err(DbError::InvalidEnum(
+                "interface and protocol era do not form a valid attribution pair".to_string(),
+            ));
+        }
+
+        sqlx::query(
+            r#"
+            INSERT INTO interface_usage_hourly
+              (bucket_started_at, interface, protocol_era, request_count,
+               successful_request_count, first_observed_at, last_observed_at)
+            VALUES (
+              date_trunc('hour', $1 AT TIME ZONE 'UTC') AT TIME ZONE 'UTC',
+              $2, $3, 1, CASE WHEN $4 THEN 1 ELSE 0 END, $1, $1
+            )
+            ON CONFLICT (bucket_started_at, interface, protocol_era) DO UPDATE SET
+              request_count = interface_usage_hourly.request_count + 1,
+              successful_request_count = interface_usage_hourly.successful_request_count
+                + CASE WHEN $4 THEN 1 ELSE 0 END,
+              first_observed_at = LEAST(interface_usage_hourly.first_observed_at, EXCLUDED.first_observed_at),
+              last_observed_at = GREATEST(interface_usage_hourly.last_observed_at, EXCLUDED.last_observed_at)
+            "#,
+        )
+        .bind(observed_at)
+        .bind(interface.as_str())
+        .bind(protocol_era.as_str())
+        .bind(succeeded)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     pub async fn reserve_social_mention_ingestion(
         &self,
         ingestion: &NewSocialMentionIngestion,
@@ -1629,6 +1730,28 @@ impl PostgresStore {
         .fetch_all(&self.pool)
         .await?;
 
+        let interface_rows = sqlx::query(
+            r#"
+            SELECT interface, protocol_era,
+                   SUM(request_count)::BIGINT AS request_count,
+                   SUM(successful_request_count)::BIGINT AS successful_request_count,
+                   MIN(first_observed_at) AS first_observed_at,
+                   MAX(last_observed_at) AS last_observed_at
+            FROM interface_usage_hourly
+            WHERE bucket_started_at >= (
+                    date_trunc('hour', $1 AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+                  )
+              AND bucket_started_at <= (
+                    date_trunc('hour', NOW() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+                  )
+            GROUP BY interface, protocol_era
+            ORDER BY request_count DESC, interface, protocol_era
+            "#,
+        )
+        .bind(window_started_at)
+        .fetch_all(&self.pool)
+        .await?;
+
         Ok(SiteAnalyticsStats {
             overview: SiteAnalyticsOverview {
                 unique_visitors: u64_from_i64(overview.try_get("unique_visitors")?)?,
@@ -1682,6 +1805,21 @@ impl PostgresStore {
                         )?,
                         funding_starts: u64_from_i64(row.try_get("funding_starts")?)?,
                         claims_confirmed: u64_from_i64(row.try_get("claims_confirmed")?)?,
+                    })
+                })
+                .collect::<DbResult<Vec<_>>>()?,
+            interfaces: interface_rows
+                .into_iter()
+                .map(|row| {
+                    Ok(InterfaceUsageStats {
+                        interface: row.try_get("interface")?,
+                        protocol_era: row.try_get("protocol_era")?,
+                        request_count: u64_from_i64(row.try_get("request_count")?)?,
+                        successful_request_count: u64_from_i64(
+                            row.try_get("successful_request_count")?,
+                        )?,
+                        first_observed_at: row.try_get("first_observed_at")?,
+                        last_observed_at: row.try_get("last_observed_at")?,
                     })
                 })
                 .collect::<DbResult<Vec<_>>>()?,
@@ -8235,6 +8373,39 @@ mod tests {
     }
 
     #[test]
+    fn interface_usage_migration_stores_only_hourly_aggregate_attribution() {
+        for invariant in [
+            "interface_usage_hourly",
+            "PRIMARY KEY (bucket_started_at, interface, protocol_era)",
+            "interface IN ('api', 'cli', 'mcp')",
+            "protocol_era IN ('not_applicable', 'legacy', 'modern', 'http_adapter')",
+            "request_count BIGINT NOT NULL",
+            "successful_request_count BIGINT NOT NULL",
+            "interface_usage_hourly_recent_idx",
+        ] {
+            assert!(
+                INTERFACE_USAGE_MIGRATION.contains(invariant),
+                "missing aggregate interface-usage invariant {invariant}"
+            );
+        }
+        for forbidden in [
+            "ip_address",
+            "user_agent",
+            "wallet_address",
+            "visitor_id",
+            "session_id",
+            "client_id",
+            "request_body",
+            "tool_arguments",
+        ] {
+            assert!(
+                !INTERFACE_USAGE_MIGRATION.contains(forbidden),
+                "interface usage must not persist {forbidden}"
+            );
+        }
+    }
+
+    #[test]
     fn social_mention_migration_is_durable_idempotent_and_lease_bounded() {
         for invariant in [
             "social_mention_ingestions",
@@ -8704,6 +8875,54 @@ mod tests {
         };
         assert!(store.record_site_analytics_event(&event).await.unwrap());
         assert!(!store.record_site_analytics_event(&event).await.unwrap());
+        let before = store
+            .site_analytics_stats(now - chrono::Duration::minutes(1))
+            .await
+            .unwrap();
+        let api_requests_before = before
+            .interfaces
+            .iter()
+            .find(|usage| usage.interface == "api")
+            .map(|usage| usage.request_count)
+            .unwrap_or(0);
+        store
+            .record_interface_usage(
+                ObservedInterface::Api,
+                ObservedProtocolEra::NotApplicable,
+                true,
+                now,
+            )
+            .await
+            .unwrap();
+        store
+            .record_interface_usage(
+                ObservedInterface::Cli,
+                ObservedProtocolEra::NotApplicable,
+                false,
+                now,
+            )
+            .await
+            .unwrap();
+        store
+            .record_interface_usage(
+                ObservedInterface::Mcp,
+                ObservedProtocolEra::McpModern,
+                true,
+                now,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            store
+                .record_interface_usage(
+                    ObservedInterface::Api,
+                    ObservedProtocolEra::McpModern,
+                    true,
+                    now,
+                )
+                .await,
+            Err(DbError::InvalidEnum(_))
+        ));
         let stats = store
             .site_analytics_stats(now - chrono::Duration::minutes(1))
             .await
@@ -8714,6 +8933,18 @@ mod tests {
             .channels
             .iter()
             .any(|channel| channel.source == "postgres-test"));
+        let api = stats
+            .interfaces
+            .iter()
+            .find(|usage| usage.interface == "api")
+            .expect("API usage is aggregated");
+        assert_eq!(api.protocol_era, "not_applicable");
+        assert!(api.request_count > api_requests_before);
+        assert!(stats.interfaces.iter().any(|usage| {
+            usage.interface == "mcp"
+                && usage.protocol_era == "modern"
+                && usage.successful_request_count >= 1
+        }));
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -8,8 +8,8 @@ use super::{
     public_base_url_from_env, publish_autonomous_submission_evidence, publish_unfunded_bounty,
     submit_unfunded_bounty_solution, tools, AgentNativeClaimArgs, AutonomousBountyFeedArgs,
     AutonomousVerificationJobsArgs, CompileObjectiveWithCloudAgentArgs, GetX402RelayStatusArgs,
-    ListUnfundedBountiesArgs, OpportunityListArgs, PaidStatusArgs,
-    PlanAutonomousAttestationSettlementArgs, PlanAutonomousBountyClaimArgs,
+    ListUnfundedBountiesArgs, ObservedInterface, ObservedProtocolEra, OpportunityListArgs,
+    PaidStatusArgs, PlanAutonomousAttestationSettlementArgs, PlanAutonomousBountyClaimArgs,
     PlanAutonomousModuleSettlementArgs, PlanAutonomousVerificationAttestationArgs,
     PrepareAgentToEarnInput, PrepareAutonomousBountySubmissionArgs, PrepareBountyPostArgs,
     PublishAutonomousSubmissionEvidenceArgs, PublishUnfundedBountyArgs, SharedState,
@@ -548,11 +548,39 @@ pub(super) async fn mcp_post(
     headers: HeaderMap,
     Json(payload): Json<Value>,
 ) -> Response {
+    let era = mcp_protocol_era(&headers, &payload);
+    let response = handle_mcp_post(state.clone(), headers, payload, era).await;
+    if let Some(store) = state.store.clone() {
+        let succeeded = response.status().is_success();
+        let protocol_era = match era {
+            McpProtocolEra::Legacy => ObservedProtocolEra::McpLegacy,
+            McpProtocolEra::Modern => ObservedProtocolEra::McpModern,
+        };
+        tokio::spawn(async move {
+            let _ = store
+                .record_interface_usage(
+                    ObservedInterface::Mcp,
+                    protocol_era,
+                    succeeded,
+                    chrono::Utc::now(),
+                )
+                .await;
+        });
+    }
+    response
+}
+
+async fn handle_mcp_post(
+    state: SharedState,
+    headers: HeaderMap,
+    payload: Value,
+    era: McpProtocolEra,
+) -> Response {
     if !mcp_origin_is_allowed(&headers) {
         return StatusCode::FORBIDDEN.into_response();
     }
 
-    if mcp_protocol_era(&headers, &payload) == McpProtocolEra::Modern {
+    if era == McpProtocolEra::Modern {
         if payload.is_array() {
             return mcp_error_response(
                 StatusCode::BAD_REQUEST,

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -19,7 +19,7 @@ use super::{
 use super::{AppState, ChatgptFileInput};
 use axum::{
     extract::State,
-    http::StatusCode,
+    http::{header::ORIGIN, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -33,7 +33,17 @@ use std::{env, net::IpAddr};
 use url::Url;
 use uuid::Uuid;
 
-const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
+const MCP_PROTOCOL_VERSION: &str = "2026-07-28";
+const MCP_LEGACY_PROTOCOL_VERSION: &str = "2025-06-18";
+const MCP_CATALOG_TTL_MS: u64 = 300_000;
+const MCP_PROTOCOL_VERSION_META: &str = "io.modelcontextprotocol/protocolVersion";
+const MCP_CLIENT_INFO_META: &str = "io.modelcontextprotocol/clientInfo";
+const MCP_CLIENT_CAPABILITIES_META: &str = "io.modelcontextprotocol/clientCapabilities";
+const MCP_SERVER_INFO_META: &str = "io.modelcontextprotocol/serverInfo";
+const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+const MCP_METHOD_HEADER: &str = "mcp-method";
+const MCP_NAME_HEADER: &str = "mcp-name";
+const MCP_ALLOWED_ORIGINS_ENV: &str = "MCP_ALLOWED_ORIGINS";
 const CHATGPT_SANDBOX_ENV: &str = "CHATGPT_APP_SANDBOX_MODE";
 const FEED_WIDGET_URI: &str = "ui://agent-bounties/live-feed-v4.html";
 const POST_PAGE_URL: &str = "https://agentbounties.app/post.html";
@@ -535,12 +545,39 @@ fn sandbox_bounty_image_reference(
 
 pub(super) async fn mcp_post(
     State(state): State<SharedState>,
+    headers: HeaderMap,
     Json(payload): Json<Value>,
 ) -> Response {
+    if !mcp_origin_is_allowed(&headers) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
+    if mcp_protocol_era(&headers, &payload) == McpProtocolEra::Modern {
+        if payload.is_array() {
+            return mcp_error_response(
+                StatusCode::BAD_REQUEST,
+                payload_id(&payload),
+                -32600,
+                "MCP 2026-07-28 accepts one JSON-RPC request per HTTP POST",
+                None,
+            );
+        }
+        if let Err(error) = validate_modern_request(&headers, &payload) {
+            return error.into_response(payload_id(&payload));
+        }
+        let Some((status, response)) = handle_request(state, payload, McpProtocolEra::Modern).await
+        else {
+            return StatusCode::ACCEPTED.into_response();
+        };
+        return (status, Json(response)).into_response();
+    }
+
     let responses = if let Some(batch) = payload.as_array() {
         let mut responses = Vec::new();
         for request in batch {
-            if let Some(response) = handle_request(state.clone(), request.clone()).await {
+            if let Some((_, response)) =
+                handle_request(state.clone(), request.clone(), McpProtocolEra::Legacy).await
+            {
                 responses.push(response);
             }
         }
@@ -548,7 +585,8 @@ pub(super) async fn mcp_post(
             return StatusCode::ACCEPTED.into_response();
         }
         Value::Array(responses)
-    } else if let Some(response) = handle_request(state, payload).await {
+    } else if let Some((_, response)) = handle_request(state, payload, McpProtocolEra::Legacy).await
+    {
         response
     } else {
         return StatusCode::ACCEPTED.into_response();
@@ -557,7 +595,10 @@ pub(super) async fn mcp_post(
     (StatusCode::OK, Json(responses)).into_response()
 }
 
-pub(super) async fn mcp_get() -> Response {
+pub(super) async fn mcp_get(headers: HeaderMap) -> Response {
+    if !mcp_origin_is_allowed(&headers) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
     (
         StatusCode::METHOD_NOT_ALLOWED,
         [("allow", "POST")],
@@ -566,39 +607,311 @@ pub(super) async fn mcp_get() -> Response {
         .into_response()
 }
 
-pub(super) async fn mcp_delete() -> Response {
-    StatusCode::METHOD_NOT_ALLOWED.into_response()
+pub(super) async fn mcp_delete(headers: HeaderMap) -> Response {
+    if !mcp_origin_is_allowed(&headers) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    (StatusCode::METHOD_NOT_ALLOWED, [("allow", "POST")]).into_response()
 }
 
-async fn handle_request(state: SharedState, request: Value) -> Option<Value> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpProtocolEra {
+    Legacy,
+    Modern,
+}
+
+#[derive(Debug)]
+struct McpProtocolError {
+    status: StatusCode,
+    code: i64,
+    message: String,
+    data: Option<Value>,
+}
+
+impl McpProtocolError {
+    fn header_mismatch(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: -32020,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    fn invalid_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: -32600,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    fn invalid_params(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: -32602,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    fn unsupported_version(requested: &str) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: -32022,
+            message: format!("Unsupported MCP protocol version: {requested}"),
+            data: Some(json!({
+                "supported": [MCP_PROTOCOL_VERSION],
+                "requested": requested
+            })),
+        }
+    }
+
+    fn into_response(self, id: Value) -> Response {
+        mcp_error_response(self.status, id, self.code, &self.message, self.data)
+    }
+}
+
+fn mcp_protocol_era(headers: &HeaderMap, payload: &Value) -> McpProtocolEra {
+    let header_is_modern = headers
+        .get(MCP_PROTOCOL_VERSION_HEADER)
+        .is_some_and(|value| {
+            value.to_str().map_or(true, |version| {
+                !matches!(version, "2024-11-05" | "2025-03-26" | "2025-06-18")
+            })
+        });
+    let body_has_request_metadata = payload
+        .get("params")
+        .and_then(|params| params.get("_meta"))
+        .and_then(|metadata| metadata.get(MCP_PROTOCOL_VERSION_META))
+        .is_some();
+    let is_discovery = payload
+        .get("method")
+        .and_then(Value::as_str)
+        .is_some_and(|method| method == "server/discover");
+
+    if header_is_modern || body_has_request_metadata || is_discovery {
+        McpProtocolEra::Modern
+    } else {
+        McpProtocolEra::Legacy
+    }
+}
+
+fn validate_modern_request(headers: &HeaderMap, request: &Value) -> Result<(), McpProtocolError> {
+    let object = request
+        .as_object()
+        .ok_or_else(|| McpProtocolError::invalid_request("Invalid Request"))?;
+    if object.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return Err(McpProtocolError::invalid_request(
+            "jsonrpc must be exactly '2.0'",
+        ));
+    }
+    if !object
+        .get("id")
+        .is_some_and(|id| id.is_string() || id.is_number())
+    {
+        return Err(McpProtocolError::invalid_request(
+            "MCP 2026-07-28 HTTP messages must be JSON-RPC requests with a string or number id",
+        ));
+    }
+    let method = object
+        .get("method")
+        .and_then(Value::as_str)
+        .ok_or_else(|| McpProtocolError::invalid_request("method must be a string"))?;
+    let params = object
+        .get("params")
+        .and_then(Value::as_object)
+        .ok_or_else(|| McpProtocolError::invalid_params("params must be an object"))?;
+    let metadata = params
+        .get("_meta")
+        .and_then(Value::as_object)
+        .ok_or_else(|| McpProtocolError::invalid_params("params._meta must be an object"))?;
+    let body_version = metadata
+        .get(MCP_PROTOCOL_VERSION_META)
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            McpProtocolError::header_mismatch(format!(
+                "params._meta.{MCP_PROTOCOL_VERSION_META} is required"
+            ))
+        })?;
+    let header_version = required_header(headers, MCP_PROTOCOL_VERSION_HEADER)?;
+    if header_version != body_version {
+        return Err(McpProtocolError::header_mismatch(format!(
+            "{MCP_PROTOCOL_VERSION_HEADER} header does not match request metadata"
+        )));
+    }
+    if body_version != MCP_PROTOCOL_VERSION {
+        return Err(McpProtocolError::unsupported_version(body_version));
+    }
+
+    let header_method = required_header(headers, MCP_METHOD_HEADER)?;
+    if header_method != method {
+        return Err(McpProtocolError::header_mismatch(format!(
+            "{MCP_METHOD_HEADER} header does not match method"
+        )));
+    }
+
+    if matches!(method, "tools/call" | "resources/read" | "prompts/get") {
+        let source_field = if method == "resources/read" {
+            "uri"
+        } else {
+            "name"
+        };
+        let body_name = params
+            .get(source_field)
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                McpProtocolError::invalid_params(format!(
+                    "{method} requires a string params.{source_field}"
+                ))
+            })?;
+        let header_name = decode_mcp_header_value(required_header(headers, MCP_NAME_HEADER)?)?;
+        if header_name != body_name {
+            return Err(McpProtocolError::header_mismatch(format!(
+                "{MCP_NAME_HEADER} header does not match params.{source_field}"
+            )));
+        }
+    }
+
+    if !metadata
+        .get(MCP_CLIENT_CAPABILITIES_META)
+        .is_some_and(Value::is_object)
+    {
+        return Err(McpProtocolError::invalid_params(format!(
+            "params._meta.{MCP_CLIENT_CAPABILITIES_META} must be an object"
+        )));
+    }
+    if let Some(client_info) = metadata.get(MCP_CLIENT_INFO_META) {
+        let valid = client_info.as_object().is_some_and(|client_info| {
+            client_info.get("name").is_some_and(Value::is_string)
+                && client_info.get("version").is_some_and(Value::is_string)
+        });
+        if !valid {
+            return Err(McpProtocolError::invalid_params(format!(
+                "params._meta.{MCP_CLIENT_INFO_META} must include string name and version fields"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn required_header<'a>(headers: &'a HeaderMap, name: &str) -> Result<&'a str, McpProtocolError> {
+    headers
+        .get(name)
+        .ok_or_else(|| McpProtocolError::header_mismatch(format!("missing {name} header")))?
+        .to_str()
+        .map_err(|_| McpProtocolError::header_mismatch(format!("malformed {name} header")))
+}
+
+fn decode_mcp_header_value(value: &str) -> Result<String, McpProtocolError> {
+    const PREFIX: &str = "=?base64?";
+    const SUFFIX: &str = "?=";
+    if value.starts_with(PREFIX) {
+        let encoded = value
+            .strip_prefix(PREFIX)
+            .and_then(|value| value.strip_suffix(SUFFIX))
+            .ok_or_else(|| McpProtocolError::header_mismatch("malformed Base64 header sentinel"))?;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|_| McpProtocolError::header_mismatch("invalid Base64 header value"))?;
+        return String::from_utf8(decoded)
+            .map_err(|_| McpProtocolError::header_mismatch("Base64 header value is not UTF-8"));
+    }
+    Ok(value.to_string())
+}
+
+fn payload_id(payload: &Value) -> Value {
+    payload.get("id").cloned().unwrap_or(Value::Null)
+}
+
+fn mcp_error_response(
+    status: StatusCode,
+    id: Value,
+    code: i64,
+    message: &str,
+    data: Option<Value>,
+) -> Response {
+    (
+        status,
+        Json(json_rpc_error_with_data(id, code, message, data)),
+    )
+        .into_response()
+}
+
+async fn handle_request(
+    state: SharedState,
+    request: Value,
+    era: McpProtocolEra,
+) -> Option<(StatusCode, Value)> {
     let Some(object) = request.as_object() else {
-        return Some(json_rpc_error(Value::Null, -32600, "Invalid Request"));
+        return Some((
+            StatusCode::OK,
+            json_rpc_error(Value::Null, -32600, "Invalid Request"),
+        ));
     };
     let id = object.get("id").cloned();
     let Some(method) = object.get("method").and_then(Value::as_str) else {
-        return Some(json_rpc_error(
-            id.unwrap_or(Value::Null),
-            -32600,
-            "Invalid Request",
+        return Some((
+            StatusCode::OK,
+            json_rpc_error(id.unwrap_or(Value::Null), -32600, "Invalid Request"),
         ));
     };
     let id = id?;
     let params = object.get("params").cloned().unwrap_or_else(|| json!({}));
 
     let result = match method {
-        "initialize" => Ok(initialize_result(&params)),
-        "ping" => Ok(json!({})),
-        "tools/list" => Ok(json!({"tools": chatgpt_tools().await})),
+        "server/discover" if era == McpProtocolEra::Modern => Ok(discover_result()),
+        "initialize" if era == McpProtocolEra::Legacy => Ok(initialize_result(&params)),
+        "ping" if era == McpProtocolEra::Legacy => Ok(json!({})),
+        "tools/list" => {
+            let mut tools = chatgpt_tools().await;
+            if era == McpProtocolEra::Modern {
+                tools.sort_by(|left, right| {
+                    left.get("name")
+                        .and_then(Value::as_str)
+                        .cmp(&right.get("name").and_then(Value::as_str))
+                });
+            }
+            Ok(json!({"tools": tools}))
+        }
         "tools/call" => call_tool(state, &params).await,
         "resources/list" => Ok(json!({"resources": [feed_widget_resource_descriptor()]})),
         "resources/templates/list" => Ok(json!({"resourceTemplates": []})),
         "resources/read" => read_resource(&params),
-        _ => return Some(json_rpc_error(id, -32601, "Method not found")),
+        _ => {
+            return Some((
+                if era == McpProtocolEra::Modern {
+                    StatusCode::NOT_FOUND
+                } else {
+                    StatusCode::OK
+                },
+                json_rpc_error(id, -32601, "Method not found"),
+            ))
+        }
     };
 
     Some(match result {
-        Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
-        Err(error) => json_rpc_error(id, -32602, &error),
+        Ok(result) => (
+            StatusCode::OK,
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": if era == McpProtocolEra::Modern {
+                    modern_result(method, result)
+                } else {
+                    result
+                }
+            }),
+        ),
+        Err(error) => (
+            if era == McpProtocolEra::Modern {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::OK
+            },
+            json_rpc_error(id, -32602, &error),
+        ),
     })
 }
 
@@ -606,45 +919,168 @@ fn initialize_result(params: &Value) -> Value {
     let requested = params
         .get("protocolVersion")
         .and_then(Value::as_str)
-        .unwrap_or(MCP_PROTOCOL_VERSION);
+        .unwrap_or(MCP_LEGACY_PROTOCOL_VERSION);
     let protocol_version = match requested {
         "2024-11-05" | "2025-03-26" | "2025-06-18" => requested,
-        _ => MCP_PROTOCOL_VERSION,
+        _ => MCP_LEGACY_PROTOCOL_VERSION,
     };
+    json!({
+        "protocolVersion": protocol_version,
+        "capabilities": mcp_server_capabilities(),
+        "serverInfo": mcp_server_info(),
+        "instructions": mcp_server_instructions()
+    })
+}
+
+fn discover_result() -> Value {
+    json!({
+        "supportedVersions": [MCP_PROTOCOL_VERSION],
+        "capabilities": mcp_server_capabilities(),
+        "instructions": mcp_server_instructions()
+    })
+}
+
+fn mcp_server_instructions() -> &'static str {
     let sandbox = chatgpt_sandbox_mode();
     let public_review = !sandbox && chatgpt_public_review_mode();
-    let instructions = if sandbox {
+    if sandbox {
         "Sandbox mode is active. Use get_bounty_feed and render_bounty_feed to exercise the complete in-chat bounty UI. Use prepare_moonpay_onramp to exercise the external top-up handoff without opening MoonPay, and use prepare_bounty_action plus get_bounty_action_status to exercise the hosted bounty lifecycle without opening a wallet. Every tool returns deterministic fixture data and performs no network write, wallet action, public comment, publication, funding, claim, submission, verification, settlement, purchase, or payment. Never describe sandbox output as canonical evidence."
     } else if public_review {
         "Public review mode is active. Show only voluntary, unfunded community requests with no payment promise. Use render_bounty_feed for the compact in-chat work queue, publish_unfunded_bounty only when the user explicitly asks to publish a voluntary request, compile_objective_with_cloud_agent only for non-economic task decomposition, and the comment and share tools for public collaboration. Funding, claiming, completion, verification, wallet, settlement, token, and payment actions are unavailable in this app configuration. Never imply otherwise or direct a user around this boundary."
     } else {
         "Use get_bounty_feed to inspect fresh structured bounty data, then render_bounty_feed to show the mounted read-only feed in ChatGPT. The widget has only Post bounty, Comment, Share, and Solve actions; each action starts a conversation. For a new bounty, interview the person until the terms and image direction are complete, generate a unique bounty image in their ChatGPT account, show it for approval, summarize the complete bounty, and obtain explicit confirmation. Then call prepare_bounty_post with that approved ChatGPT image file; Agent Bounties stores the exact file and never generates a replacement. For fund, solve or claim, complete, or verify, call prepare_bounty_action and open only its first-party HTTPS authorization URL. If a funder needs Base USDC, call prepare_moonpay_onramp and open only its first-party HTTPS handoff; MoonPay purchase, wallet connection, identity checks, and card entry stay outside ChatGPT, and buying USDC is not bounty funding. Never request or accept a wallet signature, private key, seed phrase, payment authorization, verifier signature, or card data in ChatGPT. Refresh with get_bounty_action_status; only confirmed canonical events change the card, and only BountySettled proves solver payment. Use compile_objective_with_cloud_agent to break a broad objective into smaller reviewable child bounties. Use create_share_bundle after every meaningful step."
-    };
+    }
+}
+
+fn mcp_server_capabilities() -> Value {
     json!({
-        "protocolVersion": protocol_version,
-        "capabilities": {
-            "tools": {"listChanged": false},
-            "resources": {"subscribe": false, "listChanged": false}
-        },
-        "serverInfo": {
-            "name": if sandbox {
-                "agent-bounties-sandbox"
-            } else if public_review {
-                "agent-bounties-community"
-            } else {
-                "agent-bounties"
-            },
-            "title": if sandbox {
-                "Agent Bounties Sandbox"
-            } else if public_review {
-                "Agent Bounties Community"
-            } else {
-                "Agent Bounties"
-            },
-            "version": env!("CARGO_PKG_VERSION")
-        },
-        "instructions": instructions
+        "tools": {"listChanged": false},
+        "resources": {"subscribe": false, "listChanged": false}
     })
+}
+
+fn mcp_server_info() -> Value {
+    let sandbox = chatgpt_sandbox_mode();
+    let public_review = !sandbox && chatgpt_public_review_mode();
+    json!({
+        "name": if sandbox {
+            "agent-bounties-sandbox"
+        } else if public_review {
+            "agent-bounties-community"
+        } else {
+            "agent-bounties"
+        },
+        "title": if sandbox {
+            "Agent Bounties Sandbox"
+        } else if public_review {
+            "Agent Bounties Community"
+        } else {
+            "Agent Bounties"
+        },
+        "version": env!("CARGO_PKG_VERSION")
+    })
+}
+
+fn modern_result(method: &str, mut result: Value) -> Value {
+    let object = result
+        .as_object_mut()
+        .expect("every implemented MCP method returns an object result");
+    object.insert("resultType".to_string(), json!("complete"));
+    let metadata = object
+        .entry("_meta".to_string())
+        .or_insert_with(|| json!({}));
+    if !metadata.is_object() {
+        *metadata = json!({});
+    }
+    metadata[MCP_SERVER_INFO_META] = mcp_server_info();
+    if matches!(
+        method,
+        "server/discover"
+            | "tools/list"
+            | "resources/list"
+            | "resources/templates/list"
+            | "resources/read"
+    ) {
+        object.insert("ttlMs".to_string(), json!(MCP_CATALOG_TTL_MS));
+        object.insert("cacheScope".to_string(), json!("public"));
+    }
+    result
+}
+
+fn mcp_origin_is_allowed(headers: &HeaderMap) -> bool {
+    let Some(origin) = headers.get(ORIGIN) else {
+        return true;
+    };
+    let Ok(origin) = origin.to_str() else {
+        return false;
+    };
+    mcp_origin_is_allowed_with_config(
+        origin,
+        env::var("MCP_BASE_URL").ok().as_deref(),
+        env::var(MCP_ALLOWED_ORIGINS_ENV).ok().as_deref(),
+    )
+}
+
+fn mcp_origin_is_allowed_with_config(
+    origin: &str,
+    mcp_base_url: Option<&str>,
+    configured_origins: Option<&str>,
+) -> bool {
+    let Some(origin) = normalized_mcp_origin(origin) else {
+        return false;
+    };
+    let defaults = [
+        "https://chatgpt.com",
+        "https://chat.openai.com",
+        "https://agentbounties.app",
+        "https://www.agentbounties.app",
+        "https://mcp.agentbounties.app",
+    ];
+    if defaults.contains(&origin.as_str()) || is_loopback_http_origin(&origin) {
+        return true;
+    }
+    if mcp_base_url
+        .and_then(normalized_mcp_origin)
+        .is_some_and(|allowed| allowed == origin)
+    {
+        return true;
+    }
+    configured_origins.is_some_and(|configured| {
+        configured.split(',').any(|allowed| {
+            normalized_mcp_origin(allowed.trim()).is_some_and(|allowed| allowed == origin)
+        })
+    })
+}
+
+fn normalized_mcp_origin(value: &str) -> Option<String> {
+    let url = Url::parse(value).ok()?;
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || !matches!(url.path(), "" | "/")
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.host_str().is_none()
+        || !matches!(url.scheme(), "http" | "https")
+    {
+        return None;
+    }
+    Some(url.origin().ascii_serialization())
+}
+
+fn is_loopback_http_origin(origin: &str) -> bool {
+    let Ok(url) = Url::parse(origin) else {
+        return false;
+    };
+    if url.scheme() != "http" {
+        return false;
+    }
+    match url.host_str() {
+        Some("localhost") => true,
+        Some(host) => host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback()),
+        None => false,
+    }
 }
 
 async fn chatgpt_tools() -> Vec<Value> {
@@ -3503,10 +3939,18 @@ fn format_usdc(amount: u64) -> String {
 }
 
 fn json_rpc_error(id: Value, code: i64, message: &str) -> Value {
+    json_rpc_error_with_data(id, code, message, None)
+}
+
+fn json_rpc_error_with_data(id: Value, code: i64, message: &str, data: Option<Value>) -> Value {
+    let mut error = json!({"code": code, "message": message});
+    if let Some(data) = data {
+        error["data"] = data;
+    }
     json!({
         "jsonrpc": "2.0",
         "id": id,
-        "error": {"code": code, "message": message}
+        "error": error
     })
 }
 
@@ -3847,6 +4291,218 @@ mod tests {
             store: None,
             recovery_reservations: AutonomousBountyRecoveryReservations::default(),
         })
+    }
+
+    fn modern_request(
+        method: &'static str,
+        mut params: Value,
+        name: Option<&str>,
+    ) -> (HeaderMap, Value) {
+        params["_meta"] = json!({
+            (MCP_PROTOCOL_VERSION_META): MCP_PROTOCOL_VERSION,
+            (MCP_CLIENT_INFO_META): {
+                "name": "agent-bounties-protocol-test",
+                "version": "1.0.0"
+            },
+            (MCP_CLIENT_CAPABILITIES_META): {}
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_PROTOCOL_VERSION.parse().unwrap(),
+        );
+        headers.insert(MCP_METHOD_HEADER, method.parse().unwrap());
+        if let Some(name) = name {
+            headers.insert(MCP_NAME_HEADER, name.parse().unwrap());
+        }
+        (
+            headers,
+            json!({
+                "jsonrpc": "2.0",
+                "id": "protocol-test",
+                "method": method,
+                "params": params
+            }),
+        )
+    }
+
+    #[tokio::test]
+    async fn modern_discovery_is_stateless_typed_and_cacheable() {
+        let (headers, request) = modern_request("server/discover", json!({}), None);
+        assert_eq!(mcp_protocol_era(&headers, &request), McpProtocolEra::Modern);
+        validate_modern_request(&headers, &request).unwrap();
+
+        let (status, response) =
+            handle_request(public_tool_test_state(), request, McpProtocolEra::Modern)
+                .await
+                .unwrap();
+        let result = &response["result"];
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(result["supportedVersions"], json!([MCP_PROTOCOL_VERSION]));
+        assert_eq!(result["resultType"], "complete");
+        assert_eq!(result["ttlMs"], MCP_CATALOG_TTL_MS);
+        assert_eq!(result["cacheScope"], "public");
+        assert_eq!(
+            result["_meta"][MCP_SERVER_INFO_META]["version"],
+            env!("CARGO_PKG_VERSION")
+        );
+        assert_eq!(result["capabilities"]["tools"]["listChanged"], false);
+        assert_eq!(result["capabilities"]["resources"]["subscribe"], false);
+        assert!(result.get("protocolVersion").is_none());
+    }
+
+    #[tokio::test]
+    async fn modern_tool_catalog_is_deterministic_typed_and_cacheable() {
+        let (headers, request) = modern_request("tools/list", json!({}), None);
+        validate_modern_request(&headers, &request).unwrap();
+        let (_, response) =
+            handle_request(public_tool_test_state(), request, McpProtocolEra::Modern)
+                .await
+                .unwrap();
+        let result = &response["result"];
+        let names = result["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        let mut sorted_names = names.clone();
+        sorted_names.sort_unstable();
+
+        assert_eq!(names, sorted_names);
+        assert_eq!(result["resultType"], "complete");
+        assert_eq!(result["ttlMs"], MCP_CATALOG_TTL_MS);
+        assert_eq!(result["cacheScope"], "public");
+        assert!(result["_meta"][MCP_SERVER_INFO_META].is_object());
+    }
+
+    #[test]
+    fn modern_headers_must_match_the_request_body() {
+        let (mut headers, request) = modern_request("tools/list", json!({}), None);
+        headers.insert(MCP_METHOD_HEADER, "resources/list".parse().unwrap());
+        let error = validate_modern_request(&headers, &request).unwrap_err();
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.code, -32020);
+
+        let (mut headers, mut request) = modern_request("tools/list", json!({}), None);
+        headers.insert(MCP_PROTOCOL_VERSION_HEADER, "2099-01-01".parse().unwrap());
+        request["params"]["_meta"][MCP_PROTOCOL_VERSION_META] = json!("2099-01-01");
+        let error = validate_modern_request(&headers, &request).unwrap_err();
+        assert_eq!(error.code, -32022);
+        assert_eq!(
+            error.data.unwrap()["supported"],
+            json!([MCP_PROTOCOL_VERSION])
+        );
+    }
+
+    #[test]
+    fn modern_name_header_supports_the_required_base64_sentinel() {
+        let resource_uri = "ui://agent-bounties/世界.html";
+        let encoded = format!(
+            "=?base64?{}?=",
+            base64::engine::general_purpose::STANDARD.encode(resource_uri)
+        );
+        let (mut headers, request) =
+            modern_request("resources/read", json!({"uri": resource_uri}), None);
+        headers.insert(MCP_NAME_HEADER, encoded.parse().unwrap());
+
+        validate_modern_request(&headers, &request).unwrap();
+        assert_eq!(decode_mcp_header_value(&encoded).unwrap(), resource_uri);
+        assert_eq!(decode_mcp_header_value("ordinary?=").unwrap(), "ordinary?=");
+        assert!(decode_mcp_header_value("=?base64?not-valid?=").is_err());
+    }
+
+    #[tokio::test]
+    async fn legacy_initialize_remains_available_without_modern_metadata() {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": MCP_LEGACY_PROTOCOL_VERSION}
+        });
+        assert_eq!(
+            mcp_protocol_era(&HeaderMap::new(), &request),
+            McpProtocolEra::Legacy
+        );
+        let (status, response) =
+            handle_request(public_tool_test_state(), request, McpProtocolEra::Legacy)
+                .await
+                .unwrap();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            response["result"]["protocolVersion"],
+            MCP_LEGACY_PROTOCOL_VERSION
+        );
+        assert!(response["result"].get("resultType").is_none());
+
+        let mut legacy_headers = HeaderMap::new();
+        legacy_headers.insert(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_LEGACY_PROTOCOL_VERSION.parse().unwrap(),
+        );
+        assert_eq!(
+            mcp_protocol_era(
+                &legacy_headers,
+                &json!({"method": "tools/list", "params": {}})
+            ),
+            McpProtocolEra::Legacy
+        );
+        legacy_headers.insert(MCP_PROTOCOL_VERSION_HEADER, "2099-01-01".parse().unwrap());
+        assert_eq!(
+            mcp_protocol_era(
+                &legacy_headers,
+                &json!({"method": "tools/list", "params": {}})
+            ),
+            McpProtocolEra::Modern
+        );
+    }
+
+    #[tokio::test]
+    async fn removed_handshake_methods_are_not_exposed_to_modern_clients() {
+        let (headers, request) = modern_request("initialize", json!({}), None);
+        validate_modern_request(&headers, &request).unwrap();
+        let (status, response) =
+            handle_request(public_tool_test_state(), request, McpProtocolEra::Modern)
+                .await
+                .unwrap();
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(response["error"]["code"], -32601);
+    }
+
+    #[test]
+    fn origin_validation_is_exact_and_configurable() {
+        assert!(mcp_origin_is_allowed_with_config(
+            "https://chatgpt.com",
+            None,
+            None
+        ));
+        assert!(mcp_origin_is_allowed_with_config(
+            "http://127.0.0.1:3000",
+            None,
+            None
+        ));
+        assert!(mcp_origin_is_allowed_with_config(
+            "https://tenant.example",
+            Some("https://tenant.example"),
+            None
+        ));
+        assert!(mcp_origin_is_allowed_with_config(
+            "https://client.example",
+            None,
+            Some("https://one.example, https://client.example")
+        ));
+        for rejected in [
+            "null",
+            "http://chatgpt.com",
+            "https://chatgpt.com.evil.example",
+            "https://user:secret@chatgpt.com",
+            "https://chatgpt.com/path",
+        ] {
+            assert!(
+                !mcp_origin_is_allowed_with_config(rejected, None, None),
+                "expected rejected Origin: {rejected}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -7,8 +7,9 @@ use app::{
     RejectRiskEventRequest, RiskEventFilter, SubmitResultRequest, VerifySubmissionRequest,
 };
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Request, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
@@ -32,7 +33,7 @@ use chain_base::{
     StandingMetaV2ChildPreparationRequest,
 };
 use chrono::Utc;
-use db::PostgresStore;
+use db::{ObservedInterface, ObservedProtocolEra, PostgresStore};
 use domain::{
     Agent, AutonomousBountyTermsDocument, BountyStatus, CapabilityClass,
     DiscoverySubscriptionFilters, EvalRun, HelpRequest, Id, Money, Objective, ObjectiveAction,
@@ -1969,6 +1970,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/tools/approve_risk_bounty", post(approve_risk_bounty))
         .route("/tools/approve_risk_payout", post(approve_risk_payout))
         .route("/tools/reject_risk_event", post(reject_risk_event))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            observe_mcp_http_adapter,
+        ))
         .layer(CorsLayer::permissive())
         .with_state(state);
 
@@ -1991,6 +1996,35 @@ fn service_bind_addr(configured: Option<&str>, port: Option<&str>, default_addr:
                 .map(|value| format!("0.0.0.0:{}", value.trim()))
         })
         .unwrap_or_else(|| default_addr.to_string())
+}
+
+fn is_mcp_http_adapter_path(path: &str) -> bool {
+    path == "/tools" || path.starts_with("/tools/")
+}
+
+async fn observe_mcp_http_adapter(
+    State(state): State<SharedState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let observed = is_mcp_http_adapter_path(request.uri().path());
+    let response = next.run(request).await;
+    if observed {
+        if let Some(store) = state.store.clone() {
+            let succeeded = response.status().is_success();
+            tokio::spawn(async move {
+                let _ = store
+                    .record_interface_usage(
+                        ObservedInterface::Mcp,
+                        ObservedProtocolEra::McpHttpAdapter,
+                        succeeded,
+                        Utc::now(),
+                    )
+                    .await;
+            });
+        }
+    }
+    response
 }
 
 async fn agent_bounties_discovery() -> Json<web_public::DiscoveryManifest> {
@@ -7131,6 +7165,14 @@ mod tests {
 
     fn test_state() -> SharedState {
         test_state_with_network(BountyNetwork::default())
+    }
+
+    #[test]
+    fn interface_attribution_distinguishes_http_adapter_from_protocol_endpoint() {
+        assert!(is_mcp_http_adapter_path("/tools"));
+        assert!(is_mcp_http_adapter_path("/tools/list_opportunities"));
+        assert!(!is_mcp_http_adapter_path("/mcp"));
+        assert!(!is_mcp_http_adapter_path("/health"));
     }
 
     fn test_state_with_network(network: BountyNetwork) -> SharedState {

--- a/crates/sdk-python/agent_bounties/client.py
+++ b/crates/sdk-python/agent_bounties/client.py
@@ -116,10 +116,11 @@ class AgentBountiesClient:
         self.base_url = base_url.rstrip("/")
         self.operator_api_token = operator_api_token or os.getenv("OPERATOR_API_TOKEN")
 
-    def _headers(self) -> dict[str, str] | None:
+    def _headers(self) -> dict[str, str]:
+        headers = {"x-agent-bounties-interface": "api"}
         if self.operator_api_token:
-            return {"x-operator-token": self.operator_api_token}
-        return None
+            headers["x-operator-token"] = self.operator_api_token
+        return headers
 
     def _http(
         self,

--- a/crates/sdk-python/tests/test_native_signature.py
+++ b/crates/sdk-python/tests/test_native_signature.py
@@ -159,7 +159,11 @@ class NativeSignatureTests(unittest.TestCase):
         self.assertEqual(request.call_args.kwargs["params"], {"false": False, "zero": 0})
         self.assertEqual(
             request.call_args.kwargs["headers"],
-            {"x-operator-token": "operator", "x-extra": "value"},
+            {
+                "x-agent-bounties-interface": "api",
+                "x-operator-token": "operator",
+                "x-extra": "value",
+            },
         )
 
     def test_stripe_event_methods_share_identical_transport_contract(self):
@@ -175,7 +179,11 @@ class NativeSignatureTests(unittest.TestCase):
                     self.assertEqual(request.call_args.args, ("POST", f"https://example.test{path}"))
                     self.assertEqual(
                         request.call_args.kwargs["headers"],
-                        {"x-operator-token": "operator", "stripe-signature": "signature"},
+                        {
+                            "x-agent-bounties-interface": "api",
+                            "x-operator-token": "operator",
+                            "stripe-signature": "signature",
+                        },
                     )
 
 

--- a/crates/sdk-typescript/fixtures/public-api.json
+++ b/crates/sdk-typescript/fixtures/public-api.json
@@ -1,5 +1,5 @@
 {
   "schema_version": "agent-bounties/typescript-sdk-public-api-v1",
-  "normalized_declaration_lines": 883,
-  "normalized_declaration_sha256": "394c17e575acdaa4a7a60de736c44e99cac8d5840d5dba9eb93732a5f5b7bbb8"
+  "normalized_declaration_lines": 891,
+  "normalized_declaration_sha256": "f9aff3129e21c21240b9030466f60dec2fce53c815eafd0f2fd3c4e694c5de86"
 }

--- a/crates/sdk-typescript/src/index.ts
+++ b/crates/sdk-typescript/src/index.ts
@@ -565,7 +565,7 @@ export interface OpportunityConversionFunnel extends Record<string, unknown> {
 }
 
 export interface SiteAnalyticsReport extends Record<string, unknown> {
-  schema_version: "agent-bounties/site-analytics-v1";
+  schema_version: "agent-bounties/site-analytics-v2";
   window_hours: number;
   window_started_at: string;
   generated_at: string;
@@ -580,6 +580,14 @@ export interface SiteAnalyticsReport extends Record<string, unknown> {
   event_counts: Array<Record<string, unknown>>;
   daily: Array<Record<string, unknown>>;
   channels: Array<Record<string, unknown>>;
+  interfaces: Array<{
+    interface: "api" | "cli" | "mcp";
+    protocol_era: "not_applicable" | "legacy" | "modern" | "http_adapter";
+    request_count: number;
+    successful_request_count: number;
+    first_observed_at: string;
+    last_observed_at: string;
+  }>;
   rates: Array<Record<string, unknown>>;
   definitions: string[];
   evidence_boundary: string;
@@ -998,6 +1006,7 @@ export class AgentBountiesClient {
       ...init,
       headers: {
         "content-type": "application/json",
+        "x-agent-bounties-interface": "api",
         ...(this.operatorApiToken ? { "x-operator-token": this.operatorApiToken } : {}),
         ...(init?.headers ?? {}),
       },
@@ -1072,6 +1081,7 @@ export class AgentBountiesClient {
     const response = await fetch(`${this.baseUrl}${path}`, {
       method: "GET",
       headers: {
+        "x-agent-bounties-interface": "api",
         ...(this.operatorApiToken ? { "x-operator-token": this.operatorApiToken } : {}),
         ...(request.payment_signature
           ? { "PAYMENT-SIGNATURE": request.payment_signature }
@@ -1092,9 +1102,10 @@ export class AgentBountiesClient {
   async getX402RelayStatus(relayId: string): Promise<X402BountyFundingResponse> {
     const path = `/v1/x402/base/relays/${relayId}`;
     const response = await fetch(`${this.baseUrl}${path}`, {
-      headers: this.operatorApiToken
-        ? { "x-operator-token": this.operatorApiToken }
-        : undefined,
+      headers: {
+        "x-agent-bounties-interface": "api",
+        ...(this.operatorApiToken ? { "x-operator-token": this.operatorApiToken } : {}),
+      },
     });
     if (![200, 202, 404, 422, 503].includes(response.status)) {
       throw new Error(`${path} failed: ${response.status}`);

--- a/crates/sdk-typescript/tests/native-signature.mjs
+++ b/crates/sdk-typescript/tests/native-signature.mjs
@@ -21,6 +21,27 @@ test("public declarations match the compatibility fixture", async () => {
   );
 });
 
+test("SDK requests declare API interface attribution without a client identifier", async () => {
+  const originalFetch = globalThis.fetch;
+  let observedHeaders;
+  globalThis.fetch = async (_url, init) => {
+    observedHeaders = new Headers(init.headers);
+    return new Response(JSON.stringify({ schema: "discovery" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const client = new AgentBountiesClient("https://api.example");
+    await client.getDiscoveryManifest();
+    assert.equal(observedHeaders.get("x-agent-bounties-interface"), "api");
+    assert.equal(observedHeaders.get("x-client-id"), null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("agentNativeClaim replays a native wallet signature unchanged", async () => {
   const walletSignature = `0x${"11".repeat(64)}1b`;
   const requests = [];

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -29,9 +29,10 @@ For observable cross-lifecycle conversion metrics and their explicit coverage
 limits, see
 [`docs/opportunity-conversion-analytics.md`](opportunity-conversion-analytics.md).
 
-For privacy-minimized website visitors, acquisition channels, and observed
-interface actions, see [`docs/site-analytics.md`](site-analytics.md). Browser
-identifiers are not people, wallets, or independent-agent evidence; use the
+For privacy-minimized website visitors, acquisition channels, and hourly
+aggregate API, CLI, and MCP interactions, see
+[`docs/site-analytics.md`](site-analytics.md). Browser identifiers and request
+counts are not people, wallets, or independent-agent evidence; use the
 canonical conversion funnel for lifecycle and settlement questions.
 
 Agent Bounties is a machine-first Base USDC bounty protocol. The safest entry

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -4,6 +4,12 @@ Agent Bounties is a machine-first Base USDC protocol. Agents claim measurable di
 
 Do not skip steps.
 
+Choose the correct entrypoint before continuing: use the website for human
+browsing and wallet review, MCP for agent-native actions, REST/OpenAPI for
+ordinary service integration, and the CLI for local development and release
+rehearsal. See the [interaction guide](interaction-guide.md) for setup and the
+modern-versus-legacy MCP boundary.
+
 For filtered opportunity alerts, use the signed webhook surface documented in
 [`docs/discovery-subscriptions.md`](discovery-subscriptions.md). It extends the
 existing discovery/event tables and preserves each source endpoint as the

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -217,6 +217,11 @@ re-enter or edit the bounty in another form.
 The same remote MCP endpoint exposes the canonical earning sequence for a
 person using their normal AI conversation:
 
+The endpoint supports MCP `2026-07-28` stateless discovery and per-request
+metadata while retaining the legacy initialization flow for existing clients.
+See [MCP protocol compatibility](mcp-protocol-compatibility.md) for the exact
+headers, request metadata, response fields, and fallback boundary.
+
 `list_autonomous_bounties -> prepare_agent_to_earn -> agent_native_claim -> prepare_autonomous_bounty_submission -> publish_autonomous_submission_evidence -> list_autonomous_bounty_events`
 
 The AI may prepare and explain wallet requests, but the wallet operator reviews

--- a/docs/chatgpt-app-submission.md
+++ b/docs/chatgpt-app-submission.md
@@ -204,6 +204,9 @@ Production:
 
 ```text
 MCP_BASE_URL=https://mcp.agentbounties.app
+# Optional, comma-separated exact browser origins beyond the built-in
+# first-party and ChatGPT allowlist:
+MCP_ALLOWED_ORIGINS=https://approved-client.example
 PUBLIC_BASE_URL=https://api.agentbounties.app
 WEBSITE_BASE_URL=https://agentbounties.app
 OPENAI_APPS_CHALLENGE_TOKEN=<portal-token>
@@ -216,6 +219,10 @@ Sandbox:
 CHATGPT_APP_SANDBOX_MODE=true
 MCP_BASE_URL=https://<sandbox-mcp-origin>
 ```
+
+The endpoint uses MCP `2026-07-28` stateless discovery and strict per-request
+transport metadata, with a separate legacy initialization lane for current
+clients. See [MCP protocol compatibility](mcp-protocol-compatibility.md).
 
 The exact domain challenge is served at:
 

--- a/docs/interaction-guide.md
+++ b/docs/interaction-guide.md
@@ -1,0 +1,140 @@
+# Choose an Agent Bounties interface
+
+All interfaces expose the same evidence boundary: a plan, AI response,
+signature, transaction hash, or tool result is not payment. Only a confirmed
+canonical `BountySettled` event proves solver payment.
+
+## Which interface should I use?
+
+| Need | Recommended interface | Why |
+| --- | --- | --- |
+| Browse work or review/sign a wallet action | Website | Lowest setup and the clearest human review boundary |
+| Post or manage a bounty conversationally | ChatGPT app or another MCP-capable AI | Reuses the person's conversation context while keeping signatures and payments on first-party pages |
+| Build an autonomous agent integration | MCP `2026-07-28` | Typed discovery, self-contained requests, deterministic catalogs, and cache hints |
+| Maintain an existing connector | Legacy MCP | Compatibility for clients that still use `initialize`; do not choose it for a new implementation |
+| Integrate a service in any HTTP stack | REST API/OpenAPI | Stable request/response operations without an MCP client runtime |
+| Develop, rehearse, or operate the repository locally | Rust CLI | Deterministic demos, lifecycle smoke tests, and operator/release commands |
+
+## Website and ChatGPT app
+
+Browse ready-to-earn work at <https://agentbounties.app/earn.html>. Wallet
+review, signing, funding, claiming, and verification authorization remain on
+first-party HTTPS pages.
+
+For ChatGPT development or private use:
+
+1. Enable Developer Mode under **Settings > Apps & Connectors > Advanced settings**.
+2. Create an app and set its MCP URL to
+   `https://mcp.agentbounties.app/mcp`.
+3. Refresh the app after a server tool or metadata change.
+4. Ask it to inspect work or call `prepare_bounty_post` after the exact terms
+   and image are approved.
+
+The MCP client negotiates the protocol era. Do not add protocol headers by
+hand in a normal ChatGPT conversation.
+
+## Modern MCP
+
+New MCP clients should implement `2026-07-28`. First call `server/discover`,
+then use the advertised tools and resources. Every request must carry matching
+protocol and method headers plus the required request `_meta`; calls and reads
+also carry `Mcp-Name`. SDKs that support both eras may still default to the
+legacy handshake, so explicitly select modern or automatic version negotiation
+and confirm the result with the probe below.
+
+Verify an endpoint before enabling it:
+
+```bash
+python scripts/check-mcp-protocol-eras.py \
+  --endpoint https://mcp.agentbounties.app/mcp \
+  --expect dual
+```
+
+See [MCP protocol compatibility](mcp-protocol-compatibility.md) for the exact
+wire examples, errors, Origin policy, and fallback rules.
+
+## Legacy MCP
+
+Legacy support exists for deployed clients, not as the recommended new-client
+contract. A legacy client sends `initialize` with a supported version such as
+`2025-06-18`, reads `serverInfo` and `capabilities`, and then calls
+`tools/list`, `resources/read`, or `tools/call` using legacy request shapes.
+
+To prove only the compatibility lane while diagnosing a deployment:
+
+```bash
+python scripts/check-mcp-protocol-eras.py \
+  --endpoint https://mcp.agentbounties.app/mcp \
+  --expect legacy
+```
+
+Passing that command does not prove that modern MCP is live. Release readiness
+requires `--expect dual`.
+
+## REST API
+
+Use REST when the caller already has an HTTP client or needs direct OpenAPI
+code generation.
+
+```bash
+curl -sS https://api.agentbounties.app/.well-known/agent-bounties.json
+curl -sS 'https://api.agentbounties.app/v1/opportunities?view=ready_to_earn&limit=10'
+```
+
+The discovery document links the canonical API, MCP endpoint, schemas, feeds,
+and OpenAPI document. Read the legal-policy endpoint and obtain explicit
+acceptance before a hosted wallet action. Use a stable idempotency key for
+retryable mutations.
+
+## CLI
+
+Use the CLI for repository development and deterministic operational flows:
+
+```bash
+cargo run -p cli -- demo
+cargo build -p api -p mcp-server -p cli
+cargo run -p cli -- service-smoke-spawn
+```
+
+`service-smoke-spawn` starts local API and MCP services and drives a complete
+funded bounty lifecycle through the adapters. It does not spend live money.
+
+Use the read-only hosted release gate with the exact deployed revision:
+
+```bash
+cargo run -p cli -- production-smoke \
+  --api-base-url https://api.agentbounties.app \
+  --mcp-base-url https://mcp.agentbounties.app \
+  --expected-revision <full-deployed-git-sha>
+```
+
+## What people currently use
+
+The available first-party evidence measures public website and GitHub activity,
+but does not count API, MCP, or CLI requests. As of 2026-08-13:
+
+- the preceding 720 hours of website analytics recorded 736 sessions, including
+  418 sessions that loaded the live market; 706 sessions had direct first-touch
+  attribution and 9 were attributed from `chatgpt.com`;
+- GitHub recorded 75 external active identities and 1,365 qualifying actions
+  over 28 days;
+- GitHub's rolling 14-day repository traffic recorded 396 unique cloners,
+  10,142 clone operations, 206 unique repository visitors, and 774 page views.
+
+The defensible conclusion is that the website/live market is the dominant
+measured product-discovery mechanism, while GitHub and repository cloning are
+the dominant measured contributor/agent-development mechanisms. We cannot
+honestly rank MCP versus REST versus CLI until transport-level aggregate
+request counts exist.
+
+The likely reason is lower friction and task fit: browsing needs no connector,
+and wallet actions benefit from a visible review page; developers and coding
+agents already work through GitHub and local repositories, where commits,
+tests, and review evidence are inspectable. That explanation is an inference
+from observed behavior, not a user survey.
+
+Sources: [live 720-hour site analytics](https://api.agentbounties.app/v1/analytics/site?window_hours=720)
+and [live GitHub participation](https://agentbounties.app/generated/github-participation.json).
+See [site analytics](site-analytics.md) and [platform metrics](platform-metrics.md)
+for collection rules and limitations. Their visitor, identity, and clone
+audiences overlap and must not be added together.

--- a/docs/interaction-guide.md
+++ b/docs/interaction-guide.md
@@ -77,8 +77,10 @@ Use REST when the caller already has an HTTP client or needs direct OpenAPI
 code generation.
 
 ```bash
-curl -sS https://api.agentbounties.app/.well-known/agent-bounties.json
-curl -sS 'https://api.agentbounties.app/v1/opportunities?view=ready_to_earn&limit=10'
+curl -sS -H 'X-Agent-Bounties-Interface: api' \
+  https://api.agentbounties.app/.well-known/agent-bounties.json
+curl -sS -H 'X-Agent-Bounties-Interface: api' \
+  'https://api.agentbounties.app/v1/opportunities?view=ready_to_earn&limit=10'
 ```
 
 The discovery document links the canonical API, MCP endpoint, schemas, feeds,
@@ -110,8 +112,8 @@ cargo run -p cli -- production-smoke \
 
 ## What people currently use
 
-The available first-party evidence measures public website and GitHub activity,
-but does not count API, MCP, or CLI requests. As of 2026-08-13:
+The historical first-party evidence measured public website and GitHub
+activity, but did not count API, MCP, or CLI requests. As of 2026-08-13:
 
 - the preceding 720 hours of website analytics recorded 736 sessions, including
   418 sessions that loaded the live market; 706 sessions had direct first-touch
@@ -121,11 +123,13 @@ but does not count API, MCP, or CLI requests. As of 2026-08-13:
 - GitHub's rolling 14-day repository traffic recorded 396 unique cloners,
   10,142 clone operations, 206 unique repository visitors, and 774 page views.
 
-The defensible conclusion is that the website/live market is the dominant
-measured product-discovery mechanism, while GitHub and repository cloning are
-the dominant measured contributor/agent-development mechanisms. We cannot
-honestly rank MCP versus REST versus CLI until transport-level aggregate
-request counts exist.
+The defensible historical conclusion is that the website/live market was the
+dominant measured product-discovery mechanism, while GitHub and repository
+cloning were the dominant measured contributor/agent-development mechanisms.
+The `interfaces` array in `GET /v1/analytics/site` begins collecting aggregate
+API, CLI, modern MCP, legacy MCP, and MCP HTTP-adapter interactions only after
+this release is deployed. It has no historical backfill, so do not infer a
+pre-release MCP-versus-REST-versus-CLI ranking from its first partial hours.
 
 The likely reason is lower friction and task fit: browsing needs no connector,
 and wallet actions benefit from a visible review page; developers and coding
@@ -138,3 +142,9 @@ and [live GitHub participation](https://agentbounties.app/generated/github-parti
 See [site analytics](site-analytics.md) and [platform metrics](platform-metrics.md)
 for collection rules and limitations. Their visitor, identity, and clone
 audiences overlap and must not be added together.
+
+Interface rows are hourly request aggregates, not people or agents. Official
+SDKs declare `api`, the Rust CLI declares `cli`, and the MCP service observes
+its protocol era directly. One workflow can contribute to multiple rows; API
+and CLI declarations can also be absent or spoofed. See [site
+analytics](site-analytics.md) for the exact collection and privacy contract.

--- a/docs/mcp-protocol-compatibility.md
+++ b/docs/mcp-protocol-compatibility.md
@@ -1,0 +1,95 @@
+# MCP protocol compatibility
+
+The hosted Streamable HTTP endpoint at `/mcp` implements the modern MCP
+`2026-07-28` wire contract and retains a separate legacy compatibility lane for
+clients that still initialize with `2024-11-05`, `2025-03-26`, or
+`2025-06-18`.
+
+## Compatibility boundary
+
+| Client request | Server behavior |
+| --- | --- |
+| `2026-07-28` per-request metadata | Strict modern validation and modern result shapes |
+| Legacy `initialize` handshake | Negotiates a supported legacy version and preserves legacy result shapes |
+| Modern `initialize` or `ping` | `404` with JSON-RPC `-32601`; those methods are not in the modern core |
+| Modern `GET /mcp` or `DELETE /mcp` | `405`; modern Streamable HTTP uses one `POST` per request |
+
+Modern and legacy MCP implementations are not directly interoperable. The
+endpoint therefore detects the era from the modern protocol header/request
+metadata or `server/discover`; it does not mix modern fields into legacy
+responses.
+
+## Modern request contract
+
+Every modern request is a single JSON-RPC object. It includes:
+
+- `MCP-Protocol-Version: 2026-07-28`;
+- `Mcp-Method`, equal to the body `method`;
+- `Mcp-Name` for `tools/call`, `resources/read`, and `prompts/get`, equal to the
+  body name or URI after decoding the protocol's Base64 sentinel when used;
+- `params._meta["io.modelcontextprotocol/protocolVersion"]`;
+- `params._meta["io.modelcontextprotocol/clientCapabilities"]`;
+- preferably `params._meta["io.modelcontextprotocol/clientInfo"]`.
+
+Header/body mismatches return HTTP `400` and JSON-RPC error `-32020`.
+Unsupported modern versions return HTTP `400`, error `-32022`, and the
+supported/requested version data. An invalid `Origin`, when that header is
+present, returns HTTP `403`.
+
+Use `server/discover` before calling tools:
+
+```http
+POST /mcp
+Accept: application/json, text/event-stream
+Content-Type: application/json
+MCP-Protocol-Version: 2026-07-28
+Mcp-Method: server/discover
+
+{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"example-client","version":"1"},"io.modelcontextprotocol/clientCapabilities":{}}}}
+```
+
+Successful modern results include `resultType: "complete"` and server identity
+under `_meta["io.modelcontextprotocol/serverInfo"]`. Discovery, list, and read
+results also include `ttlMs` and `cacheScope`. Catalogs are deterministic so a
+client can safely reuse the cache hint.
+
+The server advertises only tools and resources. It does not advertise Tasks,
+subscriptions, prompts, or other optional extensions that it does not
+implement.
+
+## Origin configuration
+
+Requests without an `Origin` are allowed for normal server-to-server MCP
+clients. Exact first-party, ChatGPT, and loopback development origins are
+allowed by default. `MCP_BASE_URL` adds its exact origin. Deployments with
+additional browser clients can set a comma-separated exact allowlist:
+
+```text
+MCP_ALLOWED_ORIGINS=https://client.example,https://another.example
+```
+
+Do not use wildcard origins. This check is the endpoint's DNS-rebinding
+boundary, not an authentication substitute.
+
+## Verification
+
+```powershell
+cargo test -p mcp-server chatgpt_app::tests
+cargo build -p mcp-server
+python scripts/check-chatgpt-app-runtime.py
+```
+
+The runtime check calls modern `server/discover`, modern catalogs, a resource,
+and a tool, plus legacy `initialize` and a legacy catalog through the real HTTP
+endpoint.
+
+The deployed production smoke performs modern discovery and legacy initialize
+against the published endpoint.
+
+Protocol references:
+
+- [MCP 2026-07-28 release](https://github.com/modelcontextprotocol/modelcontextprotocol/releases/tag/2026-07-28)
+- [2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [Versioning and compatibility](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning)
+- [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http)
+- [`server/discover`](https://modelcontextprotocol.io/specification/2026-07-28/server/discover)

--- a/docs/mcp-protocol-compatibility.md
+++ b/docs/mcp-protocol-compatibility.md
@@ -1,9 +1,18 @@
 # MCP protocol compatibility
 
-The hosted Streamable HTTP endpoint at `/mcp` implements the modern MCP
-`2026-07-28` wire contract and retains a separate legacy compatibility lane for
-clients that still initialize with `2024-11-05`, `2025-03-26`, or
-`2025-06-18`.
+The server revision documented here implements the modern MCP `2026-07-28`
+wire contract and retains a separate legacy compatibility lane for clients that
+still initialize with `2024-11-05`, `2025-03-26`, or `2025-06-18`.
+
+A healthy `/health` route or working legacy connector does not prove that the
+modern core is deployed. Treat a hosted endpoint as dual-era only when this
+read-only probe passes:
+
+```bash
+python scripts/check-mcp-protocol-eras.py \
+  --endpoint https://mcp.agentbounties.app/mcp \
+  --expect dual
+```
 
 ## Compatibility boundary
 
@@ -18,6 +27,37 @@ Modern and legacy MCP implementations are not directly interoperable. The
 endpoint therefore detects the era from the modern protocol header/request
 metadata or `server/discover`; it does not mix modern fields into legacy
 responses.
+
+## Why this change benefits Agent Bounties
+
+At first principles, connection state is hidden coupling: if correctness
+depends on which server handled an earlier handshake, requests need sticky
+routing or shared session storage. A self-contained request can be retried or
+sent to any healthy instance. That gives us simpler horizontal scaling and
+failure recovery on ordinary HTTP infrastructure.
+
+The remaining incentives line up across participants:
+
+- clients gain explicit version errors, safe retry/failover, and cacheable,
+  deterministic catalogs;
+- servers remove session-affinity infrastructure and can evolve optional
+  features through extensions instead of expanding the core handshake;
+- gateways can route, authorize, rate-limit, and observe a method or tool from
+  `Mcp-Method` and `Mcp-Name` without parsing the entire JSON body;
+- Agent Bounties can keep the existing ChatGPT/legacy lane while deploying the
+  modern lane independently, then measure adoption before retiring anything.
+
+The tradeoff is that each modern request carries more metadata, and the server
+must validate the header/body pair. The dual-era boundary intentionally pays
+some temporary implementation complexity to avoid pushing a flag-day migration
+onto existing users.
+
+Normal app users do not select an era manually. A dual-era client should try
+modern discovery first. A recognized modern error must be corrected as a
+modern request; an unrecognized error response identifies a legacy server and
+can trigger the `initialize` fallback. For Streamable HTTP, inspect the JSON-RPC
+body of a `4xx` response before falling back. Existing clients that only
+implement the legacy handshake continue to use that lane.
 
 ## Modern request contract
 
@@ -46,6 +86,17 @@ MCP-Protocol-Version: 2026-07-28
 Mcp-Method: server/discover
 
 {"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"example-client","version":"1"},"io.modelcontextprotocol/clientCapabilities":{}}}}
+```
+
+An older client starts with the legacy handshake and then sends legacy-shaped
+requests without modern request metadata:
+
+```http
+POST /mcp
+Accept: application/json, text/event-stream
+Content-Type: application/json
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"example-client","version":"1"}}}
 ```
 
 Successful modern results include `resultType: "complete"` and server identity
@@ -77,6 +128,7 @@ boundary, not an authentication substitute.
 cargo test -p mcp-server chatgpt_app::tests
 cargo build -p mcp-server
 python scripts/check-chatgpt-app-runtime.py
+python scripts/check-mcp-protocol-eras.py --endpoint http://127.0.0.1:8080/mcp --expect dual
 ```
 
 The runtime check calls modern `server/discover`, modern catalogs, a resource,
@@ -84,7 +136,11 @@ and a tool, plus legacy `initialize` and a legacy catalog through the real HTTP
 endpoint.
 
 The deployed production smoke performs modern discovery and legacy initialize
-against the published endpoint.
+against the published endpoint. A health response alone is not sufficient
+release evidence.
+
+For choosing between the app, raw MCP, REST API, and CLI, see the
+[interaction guide](interaction-guide.md).
 
 Protocol references:
 

--- a/docs/production-smoke.md
+++ b/docs/production-smoke.md
@@ -72,7 +72,8 @@ authority and failure boundaries.
 
 The gate checks:
 
-- API and MCP health, protocol identity, and exact deployed revision.
+- API and MCP health, exact deployed revision, MCP `2026-07-28`
+  `server/discover`, and the legacy `2025-06-18` initialization fallback.
 - Autonomous-v1 discovery manifests, JSON Schema, `/llms.txt`, and MCP tools.
 - OpenAPI paths for terms, creation, contribution, claim, submission,
   verification, settlement, expiry, cancellation, refunds, events, and

--- a/docs/production-smoke.md
+++ b/docs/production-smoke.md
@@ -86,5 +86,16 @@ The gate checks:
   authenticated star/upvote execution.
 - Persisted eval history when explicitly required.
 
+For a faster MCP-only deployment diagnosis, run:
+
+```bash
+python scripts/check-mcp-protocol-eras.py \
+  --endpoint https://mcp.agentbounties.app/mcp \
+  --expect dual
+```
+
+`--expect legacy` proves only the compatibility lane. It is not modern-core
+release evidence.
+
 Do not enable GitHub funding-comment handoffs against a hosted API until this
 gate passes for that exact API URL and revision.

--- a/docs/site-analytics.md
+++ b/docs/site-analytics.md
@@ -26,12 +26,46 @@ GA4 disabled without affecting first-party analytics.
   and occurrence time. Replaying an `event_id` is idempotent.
 - `GET /v1/analytics/site?window_hours=720` returns aggregate visitors,
   returning visitors, sessions, page views, event counts, daily series,
-  first-touch channels, and session-based conversion rates. The supported
-  lookback is 1 through 8,760 hours.
+  first-touch channels, session-based conversion rates, and hourly aggregate
+  API, CLI, and MCP request attribution. The supported lookback is 1 through
+  8,760 hours.
 - MCP `get_site_analytics`, TypeScript `getSiteAnalytics`, and Python
   `get_site_analytics` expose the same read-only aggregate report.
 
 The aggregate endpoint is public and never returns event-level identifiers.
+
+## Interface usage contract
+
+The `interfaces` array registers observed requests after deployment:
+
+- `api` and `cli` use `protocol_era=not_applicable` and are counted only when
+  the caller sends `X-Agent-Bounties-Interface: api` or
+  `X-Agent-Bounties-Interface: cli`. Official SDKs and CLI commands send the
+  appropriate value automatically.
+- `mcp` is classified by the MCP service as `modern` (`2026-07-28`), `legacy`
+  (the initialization-era protocol), or `http_adapter` (`/tools/*`).
+- Each row contains only request count, successful request count, and first and
+  last observation timestamps for the selected window. Storage is one row per
+  UTC hour, interface, and protocol era.
+
+Use direct REST with explicit attribution:
+
+```bash
+curl -sS \
+  -H 'X-Agent-Bounties-Interface: api' \
+  'https://api.agentbounties.app/v1/opportunities?view=ready_to_earn&limit=10'
+
+curl -sS \
+  -H 'X-Agent-Bounties-Interface: api' \
+  'https://api.agentbounties.app/v1/analytics/site?window_hours=720'
+```
+
+These are interaction counts, not unique-user counts. They cannot deduplicate a
+person or agent across interfaces, and one workflow can intentionally use more
+than one interface. API/CLI attribution is self-declared, so missing or spoofed
+headers affect coverage. MCP classification is server-observed. Use the report
+to compare observed interaction volume and adoption trends, not to claim a
+surveyed preference or a count of people.
 
 ## Event contract
 
@@ -77,11 +111,13 @@ storage clearing creates a new visitor identifier.
 
 ## Privacy and data quality
 
-The first-party collector uses no cookies and stores no IP address, user agent, full
-referrer URL, URL query string, wallet address, email address, or arbitrary
-metadata. It honors Global Privacy Control and Do Not Track, supports an
-explicit browser opt-out on the privacy page, uses `credentials: omit`, and
-never blocks a product action when delivery fails.
+The first-party browser collector uses no cookies and stores no IP address,
+user agent, full referrer URL, URL query string, wallet address, email address,
+or arbitrary metadata. Interface attribution additionally stores no client,
+session, visitor, account, wallet, request-body, prompt, tool-argument, or
+network identifier. It honors Global Privacy Control and Do Not Track,
+supports an explicit browser opt-out on the privacy page, uses
+`credentials: omit`, and analytics delivery never blocks a product action.
 
 Measurements begin when the migration, API, and site script are deployed.
 There is no historical backfill. Recent days can be partial, browser privacy
@@ -100,6 +136,7 @@ Not Track, explicit opt-out, or `?analytics=off` prevents GA4 from loading.
 python scripts/check-migration-history.py
 python scripts/check-site.py
 cargo test -p db site_analytics_migration_is_privacy_minimized_and_idempotent
+cargo test -p db interface_usage_migration_stores_only_hourly_aggregate_attribution
 cargo test -p api site_analytics
 ```
 

--- a/migrations/0021_interface_usage.sql
+++ b/migrations/0021_interface_usage.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS interface_usage_hourly (
+  bucket_started_at TIMESTAMPTZ NOT NULL,
+  interface TEXT NOT NULL,
+  protocol_era TEXT NOT NULL,
+  request_count BIGINT NOT NULL DEFAULT 0 CHECK (request_count >= 0),
+  successful_request_count BIGINT NOT NULL DEFAULT 0 CHECK (
+    successful_request_count >= 0
+    AND successful_request_count <= request_count
+  ),
+  first_observed_at TIMESTAMPTZ NOT NULL,
+  last_observed_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (bucket_started_at, interface, protocol_era),
+  CONSTRAINT interface_usage_interface_check CHECK (
+    interface IN ('api', 'cli', 'mcp')
+  ),
+  CONSTRAINT interface_usage_protocol_era_check CHECK (
+    protocol_era IN ('not_applicable', 'legacy', 'modern', 'http_adapter')
+  ),
+  CONSTRAINT interface_usage_interface_era_check CHECK (
+    (interface IN ('api', 'cli') AND protocol_era = 'not_applicable')
+    OR (interface = 'mcp' AND protocol_era <> 'not_applicable')
+  ),
+  CONSTRAINT interface_usage_bucket_check CHECK (
+    bucket_started_at = (
+      date_trunc('hour', bucket_started_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+    )
+  ),
+  CONSTRAINT interface_usage_observation_order_check CHECK (
+    first_observed_at <= last_observed_at
+  )
+);
+
+CREATE INDEX IF NOT EXISTS interface_usage_hourly_recent_idx
+  ON interface_usage_hourly (bucket_started_at DESC, interface, protocol_era);

--- a/migrations/checksums.json
+++ b/migrations/checksums.json
@@ -21,6 +21,7 @@
     "0017_bounty_image_assets.sql": "8a83ba6d8ac8f70b09f959791f8d6191fdcd971c582f82c4a48c82d7c8339d2c",
     "0018_rename_compete_action_to_solve.sql": "f8a0336502da26f5db5ff4bdc33fe1dbc27f003b3330730e07e21451640d116f",
     "0019_open_competition_v1.sql": "aba30d9af284eee344b11a09738fb5e8ca1c9b5fb14bd81301f902341d9dee7d",
-    "0020_open_competition_entrant_relays.sql": "96822727b50f7c4f672138082605748ea08b942505958d712715d69336a12b6f"
+    "0020_open_competition_entrant_relays.sql": "96822727b50f7c4f672138082605748ea08b942505958d712715d69336a12b6f",
+    "0021_interface_usage.sql": "979b376c8b789cf460f395d770f3986acec326db6c103ffd053b6b782e8b1489"
   }
 }

--- a/scripts/check-chatgpt-app-runtime.py
+++ b/scripts/check-chatgpt-app-runtime.py
@@ -25,11 +25,14 @@ FULL_TOOLS = {
     "prepare_bounty_action",
     "get_bounty_action_status",
     "compile_objective_with_cloud_agent",
+    "list_autonomous_bounties",
     "list_bounty_comments",
     "add_bounty_comment",
     "create_share_bundle",
 }
 FEED_WIDGET_URI = "ui://agent-bounties/live-feed-v4.html"
+MODERN_PROTOCOL_VERSION = "2026-07-28"
+LEGACY_PROTOCOL_VERSION = "2025-06-18"
 
 
 def require(condition: bool, message: str) -> None:
@@ -43,7 +46,33 @@ def available_port() -> int:
         return int(listener.getsockname()[1])
 
 
-def request(endpoint: str, request_id: int, method: str, params: dict) -> dict:
+def request(
+    endpoint: str,
+    request_id: int,
+    method: str,
+    params: dict,
+    modern: bool = False,
+) -> dict:
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    if modern:
+        params = dict(params)
+        params["_meta"] = {
+            "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "agent-bounties-release-harness",
+                "version": "1",
+            },
+            "io.modelcontextprotocol/clientCapabilities": {},
+        }
+        headers["MCP-Protocol-Version"] = MODERN_PROTOCOL_VERSION
+        headers["Mcp-Method"] = method
+        if method == "resources/read":
+            headers["Mcp-Name"] = params["uri"]
+        elif method in ("tools/call", "prompts/get"):
+            headers["Mcp-Name"] = params["name"]
     payload = {
         "jsonrpc": "2.0",
         "id": request_id,
@@ -53,7 +82,7 @@ def request(endpoint: str, request_id: int, method: str, params: dict) -> dict:
     http_request = urllib.request.Request(
         endpoint,
         data=json.dumps(payload).encode("utf-8"),
-        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     with urllib.request.urlopen(http_request, timeout=5) as response:
@@ -108,10 +137,10 @@ def main() -> int:
 
     request_id = 0
 
-    def rpc(method: str, params: dict | None = None) -> dict:
+    def rpc(method: str, params: dict | None = None, modern: bool = True) -> dict:
         nonlocal request_id
         request_id += 1
-        return request(endpoint, request_id, method, params or {})
+        return request(endpoint, request_id, method, params or {}, modern=modern)
 
     try:
         last_error: Exception | None = None
@@ -122,17 +151,7 @@ def main() -> int:
                     f"server exited {process.returncode}: {stdout}\n{stderr}"
                 )
             try:
-                initialized = rpc(
-                    "initialize",
-                    {
-                        "protocolVersion": "2025-06-18",
-                        "capabilities": {},
-                        "clientInfo": {
-                            "name": "agent-bounties-release-harness",
-                            "version": "1",
-                        },
-                    },
-                )
+                discovered = rpc("server/discover")
                 break
             except (OSError, urllib.error.URLError) as error:
                 last_error = error
@@ -141,16 +160,42 @@ def main() -> int:
             raise AssertionError(f"server did not become ready: {last_error}")
 
         require(
-            initialized["serverInfo"]["name"] == "agent-bounties",
-            "production server name drifted",
+            discovered["supportedVersions"] == [MODERN_PROTOCOL_VERSION],
+            "modern MCP version discovery drifted",
         )
         require(
-            initialized["serverInfo"]["title"] == "Agent Bounties",
-            "production server title drifted",
+            discovered["resultType"] == "complete"
+            and discovered["cacheScope"] == "public"
+            and discovered["ttlMs"] > 0,
+            "modern discovery lost typed cache metadata",
         )
+        server_info = discovered["_meta"]["io.modelcontextprotocol/serverInfo"]
+        require(server_info["name"] == "agent-bounties", "server name drifted")
+        require(server_info["title"] == "Agent Bounties", "server title drifted")
         require(
-            "Public review mode" not in initialized["instructions"],
+            "Public review mode" not in discovered["instructions"],
             "retired public-review profile is still reachable",
+        )
+
+        initialized = rpc(
+            "initialize",
+            {
+                "protocolVersion": LEGACY_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "agent-bounties-release-harness",
+                    "version": "1",
+                },
+            },
+            modern=False,
+        )
+        require(
+            initialized["protocolVersion"] == LEGACY_PROTOCOL_VERSION,
+            "legacy MCP compatibility drifted",
+        )
+        require(
+            "resultType" not in initialized,
+            "legacy response shape unexpectedly became modern",
         )
 
         tools = rpc("tools/list")["tools"]
@@ -158,6 +203,11 @@ def main() -> int:
         require(
             len(tools) == len(FULL_TOOLS) and tool_names == FULL_TOOLS,
             f"runtime tool set drifted: {sorted(tool_names)}",
+        )
+        legacy_tools = rpc("tools/list", modern=False)["tools"]
+        require(
+            {tool["name"] for tool in legacy_tools} == FULL_TOOLS,
+            "legacy tool catalog drifted",
         )
         moonpay_descriptor = next(
             tool for tool in tools if tool["name"] == "prepare_moonpay_onramp"
@@ -286,6 +336,8 @@ def main() -> int:
 
     print(
         "chatgpt_runtime_check=ok "
+        f"mcp_modern={MODERN_PROTOCOL_VERSION} "
+        f"mcp_legacy={LEGACY_PROTOCOL_VERSION} "
         f"tools={len(FULL_TOOLS)} "
         "profile=full_hosted_execution "
         "chatgpt_image_handoff=file_param "

--- a/scripts/check-mcp-protocol-eras.py
+++ b/scripts/check-mcp-protocol-eras.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Read-only probe for modern and legacy MCP on one Streamable HTTP endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+MODERN_VERSION = "2026-07-28"
+LEGACY_VERSION = "2025-06-18"
+WIDGET_URI = "ui://agent-bounties/live-feed-v4.html"
+
+
+def post_json(
+    endpoint: str, payload: dict[str, Any], headers: dict[str, str]
+) -> tuple[int, dict[str, Any]]:
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        headers={"Content-Type": "application/json", **headers},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            try:
+                decoded = json.loads(body)
+            except json.JSONDecodeError:
+                decoded = {"invalid_json": body}
+            return response.status, decoded
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        try:
+            decoded = json.loads(body)
+        except json.JSONDecodeError:
+            decoded = {"http_error": body or str(error)}
+        return error.code, decoded
+    except (urllib.error.URLError, TimeoutError) as error:
+        return 0, {"transport_error": str(error)}
+
+
+def modern_request(
+    endpoint: str,
+    request_id: int,
+    method: str,
+    params: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    params = dict(params or {})
+    params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "agent-bounties-era-probe",
+            "version": "1",
+        },
+        "io.modelcontextprotocol/clientCapabilities": {},
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": MODERN_VERSION,
+        "Mcp-Method": method,
+    }
+    if method == "resources/read":
+        headers["Mcp-Name"] = str(params["uri"])
+    elif method in ("tools/call", "prompts/get"):
+        headers["Mcp-Name"] = str(params["name"])
+    return post_json(
+        endpoint,
+        {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params},
+        headers,
+    )
+
+
+def legacy_request(
+    endpoint: str,
+    request_id: int,
+    method: str,
+    params: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    return post_json(
+        endpoint,
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params or {},
+        },
+        {"Accept": "application/json, text/event-stream"},
+    )
+
+
+def modern_ok(response: dict[str, Any]) -> bool:
+    result = response.get("result")
+    return bool(
+        isinstance(result, dict)
+        and MODERN_VERSION in result.get("supportedVersions", [])
+        and result.get("resultType") == "complete"
+        and result.get("cacheScope") == "public"
+        and type(result.get("ttlMs")) is int
+        and result["ttlMs"] > 0
+        and isinstance(
+            result.get("_meta", {}).get("io.modelcontextprotocol/serverInfo"), dict
+        )
+    )
+
+
+def legacy_ok(response: dict[str, Any]) -> bool:
+    result = response.get("result")
+    return bool(
+        isinstance(result, dict)
+        and result.get("protocolVersion") == LEGACY_VERSION
+        and isinstance(result.get("serverInfo"), dict)
+    )
+
+
+def successful_result(status: int, response: dict[str, Any]) -> bool:
+    return status == 200 and isinstance(response.get("result"), dict)
+
+
+def successful_modern_result(
+    status: int, response: dict[str, Any], *, cacheable: bool = False
+) -> bool:
+    result = response.get("result")
+    if not (
+        status == 200
+        and isinstance(result, dict)
+        and result.get("resultType") == "complete"
+        and isinstance(
+            result.get("_meta", {}).get("io.modelcontextprotocol/serverInfo"), dict
+        )
+    ):
+        return False
+    return not cacheable or bool(
+        result.get("cacheScope") == "public"
+        and type(result.get("ttlMs")) is int
+        and result["ttlMs"] > 0
+    )
+
+
+def probe(endpoint: str) -> dict[str, Any]:
+    modern_status, modern_discovery = modern_request(
+        endpoint, 1, "server/discover"
+    )
+    modern_available = modern_status == 200 and modern_ok(modern_discovery)
+    modern_checks: dict[str, bool] = {"server_discover": modern_available}
+    if modern_available:
+        status, response = modern_request(endpoint, 2, "tools/list")
+        modern_checks["tools_list"] = successful_modern_result(
+            status, response, cacheable=True
+        ) and bool(response["result"].get("tools"))
+        status, response = modern_request(endpoint, 3, "resources/read", {"uri": WIDGET_URI})
+        modern_checks["resources_read"] = successful_modern_result(
+            status, response, cacheable=True
+        ) and bool(response["result"].get("contents"))
+        status, response = modern_request(
+            endpoint,
+            4,
+            "tools/call",
+            {
+                "name": "prepare_moonpay_onramp",
+                "arguments": {
+                    "bounty_contract": "0x1111111111111111111111111111111111111111",
+                    "amount_base_units": 3_500_000,
+                },
+            },
+        )
+        modern_checks["tools_call"] = successful_modern_result(
+            status, response
+        ) and bool(response["result"].get("content"))
+        modern_available = all(modern_checks.values())
+
+    legacy_status, legacy_initialize = legacy_request(
+        endpoint,
+        11,
+        "initialize",
+        {
+            "protocolVersion": LEGACY_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "agent-bounties-era-probe", "version": "1"},
+        },
+    )
+    legacy_available = legacy_status == 200 and legacy_ok(legacy_initialize)
+    legacy_checks: dict[str, bool] = {"initialize": legacy_available}
+    if legacy_available:
+        status, response = legacy_request(endpoint, 12, "tools/list")
+        legacy_checks["tools_list"] = successful_result(status, response) and bool(
+            response["result"].get("tools")
+        )
+        status, response = legacy_request(
+            endpoint, 13, "resources/read", {"uri": WIDGET_URI}
+        )
+        legacy_checks["resources_read"] = successful_result(status, response) and bool(
+            response["result"].get("contents")
+        )
+        status, response = legacy_request(
+            endpoint,
+            14,
+            "tools/call",
+            {
+                "name": "prepare_moonpay_onramp",
+                "arguments": {
+                    "bounty_contract": "0x1111111111111111111111111111111111111111",
+                    "amount_base_units": 3_500_000,
+                },
+            },
+        )
+        legacy_checks["tools_call"] = successful_result(status, response) and bool(
+            response["result"].get("content")
+        )
+        legacy_available = all(legacy_checks.values())
+
+    modern_error = modern_discovery.get("error", {})
+    return {
+        "schema_version": "agent-bounties/mcp-era-probe-v1",
+        "endpoint": endpoint,
+        "modern": {
+            "protocol_version": MODERN_VERSION,
+            "available": modern_available,
+            "checks": modern_checks,
+            "discover_http_status": modern_status,
+            "discover_error_code": modern_error.get("code"),
+            "discover_error_message": modern_error.get("message"),
+        },
+        "legacy": {
+            "protocol_version": LEGACY_VERSION,
+            "available": legacy_available,
+            "checks": legacy_checks,
+            "initialize_http_status": legacy_status,
+        },
+    }
+
+
+def expectation_met(report: dict[str, Any], expected: str) -> bool:
+    modern = bool(report["modern"]["available"])
+    legacy = bool(report["legacy"]["available"])
+    return {
+        "dual": modern and legacy,
+        "modern": modern,
+        "legacy": legacy,
+        "either": modern or legacy,
+    }[expected]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--endpoint",
+        default="https://mcp.agentbounties.app/mcp",
+        help="Full Streamable HTTP MCP endpoint.",
+    )
+    parser.add_argument(
+        "--expect",
+        choices=("dual", "modern", "legacy", "either"),
+        default="dual",
+        help="Required availability; dual is the release target.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = probe(args.endpoint)
+    report["expected"] = args.expect
+    report["passed"] = expectation_met(report, args.expect)
+    print(json.dumps(report, indent=2))
+    if report["passed"]:
+        return 0
+    print(
+        f"mcp_era_probe=failed expected={args.expect} "
+        f"modern={str(report['modern']['available']).lower()} "
+        f"legacy={str(report['legacy']['available']).lower()}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-moonpay-onramp.py
+++ b/scripts/check-moonpay-onramp.py
@@ -81,10 +81,13 @@ def main() -> int:
             "Gas is sponsored for this funding action.",
             'data-moonpay-onramp-link',
             'src="moonpay-link.js?v=1"',
+            'src="autonomous.js?v=20260813-1"',
             "Buying USDC does not fund this bounty",
         ],
     )
-    if earn.index('src="moonpay-link.js?v=1"') > earn.index('src="autonomous.js"'):
+    if earn.index('src="moonpay-link.js?v=1"') > earn.index(
+        'src="autonomous.js?v=20260813-1"'
+    ):
         fail("moonpay-link.js must load before autonomous.js initializes the funding form")
 
     browser = require(

--- a/scripts/test_activate_routed_v3_replacements.py
+++ b/scripts/test_activate_routed_v3_replacements.py
@@ -210,7 +210,7 @@ class ActivateRoutedV3Tests(unittest.TestCase):
         )
         state = MODULE.policy_state(PolicyCast(), deployment)
         self.assertEqual(state["policy_hash"], MODULE.active_wallet.POLICY_HASH)
-        self.assertEqual(state["policy_version"], 5)
+        self.assertEqual(state["policy_version"], 6)
         self.assertEqual(state["affordable_creations"], 4)
 
     def test_active_wallet_policy_drift_fails_closed(self) -> None:
@@ -230,7 +230,7 @@ class ActivateRoutedV3Tests(unittest.TestCase):
             "deterministic_verifier": "0x" + "93" * 20,
             "signed_quorum": "0x" + "94" * 32,
             "policy_hash": "0x" + "95" * 32,
-            "policy_version": 6,
+            "policy_version": 7,
             "max_per_period": 11_000_000,
         }
         for field, observed in cases.items():


### PR DESCRIPTION
## Outcome

- serves MCP 2026-07-28 with stateless server/discover, per-request metadata/header validation, deterministic cacheable catalogs, and modern response envelopes
- retains the legacy 2025-06-18 initialize-era compatibility lane on the same /mcp endpoint
- adds a dual-era wire probe plus API/MCP/CLI end-to-end instructions
- records privacy-minimized hourly interaction counters for api, cli, and mcp (modern, legacy, http_adapter)
- exposes the aggregate counters through site analytics, MCP get_site_analytics, and both SDKs
- stores no IP, user agent, wallet, visitor/session/client identifier, body, prompt, or tool arguments

Closes #938.

## Evidence

- cargo test -p db -p api -p mcp-server -p cli — 227 passed, 15 Postgres-only tests ignored
- cargo clippy -p db -p api -p mcp-server -p cli -- -D warnings
- dual-era local wire probe — modern and legacy list/read/call passed
- cargo run -p cli -- service-smoke-spawn — final_status=Paid, 119 MCP adapter tools
- Python SDK — 8 passed
- TypeScript SDK — 9 passed
- migration history, site check, ChatGPT submission check, core preflight — passed

The durable Postgres round-trip is wired into the existing ignored database test and CI gate. Docker Desktop was not running locally, so that specific test is left for required CI rather than represented as a local pass.

## Compatibility and coordination

- the old codex/mcp-2026-07-28 branch remains pinned at 394346a11276b8cf05b5a668c158f91a031b9407
- #910 remains a separate stacked analytics proposal and must not be merged independently
- #892 must renumber/rebase its proposed 0021 migration after this PR, as documented on that PR