### PR TITLE
Harden Beta2 broker refund custody

### DIFF
--- a/.github/workflows/open-competition-v2-beta2-release.yml
+++ b/.github/workflows/open-competition-v2-beta2-release.yml
@@ -102,6 +102,7 @@ jobs:
             scripts.test_run_open_competition_v2_sepolia_rehearsal \
             scripts.test_run_open_competition_v2_x402_rehearsal \
             scripts.test_configure_open_competition_v2_beta2_render \
+            scripts.test_verify_open_competition_v2_beta2_broker_reserve \
             scripts.test_promote_open_competition_v2_beta2_release \
             scripts.test_wait_open_competition_v2_beta2_runtime \
             scripts.test_verify_open_competition_v2_beta2_interfaces \
@@ -781,17 +782,33 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           OPEN_COMPETITION_V2_PROVER_API_KEY: ${{ secrets.OPEN_COMPETITION_V2_PROVER_API_KEY }}
           OPEN_COMPETITION_V2_PROVER_URL: ${{ vars.OPEN_COMPETITION_V2_PROVER_URL }}
-          BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+          BASE_KEEPER_ADDRESS: ${{ vars.BASE_KEEPER_ADDRESS }}
+          BASE_DEPLOYER_ADDRESS: ${{ vars.BASE_DEPLOYER_ADDRESS }}
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
           BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
         run: |
           set -euo pipefail
           python -m pip install -r scripts/requirements-wallet.txt
+          test -n "$BASE_KEEPER_ADDRESS" && test -n "$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"
+          test -n "$BASE_DEPLOYER_ADDRESS"
+          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
+          KEEPER="${BASE_KEEPER_ADDRESS,,}"
+          DEPLOYER="${BASE_DEPLOYER_ADDRESS,,}"
           python scripts/verify_open_competition_v2_beta2_interfaces.py \
             --runtime target/production-control-plane/mainnet-broker.runtime.json \
             --output target/production-interfaces.json
           cp target/mainnet-canaries/release-gates.json target/release-gates.json
           evidence_uri="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          python scripts/verify_open_competition_v2_beta2_broker_reserve.py \
+            --runtime target/production-control-plane/mainnet-broker.runtime.json \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --broker "$BROKER" \
+            --keeper "$KEEPER" --deployer "$DEPLOYER" \
+            --output target/activation-broker-reserve.json
+          python scripts/record_open_competition_v2_beta2_gate.py \
+            --manifest target/release-gates.json --gate broker_refund_reserve_ready \
+            --evidence target/activation-broker-reserve.json --uri "$evidence_uri" \
+            --source-commit "$GITHUB_SHA"
           python scripts/record_open_competition_v2_beta2_gate.py \
             --manifest target/release-gates.json --gate production_interfaces_agree \
             --evidence target/production-interfaces.json --uri "$evidence_uri" \
@@ -819,12 +836,12 @@ jobs:
             --runtime-output target/mainnet-public-beta.runtime.json
           jq -e '.public_creation_enabled == true and .proof_broker_enabled == true' \
             target/mainnet-public-beta.runtime.json >/dev/null
-          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_KEEPER_PRIVATE_KEY"]).address.lower())')"
           python scripts/configure_open_competition_v2_beta2_render.py \
             --runtime target/mainnet-public-beta.runtime.json --revision "$GITHUB_SHA" \
             --primary-rpc-url "$BASE_MAINNET_RPC_URL" \
             --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --prover-url "$OPEN_COMPETITION_V2_PROVER_URL" --broker-address "$BROKER" \
+            --keeper-address "$KEEPER" --deployer-address "$DEPLOYER" \
             --output target/render-public-beta.json
           python scripts/wait_open_competition_v2_beta2_runtime.py \
             --runtime target/mainnet-public-beta.runtime.json --expect-broker true \
@@ -836,6 +853,7 @@ jobs:
             target/mainnet-public-beta.json
             target/mainnet-public-beta.runtime.json
             target/owner-public-beta-activation.json
+            target/activation-broker-reserve.json
             target/production-interfaces.json
             target/public-beta-activation.json
             target/render-public-beta.json
@@ -864,22 +882,28 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           OPEN_COMPETITION_V2_PROVER_API_KEY: ${{ secrets.OPEN_COMPETITION_V2_PROVER_API_KEY }}
           OPEN_COMPETITION_V2_PROVER_URL: ${{ vars.OPEN_COMPETITION_V2_PROVER_URL }}
-          BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+          BASE_KEEPER_ADDRESS: ${{ vars.BASE_KEEPER_ADDRESS }}
+          BASE_DEPLOYER_ADDRESS: ${{ vars.BASE_DEPLOYER_ADDRESS }}
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
           BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
         run: |
           set -euo pipefail
           test -n "$RENDER_API_KEY" && test -n "$OPEN_COMPETITION_V2_PROVER_API_KEY"
-          test -n "$OPEN_COMPETITION_V2_PROVER_URL" && test -n "$BASE_KEEPER_PRIVATE_KEY"
+          test -n "$OPEN_COMPETITION_V2_PROVER_URL" && test -n "$BASE_KEEPER_ADDRESS"
+          test -n "$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY" && test -n "$BASE_DEPLOYER_ADDRESS"
           python -m pip install -r scripts/requirements-wallet.txt
           jq -e '.complete == true' target/mainnet-deployment/mainnet-deployment-evidence.json >/dev/null
           jq '.runtime_manifest' target/mainnet-deployment/mainnet-deployment-evidence.json >target/mainnet-prebroker.runtime.json
-          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_KEEPER_PRIVATE_KEY"]).address.lower())')"
+          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
+          KEEPER="${BASE_KEEPER_ADDRESS,,}"
+          DEPLOYER="${BASE_DEPLOYER_ADDRESS,,}"
           python scripts/configure_open_competition_v2_beta2_render.py \
             --runtime target/mainnet-prebroker.runtime.json --revision "$GITHUB_SHA" \
             --primary-rpc-url "$BASE_MAINNET_RPC_URL" \
             --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --prover-url "$OPEN_COMPETITION_V2_PROVER_URL" --broker-address "$BROKER" \
+            --keeper-address "$KEEPER" --deployer-address "$DEPLOYER" \
             --output target/render-prebroker.json
           python scripts/wait_open_competition_v2_beta2_runtime.py \
             --runtime target/mainnet-prebroker.runtime.json --expect-broker false \
@@ -888,6 +912,15 @@ jobs:
           python scripts/record_open_competition_v2_beta2_gate.py \
             --manifest target/release-gates.json --gate production_indexers_agree \
             --evidence target/production-indexer-agreement.json \
+            --uri "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --source-commit "$GITHUB_SHA"
+          python scripts/verify_open_competition_v2_beta2_broker_reserve.py \
+            --runtime target/mainnet-prebroker.runtime.json --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --broker "$BROKER" --keeper "$KEEPER" --deployer "$DEPLOYER" \
+            --output target/production-broker-reserve.json
+          python scripts/record_open_competition_v2_beta2_gate.py \
+            --manifest target/release-gates.json --gate broker_refund_reserve_ready \
+            --evidence target/production-broker-reserve.json \
             --uri "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --source-commit "$GITHUB_SHA"
           python scripts/promote_open_competition_v2_beta2_release.py \
@@ -902,6 +935,7 @@ jobs:
             --primary-rpc-url "$BASE_MAINNET_RPC_URL" \
             --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --prover-url "$OPEN_COMPETITION_V2_PROVER_URL" --broker-address "$BROKER" \
+            --keeper-address "$KEEPER" --deployer-address "$DEPLOYER" \
             --output target/render-broker-enabled.json
           python scripts/wait_open_competition_v2_beta2_runtime.py \
             --runtime target/mainnet-broker.runtime.json --expect-broker true \
@@ -915,6 +949,7 @@ jobs:
             target/mainnet-prebroker.runtime.json
             target/production-indexer-agreement.json
             target/production-broker-runtime.json
+            target/production-broker-reserve.json
             target/render-prebroker.json
             target/render-broker-enabled.json
             target/release-gates.json
@@ -963,7 +998,8 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/scripts
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
           BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
-          BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+          BASE_KEEPER_ADDRESS: ${{ vars.BASE_KEEPER_ADDRESS }}
           DATABASE_URL: postgresql://agent_bounties:agent_bounties@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/agent_bounties_v2_mainnet_canary
           OPEN_COMPETITION_V2_PROVER_BINARY: ${{ github.workspace }}/target/release-assets/public-vector-metric-v1-script
           OPEN_COMPETITION_V2_PROVER_API_KEY: beta2-mainnet-refund-canary-only-key
