### PR TITLE
Buffer Beta2 ceremony transcript I/O

### DIFF
--- a/tools/open-competition-v2-ceremony/main.go
+++ b/tools/open-competition-v2-ceremony/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
@@ -20,6 +21,7 @@ import (
 )
 
 const schema = "agent-bounties/open-competition-v2-beta2-groth16-mpc-command-v1"
+const ioBufferSize = 16 << 20
 
 type record struct {
 	Schema         string   `json:"schema_version"`
@@ -323,7 +325,7 @@ func readFrom(path string, value io.ReaderFrom) error {
 		return err
 	}
 	defer file.Close()
-	_, err = value.ReadFrom(file)
+	_, err = value.ReadFrom(bufio.NewReaderSize(file, ioBufferSize))
 	return err
 }
 
@@ -339,8 +341,11 @@ func writeTo(path string, value io.WriterTo) error {
 		return err
 	}
 	defer file.Close()
-	_, err = value.WriteTo(file)
-	return err
+	writer := bufio.NewWriterSize(file, ioBufferSize)
+	if _, err = value.WriteTo(writer); err != nil {
+		return err
+	}
+	return writer.Flush()
 }
 
 func writeToExclusive(path string, value io.WriterTo) error {
@@ -355,8 +360,11 @@ func writeToExclusive(path string, value io.WriterTo) error {
 		return err
 	}
 	defer file.Close()
-	_, err = value.WriteTo(file)
-	return err
+	writer := bufio.NewWriterSize(file, ioBufferSize)
+	if _, err = value.WriteTo(writer); err != nil {
+		return err
+	}
+	return writer.Flush()
 }
 
 type dumpWriter interface {
@@ -375,7 +383,11 @@ func writeDumpExclusive(path string, value dumpWriter) error {
 		return err
 	}
 	defer file.Close()
-	return value.WriteDump(file)
+	writer := bufio.NewWriterSize(file, ioBufferSize)
+	if err := value.WriteDump(writer); err != nil {
+		return err
+	}
+	return writer.Flush()
 }
 
 func writeSolidity(path string, vk groth16.VerifyingKey) error {


### PR DESCRIPTION
## Summary

- wrap pinned Gnark transcript reads and writes in a 16 MiB buffer
- preserve the existing ReaderFrom/WriterTo serialization contract
- remove millions of tiny system calls from the 13 GiB Phase 1 path

## Evidence

- go test ./... passes for 	ools/open-competition-v2-ceremony
- the production ceremony image builds successfully
- the existing parallel-vs-sequential transcript equivalence test remains part of the image build
- no contract, metric, API, payment, identity, or contributor PR files change

## Maintainer Notice

Announced in #888 before editing. This is a release-liveness repair discovered from the live Beta2 ceremony. It does not authorize deployment or settlement by itself.