### PR TITLE
fix(v2): enforce measured proof-runner capacity

### DIFF
--- a/.github/workflows/open-competition-v2-beta2-release.yml
+++ b/.github/workflows/open-competition-v2-beta2-release.yml
@@ -34,7 +34,7 @@ on:
   workflow_dispatch:
     inputs:
       build_release_assets:
-        description: Build both patched verifiers and three CPU proofs on the 128 GiB host
+        description: Build patched verifiers and proofs on the capacity-gated high-memory host
         type: boolean
         required: true
         default: false
@@ -237,7 +237,7 @@ jobs:
   build-release-assets:
     if: github.event_name == 'workflow_dispatch' && inputs.build_release_assets && github.ref == 'refs/heads/main'
     needs: [deterministic-release, static-analysis, patched-sp1-source, compare-metric-builds]
-    runs-on: [self-hosted, linux, x64, ram-128gb, open-competition-v2-prover]
+    runs-on: [self-hosted, linux, x64, ram-192gb, open-competition-v2-prover]
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
@@ -356,7 +356,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.run_live_sepolia_rehearsal && github.ref == 'refs/heads/main'
     needs: build-release-assets
     environment: v2-beta2-sepolia
-    runs-on: [self-hosted, linux, x64, ram-128gb, open-competition-v2-prover]
+    runs-on: [self-hosted, linux, x64, ram-192gb, open-competition-v2-prover]
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
@@ -459,7 +459,7 @@ jobs:
     if: always() && github.event_name == 'workflow_dispatch' && inputs.run_mainnet_canaries && github.ref == 'refs/heads/main' && needs.build-release-assets.result == 'success' && needs.deploy-mainnet.result == 'success'
     needs: [build-release-assets, deploy-mainnet]
     environment: v2-beta2-mainnet
-    runs-on: [self-hosted, linux, x64, ram-128gb, open-competition-v2-prover]
+    runs-on: [self-hosted, linux, x64, ram-192gb, open-competition-v2-prover]
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a

--- a/docs/open-competition-v2-beta2-release.md
+++ b/docs/open-competition-v2-beta2-release.md
@@ -21,10 +21,13 @@ exact-source graph gate and transcript attack regressions must pass; any
 registry fallback or additional advisory still blocks the release.
 
 GPU proving and the public SP1 Prover Network are disabled for Beta2. A labeled
-128 GiB x86-64 Linux runner builds both circuits and project-owned Groth16 and
-PLONK verifiers, then creates one Groth16 and two PLONK proofs on CPU. The
-contracts call those exact verifiers directly; no gateway, proxy, owner, or
-upgrade route exists.
+x86-64 Linux runner with at least 180 GiB physical memory and 288 GiB combined
+memory and swap builds both circuits and project-owned Groth16 and PLONK
+verifiers, then creates one Groth16 and two PLONK proofs on CPU. These limits
+come from a measured Groth16 address-space peak near 280 GiB; a 128 GiB runner
+and a 192 GiB runner without swap both exhausted memory. The contracts call
+the exact generated verifiers directly; no gateway, proxy, owner, or upgrade
+route exists.
 
 The official SP1 installer is used only to install the compatible zkVM compiler
 toolchain. CI verifies its pinned installer hash, installs SP1 6.4.0, then
@@ -48,8 +51,8 @@ builder because Docker bind mounts reject SP1's relative Makefile output path.
    builders.
 3. Commit the reproduced identity as `reproduced_beta2`; stale Beta1 values may
    never be reused.
-4. On the 128 GiB CPU runner, build circuits, verifier bytecode, and three real
-   self-verified proofs.
+4. On the capacity-gated CPU runner, build circuits, verifier bytecode, and
+   three real self-verified proofs.
 5. Replay the exact verifier and factory deployment plus both winner modes on a
    fresh Base-mainnet fork.
 6. In protected environment `v2-beta2-sepolia`, deploy the same bytecode and
@@ -106,7 +109,7 @@ gh workflow run open-competition-v2-beta2-release.yml --ref main \
   -f run_mainnet_canaries=true
 ```
 
-It requires a self-hosted runner with labels `linux`, `x64`, `ram-128gb`, and
+It requires a self-hosted runner with labels `linux`, `x64`, `ram-192gb`, and
 `open-competition-v2-prover`. Configure protected environments as follows:
 
 - `v2-beta2-sepolia`: `BASE_SEPOLIA_RPC_URL` and
@@ -147,7 +150,7 @@ The shadow process persists a canonical event-set digest and common safe-block
 identity. Public creation and new broker quotes fail closed if that agreement
 is absent, false, older than 120 seconds, or predates deployment.
 
-The 128 GiB host runs
+The same high-memory host runs
 `scripts/open_competition_v2_prover_service.py` with
 `ops/open-competition-v2-prover.service`. Caddy terminates HTTPS using
 `ops/open-competition-v2-prover.Caddyfile`. Set:

--- a/scripts/build_open_competition_v2_circuits.sh
+++ b/scripts/build_open_competition_v2_circuits.sh
@@ -3,6 +3,21 @@ set -euo pipefail
 
 : "${SP1_GNARK_IMAGE:?SP1_GNARK_IMAGE must name the source-built safe image}"
 
+if [[ -r /proc/meminfo ]]; then
+  memory_kib="$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo)"
+  swap_kib="$(awk '/^SwapTotal:/ { print $2 }' /proc/meminfo)"
+  minimum_memory_kib=$((180 * 1024 * 1024))
+  minimum_combined_kib=$((288 * 1024 * 1024))
+  if (( memory_kib < minimum_memory_kib )); then
+    echo "circuit build requires at least 180 GiB physical memory" >&2
+    exit 2
+  fi
+  if (( memory_kib + swap_kib < minimum_combined_kib )); then
+    echo "circuit build requires at least 288 GiB combined memory and swap" >&2
+    exit 2
+  fi
+fi
+
 source_root="${1:-.sp1-safe}"
 source_root="$(cd "$source_root" && pwd)"
 build_dir="$source_root/crates/prover/build"

--- a/scripts/verify_open_competition_v2_gnark_image.py
+++ b/scripts/verify_open_competition_v2_gnark_image.py
@@ -54,6 +54,8 @@ def verify(
     if "ghcr.io/succinctlabs/sp1-gnark" in release_source:
         raise ValueError("release workflow must not use the upstream mutable gnark image route")
     required_builder_fragments = (
+        "minimum_memory_kib=$((180 * 1024 * 1024))",
+        "minimum_combined_kib=$((288 * 1024 * 1024))",
         'source_root="$(cd "$source_root" && pwd)"',
         '--build-dir="$build_dir/groth16"',
         '--build-dir="$build_dir/plonk"',


### PR DESCRIPTION
## Summary
- replace the invalid 128 GiB runner assumption with measured capacity requirements
- fail circuit generation unless physical RAM is at least 180 GiB and RAM plus swap is at least 288 GiB
- move release jobs to the am-192gb runner label
- document the observed approximately 280 GiB Groth16 address-space peak

## Evidence
- 128 GiB exhausted memory
- 192 GiB without swap exhausted memory
- 192 GiB plus swap remains active at the prior failure point
- 48 targeted V2 release tests pass

No contract, proof input, vkey, or settlement logic changes.