### PR TITLE
Parallelize Beta2 transcript decoding

### DIFF
--- a/ops/open-competition-v2-ceremony.Dockerfile
+++ b/ops/open-competition-v2-ceremony.Dockerfile
@@ -6,11 +6,12 @@ COPY phase1-parallel.patch phase1_parallel_test.go.txt /tmp/
 RUN module_dir="$(go env GOMODCACHE)/github.com/p4u/gnark@v0.0.0-20251217225531-cd7874155e26" \
     && chmod -R u+w "$module_dir" \
     && cd "$module_dir" \
-    && git apply /tmp/phase1-parallel.patch \
+    && git apply --unidiff-zero /tmp/phase1-parallel.patch \
     && cp /tmp/phase1_parallel_test.go.txt backend/groth16/bn254/mpcsetup/phase1_parallel_test.go \
-    && go test ./backend/groth16/bn254/mpcsetup -run TestParallelUpdateMatchesSequential -count=1
-COPY main.go ./
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /ceremony .
+    && go test ./backend/groth16/bn254/mpcsetup -run 'TestParallel(UpdateMatchesSequential|CompressedRead)' -count=1
+COPY main.go main_test.go ./
+RUN go test ./... -count=1 \
+    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /ceremony .
 
 FROM scratch
 COPY --from=build /ceremony /ceremony

