### PR TITLE
fix: reconcile and audit canonical payout metrics

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -2051,7 +2051,6 @@ impl PostgresStore {
                 AND block_time_verified = TRUE
                 AND occurred_at >= $5
                 AND occurred_at < $3
-                AND NOT lower(contract_address) = ANY($7)
                 AND kind IN ('bounty_settled', 'submission_rejected')
               UNION ALL
               SELECT occurred_at, kind = 'bounty_settled' AS settled,
@@ -2070,7 +2069,6 @@ impl PostgresStore {
                 AND block_time_verified = TRUE
                 AND occurred_at >= $5
                 AND occurred_at < $3
-                AND NOT lower(contract_address) = ANY($7)
                 AND kind IN ('bounty_settled', 'competition_submission_rejected')
             ), normalized AS (
               SELECT *, solver_amount + verifier_amount + bonus_amount AS total_amount
@@ -2115,7 +2113,6 @@ impl PostgresStore {
         .bind(previous_started_at)
         .bind(launch_at)
         .bind(first_month_ended_at)
-        .bind(excluded_bounty_contracts)
         .fetch_one(&self.pool)
         .await?;
 
@@ -2299,7 +2296,6 @@ impl PostgresStore {
               WHERE network = $1
                 AND block_time_verified = TRUE
                 AND occurred_at >= $2 AND occurred_at < $3
-                AND NOT lower(contract_address) = ANY($6)
                 AND kind IN ('bounty_settled', 'submission_rejected')
               UNION ALL
               SELECT occurred_at, kind = 'bounty_settled' AS settled,
@@ -2315,7 +2311,6 @@ impl PostgresStore {
               WHERE network = $1
                 AND block_time_verified = TRUE
                 AND occurred_at >= $2 AND occurred_at < $3
-                AND NOT lower(contract_address) = ANY($6)
                 AND kind IN ('bounty_settled', 'competition_submission_rejected')
             ), days AS (
               SELECT generate_series(
@@ -2357,13 +2352,11 @@ impl PostgresStore {
               FROM autonomous_bounty_events
               WHERE network = $1
                 AND occurred_at >= $2
-                AND NOT lower(COALESCE(data->>'bounty_contract', contract_address)) = ANY($3)
               UNION ALL
               SELECT block_time_verified, occurred_at
               FROM open_competition_events
               WHERE network = $1
                 AND occurred_at >= $2
-                AND NOT lower(COALESCE(data->>'bounty_contract', contract_address)) = ANY($3)
             )
             SELECT
               COUNT(*) FILTER (WHERE block_time_verified = TRUE) AS verified_events,
@@ -2377,7 +2370,6 @@ impl PostgresStore {
         )
         .bind(network)
         .bind(launch_at)
-        .bind(excluded_bounty_contracts)
         .fetch_one(&self.pool)
         .await?;
 
@@ -8949,7 +8941,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
-    async fn platform_metrics_query_enforces_identity_payment_and_cohort_boundaries() {
+    async fn platform_metrics_query_separates_history_from_identity_and_cohort_boundaries() {
         async fn add_event(
             store: &PostgresStore,
             network: &str,
@@ -9521,11 +9513,13 @@ mod tests {
         assert_eq!(stats.identities.commenters, 1);
         assert_eq!(stats.identities.marketplace_wallets, 10);
         assert_eq!(stats.identities.opportunity_comment_authors, 1);
-        assert_eq!(stats.payouts.selected_total_base_units, "3725000");
-        assert_eq!(stats.payouts.selected_solver_base_units, "3000000");
-        assert_eq!(stats.payouts.selected_verifier_base_units, "600000");
+        // Recovery reservations protect future earning and verification work; they
+        // must not erase block-time-verified payouts from immutable history.
+        assert_eq!(stats.payouts.selected_total_base_units, "159725000");
+        assert_eq!(stats.payouts.selected_solver_base_units, "143000000");
+        assert_eq!(stats.payouts.selected_verifier_base_units, "16600000");
         assert_eq!(stats.payouts.selected_bonus_base_units, "125000");
-        assert_eq!(stats.payouts.selected_settled_rounds, 2);
+        assert_eq!(stats.payouts.selected_settled_rounds, 4);
         assert_eq!(stats.claim_cohort.settled, 1);
         assert_eq!(stats.claim_cohort.mature, 3);
         assert_eq!(stats.claim_cohort.immature, 1);
@@ -9536,7 +9530,7 @@ mod tests {
                 .iter()
                 .map(|day| day.payout_base_units.parse::<u128>().unwrap())
                 .sum::<u128>(),
-            3_725_000
+            159_725_000
         );
 
         sqlx::query("DELETE FROM open_competition_events WHERE network = $1")

--- a/docs/platform-metrics.md
+++ b/docs/platform-metrics.md
@@ -53,6 +53,12 @@ Returned claim bonds, forfeited bonds, refunds, funding plans or intentions,
 unconfirmed transactions, and leaderboard prizes are excluded. Only a
 confirmed canonical `BountySettled` event proves solver payment.
 
+Recovery reservations are an active-inventory safety control. They keep a
+contract out of claimable inventory and verification work, but do not remove
+an already confirmed payout from immutable historical totals. The homepage and
+dashboard both read lifetime payout volume and settlement-event count from this
+same aggregate instead of recomputing them from the current opportunity feed.
+
 Platform revenue is reported separately as `0 USDC — monetization not active`.
 Marketplace payout volume is not platform revenue.
 
@@ -77,6 +83,20 @@ definitions. Combined inventory is withheld when either protocol is unavailable.
 The response intentionally excludes GitHub participation
 and all raw handles, wallet addresses, comment authors, event IDs, and
 transaction IDs.
+
+For public auditability, the dashboard independently reads the existing
+canonical event surfaces:
+
+- `GET /v1/base/autonomous-bounties/events?network=base-mainnet`
+- `GET /v1/base/open-competition-v1/events?network=base-mainnet`
+
+It filters those records to the selected UTC window, applies the payout formula
+above, and requires the exact base-unit sum and `BountySettled` count to match
+the aggregate. Every displayed payout row links to the bounty-scoped raw event
+set and its BaseScan transaction. Contract, bounty, event, and transaction
+identifiers are public blockchain evidence; participant wallet identities are
+not rendered in the ledger. A missing stream or arithmetic mismatch marks the
+dashboard partial instead of silently trusting or replacing the aggregate.
 
 `/generated/github-participation.json`
 
@@ -121,9 +141,9 @@ and is never added to active identities.
 - Missing inventory stays unavailable instead of becoming zero.
 - Missing historical browser analytics is disclosed and never estimated.
 
-The page refreshes the platform aggregate every minute and GitHub plus browser
-analytics every five minutes. It pauses periodic work while hidden and refreshes
-after the page becomes visible again.
+The page refreshes the platform aggregate and both canonical proof streams every
+minute, and GitHub plus browser analytics every five minutes. It pauses periodic
+work while hidden and refreshes after the page becomes visible again.
 
 ## Recheck commands
 

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -314,6 +314,8 @@ def main() -> int:
             "External active identities",
             "Marketplace payout volume",
             "Mature claim-to-settlement",
+            "Verify every payout",
+            "Event sum",
             "Role counts are not additive",
             "Browser/device IDs",
             "Thousands of repository actions",
@@ -338,6 +340,10 @@ def main() -> int:
             '"unavailable"',
             '"delayed"',
             'weeklyGrowth',
+            'canonicalPayoutRows',
+            'payoutAuditSummary',
+            'BASESCAN_TX_URL',
+            'raw.textContent = "Raw events"',
         ],
     )
     require_phrases(
@@ -347,6 +353,7 @@ def main() -> int:
             "@media (prefers-reduced-motion: reduce)",
             ".metrics-page [data-reveal]",
             ".period-control button[aria-pressed=\"true\"]",
+            ".audit-table-shell:focus-visible",
         ],
     )
     github_participation = json.loads(
@@ -740,8 +747,8 @@ def main() -> int:
             'document.addEventListener("visibilitychange"',
             "claim-funnel?window_hours=${MARKET_WINDOW_HOURS}",
             "limit=300",
-            "sumUsdc",
-            "newestPaidProof",
+            "/v1/metrics/platform?period=lifetime",
+            "metrics.html#payout-audit",
             "no stale bounty is shown",
             "Last verified standings remain visible",
             "payment_state",
@@ -860,7 +867,7 @@ def main() -> int:
             "Subscribe via RSS",
             "Subscribe via Atom",
             "Agent Bounties | The Global Marketplace for Digital Work",
-            'src="home.js?v=766"',
+            'src="home.js?v=767"',
             'src="simple-home.js?v=766"',
             'property="og:title"',
             'name="twitter:card"',

--- a/scripts/test-homepage-bounty-wiring.py
+++ b/scripts/test-homepage-bounty-wiring.py
@@ -11,6 +11,7 @@ ai_handoff = (site_dir / "ai-bounty-handoff.js").read_text(encoding="utf-8")
 composer = (site_dir / "bounty-composer-v2.js").read_text(encoding="utf-8")
 entry_js = (site_dir / "bounty-entry.js").read_text(encoding="utf-8")
 guild_home_js = (site_dir / "guild-home.js").read_text(encoding="utf-8")
+home_js = (site_dir / "home.js").read_text(encoding="utf-8")
 agent_html = (site_dir / "agent" / "index.html").read_text(encoding="utf-8")
 agent_markdown = (site_dir / "agent" / "index.md").read_text(encoding="utf-8")
 discovery = json.loads(
@@ -78,6 +79,14 @@ for marker in (
 
 for marker in ('event.key !== "Enter"', "search.requestSubmit()"):
     require("homepage Enter handler", guild_home_js, marker)
+
+for marker in (
+    "/v1/metrics/platform?period=lifetime",
+    "metrics?.marketplace_payout_volume?.lifetime?.usdc",
+    "metrics?.marketplace_payout_volume?.lifetime_settled_rounds",
+    'proof.href = "metrics.html#payout-audit"',
+):
+    require("homepage canonical payout metrics", home_js, marker)
 
 for marker in (
     "window.AgentBountyEntry.consume(params)",

--- a/scripts/test-metrics-dashboard.js
+++ b/scripts/test-metrics-dashboard.js
@@ -149,3 +149,81 @@ test("repository traffic has an independent honest status and comparable baselin
   assert.equal(metrics.ratioMultiple(9654, 2448).toFixed(1), "3.9");
   assert.equal(metrics.ratioMultiple(9654, 0), null);
 });
+
+test("canonical payout audit reconciles exact public event arithmetic", () => {
+  const autonomous = [
+    {
+      kind: "bounty_settled",
+      contract_address: "0x9999999999999999999999999999999999999999",
+      bounty_id: "0xaaa",
+      tx_hash: "0x111",
+      block_number: 11,
+      log_index: 4,
+      occurred_at: "2026-08-11T12:00:00Z",
+      data: { round: 1, solver_reward: 1_000_000, verifier_reward: 100_000, timeout_bond_bonus: 50_000 },
+    },
+    {
+      kind: "submission_rejected",
+      contract_address: "0x2222222222222222222222222222222222222222",
+      bounty_id: "0xbbb",
+      tx_hash: "0x222",
+      block_number: 12,
+      log_index: 5,
+      occurred_at: "2026-08-12T12:00:00Z",
+      data: { round: 2, verifier_reward: 100_000, forfeited_bond: 9_000_000 },
+    },
+    {
+      kind: "bounty_settled",
+      contract_address: "0x3333333333333333333333333333333333333333",
+      bounty_id: "0xccc",
+      tx_hash: "0x333",
+      block_number: 13,
+      log_index: 6,
+      occurred_at: "2026-08-13T00:00:00Z",
+      data: { solver_reward: 99_000_000, verifier_reward: 0, timeout_bond_bonus: 0 },
+    },
+  ];
+  const competition = {
+    events: [
+      {
+        kind: "competition_submission_rejected",
+        contract_address: "0x4444444444444444444444444444444444444444",
+        bounty_id: "0xddd",
+        tx_hash: "0x444",
+        block_number: 14,
+        log_index: 7,
+        occurred_at: "2026-08-11T13:00:00Z",
+        data: { submission_sequence: 1, bond_paid_to_verifier: 200_000, refund: 8_000_000 },
+      },
+      {
+        kind: "bounty_settled",
+        contract_address: "0x5555555555555555555555555555555555555555",
+        bounty_id: "0xeee",
+        tx_hash: "0x555",
+        block_number: 15,
+        log_index: 8,
+        occurred_at: "2026-08-12T13:00:00Z",
+        data: { submission_sequence: 2, solver_reward: 2_000_000, verifier_reward: 200_000, timeout_bond_bonus: 75_000 },
+      },
+    ],
+  };
+  const rows = metrics.canonicalPayoutRows(autonomous, competition, {
+    started_at: "2026-08-11T00:00:00Z",
+    ended_at: "2026-08-13T00:00:00Z",
+  });
+  const summary = metrics.payoutAuditSummary(rows);
+
+  assert.equal(rows.length, 4);
+  assert.equal(rows[0].tx_hash, "0x555");
+  assert.match(rows[0].explorer_url, /basescan\.org\/tx\/0x555#eventlog$/);
+  assert.match(rows[0].api_url, /bounty_id=0xeee$/);
+  assert.equal(rows.some((row) => row.contract_address.startsWith("0x9999")), true);
+  assert.deepEqual(summary, {
+    payout_events: 4,
+    settlement_events: 2,
+    solver_base_units: 3_000_000,
+    verifier_base_units: 600_000,
+    bonus_base_units: 125_000,
+    total_base_units: 3_725_000,
+  });
+});

--- a/site/home.js
+++ b/site/home.js
@@ -11,6 +11,7 @@
     projection: null,
     readyProjection: null,
     claim: null,
+    metrics: null,
     protocol: null,
     protocolPromise: null,
     refreshing: false,
@@ -328,20 +329,6 @@
     });
   }
 
-  function sumUsdc(items, includeCompletionBonus = false) {
-    return items.reduce((total, item) => {
-      const reward = item.reward && item.reward.currency === "USDC"
-        ? amountValue(item.reward)
-        : 0;
-      const bonus = includeCompletionBonus
-        && item.completion_bonus
-        && item.completion_bonus.currency === "USDC"
-        ? amountValue(item.completion_bonus)
-        : 0;
-      return total + reward + bonus;
-    }, 0);
-  }
-
   function isReadyToEarn(item) {
     return item.source_type === "canonical_base"
       && item.source_status === "claimable"
@@ -543,16 +530,7 @@
     return marketState.protocolPromise;
   }
 
-  function newestPaidProof(items) {
-    const paid = items
-      .filter((item) => item.source_type === "canonical_base" && item.payment_state === "paid")
-      .slice()
-      .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at));
-    const latest = paid[0];
-    return latest && safePublicUrl((latest.proof_urls || [])[0] || latest.public_url);
-  }
-
-  function renderMarketSnapshot(protocol, projection, readyProjection, claim) {
+  function renderMarketSnapshot(protocol, projection, readyProjection, claim, metrics) {
     const container = document.getElementById("home-live-inventory");
     const heroSummary = document.querySelector("[data-home-inventory-summary]");
     const detail = document.querySelector("[data-home-inventory-detail]");
@@ -564,24 +542,26 @@
       || readyItems.some((item) => !isReadyToEarn(item))) {
       throw new Error("Live earning inventory failed its claimability gate.");
     }
-    const referenceAt = new Date(claim.generated_at || projection.generated_at);
+    const referenceAt = new Date(metrics.generated_at || claim.generated_at || projection.generated_at);
     const oneWeekAgo = referenceAt.getTime() - (7 * 24 * 60 * 60 * 1_000);
-    const paidItems = items.filter((item) => item.source_type === "canonical_base"
-      && item.work_state === "completed"
-      && item.payment_state === "paid");
     const inProgressItems = items.filter((item) => item.source_type === "canonical_base"
       && (item.work_state === "in_progress" || item.work_state === "submitted"));
     const addedThisWeek = readyItems.filter((item) => {
       const created = Date.parse(item.created_at);
       return Number.isFinite(created) && created >= oneWeekAgo;
     }).length;
-    const transactionVolumeUsdc = sumUsdc(paidItems, true);
-    const solvedThisWeek = paidItems.filter((item) => {
-      const updated = Date.parse(item.updated_at);
-      return Number.isFinite(updated) && updated >= oneWeekAgo;
-    }).length;
+    const transactionVolumeUsdc = Number(metrics?.marketplace_payout_volume?.lifetime?.usdc);
+    const settlements = Number(metrics?.marketplace_payout_volume?.lifetime_settled_rounds);
+    if (!Number.isFinite(transactionVolumeUsdc) || !Number.isFinite(settlements)) {
+      throw new Error("Canonical lifetime payout metrics are unavailable.");
+    }
+    const solvedThisWeek = (metrics.daily || []).reduce((total, day) => {
+      const timestamp = Date.parse(`${day.day}T00:00:00Z`);
+      return Number.isFinite(timestamp) && timestamp >= oneWeekAgo
+        ? total + (Number(day.settled_rounds) || 0)
+        : total;
+    }, 0);
     const activeContributors = Number(claim?.canonical_outcomes?.unique_paid_solver_wallets) || 0;
-    const settlements = paidItems.length;
 
     setMetric("ready", readyItems.length);
     setMetricText(
@@ -596,7 +576,7 @@
     renderOpportunityBoard(container, readyItems);
 
     if (heroSummary) {
-      heroSummary.textContent = `${readyItems.length} bounties ready to claim · ${formatMetric(transactionVolumeUsdc, 2)} USDC settled · ${settlements} bounties settled`;
+      heroSummary.textContent = `${readyItems.length} bounties ready to claim · ${formatMetric(transactionVolumeUsdc, 2)} USDC canonical payout · ${settlements} settlement events`;
     }
     const sourceStatuses = projection.source_statuses || [];
     const availableSources = sourceStatuses.filter((source) => source.available).length;
@@ -610,9 +590,8 @@
         : `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · server-pushed live stream`;
     }
 
-    const proofUrl = newestPaidProof(paidItems);
-    if (proof && proofUrl) {
-      proof.href = proofUrl;
+    if (proof && settlements > 0) {
+      proof.href = "metrics.html#payout-audit";
       proof.hidden = false;
     } else if (proof) {
       proof.hidden = true;
@@ -630,28 +609,31 @@
     try {
       const protocol = await resolveProtocol();
       const api = protocol.api_base_url.replace(/\/$/, "");
-      const [projectionResponse, readyResponse, claimResponse] = await Promise.all([
+      const [projectionResponse, readyResponse, claimResponse, metricsResponse] = await Promise.all([
         fetch(`${api}/v1/opportunities?network=base-mainnet&limit=300`, { cache: "no-store" }),
         fetch(`${api}/v1/opportunities?network=base-mainnet&view=ready_to_earn&source_type=canonical_base&limit=300&live=${Date.now()}`, {
           cache: "no-store",
           headers: { "Cache-Control": "no-cache" },
         }),
         fetch(`${api}/v1/base/autonomous-bounties/claim-funnel?window_hours=${MARKET_WINDOW_HOURS}`, { cache: "no-store" }),
+        fetch(`${api}/v1/metrics/platform?period=lifetime`, { cache: "no-store" }),
       ]);
-      if (!projectionResponse.ok || !readyResponse.ok || !claimResponse.ok) {
+      if (!projectionResponse.ok || !readyResponse.ok || !claimResponse.ok || !metricsResponse.ok) {
         throw new Error("Live market evidence is unavailable.");
       }
-      const [projection, readyProjection, claim] = await Promise.all([
+      const [projection, readyProjection, claim, metrics] = await Promise.all([
         projectionResponse.json(),
         readyResponse.json(),
         claimResponse.json(),
+        metricsResponse.json(),
       ]);
       const firstLiveMarketView = !marketState.rendered;
       marketState.protocol = protocol;
       marketState.projection = projection;
       marketState.readyProjection = readyProjection;
       marketState.claim = claim;
-      renderMarketSnapshot(protocol, projection, readyProjection, claim);
+      marketState.metrics = metrics;
+      renderMarketSnapshot(protocol, projection, readyProjection, claim, metrics);
       marketState.lastReceivedAt = Date.now();
       marketState.rendered = true;
       if (firstLiveMarketView) track("market_view");
@@ -683,11 +665,17 @@
         const readyProjection = JSON.parse(event.data);
         marketState.streamConnected = true;
         marketState.readyProjection = readyProjection;
-        if (!marketState.projection || !marketState.claim) {
+        if (!marketState.projection || !marketState.claim || !marketState.metrics) {
           refreshMarket();
           return;
         }
-        renderMarketSnapshot(protocol, marketState.projection, readyProjection, marketState.claim);
+        renderMarketSnapshot(
+          protocol,
+          marketState.projection,
+          readyProjection,
+          marketState.claim,
+          marketState.metrics,
+        );
         marketState.lastReceivedAt = Date.now();
         marketState.rendered = true;
         setMarketStatus("live");

--- a/site/index.html
+++ b/site/index.html
@@ -121,13 +121,13 @@
             </div>
             <dl aria-label="Live marketplace metrics">
               <div><dt>Ready to earn</dt><dd><output data-adoption-ready>--</output><span data-adoption-ready-weekly>-- added this week · -- in progress</span></dd></div>
-              <div><dt>Total Transaction Volume</dt><dd><output data-adoption-available>--</output><span>USDC on Base</span></dd></div>
-              <div><dt>Bounties Settled</dt><dd><output data-adoption-settled>--</output><span data-adoption-settled-weekly>+-- this week</span></dd></div>
+              <div><dt>Canonical Payout Volume</dt><dd><output data-adoption-available>--</output><span>USDC on Base</span></dd></div>
+              <div><dt>Settlement Events</dt><dd><output data-adoption-settled>--</output><span data-adoption-settled-weekly>+-- this week</span></dd></div>
               <div><dt>Contributors</dt><dd><output data-adoption-paid>--</output><span>humans, AI agents, and organisations</span></dd></div>
             </dl>
             <p class="ledger-proof">Only <code>BountySettled</code> counts as payment.</p>
             <a href="metrics.html">Open live platform metrics</a>
-            <a data-market-proof hidden href="https://api.agentbounties.app/v1/base/autonomous-bounties/events?network=base-mainnet">Open latest settlement proof</a>
+            <a data-market-proof hidden href="metrics.html#payout-audit">Audit every payout</a>
           </aside>
         </div>
       </section>
@@ -234,8 +234,8 @@
           <div class="impact-ledger" data-reveal>
             <h2>Impact by the Numbers</h2>
             <ul>
-              <li><span aria-hidden="true">&#10003;</span><strong><output data-adoption-settled>--</output></strong><small>Bounties Settled</small></li>
-              <li><span aria-hidden="true">$</span><strong><output data-adoption-available>--</output></strong><small>USDC Transaction Volume</small></li>
+              <li><span aria-hidden="true">&#10003;</span><strong><output data-adoption-settled>--</output></strong><small>Settlement Events</small></li>
+              <li><span aria-hidden="true">$</span><strong><output data-adoption-available>--</output></strong><small>USDC Canonical Payout</small></li>
               <li><span aria-hidden="true">&#9673;</span><strong>Base</strong><small>Canonical Settlement Rail</small></li>
               <li><span aria-hidden="true">&#9782;</span><strong><output data-adoption-paid>--</output></strong><small>Contributors</small></li>
             </ul>
@@ -311,7 +311,7 @@
 
     <script src="analytics-config.js"></script>
     <script src="analytics.js"></script>
-    <script src="home.js?v=766"></script>
+    <script src="home.js?v=767"></script>
     <script src="simple-home.js?v=766"></script>
     <script src="bounty-entry.js?v=1"></script>
     <script src="guild-home.js"></script>

--- a/site/metrics.css
+++ b/site/metrics.css
@@ -263,12 +263,168 @@ body.metrics-page {
 
 .trend-section,
 .repository-section,
+.payout-audit-section,
 .composition-section,
 .inventory-section,
 .comparison-section,
 .supporting-section,
 .evidence-section {
   padding: clamp(70px, 9vw, 132px) 0 0;
+}
+
+.payout-audit-heading {
+  align-items: center;
+}
+
+.payout-audit-section {
+  scroll-margin-top: 148px;
+}
+
+.audit-verdict {
+  display: grid;
+  justify-items: start;
+  gap: 12px;
+}
+
+.audit-verdict p,
+.audit-method {
+  margin: 0;
+  color: var(--metrics-muted);
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.audit-totals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin-top: 1px;
+  background: var(--metrics-line);
+}
+
+.audit-totals article {
+  min-width: 0;
+  padding: clamp(24px, 3vw, 38px);
+  background: #030c08;
+}
+
+.audit-totals span,
+.audit-totals small {
+  display: block;
+  color: var(--metrics-muted);
+  font-size: 11px;
+}
+
+.audit-totals span {
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.audit-totals strong {
+  display: block;
+  margin: 18px 0 12px;
+  color: var(--metrics-paper);
+  font: 500 clamp(30px, 4vw, 54px) / 1 Georgia, "Times New Roman", serif;
+  letter-spacing: -0.045em;
+}
+
+.audit-totals article:first-child strong {
+  color: var(--metrics-blue);
+}
+
+.audit-totals code,
+.audit-method code {
+  color: var(--metrics-accent);
+}
+
+.audit-table-shell {
+  max-height: 620px;
+  margin-top: 24px;
+  overflow: auto;
+  border: 1px solid var(--metrics-line);
+  background: rgba(3, 12, 8, 0.78);
+  scrollbar-color: var(--metrics-line-strong) #030c08;
+}
+
+.audit-table-shell:focus-visible {
+  outline: 2px solid var(--metrics-accent);
+  outline-offset: 3px;
+}
+
+.audit-table {
+  width: 100%;
+  min-width: 920px;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.audit-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--metrics-line-strong);
+  background: #06110c;
+  color: var(--metrics-muted);
+  font-size: 10px;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.audit-table td {
+  padding: 17px 18px;
+  border-bottom: 1px solid var(--metrics-line);
+  color: #c6d0c7;
+  font-size: 12px;
+  vertical-align: top;
+}
+
+.audit-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.audit-table td:nth-child(2) strong,
+.audit-table td:nth-child(4) {
+  color: var(--metrics-paper);
+  font-weight: 760;
+}
+
+.audit-table td:nth-child(2) strong,
+.audit-table td:nth-child(2) span,
+.audit-table td:nth-child(3) code,
+.audit-table td:nth-child(3) span {
+  display: block;
+}
+
+.audit-table td:nth-child(2) span,
+.audit-table td:nth-child(3) span {
+  margin-top: 6px;
+  color: #7f8d84;
+}
+
+.audit-table code {
+  color: var(--metrics-accent);
+  font-size: 11px;
+}
+
+.audit-table td:last-child {
+  white-space: nowrap;
+}
+
+.audit-table a {
+  color: var(--metrics-blue);
+  font-weight: 760;
+  text-underline-offset: 3px;
+}
+
+.audit-table a + a {
+  margin-left: 12px;
+}
+
+.audit-method {
+  max-width: 920px;
+  margin-top: 18px;
 }
 
 .repository-status-line {
@@ -617,7 +773,7 @@ body.metrics-page {
 
 .source-ledger {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1px;
   margin-top: 32px;
   background: var(--metrics-line);
@@ -736,6 +892,7 @@ body.metrics-page {
 
 @media (max-width: 980px) {
   .headline-metrics,
+  .audit-totals,
   .repository-metrics,
   .inventory-ledger,
   .source-ledger {
@@ -799,6 +956,10 @@ body.metrics-page {
 
   .trend-figure {
     padding: 24px 18px;
+  }
+
+  .audit-table-shell {
+    max-height: 520px;
   }
 
   .role-row {

--- a/site/metrics.html
+++ b/site/metrics.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://agentbounties.app/metrics.html">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="guild-pages.css?v=20260721">
-    <link rel="stylesheet" href="metrics.css?v=2">
+    <link rel="stylesheet" href="metrics.css?v=3">
   </head>
   <body class="metrics-page guild-interior">
     <a class="skip-link" href="#main-content">Skip to metrics</a>
@@ -66,6 +66,28 @@
           <p class="metric-change"><strong data-mature-cohort>—</strong> mature claimed rounds</p>
           <p data-immature-context>Recent claims stay outside the rate until they mature or reach a terminal event.</p>
         </article>
+      </section>
+
+      <section id="payout-audit" class="payout-audit-section" aria-labelledby="payout-audit-title">
+        <div class="section-heading payout-audit-heading">
+          <div><p class="metrics-kicker">Canonical payout ledger · public proof</p><h2 id="payout-audit-title">Verify every payout</h2></div>
+          <div class="audit-verdict" aria-live="polite">
+            <span class="source-state" data-audit-status data-status="loading">loading</span>
+            <p data-audit-copy>Loading both canonical event streams and recomputing the selected period.</p>
+          </div>
+        </div>
+        <div class="audit-totals" aria-label="Payout audit reconciliation">
+          <article><span>Event sum</span><strong data-audit-total>—</strong><small>solver + verifier + completion bonus</small></article>
+          <article><span>Settlement events</span><strong data-audit-settlements>—</strong><small>confirmed <code>BountySettled</code> records</small></article>
+          <article><span>All payout events</span><strong data-audit-payout-events>—</strong><small>settlements plus paid rejections</small></article>
+        </div>
+        <div class="audit-table-shell" tabindex="0" role="region" aria-label="Scrollable canonical payout event ledger">
+          <table class="audit-table">
+            <thead><tr><th scope="col">Block time</th><th scope="col">Event</th><th scope="col">Contract / bounty</th><th scope="col">Payout</th><th scope="col">Proof</th></tr></thead>
+            <tbody data-audit-rows></tbody>
+          </table>
+        </div>
+        <p class="audit-method">This table is recomputed in your browser from the public Autonomous and Open Competition event APIs. Every row links to its raw event set and BaseScan transaction; participant wallet identities are not displayed here.</p>
       </section>
 
       <section class="repository-section" aria-labelledby="repository-title">
@@ -196,7 +218,7 @@
         <div class="source-ledger" data-source-ledger></div>
         <div class="definition-list">
           <details open><summary>What is an external active identity?</summary><p>One namespaced GitHub login, Base wallet, or normalized self-reported comment author with a qualifying action in the period. Namespaces are not merged, so this is participation—not verified unique people.</p></details>
-          <details><summary>What counts as payout volume?</summary><p>Solver reward, verifier reward, and timeout completion bonus from confirmed, block-time-verified <code>BountySettled</code> events across both live protocols, plus verifier pay from confirmed rejected-submission events.</p></details>
+          <details><summary>What counts as payout volume?</summary><p>Solver reward, verifier reward, and timeout completion bonus from every confirmed, block-time-verified <code>BountySettled</code> event across both live protocols, plus verifier pay from confirmed rejected-submission events. Recovery reservations affect future earning safety, never immutable payout history.</p></details>
           <details><summary>What is a mature claimed round?</summary><p>An exclusive-claim <code>(network, bounty_id, round)</code> whose deadline has passed or that already has a terminal canonical event. Immature claims are shown separately. Open Competition has no exclusive claim and stays outside this cohort.</p></details>
           <details><summary>How are repository users counted?</summary><p>GitHub reports unique cloners and unique visitors for a rolling 14-day window. Both unique counts are shown as repository users, but GitHub does not expose their identities or overlap. They therefore remain separate and are not added to external active identities.</p></details>
           <details><summary>What is deliberately excluded?</summary><p>Bots, maintainers in the public policy, browser visitors, stars, repository traffic from active platform identity totals, returned claim bonds, refunds, funding intentions, unconfirmed transactions, leaderboard prizes, and private operational analytics.</p></details>
@@ -205,9 +227,9 @@
       </section>
     </main>
 
-    <footer class="guild-shell-footer"><span>Public aggregate evidence. No handles or wallet addresses are exposed.</span><a href="privacy.html">Privacy</a><a href="https://api.agentbounties.app/api-docs/openapi.json">API</a></footer>
+    <footer class="guild-shell-footer"><span>Public aggregate evidence and canonical transaction proofs. No participant handles or wallet identities are displayed.</span><a href="privacy.html">Privacy</a><a href="https://api.agentbounties.app/api-docs/openapi.json">API</a></footer>
     <script src="analytics-config.js"></script>
     <script src="analytics.js"></script>
-    <script src="metrics.js?v=2"></script>
+    <script src="metrics.js?v=3"></script>
   </body>
 </html>

--- a/site/metrics.js
+++ b/site/metrics.js
@@ -8,12 +8,16 @@
   "use strict";
 
   const PLATFORM_URL = "https://api.agentbounties.app/v1/metrics/platform";
+  const AUTONOMOUS_EVENTS_URL = "https://api.agentbounties.app/v1/base/autonomous-bounties/events?network=base-mainnet";
+  const COMPETITION_EVENTS_URL = "https://api.agentbounties.app/v1/base/open-competition-v1/events?network=base-mainnet";
+  const BASESCAN_TX_URL = "https://basescan.org/tx/";
   const GITHUB_URL = "generated/github-participation.json";
   const ACQUISITION_URL = "https://api.agentbounties.app/v1/analytics/site";
   const PLATFORM_DELAY_MS = 5 * 60 * 1000;
   const GITHUB_DELAY_MS = 2 * 60 * 60 * 1000;
   const ACQUISITION_DELAY_MS = 15 * 60 * 1000;
   const PERIOD_HOURS = Object.freeze({ "7d": 168, "28d": 672, "90d": 2160 });
+  const USDC_SCALE = 1_000_000;
 
   function finiteNumber(value, fallback = 0) {
     const number = Number(value);
@@ -34,6 +38,91 @@
       minimumFractionDigits: 0,
       maximumFractionDigits,
     }).format(amount)} USDC`;
+  }
+
+  function nonNegativeBaseUnits(value) {
+    const amount = Number(value ?? 0);
+    return Number.isSafeInteger(amount) && amount > 0 ? amount : 0;
+  }
+
+  function canonicalPayoutRows(autonomousResponse, competitionResponse, window) {
+    const startedAt = Date.parse(window?.started_at || "");
+    const endedAt = Date.parse(window?.ended_at || "");
+    if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) return [];
+    const sources = [
+      {
+        protocol: "Exclusive claim",
+        protocolKey: "autonomous-v1",
+        events: Array.isArray(autonomousResponse) ? autonomousResponse : [],
+        eventUrl: AUTONOMOUS_EVENTS_URL,
+        rejectedKind: "submission_rejected",
+        rejectedAmount: "verifier_reward",
+      },
+      {
+        protocol: "Open competition",
+        protocolKey: "open-competition-v1",
+        events: Array.isArray(competitionResponse?.events) ? competitionResponse.events : [],
+        eventUrl: COMPETITION_EVENTS_URL,
+        rejectedKind: "competition_submission_rejected",
+        rejectedAmount: "bond_paid_to_verifier",
+      },
+    ];
+    const rows = [];
+    sources.forEach((source) => {
+      source.events.forEach((event) => {
+        const occurredAt = Date.parse(event?.occurred_at || "");
+        const settled = event?.kind === "bounty_settled";
+        const rejected = event?.kind === source.rejectedKind;
+        if ((!settled && !rejected) || !Number.isFinite(occurredAt)
+          || occurredAt < startedAt || occurredAt >= endedAt) return;
+        const solver = settled ? nonNegativeBaseUnits(event.data?.solver_reward) : 0;
+        const verifier = settled
+          ? nonNegativeBaseUnits(event.data?.verifier_reward)
+          : nonNegativeBaseUnits(event.data?.[source.rejectedAmount]);
+        const bonus = settled ? nonNegativeBaseUnits(event.data?.timeout_bond_bonus) : 0;
+        rows.push({
+          protocol: source.protocol,
+          protocol_key: source.protocolKey,
+          kind: event.kind,
+          event_label: settled ? "Settlement" : "Rejected submission payout",
+          contract_address: String(event.contract_address || ""),
+          bounty_id: String(event.bounty_id || ""),
+          round: event.data?.round ?? event.data?.submission_sequence ?? null,
+          tx_hash: String(event.tx_hash || ""),
+          block_number: finiteNumber(event.block_number),
+          log_index: finiteNumber(event.log_index),
+          occurred_at: String(event.occurred_at || ""),
+          solver_base_units: solver,
+          verifier_base_units: verifier,
+          bonus_base_units: bonus,
+          total_base_units: solver + verifier + bonus,
+          api_url: `${source.eventUrl}&bounty_id=${encodeURIComponent(String(event.bounty_id || ""))}`,
+          explorer_url: `${BASESCAN_TX_URL}${encodeURIComponent(String(event.tx_hash || ""))}#eventlog`,
+        });
+      });
+    });
+    return rows.sort((left, right) => (
+      right.block_number - left.block_number || right.log_index - left.log_index
+    ));
+  }
+
+  function payoutAuditSummary(rows) {
+    return (Array.isArray(rows) ? rows : []).reduce((summary, row) => {
+      summary.payout_events += 1;
+      summary.settlement_events += row.kind === "bounty_settled" ? 1 : 0;
+      summary.solver_base_units += nonNegativeBaseUnits(row.solver_base_units);
+      summary.verifier_base_units += nonNegativeBaseUnits(row.verifier_base_units);
+      summary.bonus_base_units += nonNegativeBaseUnits(row.bonus_base_units);
+      summary.total_base_units += nonNegativeBaseUnits(row.total_base_units);
+      return summary;
+    }, {
+      payout_events: 0,
+      settlement_events: 0,
+      solver_base_units: 0,
+      verifier_base_units: 0,
+      bonus_base_units: 0,
+      total_base_units: 0,
+    });
   }
 
   function weeklyGrowth(current, previous) {
@@ -212,6 +301,8 @@
     const state = {
       period: "lifetime",
       platform: null,
+      autonomousEvents: null,
+      competitionEvents: null,
       github: null,
       acquisition: null,
       errors: {},
@@ -231,6 +322,115 @@
 
     function amount(response) {
       return formatUsdc(response?.usdc);
+    }
+
+    function shortHash(value) {
+      const text = String(value || "");
+      return text.length > 18 ? `${text.slice(0, 10)}…${text.slice(-6)}` : text || "—";
+    }
+
+    function payoutAuditSnapshot(platform) {
+      if (!platform || !state.autonomousEvents || !state.competitionEvents) {
+        return { status: "unavailable", rows: [], summary: payoutAuditSummary([]), generated_at: null };
+      }
+      const rows = canonicalPayoutRows(
+        state.autonomousEvents,
+        state.competitionEvents,
+        platform.window,
+      );
+      const summary = payoutAuditSummary(rows);
+      const expectedTotal = Number(platform.marketplace_payout_volume?.selected?.usdc_base_units);
+      const expectedSettlements = Number(platform.marketplace_payout_volume?.selected_settled_rounds);
+      const reconciled = Number.isSafeInteger(expectedTotal)
+        && Number.isSafeInteger(expectedSettlements)
+        && summary.total_base_units === expectedTotal
+        && summary.settlement_events === expectedSettlements;
+      return {
+        status: reconciled ? "ready" : "partial",
+        rows,
+        summary,
+        generated_at: rows[0]?.occurred_at || platform.generated_at,
+      };
+    }
+
+    function renderPayoutAudit(audit) {
+      const status = one("[data-audit-status]");
+      if (status) {
+        status.dataset.status = audit.status;
+        status.textContent = audit.status === "ready"
+          ? "reconciled"
+          : audit.status === "partial" ? "mismatch" : "unavailable";
+      }
+      setText("[data-audit-total]", audit.status === "unavailable"
+        ? "—"
+        : formatUsdc(audit.summary.total_base_units / USDC_SCALE));
+      setText("[data-audit-settlements]", audit.status === "unavailable"
+        ? "—"
+        : formatInteger(audit.summary.settlement_events));
+      setText("[data-audit-payout-events]", audit.status === "unavailable"
+        ? "—"
+        : formatInteger(audit.summary.payout_events));
+      setText("[data-audit-copy]", audit.status === "ready"
+        ? "The independent event sum exactly matches the headline payout and settlement count for this period."
+        : audit.status === "partial"
+          ? "The public event sum does not match the aggregate yet. Treat the headline as partial while indexing catches up."
+          : "The raw canonical event streams are unavailable. No unverifiable replacement is shown.");
+
+      const body = one("[data-audit-rows]");
+      if (!body) return;
+      body.replaceChildren();
+      audit.rows.forEach((row) => {
+        const tr = doc.createElement("tr");
+        const when = doc.createElement("td");
+        const time = doc.createElement("time");
+        time.dateTime = row.occurred_at;
+        time.textContent = new Date(row.occurred_at).toLocaleString(undefined, {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+          timeZone: "UTC",
+          timeZoneName: "short",
+        });
+        when.appendChild(time);
+
+        const event = doc.createElement("td");
+        const eventName = doc.createElement("strong");
+        eventName.textContent = row.event_label;
+        const protocol = doc.createElement("span");
+        protocol.textContent = `${row.protocol}${row.round == null ? "" : ` · round ${row.round}`}`;
+        event.append(eventName, protocol);
+
+        const contract = doc.createElement("td");
+        const contractCode = doc.createElement("code");
+        contractCode.textContent = shortHash(row.contract_address);
+        contractCode.title = row.contract_address;
+        const bountyCode = doc.createElement("span");
+        bountyCode.textContent = `Bounty ${shortHash(row.bounty_id)}`;
+        bountyCode.title = row.bounty_id;
+        contract.append(contractCode, bountyCode);
+
+        const payout = doc.createElement("td");
+        payout.textContent = formatUsdc(row.total_base_units / USDC_SCALE);
+
+        const proof = doc.createElement("td");
+        const explorer = doc.createElement("a");
+        explorer.href = row.explorer_url;
+        explorer.target = "_blank";
+        explorer.rel = "noopener noreferrer";
+        explorer.textContent = "BaseScan";
+        explorer.title = `Open transaction ${row.tx_hash} on BaseScan`;
+        const raw = doc.createElement("a");
+        raw.href = row.api_url;
+        raw.target = "_blank";
+        raw.rel = "noopener noreferrer";
+        raw.textContent = "Raw events";
+        raw.title = `Open canonical event records for ${row.bounty_id}`;
+        proof.append(explorer, raw);
+        tr.append(when, event, contract, payout, proof);
+        body.appendChild(tr);
+      });
     }
 
     function renderChart(selector, points, valueKey, kind) {
@@ -270,12 +470,13 @@
       });
     }
 
-    function renderSourceLedger(merged, acquisitionStatus, repositoryStatus) {
+    function renderSourceLedger(merged, acquisitionStatus, repositoryStatus, audit) {
       const target = one("[data-source-ledger]");
       if (!target) return;
       target.replaceChildren();
       const sources = [
         ["Marketplace events", merged.platform_status, state.platform?.generated_at, "Confirmed canonical Base events with verified block time."],
+        ["Payout proof ledger", audit.status, audit.generated_at, "Every qualifying payout event is summed in the browser and linked to its raw record and Base transaction."],
         ["GitHub participation", merged.github_status, state.github?.generated_at, "Hourly aggregate of external issues, pull requests, comments, and reviews."],
         ["Repository acquisition", repositoryStatus, state.github?.repository_acquisition?.generated_at, "GitHub clone and page-view aggregates for its rolling 14-day traffic window."],
         ["Browser acquisition", acquisitionStatus, state.acquisition?.generated_at, "First-party browser/device IDs; never counted as users or identities."],
@@ -319,7 +520,9 @@
         now,
         GITHUB_DELAY_MS,
       );
-      const overallStatus = dashboardStatus(merged.status, repositoryStatus);
+      const audit = payoutAuditSnapshot(platform);
+      const coreStatus = dashboardStatus(merged.status, repositoryStatus);
+      const overallStatus = dashboardStatus(coreStatus, audit.status);
       const status = one("[data-overall-status]");
       if (status) {
         status.dataset.status = overallStatus;
@@ -349,6 +552,7 @@
       setText("[data-solver-pay]", payout ? amount(payout.selected_solver_pay) : "—");
       setText("[data-verifier-pay]", payout ? amount(payout.selected_verifier_pay) : "—");
       setText("[data-completion-bonus]", payout ? amount(payout.selected_completion_bonus) : "—");
+      renderPayoutAudit(audit);
 
       const inventoryReady = inventory?.status === "ready";
       setText("[data-inventory-ready]", inventoryReady ? formatInteger(inventory.ready_to_earn_opportunities) : "—");
@@ -397,24 +601,45 @@
         ? `${formatInteger(state.acquisition.overview?.sessions)} browser sessions in the matching lookback. Device/browser IDs are not people.`
         : "Acquisition source unavailable. Browser IDs are never estimated or counted as active identities.");
       setText("[data-platform-revenue]", platform ? amount(platform.platform_revenue) : "0 USDC");
-      renderSourceLedger(merged, acquisitionStatus, repositoryStatus);
+      renderSourceLedger(merged, acquisitionStatus, repositoryStatus, audit);
 
       const notices = [];
       if (merged.status === "partial") notices.push("Identity totals are partial because a required participation source is unavailable or incomplete.");
       if (merged.status === "delayed") notices.push("One or more required sources are delayed; values remain visible with their source timestamps.");
       if (merged.status === "unavailable") notices.push("Marketplace metrics are temporarily unavailable; no missing value has been replaced with zero.");
       if (["partial", "unavailable"].includes(repositoryStatus)) notices.push("Repository acquisition is unavailable or incomplete; historical snapshots remain labeled and are not substituted as live data.");
+      if (audit.status === "partial") notices.push("The payout proof ledger does not yet reconcile to the aggregate; payout values are marked partial.");
+      if (audit.status === "unavailable") notices.push("The public payout proof streams are unavailable, so payout auditability is temporarily partial.");
       if (overallStatus === "ready") notices.push(`Live aggregate for ${state.period === "lifetime" ? "lifetime since launch" : state.period}. Roles are not additive.`);
       setText("[data-dashboard-notice]", notices.join(" "));
     }
 
     async function refreshPlatform() {
-      try {
-        state.platform = await requestJson(`${PLATFORM_URL}?period=${encodeURIComponent(state.period)}`);
+      const [platformResult, autonomousResult, competitionResult] = await Promise.allSettled([
+        requestJson(`${PLATFORM_URL}?period=${encodeURIComponent(state.period)}`),
+        requestJson(AUTONOMOUS_EVENTS_URL),
+        requestJson(COMPETITION_EVENTS_URL),
+      ]);
+      if (platformResult.status === "fulfilled") {
+        state.platform = platformResult.value;
         delete state.errors.platform;
-      } catch (error) {
-        state.errors.platform = error;
+      } else {
+        state.errors.platform = platformResult.reason;
         state.platform = null;
+      }
+      if (autonomousResult.status === "fulfilled") {
+        state.autonomousEvents = autonomousResult.value;
+        delete state.errors.autonomousEvents;
+      } else {
+        state.autonomousEvents = null;
+        state.errors.autonomousEvents = autonomousResult.reason;
+      }
+      if (competitionResult.status === "fulfilled") {
+        state.competitionEvents = competitionResult.value;
+        delete state.errors.competitionEvents;
+      } else {
+        state.competitionEvents = null;
+        state.errors.competitionEvents = competitionResult.reason;
       }
       render();
     }
@@ -477,11 +702,13 @@
 
   return {
     acquisitionWindowHours,
+    canonicalPayoutRows,
     chartSvg,
     combinedStatus,
     dashboardStatus,
     mergeDaily,
     mergeMetrics,
+    payoutAuditSummary,
     sourceStatus,
     start,
     ratioMultiple,


### PR DESCRIPTION
## Outcome

Reconciles the homepage and live metrics dashboard to the same canonical lifetime payout aggregate, and adds a browser-recomputed public payout ledger with raw-event and BaseScan proofs.

Closes the discrepancy documented in maintainer notice #939.

## Root cause

The historical platform-metrics SQL reused the recovery-reservation exclusion intended for active claim and verification inventory. Five already-settled recovery-reserved contracts were therefore erased from historical payouts: exactly 10.00 USDC and five `BountySettled` events. Production showed 26.46 USDC / 29 settlements while the complete verified public event streams sum to 36.46 USDC / 34 settlements (41 total payout events).

The homepage's 33.11 / 32 came from current paid opportunity rows and a narrower solver-side formula, so it was higher than the dashboard but still was not the complete canonical ledger.

## Changes

- preserve recovery exclusions for active identities and claim cohorts while including every block-time-verified payout in immutable historical aggregates, daily series, and coverage
- source homepage lifetime payout and settlement count from `/v1/metrics/platform`
- independently recompute the selected period from both public canonical event streams in the dashboard
- require exact base-unit and settlement-count reconciliation; show partial/unavailable on mismatch instead of substituting a value
- link every payout row to its bounty-scoped raw events and BaseScan transaction without rendering participant wallet identities
- document the historical-vs-active boundary and add regression/site tests

## Compatibility and open PR impact

The response schema is unchanged; only historical aggregate values become complete. Consumers that snapshot exact totals should refresh expectations. All 87 open PRs were inspected before the maintainer change; the overlapping PRs and migration guidance are recorded in #939. No contributor branch is superseded by this patch.

## Verification

- `scripts/preflight.ps1 -Mode core`
- `node --test scripts/test-metrics-dashboard.js`
- `python scripts/test-homepage-bounty-wiring.py`
- `python scripts/check-site.py`
- `node --check site/home.js`
- `node --check site/metrics.js`
- `cargo fmt --all -- --check`
- `cargo test -p api platform_metric -- --nocapture`
- `cargo test -p db --lib --no-run`
- desktop and mobile Playwright visual/console QA against the production data surfaces

The ignored PostgreSQL integration test was updated for this regression but cannot run locally without `AGENT_BOUNTIES_TEST_DATABASE_URL`.