### PR TITLE
Verify Beta3 PLONK setup by independent replay

### DIFF
--- a/scripts/replay_open_competition_v2_plonk_setup.py
+++ b/scripts/replay_open_competition_v2_plonk_setup.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 from pathlib import Path
+import shutil
 import subprocess
 import tempfile
 
@@ -24,6 +26,7 @@ def main() -> int:
     parser.add_argument("--sp1-source-commit", required=True)
     parser.add_argument("--expected-srs", type=Path, required=True)
     parser.add_argument("--replayed-srs", type=Path, required=True)
+    parser.add_argument("--manifest-output", type=Path, required=True)
     parser.add_argument("--log", type=Path, required=True)
     args = parser.parse_args()
 
@@ -40,6 +43,7 @@ def main() -> int:
         raise SystemExit(f"expected SRS is missing: {args.expected_srs}")
 
     args.replayed_srs.parent.mkdir(parents=True, exist_ok=True)
+    args.manifest_output.parent.mkdir(parents=True, exist_ok=True)
     args.log.parent.mkdir(parents=True, exist_ok=True)
     args.replayed_srs.unlink(missing_ok=True)
     helper = """package main
@@ -77,6 +81,12 @@ func main() {
             status = process.wait()
             if status != 0:
                 raise SystemExit(f"PLONK setup replay failed with exit code {status}")
+
+    cached_manifest = module_root / "data" / "MAIN IGNITION" / "manifest.json"
+    manifest = json.loads(cached_manifest.read_text(encoding="utf-8"))
+    if manifest.get("name") != "MAIN IGNITION" or not isinstance(manifest.get("participants"), list):
+        raise SystemExit("replayed PLONK setup did not preserve a valid MAIN IGNITION manifest")
+    shutil.copyfile(cached_manifest, args.manifest_output)
 
     expected_hash = sha256(args.expected_srs)
     replayed_hash = sha256(args.replayed_srs)

--- a/scripts/replay_open_competition_v2_plonk_setup.py
+++ b/scripts/replay_open_competition_v2_plonk_setup.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Replay the pinned Aztec Ignition chain and reproduce the PLONK SRS."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sp1-root", type=Path, required=True)
+    parser.add_argument("--sp1-source-commit", required=True)
+    parser.add_argument("--expected-srs", type=Path, required=True)
+    parser.add_argument("--replayed-srs", type=Path, required=True)
+    parser.add_argument("--log", type=Path, required=True)
+    args = parser.parse_args()
+
+    sp1_root = args.sp1_root.resolve()
+    module_root = sp1_root / "crates" / "recursion" / "gnark-ffi" / "go"
+    actual_commit = subprocess.check_output(
+        ["git", "-C", str(sp1_root), "rev-parse", "HEAD"], text=True
+    ).strip()
+    if actual_commit != args.sp1_source_commit:
+        raise SystemExit(
+            f"SP1 source commit mismatch: expected {args.sp1_source_commit}, got {actual_commit}"
+        )
+    if not args.expected_srs.is_file():
+        raise SystemExit(f"expected SRS is missing: {args.expected_srs}")
+
+    args.replayed_srs.parent.mkdir(parents=True, exist_ok=True)
+    args.log.parent.mkdir(parents=True, exist_ok=True)
+    args.replayed_srs.unlink(missing_ok=True)
+    helper = """package main
+
+import (
+    "os"
+
+    "github.com/succinctlabs/sp1-recursion-gnark/sp1/trusted_setup"
+)
+
+func main() {
+    if len(os.Args) != 2 {
+        panic("expected output path")
+    }
+    trusted_setup.DownloadAndSaveAztecIgnitionSrs(174, os.Args[1])
+}
+"""
+    with tempfile.TemporaryDirectory(prefix="agent-bounties-plonk-replay-") as directory:
+        helper_path = Path(directory) / "main.go"
+        helper_path.write_text(helper, encoding="utf-8")
+        with args.log.open("w", encoding="utf-8") as log:
+            process = subprocess.Popen(
+                ["go", "run", str(helper_path), str(args.replayed_srs.resolve())],
+                cwd=module_root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            assert process.stdout is not None
+            for line in process.stdout:
+                print(line, end="", flush=True)
+                log.write(line)
+                log.flush()
+            status = process.wait()
+            if status != 0:
+                raise SystemExit(f"PLONK setup replay failed with exit code {status}")
+
+    expected_hash = sha256(args.expected_srs)
+    replayed_hash = sha256(args.replayed_srs)
+    if replayed_hash != expected_hash:
+        raise SystemExit(
+            f"PLONK SRS mismatch: expected {expected_hash}, replayed {replayed_hash}"
+        )
+    print(f"replayed_srs_sha256={replayed_hash}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_verify_open_competition_v2_plonk_setup.py
+++ b/scripts/test_verify_open_competition_v2_plonk_setup.py
@@ -13,15 +13,27 @@ SPEC.loader.exec_module(MODULE)
 
 class PlonkSetupTests(unittest.TestCase):
     def test_requires_chain_and_kzg_success(self) -> None:
-        log = "processing contribution 176\nsuccess ✅: all contributions are valid\nsuccess ✅: kzg sanity check with SRS"
-        final, count = MODULE.contribution_count(log)
+        manifest = {"name": "MAIN IGNITION", "participants": [{}] * 176}
+        log = "success ✅: all contributions are valid\nsuccess ✅: kzg sanity check with SRS"
+        final, count = MODULE.contribution_count(log, manifest)
         self.assertEqual((final, count), (176, 2))
-        for invalid in (
-            "processing contribution 176\nsuccess ✅: all contributions are valid",
-            "processing contribution 175\nsuccess ✅: all contributions are valid\nsuccess ✅: kzg sanity check with SRS",
+        for invalid_log, invalid_manifest in (
+            ("success ✅: all contributions are valid", manifest),
+            (log, {"name": "MAIN IGNITION", "participants": [{}] * 175}),
+            ("processing contribution 176\n" + log, manifest),
+            (log, {"name": "TINY_TEST_5", "participants": [{}] * 176}),
         ):
             with self.assertRaises(ValueError):
-                MODULE.contribution_count(invalid)
+                MODULE.contribution_count(invalid_log, invalid_manifest)
+
+    def test_matches_manifest_entries_after_initial_pair(self) -> None:
+        manifest = {"name": "MAIN IGNITION", "participants": [{}] * 178}
+        log = (
+            "processing contribution 177\nprocessing contribution 178\n"
+            "success ✅: all contributions are valid\n"
+            "success ✅: kzg sanity check with SRS"
+        )
+        self.assertEqual(MODULE.contribution_count(log, manifest), (178, 4))
 
     def test_pins_safe_source_branches(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_verify_open_competition_v2_plonk_setup.py
+++ b/scripts/test_verify_open_competition_v2_plonk_setup.py
@@ -34,14 +34,44 @@ class PlonkSetupTests(unittest.TestCase):
             )
             setup.write_text(
                 'BaseURL:  "https://aztec-ignition.s3.amazonaws.com/"\n'
-                'Ceremony: "MAIN IGNITION"\nif !next.Follows(&current)\nsanityCheck(&srs)',
+                'Ceremony: "MAIN IGNITION"\nif !next.Follows(&current)\n'
+                'if !next.Follows(&current)\nsanityCheck(&srs)',
                 encoding="utf-8",
             )
             value = MODULE.verify_source(build, setup)
             self.assertRegex(value["build_go_sha256"], r"^[0-9a-f]{64}$")
             setup.write_text(setup.read_text().replace("MAIN IGNITION", "TINY_TEST_5"))
-            with self.assertRaisesRegex(ValueError, "lacks exact fragment"):
+            with self.assertRaisesRegex(ValueError, "requires 1 exact occurrences"):
                 MODULE.verify_source(build, setup)
+
+    def test_requires_both_chain_guards(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            build = root / "build.go"
+            setup = root / "trusted_setup.go"
+            build.write_text(
+                'DownloadAndSaveAztecIgnitionSrs(174, srsFileName)\nif !strings.Contains(dataDir, "dev")',
+                encoding="utf-8",
+            )
+            setup.write_text(
+                'BaseURL:  "https://aztec-ignition.s3.amazonaws.com/"\n'
+                'Ceremony: "MAIN IGNITION"\nif !next.Follows(&current)\nsanityCheck(&srs)',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "requires 2 exact occurrences"):
+                MODULE.verify_source(build, setup)
+
+    def test_replayed_srs_must_match_build_srs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            expected = root / "expected.bin"
+            replayed = root / "replayed.bin"
+            expected.write_bytes(b"canonical-srs")
+            replayed.write_bytes(b"canonical-srs")
+            self.assertEqual(MODULE.require_matching_srs(expected, replayed), MODULE.sha256(expected))
+            replayed.write_bytes(b"different-srs")
+            with self.assertRaisesRegex(ValueError, "differs from the build SRS"):
+                MODULE.require_matching_srs(expected, replayed)
 
 
 if __name__ == "__main__":

--- a/scripts/verify_open_competition_v2_plonk_setup.py
+++ b/scripts/verify_open_competition_v2_plonk_setup.py
@@ -16,7 +16,19 @@ START_INDEX = 174
 
 
 def sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_matching_srs(expected: Path, replayed: Path) -> str:
+    expected_hash = sha256(expected)
+    replayed_hash = sha256(replayed)
+    if replayed_hash != expected_hash:
+        raise ValueError("independently replayed PLONK SRS differs from the build SRS")
+    return replayed_hash
 
 
 def verify_source(build_go: Path, trusted_setup_go: Path) -> dict[str, str]:
@@ -26,18 +38,20 @@ def verify_source(build_go: Path, trusted_setup_go: Path) -> dict[str, str]:
         'DownloadAndSaveAztecIgnitionSrs(174, srsFileName)',
         'if !strings.Contains(dataDir, "dev")',
     )
-    required_setup = (
-        'BaseURL:  "https://aztec-ignition.s3.amazonaws.com/"',
-        'Ceremony: "MAIN IGNITION"',
-        'if !next.Follows(&current)',
-        'sanityCheck(&srs)',
-    )
+    required_setup = {
+        'BaseURL:  "https://aztec-ignition.s3.amazonaws.com/"': 1,
+        'Ceremony: "MAIN IGNITION"': 1,
+        'if !next.Follows(&current)': 2,
+        'sanityCheck(&srs)': 1,
+    }
     for fragment in required_build:
         if build.count(fragment) != 1:
             raise ValueError(f"PLONK build source lacks exact fragment: {fragment}")
-    for fragment in required_setup:
-        if setup.count(fragment) != 1:
-            raise ValueError(f"PLONK setup source lacks exact fragment: {fragment}")
+    for fragment, expected_count in required_setup.items():
+        if setup.count(fragment) != expected_count:
+            raise ValueError(
+                f"PLONK setup source requires {expected_count} exact occurrences: {fragment}"
+            )
     return {"build_go_sha256": sha256(build_go), "trusted_setup_go_sha256": sha256(trusted_setup_go)}
 
 
@@ -61,6 +75,8 @@ def main() -> int:
     parser.add_argument("--sp1-build-source", type=Path, required=True)
     parser.add_argument("--sp1-trusted-setup-source", type=Path, required=True)
     parser.add_argument("--build-log", type=Path, required=True)
+    parser.add_argument("--setup-replay-log", type=Path, required=True)
+    parser.add_argument("--replayed-srs", type=Path, required=True)
     parser.add_argument("--build-dir", type=Path, required=True)
     parser.add_argument("--transcript-output", type=Path, required=True)
     parser.add_argument("--evidence-output", type=Path, required=True)
@@ -68,8 +84,8 @@ def main() -> int:
     if "dev" in str(args.build_dir).lower():
         raise SystemExit("PLONK build directory selects SP1's unsafe dev setup path")
     source_hashes = verify_source(args.sp1_build_source, args.sp1_trusted_setup_source)
-    log = args.build_log.read_text(encoding="utf-8")
-    final_number, count = contribution_count(log)
+    setup_log = args.setup_replay_log.read_text(encoding="utf-8")
+    final_number, count = contribution_count(setup_log)
     files = {
         "constraint_system": args.build_dir / "plonk_circuit.bin",
         "proving_key": args.build_dir / "plonk_pk.bin",
@@ -78,6 +94,7 @@ def main() -> int:
         "srs_lagrange": args.build_dir / "srs_lagrange.bin",
     }
     hashes = {f"{name}_sha256": sha256(path) for name, path in files.items()}
+    replayed_srs_sha256 = require_matching_srs(files["srs"], args.replayed_srs)
     transcript = {
         "schema_version": TRANSCRIPT_SCHEMA,
         "ceremony": "MAIN IGNITION",
@@ -86,6 +103,8 @@ def main() -> int:
         "final_contribution_number": final_number,
         "contribution_count": count,
         "build_log_sha256": sha256(args.build_log),
+        "setup_replay_log_sha256": sha256(args.setup_replay_log),
+        "replayed_srs_sha256": replayed_srs_sha256,
         **source_hashes,
         "srs_sha256": hashes["srs_sha256"],
         "srs_lagrange_sha256": hashes["srs_lagrange_sha256"],

--- a/scripts/verify_open_competition_v2_plonk_setup.py
+++ b/scripts/verify_open_competition_v2_plonk_setup.py
@@ -55,19 +55,25 @@ def verify_source(build_go: Path, trusted_setup_go: Path) -> dict[str, str]:
     return {"build_go_sha256": sha256(build_go), "trusted_setup_go_sha256": sha256(trusted_setup_go)}
 
 
-def contribution_count(log: str) -> tuple[int, int]:
+def contribution_count(log: str, manifest: dict) -> tuple[int, int]:
     if "success ✅: all contributions are valid" not in log:
         raise ValueError("PLONK setup log lacks contribution-chain success")
     if "success ✅: kzg sanity check with SRS" not in log:
         raise ValueError("PLONK setup log lacks KZG sanity-check success")
-    processed = [int(value) for value in re.findall(r"processing contribution\s+(\d+)", log)]
-    if not processed:
-        raise ValueError("PLONK setup log has no processed contribution inventory")
-    final_number = max(processed)
-    count = final_number - START_INDEX
+    if manifest.get("name") != "MAIN IGNITION":
+        raise ValueError("PLONK setup manifest is not MAIN IGNITION")
+    participants = manifest.get("participants")
+    if not isinstance(participants, list):
+        raise ValueError("PLONK setup manifest lacks participant inventory")
+    participant_count = len(participants)
+    count = participant_count - START_INDEX
     if count < 2:
         raise ValueError("PLONK setup evidence has fewer than two contributions")
-    return final_number, count
+    processed = [int(value) for value in re.findall(r"processing contribution\s+(\d+)", log)]
+    expected_processed = list(range(START_INDEX + 3, participant_count + 1))
+    if processed != expected_processed:
+        raise ValueError("PLONK setup log does not match manifest contribution inventory")
+    return participant_count, count
 
 
 def main() -> int:
@@ -76,6 +82,7 @@ def main() -> int:
     parser.add_argument("--sp1-trusted-setup-source", type=Path, required=True)
     parser.add_argument("--build-log", type=Path, required=True)
     parser.add_argument("--setup-replay-log", type=Path, required=True)
+    parser.add_argument("--setup-manifest", type=Path, required=True)
     parser.add_argument("--replayed-srs", type=Path, required=True)
     parser.add_argument("--build-dir", type=Path, required=True)
     parser.add_argument("--transcript-output", type=Path, required=True)
@@ -85,7 +92,8 @@ def main() -> int:
         raise SystemExit("PLONK build directory selects SP1's unsafe dev setup path")
     source_hashes = verify_source(args.sp1_build_source, args.sp1_trusted_setup_source)
     setup_log = args.setup_replay_log.read_text(encoding="utf-8")
-    final_number, count = contribution_count(setup_log)
+    setup_manifest = json.loads(args.setup_manifest.read_text(encoding="utf-8"))
+    final_number, count = contribution_count(setup_log, setup_manifest)
     files = {
         "constraint_system": args.build_dir / "plonk_circuit.bin",
         "proving_key": args.build_dir / "plonk_pk.bin",
@@ -104,6 +112,7 @@ def main() -> int:
         "contribution_count": count,
         "build_log_sha256": sha256(args.build_log),
         "setup_replay_log_sha256": sha256(args.setup_replay_log),
+        "setup_manifest_sha256": sha256(args.setup_manifest),
         "replayed_srs_sha256": replayed_srs_sha256,
         **source_hashes,
         "srs_sha256": hashes["srs_sha256"],


### PR DESCRIPTION
## Summary
- pin both trusted-source contribution-chain guards
- replay the public Aztec Ignition setup independently and reproduce the SRS
- require the replayed SRS hash to match the SRS used for PLONK keys
- bind the original build log and replay transcript into release evidence

This changes provenance tooling only. It does not change contracts, SP1 source or circuit identity, ELF, vkey, verifier bytecode, or payment behavior.

## Verification
- scripts/preflight.ps1 -Mode core
- python -m unittest discover -s scripts -p test_*open_competition_v2*.py (102 passed)
- python -m py_compile for both provenance scripts
- git diff --check