### PR TITLE
fix(v2): build patched gnark verifier image from source

### DIFF
--- a/.github/workflows/open-competition-v2-beta2-release.yml
+++ b/.github/workflows/open-competition-v2-beta2-release.yml
@@ -25,6 +25,7 @@ on:
       - "deployments/open-competition-v2-beta2-*"
       - "migrations/0023_open_competition_v2_beta2.sql"
       - "migrations/checksums.json"
+      - "ops/open-competition-v2-gnark-safe.Dockerfile"
       - "ops/open-competition-v2-prover*"
       - "render.yaml"
       - "scripts/*open_competition_v2*"
@@ -63,6 +64,7 @@ concurrency:
 env:
   SP1_SAFE_COMMIT: 87c57583c77a15fa6dd191a1c6ff6947564e4ef8
   SP1_SAFE_CIRCUIT_VERSION: agent-bounties-sp1-safe-v1
+  SP1_GNARK_IMAGE: agent-bounties-sp1-gnark-safe-v1:87c57583c77a15fa6dd191a1c6ff6947564e4ef8
 
 jobs:
   deterministic-release:
@@ -81,6 +83,7 @@ jobs:
           set -euo pipefail
           python -m pip install -r scripts/requirements-wallet.txt
           python scripts/verify_sp1_patched_graph.py
+          python scripts/verify_open_competition_v2_gnark_image.py
           forge build --root contracts/base-escrow --force --ast
           FOUNDRY_INVARIANT_RUNS=10000 FOUNDRY_INVARIANT_DEPTH=50 forge test --root contracts/base-escrow \
             --match-contract '(OpenCompetitionBountyV2Beta2Test|OpenCompetitionBountyV2Beta2InvariantTest)' \
@@ -95,6 +98,7 @@ jobs:
             scripts.test_run_open_competition_v2_sepolia_rehearsal \
             scripts.test_deploy_open_competition_v2_beta2 \
             scripts.test_record_open_competition_v2_beta2_gate \
+            scripts.test_verify_open_competition_v2_gnark_image \
             scripts.test_verify_sp1_patched_graph -v
 
   static-analysis:
@@ -257,7 +261,17 @@ jobs:
           set -euo pipefail
           python -m pip install -r scripts/requirements-wallet.txt
           test "$(python -c 'import json; print(json.load(open("programs/public-vector-metric-v1/release-identity.json"))["status"])')" = reproduced_beta2
-          make -C .sp1-safe/crates/prover build-circuits
+          rm -rf .sp1-safe/crates/prover/build
+          DOCKER_BUILDKIT=1 docker build --pull=false \
+            --file - \
+            --build-arg SP1_SOURCE_COMMIT="$SP1_SAFE_COMMIT" \
+            --build-arg SP1_CIRCUIT_VERSION="$SP1_SAFE_CIRCUIT_VERSION" \
+            --tag "$SP1_GNARK_IMAGE" .sp1-safe \
+            < ops/open-competition-v2-gnark-safe.Dockerfile
+          test "$(docker image inspect "$SP1_GNARK_IMAGE" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')" = "$SP1_SAFE_COMMIT"
+          test "$(docker image inspect "$SP1_GNARK_IMAGE" --format '{{ index .Config.Labels "app.agent-bounties.circuit-version" }}')" = "$SP1_SAFE_CIRCUIT_VERSION"
+          docker image inspect "$SP1_GNARK_IMAGE" > target/gnark-image.json
+          bash scripts/build_open_competition_v2_circuits.sh .sp1-safe
           cache="$HOME/.cache/agent-bounties/$SP1_SAFE_CIRCUIT_VERSION"
           for system in groth16 plonk; do
             root="target/generated-verifier-$system"
