### PR TITLE
Fix Beta3 ceremony Python portability

### DIFF
--- a/scripts/run_open_competition_v2_groth16_ceremony.sh
+++ b/scripts/run_open_competition_v2_groth16_ceremony.sh
@@ -25,6 +25,7 @@ cp --reflink=auto "$r1cs" "$output_dir/groth16_circuit.bin"
 
 container() {
   docker run --rm --network none --read-only \
+    --user "$(id -u):$(id -g)" \
     -v "$output_dir:/data" \
     -v "$r1cs:/inputs/groth16_circuit.bin:ro" \
     "$OPEN_COMPETITION_V2_CEREMONY_IMAGE" "$@"

--- a/scripts/run_open_competition_v2_groth16_ceremony.sh
+++ b/scripts/run_open_competition_v2_groth16_ceremony.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 : "${OPEN_COMPETITION_V2_CEREMONY_IMAGE:?set the digest-pinned ceremony image}"
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 is required to run the ceremony" >&2
+  exit 127
+}
 
 if [[ $# -ne 3 ]]; then
   echo "usage: $0 OUTPUT_DIR R1CS SAFE_V5_REFERENCE_WRAPPER" >&2
@@ -30,7 +34,7 @@ fetch_beacon() {
   local destination="$1"
   curl --fail --silent --show-error --proto '=https' --tlsv1.2 \
     https://api.drand.sh/public/latest -o "$destination"
-  python - "$destination" <<'PY'
+  python3 - "$destination" <<'PY'
 import json, re, sys
 value = json.load(open(sys.argv[1], encoding="utf-8"))
 randomness = value.get("randomness", "")
@@ -69,11 +73,11 @@ container finalize --r1cs /inputs/groth16_circuit.bin --commons /data/phase1-com
   --beacon "$phase2_beacon" --pk /data/groth16_pk.bin --vk /data/groth16_vk.bin \
   --solidity /data/Groth16Verifier.sol | tee "$output_dir/10-finalize.json"
 
-python scripts/rebind_open_competition_v2_sp1_wrapper.py \
+python3 scripts/rebind_open_competition_v2_sp1_wrapper.py \
   --reference "$reference" --verifying-key "$output_dir/groth16_vk.bin" \
   --proof-system groth16 --output "$output_dir/SP1VerifierGroth16.sol" \
   | tee "$output_dir/verifier-hash.txt"
-python - "$output_dir" "$r1cs" <<'PY'
+python3 - "$output_dir" "$r1cs" <<'PY'
 import json, pathlib, sys
 root = pathlib.Path(sys.argv[1])
 records = []
@@ -88,7 +92,7 @@ value = {
 }
 (root / "transcript.json").write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
 PY
-python scripts/verify_open_competition_v2_groth16_ceremony.py \
+python3 scripts/verify_open_competition_v2_groth16_ceremony.py \
   --root "$output_dir" --r1cs "$r1cs" \
   --ceremony-uri https://github.com/NSPG13/agent-bounties/issues/888 \
   --output "$output_dir/verification-evidence.json"

--- a/scripts/test_verify_open_competition_v2_groth16_ceremony.py
+++ b/scripts/test_verify_open_competition_v2_groth16_ceremony.py
@@ -20,6 +20,12 @@ class Groth16CeremonyTests(unittest.TestCase):
         self.assertIn(copy, source)
         self.assertLess(source.index(copy), source.index("container init-phase1"))
 
+    def test_runner_requires_the_portable_python3_command(self) -> None:
+        source = RUNNER.read_text(encoding="utf-8")
+        self.assertIn("command -v python3", source)
+        self.assertNotIn("\npython ", source)
+        self.assertNotIn("  python -", source)
+
     def test_inventory_rejects_ambiguous_or_invalid_entries(self) -> None:
         with self.assertRaisesRegex(ValueError, "ambiguous"):
             MODULE.inventory(

--- a/scripts/test_verify_open_competition_v2_groth16_ceremony.py
+++ b/scripts/test_verify_open_competition_v2_groth16_ceremony.py
@@ -26,6 +26,10 @@ class Groth16CeremonyTests(unittest.TestCase):
         self.assertNotIn("\npython ", source)
         self.assertNotIn("  python -", source)
 
+    def test_container_outputs_use_the_host_runner_identity(self) -> None:
+        source = RUNNER.read_text(encoding="utf-8")
+        self.assertIn('--user "$(id -u):$(id -g)"', source)
+
     def test_inventory_rejects_ambiguous_or_invalid_entries(self) -> None:
         with self.assertRaisesRegex(ValueError, "ambiguous"):
             MODULE.inventory(


### PR DESCRIPTION
## Summary
- require the portable python3 command before ceremony work begins
- use python3 for beacon parsing, wrapper rebinding, transcript generation, and evidence verification
- add a regression assertion that the runner never relies on a python alias

## Incident
The clean proving host completed and verified both Phase 1 contributions, then stopped because it has python3 but no python alias. The checkpoint is preserved and will be resumed after this fix.

## Verification
- python -m unittest scripts.test_verify_open_competition_v2_groth16_ceremony -v`n- ash -n scripts/run_open_competition_v2_groth16_ceremony.sh`n- git diff --check`n
Relates to #888.