### PR TITLE
feat(metrics): show live API CLI and MCP usage

### DIFF
--- a/docs/platform-metrics.md
+++ b/docs/platform-metrics.md
@@ -128,6 +128,14 @@ This optional acquisition section reports privacy-minimized browser/device IDs.
 It is labeled as acquisition context, not users, has no pre-deployment backfill,
 and is never added to active identities.
 
+The same response supplies the dashboard's live interface-usage section. It
+shows hourly aggregate request totals and successful HTTP responses for REST API,
+CLI, modern MCP, legacy MCP, and the MCP HTTP adapter. These are interactions,
+not unique people, agents, clients, sessions, or surveyed preferences. API and
+CLI attribution is self-declared through `X-Agent-Bounties-Interface`; MCP era
+is observed by the MCP service. The rows are stored in Postgres table
+`interface_usage_hourly` and have no historical backfill before deployment.
+
 ## Freshness and honest gaps
 
 - Platform data older than five minutes is delayed.
@@ -141,9 +149,10 @@ and is never added to active identities.
 - Missing inventory stays unavailable instead of becoming zero.
 - Missing historical browser analytics is disclosed and never estimated.
 
-The page refreshes the platform aggregate and both canonical proof streams every
-minute, and GitHub plus browser analytics every five minutes. It pauses periodic
-work while hidden and refreshes after the page becomes visible again.
+The page refreshes the platform aggregate, both canonical proof streams, and
+interface/browser analytics every minute. GitHub participation and repository
+traffic refresh every five minutes. It pauses periodic work while hidden and
+refreshes after the page becomes visible again.
 
 ## Recheck commands
 

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -314,6 +314,10 @@ def main() -> int:
             "External active identities",
             "Marketplace payout volume",
             "Mature claim-to-settlement",
+            "API, CLI, and MCP usage",
+            "Observed requests",
+            "MCP request share",
+            "Counts are requests, not unique people, agents, clients, or sessions",
             "Verify every payout",
             "Event sum",
             "Role counts are not additive",
@@ -340,6 +344,8 @@ def main() -> int:
             '"unavailable"',
             '"delayed"',
             'weeklyGrowth',
+            'interfaceUsageSummary',
+            'data-interface-status',
             'canonicalPayoutRows',
             'payoutAuditSummary',
             'BASESCAN_TX_URL',
@@ -354,6 +360,7 @@ def main() -> int:
             ".metrics-page [data-reveal]",
             ".period-control button[aria-pressed=\"true\"]",
             ".audit-table-shell:focus-visible",
+            ".interface-track i",
         ],
     )
     github_participation = json.loads(

--- a/scripts/test-metrics-dashboard.js
+++ b/scripts/test-metrics-dashboard.js
@@ -150,6 +150,51 @@ test("repository traffic has an independent honest status and comparable baselin
   assert.equal(metrics.ratioMultiple(9654, 0), null);
 });
 