@@ -974,11 +1010,20 @@ jobs:
           export SP1_PLONK_CIRCUIT_PATH="$HOME/.cache/agent-bounties/$SP1_SAFE_CIRCUIT_VERSION/plonk"
           export BETA2_ACTOR_DERIVATION_SALT="$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT:mainnet"
           test -n "$BASE_MAINNET_RPC_URL" && test -n "$BASE_MAINNET_DEPLOYER_PRIVATE_KEY"
+          test -n "$BASE_KEEPER_ADDRESS" && test -n "$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"
           test -f "$SP1_GROTH16_CIRCUIT_PATH/.complete" && test -f "$SP1_PLONK_CIRCUIT_PATH/.complete"
           python -m pip install -r scripts/requirements-wallet.txt
+          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
+          KEEPER="${BASE_KEEPER_ADDRESS,,}"
+          DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
           chmod 0755 "$OPEN_COMPETITION_V2_PROVER_BINARY"
           cargo build --locked --release -p api -p worker
           bundle=target/mainnet-deployment/mainnet-exact.json
+          python scripts/verify_open_competition_v2_beta2_broker_reserve.py \
+            --runtime target/production-control-plane/mainnet-broker.runtime.json \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --broker "$BROKER" \
+            --keeper "$KEEPER" --deployer "$DEPLOYER" \
+            --output target/mainnet-broker-reserve-before.json
           python scripts/run_open_competition_v2_sepolia_rehearsal.py --network base-mainnet \
             --bundle "$bundle" --rpc-url "$BASE_MAINNET_RPC_URL" \
             --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
@@ -1006,8 +1051,8 @@ jobs:
           export OPEN_COMPETITION_V2_INDEXER_RPC_URL="$BASE_MAINNET_RPC_URL"
           export OPEN_COMPETITION_V2_SHADOW_RPC_URL="${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}"
           export OPEN_COMPETITION_V2_INDEXER_CONFIRMATIONS=2
-          export X402_RELAYER_PRIVATE_KEY="$BASE_KEEPER_PRIVATE_KEY"
-          export OPEN_COMPETITION_V2_BROKER_PAYMENT_ADDRESS="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_KEEPER_PRIVATE_KEY"]).address.lower())')"
+          export X402_RELAYER_PRIVATE_KEY="$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"
+          export OPEN_COMPETITION_V2_BROKER_PAYMENT_ADDRESS="$BROKER"
           export OPEN_COMPETITION_V2_GROTH16_PROOF_FEE_BASE_UNITS=100000
           export OPEN_COMPETITION_V2_PLONK_PROOF_FEE_BASE_UNITS=100000
           export OPEN_COMPETITION_V2_RELAY_FEE_BASE_UNITS=10000
@@ -1058,6 +1103,11 @@ jobs:
             --rehearsal target/mainnet-canaries.json \
             --x402-success target/mainnet-x402-success.json \
             --output target/mainnet-fresh-agent-flow.json
+          python scripts/verify_open_competition_v2_beta2_broker_reserve.py \
+            --runtime target/production-control-plane/mainnet-broker.runtime.json \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --broker "$BROKER" \
+            --keeper "$KEEPER" --deployer "$DEPLOYER" \
+            --output target/mainnet-broker-reserve-after.json
           python - <<'PY'
           import json
           canaries = json.load(open("target/mainnet-canaries.json"))
@@ -1080,12 +1130,15 @@ jobs:
           cp target/production-control-plane/release-gates.json target/release-gates.json
           evidence_uri="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           python scripts/record_open_competition_v2_beta2_gate.py --manifest target/release-gates.json \
+            --gate broker_refund_reserve_ready --evidence target/mainnet-broker-reserve-after.json \
+            --uri "$evidence_uri" --source-commit "$GITHUB_SHA"
+          python scripts/record_open_competition_v2_beta2_gate.py --manifest target/release-gates.json \
             --gate mainnet_groth16_canary_complete --evidence target/mainnet-x402-success.json \
             --uri "$evidence_uri" --source-commit "$GITHUB_SHA"
           python scripts/record_open_competition_v2_beta2_gate.py --manifest target/release-gates.json \
             --gate mainnet_plonk_canary_complete --evidence target/mainnet-canaries.json \
             --uri "$evidence_uri" --source-commit "$GITHUB_SHA"
-          for gate in mainnet_canary_accounting_reconciled x402_success_and_refund_canaries_complete; do
+          for gate in mainnet_canary_accounting_reconciled x402_success_and_refund_complete; do
             python scripts/record_open_competition_v2_beta2_gate.py --manifest target/release-gates.json \
               --gate "$gate" --evidence target/mainnet-accounting.json \
               --uri "$evidence_uri" --source-commit "$GITHUB_SHA"
@@ -1105,6 +1158,8 @@ jobs:
             target/mainnet-x402-refund.json
             target/mainnet-accounting.json
             target/mainnet-fresh-agent-flow.json
