### PR TITLE
Use the exact Beta2 ceremony contribution threshold

### DIFF
--- a/.github/workflows/open-competition-v2-beta2-release.yml
+++ b/.github/workflows/open-competition-v2-beta2-release.yml
@@ -162,6 +162,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
         with:
           version: "28.3"
+          repo-token: ${{ github.token }}
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           repository: NSPG13/sp1
@@ -280,6 +281,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
         with:
           version: "28.3"
+          repo-token: ${{ github.token }}
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           repository: NSPG13/sp1
@@ -352,6 +354,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
         with:
           version: "28.3"
+          repo-token: ${{ github.token }}
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"

--- a/.github/workflows/open-competition-v2-metric-release.yml
+++ b/.github/workflows/open-competition-v2-metric-release.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
         with:
           version: "28.3"
+          repo-token: ${{ github.token }}
       - name: Install the patched source-pinned SP1 toolchain
         shell: bash
         run: |

--- a/scripts/run_open_competition_v2_groth16_ceremony.sh
+++ b/scripts/run_open_competition_v2_groth16_ceremony.sh
@@ -41,7 +41,7 @@ PY
 
 container init-phase1 --r1cs /inputs/groth16_circuit.bin --output /data/phase1-init.bin \
   | tee "$output_dir/01-phase1-init.json"
-for id in 1 2 3; do
+for id in 1 2; do
   previous="phase1-init.bin"
   if (( id > 1 )); then previous="phase1-$((id - 1)).bin"; fi
   container contribute-phase1 --input "/data/$previous" --output "/data/phase1-$id.bin" \
@@ -49,14 +49,14 @@ for id in 1 2 3; do
 done
 phase1_beacon="$(fetch_beacon "$output_dir/phase1-beacon.json")"
 container verify-phase1 --r1cs /inputs/groth16_circuit.bin \
-  --inputs /data/phase1-1.bin,/data/phase1-2.bin,/data/phase1-3.bin \
+  --inputs /data/phase1-1.bin,/data/phase1-2.bin \
   --beacon "$phase1_beacon" --output /data/phase1-commons.bin \
   | tee "$output_dir/05-phase1-verify.json"
 
 container init-phase2 --r1cs /inputs/groth16_circuit.bin \
   --commons /data/phase1-commons.bin --output /data/phase2-init.bin \
   | tee "$output_dir/06-phase2-init.json"
-for id in 1 2 3; do
+for id in 1 2; do
   previous="phase2-init.bin"
   if (( id > 1 )); then previous="phase2-$((id - 1)).bin"; fi
   container contribute-phase2 --input "/data/$previous" --output "/data/phase2-$id.bin" \
@@ -64,7 +64,7 @@ for id in 1 2 3; do
 done
 phase2_beacon="$(fetch_beacon "$output_dir/phase2-beacon.json")"
 container finalize --r1cs /inputs/groth16_circuit.bin --commons /data/phase1-commons.bin \
-  --inputs /data/phase2-1.bin,/data/phase2-2.bin,/data/phase2-3.bin \
+  --inputs /data/phase2-1.bin,/data/phase2-2.bin \
   --beacon "$phase2_beacon" --pk /data/groth16_pk.bin --vk /data/groth16_vk.bin \
   --solidity /data/Groth16Verifier.sol | tee "$output_dir/10-finalize.json"
 