@@ -334,6 +348,7 @@ jobs:
             target/proofs/*.json
             target/public-vector-metric-v1-script
             target/prover-capabilities.json
+            target/gnark-image.json
           if-no-files-found: error
           retention-days: 90
 

--- a/docs/open-competition-v2-beta2-release.md
+++ b/docs/open-competition-v2-beta2-release.md
@@ -30,6 +30,16 @@ The official SP1 installer is used only to install the compatible zkVM compiler
 toolchain. CI verifies its pinned installer hash, installs SP1 6.4.0, then
 overwrites `cargo-prove` with a binary compiled from the safe fork.
 
+The gnark CLI is not pulled from Succinct's circuit-version registry. The
+release builds `ops/open-competition-v2-gnark-safe.Dockerfile` locally from the
+exact safe-fork checkout, pins all three base-image digests and the Rust
+toolchain, verifies source-commit and circuit-version labels, and publishes the
+resulting image inspection record with the proof bundle. The Dockerfile is
+passed over stdin so the exact SP1 checkout remains the only image build
+context, and stale generated circuit output is removed before every attempt.
+The release circuit wrapper resolves the SP1 checkout before invoking either
+builder because Docker bind mounts reject SP1's relative Makefile output path.
+
 ## Release Order
 
 1. Run repository tests, 10,000-run Foundry fuzz/invariants, dependency review,

--- a/ops/open-competition-v2-gnark-safe.Dockerfile
+++ b/ops/open-competition-v2-gnark-safe.Dockerfile
@@ -1,0 +1,40 @@
+ARG SP1_SOURCE_COMMIT
+ARG SP1_CIRCUIT_VERSION
+
+FROM golang:1.26@sha256:26326682769ca980f8f1d3b1f52be2dd1c1d25270e3de3fe0c97d6bb65df3556 AS go-builder
+
+FROM rust:1.91-slim-bookworm@sha256:8514999d4786ef12efe89239e86b3d0a021b94b9d35108c8efe6c79ca7dc1a65 AS rust-builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends clang=1:14.0-55.7~deb12u1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=go-builder /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:$PATH"
+ENV RUSTUP_TOOLCHAIN="1.91.1"
+
+WORKDIR /sp1
+COPY . /sp1
+
+WORKDIR /sp1/crates/recursion/gnark-cli
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/sp1/target \
+    cargo build --release --locked \
+    && cp ../../../target/release/sp1-recursion-gnark-cli /gnark-cli
+
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
+
+ARG SP1_SOURCE_COMMIT
+ARG SP1_CIRCUIT_VERSION
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates=20250419~deb12u1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=rust-builder /gnark-cli /gnark-cli
+
+LABEL org.opencontainers.image.source="https://github.com/NSPG13/sp1" \
+      org.opencontainers.image.revision="${SP1_SOURCE_COMMIT}" \
+      app.agent-bounties.circuit-version="${SP1_CIRCUIT_VERSION}"
+
+ENTRYPOINT ["/gnark-cli"]

--- a/scripts/build_open_competition_v2_circuits.sh
+++ b/scripts/build_open_competition_v2_circuits.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SP1_GNARK_IMAGE:?SP1_GNARK_IMAGE must name the source-built safe image}"
+
+source_root="${1:-.sp1-safe}"
+source_root="$(cd "$source_root" && pwd)"
+build_dir="$source_root/crates/prover/build"
+
+rm -rf "$build_dir"
+mkdir -p "$build_dir/groth16" "$build_dir/plonk"
+
+cd "$source_root"
+RUST_LOG=debug cargo run -p sp1-prover --release --bin build_groth16_bn254 -- \
+  --build-dir="$build_dir/groth16"
+RUST_LOG=debug cargo run -p sp1-prover --release --bin build_plonk_bn254 -- \
+  --build-dir="$build_dir/plonk"

--- a/scripts/test_verify_open_competition_v2_gnark_image.py
+++ b/scripts/test_verify_open_competition_v2_gnark_image.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("verify_open_competition_v2_gnark_image.py")
+SPEC = importlib.util.spec_from_file_location("verify_v2_gnark_image", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class GnarkImageTests(unittest.TestCase):
+    def test_current_image_build_is_exact(self) -> None:
+        result = MODULE.verify()
+        self.assertEqual(result["status"], "digest_pinned_local_build")
+
+    def test_unpinned_base_fails_closed(self) -> None:
+        source = MODULE.DOCKERFILE.read_text(encoding="utf-8").replace(
+            MODULE.EXPECTED_BASES[0], "golang:1.26", 1
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "Dockerfile"
+            path.write_text(source, encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "exact digests"):
+                MODULE.verify(path, MODULE.WORKFLOW, MODULE.CIRCUIT_BUILDER)
+
+    def test_relative_circuit_mount_fails_closed(self) -> None:
+        source = MODULE.CIRCUIT_BUILDER.read_text(encoding="utf-8").replace(
+            'source_root="$(cd "$source_root" && pwd)"', "# relative checkout", 1
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "build-circuits.sh"
+            path.write_text(source, encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "absolute"):
+                MODULE.verify(MODULE.DOCKERFILE, MODULE.WORKFLOW, path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_open_competition_v2_gnark_image.py
+++ b/scripts/verify_open_competition_v2_gnark_image.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Verify the Beta2 gnark image build is local, source-bound and digest-pinned."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = ROOT / "ops/open-competition-v2-gnark-safe.Dockerfile"
+WORKFLOW = ROOT / ".github/workflows/open-competition-v2-beta2-release.yml"
+CIRCUIT_BUILDER = ROOT / "scripts/build_open_competition_v2_circuits.sh"
+EXPECTED_BASES = (
+    "golang:1.26@sha256:26326682769ca980f8f1d3b1f52be2dd1c1d25270e3de3fe0c97d6bb65df3556",
+    "rust:1.91-slim-bookworm@sha256:8514999d4786ef12efe89239e86b3d0a021b94b9d35108c8efe6c79ca7dc1a65",
+    "debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241",
+)
+
+
+def verify(
+    dockerfile: Path = DOCKERFILE,
+    workflow: Path = WORKFLOW,
+    circuit_builder: Path = CIRCUIT_BUILDER,
+) -> dict[str, object]:
+    image_source = dockerfile.read_text(encoding="utf-8")
+    release_source = workflow.read_text(encoding="utf-8")
+    circuit_source = circuit_builder.read_text(encoding="utf-8")
+    from_images = tuple(
+        match.group(1)
+        for match in re.finditer(r"^FROM\s+(\S+)", image_source, re.MULTILINE)
+    )
+    if from_images != EXPECTED_BASES:
+        raise ValueError("gnark image bases must match the three exact digests")
+    required_image_fragments = (
+        'ENV RUSTUP_TOOLCHAIN="1.91.1"',
+        "cargo build --release --locked",
+        'org.opencontainers.image.revision="${SP1_SOURCE_COMMIT}"',
+        'app.agent-bounties.circuit-version="${SP1_CIRCUIT_VERSION}"',
+    )
+    if any(fragment not in image_source for fragment in required_image_fragments):
+        raise ValueError("gnark image omits a compiler or source-identity pin")
+    required_workflow_fragments = (
+        "SP1_GNARK_IMAGE: agent-bounties-sp1-gnark-safe-v1:87c57583c77a15fa6dd191a1c6ff6947564e4ef8",
+        "rm -rf .sp1-safe/crates/prover/build",
+        "--file -",
+        "< ops/open-competition-v2-gnark-safe.Dockerfile",
+        'docker image inspect "$SP1_GNARK_IMAGE"',
+        "bash scripts/build_open_competition_v2_circuits.sh .sp1-safe",
+    )
+    if any(fragment not in release_source for fragment in required_workflow_fragments):
+        raise ValueError("release workflow does not build and inspect the local gnark image")
+    if "ghcr.io/succinctlabs/sp1-gnark" in release_source:
+        raise ValueError("release workflow must not use the upstream mutable gnark image route")
+    required_builder_fragments = (
+        'source_root="$(cd "$source_root" && pwd)"',
+        '--build-dir="$build_dir/groth16"',
+        '--build-dir="$build_dir/plonk"',
+    )
+    if any(fragment not in circuit_source for fragment in required_builder_fragments):
+        raise ValueError("circuit builder must pass absolute Groth16 and PLONK mount paths")
+    return {
+        "schema": "agent-bounties/open-competition-v2-gnark-image-check-v1",
+        "status": "digest_pinned_local_build",
+        "base_images": list(EXPECTED_BASES),
+        "dockerfile": str(dockerfile.relative_to(ROOT)).replace("\\", "/"),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(verify(), sort_keys=True))


### PR DESCRIPTION
## Summary
- build the Beta2 gnark CLI locally from the exact patched SP1 checkout
- pin all base-image digests, Rust toolchain, source commit, and circuit identity
- replace the rejected relative Docker mount with an absolute-path circuit builder
- publish image identity evidence with the proof bundle

## Evidence
- local source image built successfully with expected labels
- stdin/context isolation reproduced on the 128 GiB proof runner
- 48 targeted Open Competition V2 release tests pass
- Groth16 and PLONK circuit generation rehearsal is running on the proof host

## Safety
- no contract deployment or transaction occurs in this change
- Beta2 remains fail-closed until the complete proof, rehearsal, deployment, and canary gates pass