--- a/tools/open-competition-v2-ceremony/phase1-parallel.patch
+++ b/tools/open-competition-v2-ceremony/phase1-parallel.patch
@@ -1,18 +1,116 @@
+diff --git a/backend/groth16/bn254/mpcsetup/marshal.go b/backend/groth16/bn254/mpcsetup/marshal.go
+index 23642e06..f34da87c 100644
+--- a/backend/groth16/bn254/mpcsetup/marshal.go
++++ b/backend/groth16/bn254/mpcsetup/marshal.go
+@@ -9,0 +10 @@ import (
++	"errors"
+@@ -10,0 +12 @@ import (
++	"sync/atomic"
+@@ -45 +46,0 @@ func (p *Phase1) ReadFrom(reader io.Reader) (n int64, err error) {
+-		&p.parameters,
+@@ -53,0 +55,6 @@ func (p *Phase1) ReadFrom(reader io.Reader) (n int64, err error) {
++	dn, err = p.parameters.readFromParallelCompressed(reader)
++	n += dn
++	if err != nil {
++		return
++	}
++
+@@ -58,0 +66,88 @@ func (p *Phase1) ReadFrom(reader io.Reader) (n int64, err error) {
++func (c *SrsCommons) readFromParallelCompressed(reader io.Reader) (n int64, err error) {
++	var domain uint64
++	if err = binary.Read(reader, binary.BigEndian, &domain); err != nil {
++		return -1, err
++	}
++	n = 8
++	if domain == 0 || domain&(domain-1) != 0 || domain > 1<<27 {
++		return n, errors.New("invalid Phase 1 domain")
++	}
++
++	c.setContributionsZero(domain)
++	g1Count := 4*domain - 2
++	g2Count := domain
++	encodedBytes := g1Count*curve.SizeOfG1AffineCompressed + g2Count*curve.SizeOfG2AffineCompressed
++	raw := make([]byte, int(encodedBytes))
++	read, readErr := io.ReadFull(reader, raw)
++	n += int64(read)
++	if readErr != nil {
++		return n, readErr
++	}
++
++	offset := 0
++	decodeG1 := func(points []curve.G1Affine) error {
++		if len(points) == 0 {
++			return nil
++		}
++		startOffset := offset
++		offset += len(points) * curve.SizeOfG1AffineCompressed
++		var invalid atomic.Uint64
++		utils.Parallelize(len(points), func(start, end int) {
++			for i := start; i < end; i++ {
++				pointOffset := startOffset + i*curve.SizeOfG1AffineCompressed
++				consumed, pointErr := points[i].SetBytes(raw[pointOffset : pointOffset+curve.SizeOfG1AffineCompressed])
++				if pointErr != nil || consumed != curve.SizeOfG1AffineCompressed {
++					invalid.Add(1)
++				}
++			}
++		})
++		if invalid.Load() != 0 {
++			return errors.New("G1 point decompression failed")
++		}
++		return nil
++	}
++	decodeG2 := func(points []curve.G2Affine) error {
++		if len(points) == 0 {
++			return nil
++		}
++		startOffset := offset
++		offset += len(points) * curve.SizeOfG2AffineCompressed
++		var invalid atomic.Uint64
++		utils.Parallelize(len(points), func(start, end int) {
++			for i := start; i < end; i++ {
++				pointOffset := startOffset + i*curve.SizeOfG2AffineCompressed
++				consumed, pointErr := points[i].SetBytes(raw[pointOffset : pointOffset+curve.SizeOfG2AffineCompressed])
++				if pointErr != nil || consumed != curve.SizeOfG2AffineCompressed {
++					invalid.Add(1)
++				}
++			}
++		})
++		if invalid.Load() != 0 {
++			return errors.New("G2 point decompression failed")
++		}
++		return nil
++	}
++
++	beta := []curve.G2Affine{c.G2.Beta}
++	if err = decodeG2(beta); err != nil {
++		return n, err
++	}
++	c.G2.Beta = beta[0]
++	if err = decodeG1(c.G1.Tau[1:]); err != nil {
++		return n, err
++	}
++	if err = decodeG2(c.G2.Tau[1:]); err != nil {
++		return n, err
++	}
++	if err = decodeG1(c.G1.BetaTau); err != nil {
++		return n, err
++	}
++	if err = decodeG1(c.G1.AlphaTau); err != nil {
++		return n, err
++	}
++	if offset != len(raw) {
++		return n, errors.New("Phase 1 transcript length mismatch")
++	}
++	return n, nil
++}
++
 diff --git a/backend/groth16/bn254/mpcsetup/phase1.go b/backend/groth16/bn254/mpcsetup/phase1.go
+index 3f08b2cd..8186824a 100644
 --- a/backend/groth16/bn254/mpcsetup/phase1.go
 +++ b/backend/groth16/bn254/mpcsetup/phase1.go
-@@ -17,6 +17,7 @@ import (
- 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
- 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
- 	"github.com/consensys/gnark-crypto/ecc/bn254/mpcsetup"
+@@ -18,0 +19 @@ import (
 +	"github.com/consensys/gnark/internal/utils"
- )
- 
- // SrsCommons are the circuit-independent components of the Groth16 SRS,
-@@ -105,37 +106,48 @@ func (c *SrsCommons) update(tauUpdate, alphaUpdate, betaUpdate *fr.Element) {
- 	c.G1.BetaTau[0].ScalarMultiplication(&c.G1.BetaTau[0], &coeff)
- 	c.G2.Beta.ScalarMultiplication(&c.G2.Beta, &coeff)
- 
+@@ -116,31 +117,42 @@ func (c *SrsCommons) update(tauUpdate, alphaUpdate, betaUpdate *fr.Element) {
 -	// update all values from 1 to N-1
 -	tauPowI := *tauUpdate
 -	for i := 1; i < len(c.G2.Tau); i++ {
@@ -86,6 +184,3 @@ diff --git a/backend/groth16/bn254/mpcsetup/phase1.go b/backend/groth16/bn254/mp
 +			tauPowI.Mul(&tauPowI, tauUpdate)
 +		}
 +	})
- }
- 
- // Seal performs the final contribution and outputs the final parameters.

--- a/tools/open-competition-v2-ceremony/phase1_parallel_test.go.txt
+++ b/tools/open-competition-v2-ceremony/phase1_parallel_test.go.txt
@@ -3,11 +3,13 @@ package mpcsetup
 
 import (
 	"bytes"
+	"io"
 	"math/big"
 	"testing"
 
 	curve "github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	gIo "github.com/consensys/gnark/io"
 )
 
 func clonePhase1(t *testing.T, source *Phase1) *Phase1 {
@@ -74,6 +76,87 @@ func TestParallelUpdateMatchesSequential(t *testing.T) {
 			assertSamePoints(t, parallel.parameters.G1.Tau, sequential.parameters.G1.Tau)
 		})
 	}
+}
+
+func TestParallelCompressedReadMatchesCanonicalRead(t *testing.T) {
+	for _, domain := range []uint64{1, 2, 16, 64} {
+		t.Run(new(big.Int).SetUint64(domain).String(), func(t *testing.T) {
+			source := new(Phase1)
+			source.Initialize(domain)
+			var encoded bytes.Buffer
+			if _, err := source.WriteTo(&encoded); err != nil {
+				t.Fatal(err)
+			}
+
+			canonical := new(Phase1)
+			if _, err := readPhase1Canonical(canonical, bytes.NewReader(encoded.Bytes())); err != nil {
+				t.Fatal(err)
+			}
+			parallel := new(Phase1)
+			if _, err := parallel.ReadFrom(bytes.NewReader(encoded.Bytes())); err != nil {
+				t.Fatal(err)
+			}
+
+			var canonicalBytes, parallelBytes bytes.Buffer
+			if _, err := canonical.WriteTo(&canonicalBytes); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := parallel.WriteTo(&parallelBytes); err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(canonicalBytes.Bytes(), parallelBytes.Bytes()) {
+				t.Fatal("parallel reader changed the canonical transcript")
+			}
+		})
+	}
+}
+
+func TestParallelCompressedReadRejectsMalformedPoint(t *testing.T) {
+	source := new(Phase1)
+	source.Initialize(2)
+	var encoded bytes.Buffer
+	if _, err := source.WriteTo(&encoded); err != nil {
+		t.Fatal(err)
+	}
+	malformed := append([]byte(nil), encoded.Bytes()...)
+
+	// Locate the parameter encoding by serializing the three update proofs.
+	var proofs bytes.Buffer
+	if _, err := source.proofs.Tau.WriteTo(&proofs); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.proofs.Alpha.WriteTo(&proofs); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.proofs.Beta.WriteTo(&proofs); err != nil {
+		t.Fatal(err)
+	}
+	firstPoint := proofs.Len() + 8
+	malformed[firstPoint] &^= 0xc0
+
+	decoded := new(Phase1)
+	if _, err := decoded.ReadFrom(bytes.NewReader(malformed)); err == nil {
+		t.Fatal("malformed compressed point was accepted")
+	}
+}
+
+func readPhase1Canonical(p *Phase1, reader io.Reader) (n int64, err error) {
+	var dn int64
+	for _, value := range []io.ReaderFrom{
+		&p.proofs.Tau,
+		&p.proofs.Alpha,
+		&p.proofs.Beta,
+		&p.parameters,
+	} {
+		dn, err = value.ReadFrom(reader)
+		n += dn
+		if err != nil {
+			return
+		}
+	}
+	challenge, dn, err := gIo.ReadBytesShort(reader)
+	p.Challenge = challenge
+	return n + dn, err
 }
 
 func assertSamePoints(t *testing.T, left, right []curve.G1Affine) {


### PR DESCRIPTION
## Summary
- preserve canonical compressed Phase1 encoding while parallelizing checked point decoding
- retain curve and subgroup validation and bound accepted ceremony domains
- use the fast reader for contributions and final verification
- prove byte-for-byte serial equivalence and malformed-point rejection

## Evidence
- Docker build and injected Gnark tests pass
- ceremony package tests pass
- full 12,884,902,121-byte host read completed in under 33 seconds before checked parallel decoding; the old reader had consumed 2.6 GB after 22 minutes
- scripts/preflight.ps1 -Mode core passes
- git diff --check passes

## Scope
Ceremony infrastructure only. No contract, circuit, vkey, API, payment, inventory, or contributor workflow changes.