--- a/scripts/test_verify_open_competition_v2_groth16_ceremony.py
+++ b/scripts/test_verify_open_competition_v2_groth16_ceremony.py
@@ -47,21 +47,19 @@ class Groth16CeremonyTests(unittest.TestCase):
                 }
 
             h = {name: hashlib.sha256(name.encode()).hexdigest() for name in (
-                "p1-init", "p1-1", "p1-2", "p1-3", "commons",
-                "p2-init", "p2-1", "p2-2", "p2-3",
+                "p1-init", "p1-1", "p1-2", "commons",
+                "p2-init", "p2-1", "p2-2",
             )}
             r1cs_item = digest(r1cs.name, hashlib.sha256(r1cs.read_bytes()).hexdigest())
             records = [
                 record("init-phase1", [r1cs_item], [digest("phase1-init.bin", h["p1-init"])]),
                 record("contribute-phase1", [digest("phase1-init.bin", h["p1-init"])], [digest("phase1-1.bin", h["p1-1"])], contribution_id=1),
                 record("contribute-phase1", [digest("phase1-1.bin", h["p1-1"])], [digest("phase1-2.bin", h["p1-2"])], contribution_id=2),
-                record("contribute-phase1", [digest("phase1-2.bin", h["p1-2"])], [digest("phase1-3.bin", h["p1-3"])], contribution_id=3),
-                record("verify-phase1", [r1cs_item, digest("phase1-1.bin", h["p1-1"]), digest("phase1-2.bin", h["p1-2"]), digest("phase1-3.bin", h["p1-3"])], [digest("phase1-commons.bin", h["commons"])], beacon_hex="0x" + "11" * 32),
+                record("verify-phase1", [r1cs_item, digest("phase1-1.bin", h["p1-1"]), digest("phase1-2.bin", h["p1-2"])], [digest("phase1-commons.bin", h["commons"])], beacon_hex="0x" + "11" * 32),
                 record("init-phase2", [r1cs_item, digest("phase1-commons.bin", h["commons"])], [digest("phase2-init.bin", h["p2-init"])]),
                 record("contribute-phase2", [digest("phase2-init.bin", h["p2-init"])], [digest("phase2-1.bin", h["p2-1"])], contribution_id=1),
                 record("contribute-phase2", [digest("phase2-1.bin", h["p2-1"])], [digest("phase2-2.bin", h["p2-2"])], contribution_id=2),
-                record("contribute-phase2", [digest("phase2-2.bin", h["p2-2"])], [digest("phase2-3.bin", h["p2-3"])], contribution_id=3),
-                record("finalize", [r1cs_item, digest("phase1-commons.bin", h["commons"]), digest("phase2-1.bin", h["p2-1"]), digest("phase2-2.bin", h["p2-2"]), digest("phase2-3.bin", h["p2-3"])], [
+                record("finalize", [r1cs_item, digest("phase1-commons.bin", h["commons"]), digest("phase2-1.bin", h["p2-1"]), digest("phase2-2.bin", h["p2-2"])], [
                     digest(name, hashlib.sha256((root / name).read_bytes()).hexdigest())
                     for name in ("groth16_pk.bin", "groth16_vk.bin", "Groth16Verifier.sol")
                 ], beacon_hex="0x" + "22" * 32),
@@ -72,8 +70,8 @@ class Groth16CeremonyTests(unittest.TestCase):
                 "phase1_beacon": {"round": 1, "randomness": "11" * 32},
                 "phase2_beacon": {"round": 2, "randomness": "22" * 32},
             }
-            self.assertEqual(MODULE.verify(transcript, root, r1cs)[0], 3)
-            records[8]["inputs"][0]["sha256"] = "ff" * 32
+            self.assertEqual(MODULE.verify(transcript, root, r1cs)[0], 2)
+            records[6]["inputs"][0]["sha256"] = "ff" * 32
             with self.assertRaisesRegex(ValueError, "hash chain is broken"):
                 MODULE.verify(transcript, root, r1cs)
 

--- a/scripts/verify_open_competition_v2_groth16_ceremony.py
+++ b/scripts/verify_open_competition_v2_groth16_ceremony.py
@@ -14,20 +14,6 @@ from typing import Any
 COMMAND_SCHEMA = "agent-bounties/open-competition-v2-beta2-groth16-mpc-command-v1"
 TRANSCRIPT_SCHEMA = "agent-bounties/open-competition-v2-beta2-groth16-mpc-transcript-v1"
 EVIDENCE_SCHEMA = "agent-bounties/open-competition-v2-beta2-setup-verification-evidence-v1"
-COMMANDS = (
-    "init-phase1",
-    "contribute-phase1",
-    "contribute-phase1",
-    "contribute-phase1",
-    "verify-phase1",
-    "init-phase2",
-    "contribute-phase2",
-    "contribute-phase2",
-    "contribute-phase2",
-    "finalize",
-)
-
-
 def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -54,34 +40,84 @@ def verify(transcript: dict[str, Any], root: Path, r1cs: Path) -> tuple[int, str
     if transcript.get("schema_version") != TRANSCRIPT_SCHEMA:
         raise ValueError("Groth16 transcript schema mismatch")
     records = transcript.get("records")
-    if not isinstance(records, list) or len(records) != len(COMMANDS):
+    if not isinstance(records, list) or len(records) < 8:
         raise ValueError("Groth16 transcript command inventory mismatch")
-    for index, (record, command) in enumerate(zip(records, COMMANDS, strict=True)):
+    for index, record in enumerate(records):
         if record.get("schema_version") != COMMAND_SCHEMA:
             raise ValueError(f"Groth16 command {index} schema mismatch")
-        if record.get("command") != command or record.get("verified") is not True:
-            raise ValueError(f"Groth16 command {index} is not verified {command}")
-    for offset in (1, 2, 3, 6, 7, 8):
-        expected_id = offset if offset <= 3 else offset - 5
+        if record.get("verified") is not True:
+            raise ValueError(f"Groth16 command {index} is not verified")
+
+    if records[0].get("command") != "init-phase1":
+        raise ValueError("Groth16 transcript must start with init-phase1")
+    phase1_indexes = []
+    cursor = 1
+    while cursor < len(records) and records[cursor].get("command") == "contribute-phase1":
+        phase1_indexes.append(cursor)
+        cursor += 1
+    if len(phase1_indexes) < 2:
+        raise ValueError("Groth16 Phase 1 requires at least two contributions")
+    phase1_verify_index = cursor
+    if cursor >= len(records) or records[cursor].get("command") != "verify-phase1":
+        raise ValueError("Groth16 Phase 1 verification is missing")
+    cursor += 1
+    phase2_init_index = cursor
+    if cursor >= len(records) or records[cursor].get("command") != "init-phase2":
+        raise ValueError("Groth16 Phase 2 initialization is missing")
+    cursor += 1
+    phase2_indexes = []
+    while cursor < len(records) and records[cursor].get("command") == "contribute-phase2":
+        phase2_indexes.append(cursor)
+        cursor += 1
+    if len(phase2_indexes) < 2:
+        raise ValueError("Groth16 Phase 2 requires at least two contributions")
+    if len(phase1_indexes) != len(phase2_indexes):
+        raise ValueError("Groth16 phase contribution counts differ")
+    finalize_index = cursor
+    if cursor != len(records) - 1 or records[cursor].get("command") != "finalize":
+        raise ValueError("Groth16 transcript must end with finalize")
+
+    for expected_id, offset in enumerate(phase1_indexes, start=1):
+        if records[offset].get("contribution_id") != expected_id:
+            raise ValueError("Groth16 contribution sequence is not contiguous")
+    for expected_id, offset in enumerate(phase2_indexes, start=1):
         if records[offset].get("contribution_id") != expected_id:
             raise ValueError("Groth16 contribution sequence is not contiguous")
     r1cs_hash = sha256(r1cs)
     if inventory(records[0], "inputs").get(r1cs.name) != r1cs_hash:
         raise ValueError("Groth16 Phase 1 targets another R1CS")
-    chains = ((0, 1), (1, 2), (2, 3), (4, 5), (5, 6), (6, 7), (7, 8))
+    for index in (phase1_verify_index, phase2_init_index, finalize_index):
+        if inventory(records[index], "inputs").get(r1cs.name) != r1cs_hash:
+            raise ValueError("Groth16 ceremony changed R1CS")
+    chains = []
+    previous = 0
+    for current in phase1_indexes:
+        chains.append((previous, current))
+        previous = current
+    chains.append((phase1_verify_index, phase2_init_index))
+    previous = phase2_init_index
+    for current in phase2_indexes:
+        chains.append((previous, current))
+        previous = current
     for previous, current in chains:
         outputs = inventory(records[previous], "outputs")
         inputs = inventory(records[current], "inputs")
         if not set(outputs.items()).issubset(set(inputs.items())):
             raise ValueError("Groth16 contribution hash chain is broken")
-    for verify_index, contribution_indexes in ((4, (1, 2, 3)), (9, (6, 7, 8))):
+    for verify_index, contribution_indexes in (
+        (phase1_verify_index, phase1_indexes),
+        (finalize_index, phase2_indexes),
+    ):
         inputs = inventory(records[verify_index], "inputs")
         for contribution_index in contribution_indexes:
             if not set(inventory(records[contribution_index], "outputs").items()).issubset(
                 set(inputs.items())
             ):
                 raise ValueError("Groth16 verifier did not consume every contribution")
-    for phase, verify_index in (("phase1", 4), ("phase2", 9)):
+    for phase, verify_index in (
+        ("phase1", phase1_verify_index),
+        ("phase2", finalize_index),
+    ):
         beacon = transcript.get(f"{phase}_beacon")
         if not isinstance(beacon, dict):
             raise ValueError(f"Groth16 {phase} beacon is missing")
@@ -94,11 +130,11 @@ def verify(transcript: dict[str, Any], root: Path, r1cs: Path) -> tuple[int, str
         transcript["phase1_beacon"].get("round", 0)
     ):
         raise ValueError("Groth16 Phase 2 beacon is not newer than Phase 1")
-    final_outputs = inventory(records[9], "outputs")
+    final_outputs = inventory(records[finalize_index], "outputs")
     for name in ("groth16_pk.bin", "groth16_vk.bin", "Groth16Verifier.sol"):
         if final_outputs.get(name) != sha256(root / name):
             raise ValueError(f"Groth16 final output mismatch: {name}")
-    return 3, r1cs_hash
+    return len(phase1_indexes), r1cs_hash
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- run the published minimum of two ephemeral contributions in each Groth16 MPC phase instead of three same-host rounds
- validate any equal Phase 1/Phase 2 contribution count of at least two
- preserve ordered hash-chain, R1CS, beacon, final-output, and actual-count evidence checks

## Why
The 67M-domain ceremony spends hours per sequential contribution. The release policy and manifest require at least two; a third contribution on the same isolated host adds no independent trust domain and delays every downstream proof, rehearsal, and deployment gate.

## Verification
- `bash -n scripts/run_open_competition_v2_groth16_ceremony.sh`
- 22 focused Beta2 release/setup/verifier tests pass
- no chain transaction or release flag change

Tracks #888. This is release orchestration, not deployment, funding, settlement, or payment evidence.