### PR TITLE
Securely deploy MoonPay checkout credentials

### DIFF
--- a/.github/workflows/render-deploy-recovery.yml
+++ b/.github/workflows/render-deploy-recovery.yml
@@ -185,6 +185,9 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           CLOUD_AGENT_API_KEY: ${{ secrets.CLOUD_AGENT_API_KEY }}
+          MOONPAY_PUBLISHABLE_KEY: ${{ secrets.MOONPAY_PUBLISHABLE_KEY }}
+          MOONPAY_SECRET_KEY: ${{ secrets.MOONPAY_SECRET_KEY }}
+          MOONPAY_ENVIRONMENT: ${{ vars.MOONPAY_ENVIRONMENT || 'sandbox' }}
           NEYNAR_API_KEY: ${{ secrets.NEYNAR_API_KEY }}
           NEYNAR_SIGNER_UUID: ${{ secrets.NEYNAR_SIGNER_UUID }}
           NEYNAR_BOT_FID: ${{ vars.NEYNAR_BOT_FID }}
@@ -256,6 +259,7 @@ jobs:
               f"- Cloud runtime variables: `{len(evidence.get('cloud_environment', []))}/10`",
               f"- Cloud model credential supplied: `{bool(evidence.get('secret_environment'))}`",
               f"- Cloud drafting ready: `{bool(evidence.get('cloud_readiness', {}).get('available'))}`",
+              f"- MoonPay values reconciled: `{len(evidence.get('moonpay_environment', []))}/3`",
               f"- Neynar provider values reconciled: `{len(evidence.get('social_environment', []))}/5`",
               f"- Neynar webhook registered: `{bool(evidence.get('social_webhook', {}).get('active'))}`",
               f"- Social mention ingestion ready: `{bool(evidence.get('social_readiness', {}).get('enabled'))}`",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,6 +47,15 @@ secret `CLOUD_AGENT_API_KEY` into the API service without logging it. Verify
 `GET /v1/cloud-agent/readiness`; see
 [`cloud-agent-operations.md`](cloud-agent-operations.md).
 
+MoonPay signed external checkout uses two direct `sync: false` values on
+`agent-bounties-mcp`: `MOONPAY_PUBLISHABLE_KEY` and `MOONPAY_SECRET_KEY`.
+Store both as repository Actions secrets. The exact-SHA controller installs
+them all-or-none, verifies that their test/live prefixes match the repository
+`MOONPAY_ENVIRONMENT` variable (default `sandbox`), and records only redacted
+configuration evidence. The MCP service returns a signed external MoonPay URL;
+it does not embed checkout, complete a purchase, transfer crypto, or prove
+canonical bounty funding.
+
 Farcaster mention ingestion uses five direct `sync: false` API-service values:
 `NEYNAR_API_KEY`, `NEYNAR_WEBHOOK_SECRET`, `NEYNAR_SIGNER_UUID`,
 `NEYNAR_BOT_FID`, and `NEYNAR_BOT_USERNAME`. They are all-or-none at runtime.
@@ -89,16 +98,18 @@ succeeds on a push to `main`, the workflow:
    both public services;
 8. reconciles all nonsecret cloud-agent settings on API and copies the optional
    GitHub-held model key without including its value in evidence;
-9. creates or updates the optional FID-filtered Neynar provider webhook and
+9. reconciles the optional all-or-none MoonPay key pair and environment on MCP
+   without including either key in evidence;
+10. creates or updates the optional FID-filtered Neynar provider webhook and
    reconciles its bot identity, reply signer, and generated signing secret on
    API without including their values in evidence;
-10. calls Render's deploy API with the exact commit for API, MCP, and both workers;
-11. waits for all four deploys to reach `live` and fails on terminal errors;
-12. verifies exact revision and protocol headers from API and MCP `/health`;
-13. attests cloud readiness and fails if a supplied model credential did not
+11. calls Render's deploy API with the exact commit for API, MCP, and both workers;
+12. waits for all four deploys to reach `live` and fails on terminal errors;
+13. verifies exact revision and protocol headers from API and MCP `/health`;
+14. attests cloud readiness and fails if a supplied model credential did not
     become usable;
