### PR TITLE
Fix analytics exclusion deployment canary

### DIFF
--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -1850,7 +1850,9 @@ def validate_analytics_exclusion_canaries(
             token=token,
             interface=interface,
         )
-        if not isinstance(payload.get("schema_version"), str):
+        if payload.get("schema") != (
+            "https://agentbounties.org/schemas/discovery-manifest.v2.json"
+        ):
             raise RecoveryError(
                 f"{interface} analytics exclusion canary returned invalid discovery"
             )

--- a/scripts/test_render_deploy_recovery.py
+++ b/scripts/test_render_deploy_recovery.py
@@ -289,8 +289,18 @@ class RenderDeployRecoveryTests(unittest.TestCase):
 
     def test_exclusion_canaries_cover_every_interface_and_both_mcp_eras(self) -> None:
         responses = [
-            {"schema_version": "agent-bounties/discovery-v2"},
-            {"schema_version": "agent-bounties/discovery-v2"},
+            {
+                "schema": (
+                    "https://agentbounties.org/schemas/"
+                    "discovery-manifest.v2.json"
+                )
+            },
+            {
+                "schema": (
+                    "https://agentbounties.org/schemas/"
+                    "discovery-manifest.v2.json"
+                )
+            },
             {
                 "result": {
                     "protocolVersion": recovery.LEGACY_MCP_PROTOCOL_VERSION


### PR DESCRIPTION
## Summary
- validate the production discovery manifest by its canonical `schema` URI
- keep the exclusion canary strict while matching the actual public contract
- update the controller fixture so the regression is exercised

## Why
The exact-revision rollout for #946 brought both services live, then failed post-deploy attestation because the canary expected a nonexistent `schema_version` field. The public discovery contract uses `schema`.

## Verification
- `python -m unittest scripts.test_render_deploy_recovery` (90 passed)
- production API and MCP both already attest merge revision `09da0d12619c25bf94c5abbdb48819bc8f094f91`

## Scope
Controller/test correction only. No runtime, migration, secret, authority, payment, or public metric semantics change.