+            target/mainnet-broker-reserve-before.json
+            target/mainnet-broker-reserve-after.json
             target/mainnet-proofs/*.json
             target/release-gates.json
             target/mainnet-canary-api.log

--- a/.github/workflows/open-competition-v2-beta2-release.yml
+++ b/.github/workflows/open-competition-v2-beta2-release.yml
@@ -570,6 +570,8 @@ jobs:
           BASE_SEPOLIA_RPC_URL: ${{ vars.BASE_SEPOLIA_RPC_URL }}
           BASE_SEPOLIA_SHADOW_RPC_URL: ${{ vars.BASE_SEPOLIA_SHADOW_RPC_URL }}
           BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+          OPEN_COMPETITION_V2_BROKER_ADDRESS: ${{ vars.OPEN_COMPETITION_V2_BROKER_ADDRESS }}
           DATABASE_URL: postgresql://agent_bounties:agent_bounties@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/agent_bounties_v2
           OPEN_COMPETITION_V2_PROVER_BINARY: ${{ github.workspace }}/target/release-assets/public-vector-metric-v1-script
           OPEN_COMPETITION_V2_PROVER_API_KEY: beta2-sepolia-rehearsal-only-api-key
@@ -580,11 +582,19 @@ jobs:
           export SP1_PLONK_CIRCUIT_PATH="$HOME/.cache/agent-bounties/$SP1_SAFE_CIRCUIT_VERSION/plonk"
           export BETA2_ACTOR_DERIVATION_SALT="$GITHUB_RUN_ID:$GITHUB_RUN_ATTEMPT:sepolia"
           test -n "$BASE_SEPOLIA_RPC_URL" && test -n "$BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY"
+          test -n "$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY" && test -n "$OPEN_COMPETITION_V2_BROKER_ADDRESS"
           python -m pip install -r scripts/requirements-wallet.txt
           chmod 0755 "$OPEN_COMPETITION_V2_PROVER_BINARY"
           forge build --root contracts/base-escrow --force --ast
           cargo build --locked --release -p api -p worker
           DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
+          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
+          test "$BROKER" = "$(printf '%s' "$OPEN_COMPETITION_V2_BROKER_ADDRESS" | tr '[:upper:]' '[:lower:]')"
+          test "$BROKER" != "$DEPLOYER"
+          python scripts/fund_open_competition_v2_beta2_broker.py --network base-sepolia \
+            --rpc-url "$BASE_SEPOLIA_RPC_URL" --private-key-env BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY \
+            --broker "$BROKER" --target-usdc-base-units 0 --target-eth-wei 100000000000000 \
+            --output target/sepolia-broker-seed.json
           python scripts/build_open_competition_v2_beta2_release.py --network base-sepolia \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" --deployer "$DEPLOYER" --source-commit "$GITHUB_SHA" \
             --verifier-assets target/release-assets/verifier-assets.json \
@@ -614,7 +624,7 @@ jobs:
           export OPEN_COMPETITION_V2_INDEXER_RPC_URL="$BASE_SEPOLIA_RPC_URL"
           export OPEN_COMPETITION_V2_SHADOW_RPC_URL="$BASE_SEPOLIA_SHADOW_RPC_URL"
           export OPEN_COMPETITION_V2_INDEXER_CONFIRMATIONS=2
-          export OPEN_COMPETITION_V2_BROKER_PAYMENT_ADDRESS="$DEPLOYER"
+          export OPEN_COMPETITION_V2_BROKER_PAYMENT_ADDRESS="$BROKER"
           export OPEN_COMPETITION_V2_GROTH16_PROOF_FEE_BASE_UNITS=100000
           export OPEN_COMPETITION_V2_PLONK_PROOF_FEE_BASE_UNITS=100000
           export OPEN_COMPETITION_V2_RELAY_FEE_BASE_UNITS=10000
@@ -625,7 +635,7 @@ jobs:
           export OPEN_COMPETITION_V2_BROKER_LEASE_SECONDS=630
           export OPEN_COMPETITION_V2_PROVER_MAX_SECONDS=1800
           export OPEN_COMPETITION_V2_PROVER_JOB_DIR="$RUNNER_TEMP/beta2-sepolia-prover-jobs"
-          export X402_RELAYER_PRIVATE_KEY="$BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY"
+          export X402_RELAYER_PRIVATE_KEY="$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"
           export X402_RELAYER_MIN_USDC_BASE_UNITS=100000
           export X402_RELAYER_MAX_USDC_BASE_UNITS=500000
           export ENABLE_X402_HOSTED_RELAY=true
@@ -681,6 +691,7 @@ jobs:
           path: |
             target/sepolia.json
             target/sepolia.runtime.json
+            target/sepolia-broker-seed.json
             target/sepolia-rehearsal.json
             target/sepolia-x402-rehearsal.json
             target/sepolia-proofs/*.json

--- a/.github/workflows/open-competition-v2-beta2-release.yml
+++ b/.github/workflows/open-competition-v2-beta2-release.yml
@@ -101,6 +101,7 @@ jobs:
             scripts.test_open_competition_v2_prover_service \
             scripts.test_run_open_competition_v2_sepolia_rehearsal \
             scripts.test_run_open_competition_v2_x402_rehearsal \
+            scripts.test_fund_open_competition_v2_beta2_broker \
             scripts.test_configure_open_competition_v2_beta2_render \
             scripts.test_verify_open_competition_v2_beta2_broker_reserve \
             scripts.test_promote_open_competition_v2_beta2_release \
@@ -714,10 +715,15 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/scripts
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
           BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
+          OPEN_COMPETITION_V2_BROKER_ADDRESS: ${{ vars.OPEN_COMPETITION_V2_BROKER_ADDRESS }}
         run: |
           set -euo pipefail
           test -n "$BASE_MAINNET_RPC_URL" && test -n "$BASE_MAINNET_DEPLOYER_PRIVATE_KEY"
+          test -n "$OPEN_COMPETITION_V2_BROKER_ADDRESS"
           python -m pip install -r scripts/requirements-wallet.txt
+          python scripts/fund_open_competition_v2_beta2_broker.py \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --broker "$OPEN_COMPETITION_V2_BROKER_ADDRESS" \
+            --output target/mainnet-broker-seed.json
           forge build --root contracts/base-escrow --force --ast
           DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
           cp target/live-sepolia/release-gates.json target/release-gates.json
@@ -748,6 +754,7 @@ jobs:
             target/mainnet-exact.json
             target/mainnet-exact.runtime.json
             target/mainnet-deployment-evidence.json
+            target/mainnet-broker-seed.json
             target/owner-mainnet-deployment-approval.json
             target/release-gates.json
           if-no-files-found: error

--- a/deployments/open-competition-v2-beta2-release-gates.json
+++ b/deployments/open-competition-v2-beta2-release-gates.json
@@ -1,7 +1,7 @@
 {
-  "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v4",
+  "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v5",
   "protocol_version": "agent-bounties/open-competition-v2-beta2",
-  "beta_risk_preimage": "agent-bounties/open-competition-v2-beta2/risk/2026-08-15-trusted-setup-v1",
+  "beta_risk_preimage": "agent-bounties/open-competition-v2-beta2/risk/2026-08-15-segregated-broker-v2",
   "gates": {
     "repository_gate_complete": false,
     "patched_sp1_dependency_graph_clean": false,
@@ -23,6 +23,7 @@
     "mainnet_groth16_canary_complete": false,
     "mainnet_plonk_canary_complete": false,
     "mainnet_canary_accounting_reconciled": false,
+    "broker_refund_reserve_ready": false,
     "x402_success_and_refund_complete": false,
     "production_indexers_agree": false,
     "fresh_agent_wallet_flow_complete": false,
@@ -60,6 +61,7 @@
     "mainnet_groth16_canary_complete": null,
     "mainnet_plonk_canary_complete": null,
     "mainnet_canary_accounting_reconciled": null,
+    "broker_refund_reserve_ready": null,
     "x402_success_and_refund_complete": null,
     "production_indexers_agree": null,
     "fresh_agent_wallet_flow_complete": null,

--- a/docs/open-competition-v2-beta2-release.md
+++ b/docs/open-competition-v2-beta2-release.md
@@ -86,7 +86,11 @@ builder because Docker bind mounts reject SP1's relative Makefile output path.
 9. Fund a dedicated broker address with at least 0.11 USDC of segregated
    refund reserve and 0.00002 ETH for relay gas. The broker, keeper and
    deployment signer must be three distinct keys. Safe-block reserve evidence
-   is required before the broker can be enabled.
+   is required before the broker can be enabled. For the initial release, fund
+   the deployment signer with 0.745 USDC and 0.0012 ETH. The protected job
+   idempotently moves 0.11 USDC and 0.0001 ETH to the broker, leaving the
+   signer with the exact 0.635 USDC canary and generated-agent budget plus
+   deployment gas.
 10. Run the two 0.25 USDC canaries, x402 success/failure refund, and
    primary/shadow indexer comparison. Derive a unique solver wallet for the
    release run and attempt, fund its bounded gas and USDC budgets, and require

--- a/docs/open-competition-v2-beta2-release.md
+++ b/docs/open-competition-v2-beta2-release.md
@@ -83,12 +83,17 @@ builder because Docker bind mounts reject SP1's relative Makefile output path.
 7. Record owner deployment approval against the exact repository subject.
 8. In protected environment `v2-beta2-mainnet`, deploy immutable verifiers and
    factory while public creation remains disabled.
-9. Run the two 0.25 USDC canaries, x402 success/failure refund, and
+9. Fund a dedicated broker address with at least 0.11 USDC of segregated
+   refund reserve and 0.00002 ETH for relay gas. The broker, keeper and
+   deployment signer must be three distinct keys. Safe-block reserve evidence
+   is required before the broker can be enabled.
+10. Run the two 0.25 USDC canaries, x402 success/failure refund, and
    primary/shadow indexer comparison. Derive a unique solver wallet for the
    release run and attempt, fund its bounded gas and USDC budgets, and require
    that exact wallet to pay, authorize relay, and settle without manual state
    correction before clearing the fresh-wallet gate.
-10. Record owner activation approval, then enable the exact runtime manifest.
+11. Recheck the broker reserve, record owner activation approval, then enable
+    the exact runtime manifest.
 
 The source of truth is
 `deployments/open-competition-v2-beta2-release-gates.json`. Each true gate must
@@ -147,7 +152,11 @@ environments as follows:
 - `v2-beta2-sepolia`: `BASE_SEPOLIA_RPC_URL` and
   `BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY`;
 - `v2-beta2-mainnet`: `BASE_MAINNET_RPC_URL` and
-  `BASE_MAINNET_DEPLOYER_PRIVATE_KEY`.
+  `BASE_MAINNET_DEPLOYER_PRIVATE_KEY`, plus the isolated
+  `OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY` secret and the public
+  `BASE_DEPLOYER_ADDRESS` and `BASE_KEEPER_ADDRESS` variables. Keeper signing
+  authority stays in its existing operations environment and is not exposed to
+  release control-plane jobs.
 
 The mainnet deployment job refuses to sign unless every prelaunch gate is true,
 has HTTPS hash-bound evidence, targets the exact repository subject, and the
@@ -207,7 +216,10 @@ restart, rejects journal drift, and never enables GPU or network proving.
 The initial deployment manifest has both public flags false. After immutable
 deployment and live primary/shadow indexer agreement are recorded, rebuild the
 same manifest to enable the broker only for internal canaries while
-`public_creation_enabled` stays false. Run one paid x402 proof job and one
+`public_creation_enabled` stays false. Render configuration rejects a broker
+key that resolves to the keeper or deployment address. The release also checks
+at a Base safe block that the broker controls at least 0.11 USDC for one full
+refund and 0.00002 ETH for bounded relay gas. Run one paid x402 proof job and one
 forced provider failure, then record canonical USDC success or refund evidence.
 Only the complete public launch gate enables creation.
 

--- a/docs/open-competition-v2-beta2-release.md
+++ b/docs/open-competition-v2-beta2-release.md
@@ -162,9 +162,10 @@ environments as follows:
 - `v2-beta2-mainnet`: `BASE_MAINNET_RPC_URL` and
   `BASE_MAINNET_DEPLOYER_PRIVATE_KEY`, plus the isolated
   `OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY` secret and the public
-  `BASE_DEPLOYER_ADDRESS` and `BASE_KEEPER_ADDRESS` variables. Keeper signing
-  authority stays in its existing operations environment and is not exposed to
-  release control-plane jobs.
+  `OPEN_COMPETITION_V2_BROKER_ADDRESS`, `BASE_DEPLOYER_ADDRESS`, and
+  `BASE_KEEPER_ADDRESS` variables. Keeper signing authority stays in its
+  existing operations environment and is not exposed to release control-plane
+  jobs.
 
 The mainnet deployment job refuses to sign unless every prelaunch gate is true,
 has HTTPS hash-bound evidence, targets the exact repository subject, and the

--- a/docs/open-competition-v2-beta2-release.md
+++ b/docs/open-competition-v2-beta2-release.md
@@ -153,8 +153,12 @@ It requires a self-hosted runner with labels `linux`, `x64`, `ram-256gb`, and
 `/mnt/agent-bounties-artifacts/sp1-safe-v4-trusted`. Configure protected
 environments as follows:
 
-- `v2-beta2-sepolia`: `BASE_SEPOLIA_RPC_URL` and
-  `BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY`;
+- `v2-beta2-sepolia`: `BASE_SEPOLIA_RPC_URL`,
+  `BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY`, a dedicated
+  `OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY` secret, and its public
+  `OPEN_COMPETITION_V2_BROKER_ADDRESS` variable. The protected job derives the
+  broker address from the key, rejects deployer reuse, and seeds only its
+  bounded Base Sepolia ETH relay reserve before rehearsal;
 - `v2-beta2-mainnet`: `BASE_MAINNET_RPC_URL` and
   `BASE_MAINNET_DEPLOYER_PRIVATE_KEY`, plus the isolated
   `OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY` secret and the public

--- a/docs/threat-model-open-competition-v2-beta2.md
+++ b/docs/threat-model-open-competition-v2-beta2.md
@@ -32,7 +32,7 @@ decide payment eligibility.
 | Best-score tie manipulation | Strict improvement only; canonical accepted sequence wins ties. |
 | Timestamp ambiguity | Inclusive proof deadline and strictly-after finalization/expiry. |
 | Refund griefing | Anyone may withdraw for a contributor, but cannot redirect the recipient. |
-| Broker overcharge or abandonment | Five-minute bound quote, maximum charge, 30-minute canonical refund SLA, and segregated refund reserve. |
+| Broker overcharge or abandonment | Five-minute bound quote, maximum charge, 30-minute canonical refund SLA, dedicated broker key, and a safe-block gate requiring one full-charge USDC refund reserve plus bounded relay gas. |
 | Indexer reorg | Safe-block projection, event identity dedupe, and primary/shadow RPC comparison. |
 | Synthetic adoption inflation | Canary IDs are marked and excluded from adoption metrics. |
 
@@ -68,4 +68,6 @@ decide payment eligibility.
   metric identity.
 - Mainnet deployment, canaries, and activation require separate evidence-bound
   owner approvals.
+- The broker, keeper, and deployment signer must be distinct. Broker and public
+  activation fail closed below the release-pinned USDC and Base ETH reserves.
 - Deployment and transaction hashes are never payment evidence.

--- a/scripts/build_open_competition_v2_beta2_release.py
+++ b/scripts/build_open_competition_v2_beta2_release.py
@@ -69,6 +69,7 @@ PUBLIC_BETA_GATE_NAMES = PRELAUNCH_GATE_NAMES + (
     "mainnet_groth16_canary_complete",
     "mainnet_plonk_canary_complete",
     "mainnet_canary_accounting_reconciled",
+    "broker_refund_reserve_ready",
     "x402_success_and_refund_complete",
     "production_indexers_agree",
     "fresh_agent_wallet_flow_complete",
@@ -78,6 +79,7 @@ PUBLIC_BETA_GATE_NAMES = PRELAUNCH_GATE_NAMES + (
 BROKER_CANARY_GATE_NAMES = PRELAUNCH_GATE_NAMES + (
     "mainnet_verifiers_factory_deployed",
     "production_indexers_agree",
+    "broker_refund_reserve_ready",
 )
 SEPOLIA_BROKER_REHEARSAL_GATE_NAMES = (
     "repository_gate_complete",
@@ -341,7 +343,7 @@ def load_gates(path: Path, expected_subject_hash: str | None = None) -> dict[str
     value = json.loads(path.read_text(encoding="utf-8"))
     gates = value.get("gates")
     evidence = value.get("evidence")
-    if value.get("schema_version") != "agent-bounties/open-competition-v2-beta2-release-gates-v4":
+    if value.get("schema_version") != "agent-bounties/open-competition-v2-beta2-release-gates-v5":
         raise ValueError("release gate schema mismatch")
     if not isinstance(gates, dict) or set(gates) != set(REQUIRED_GATE_NAMES):
         raise ValueError("release gate inventory mismatch")

--- a/scripts/configure_open_competition_v2_beta2_render.py
+++ b/scripts/configure_open_competition_v2_beta2_render.py
@@ -13,6 +13,8 @@ import re
 import urllib.parse
 from typing import Any
 
+from eth_account import Account
+
 import render_deploy_recovery as render
 
 
@@ -68,13 +70,22 @@ def runtime_environment(
     prover_url: str,
     prover_api_key: str,
     broker_address: str,
+    keeper_address: str,
+    deployer_address: str,
+    refund_reserve_min_base_units: int,
 ) -> dict[str, str]:
     require(primary_rpc_url.startswith("https://"), "primary RPC must use HTTPS")
     require(shadow_rpc_url.startswith("https://"), "shadow RPC must use HTTPS")
     require(primary_rpc_url.rstrip("/") != shadow_rpc_url.rstrip("/"), "primary and shadow RPCs must differ")
     require(prover_url.startswith("https://"), "production prover must use HTTPS")
     require(len(prover_api_key) >= 32, "prover API key must contain at least 32 characters")
-    require(ADDRESS.fullmatch(broker_address) is not None, "broker address is invalid")
+    roles = {broker_address.lower(), keeper_address.lower(), deployer_address.lower()}
+    require(
+        all(ADDRESS.fullmatch(value) is not None for value in roles),
+        "broker, keeper or deployer address is invalid",
+    )
+    require(len(roles) == 3, "broker, keeper and deployer addresses must be distinct")
+    require(refund_reserve_min_base_units > 0, "refund reserve minimum must be positive")
     return {
         "BASE_MAINNET_OPEN_COMPETITION_V2_BETA2_RELEASE_MANIFEST_JSON": json.dumps(runtime, separators=(",", ":"), sort_keys=True),
         "OPEN_COMPETITION_V2_FACTORY_CONTRACT": runtime["factory_contract"].lower(),
@@ -85,6 +96,7 @@ def runtime_environment(
         "OPEN_COMPETITION_V2_PROVER_URL": prover_url,
         "OPEN_COMPETITION_V2_PROVER_API_KEY": prover_api_key,
         "OPEN_COMPETITION_V2_BROKER_PAYMENT_ADDRESS": broker_address.lower(),
+        "OPEN_COMPETITION_V2_REFUND_RESERVE_MIN_BASE_UNITS": str(refund_reserve_min_base_units),
         "OPEN_COMPETITION_V2_GROTH16_PROOF_FEE_BASE_UNITS": "100000",
         "OPEN_COMPETITION_V2_PLONK_PROOF_FEE_BASE_UNITS": "100000",
         "OPEN_COMPETITION_V2_RELAY_FEE_BASE_UNITS": "10000",
@@ -118,6 +130,11 @@ def deploy(
 ) -> dict[str, Any]:
     revision = render.validate_revision(revision)
     require(re.fullmatch(r"0x[0-9a-fA-F]{64}", relayer_private_key) is not None, "relayer private key is invalid")
+    require(
+        Account.from_key(relayer_private_key).address.lower()
+        == environment["OPEN_COMPETITION_V2_BROKER_PAYMENT_ADDRESS"],
+        "relayer private key does not match the isolated broker address",
+    )
     services = {spec.name: client.resolve_service(spec) for spec in V2_SERVICES}
     owner_ids = {str(service.get("ownerId")) for service in services.values()}
     require(len(owner_ids) == 1, "Beta2 services do not share one Render workspace")
@@ -185,8 +202,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--shadow-rpc-url", required=True)
     parser.add_argument("--prover-url", required=True)
     parser.add_argument("--prover-api-key-env", default="OPEN_COMPETITION_V2_PROVER_API_KEY")
-    parser.add_argument("--relayer-private-key-env", default="BASE_KEEPER_PRIVATE_KEY")
+    parser.add_argument("--relayer-private-key-env", default="OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY")
     parser.add_argument("--broker-address", required=True)
+    parser.add_argument("--keeper-address", required=True)
+    parser.add_argument("--deployer-address", required=True)
+    parser.add_argument("--refund-reserve-min-base-units", type=int, default=110_000)
     parser.add_argument("--timeout-seconds", type=float, default=2400)
     parser.add_argument("--poll-seconds", type=float, default=10)
     parser.add_argument("--output", type=Path, required=True)
@@ -205,6 +225,9 @@ def main() -> int:
         prover_url=args.prover_url,
         prover_api_key=prover_api_key,
         broker_address=args.broker_address,
+        keeper_address=args.keeper_address,
+        deployer_address=args.deployer_address,
+        refund_reserve_min_base_units=args.refund_reserve_min_base_units,
     )
     client = render.RenderClient(os.environ.get("RENDER_API_KEY", ""))
     evidence = deploy(

--- a/scripts/fund_open_competition_v2_beta2_broker.py
+++ b/scripts/fund_open_competition_v2_beta2_broker.py
@@ -17,12 +17,22 @@ from _shared.evm import address_word, uint_word
 from _shared.rpc import rpc
 
 
-CHAIN_ID = 8453
-USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+NETWORKS = {
+    "base-mainnet": {
+        "chain_id": 8453,
+        "usdc": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "minimum_deployer_usdc_after": 635_000,
+        "minimum_deployer_eth_after": 100_000_000_000_000,
+    },
+    "base-sepolia": {
+        "chain_id": 84532,
+        "usdc": "0x036cbd53842c5426634e7929541ec2318f3dcf7e",
+        "minimum_deployer_usdc_after": 900_000,
+        "minimum_deployer_eth_after": 500_000_000_000_000,
+    },
+}
 TRANSFER_SELECTOR = "a9059cbb"
 ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
-MIN_DEPLOYER_USDC_AFTER = 635_000
-MIN_DEPLOYER_ETH_AFTER = 100_000_000_000_000
 
 
 class BrokerFundingError(RuntimeError):
@@ -38,20 +48,21 @@ def deficits(
     *, current_usdc: int, current_eth: int, target_usdc: int, target_eth: int
 ) -> tuple[int, int]:
     require(min(current_usdc, current_eth, target_usdc, target_eth) >= 0, "balances cannot be negative")
-    require(target_usdc > 0 and target_eth > 0, "broker reserve targets must be positive")
+    require(target_usdc >= 0 and target_eth > 0, "broker reserve targets are invalid")
     return max(target_usdc - current_usdc, 0), max(target_eth - current_eth, 0)
 
 
-def usdc_balance(url: str, address: str, block: str) -> int:
+def usdc_balance(url: str, token: str, address: str, block: str) -> int:
     data = "0x70a08231" + address_word(address).hex()
-    return int(rpc(url, "eth_call", [{"to": USDC, "data": data}, block]), 16)
+    return int(rpc(url, "eth_call", [{"to": token, "data": data}, block]), 16)
 
 
 class SignedRpc:
-    def __init__(self, url: str, signer: Any) -> None:
+    def __init__(self, url: str, signer: Any, chain_id: int) -> None:
         self.url = url
         self.signer = signer
-        require(int(rpc(url, "eth_chainId", []), 16) == CHAIN_ID, "RPC is not Base mainnet")
+        self.chain_id = chain_id
+        require(int(rpc(url, "eth_chainId", []), 16) == chain_id, "RPC chain ID mismatch")
 
     def send(self, *, to: str, data: str = "0x", value: int = 0) -> dict[str, Any]:
         nonce = int(rpc(self.url, "eth_getTransactionCount", [self.signer.address, "pending"]), 16)
@@ -75,7 +86,7 @@ class SignedRpc:
         require(gas <= 150_000, "broker reserve transfer gas exceeds cap")
         signed = self.signer.sign_transaction(
             {
-                "chainId": CHAIN_ID,
+                "chainId": self.chain_id,
                 "from": self.signer.address,
                 "to": to,
                 "nonce": nonce,
@@ -113,20 +124,23 @@ class SignedRpc:
 
 def fund(
     *,
+    network_name: str,
     rpc_url: str,
     private_key: str,
     broker: str,
     target_usdc: int,
     target_eth: int,
 ) -> dict[str, Any]:
-    require(rpc_url.startswith("https://"), "production RPC must use HTTPS")
+    require(network_name in NETWORKS, "unsupported broker funding network")
+    network = NETWORKS[network_name]
+    require(rpc_url.startswith("https://"), "broker funding RPC must use HTTPS")
     require(ADDRESS.fullmatch(broker) is not None, "broker address is invalid")
     signer = Account.from_key(private_key)
     require(signer.address.lower() != broker.lower(), "broker and deployer must be distinct")
-    client = SignedRpc(rpc_url, signer)
+    client = SignedRpc(rpc_url, signer, network["chain_id"])
     safe_before = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False])
     require(safe_before and safe_before.get("hash"), "RPC did not return a safe block")
-    current_usdc = usdc_balance(rpc_url, broker, safe_before["number"])
+    current_usdc = usdc_balance(rpc_url, network["usdc"], broker, safe_before["number"])
     current_eth = int(rpc(rpc_url, "eth_getBalance", [broker, safe_before["number"]]), 16)
     usdc_deficit, eth_deficit = deficits(
         current_usdc=current_usdc,
@@ -134,21 +148,21 @@ def fund(
         target_usdc=target_usdc,
         target_eth=target_eth,
     )
-    deployer_usdc = usdc_balance(rpc_url, signer.address, "latest")
+    deployer_usdc = usdc_balance(rpc_url, network["usdc"], signer.address, "latest")
     deployer_eth = int(rpc(rpc_url, "eth_getBalance", [signer.address, "latest"]), 16)
     require(
-        deployer_usdc >= usdc_deficit + MIN_DEPLOYER_USDC_AFTER,
+        deployer_usdc >= usdc_deficit + network["minimum_deployer_usdc_after"],
         "deployer USDC cannot seed broker and retain the canary budget",
     )
     require(
-        deployer_eth >= eth_deficit + MIN_DEPLOYER_ETH_AFTER,
+        deployer_eth >= eth_deficit + network["minimum_deployer_eth_after"],
         "deployer ETH cannot seed broker and retain deployment gas",
     )
 
     receipts: list[dict[str, Any]] = []
     if usdc_deficit:
         calldata = "0x" + TRANSFER_SELECTOR + address_word(broker).hex() + uint_word(usdc_deficit).hex()
-        receipts.append(client.send(to=USDC, data=calldata))
+        receipts.append(client.send(to=network["usdc"], data=calldata))
     if eth_deficit:
         receipts.append(client.send(to=broker, value=eth_deficit))
     last_block = max(
@@ -156,14 +170,14 @@ def fund(
         or [int(safe_before["number"], 16)]
     )
     safe_after = client.wait_safe(last_block)
-    final_usdc = usdc_balance(rpc_url, broker, safe_after["number"])
+    final_usdc = usdc_balance(rpc_url, network["usdc"], broker, safe_after["number"])
     final_eth = int(rpc(rpc_url, "eth_getBalance", [broker, safe_after["number"]]), 16)
     require(final_usdc >= target_usdc, "broker USDC reserve did not reconcile")
     require(final_eth >= target_eth, "broker ETH reserve did not reconcile")
     return {
         "schema_version": "agent-bounties/open-competition-v2-beta2-broker-seed-v1",
         "passed": True,
-        "network": "base-mainnet",
+        "network": network_name,
         "deployer": signer.address.lower(),
         "broker": broker.lower(),
         "target_usdc_base_units": target_usdc,
@@ -181,20 +195,25 @@ def fund(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--network", choices=tuple(NETWORKS), default="base-mainnet")
     parser.add_argument("--rpc-url", required=True)
     parser.add_argument("--private-key-env", default="BASE_MAINNET_DEPLOYER_PRIVATE_KEY")
     parser.add_argument("--broker", required=True)
-    parser.add_argument("--target-usdc-base-units", type=int, default=110_000)
+    parser.add_argument("--target-usdc-base-units", type=int)
     parser.add_argument("--target-eth-wei", type=int, default=100_000_000_000_000)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
     private_key = os.environ.get(args.private_key_env, "")
     require(bool(private_key), f"{args.private_key_env} is required")
+    target_usdc = args.target_usdc_base_units
+    if target_usdc is None:
+        target_usdc = 110_000 if args.network == "base-mainnet" else 0
     result = fund(
+        network_name=args.network,
         rpc_url=args.rpc_url,
         private_key=private_key,
         broker=args.broker,
-        target_usdc=args.target_usdc_base_units,
+        target_usdc=target_usdc,
         target_eth=args.target_eth_wei,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/fund_open_competition_v2_beta2_broker.py
+++ b/scripts/fund_open_competition_v2_beta2_broker.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Idempotently seed the isolated Beta2 broker from the protected deployer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import time
+from typing import Any
+
+from eth_account import Account
+
+from _shared.evm import address_word, uint_word
+from _shared.rpc import rpc
+
+
+CHAIN_ID = 8453
+USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+TRANSFER_SELECTOR = "a9059cbb"
+ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
+MIN_DEPLOYER_USDC_AFTER = 635_000
+MIN_DEPLOYER_ETH_AFTER = 100_000_000_000_000
+
+
+class BrokerFundingError(RuntimeError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise BrokerFundingError(message)
+
+
+def deficits(
+    *, current_usdc: int, current_eth: int, target_usdc: int, target_eth: int
+) -> tuple[int, int]:
+    require(min(current_usdc, current_eth, target_usdc, target_eth) >= 0, "balances cannot be negative")
+    require(target_usdc > 0 and target_eth > 0, "broker reserve targets must be positive")
+    return max(target_usdc - current_usdc, 0), max(target_eth - current_eth, 0)
+
+
+def usdc_balance(url: str, address: str, block: str) -> int:
+    data = "0x70a08231" + address_word(address).hex()
+    return int(rpc(url, "eth_call", [{"to": USDC, "data": data}, block]), 16)
+
+
+class SignedRpc:
+    def __init__(self, url: str, signer: Any) -> None:
+        self.url = url
+        self.signer = signer
+        require(int(rpc(url, "eth_chainId", []), 16) == CHAIN_ID, "RPC is not Base mainnet")
+
+    def send(self, *, to: str, data: str = "0x", value: int = 0) -> dict[str, Any]:
+        nonce = int(rpc(self.url, "eth_getTransactionCount", [self.signer.address, "pending"]), 16)
+        block = rpc(self.url, "eth_getBlockByNumber", ["latest", False])
+        base_fee = int(block.get("baseFeePerGas", "0x0"), 16)
+        try:
+            priority = int(rpc(self.url, "eth_maxPriorityFeePerGas", []), 16)
+        except RuntimeError:
+            priority = 1_000_000
+        priority = max(priority, 1_000_000)
+        maximum = base_fee * 2 + priority
+        estimate = {
+            "from": self.signer.address,
+            "to": to,
+            "value": hex(value),
+            "data": data,
+            "maxFeePerGas": hex(maximum),
+            "maxPriorityFeePerGas": hex(priority),
+        }
+        gas = int(rpc(self.url, "eth_estimateGas", [estimate]), 16)
+        require(gas <= 150_000, "broker reserve transfer gas exceeds cap")
+        signed = self.signer.sign_transaction(
+            {
+                "chainId": CHAIN_ID,
+                "from": self.signer.address,
+                "to": to,
+                "nonce": nonce,
+                "value": value,
+                "data": data,
+                "gas": gas * 5 // 4 + 10_000,
+                "maxFeePerGas": maximum,
+                "maxPriorityFeePerGas": priority,
+                "type": 2,
+            }
+        )
+        tx_hash = rpc(
+            self.url,
+            "eth_sendRawTransaction",
+            ["0x" + bytes(signed.raw_transaction).hex()],
+        )
+        deadline = time.time() + 300
+        while time.time() < deadline:
+            receipt = rpc(self.url, "eth_getTransactionReceipt", [tx_hash])
+            if receipt:
+                require(int(receipt["status"], 16) == 1, f"reserve transfer reverted: {tx_hash}")
+                return receipt
+            time.sleep(2)
+        raise BrokerFundingError(f"reserve transfer timed out: {tx_hash}")
+
+    def wait_safe(self, block_number: int) -> dict[str, Any]:
+        deadline = time.time() + 1_800
+        while time.time() < deadline:
+            block = rpc(self.url, "eth_getBlockByNumber", ["safe", False])
+            if block and int(block["number"], 16) >= block_number:
+                return block
+            time.sleep(5)
+        raise BrokerFundingError("broker reserve did not reach a Base safe block")
+
+
+def fund(
+    *,
+    rpc_url: str,
+    private_key: str,
+    broker: str,
+    target_usdc: int,
+    target_eth: int,
+) -> dict[str, Any]:
+    require(rpc_url.startswith("https://"), "production RPC must use HTTPS")
+    require(ADDRESS.fullmatch(broker) is not None, "broker address is invalid")
+    signer = Account.from_key(private_key)
+    require(signer.address.lower() != broker.lower(), "broker and deployer must be distinct")
+    client = SignedRpc(rpc_url, signer)
+    safe_before = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False])
+    require(safe_before and safe_before.get("hash"), "RPC did not return a safe block")
+    current_usdc = usdc_balance(rpc_url, broker, safe_before["number"])
+    current_eth = int(rpc(rpc_url, "eth_getBalance", [broker, safe_before["number"]]), 16)
+    usdc_deficit, eth_deficit = deficits(
+        current_usdc=current_usdc,
+        current_eth=current_eth,
+        target_usdc=target_usdc,
+        target_eth=target_eth,
+    )
+    deployer_usdc = usdc_balance(rpc_url, signer.address, "latest")
+    deployer_eth = int(rpc(rpc_url, "eth_getBalance", [signer.address, "latest"]), 16)
+    require(
+        deployer_usdc >= usdc_deficit + MIN_DEPLOYER_USDC_AFTER,
+        "deployer USDC cannot seed broker and retain the canary budget",
+    )
+    require(
+        deployer_eth >= eth_deficit + MIN_DEPLOYER_ETH_AFTER,
+        "deployer ETH cannot seed broker and retain deployment gas",
+    )
+
+    receipts: list[dict[str, Any]] = []
+    if usdc_deficit:
+        calldata = "0x" + TRANSFER_SELECTOR + address_word(broker).hex() + uint_word(usdc_deficit).hex()
+        receipts.append(client.send(to=USDC, data=calldata))
+    if eth_deficit:
+        receipts.append(client.send(to=broker, value=eth_deficit))
+    last_block = max(
+        [int(receipt["blockNumber"], 16) for receipt in receipts]
+        or [int(safe_before["number"], 16)]
+    )
+    safe_after = client.wait_safe(last_block)
+    final_usdc = usdc_balance(rpc_url, broker, safe_after["number"])
+    final_eth = int(rpc(rpc_url, "eth_getBalance", [broker, safe_after["number"]]), 16)
+    require(final_usdc >= target_usdc, "broker USDC reserve did not reconcile")
+    require(final_eth >= target_eth, "broker ETH reserve did not reconcile")
+    return {
+        "schema_version": "agent-bounties/open-competition-v2-beta2-broker-seed-v1",
+        "passed": True,
+        "network": "base-mainnet",
+        "deployer": signer.address.lower(),
+        "broker": broker.lower(),
+        "target_usdc_base_units": target_usdc,
+        "target_eth_wei": target_eth,
+        "funded_usdc_base_units": usdc_deficit,
+        "funded_eth_wei": eth_deficit,
+        "transactions": [receipt["transactionHash"].lower() for receipt in receipts],
+        "safe_block_number": int(safe_after["number"], 16),
+        "safe_block_hash": safe_after["hash"].lower(),
+        "final_usdc_base_units": final_usdc,
+        "final_eth_wei": final_eth,
+        "evidence_boundary": "These canonical transfers seed the dedicated broker reserve. They are not proof-job refunds, solver payments, or competition settlements.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--private-key-env", default="BASE_MAINNET_DEPLOYER_PRIVATE_KEY")
+    parser.add_argument("--broker", required=True)
+    parser.add_argument("--target-usdc-base-units", type=int, default=110_000)
+    parser.add_argument("--target-eth-wei", type=int, default=100_000_000_000_000)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    private_key = os.environ.get(args.private_key_env, "")
+    require(bool(private_key), f"{args.private_key_env} is required")
+    result = fund(
+        rpc_url=args.rpc_url,
+        private_key=private_key,
+        broker=args.broker,
+        target_usdc=args.target_usdc_base_units,
+        target_eth=args.target_eth_wei,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"passed": True, "broker": result["broker"], "output": str(args.output)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_build_open_competition_v2_beta2_release.py
+++ b/scripts/test_build_open_competition_v2_beta2_release.py
@@ -14,6 +14,16 @@ SPEC.loader.exec_module(MODULE)
 class OpenCompetitionV2ReleaseTests(unittest.TestCase):
     subject_hash = "0x" + "33" * 32
 
+    def test_mainnet_workflow_records_the_exact_x402_gate(self):
+        workflow = (MODULE.ROOT / ".github/workflows/open-competition-v2-beta2-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "mainnet_canary_accounting_reconciled x402_success_and_refund_complete",
+            workflow,
+        )
+        self.assertNotIn("x402_success_and_refund_canaries_complete", workflow)
+
     @staticmethod
     def verifier_assets() -> dict:
         systems = {}
@@ -134,7 +144,7 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
             "uri": "https://example.test/evidence",
         }
         value = {
-            "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v4",
+            "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v5",
             "protocol_version": "agent-bounties/open-competition-v2-beta2",
             "beta_risk_preimage": "risk",
             "gates": {name: False for name in MODULE.REQUIRED_GATE_NAMES},
@@ -245,7 +255,7 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
             "uri": "https://example.test/evidence",
         }
         value = {
-            "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v4",
+            "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v5",
             "protocol_version": "agent-bounties/open-competition-v2-beta2",
             "beta_risk_preimage": "risk",
             "gates": {name: False for name in MODULE.REQUIRED_GATE_NAMES},
@@ -290,7 +300,7 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
         gates = {name: False for name in MODULE.REQUIRED_GATE_NAMES}
         gates["repository_gate_complete"] = True
         value = {
-            "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v4",
+            "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v5",
             "protocol_version": "agent-bounties/open-competition-v2-beta2",
             "beta_risk_preimage": "risk",
             "gates": gates,
@@ -304,7 +314,7 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
     def test_completed_gate_must_target_exact_repository_subject(self) -> None:
         path = MODULE.ROOT / "target/tmp/open-competition-v2-wrong-subject.json"
         value = {
-            "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v4",
+            "schema_version": "agent-bounties/open-competition-v2-beta2-release-gates-v5",
             "protocol_version": "agent-bounties/open-competition-v2-beta2",
             "beta_risk_preimage": "risk",
             "gates": {name: name == "repository_gate_complete" for name in MODULE.REQUIRED_GATE_NAMES},

--- a/scripts/test_build_open_competition_v2_beta2_release.py
+++ b/scripts/test_build_open_competition_v2_beta2_release.py
@@ -24,6 +24,19 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
         )
         self.assertNotIn("x402_success_and_refund_canaries_complete", workflow)
 
+    def test_sepolia_rehearsal_uses_an_isolated_broker(self):
+        workflow = (MODULE.ROOT / ".github/workflows/open-competition-v2-beta2-release.yml").read_text(
+            encoding="utf-8"
+        )
+        sepolia = workflow.split("  live-sepolia-rehearsal:", 1)[1].split(
+            "  deploy-mainnet:", 1
+        )[0]
+        self.assertIn("OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY", sepolia)
+        self.assertIn("--network base-sepolia", sepolia)
+        self.assertIn('OPEN_COMPETITION_V2_BROKER_PAYMENT_ADDRESS="$BROKER"', sepolia)
+        self.assertIn('X402_RELAYER_PRIVATE_KEY="$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"', sepolia)
+        self.assertNotIn('X402_RELAYER_PRIVATE_KEY="$BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY"', sepolia)
+
     @staticmethod
     def verifier_assets() -> dict:
         systems = {}

--- a/scripts/test_configure_open_competition_v2_beta2_render.py
+++ b/scripts/test_configure_open_competition_v2_beta2_render.py
@@ -47,12 +47,16 @@ class Beta2RenderTests(unittest.TestCase):
             prover_url="https://prover.example/v1/prove",
             prover_api_key="a" * 32,
             broker_address="0x" + "55" * 20,
+            keeper_address="0x" + "66" * 20,
+            deployer_address="0x" + "77" * 20,
+            refund_reserve_min_base_units=110_000,
         )
         manifest = json.loads(environment["BASE_MAINNET_OPEN_COMPETITION_V2_BETA2_RELEASE_MANIFEST_JSON"])
         self.assertFalse(manifest["public_creation_enabled"])
         self.assertFalse(manifest["proof_broker_enabled"])
         self.assertEqual(environment["OPEN_COMPETITION_V2_DEPLOYMENT_BLOCK"], "123")
         self.assertNotIn("X402_RELAYER_PRIVATE_KEY", environment)
+        self.assertEqual(environment["OPEN_COMPETITION_V2_REFUND_RESERVE_MIN_BASE_UNITS"], "110000")
 
     def test_environment_rejects_shared_rpc_and_insecure_prover(self):
         common = dict(
@@ -62,9 +66,26 @@ class Beta2RenderTests(unittest.TestCase):
             prover_url="http://prover.example/v1/prove",
             prover_api_key="a" * 32,
             broker_address="0x" + "55" * 20,
+            keeper_address="0x" + "66" * 20,
+            deployer_address="0x" + "77" * 20,
+            refund_reserve_min_base_units=110_000,
         )
         with self.assertRaises(MODULE.Beta2RenderError):
             MODULE.runtime_environment(**common)
+
+    def test_environment_rejects_reused_signing_role(self):
+        with self.assertRaisesRegex(MODULE.Beta2RenderError, "must be distinct"):
+            MODULE.runtime_environment(
+                runtime(),
+                primary_rpc_url="https://primary.example",
+                shadow_rpc_url="https://shadow.example",
+                prover_url="https://prover.example/v1/prove",
+                prover_api_key="a" * 32,
+                broker_address="0x" + "55" * 20,
+                keeper_address="0x" + "55" * 20,
+                deployer_address="0x" + "77" * 20,
+                refund_reserve_min_base_units=110_000,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test_fund_open_competition_v2_beta2_broker.py
+++ b/scripts/test_fund_open_competition_v2_beta2_broker.py
@@ -1,0 +1,35 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+PATH = Path(__file__).with_name("fund_open_competition_v2_beta2_broker.py")
+SPEC = importlib.util.spec_from_file_location("fund_open_competition_v2_beta2_broker", PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class BrokerFundingTests(unittest.TestCase):
+    def test_deficits_are_idempotent(self):
+        self.assertEqual(
+            MODULE.deficits(current_usdc=0, current_eth=0, target_usdc=110_000, target_eth=100),
+            (110_000, 100),
+        )
+        self.assertEqual(
+            MODULE.deficits(
+                current_usdc=200_000,
+                current_eth=200,
+                target_usdc=110_000,
+                target_eth=100,
+            ),
+            (0, 0),
+        )
+
+    def test_deficits_reject_invalid_targets(self):
+        with self.assertRaisesRegex(MODULE.BrokerFundingError, "must be positive"):
+            MODULE.deficits(current_usdc=0, current_eth=0, target_usdc=0, target_eth=100)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_fund_open_competition_v2_beta2_broker.py
+++ b/scripts/test_fund_open_competition_v2_beta2_broker.py
@@ -27,8 +27,12 @@ class BrokerFundingTests(unittest.TestCase):
         )
 
     def test_deficits_reject_invalid_targets(self):
-        with self.assertRaisesRegex(MODULE.BrokerFundingError, "must be positive"):
-            MODULE.deficits(current_usdc=0, current_eth=0, target_usdc=0, target_eth=100)
+        self.assertEqual(
+            MODULE.deficits(current_usdc=0, current_eth=0, target_usdc=0, target_eth=100),
+            (0, 100),
+        )
+        with self.assertRaisesRegex(MODULE.BrokerFundingError, "are invalid"):
+            MODULE.deficits(current_usdc=0, current_eth=0, target_usdc=0, target_eth=0)
 
 
 if __name__ == "__main__":

--- a/scripts/test_verify_open_competition_v2_beta2_broker_reserve.py
+++ b/scripts/test_verify_open_competition_v2_beta2_broker_reserve.py
@@ -1,0 +1,84 @@
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+PATH = Path(__file__).with_name("verify_open_competition_v2_beta2_broker_reserve.py")
+SPEC = importlib.util.spec_from_file_location("verify_open_competition_v2_beta2_broker_reserve", PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def runtime() -> dict:
+    return {
+        "protocol_version": MODULE.PROTOCOL_VERSION,
+        "network": "base-mainnet",
+        "settlement_token": "0x" + "44" * 20,
+    }
+
+
+def rpc_result(_url: str, method: str, params: list):
+    if method == "eth_chainId":
+        return "0x2105"
+    if method == "eth_getBlockByNumber":
+        return {"number": "0x7b", "hash": "0x" + "aa" * 32}
+    if method == "eth_getCode":
+        return "0x6000"
+    if method == "eth_call":
+        return hex(110_000)
+    if method == "eth_getBalance":
+        return hex(20_000_000_000_000)
+    raise AssertionError((method, params))
+
+
+class BrokerReserveTests(unittest.TestCase):
+    @patch.object(MODULE, "rpc", side_effect=rpc_result)
+    def test_accepts_exact_isolated_reserves(self, _rpc):
+        result = MODULE.inspect_reserve(
+            runtime(),
+            rpc_url="https://mainnet.example",
+            broker="0x" + "11" * 20,
+            keeper="0x" + "22" * 20,
+            deployer="0x" + "33" * 20,
+            minimum_usdc_base_units=110_000,
+            minimum_eth_wei=20_000_000_000_000,
+        )
+        self.assertTrue(result["passed"])
+        self.assertTrue(result["roles_are_isolated"])
+        self.assertEqual(result["safe_block_number"], 123)
+
+    @patch.object(MODULE, "rpc", side_effect=rpc_result)
+    def test_rejects_reused_role_address(self, _rpc):
+        with self.assertRaisesRegex(MODULE.BrokerReserveError, "must be distinct"):
+            MODULE.inspect_reserve(
+                runtime(),
+                rpc_url="https://mainnet.example",
+                broker="0x" + "11" * 20,
+                keeper="0x" + "11" * 20,
+                deployer="0x" + "33" * 20,
+                minimum_usdc_base_units=110_000,
+                minimum_eth_wei=20_000_000_000_000,
+            )
+
+    @patch.object(
+        MODULE,
+        "rpc",
+        side_effect=lambda u, m, p: hex(109_999) if m == "eth_call" else rpc_result(u, m, p),
+    )
+    def test_rejects_underfunded_usdc_reserve(self, _rpc):
+        with self.assertRaisesRegex(MODULE.BrokerReserveError, "USDC refund reserve"):
+            MODULE.inspect_reserve(
+                runtime(),
+                rpc_url="https://mainnet.example",
+                broker="0x" + "11" * 20,
+                keeper="0x" + "22" * 20,
+                deployer="0x" + "33" * 20,
+                minimum_usdc_base_units=110_000,
+                minimum_eth_wei=20_000_000_000_000,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_open_competition_v2_beta2_broker_reserve.py
+++ b/scripts/verify_open_competition_v2_beta2_broker_reserve.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Verify the isolated Beta2 broker has bounded Base gas and refund reserves."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from _shared.evm import address_word
+from _shared.rpc import rpc
+
+
+PROTOCOL_VERSION = "agent-bounties/open-competition-v2-beta2"
+BASE_MAINNET_CHAIN_ID = "0x2105"
+ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+
+class BrokerReserveError(RuntimeError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise BrokerReserveError(message)
+
+
+def inspect_reserve(
+    runtime: dict[str, Any],
+    *,
+    rpc_url: str,
+    broker: str,
+    keeper: str,
+    deployer: str,
+    minimum_usdc_base_units: int,
+    minimum_eth_wei: int,
+) -> dict[str, Any]:
+    require(runtime.get("protocol_version") == PROTOCOL_VERSION, "runtime protocol mismatch")
+    require(runtime.get("network") == "base-mainnet", "reserve gate accepts only Base mainnet")
+    require(rpc_url.startswith("https://"), "production RPC must use HTTPS")
+    roles = {"broker": broker.lower(), "keeper": keeper.lower(), "deployer": deployer.lower()}
+    require(all(ADDRESS.fullmatch(value) for value in roles.values()), "release role address is invalid")
+    require(len(set(roles.values())) == len(roles), "broker, keeper and deployer must be distinct")
+    require(minimum_usdc_base_units > 0, "minimum USDC reserve must be positive")
+    require(minimum_eth_wei > 0, "minimum ETH reserve must be positive")
+    require(rpc(rpc_url, "eth_chainId", []) == BASE_MAINNET_CHAIN_ID, "RPC is not Base mainnet")
+
+    block = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False])
+    require(isinstance(block, dict) and block.get("hash"), "RPC did not return a safe block")
+    block_tag = block["number"]
+    token = str(runtime.get("settlement_token", "")).lower()
+    require(ADDRESS.fullmatch(token) is not None, "runtime settlement token is invalid")
+    require(rpc(rpc_url, "eth_getCode", [token, block_tag]) != "0x", "settlement token has no code")
+
+    balance_data = "0x70a08231" + address_word(roles["broker"]).hex()
+    usdc_balance = int(
+        rpc(rpc_url, "eth_call", [{"to": token, "data": balance_data}, block_tag]), 16
+    )
+    eth_balance = int(rpc(rpc_url, "eth_getBalance", [roles["broker"], block_tag]), 16)
+    require(usdc_balance >= minimum_usdc_base_units, "broker USDC refund reserve is below minimum")
+    require(eth_balance >= minimum_eth_wei, "broker Base ETH gas reserve is below minimum")
+
+    return {
+        "schema_version": "agent-bounties/open-competition-v2-beta2-broker-reserve-v1",
+        "passed": True,
+        "network": "base-mainnet",
+        "broker": roles["broker"],
+        "keeper": roles["keeper"],
+        "deployer": roles["deployer"],
+        "settlement_token": token,
+        "safe_block_number": int(block_tag, 16),
+        "safe_block_hash": str(block["hash"]).lower(),
+        "usdc_balance_base_units": usdc_balance,
+        "minimum_usdc_base_units": minimum_usdc_base_units,
+        "eth_balance_wei": eth_balance,
+        "minimum_eth_wei": minimum_eth_wei,
+        "roles_are_isolated": True,
+        "evidence_boundary": "This safe-block observation proves bounded broker reserves and role separation at one canonical block. It is not proof generation, refund, relay, competition settlement, or future solvency evidence.",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime", type=Path, required=True)
+    parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--broker", required=True)
+    parser.add_argument("--keeper", required=True)
+    parser.add_argument("--deployer", required=True)
+    parser.add_argument("--minimum-usdc-base-units", type=int, default=110_000)
+    parser.add_argument("--minimum-eth-wei", type=int, default=20_000_000_000_000)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = inspect_reserve(
+        json.loads(args.runtime.read_text(encoding="utf-8")),
+        rpc_url=args.rpc_url,
+        broker=args.broker,
+        keeper=args.keeper,
+        deployer=args.deployer,
+        minimum_usdc_base_units=args.minimum_usdc_base_units,
+        minimum_eth_wei=args.minimum_eth_wei,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"passed": True, "broker": result["broker"], "output": str(args.output)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- split the Base-mainnet x402 broker/refund signer from the keeper and deployment signer\n- require safe-block evidence for at least 0.11 USDC refund reserve and 0.00002 ETH relay gas before broker/public activation\n- make broker reserve readiness a formal Beta2 release gate\n- fix the mainnet canary workflow's stale x402 gate name\n- remove keeper/deployer secrets from control-plane jobs and use public addresses\n\n## Evidence\n- core preflight passed\n- 87 Beta2 release tests passed\n- Ruff and Python compilation passed\n- workflow YAML parsed successfully\n- local 10,000-run Foundry gate was unavailable because forge is absent; required GitHub CI uses the pinned Foundry action\n\n## Payment boundary\nNo funds move in this PR. The protected environment now contains a dedicated broker secret; public activation remains fail-closed until canonical reserve, canary, refund, indexer, and interface evidence are recorded.