-14. attests social mention readiness when provider values were supplied;
-15. stores a redacted 30-day deployment evidence artifact.
+15. attests social mention readiness when provider values were supplied;
+16. stores a redacted 30-day deployment evidence artifact.
 
 Configure the GitHub Actions secret `RENDER_API_KEY`. Create it in the
 Render Dashboard for the workspace that owns these four services, then store
@@ -115,6 +126,15 @@ To enable hosted bounty drafting, also configure the repository Actions secret
 only to `agent-bounties-api`, and redacted from evidence. If it is absent, the
 deployment still succeeds but `/v1/cloud-agent/readiness` remains unavailable
 and reports the missing credential explicitly; no local-model fallback runs.
+
+To enable signed MoonPay checkout, configure both repository Actions secrets
+`MOONPAY_PUBLISHABLE_KEY` and `MOONPAY_SECRET_KEY`. Keep the repository Actions
+variable `MOONPAY_ENVIRONMENT=sandbox` while using `pk_test_`/`sk_test_` keys;
+switch it to `live` only together with an approved `pk_live_`/`sk_live_` pair.
+A partial or mode-mismatched pair fails before Render is changed. Run
+`python scripts/check-moonpay-production.py --require-checkout` after the exact
+revision is live; this validates URL generation and signature boundaries but
+does not complete a purchase or establish bounty funding.
 
 To activate Farcaster ingestion, provision one approved Neynar signer owned by
 the Agent Bounties bot account. Store `NEYNAR_API_KEY` and `NEYNAR_SIGNER_UUID`
@@ -156,9 +176,9 @@ Use `deploy_only` for runtime-only configuration after capacity is available:
 
 `deploy_only` rejects a service whose current live artifact does not match the
 supplied SHA. It reuses that artifact, applies saved environment values, and
-does not build new code. It restarts only API unless a shared environment
-change requires another linked service, then requires the supplied SHA from
-`/health` and the exact leaderboard contracts from the live API. Render's
+does not build new code. It restarts API plus any service whose direct or
+shared environment changed, then requires the supplied SHA from `/health` and
+the exact leaderboard contracts from the live API. Render's
 branch label is recorded but is not artifact evidence. Render currently applies
 the workspace pipeline quota before both deployment modes, so `deploy_only` is
 not a quota bypass.

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -111,6 +111,7 @@ PUBLIC_ENV_SERVICE_NAMES = {
     "agent-bounties-mcp",
 }
 CLOUD_AGENT_API_SERVICE_NAME = "agent-bounties-api"
