### PR TITLE
Add direct bounty evidence checklist

### DIFF
--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -60,6 +60,113 @@ pub struct PayoutRiskInput {
     pub amount: Money,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct DirectBountyEvidenceChecklist {
+    pub submission: Vec<String>,
+    pub verification: Vec<String>,
+    pub payment: Vec<String>,
+    pub rejection_rules: Vec<String>,
+}
+
+impl Default for DirectBountyEvidenceChecklist {
+    fn default() -> Self {
+        Self {
+            submission: vec![
+                "exact source repository HTTPS URL".to_string(),
+                "exact source commit SHA".to_string(),
+                "repository subdirectory, or . when the repository root is the artifact"
+                    .to_string(),
+                "pull request HTTPS URL".to_string(),
+                "immutable HTTPS artifact URL".to_string(),
+                "artifact SHA-256 digest".to_string(),
+            ],
+            verification: vec![
+                "check-run HTTPS URLs for the benchmark or CI runs used by the verifier"
+                    .to_string(),
+                "artifact digest that the verifier evaluated".to_string(),
+            ],
+            payment: vec![
+                "canonical BountySettled event URL or transaction reference".to_string(),
+                "submission, verification, PR, and test evidence are not payment evidence"
+                    .to_string(),
+            ],
+            rejection_rules: vec![
+                "empty evidence fields are rejected".to_string(),
+                "non-HTTPS repository, pull request, check-run, artifact, or settlement references are rejected".to_string(),
+                "mutable artifact references such as branch, latest, raw main, or unpinned download URLs are rejected".to_string(),
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct DirectBountyEvidence {
+    pub repository_url: String,
+    pub source_commit: String,
+    pub subdirectory: String,
+    pub pull_request_url: String,
+    pub check_run_urls: Vec<String>,
+    pub artifact_url: String,
+    pub artifact_sha256: String,
+    pub bounty_settled_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct DirectBountyEvidenceReport {
+    pub checklist: DirectBountyEvidenceChecklist,
+    pub accepted: bool,
+    pub errors: Vec<String>,
+    pub evidence_boundary: String,
+}
+
+pub fn direct_bounty_evidence_checklist() -> DirectBountyEvidenceChecklist {
+    DirectBountyEvidenceChecklist::default()
+}
+
+pub fn validate_direct_bounty_evidence(
+    evidence: &DirectBountyEvidence,
+) -> DirectBountyEvidenceReport {
+    let mut errors = Vec::new();
+
+    require_non_empty(&mut errors, "repository_url", &evidence.repository_url);
+    require_non_empty(&mut errors, "source_commit", &evidence.source_commit);
+    require_non_empty(&mut errors, "subdirectory", &evidence.subdirectory);
+    require_non_empty(&mut errors, "pull_request_url", &evidence.pull_request_url);
+    require_non_empty(&mut errors, "artifact_url", &evidence.artifact_url);
+    require_non_empty(&mut errors, "artifact_sha256", &evidence.artifact_sha256);
+    require_non_empty(&mut errors, "bounty_settled_url", &evidence.bounty_settled_url);
+
+    require_https(&mut errors, "repository_url", &evidence.repository_url);
+    require_https(&mut errors, "pull_request_url", &evidence.pull_request_url);
+    require_https(&mut errors, "artifact_url", &evidence.artifact_url);
+    require_https(&mut errors, "bounty_settled_url", &evidence.bounty_settled_url);
+
+    if evidence.check_run_urls.is_empty() {
+        errors.push("check_run_urls must contain at least one HTTPS check-run URL".to_string());
+    }
+    for (index, url) in evidence.check_run_urls.iter().enumerate() {
+        require_non_empty(&mut errors, &format!("check_run_urls[{index}]"), url);
+        require_https(&mut errors, &format!("check_run_urls[{index}]"), url);
+    }
+
+    if !is_hex_sha(&evidence.source_commit, 40) {
+        errors.push("source_commit must be a full 40-character hexadecimal commit SHA".to_string());
+    }
+    if !is_hex_sha(&evidence.artifact_sha256, 64) {
+        errors.push("artifact_sha256 must be a 64-character hexadecimal SHA-256 digest".to_string());
+    }
+    if is_mutable_artifact_reference(&evidence.artifact_url) {
+        errors.push("artifact_url must be immutable and pinned, not a branch/latest/raw-main reference".to_string());
+    }
+
+    DirectBountyEvidenceReport {
+        checklist: DirectBountyEvidenceChecklist::default(),
+        accepted: errors.is_empty(),
+        errors,
+        evidence_boundary: "Submission, verification, and payment evidence are separate. Only canonical BountySettled proves payment.".to_string(),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RiskPolicy {
     pub low_value_usdc_cap_minor: i64,
@@ -253,6 +360,34 @@ impl RiskPolicy {
     }
 }
 
+fn require_non_empty(errors: &mut Vec<String>, field: &str, value: &str) {
+    if value.trim().is_empty() {
+        errors.push(format!("{field} must not be empty"));
+    }
+}
+
+fn require_https(errors: &mut Vec<String>, field: &str, value: &str) {
+    if !value.starts_with("https://") {
+        errors.push(format!("{field} must be an HTTPS URL"));
+    }
+}
+
+fn is_hex_sha(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_mutable_artifact_reference(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("/latest")
+        || lower.contains("?latest")
+        || lower.contains("/raw/main/")
+        || lower.contains("/raw/master/")
+        || lower.contains("/main/")
+        || lower.contains("/master/")
+        || lower.ends_with("/main")
+        || lower.ends_with("/master")
+}
+
 fn strongest(left: RiskAction, right: RiskAction) -> RiskAction {
     match (left, right) {
         (RiskAction::Block, _) | (_, RiskAction::Block) => RiskAction::Block,
@@ -309,5 +444,99 @@ mod tests {
             .blocked_rules
             .iter()
             .any(|rule| rule.contains("active claim")));
+    }
+
+    #[test]
+    fn direct_bounty_evidence_accepts_complete_pinned_https_record() {
+        let report = validate_direct_bounty_evidence(&DirectBountyEvidence {
+            repository_url: "https://github.com/agent-bounties/agent-bounties".to_string(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            subdirectory: "crates/risk".to_string(),
+            pull_request_url: "https://github.com/agent-bounties/agent-bounties/pull/686"
+                .to_string(),
+            check_run_urls: vec![
+                "https://github.com/agent-bounties/agent-bounties/actions/runs/123456789"
+                    .to_string(),
+            ],
+            artifact_url:
+                "https://github.com/agent-bounties/agent-bounties/releases/download/evidence-686/report.json"
+                    .to_string(),
+            artifact_sha256:
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            bounty_settled_url:
+                "https://basescan.org/tx/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    .to_string(),
+        });
+
+        assert!(report.accepted, "{:?}", report.errors);
+        assert!(report.errors.is_empty());
+        assert!(report
+            .checklist
+            .payment
+            .iter()
+            .any(|item| item.contains("BountySettled")));
+        assert!(report.evidence_boundary.contains("Only canonical BountySettled"));
+    }
+
+    #[test]
+    fn direct_bounty_evidence_rejects_missing_and_malformed_fields() {
+        let report = validate_direct_bounty_evidence(&DirectBountyEvidence {
+            repository_url: "".to_string(),
+            source_commit: "abc".to_string(),
+            subdirectory: "".to_string(),
+            pull_request_url: "http://github.com/example/repo/pull/1".to_string(),
+            check_run_urls: vec!["".to_string()],
+            artifact_url: "https://example.com/artifacts/latest/report.json".to_string(),
+            artifact_sha256: "not-a-digest".to_string(),
+            bounty_settled_url: "ipfs://settled".to_string(),
+        });
+
+        assert!(!report.accepted);
+        assert!(report
+            .errors
+            .iter()
+            .any(|error| error.contains("repository_url must not be empty")));
+        assert!(report
+            .errors
+            .iter()
+            .any(|error| error.contains("source_commit must be a full")));
+        assert!(report
+            .errors
+            .iter()
+            .any(|error| error.contains("pull_request_url must be an HTTPS URL")));
+        assert!(report
+            .errors
+            .iter()
+            .any(|error| error.contains("artifact_url must be immutable")));
+        assert!(report
+            .errors
+            .iter()
+            .any(|error| error.contains("bounty_settled_url must be an HTTPS URL")));
+    }
+
+    #[test]
+    fn direct_bounty_evidence_requires_check_run_urls() {
+        let report = validate_direct_bounty_evidence(&DirectBountyEvidence {
+            repository_url: "https://github.com/agent-bounties/agent-bounties".to_string(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            subdirectory: ".".to_string(),
+            pull_request_url: "https://github.com/agent-bounties/agent-bounties/pull/686"
+                .to_string(),
+            check_run_urls: Vec::new(),
+            artifact_url:
+                "https://github.com/agent-bounties/agent-bounties/releases/download/evidence-686/report.json"
+                    .to_string(),
+            artifact_sha256:
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            bounty_settled_url:
+                "https://basescan.org/tx/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    .to_string(),
+        });
+
+        assert!(!report.accepted);
+        assert!(report
+            .errors
+            .iter()
+            .any(|error| error.contains("check_run_urls must contain at least one")));
     }
 }

--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -94,6 +94,7 @@ impl Default for DirectBountyEvidenceChecklist {
                 "empty evidence fields are rejected".to_string(),
                 "non-HTTPS repository, pull request, check-run, artifact, or settlement references are rejected".to_string(),
                 "mutable artifact references such as branch names, tags, releases, query refs, encoded lookalikes, or unpinned download URLs are rejected".to_string(),
+                "evidence fields from mismatched repositories or mismatched source commits are rejected".to_string(),
                 "payment evidence without a matching canonical BountySettled event is rejected".to_string(),
             ],
         }
@@ -151,14 +152,56 @@ pub fn validate_direct_bounty_evidence(
         require_https(&mut errors, &format!("check_run_urls[{index}]"), url);
     }
 
-    if !is_hex_sha(&evidence.source_commit, 40) {
+    let is_valid_source_commit = is_hex_sha(&evidence.source_commit, 40);
+    if !is_valid_source_commit {
         errors.push("source_commit must be a full 40-character hexadecimal commit SHA".to_string());
     }
     if !is_hex_sha(&evidence.artifact_sha256, 64) {
         errors.push("artifact_sha256 must be a 64-character hexadecimal SHA-256 digest".to_string());
     }
-    if !is_immutable_artifact_url(&evidence.artifact_url) {
-        errors.push("artifact_url must be immutable by construction (pinned commit blob/raw HTTPS URL)".to_string());
+
+    let repo_canonical = parse_github_repo(&evidence.repository_url);
+    if repo_canonical.is_none() && evidence.repository_url.starts_with("https://") && !evidence.repository_url.trim().is_empty() {
+        errors.push("repository_url must be a valid GitHub repository URL (https://github.com/owner/repo)".to_string());
+    }
+
+    if let Some((owner, repo)) = &repo_canonical {
+        if let Some((pr_owner, pr_repo)) = parse_github_pr_repo(&evidence.pull_request_url) {
+            if pr_owner != *owner || pr_repo != *repo {
+                errors.push("pull_request_url must belong to the same repository as repository_url".to_string());
+            }
+        } else if evidence.pull_request_url.starts_with("https://") && !evidence.pull_request_url.trim().is_empty() {
+            errors.push("pull_request_url must be a valid pull request URL for repository_url".to_string());
+        }
+
+        for (index, cr_url) in evidence.check_run_urls.iter().enumerate() {
+            if let Some((cr_owner, cr_repo)) = parse_github_repo_from_any_url(cr_url) {
+                if cr_owner != *owner || cr_repo != *repo {
+                    errors.push(format!("check_run_urls[{index}] must belong to the same repository as repository_url"));
+                }
+            } else if cr_url.starts_with("https://") && !cr_url.trim().is_empty() {
+                errors.push(format!("check_run_urls[{index}] must belong to the same repository as repository_url"));
+            }
+        }
+    }
+
+    match parse_immutable_artifact_url(&evidence.artifact_url) {
+        Some(artifact) => {
+            if let Some((owner, repo)) = &repo_canonical {
+                if artifact.owner != *owner || artifact.repo != *repo {
+                    errors.push("artifact_url repository must match repository_url".to_string());
+                }
+            }
+            if is_valid_source_commit && !artifact.commit.eq_ignore_ascii_case(&evidence.source_commit) {
+                errors.push("artifact_url commit SHA must match source_commit".to_string());
+            }
+            if artifact.path.trim().is_empty() {
+                errors.push("artifact_url must specify a non-empty file path".to_string());
+            }
+        }
+        None => {
+            errors.push("artifact_url must be immutable by construction (pinned commit blob/raw HTTPS URL with non-empty path)".to_string());
+        }
     }
 
     DirectBountyEvidenceReport {
@@ -379,14 +422,84 @@ fn is_hex_sha(value: &str, expected_len: usize) -> bool {
     value.len() == expected_len && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
-fn is_immutable_artifact_url(url: &str) -> bool {
+#[derive(Debug, PartialEq, Eq)]
+struct ParsedArtifactUrl {
+    owner: String,
+    repo: String,
+    commit: String,
+    path: String,
+}
+
+fn sanitize_repo_name(name: &str) -> String {
+    let lower = name.to_ascii_lowercase();
+    if let Some(stripped) = lower.strip_suffix(".git") {
+        stripped.to_string()
+    } else {
+        lower
+    }
+}
+
+fn parse_github_repo(url: &str) -> Option<(String, String)> {
+    if !url.starts_with("https://github.com/") {
+        return None;
+    }
+    if url.contains('?') || url.contains('#') || url.contains('%') {
+        return None;
+    }
+    let rest = url.strip_prefix("https://github.com/")?;
+    let parts: Vec<&str> = rest.split('/').filter(|p| !p.is_empty()).collect();
+    if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Some((parts[0].to_ascii_lowercase(), sanitize_repo_name(parts[1])))
+    } else {
+        None
+    }
+}
+
+fn parse_github_pr_repo(url: &str) -> Option<(String, String)> {
+    if !url.starts_with("https://github.com/") {
+        return None;
+    }
+    if url.contains('?') || url.contains('#') || url.contains('%') {
+        return None;
+    }
+    let rest = url.strip_prefix("https://github.com/")?;
+    let parts: Vec<&str> = rest.split('/').filter(|p| !p.is_empty()).collect();
+    if parts.len() >= 4
+        && !parts[0].is_empty()
+        && !parts[1].is_empty()
+        && parts[2] == "pull"
+        && parts[3].chars().all(|c| c.is_ascii_digit())
+    {
+        Some((parts[0].to_ascii_lowercase(), sanitize_repo_name(parts[1])))
+    } else {
+        None
+    }
+}
+
+fn parse_github_repo_from_any_url(url: &str) -> Option<(String, String)> {
+    if !url.starts_with("https://github.com/") {
+        return None;
+    }
+    if url.contains('?') || url.contains('#') || url.contains('%') {
+        return None;
+    }
+    let rest = url.strip_prefix("https://github.com/")?;
+    let parts: Vec<&str> = rest.split('/').filter(|p| !p.is_empty()).collect();
+    if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Some((parts[0].to_ascii_lowercase(), sanitize_repo_name(parts[1])))
+    } else {
+        None
+    }
+}
+
+fn parse_immutable_artifact_url(url: &str) -> Option<ParsedArtifactUrl> {
     if !url.starts_with("https://") {
-        return false;
+        return None;
     }
 
     // Reject query parameters, fragments, or percent-encoded lookalikes that could evade branch/tag checks
     if url.contains('?') || url.contains('#') || url.contains('%') {
-        return false;
+        return None;
     }
 
     // Check for GitHub pinned commit SHA (raw or blob)
@@ -400,8 +513,14 @@ fn is_immutable_artifact_url(url: &str) -> bool {
             && (parts[2] == "blob" || parts[2] == "raw")
         {
             let sha = parts[3];
-            if is_hex_sha(sha, 40) {
-                return true;
+            let path = parts[4..].join("/");
+            if is_hex_sha(sha, 40) && !path.trim().is_empty() {
+                return Some(ParsedArtifactUrl {
+                    owner: parts[0].to_ascii_lowercase(),
+                    repo: sanitize_repo_name(parts[1]),
+                    commit: sha.to_ascii_lowercase(),
+                    path,
+                });
             }
         }
     }
@@ -411,13 +530,23 @@ fn is_immutable_artifact_url(url: &str) -> bool {
         let parts: Vec<&str> = rest.split('/').collect();
         if parts.len() >= 4 && !parts[0].is_empty() && !parts[1].is_empty() {
             let sha = parts[2];
-            if is_hex_sha(sha, 40) {
-                return true;
+            let path = parts[3..].join("/");
+            if is_hex_sha(sha, 40) && !path.trim().is_empty() {
+                return Some(ParsedArtifactUrl {
+                    owner: parts[0].to_ascii_lowercase(),
+                    repo: sanitize_repo_name(parts[1]),
+                    commit: sha.to_ascii_lowercase(),
+                    path,
+                });
             }
         }
     }
 
-    false
+    None
+}
+
+fn is_immutable_artifact_url(url: &str) -> bool {
+    parse_immutable_artifact_url(url).is_some()
 }
 
 fn strongest(left: RiskAction, right: RiskAction) -> RiskAction {
@@ -603,5 +732,55 @@ mod tests {
             .errors
             .iter()
             .any(|error| error.contains("check_run_urls must contain at least one")));
+    }
+    #[test]
+    fn direct_bounty_evidence_rejects_cross_binding_mismatches() {
+        let base_evidence = DirectBountyEvidence {
+            repository_url: "https://github.com/agent-bounties/agent-bounties".to_string(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            subdirectory: "crates/risk".to_string(),
+            pull_request_url: "https://github.com/agent-bounties/agent-bounties/pull/686".to_string(),
+            check_run_urls: vec![
+                "https://github.com/agent-bounties/agent-bounties/actions/runs/123456789".to_string(),
+            ],
+            artifact_url: "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/crates/risk/tests/fixtures/report.json".to_string(),
+            artifact_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            bounty_settled_url: "https://basescan.org/tx/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        };
+
+        // Mismatched PR repository -> Denied
+        let mut pr_mismatch = base_evidence.clone();
+        pr_mismatch.pull_request_url = "https://github.com/other-org/other-repo/pull/686".to_string();
+        let report = validate_direct_bounty_evidence(&pr_mismatch);
+        assert!(!report.accepted);
+        assert!(report.errors.iter().any(|e| e.contains("pull_request_url must belong to the same repository")));
+
+        // Mismatched artifact repository -> Denied
+        let mut art_repo_mismatch = base_evidence.clone();
+        art_repo_mismatch.artifact_url = "https://raw.githubusercontent.com/other-org/other-repo/0123456789abcdef0123456789abcdef01234567/report.json".to_string();
+        let report = validate_direct_bounty_evidence(&art_repo_mismatch);
+        assert!(!report.accepted);
+        assert!(report.errors.iter().any(|e| e.contains("artifact_url repository must match repository_url")));
+
+        // Mismatched artifact commit SHA -> Denied
+        let mut art_commit_mismatch = base_evidence.clone();
+        art_commit_mismatch.artifact_url = "https://raw.githubusercontent.com/agent-bounties/agent-bounties/fedcba9876543210fedcba9876543210fedcba98/crates/risk/tests/fixtures/report.json".to_string();
+        let report = validate_direct_bounty_evidence(&art_commit_mismatch);
+        assert!(!report.accepted);
+        assert!(report.errors.iter().any(|e| e.contains("artifact_url commit SHA must match source_commit")));
+
+        // Unrelated check-run URL -> Denied
+        let mut check_mismatch = base_evidence.clone();
+        check_mismatch.check_run_urls = vec!["https://github.com/unrelated-org/unrelated-repo/actions/runs/999".to_string()];
+        let report = validate_direct_bounty_evidence(&check_mismatch);
+        assert!(!report.accepted);
+        assert!(report.errors.iter().any(|e| e.contains("check_run_urls[0] must belong to the same repository")));
+
+        // Empty artifact path -> Denied
+        let mut empty_path = base_evidence.clone();
+        empty_path.artifact_url = "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/".to_string();
+        let report = validate_direct_bounty_evidence(&empty_path);
+        assert!(!report.accepted);
+        assert!(report.errors.iter().any(|e| e.contains("artifact_url must specify a non-empty file path") || e.contains("artifact_url must be immutable")));
     }
 }

--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -93,7 +93,8 @@ impl Default for DirectBountyEvidenceChecklist {
             rejection_rules: vec![
                 "empty evidence fields are rejected".to_string(),
                 "non-HTTPS repository, pull request, check-run, artifact, or settlement references are rejected".to_string(),
-                "mutable artifact references such as branch, latest, raw main, or unpinned download URLs are rejected".to_string(),
+                "mutable artifact references such as branch names, tags, releases, query refs, encoded lookalikes, or unpinned download URLs are rejected".to_string(),
+                "payment evidence without a matching canonical BountySettled event is rejected".to_string(),
             ],
         }
     }
@@ -115,6 +116,7 @@ pub struct DirectBountyEvidence {
 pub struct DirectBountyEvidenceReport {
     pub checklist: DirectBountyEvidenceChecklist,
     pub accepted: bool,
+    pub payment_settlement_status: String,
     pub errors: Vec<String>,
     pub evidence_boundary: String,
 }
@@ -155,13 +157,14 @@ pub fn validate_direct_bounty_evidence(
     if !is_hex_sha(&evidence.artifact_sha256, 64) {
         errors.push("artifact_sha256 must be a 64-character hexadecimal SHA-256 digest".to_string());
     }
-    if is_mutable_artifact_reference(&evidence.artifact_url) {
-        errors.push("artifact_url must be immutable and pinned, not a branch/latest/raw-main reference".to_string());
+    if !is_immutable_artifact_url(&evidence.artifact_url) {
+        errors.push("artifact_url must be immutable by construction (pinned commit blob/raw or content-addressed HTTPS form)".to_string());
     }
 
     DirectBountyEvidenceReport {
         checklist: DirectBountyEvidenceChecklist::default(),
         accepted: errors.is_empty(),
+        payment_settlement_status: "unverified: structural checklist references provided; requires canonical BountySettled event verification".to_string(),
         errors,
         evidence_boundary: "Submission, verification, and payment evidence are separate. Only canonical BountySettled proves payment.".to_string(),
     }
@@ -376,16 +379,75 @@ fn is_hex_sha(value: &str, expected_len: usize) -> bool {
     value.len() == expected_len && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
-fn is_mutable_artifact_reference(value: &str) -> bool {
-    let lower = value.to_ascii_lowercase();
-    lower.contains("/latest")
-        || lower.contains("?latest")
-        || lower.contains("/raw/main/")
-        || lower.contains("/raw/master/")
-        || lower.contains("/main/")
-        || lower.contains("/master/")
-        || lower.ends_with("/main")
-        || lower.ends_with("/master")
+fn is_immutable_artifact_url(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+
+    if !lower.starts_with("https://") {
+        return false;
+    }
+
+    // Reject query parameters, fragments, or percent-encoded lookalikes that could evade branch/tag checks
+    if lower.contains('?') || lower.contains('#') || lower.contains("%2f") || lower.contains("%2e") || lower.contains("%3a") {
+        return false;
+    }
+
+    // Reject known mutable path components or replaceable release downloads
+    if lower.contains("/releases/download/")
+        || lower.contains("/releases/tag/")
+        || lower.contains("/tags/")
+        || lower.contains("/branches/")
+        || lower.contains("/tree/")
+    {
+        return false;
+    }
+
+    // Check for GitHub pinned commit SHA (raw or blob)
+    // Format 1: https://github.com/{owner}/{repo}/blob/{40-hex-sha}/{path...}
+    // Format 2: https://github.com/{owner}/{repo}/raw/{40-hex-sha}/{path...}
+    if let Some(rest) = lower.strip_prefix("https://github.com/") {
+        let parts: Vec<&str> = rest.split('/').collect();
+        if parts.len() >= 5 && (parts[2] == "blob" || parts[2] == "raw") {
+            let sha = parts[3];
+            if is_hex_sha(sha, 40) {
+                return true;
+            }
+        }
+    }
+
+    // Format 3: https://raw.githubusercontent.com/{owner}/{repo}/{40-hex-sha}/{path...}
+    if let Some(rest) = lower.strip_prefix("https://raw.githubusercontent.com/") {
+        let parts: Vec<&str> = rest.split('/').collect();
+        if parts.len() >= 4 {
+            let sha = parts[2];
+            if is_hex_sha(sha, 40) {
+                return true;
+            }
+        }
+    }
+
+    // Check for IPFS content-addressed URL (CIDv0 Qm... or CIDv1 bafy.../bafk...)
+    if lower.contains("/ipfs/") {
+        if let Some(pos) = lower.find("/ipfs/") {
+            let cid_part = &lower[pos + 6..];
+            let cid = cid_part.split('/').next().unwrap_or("");
+            if (cid.starts_with("qm") && cid.len() >= 46) || cid.starts_with("bafy") || cid.starts_with("bafk") {
+                return true;
+            }
+        }
+    }
+
+    // Check for Arweave content-addressed transaction
+    if lower.contains("/arweave/") {
+        if let Some(pos) = lower.find("/arweave/") {
+            let tx_part = &lower[pos + 9..];
+            let tx_id = tx_part.split('/').next().unwrap_or("");
+            if tx_id.len() == 43 {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 fn strongest(left: RiskAction, right: RiskAction) -> RiskAction {
@@ -459,7 +521,7 @@ mod tests {
                     .to_string(),
             ],
             artifact_url:
-                "https://github.com/agent-bounties/agent-bounties/releases/download/evidence-686/report.json"
+                "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/crates/risk/tests/fixtures/report.json"
                     .to_string(),
             artifact_sha256:
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
@@ -470,6 +532,7 @@ mod tests {
 
         assert!(report.accepted, "{:?}", report.errors);
         assert!(report.errors.is_empty());
+        assert!(report.payment_settlement_status.contains("unverified"));
         assert!(report
             .checklist
             .payment
@@ -515,6 +578,38 @@ mod tests {
     }
 
     #[test]
+    fn direct_bounty_evidence_allow_deny_table_tests() {
+        // Pinned valid commit SHA raw URL -> Allowed
+        assert!(is_immutable_artifact_url("https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/report.json"));
+        // Pinned valid commit SHA blob URL -> Allowed
+        assert!(is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/blob/0123456789abcdef0123456789abcdef01234567/crates/risk/report.json"));
+        // Pinned valid commit SHA github raw URL -> Allowed
+        assert!(is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/raw/0123456789abcdef0123456789abcdef01234567/crates/risk/report.json"));
+        // Content-addressed IPFS URL -> Allowed
+        assert!(is_immutable_artifact_url("https://ipfs.io/ipfs/QmT78zSuBKGvaFFB8JNjAYAkChFSFCZa17z5W33cyS2PHe/report.json"));
+        assert!(is_immutable_artifact_url("https://gateway.pinata.cloud/ipfs/bafybeicg2wtshqqgahsqe4h7jhvhw4gjrxzgy3pd52mxuvpfs6yv67m75e/artifact.json"));
+
+        // Mutable branch URLs -> Denied
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/raw/main/report.json"));
+        assert!(!is_immutable_artifact_url("https://raw.githubusercontent.com/agent-bounties/agent-bounties/master/report.json"));
+        assert!(!is_immutable_artifact_url("https://raw.githubusercontent.com/agent-bounties/agent-bounties/feature-branch/report.json"));
+
+        // Replaceable release assets and tags -> Denied
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/releases/download/v1.0.0/report.json"));
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/releases/tag/v1.0.0"));
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/tags/v1.0.0"));
+
+        // Query parameters and lookalikes -> Denied
+        assert!(!is_immutable_artifact_url("https://example.com/report.json?commit=0123456789abcdef0123456789abcdef01234567"));
+        assert!(!is_immutable_artifact_url("https://github.com/org/repo/raw/0123456789abcdef0123456789abcdef01234567/report.json?v=latest"));
+        assert!(!is_immutable_artifact_url("https://github.com/org/repo/raw/0123456789abcdef0123456789abcdef01234567%2Freport.json"));
+
+        // Generic unpinned URLs -> Denied
+        assert!(!is_immutable_artifact_url("https://example.com/report.json"));
+        assert!(!is_immutable_artifact_url("http://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/report.json"));
+    }
+
+    #[test]
     fn direct_bounty_evidence_requires_check_run_urls() {
         let report = validate_direct_bounty_evidence(&DirectBountyEvidence {
             repository_url: "https://github.com/agent-bounties/agent-bounties".to_string(),
@@ -524,7 +619,7 @@ mod tests {
                 .to_string(),
             check_run_urls: Vec::new(),
             artifact_url:
-                "https://github.com/agent-bounties/agent-bounties/releases/download/evidence-686/report.json"
+                "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/crates/risk/tests/fixtures/report.json"
                     .to_string(),
             artifact_sha256:
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),

--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -158,7 +158,7 @@ pub fn validate_direct_bounty_evidence(
         errors.push("artifact_sha256 must be a 64-character hexadecimal SHA-256 digest".to_string());
     }
     if !is_immutable_artifact_url(&evidence.artifact_url) {
-        errors.push("artifact_url must be immutable by construction (pinned commit blob/raw or content-addressed HTTPS form)".to_string());
+        errors.push("artifact_url must be immutable by construction (pinned commit blob/raw HTTPS URL)".to_string());
     }
 
     DirectBountyEvidenceReport {
@@ -380,33 +380,25 @@ fn is_hex_sha(value: &str, expected_len: usize) -> bool {
 }
 
 fn is_immutable_artifact_url(url: &str) -> bool {
-    let lower = url.to_ascii_lowercase();
-
-    if !lower.starts_with("https://") {
+    if !url.starts_with("https://") {
         return false;
     }
 
     // Reject query parameters, fragments, or percent-encoded lookalikes that could evade branch/tag checks
-    if lower.contains('?') || lower.contains('#') || lower.contains("%2f") || lower.contains("%2e") || lower.contains("%3a") {
-        return false;
-    }
-
-    // Reject known mutable path components or replaceable release downloads
-    if lower.contains("/releases/download/")
-        || lower.contains("/releases/tag/")
-        || lower.contains("/tags/")
-        || lower.contains("/branches/")
-        || lower.contains("/tree/")
-    {
+    if url.contains('?') || url.contains('#') || url.contains('%') {
         return false;
     }
 
     // Check for GitHub pinned commit SHA (raw or blob)
     // Format 1: https://github.com/{owner}/{repo}/blob/{40-hex-sha}/{path...}
     // Format 2: https://github.com/{owner}/{repo}/raw/{40-hex-sha}/{path...}
-    if let Some(rest) = lower.strip_prefix("https://github.com/") {
+    if let Some(rest) = url.strip_prefix("https://github.com/") {
         let parts: Vec<&str> = rest.split('/').collect();
-        if parts.len() >= 5 && (parts[2] == "blob" || parts[2] == "raw") {
+        if parts.len() >= 5
+            && !parts[0].is_empty()
+            && !parts[1].is_empty()
+            && (parts[2] == "blob" || parts[2] == "raw")
+        {
             let sha = parts[3];
             if is_hex_sha(sha, 40) {
                 return true;
@@ -415,33 +407,11 @@ fn is_immutable_artifact_url(url: &str) -> bool {
     }
 
     // Format 3: https://raw.githubusercontent.com/{owner}/{repo}/{40-hex-sha}/{path...}
-    if let Some(rest) = lower.strip_prefix("https://raw.githubusercontent.com/") {
+    if let Some(rest) = url.strip_prefix("https://raw.githubusercontent.com/") {
         let parts: Vec<&str> = rest.split('/').collect();
-        if parts.len() >= 4 {
+        if parts.len() >= 4 && !parts[0].is_empty() && !parts[1].is_empty() {
             let sha = parts[2];
             if is_hex_sha(sha, 40) {
-                return true;
-            }
-        }
-    }
-
-    // Check for IPFS content-addressed URL (CIDv0 Qm... or CIDv1 bafy.../bafk...)
-    if lower.contains("/ipfs/") {
-        if let Some(pos) = lower.find("/ipfs/") {
-            let cid_part = &lower[pos + 6..];
-            let cid = cid_part.split('/').next().unwrap_or("");
-            if (cid.starts_with("qm") && cid.len() >= 46) || cid.starts_with("bafy") || cid.starts_with("bafk") {
-                return true;
-            }
-        }
-    }
-
-    // Check for Arweave content-addressed transaction
-    if lower.contains("/arweave/") {
-        if let Some(pos) = lower.find("/arweave/") {
-            let tx_part = &lower[pos + 9..];
-            let tx_id = tx_part.split('/').next().unwrap_or("");
-            if tx_id.len() == 43 {
                 return true;
             }
         }
@@ -585,9 +555,6 @@ mod tests {
         assert!(is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/blob/0123456789abcdef0123456789abcdef01234567/crates/risk/report.json"));
         // Pinned valid commit SHA github raw URL -> Allowed
         assert!(is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/raw/0123456789abcdef0123456789abcdef01234567/crates/risk/report.json"));
-        // Content-addressed IPFS URL -> Allowed
-        assert!(is_immutable_artifact_url("https://ipfs.io/ipfs/QmT78zSuBKGvaFFB8JNjAYAkChFSFCZa17z5W33cyS2PHe/report.json"));
-        assert!(is_immutable_artifact_url("https://gateway.pinata.cloud/ipfs/bafybeicg2wtshqqgahsqe4h7jhvhw4gjrxzgy3pd52mxuvpfs6yv67m75e/artifact.json"));
 
         // Mutable branch URLs -> Denied
         assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/raw/main/report.json"));
@@ -599,13 +566,16 @@ mod tests {
         assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/releases/tag/v1.0.0"));
         assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/tags/v1.0.0"));
 
-        // Query parameters and lookalikes -> Denied
+        // Query parameters, fragments, and lookalikes -> Denied
         assert!(!is_immutable_artifact_url("https://example.com/report.json?commit=0123456789abcdef0123456789abcdef01234567"));
         assert!(!is_immutable_artifact_url("https://github.com/org/repo/raw/0123456789abcdef0123456789abcdef01234567/report.json?v=latest"));
         assert!(!is_immutable_artifact_url("https://github.com/org/repo/raw/0123456789abcdef0123456789abcdef01234567%2Freport.json"));
 
-        // Generic unpinned URLs -> Denied
+        // Generic unpinned URLs, IPFS, Arweave or other mutable paths -> Denied
         assert!(!is_immutable_artifact_url("https://example.com/report.json"));
+        assert!(!is_immutable_artifact_url("https://example.com/ipfs/bafy"));
+        assert!(!is_immutable_artifact_url("https://example.com/arweave/abcdef"));
+        assert!(!is_immutable_artifact_url("https://ipfs.io/ipfs/QmT78zSuBKGvaFFB8JNjAYAkChFSFCZa17z5W33cyS2PHe/report.json"));
         assert!(!is_immutable_artifact_url("http://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/report.json"));
     }
 

--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -96,6 +96,7 @@ impl Default for DirectBountyEvidenceChecklist {
                 "mutable artifact references such as branch names, tags, releases, query refs, encoded lookalikes, or unpinned download URLs are rejected".to_string(),
                 "evidence fields from mismatched repositories or mismatched source commits are rejected".to_string(),
                 "payment evidence without a matching canonical BountySettled event is rejected".to_string(),
+                "check-run URLs must be GitHub Actions or Checks run URLs; issue, PR, blob, and release URLs are rejected as check-run evidence".to_string(),
             ],
         }
     }
@@ -116,7 +117,14 @@ pub struct DirectBountyEvidence {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub struct DirectBountyEvidenceReport {
     pub checklist: DirectBountyEvidenceChecklist,
+    /// True when all structural evidence fields are present, valid, and internally consistent.
+    /// This does NOT indicate payment has been made or verified.
+    pub structure_valid: bool,
+    /// True only when `structure_valid` is true AND a canonical `BountySettled` event has been
+    /// verified. Currently always `false` because automated settlement verification is not
+    /// implemented; callers must not treat `accepted` as payment evidence.
     pub accepted: bool,
+    /// Human-readable settlement verification status.
     pub payment_settlement_status: String,
     pub errors: Vec<String>,
     pub evidence_boundary: String,
@@ -137,12 +145,20 @@ pub fn validate_direct_bounty_evidence(
     require_non_empty(&mut errors, "pull_request_url", &evidence.pull_request_url);
     require_non_empty(&mut errors, "artifact_url", &evidence.artifact_url);
     require_non_empty(&mut errors, "artifact_sha256", &evidence.artifact_sha256);
-    require_non_empty(&mut errors, "bounty_settled_url", &evidence.bounty_settled_url);
+    require_non_empty(
+        &mut errors,
+        "bounty_settled_url",
+        &evidence.bounty_settled_url,
+    );
 
     require_https(&mut errors, "repository_url", &evidence.repository_url);
     require_https(&mut errors, "pull_request_url", &evidence.pull_request_url);
     require_https(&mut errors, "artifact_url", &evidence.artifact_url);
-    require_https(&mut errors, "bounty_settled_url", &evidence.bounty_settled_url);
+    require_https(
+        &mut errors,
+        "bounty_settled_url",
+        &evidence.bounty_settled_url,
+    );
 
     if evidence.check_run_urls.is_empty() {
         errors.push("check_run_urls must contain at least one HTTPS check-run URL".to_string());
@@ -150,6 +166,16 @@ pub fn validate_direct_bounty_evidence(
     for (index, url) in evidence.check_run_urls.iter().enumerate() {
         require_non_empty(&mut errors, &format!("check_run_urls[{index}]"), url);
         require_https(&mut errors, &format!("check_run_urls[{index}]"), url);
+        // Reject same-repository issue, PR, blob, and release URLs as check-run evidence.
+        // Only GitHub Actions run URLs and Checks run URLs are accepted.
+        if url.starts_with("https://") && !is_github_check_run_url(url) {
+            errors.push(format!(
+                "check_run_urls[{index}] must be a GitHub Actions or Checks run URL \
+                 (https://github.com/{{owner}}/{{repo}}/actions/runs/{{id}} or \
+                 https://github.com/{{owner}}/{{repo}}/runs/{{id}}); \
+                 issue, PR, blob, and release URLs are not accepted as check-run evidence"
+            ));
+        }
     }
 
     let is_valid_source_commit = is_hex_sha(&evidence.source_commit, 40);
@@ -157,30 +183,51 @@ pub fn validate_direct_bounty_evidence(
         errors.push("source_commit must be a full 40-character hexadecimal commit SHA".to_string());
     }
     if !is_hex_sha(&evidence.artifact_sha256, 64) {
-        errors.push("artifact_sha256 must be a 64-character hexadecimal SHA-256 digest".to_string());
+        errors
+            .push("artifact_sha256 must be a 64-character hexadecimal SHA-256 digest".to_string());
     }
 
     let repo_canonical = parse_github_repo(&evidence.repository_url);
-    if repo_canonical.is_none() && evidence.repository_url.starts_with("https://") && !evidence.repository_url.trim().is_empty() {
-        errors.push("repository_url must be a valid GitHub repository URL (https://github.com/owner/repo)".to_string());
+    if repo_canonical.is_none()
+        && evidence.repository_url.starts_with("https://")
+        && !evidence.repository_url.trim().is_empty()
+    {
+        errors.push(
+            "repository_url must be a valid GitHub repository URL (https://github.com/owner/repo)"
+                .to_string(),
+        );
     }
 
     if let Some((owner, repo)) = &repo_canonical {
         if let Some((pr_owner, pr_repo)) = parse_github_pr_repo(&evidence.pull_request_url) {
             if pr_owner != *owner || pr_repo != *repo {
-                errors.push("pull_request_url must belong to the same repository as repository_url".to_string());
+                errors.push(
+                    "pull_request_url must belong to the same repository as repository_url"
+                        .to_string(),
+                );
             }
-        } else if evidence.pull_request_url.starts_with("https://") && !evidence.pull_request_url.trim().is_empty() {
-            errors.push("pull_request_url must be a valid pull request URL for repository_url".to_string());
+        } else if evidence.pull_request_url.starts_with("https://")
+            && !evidence.pull_request_url.trim().is_empty()
+        {
+            errors.push(
+                "pull_request_url must be a valid pull request URL for repository_url".to_string(),
+            );
         }
 
         for (index, cr_url) in evidence.check_run_urls.iter().enumerate() {
-            if let Some((cr_owner, cr_repo)) = parse_github_repo_from_any_url(cr_url) {
-                if cr_owner != *owner || cr_repo != *repo {
-                    errors.push(format!("check_run_urls[{index}] must belong to the same repository as repository_url"));
+            // Only validate repository binding for URLs that passed the check-run format check.
+            if is_github_check_run_url(cr_url) {
+                if let Some((cr_owner, cr_repo)) = parse_github_repo_from_check_run_url(cr_url) {
+                    if cr_owner != *owner || cr_repo != *repo {
+                        errors.push(format!(
+                            "check_run_urls[{index}] must belong to the same repository as repository_url"
+                        ));
+                    }
+                } else if cr_url.starts_with("https://") && !cr_url.trim().is_empty() {
+                    errors.push(format!(
+                        "check_run_urls[{index}] must belong to the same repository as repository_url"
+                    ));
                 }
-            } else if cr_url.starts_with("https://") && !cr_url.trim().is_empty() {
-                errors.push(format!("check_run_urls[{index}] must belong to the same repository as repository_url"));
             }
         }
     }
@@ -192,7 +239,11 @@ pub fn validate_direct_bounty_evidence(
                     errors.push("artifact_url repository must match repository_url".to_string());
                 }
             }
-            if is_valid_source_commit && !artifact.commit.eq_ignore_ascii_case(&evidence.source_commit) {
+            if is_valid_source_commit
+                && !artifact
+                    .commit
+                    .eq_ignore_ascii_case(&evidence.source_commit)
+            {
                 errors.push("artifact_url commit SHA must match source_commit".to_string());
             }
             if artifact.path.trim().is_empty() {
@@ -204,10 +255,20 @@ pub fn validate_direct_bounty_evidence(
         }
     }
 
+    let structure_valid = errors.is_empty();
+    // `accepted` requires both structural validity AND verified canonical settlement.
+    // Settlement verification is not automated, so `accepted` is always false here.
+    let accepted = false;
+
     DirectBountyEvidenceReport {
         checklist: DirectBountyEvidenceChecklist::default(),
-        accepted: errors.is_empty(),
-        payment_settlement_status: "unverified: structural checklist references provided; requires canonical BountySettled event verification".to_string(),
+        structure_valid,
+        accepted,
+        payment_settlement_status: if structure_valid {
+            "unverified: structural checklist references provided; requires canonical BountySettled event verification".to_string()
+        } else {
+            "invalid: structural evidence errors must be resolved before settlement verification".to_string()
+        },
         errors,
         evidence_boundary: "Submission, verification, and payment evidence are separate. Only canonical BountySettled proves payment.".to_string(),
     }
@@ -476,7 +537,25 @@ fn parse_github_pr_repo(url: &str) -> Option<(String, String)> {
     }
 }
 
-fn parse_github_repo_from_any_url(url: &str) -> Option<(String, String)> {
+/// Returns true only for GitHub Actions run URLs and GitHub Checks run URLs.
+///
+/// Accepted patterns:
+/// - `https://github.com/{owner}/{repo}/actions/runs/{id}[/...]`
+/// - `https://github.com/{owner}/{repo}/runs/{id}[/...]`
+///
+/// Explicitly rejected as check-run evidence (even when in the same repository):
+/// - issue URLs   (`/issues/{n}`)
+/// - PR URLs      (`/pull/{n}`)
+/// - blob/raw URLs (`/blob/`, `/raw/`)
+/// - release URLs (`/releases/`)
+/// - tree/commit URLs (`/tree/`, `/commit/`)
+fn is_github_check_run_url(url: &str) -> bool {
+    parse_github_repo_from_check_run_url(url).is_some()
+}
+
+/// Parses (owner, repo) from a GitHub Actions or Checks run URL.
+/// Returns `None` for issue, PR, blob, release, or other non-check-run GitHub URLs.
+fn parse_github_repo_from_check_run_url(url: &str) -> Option<(String, String)> {
     if !url.starts_with("https://github.com/") {
         return None;
     }
@@ -485,11 +564,27 @@ fn parse_github_repo_from_any_url(url: &str) -> Option<(String, String)> {
     }
     let rest = url.strip_prefix("https://github.com/")?;
     let parts: Vec<&str> = rest.split('/').filter(|p| !p.is_empty()).collect();
-    if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-        Some((parts[0].to_ascii_lowercase(), sanitize_repo_name(parts[1])))
-    } else {
-        None
+    // Minimum: owner / repo / (actions/) runs / id  → at least 4 parts
+    if parts.len() < 4 || parts[0].is_empty() || parts[1].is_empty() {
+        return None;
     }
+    let owner = parts[0].to_ascii_lowercase();
+    let repo = sanitize_repo_name(parts[1]);
+
+    // Pattern: /actions/runs/{numeric-id}[/...]
+    if parts[2] == "actions" && parts.len() >= 4 && parts[3] == "runs" {
+        if parts.len() >= 5 && parts[4].chars().all(|c| c.is_ascii_digit()) {
+            return Some((owner, repo));
+        }
+        return None;
+    }
+
+    // Pattern: /runs/{numeric-id}[/...]  (GitHub Checks API URLs)
+    if parts[2] == "runs" && parts[3].chars().all(|c| c.is_ascii_digit()) {
+        return Some((owner, repo));
+    }
+
+    None
 }
 
 fn parse_immutable_artifact_url(url: &str) -> Option<ParsedArtifactUrl> {
@@ -629,15 +724,22 @@ mod tests {
                     .to_string(),
         });
 
-        assert!(report.accepted, "{:?}", report.errors);
+        assert!(report.structure_valid, "{:?}", report.errors);
         assert!(report.errors.is_empty());
+        // `accepted` is always false: settlement is never auto-verified.
+        assert!(
+            !report.accepted,
+            "accepted must be false until settlement is verified"
+        );
         assert!(report.payment_settlement_status.contains("unverified"));
         assert!(report
             .checklist
             .payment
             .iter()
             .any(|item| item.contains("BountySettled")));
-        assert!(report.evidence_boundary.contains("Only canonical BountySettled"));
+        assert!(report
+            .evidence_boundary
+            .contains("Only canonical BountySettled"));
     }
 
     #[test]
@@ -653,6 +755,7 @@ mod tests {
             bounty_settled_url: "ipfs://settled".to_string(),
         });
 
+        assert!(!report.structure_valid);
         assert!(!report.accepted);
         assert!(report
             .errors
@@ -686,25 +789,43 @@ mod tests {
         assert!(is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/raw/0123456789abcdef0123456789abcdef01234567/crates/risk/report.json"));
 
         // Mutable branch URLs -> Denied
-        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/raw/main/report.json"));
-        assert!(!is_immutable_artifact_url("https://raw.githubusercontent.com/agent-bounties/agent-bounties/master/report.json"));
+        assert!(!is_immutable_artifact_url(
+            "https://github.com/agent-bounties/agent-bounties/raw/main/report.json"
+        ));
+        assert!(!is_immutable_artifact_url(
+            "https://raw.githubusercontent.com/agent-bounties/agent-bounties/master/report.json"
+        ));
         assert!(!is_immutable_artifact_url("https://raw.githubusercontent.com/agent-bounties/agent-bounties/feature-branch/report.json"));
 
         // Replaceable release assets and tags -> Denied
-        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/releases/download/v1.0.0/report.json"));
-        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/releases/tag/v1.0.0"));
-        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/tags/v1.0.0"));
+        assert!(!is_immutable_artifact_url(
+            "https://github.com/agent-bounties/agent-bounties/releases/download/v1.0.0/report.json"
+        ));
+        assert!(!is_immutable_artifact_url(
+            "https://github.com/agent-bounties/agent-bounties/releases/tag/v1.0.0"
+        ));
+        assert!(!is_immutable_artifact_url(
+            "https://github.com/agent-bounties/agent-bounties/tags/v1.0.0"
+        ));
 
         // Query parameters, fragments, and lookalikes -> Denied
-        assert!(!is_immutable_artifact_url("https://example.com/report.json?commit=0123456789abcdef0123456789abcdef01234567"));
+        assert!(!is_immutable_artifact_url(
+            "https://example.com/report.json?commit=0123456789abcdef0123456789abcdef01234567"
+        ));
         assert!(!is_immutable_artifact_url("https://github.com/org/repo/raw/0123456789abcdef0123456789abcdef01234567/report.json?v=latest"));
         assert!(!is_immutable_artifact_url("https://github.com/org/repo/raw/0123456789abcdef0123456789abcdef01234567%2Freport.json"));
 
         // Generic unpinned URLs, IPFS, Arweave or other mutable paths -> Denied
-        assert!(!is_immutable_artifact_url("https://example.com/report.json"));
+        assert!(!is_immutable_artifact_url(
+            "https://example.com/report.json"
+        ));
         assert!(!is_immutable_artifact_url("https://example.com/ipfs/bafy"));
-        assert!(!is_immutable_artifact_url("https://example.com/arweave/abcdef"));
-        assert!(!is_immutable_artifact_url("https://ipfs.io/ipfs/QmT78zSuBKGvaFFB8JNjAYAkChFSFCZa17z5W33cyS2PHe/report.json"));
+        assert!(!is_immutable_artifact_url(
+            "https://example.com/arweave/abcdef"
+        ));
+        assert!(!is_immutable_artifact_url(
+            "https://ipfs.io/ipfs/QmT78zSuBKGvaFFB8JNjAYAkChFSFCZa17z5W33cyS2PHe/report.json"
+        ));
         assert!(!is_immutable_artifact_url("http://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/report.json"));
     }
 
@@ -727,60 +848,239 @@ mod tests {
                     .to_string(),
         });
 
+        assert!(!report.structure_valid);
         assert!(!report.accepted);
         assert!(report
             .errors
             .iter()
             .any(|error| error.contains("check_run_urls must contain at least one")));
     }
+
     #[test]
     fn direct_bounty_evidence_rejects_cross_binding_mismatches() {
         let base_evidence = DirectBountyEvidence {
             repository_url: "https://github.com/agent-bounties/agent-bounties".to_string(),
             source_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
             subdirectory: "crates/risk".to_string(),
-            pull_request_url: "https://github.com/agent-bounties/agent-bounties/pull/686".to_string(),
+            pull_request_url: "https://github.com/agent-bounties/agent-bounties/pull/686"
+                .to_string(),
             check_run_urls: vec![
-                "https://github.com/agent-bounties/agent-bounties/actions/runs/123456789".to_string(),
+                "https://github.com/agent-bounties/agent-bounties/actions/runs/123456789"
+                    .to_string(),
             ],
             artifact_url: "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/crates/risk/tests/fixtures/report.json".to_string(),
-            artifact_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            artifact_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
             bounty_settled_url: "https://basescan.org/tx/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
         };
 
         // Mismatched PR repository -> Denied
         let mut pr_mismatch = base_evidence.clone();
-        pr_mismatch.pull_request_url = "https://github.com/other-org/other-repo/pull/686".to_string();
+        pr_mismatch.pull_request_url =
+            "https://github.com/other-org/other-repo/pull/686".to_string();
         let report = validate_direct_bounty_evidence(&pr_mismatch);
+        assert!(!report.structure_valid);
         assert!(!report.accepted);
-        assert!(report.errors.iter().any(|e| e.contains("pull_request_url must belong to the same repository")));
+        assert!(report
+            .errors
+            .iter()
+            .any(|e| e.contains("pull_request_url must belong to the same repository")));
 
         // Mismatched artifact repository -> Denied
         let mut art_repo_mismatch = base_evidence.clone();
         art_repo_mismatch.artifact_url = "https://raw.githubusercontent.com/other-org/other-repo/0123456789abcdef0123456789abcdef01234567/report.json".to_string();
         let report = validate_direct_bounty_evidence(&art_repo_mismatch);
+        assert!(!report.structure_valid);
         assert!(!report.accepted);
-        assert!(report.errors.iter().any(|e| e.contains("artifact_url repository must match repository_url")));
+        assert!(report
+            .errors
+            .iter()
+            .any(|e| e.contains("artifact_url repository must match repository_url")));
 
         // Mismatched artifact commit SHA -> Denied
         let mut art_commit_mismatch = base_evidence.clone();
         art_commit_mismatch.artifact_url = "https://raw.githubusercontent.com/agent-bounties/agent-bounties/fedcba9876543210fedcba9876543210fedcba98/crates/risk/tests/fixtures/report.json".to_string();
         let report = validate_direct_bounty_evidence(&art_commit_mismatch);
+        assert!(!report.structure_valid);
         assert!(!report.accepted);
-        assert!(report.errors.iter().any(|e| e.contains("artifact_url commit SHA must match source_commit")));
+        assert!(report
+            .errors
+            .iter()
+            .any(|e| e.contains("artifact_url commit SHA must match source_commit")));
 
-        // Unrelated check-run URL -> Denied
+        // Unrelated check-run URL from different repo -> Denied
         let mut check_mismatch = base_evidence.clone();
-        check_mismatch.check_run_urls = vec!["https://github.com/unrelated-org/unrelated-repo/actions/runs/999".to_string()];
+        check_mismatch.check_run_urls =
+            vec!["https://github.com/unrelated-org/unrelated-repo/actions/runs/999".to_string()];
         let report = validate_direct_bounty_evidence(&check_mismatch);
+        assert!(!report.structure_valid);
         assert!(!report.accepted);
-        assert!(report.errors.iter().any(|e| e.contains("check_run_urls[0] must belong to the same repository")));
+        assert!(report
+            .errors
+            .iter()
+            .any(|e| e.contains("check_run_urls[0] must belong to the same repository")));
 
         // Empty artifact path -> Denied
         let mut empty_path = base_evidence.clone();
         empty_path.artifact_url = "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/".to_string();
         let report = validate_direct_bounty_evidence(&empty_path);
+        assert!(!report.structure_valid);
         assert!(!report.accepted);
-        assert!(report.errors.iter().any(|e| e.contains("artifact_url must specify a non-empty file path") || e.contains("artifact_url must be immutable")));
+        assert!(report.errors.iter().any(|e| e
+            .contains("artifact_url must specify a non-empty file path")
+            || e.contains("artifact_url must be immutable")));
+    }
+
+    /// Adversarial: same-repository issue URL must be rejected as check-run evidence.
+    #[test]
+    fn direct_bounty_evidence_rejects_same_repo_issue_url_as_check_run() {
+        let report = validate_direct_bounty_evidence(&DirectBountyEvidence {
+            repository_url: "https://github.com/agent-bounties/agent-bounties".to_string(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            subdirectory: "crates/risk".to_string(),
+            pull_request_url: "https://github.com/agent-bounties/agent-bounties/pull/686"
+                .to_string(),
+            // Same repository, but an issue URL — not a valid check-run URL.
+            check_run_urls: vec![
+                "https://github.com/agent-bounties/agent-bounties/issues/686".to_string(),
+            ],
+            artifact_url: "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/crates/risk/tests/fixtures/report.json".to_string(),
+            artifact_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
+            bounty_settled_url: "https://basescan.org/tx/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        });
+
+        assert!(
+            !report.structure_valid,
+            "issue URL must not be accepted as check-run evidence"
+        );
+        assert!(!report.accepted);
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|e| e.contains("GitHub Actions or Checks run URL")),
+            "error must explain that only Actions/Checks run URLs are accepted; got: {:?}",
+            report.errors
+        );
+    }
+
+    /// Adversarial: same-repository PR URL must be rejected as check-run evidence.
+    #[test]
+    fn direct_bounty_evidence_rejects_same_repo_pr_url_as_check_run() {
+        let report = validate_direct_bounty_evidence(&DirectBountyEvidence {
+            repository_url: "https://github.com/agent-bounties/agent-bounties".to_string(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            subdirectory: "crates/risk".to_string(),
+            pull_request_url: "https://github.com/agent-bounties/agent-bounties/pull/686"
+                .to_string(),
+            // Same repository, but a PR URL — not a valid check-run URL.
+            check_run_urls: vec![
+                "https://github.com/agent-bounties/agent-bounties/pull/948".to_string(),
+            ],
+            artifact_url: "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/crates/risk/tests/fixtures/report.json".to_string(),
+            artifact_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
+            bounty_settled_url: "https://basescan.org/tx/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        });
+
+        assert!(
+            !report.structure_valid,
+            "PR URL must not be accepted as check-run evidence"
+        );
+        assert!(!report.accepted);
+        assert!(
+            report
+                .errors
+                .iter()
+                .any(|e| e.contains("GitHub Actions or Checks run URL")),
+            "error must explain that only Actions/Checks run URLs are accepted; got: {:?}",
+            report.errors
+        );
+    }
+
+    /// Adversarial: arbitrary HTTPS bounty_settled_url must not make `accepted` true.
+    #[test]
+    fn direct_bounty_evidence_arbitrary_https_settlement_url_does_not_set_accepted() {
+        let report = validate_direct_bounty_evidence(&DirectBountyEvidence {
+            repository_url: "https://github.com/agent-bounties/agent-bounties".to_string(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            subdirectory: "crates/risk".to_string(),
+            pull_request_url: "https://github.com/agent-bounties/agent-bounties/pull/686"
+                .to_string(),
+            check_run_urls: vec![
+                "https://github.com/agent-bounties/agent-bounties/actions/runs/123456789"
+                    .to_string(),
+            ],
+            artifact_url: "https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/crates/risk/tests/fixtures/report.json".to_string(),
+            artifact_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .to_string(),
+            // Arbitrary HTTPS URL that is NOT a canonical BountySettled event reference.
+            bounty_settled_url: "https://example.com/definitely-not-a-settlement".to_string(),
+        });
+
+        // structure_valid may be true (all structural fields are present and valid),
+        // but `accepted` must remain false because settlement is not verified.
+        assert!(
+            !report.accepted,
+            "accepted must be false regardless of bounty_settled_url content"
+        );
+        assert!(
+            report.payment_settlement_status.contains("unverified"),
+            "payment_settlement_status must indicate unverified; got: {}",
+            report.payment_settlement_status
+        );
+    }
+
+    /// Check-run URL format allow/deny table.
+    #[test]
+    fn check_run_url_allow_deny_table() {
+        // Allowed: GitHub Actions run URLs
+        assert!(is_github_check_run_url(
+            "https://github.com/owner/repo/actions/runs/123456789"
+        ));
+        assert!(is_github_check_run_url(
+            "https://github.com/owner/repo/actions/runs/123456789/jobs/987654321"
+        ));
+
+        // Allowed: GitHub Checks run URLs
+        assert!(is_github_check_run_url(
+            "https://github.com/owner/repo/runs/123456789"
+        ));
+
+        // Denied: issue URL (same or different repo)
+        assert!(!is_github_check_run_url(
+            "https://github.com/owner/repo/issues/686"
+        ));
+        // Denied: PR URL
+        assert!(!is_github_check_run_url(
+            "https://github.com/owner/repo/pull/948"
+        ));
+        // Denied: blob URL
+        assert!(!is_github_check_run_url(
+            "https://github.com/owner/repo/blob/0123456789abcdef0123456789abcdef01234567/file.rs"
+        ));
+        // Denied: release URL
+        assert!(!is_github_check_run_url(
+            "https://github.com/owner/repo/releases/download/v1.0.0/asset.zip"
+        ));
+        // Denied: tree URL
+        assert!(!is_github_check_run_url(
+            "https://github.com/owner/repo/tree/main"
+        ));
+        // Denied: commit URL
+        assert!(!is_github_check_run_url(
+            "https://github.com/owner/repo/commit/0123456789abcdef0123456789abcdef01234567"
+        ));
+        // Denied: non-GitHub URL
+        assert!(!is_github_check_run_url("https://example.com/runs/123"));
+        // Denied: actions/runs without numeric ID
+        assert!(!is_github_check_run_url(
+            "https://github.com/owner/repo/actions/runs/not-a-number"
+        ));
+        // Denied: query parameters
+        assert!(!is_github_check_run_url(
+            "https://github.com/owner/repo/actions/runs/123?foo=bar"
+        ));
     }
 }

--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -587,6 +587,13 @@ fn parse_github_repo_from_check_run_url(url: &str) -> Option<(String, String)> {
     None
 }
 
+fn is_canonical_path_segment(segment: &str) -> bool {
+    if segment.is_empty() || segment == "." || segment == ".." {
+        return false;
+    }
+    !segment.chars().any(|c| c == '\\' || c.is_ascii_control())
+}
+
 fn parse_immutable_artifact_url(url: &str) -> Option<ParsedArtifactUrl> {
     if !url.starts_with("https://") {
         return None;
@@ -608,13 +615,16 @@ fn parse_immutable_artifact_url(url: &str) -> Option<ParsedArtifactUrl> {
             && (parts[2] == "blob" || parts[2] == "raw")
         {
             let sha = parts[3];
-            let path = parts[4..].join("/");
-            if is_hex_sha(sha, 40) && !path.trim().is_empty() {
+            let path_segments = &parts[4..];
+            if is_hex_sha(sha, 40)
+                && !path_segments.is_empty()
+                && path_segments.iter().all(|s| is_canonical_path_segment(s))
+            {
                 return Some(ParsedArtifactUrl {
                     owner: parts[0].to_ascii_lowercase(),
                     repo: sanitize_repo_name(parts[1]),
                     commit: sha.to_ascii_lowercase(),
-                    path,
+                    path: path_segments.join("/"),
                 });
             }
         }
@@ -625,13 +635,16 @@ fn parse_immutable_artifact_url(url: &str) -> Option<ParsedArtifactUrl> {
         let parts: Vec<&str> = rest.split('/').collect();
         if parts.len() >= 4 && !parts[0].is_empty() && !parts[1].is_empty() {
             let sha = parts[2];
-            let path = parts[3..].join("/");
-            if is_hex_sha(sha, 40) && !path.trim().is_empty() {
+            let path_segments = &parts[3..];
+            if is_hex_sha(sha, 40)
+                && !path_segments.is_empty()
+                && path_segments.iter().all(|s| is_canonical_path_segment(s))
+            {
                 return Some(ParsedArtifactUrl {
                     owner: parts[0].to_ascii_lowercase(),
                     repo: sanitize_repo_name(parts[1]),
                     commit: sha.to_ascii_lowercase(),
-                    path,
+                    path: path_segments.join("/"),
                 });
             }
         }
@@ -814,6 +827,16 @@ mod tests {
         ));
         assert!(!is_immutable_artifact_url("https://github.com/org/repo/raw/0123456789abcdef0123456789abcdef01234567/report.json?v=latest"));
         assert!(!is_immutable_artifact_url("https://github.com/org/repo/raw/0123456789abcdef0123456789abcdef01234567%2Freport.json"));
+
+        // Dot-segments, path traversal, backslashes, and noncanonical segments -> Denied
+        assert!(!is_immutable_artifact_url("https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/../main/README.md"));
+        assert!(!is_immutable_artifact_url("https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/./report.json"));
+        assert!(!is_immutable_artifact_url("https://raw.githubusercontent.com/agent-bounties/agent-bounties/0123456789abcdef0123456789abcdef01234567/crates/../report.json"));
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/blob/0123456789abcdef0123456789abcdef01234567/../main/README.md"));
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/blob/0123456789abcdef0123456789abcdef01234567/crates/.."));
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/raw/0123456789abcdef0123456789abcdef01234567/crates/.."));
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/blob/0123456789abcdef0123456789abcdef01234567/crates\\\\report.json"));
+        assert!(!is_immutable_artifact_url("https://github.com/agent-bounties/agent-bounties/blob/0123456789abcdef0123456789abcdef01234567/crates//report.json"));
 
         // Generic unpinned URLs, IPFS, Arweave or other mutable paths -> Denied
         assert!(!is_immutable_artifact_url(


### PR DESCRIPTION
## What Changed

Adds a small direct-bounty evidence checklist and validator in the risk crate. The checklist captures repository URL, exact source commit, subdirectory, PR URL, check-run URLs, immutable artifact URL, artifact SHA-256 digest, and canonical settlement reference.

## Linked Bounty Or Issue

Closes #686.

## Maintainer Change Notice

- Notice issue/comment: not maintainer-owned
- Open PR queue checked before edits: not maintainer-owned
- Active PR impact or repair path: no active PR found for this branch/issue before opening this PR
- Collaboration branch impact, if any: none

## Discovery Feedback

- How did you find Agent Bounties? Local earning scanner / GitHub bounty workflow.
- What made this bounty or project worth participating in? Small deterministic change with clear acceptance criteria and low settlement risk.
- If an AI agent helped you find or complete this work, what tool, prompt, link, label, scanner, or workflow led it here? OpenClaw agent workflow from Patrick's auto-earner setup.
- What would make the project easier or more trustworthy before you participate again? A single visible claim/PR checklist on each direct bounty issue would reduce contributor uncertainty.

Default CTA after value is delivered: **Post your own bounty**.

## Acceptance Criteria

- [x] The PR has a clear verifier or review path.
- [x] Deterministic behavior has tests or a documented manual check.
- [x] Payment, settlement, and payout behavior is unchanged or explicitly covered by tests and docs.

## SDLC And Recovery

- Change class: R1
- Authoritative source of truth: issue #686 acceptance criteria and `crates/risk/src/lib.rs`
- Expected failure modes: malformed evidence may be rejected with explicit validation errors
- Idempotency or replay key: pure validation; no state mutation
- Rollback or forward-repair path: revert this risk-crate-only commit or adjust validator predicates
- Health/readiness/SLO signal: CI and `cargo test -p risk`
- Recovery fixture added or reason not applicable: not applicable for pure validation helper
- Release/canary impact: none expected

Automatic recovery is limited to allowlisted R0-R2 actions in `ops/self-healing-policy.json`. R3-R4 changes require explicit risk evidence; they cannot be made self-healing by adding a retry.

## Local Checks

```bash
cargo test -p risk
bash scripts/preflight.sh core
```

Not completed locally: this execution environment does not have `cargo`, `rustc`, or `rg` installed. The targeted Rust tests are included for CI.

## Review Lane

- [x] I believe this is ready for `main`.
- [x] If useful but not main-ready, I am comfortable with maintainers preserving this work on a `collab/pr-<number>-<topic>` branch for follow-up PRs.
- [ ] This touches risky paths and needs manual maintainer security review.

Code review, CI approval, and collaboration-branch preservation do not approve bounty acceptance, payout, or payment settlement.