+test("interface usage aggregates fixed API CLI and MCP rows without claiming users", () => {
+  const summary = metrics.interfaceUsageSummary({
+    interfaces: [
+      { interface: "mcp", protocol_era: "legacy", request_count: 20, successful_request_count: 19, first_observed_at: "2026-08-13T17:00:00Z", last_observed_at: "2026-08-13T17:12:00Z" },
+      { interface: "cli", protocol_era: "not_applicable", request_count: 7, successful_request_count: 7, first_observed_at: "2026-08-13T17:02:00Z", last_observed_at: "2026-08-13T17:13:00Z" },
+      { interface: "mcp", protocol_era: "http_adapter", request_count: 5, successful_request_count: 5, first_observed_at: "2026-08-13T17:03:00Z", last_observed_at: "2026-08-13T17:14:00Z" },
+      { interface: "mcp", protocol_era: "modern", request_count: 5, successful_request_count: 5, first_observed_at: "2026-08-13T17:04:00Z", last_observed_at: "2026-08-13T17:15:00Z" },
+      { interface: "api", protocol_era: "not_applicable", request_count: 3, successful_request_count: 3, first_observed_at: "2026-08-13T17:05:00Z", last_observed_at: "2026-08-13T17:16:00Z" },
+    ],
+  });
+
+  assert.equal(summary.status, "ready");
+  assert.equal(summary.rows.length, 5);
+  assert.equal(summary.request_count, 40);
+  assert.equal(summary.successful_request_count, 39);
+  assert.equal(summary.success_rate, 39 / 40);
+  assert.equal(summary.mcp_request_count, 30);
+  assert.equal(summary.mcp_share, 0.75);
+  assert.equal(summary.rows.find((row) => row.key === "mcp:legacy").success_rate, 19 / 20);
+  assert.equal(summary.first_observed_at, "2026-08-13T17:00:00.000Z");
+  assert.equal(summary.last_observed_at, "2026-08-13T17:16:00.000Z");
+});
+
+test("interface usage handles empty coverage duplicate buckets and malformed success counts", () => {
+  assert.equal(metrics.interfaceUsageSummary(null).status, "unavailable");
+
+  const empty = metrics.interfaceUsageSummary({ interfaces: [] });
+  assert.equal(empty.status, "ready");
+  assert.equal(empty.request_count, 0);
+  assert.equal(empty.mcp_share, null);
+  assert.equal(empty.rows.every((row) => row.request_count === 0), true);
+
+  const combined = metrics.interfaceUsageSummary({
+    interfaces: [
+      { interface: "api", protocol_era: "not_applicable", request_count: 2, successful_request_count: 9 },
+      { interface: "api", protocol_era: "not_applicable", request_count: 3, successful_request_count: -1 },
+      { interface: "unknown", protocol_era: "future", request_count: 100, successful_request_count: 100 },
+    ],
+  });
+  assert.equal(combined.request_count, 5);
+  assert.equal(combined.successful_request_count, 2);
+  assert.equal(combined.rows.find((row) => row.key === "api:not_applicable").request_count, 5);
+  assert.equal(combined.rows.find((row) => row.key === "api:not_applicable").successful_request_count, 2);
+});
+
 test("canonical payout audit reconciles exact public event arithmetic", () => {
   const autonomous = [
     {

--- a/site/metrics.css
+++ b/site/metrics.css
@@ -263,6 +263,7 @@ body.metrics-page {
 
 .trend-section,
 .repository-section,
+.interface-usage-section,
 .payout-audit-section,
 .composition-section,
 .inventory-section,
@@ -270,6 +271,175 @@ body.metrics-page {
 .supporting-section,
 .evidence-section {
   padding: clamp(70px, 9vw, 132px) 0 0;
+}
+
+.interface-usage-section {
+  scroll-margin-top: 148px;
+}
+
+.interface-usage-heading {
+  align-items: end;
+}
+
+.interface-live-state {
+  display: grid;
+  justify-items: start;
+  gap: 12px;
+}
+
+.interface-live-state p,
+.interface-boundary {
+  margin: 0;
+  color: var(--metrics-muted);
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.interface-totals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 34px;
+  border-top: 1px solid var(--metrics-line-strong);
+  border-bottom: 1px solid var(--metrics-line);
+}
+
+.interface-totals > div {
+  min-width: 0;
+  padding: 24px clamp(18px, 3vw, 34px) 26px 0;
+}
+
+.interface-totals > div + div {
+  padding-left: clamp(18px, 3vw, 34px);
+  border-left: 1px solid var(--metrics-line);
+}
+
+.interface-totals span {
+  display: block;
+  color: var(--metrics-muted);
+  font-size: 10px;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.interface-totals output {
+  display: block;
+  margin-top: 14px;
+  color: var(--metrics-paper);
+  font: 500 clamp(28px, 4vw, 48px) / 1 Georgia, "Times New Roman", serif;
+  letter-spacing: -0.045em;
+}
+
+.interface-totals > div:first-child output {
+  color: var(--metrics-accent);
+}
+
+.interface-ledger {
+  border-bottom: 1px solid var(--metrics-line-strong);
+}
+
+.interface-row {
+  --interface-color: var(--metrics-accent);
+  display: grid;
+  grid-template-columns: minmax(230px, 1fr) minmax(170px, 0.6fr) minmax(280px, 1.25fr);
+  align-items: center;
+  gap: clamp(24px, 4vw, 70px);
+  min-height: 112px;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--metrics-line);
+  transition: background-color 160ms ease, padding 160ms ease;
+}
+
+.interface-row[data-tone="modern"] {
+  --interface-color: var(--metrics-blue);
+}
+
+.interface-row[data-tone="legacy"] {
+  --interface-color: #b49bff;
+}
+
+.interface-row[data-tone="adapter"] {
+  --interface-color: #7fd7c4;
+}
+
+.interface-row[data-tone="cli"] {
+  --interface-color: #ffd172;
+}
+
+.interface-row:hover {
+  margin: 0 -14px;
+  padding-right: 14px;
+  padding-left: 14px;
+  background: rgba(241, 243, 235, 0.025);
+}
+
+.interface-identity h3,
+.interface-identity p {
+  margin: 0;
+}
+
+.interface-identity h3 {
+  color: var(--metrics-paper);
+  font-size: clamp(15px, 1.4vw, 20px);
+}
+
+.interface-identity p,
+.interface-volume span,
+.interface-share > span {
+  color: var(--metrics-muted);
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.interface-identity p {
+  margin-top: 7px;
+}
+
+.interface-volume strong,
+.interface-volume span {
+  display: block;
+}
+
+.interface-volume strong {
+  color: var(--interface-color);
+  font: 650 clamp(25px, 3vw, 39px) / 1 ui-monospace, SFMono-Regular, Consolas, monospace;
+  letter-spacing: -0.05em;
+}
+
+.interface-volume span {
+  margin-top: 9px;
+}
+
+.interface-share {
+  display: grid;
+  gap: 10px;
+}
+
+.interface-track {
+  display: block;
+  height: 6px;
+  overflow: hidden;
+  background: rgba(212, 233, 208, 0.1);
+}
+
+.interface-track i {
+  display: block;
+  width: var(--interface-width);
+  height: 100%;
+  background: var(--interface-color);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--interface-color) 45%, transparent);
+  transform-origin: left;
+  animation: interface-fill 520ms cubic-bezier(.22, .75, .25, 1) both;
+}
+
+.interface-boundary {
+  max-width: 900px;
+  margin-top: 18px;
+}
+
+@keyframes interface-fill {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
 }
 
 .payout-audit-heading {
@@ -892,11 +1062,17 @@ body.metrics-page {
 
 @media (max-width: 980px) {
   .headline-metrics,
+  .interface-totals,
   .audit-totals,
   .repository-metrics,
   .inventory-ledger,
   .source-ledger {
     grid-template-columns: 1fr;
+  }
+
+  .interface-row {
+    grid-template-columns: minmax(190px, 1fr) minmax(140px, 0.7fr) minmax(200px, 1fr);
+    gap: 24px;
   }
 
   .headline-metric,
@@ -958,6 +1134,32 @@ body.metrics-page {
     padding: 24px 18px;
   }
 
+  .interface-totals > div,
+  .interface-totals > div + div {
+    padding: 22px 0;
+    border-left: 0;
+  }
+
+  .interface-totals > div + div {
+    border-top: 1px solid var(--metrics-line);
+  }
+
+  .interface-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 18px;
+  }
+
+  .interface-share {
+    grid-column: 1 / -1;
+  }
+
+  .interface-row:hover {
+    margin: 0;
+    padding-right: 0;
+    padding-left: 0;
+    background: transparent;
+  }
+
   .audit-table-shell {
     max-height: 520px;
   }
@@ -983,6 +1185,9 @@ body.metrics-page {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .interface-track i {
+    animation: none;
+  }
   html:has(body.metrics-page) { scroll-behavior: auto; }
   .metrics-page [data-reveal],
   .role-track i { animation: none; }

--- a/site/metrics.html
+++ b/site/metrics.html
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://agentbounties.app/metrics.html">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="guild-pages.css?v=20260721">
-    <link rel="stylesheet" href="metrics.css?v=3">
+    <link rel="stylesheet" href="metrics.css?v=4">
   </head>
   <body class="metrics-page guild-interior">
     <a class="skip-link" href="#main-content">Skip to metrics</a>
@@ -66,6 +66,23 @@
           <p class="metric-change"><strong data-mature-cohort>—</strong> mature claimed rounds</p>
           <p data-immature-context>Recent claims stay outside the rate until they mature or reach a terminal event.</p>
         </article>
+      </section>
+
+      <section id="interface-usage" class="interface-usage-section" aria-labelledby="interface-usage-title" data-reveal>
+        <div class="section-heading interface-usage-heading">
+          <div><p class="metrics-kicker">Live interface adoption</p><h2 id="interface-usage-title">API, CLI, and MCP usage</h2></div>
+          <div class="interface-live-state" aria-live="polite">
+            <span class="source-state" data-interface-status data-status="loading">loading</span>
+            <p data-interface-window>Loading hourly aggregate request counts for the selected period.</p>
+          </div>
+        </div>
+        <div class="interface-totals" aria-label="Interface request totals">
+          <div><span>Observed requests</span><output data-interface-total>—</output></div>
+          <div><span>Successful HTTP responses</span><output data-interface-success>—</output></div>
+          <div><span>MCP request share</span><output data-interface-mcp-share>—</output></div>
+        </div>
+        <div class="interface-ledger" data-interface-rows aria-label="Usage by interface and MCP protocol era"></div>
+        <p class="interface-boundary">Counts are requests, not unique people, agents, clients, or sessions. “Successful” means an HTTP 2xx response. API and CLI attribution is self-declared; MCP protocol era is observed by the MCP service. One workflow can use several interfaces.</p>
       </section>
 
       <section id="payout-audit" class="payout-audit-section" aria-labelledby="payout-audit-title">
@@ -230,6 +247,6 @@
     <footer class="guild-shell-footer"><span>Public aggregate evidence and canonical transaction proofs. No participant handles or wallet identities are displayed.</span><a href="privacy.html">Privacy</a><a href="https://api.agentbounties.app/api-docs/openapi.json">API</a></footer>
     <script src="analytics-config.js"></script>
     <script src="analytics.js"></script>
-    <script src="metrics.js?v=3"></script>
+    <script src="metrics.js?v=4"></script>
   </body>
 </html>

--- a/site/metrics.js
+++ b/site/metrics.js
@@ -18,6 +18,13 @@
   const ACQUISITION_DELAY_MS = 15 * 60 * 1000;
   const PERIOD_HOURS = Object.freeze({ "7d": 168, "28d": 672, "90d": 2160 });
   const USDC_SCALE = 1_000_000;
+  const INTERFACE_DEFINITIONS = Object.freeze([
+    { key: "api:not_applicable", interface: "api", label: "REST API", detail: "Direct HTTP and official SDK requests", tone: "api" },
+    { key: "cli:not_applicable", interface: "cli", label: "CLI", detail: "Rust command-line workflows", tone: "cli" },
+    { key: "mcp:modern", interface: "mcp", label: "MCP 2026-07-28", detail: "Stateless discovery and self-contained requests", tone: "modern" },
+    { key: "mcp:legacy", interface: "mcp", label: "Legacy MCP", detail: "Initialization-era compatible clients", tone: "legacy" },
+    { key: "mcp:http_adapter", interface: "mcp", label: "MCP HTTP adapter", detail: "Direct /tools/* compatibility calls", tone: "adapter" },
+  ]);
 
   function finiteNumber(value, fallback = 0) {
     const number = Number(value);
@@ -38,6 +45,94 @@
       minimumFractionDigits: 0,
       maximumFractionDigits,
     }).format(amount)} USDC`;
+  }
+
+  function formatPercent(value) {
+    const percent = Math.max(0, Math.min(1, finiteNumber(value))) * 100;
+    return `${percent.toLocaleString("en-US", { maximumFractionDigits: 1 })}%`;
+  }
+
+  function interfaceUsageSummary(response) {
+    const emptyRows = () => INTERFACE_DEFINITIONS.map((definition) => ({
+      ...definition,
+      request_count: 0,
+      successful_request_count: 0,
+      success_rate: null,
+      share: 0,
+      first_observed_at: null,
+      last_observed_at: null,
+    }));
+    if (!response || !Array.isArray(response.interfaces)) {
+      return {
+        status: "unavailable",
+        rows: emptyRows(),
+        request_count: 0,
+        successful_request_count: 0,
+        success_rate: null,
+        mcp_request_count: 0,
+        mcp_share: null,
+        first_observed_at: null,
+        last_observed_at: null,
+      };
+    }
+    const observed = new Map();
+    response.interfaces.forEach((item) => {
+      const key = `${String(item?.interface || "")}:${String(item?.protocol_era || "")}`;
+      if (!INTERFACE_DEFINITIONS.some((definition) => definition.key === key)) return;
+      const current = observed.get(key) || {
+        request_count: 0,
+        successful_request_count: 0,
+        first_observed_at: null,
+        last_observed_at: null,
+      };
+      const requestCount = Math.max(0, finiteNumber(item?.request_count));
+      const successfulCount = Math.min(requestCount, Math.max(0, finiteNumber(item?.successful_request_count)));
+      const firstObserved = Date.parse(item?.first_observed_at || "");
+      const lastObserved = Date.parse(item?.last_observed_at || "");
+      current.request_count += requestCount;
+      current.successful_request_count += successfulCount;
+      if (Number.isFinite(firstObserved) && (!current.first_observed_at || firstObserved < Date.parse(current.first_observed_at))) {
+        current.first_observed_at = new Date(firstObserved).toISOString();
+      }
+      if (Number.isFinite(lastObserved) && (!current.last_observed_at || lastObserved > Date.parse(current.last_observed_at))) {
+        current.last_observed_at = new Date(lastObserved).toISOString();
+      }
+      observed.set(key, current);
+    });
+    const requestCount = [...observed.values()].reduce((sum, row) => sum + row.request_count, 0);
+    const successfulRequestCount = [...observed.values()].reduce((sum, row) => sum + row.successful_request_count, 0);
+    const rows = INTERFACE_DEFINITIONS.map((definition) => {
+      const row = observed.get(definition.key) || {
+        request_count: 0,
+        successful_request_count: 0,
+        first_observed_at: null,
+        last_observed_at: null,
+      };
+      return {
+        ...definition,
+        ...row,
+        success_rate: row.request_count ? row.successful_request_count / row.request_count : null,
+        share: requestCount ? row.request_count / requestCount : 0,
+      };
+    });
+    const mcpRequestCount = rows
+      .filter((row) => row.interface === "mcp")
+      .reduce((sum, row) => sum + row.request_count, 0);
+    const timestamps = rows.flatMap((row) => [
+      Date.parse(row.first_observed_at || ""),
+      Date.parse(row.last_observed_at || ""),
+    ]).filter(Number.isFinite);
+    return {
+      status: "ready",
+      rows,
+      request_count: requestCount,
+      successful_request_count: successfulRequestCount,
+      success_rate: requestCount ? successfulRequestCount / requestCount : null,
+      mcp_request_count: mcpRequestCount,
+      mcp_share: requestCount ? mcpRequestCount / requestCount : null,
+      first_observed_at: timestamps.length ? new Date(Math.min(...timestamps)).toISOString() : null,
+      last_observed_at: timestamps.length ? new Date(Math.max(...timestamps)).toISOString() : null,
+    };
   }
 
   function nonNegativeBaseUnits(value) {
@@ -470,13 +565,86 @@
       });
     }
 
-    function renderSourceLedger(merged, acquisitionStatus, repositoryStatus, audit) {
+    function renderInterfaceUsage(summary) {
+      const available = summary.status !== "unavailable";
+      const status = one("[data-interface-status]");
+      if (status) {
+        status.dataset.status = summary.status;
+        status.textContent = summary.status === "ready"
+          ? "live aggregate"
+          : summary.status === "delayed" ? "delayed" : summary.status;
+      }
+      setText("[data-interface-total]", available ? formatInteger(summary.request_count) : "—");
+      setText("[data-interface-success]", available
+        ? `${formatInteger(summary.successful_request_count)}${summary.success_rate == null ? "" : ` · ${formatPercent(summary.success_rate)}`}`
+        : "—");
+      setText("[data-interface-mcp-share]", available
+        ? (summary.mcp_share == null ? "No traffic yet" : formatPercent(summary.mcp_share))
+        : "—");
+      const windowLabel = state.period === "lifetime" ? "lifetime since interface tracking began" : state.period;
+      setText("[data-interface-window]", summary.status === "unavailable"
+        ? "The aggregate interface report is unavailable; no counts are estimated."
+        : summary.last_observed_at
+          ? `${windowLabel} · last observed ${new Date(summary.last_observed_at).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })}`
+          : `${windowLabel} · no attributed requests observed yet`);
+
+      const target = one("[data-interface-rows]");
+      if (!target) return;
+      target.replaceChildren();
+      summary.rows.forEach((row) => {
+        const item = doc.createElement("article");
+        item.className = "interface-row";
+        item.dataset.tone = row.tone;
+
+        const identity = doc.createElement("div");
+        identity.className = "interface-identity";
+        const label = doc.createElement("h3");
+        label.textContent = row.label;
+        const detail = doc.createElement("p");
+        detail.textContent = row.detail;
+        identity.append(label, detail);
+
+        const volume = doc.createElement("div");
+        volume.className = "interface-volume";
+        const count = doc.createElement("strong");
+        count.textContent = available ? formatInteger(row.request_count) : "—";
+        const success = doc.createElement("span");
+        success.textContent = !available
+          ? "source unavailable"
+          : row.success_rate == null
+            ? "no requests in window"
+            : `${formatInteger(row.successful_request_count)} HTTP 2xx · ${formatPercent(row.success_rate)}`;
+        volume.append(count, success);
+
+        const share = doc.createElement("div");
+        share.className = "interface-share";
+        const track = doc.createElement("span");
+        track.className = "interface-track";
+        track.setAttribute("role", "progressbar");
+        track.setAttribute("aria-label", `${row.label} share of observed requests`);
+        track.setAttribute("aria-valuemin", "0");
+        track.setAttribute("aria-valuemax", "100");
+        track.setAttribute("aria-valuenow", String(Math.round(row.share * 100)));
+        const fill = doc.createElement("i");
+        fill.style.setProperty("--interface-width", `${row.share * 100}%`);
+        track.appendChild(fill);
+        const shareText = doc.createElement("span");
+        shareText.textContent = summary.request_count ? `${formatPercent(row.share)} of requests` : "No share yet";
+        share.append(track, shareText);
+
+        item.append(identity, volume, share);
+        target.appendChild(item);
+      });
+    }
+
+    function renderSourceLedger(merged, acquisitionStatus, repositoryStatus, audit, interfaceUsage) {
       const target = one("[data-source-ledger]");
       if (!target) return;
       target.replaceChildren();
       const sources = [
         ["Marketplace events", merged.platform_status, state.platform?.generated_at, "Confirmed canonical Base events with verified block time."],
         ["Payout proof ledger", audit.status, audit.generated_at, "Every qualifying payout event is summed in the browser and linked to its raw record and Base transaction."],
+        ["Interface usage", interfaceUsage.status, state.acquisition?.generated_at, "Hourly API, CLI, and MCP request aggregates; not people, clients, or sessions."],
         ["GitHub participation", merged.github_status, state.github?.generated_at, "Hourly aggregate of external issues, pull requests, comments, and reviews."],
         ["Repository acquisition", repositoryStatus, state.github?.repository_acquisition?.generated_at, "GitHub clone and page-view aggregates for its rolling 14-day traffic window."],
         ["Browser acquisition", acquisitionStatus, state.acquisition?.generated_at, "First-party browser/device IDs; never counted as users or identities."],
@@ -521,8 +689,13 @@
         GITHUB_DELAY_MS,
       );
       const audit = payoutAuditSnapshot(platform);
+      const interfaceSummary = interfaceUsageSummary(state.acquisition);
+      const interfaceUsage = interfaceSummary.status === "unavailable"
+        ? interfaceSummary
+        : { ...interfaceSummary, status: acquisitionStatus };
       const coreStatus = dashboardStatus(merged.status, repositoryStatus);
-      const overallStatus = dashboardStatus(coreStatus, audit.status);
+      const auditedStatus = dashboardStatus(coreStatus, audit.status);
+      const overallStatus = dashboardStatus(auditedStatus, interfaceUsage.status);
       const status = one("[data-overall-status]");
       if (status) {
         status.dataset.status = overallStatus;
@@ -552,6 +725,7 @@
       setText("[data-solver-pay]", payout ? amount(payout.selected_solver_pay) : "—");
       setText("[data-verifier-pay]", payout ? amount(payout.selected_verifier_pay) : "—");
       setText("[data-completion-bonus]", payout ? amount(payout.selected_completion_bonus) : "—");
+      renderInterfaceUsage(interfaceUsage);
       renderPayoutAudit(audit);
 
       const inventoryReady = inventory?.status === "ready";
@@ -601,13 +775,15 @@
         ? `${formatInteger(state.acquisition.overview?.sessions)} browser sessions in the matching lookback. Device/browser IDs are not people.`
         : "Acquisition source unavailable. Browser IDs are never estimated or counted as active identities.");
       setText("[data-platform-revenue]", platform ? amount(platform.platform_revenue) : "0 USDC");
-      renderSourceLedger(merged, acquisitionStatus, repositoryStatus, audit);
+      renderSourceLedger(merged, acquisitionStatus, repositoryStatus, audit, interfaceUsage);
 
       const notices = [];
       if (merged.status === "partial") notices.push("Identity totals are partial because a required participation source is unavailable or incomplete.");
       if (merged.status === "delayed") notices.push("One or more required sources are delayed; values remain visible with their source timestamps.");
       if (merged.status === "unavailable") notices.push("Marketplace metrics are temporarily unavailable; no missing value has been replaced with zero.");
       if (["partial", "unavailable"].includes(repositoryStatus)) notices.push("Repository acquisition is unavailable or incomplete; historical snapshots remain labeled and are not substituted as live data.");
+      if (interfaceUsage.status === "unavailable") notices.push("Interface usage is unavailable; API, CLI, and MCP request counts are not estimated.");
+      if (["partial", "delayed"].includes(interfaceUsage.status)) notices.push("Interface usage is delayed or incomplete; the last observed aggregate remains labeled with its timestamp.");
       if (audit.status === "partial") notices.push("The payout proof ledger does not yet reconcile to the aggregate; payout values are marked partial.");
       if (audit.status === "unavailable") notices.push("The public payout proof streams are unavailable, so payout auditability is temporarily partial.");
       if (overallStatus === "ready") notices.push(`Live aggregate for ${state.period === "lifetime" ? "lifetime since launch" : state.period}. Roles are not additive.`);
@@ -644,25 +820,25 @@
       render();
     }
 
-    async function refreshSupporting() {
-      const hours = acquisitionWindowHours(state.period);
-      const [githubResult, acquisitionResult] = await Promise.allSettled([
-        requestJson(`${GITHUB_URL}?v=${Date.now()}`),
-        requestJson(`${ACQUISITION_URL}?window_hours=${hours}`),
-      ]);
-      if (githubResult.status === "fulfilled") {
-        state.github = githubResult.value;
+    async function refreshRepository() {
+      try {
+        state.github = await requestJson(`${GITHUB_URL}?v=${Date.now()}`);
         delete state.errors.github;
-      } else {
+      } catch (error) {
         state.github = null;
-        state.errors.github = githubResult.reason;
+        state.errors.github = error;
       }
-      if (acquisitionResult.status === "fulfilled") {
-        state.acquisition = acquisitionResult.value;
+      render();
+    }
+
+    async function refreshAcquisition() {
+      const hours = acquisitionWindowHours(state.period);
+      try {
+        state.acquisition = await requestJson(`${ACQUISITION_URL}?window_hours=${hours}`);
         delete state.errors.acquisition;
-      } else {
+      } catch (error) {
         state.acquisition = null;
-        state.errors.acquisition = acquisitionResult.reason;
+        state.errors.acquisition = error;
       }
       render();
     }
@@ -678,7 +854,7 @@
         state.platform = null;
         state.acquisition = null;
         render();
-        void Promise.all([refreshPlatform(), refreshSupporting()]);
+        void Promise.all([refreshPlatform(), refreshRepository(), refreshAcquisition()]);
       });
     });
 
@@ -687,15 +863,18 @@
         if (!doc.hidden) void refreshPlatform();
       }, 60_000));
       state.timers.push(win.setInterval(() => {
-        if (!doc.hidden) void refreshSupporting();
+        if (!doc.hidden) void refreshAcquisition();
+      }, 60_000));
+      state.timers.push(win.setInterval(() => {
+        if (!doc.hidden) void refreshRepository();
       }, 300_000));
     }
 
     doc.addEventListener("visibilitychange", () => {
-      if (!doc.hidden) void Promise.all([refreshPlatform(), refreshSupporting()]);
+      if (!doc.hidden) void Promise.all([refreshPlatform(), refreshRepository(), refreshAcquisition()]);
     });
     render();
-    void Promise.all([refreshPlatform(), refreshSupporting()]);
+    void Promise.all([refreshPlatform(), refreshRepository(), refreshAcquisition()]);
     schedule();
     return state;
   }
@@ -709,6 +888,7 @@
     mergeDaily,
     mergeMetrics,
     payoutAuditSummary,
+    interfaceUsageSummary,
     sourceStatus,
     start,
     ratioMultiple,


### PR DESCRIPTION
## Outcome

Adds a live interface-adoption section to the public metrics dashboard using the already-deployed aggregate tracker from #940. The section displays REST API, CLI, MCP 2026-07-28, legacy MCP, and MCP HTTP-adapter request counts, HTTP-2xx counts/rates, shares, selected-window scope, and the last observation timestamp.

Closes #942.

## Storage and privacy boundary

No new storage or API contract is introduced. The source remains Postgres table `interface_usage_hourly` created by `migrations/0021_interface_usage.sql` and exposed through `GET /v1/analytics/site`. Rows are hourly aggregates keyed by UTC hour, interface, and protocol era.

The UI explicitly states that requests are not unique people, agents, clients, sessions, or surveyed preferences. API and CLI attribution is self-declared; MCP era is observed server-side. No IP, user agent, wallet, client ID, prompt, request body, or tool arguments are collected.

## Dashboard behavior

- Reuses the existing lifetime/90d/28d/7d selector.
- Refreshes interface/browser analytics every minute, separately from the five-minute GitHub aggregate loop.
- Renders five fixed rows with accessible progress bars and reduced-motion support.
- Keeps missing, delayed, or empty coverage explicit without substituting estimates.
- Preserves the canonical payout audit added on current main.

## Maintainer coordination

Notice: #942.

All 87 open PRs were inspected before edits. No open PR owns `site/metrics.*`. PRs #918, #889, and #885 touch inventory/homepage work only. PR #910 is a stacked analytics API/DB change; this PR avoids those files and changes no migration. PR #922 received its formatting repair path. PR #934 received its deployed-0021 migration-conflict repair path.

Compatibility risk: low/R0 presentation-only. No contributor migration is required. If concurrent work begins on `site/metrics.*`, rebase it and preserve the aggregate/privacy language.

## Verification

Passed:

- `node --check site/metrics.js`
- `node --test scripts/test-metrics-dashboard.js` (10/10)
- `python scripts/check-site.py`
- `git diff --check`
- Playwright desktop 1440x1000 and mobile 390x844 render against the live production analytics response
- Browser console: zero warnings/errors
- Live API contract: schema v2, five rows, 57 requests / 55 HTTP-2xx responses at verification time

Core preflight passed before implementation. Full local preflight was attempted but cannot run because Foundry is absent on this workstation; protected CI has the required Foundry toolchain and remains the deployment gate.

## Release

After protected CI succeeds, merge the reviewed exact SHA and verify the GitHub Pages dashboard plus API/MCP exact revisions. Render deployment remains handled by the existing exact-main workflow; this PR does not change service or database configuration.

This PR does not approve bounty acceptance, payout, escrow release, or payment settlement.