+MOONPAY_MCP_SERVICE_NAME = "agent-bounties-mcp"
 API_RUNTIME_ENVIRONMENT = {
     "AGENT_BOUNTIES_SOCIAL_MENTION_DRAFTS_ENABLED": "true",
     # The hosted relayer applies its own 120% padding after eth_estimateGas.
@@ -131,6 +132,12 @@ CLOUD_AGENT_RUNTIME_ENVIRONMENT = {
     "CLOUD_AGENT_MAX_OUTPUT_TOKENS": "12000",
     "CLOUD_AGENT_MAX_DAILY_DRAFTS": "50",
     "CLOUD_AGENT_TIMEOUT_SECONDS": "90",
+}
+MOONPAY_ENVIRONMENTS = {
+    "sandbox": ("sandbox", "pk_test_", "sk_test_"),
+    "test": ("sandbox", "pk_test_", "sk_test_"),
+    "live": ("live", "pk_live_", "sk_live_"),
+    "production": ("live", "pk_live_", "sk_live_"),
 }
 
 
@@ -247,6 +254,11 @@ def redact(value: str) -> str:
     value = re.sub(r"(?i)(authorization:\s*bearer\s+)[^\s]+", r"\1[redacted]", value)
     value = re.sub(r"(?i)([?&](?:key|token)=)[^&\s]+", r"\1[redacted]", value)
     value = re.sub(r"(?i)(render_api_key\s*[=:]\s*)[^\s,;]+", r"\1[redacted]", value)
+    value = re.sub(
+        r"(?i)\b(?:pk|sk)_(?:test|live)_[a-z0-9_-]{4,}\b",
+        "[moonpay-key-redacted]",
+        value,
+    )
     value = re.sub(r"(?i)postgres(?:ql)?://[^\s\"']+", "[database-url-redacted]", value)
     return value[:1000]
 
@@ -492,8 +504,11 @@ def deploy_only_can_reuse_current(
     *,
     open_competition_environment_changed: bool,
     operator_token_changed: bool,
+    service_environment_changed: bool = False,
 ) -> bool:
     if service_name == CLOUD_AGENT_API_SERVICE_NAME:
+        return False
+    if service_environment_changed:
         return False
     if open_competition_environment_changed:
         return False
@@ -1883,6 +1898,82 @@ def reconcile_cloud_agent_environment(
     return runtime_environment, secret_environment, changed
 
 
+def normalize_moonpay_environment(
+    *,
+    publishable_key: str | None,
+    secret_key: str | None,
+    environment: str | None,
+) -> dict[str, str]:
+    supplied_publishable_key = (
+        publishable_key.strip() if isinstance(publishable_key, str) else ""
+    )
+    supplied_secret_key = secret_key.strip() if isinstance(secret_key, str) else ""
+    supplied = [bool(supplied_publishable_key), bool(supplied_secret_key)]
+    if not any(supplied):
+        return {}
+    if not all(supplied):
+        raise RecoveryError(
+            "MoonPay checkout requires publishable and secret keys together"
+        )
+
+    requested_environment = (
+        environment.strip().lower() if isinstance(environment, str) else "sandbox"
+    )
+    normalized = MOONPAY_ENVIRONMENTS.get(requested_environment)
+    if normalized is None:
+        raise RecoveryError("MoonPay environment must be sandbox or live")
+    normalized_environment, publishable_prefix, secret_prefix = normalized
+    if not supplied_publishable_key.startswith(publishable_prefix) or not supplied_secret_key.startswith(
+        secret_prefix
+    ):
+        raise RecoveryError(
+            "MoonPay keys do not match the configured environment"
+        )
+    return {
+        "MOONPAY_ENVIRONMENT": normalized_environment,
+        "MOONPAY_PUBLISHABLE_KEY": supplied_publishable_key,
+        "MOONPAY_SECRET_KEY": supplied_secret_key,
+    }
+
+
+def reconcile_moonpay_environment(
+    client: RenderClient,
+    service: dict[str, Any],
+    *,
+    publishable_key: str | None,
+    secret_key: str | None,
+    environment: str | None,
+) -> tuple[list[dict[str, Any]], bool]:
+    normalized = normalize_moonpay_environment(
+        publishable_key=publishable_key,
+        secret_key=secret_key,
+        environment=environment,
+    )
+    if not normalized:
+        return [], False
+
+    desired = (
+        ("MOONPAY_ENVIRONMENT", normalized["MOONPAY_ENVIRONMENT"], False),
+        ("MOONPAY_PUBLISHABLE_KEY", normalized["MOONPAY_PUBLISHABLE_KEY"], True),
+        ("MOONPAY_SECRET_KEY", normalized["MOONPAY_SECRET_KEY"], True),
+    )
+    evidence = []
+    changed = False
+    for key, value, secret in desired:
+        record = client.ensure_env_var(service, key, value)
+        changed |= record["changed"]
+        item = {
+            "service": service["name"],
+            "key": key,
+            "configured": True,
+            "changed": record["changed"],
+        }
+        if not secret:
+            item["value"] = value
+        evidence.append(item)
+    return evidence, changed
+
+
 def rotate_operator_token(
     client: RenderClient,
     group: dict[str, Any],
@@ -2164,6 +2255,9 @@ def deploy(
     mcp_base_url: str = "https://mcp.agentbounties.app",
     website_base_url: str = "https://agentbounties.app",
     cloud_agent_api_key: str | None = None,
+    moonpay_publishable_key: str | None = None,
+    moonpay_secret_key: str | None = None,
+    moonpay_environment: str | None = "sandbox",
     neynar_api_key: str | None = None,
     neynar_signer_uuid: str | None = None,
     neynar_bot_fid: str | None = None,
@@ -2176,6 +2270,11 @@ def deploy(
     deploy_mode = validate_deploy_mode(deploy_mode)
     if rotate_operator_api_token and deploy_mode != "deploy_only":
         raise RecoveryError("operator token rotation requires deploy_only")
+    moonpay_inputs = normalize_moonpay_environment(
+        publishable_key=moonpay_publishable_key,
+        secret_key=moonpay_secret_key,
+        environment=moonpay_environment,
+    )
     services: list[tuple[ServiceSpec, dict[str, Any]]] = []
     pending: dict[str, tuple[dict[str, Any], str]] = {}
     initial: dict[str, dict[str, Any]] = {}
@@ -2331,6 +2430,17 @@ def deploy(
         reconcile_cloud_agent_environment(client, api_service, cloud_agent_api_key)
     )
     public_environment_changed[CLOUD_AGENT_API_SERVICE_NAME] |= cloud_environment_changed
+    mcp_service = next(
+        service for spec, service in services if spec.name == MOONPAY_MCP_SERVICE_NAME
+    )
+    moonpay_evidence, moonpay_environment_changed = reconcile_moonpay_environment(
+        client,
+        mcp_service,
+        publishable_key=moonpay_inputs.get("MOONPAY_PUBLISHABLE_KEY"),
+        secret_key=moonpay_inputs.get("MOONPAY_SECRET_KEY"),
+        environment=moonpay_inputs.get("MOONPAY_ENVIRONMENT"),
+    )
+    public_environment_changed[MOONPAY_MCP_SERVICE_NAME] |= moonpay_environment_changed
     social_environment, social_environment_changed = reconcile_neynar_social_environment(
         client,
         api_service,
@@ -2372,6 +2482,9 @@ def deploy(
                     open_competition_environment_changed
                 ),
                 operator_token_changed=operator_token_changed,
+                service_environment_changed=public_environment_changed.get(
+                    spec.name, False
+                ),
             )
         ):
             created = preexisting_live[spec.name]
@@ -2502,6 +2615,7 @@ def deploy(
         "open_competition_environment": reconciled_open_competition_environment,
         "cloud_environment": cloud_environment,
         "secret_environment": secret_environment,
+        "moonpay_environment": moonpay_evidence,
         "social_environment": social_environment,
         "social_webhook": social_webhook,
         "cloud_readiness": cloud_readiness,
@@ -2580,6 +2694,7 @@ def main() -> int:
         "public_environment": [],
         "cloud_environment": [],
         "secret_environment": [],
+        "moonpay_environment": [],
         "social_environment": [],
         "social_webhook": {},
         "cloud_readiness": {},
@@ -2607,6 +2722,9 @@ def main() -> int:
             mcp_base_url=args.mcp_base_url,
             website_base_url=args.website_base_url,
             cloud_agent_api_key=os.environ.get("CLOUD_AGENT_API_KEY"),
+            moonpay_publishable_key=os.environ.get("MOONPAY_PUBLISHABLE_KEY"),
+            moonpay_secret_key=os.environ.get("MOONPAY_SECRET_KEY"),
+            moonpay_environment=os.environ.get("MOONPAY_ENVIRONMENT", "sandbox"),
             neynar_api_key=os.environ.get("NEYNAR_API_KEY"),
             neynar_signer_uuid=os.environ.get("NEYNAR_SIGNER_UUID"),
             neynar_bot_fid=os.environ.get("NEYNAR_BOT_FID"),

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -1267,6 +1267,103 @@ class RenderDeployRecoveryTests(unittest.TestCase):
         self.assertEqual(secrets, [])
         self.assertNotIn("CLOUD_AGENT_API_KEY", [key for _, key, _ in client.calls])
 
+    def test_moonpay_environment_is_all_or_none_and_evidence_is_redacted(self) -> None:
+        client = EnvironmentClient()
+        service = {"id": "srv-mcp", "name": "agent-bounties-mcp"}
+        evidence, changed = recovery.reconcile_moonpay_environment(
+            client,
+            service,
+            publishable_key=" pk_test_example_publishable ",
+            secret_key=" sk_test_example_secret ",
+            environment="test",
+        )
+        self.assertTrue(changed)
+        self.assertEqual(len(evidence), 3)
+        self.assertEqual(evidence[0]["value"], "sandbox")
+        self.assertNotIn("value", evidence[1])
+        self.assertNotIn("value", evidence[2])
+        self.assertIn(
+            ("agent-bounties-mcp", "MOONPAY_ENVIRONMENT", "sandbox"),
+            client.calls,
+        )
+        serialized = recovery.json.dumps(evidence)
+        self.assertNotIn("pk_test_example_publishable", serialized)
+        self.assertNotIn("sk_test_example_secret", serialized)
+
+        with self.assertRaisesRegex(recovery.RecoveryError, "keys together"):
+            recovery.reconcile_moonpay_environment(
+                client,
+                service,
+                publishable_key="pk_test_example_publishable",
+                secret_key=None,
+                environment="sandbox",
+            )
+
+    def test_workflow_passes_moonpay_values_only_as_runtime_environment(self) -> None:
+        workflow = (
+            SCRIPT.parent.parent
+            / ".github"
+            / "workflows"
+            / "render-deploy-recovery.yml"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(workflow.count("secrets.MOONPAY_PUBLISHABLE_KEY"), 1)
+        self.assertEqual(workflow.count("secrets.MOONPAY_SECRET_KEY"), 1)
+        self.assertEqual(workflow.count("vars.MOONPAY_ENVIRONMENT"), 1)
+        self.assertNotIn("pk_test_", workflow)
+        self.assertNotIn("sk_test_", workflow)
+
+    def test_deploy_only_restarts_service_after_direct_environment_change(self) -> None:
+        self.assertFalse(
+            recovery.deploy_only_can_reuse_current(
+                "agent-bounties-mcp",
+                open_competition_environment_changed=False,
+                operator_token_changed=False,
+                service_environment_changed=True,
+            )
+        )
+
+    def test_moonpay_environment_rejects_key_mode_mismatch(self) -> None:
+        client = EnvironmentClient()
+        service = {"id": "srv-mcp", "name": "agent-bounties-mcp"}
+        with self.assertRaisesRegex(recovery.RecoveryError, "do not match"):
+            recovery.reconcile_moonpay_environment(
+                client,
+                service,
+                publishable_key="pk_test_example_publishable",
+                secret_key="sk_test_example_secret",
+                environment="live",
+            )
+        self.assertEqual(client.calls, [])
+
+    def test_partial_moonpay_configuration_fails_before_render_access(self) -> None:
+        client = ResolutionFailureClient()
+        with self.assertRaisesRegex(recovery.RecoveryError, "keys together"):
+            recovery.deploy(
+                client,
+                "a" * 40,
+                moonpay_publishable_key="pk_test_example_publishable",
+                moonpay_secret_key=None,
+                moonpay_environment="sandbox",
+                deploy_timeout_seconds=1,
+                health_timeout_seconds=1,
+                poll_seconds=0,
+            )
+        self.assertEqual(client.resolved, [])
+        self.assertEqual(client.mutations, [])
+
+    def test_omitted_moonpay_environment_is_not_invented(self) -> None:
+        client = EnvironmentClient(changed=False)
+        evidence, changed = recovery.reconcile_moonpay_environment(
+            client,
+            {"id": "srv-mcp", "name": "agent-bounties-mcp"},
+            publishable_key=None,
+            secret_key=None,
+            environment="sandbox",
+        )
+        self.assertEqual(evidence, [])
+        self.assertFalse(changed)
+        self.assertEqual(client.calls, [])
+
     def test_neynar_environment_is_all_or_none_and_evidence_is_redacted(self) -> None:
         client = EnvironmentClient()
         service = {"id": "srv-api", "name": "agent-bounties-api"}
@@ -1887,6 +1984,12 @@ class RenderDeployRecoveryTests(unittest.TestCase):
                 'bad payload {"value":"postgresql://worker:private-value@db/app"}'
             ),
         )
+        moonpay_values = recovery.redact(
+            "pk_test_publishableexample sk_test_secretexample"
+        )
+        self.assertNotIn("pk_test_publishableexample", moonpay_values)
+        self.assertNotIn("sk_test_secretexample", moonpay_values)
+        self.assertEqual(moonpay_values.count("[moonpay-key-redacted]"), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Outcome

Securely carries the existing MoonPay test key pair from repository Actions secrets into the Render MCP service and forces the exact service restart needed for signed sandbox checkout.

## Scope

- pass `MOONPAY_PUBLISHABLE_KEY`, `MOONPAY_SECRET_KEY`, and the nonsecret environment mode only to the bounded deploy job
- require the key pair all-or-none and validate test/live prefixes before any Render access
- reconcile the values only on `agent-bounties-mcp`
- restart a deploy-only MCP artifact when its direct environment changes
- keep both keys out of deployment evidence and redact provider error echoes
- document the external-checkout, no-purchase/no-funding evidence boundary

Change class: R3 credential configuration through the reviewed R2 exact-SHA application controller.

Public maintainer notice: #631, update https://github.com/NSPG13/agent-bounties/issues/631#issuecomment-5284641570

## Open PR impact

All 87 open PRs were inspected before edits. No open PR changes the four files in this PR. Active collaborator failures and merge conflicts were reviewed; none is caused or superseded by this slice. #876 remains contributor-owned and does not overlap because this PR does not change `crates/mcp-server/src/chatgpt_app.rs`.

Compatibility risk is limited to deployment configuration. Missing MoonPay values remain optional; a partial or environment-mismatched pair fails closed before Render access. The rollback path is the prior application revision plus removal of the two MCP environment entries.

## Verification

- `scripts/preflight.ps1 -Mode core`
- `python scripts/test_render_deploy_recovery.py -q` (86 passed)
- `python scripts/check-render-blueprint.py`
- `python -m py_compile scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py`
- `ruff check scripts/render_deploy_recovery.py scripts/test_render_deploy_recovery.py`
- `python scripts/check-moonpay-onramp.py`
- `node scripts/test-moonpay-direct-fallback.js`
- `cargo test -p mcp-server moonpay -- --nocapture` (7 passed)
- `git diff --check`
- credential-pattern scan of the complete diff (0 matches)

Full preflight could not run because Foundry `forge` is not installed on this workstation; no contract file or contract behavior changes.

## Canary boundary

After merge and exact-SHA deployment, run `python scripts/check-moonpay-production.py --require-checkout`. The canary stops after validating a signed `buy-sandbox.moonpay.com` URL. It does not open or complete checkout, move crypto, sign a wallet action, fund a bounty, or prove settlement.

This PR and its CI do not authorize bounty acceptance, wallet activity, funding, payout, escrow release, or settlement.