### PR TITLE
Make Beta3 Groth16 Phase 2 recovery reproducible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 *.sh text eol=lf
 *.sol text eol=lf
+*.patch text eol=lf
+*.go.txt text eol=lf
 benchmarks/** text eol=lf

--- a/scripts/continue_open_competition_v2_groth16_phase2.sh
+++ b/scripts/continue_open_competition_v2_groth16_phase2.sh
@@ -2,26 +2,28 @@
 set -euo pipefail
 
 : "${OPEN_COMPETITION_V2_CEREMONY_IMAGE:?set the digest-pinned ceremony image}"
-command -v python3 >/dev/null 2>&1 || {
-  echo "python3 is required to run the ceremony" >&2
-  exit 127
-}
+: "${OPEN_COMPETITION_V2_R1CS_SHA256:?set the pinned R1CS hash}"
+: "${OPEN_COMPETITION_V2_PHASE1_1_SHA256:?set the pinned first contribution hash}"
+: "${OPEN_COMPETITION_V2_PHASE1_2_SHA256:?set the pinned second contribution hash}"
+: "${OPEN_COMPETITION_V2_PHASE1_COMMONS_SHA256:?set the pinned commons hash}"
+: "${OPEN_COMPETITION_V2_PHASE1_BEACON:?set the pinned Phase 1 beacon}"
 
-if [[ $# -ne 3 ]]; then
-  echo "usage: $0 OUTPUT_DIR R1CS SAFE_V5_REFERENCE_WRAPPER" >&2
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 OUTPUT_DIR R1CS SAFE_REFERENCE_WRAPPER REPOSITORY" >&2
   exit 2
 fi
-
-output_dir="$(mkdir -p "$1" && cd "$1" && pwd)"
+output_dir="$(cd "$1" && pwd)"
 r1cs="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 reference="$(cd "$(dirname "$3")" && pwd)/$(basename "$3")"
-test -f "$r1cs"
-test -f "$reference"
-if find "$output_dir" -mindepth 1 -print -quit | grep -q .; then
-  echo "ceremony output directory must be empty: $output_dir" >&2
-  exit 2
-fi
-cp --reflink=auto "$r1cs" "$output_dir/groth16_circuit.bin"
+repo="$(cd "$4" && pwd)"
+
+python3 "$repo/scripts/verify_open_competition_v2_groth16_phase1_checkpoint.py" \
+  --root "$output_dir" --r1cs "$r1cs" \
+  --r1cs-sha256 "$OPEN_COMPETITION_V2_R1CS_SHA256" \
+  --phase1-1-sha256 "$OPEN_COMPETITION_V2_PHASE1_1_SHA256" \
+  --phase1-2-sha256 "$OPEN_COMPETITION_V2_PHASE1_2_SHA256" \
+  --commons-sha256 "$OPEN_COMPETITION_V2_PHASE1_COMMONS_SHA256" \
+  --beacon "$OPEN_COMPETITION_V2_PHASE1_BEACON"
 
 container() {
   docker run --rm --network none --read-only \
@@ -30,7 +32,6 @@ container() {
     -v "$r1cs:/inputs/groth16_circuit.bin:ro" \
     "$OPEN_COMPETITION_V2_CEREMONY_IMAGE" "$@"
 }
-
 fetch_beacon() {
   local destination="$1"
   local baseline="$destination.baseline"
@@ -72,19 +73,13 @@ PY
   return 1
 }
 
-container init-phase1 --r1cs /inputs/groth16_circuit.bin --output /data/phase1-init.bin \
-  | tee "$output_dir/01-phase1-init.json"
-for id in 1 2; do
-  previous="phase1-init.bin"
-  if (( id > 1 )); then previous="phase1-$((id - 1)).bin"; fi
-  container contribute-phase1 --input "/data/$previous" --output "/data/phase1-$id.bin" \
-    --contribution-id "$id" | tee "$output_dir/0$((id + 1))-phase1-$id.json"
-done
-phase1_beacon="$(fetch_beacon "$output_dir/phase1-beacon.json")"
-container verify-phase1 --r1cs /inputs/groth16_circuit.bin \
-  --inputs /data/phase1-1.bin,/data/phase1-2.bin \
-  --beacon "$phase1_beacon" --output /data/phase1-commons.bin \
-  | tee "$output_dir/05-phase1-verify.json"
+rm -f "$output_dir"/phase2-*.bin "$output_dir"/0{6,7,8}-phase2-*.json \
+  "$output_dir/phase2-beacon.json" "$output_dir/10-finalize.json" \
+  "$output_dir/groth16_pk.bin" "$output_dir/groth16_vk.bin" \
+  "$output_dir/Groth16Verifier.sol" "$output_dir/SP1VerifierGroth16.sol" \
+  "$output_dir/transcript.json" "$output_dir/verification-evidence.json" \
+  "$output_dir/verifier-hash.txt" "$output_dir/phase2-finalize.ready" \
+  "$output_dir/complete"
 
 coordinator_pid=""
 stop_coordinator() {
@@ -111,10 +106,11 @@ while [[ ! -s "$output_dir/06-phase2-init.json" ]]; do
   sleep 5
 done
 for id in 1 2; do
-  previous="phase2-init.bin"
+  previous=phase2-init.bin
   if (( id > 1 )); then previous="phase2-$((id - 1)).bin"; fi
-  container contribute-phase2 --input "/data/$previous" --output "/data/phase2-$id.bin" \
-    --contribution-id "$id" | tee "$output_dir/0$((id + 6))-phase2-$id.json"
+  container contribute-phase2 --input "/data/$previous" \
+    --output "/data/phase2-$id.bin" --contribution-id "$id" \
+    | tee "$output_dir/0$((id + 6))-phase2-$id.json"
 done
 fetch_beacon "$output_dir/phase2-beacon.json" >/dev/null
 touch "$output_dir/phase2-finalize.ready"
@@ -122,6 +118,7 @@ wait "$coordinator_pid"
 coordinator_pid=""
 trap - EXIT
 
+cd "$repo"
 python3 scripts/rebind_open_competition_v2_sp1_wrapper.py \
   --reference "$reference" --verifying-key "$output_dir/groth16_vk.bin" \
   --proof-system groth16 --output "$output_dir/SP1VerifierGroth16.sol" \
@@ -129,9 +126,7 @@ python3 scripts/rebind_open_competition_v2_sp1_wrapper.py \
 python3 - "$output_dir" "$r1cs" <<'PY'
 import json, pathlib, sys
 root = pathlib.Path(sys.argv[1])
-records = []
-for path in sorted(root.glob("[0-9][0-9]-*.json")):
-    records.append(json.loads(path.read_text(encoding="utf-8")))
+records = [json.loads(path.read_text(encoding="utf-8")) for path in sorted(root.glob("[0-9][0-9]-*.json"))]
 value = {
     "schema_version": "agent-bounties/open-competition-v2-beta3-groth16-mpc-transcript-v1",
     "r1cs": pathlib.Path(sys.argv[2]).name,
@@ -145,4 +140,6 @@ python3 scripts/verify_open_competition_v2_groth16_ceremony.py \
   --root "$output_dir" --r1cs "$r1cs" \
   --ceremony-uri https://github.com/NSPG13/agent-bounties/issues/888 \
   --output "$output_dir/verification-evidence.json"
+find "$output_dir" -maxdepth 1 -type f ! -name SHA256SUMS -print0 \
+  | sort -z | xargs -0 sha256sum > "$output_dir/SHA256SUMS"
 touch "$output_dir/complete"

--- a/scripts/test_verify_open_competition_v2_groth16_ceremony.py
+++ b/scripts/test_verify_open_competition_v2_groth16_ceremony.py
@@ -7,6 +7,7 @@ import unittest
 
 SCRIPT = Path(__file__).with_name("verify_open_competition_v2_groth16_ceremony.py")
 RUNNER = Path(__file__).with_name("run_open_competition_v2_groth16_ceremony.sh")
+CONTINUATION = Path(__file__).with_name("continue_open_competition_v2_groth16_phase2.sh")
 SPEC = importlib.util.spec_from_file_location("v2_groth16_ceremony", SCRIPT)
 MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -29,6 +30,31 @@ class Groth16CeremonyTests(unittest.TestCase):
     def test_container_outputs_use_the_host_runner_identity(self) -> None:
         source = RUNNER.read_text(encoding="utf-8")
         self.assertIn('--user "$(id -u):$(id -g)"', source)
+
+    def test_phase2_retains_initialization_until_later_beacon(self) -> None:
+        for path in (RUNNER, CONTINUATION):
+            with self.subTest(path=path.name):
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("container coordinate-phase2", source)
+                self.assertNotIn("container init-phase2", source)
+                self.assertNotIn("container finalize", source)
+                coordinate = source.index("container coordinate-phase2")
+                contribute = source.index("container contribute-phase2")
+                beacon = source.index('fetch_beacon "$output_dir/phase2-beacon.json"')
+                ready = source.index('touch "$output_dir/phase2-finalize.ready"')
+                wait = source.index('wait "$coordinator_pid"', ready)
+                self.assertLess(coordinate, contribute)
+                self.assertLess(contribute, beacon)
+                self.assertLess(beacon, ready)
+                self.assertLess(ready, wait)
+
+    def test_beacons_use_a_round_unavailable_after_the_contribution(self) -> None:
+        for path in (RUNNER, CONTINUATION):
+            with self.subTest(path=path.name):
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("round_number + 1", source)
+                self.assertIn('https://api.drand.sh/public/$next_round', source)
+                self.assertIn('mv "$candidate" "$destination"', source)
 
     def test_inventory_rejects_ambiguous_or_invalid_entries(self) -> None:
         with self.assertRaisesRegex(ValueError, "ambiguous"):

--- a/scripts/test_verify_open_competition_v2_groth16_phase1_checkpoint.py
+++ b/scripts/test_verify_open_competition_v2_groth16_phase1_checkpoint.py
@@ -1,0 +1,81 @@
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("verify_open_competition_v2_groth16_phase1_checkpoint.py")
+SPEC = importlib.util.spec_from_file_location("v2_groth16_phase1_checkpoint", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+class Groth16Phase1CheckpointTests(unittest.TestCase):
+    def fixture(self, root: Path) -> tuple[Path, tuple[str, str, str, str, str]]:
+        values = {
+            "circuit.bin": b"r1cs",
+            "phase1-1.bin": b"first",
+            "phase1-2.bin": b"second",
+            "phase1-commons.bin": b"commons",
+        }
+        for name, value in values.items():
+            (root / name).write_bytes(value)
+        hashes = {name: digest(value) for name, value in values.items()}
+        beacon = "0x" + "12" * 32
+        record = {
+            "schema_version": MODULE.COMMAND_SCHEMA,
+            "command": "verify-phase1",
+            "verified": True,
+            "inputs": [
+                {"path": name, "sha256": hashes[name]}
+                for name in ("circuit.bin", "phase1-1.bin", "phase1-2.bin")
+            ],
+            "outputs": [{"path": "phase1-commons.bin", "sha256": hashes["phase1-commons.bin"]}],
+            "beacon_hex": beacon,
+        }
+        (root / "05-phase1-verify.json").write_text(json.dumps(record), encoding="utf-8")
+        (root / "phase1-beacon.json").write_text(
+            json.dumps({"round": 10, "randomness": beacon[2:]}), encoding="utf-8"
+        )
+        return root / "circuit.bin", (
+            hashes["circuit.bin"],
+            hashes["phase1-1.bin"],
+            hashes["phase1-2.bin"],
+            hashes["phase1-commons.bin"],
+            beacon,
+        )
+
+    def test_accepts_exact_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            r1cs, expected = self.fixture(root)
+            MODULE.verify_checkpoint(root, r1cs, *expected)
+
+    def test_rejects_file_record_and_beacon_drift(self) -> None:
+        for mutate in ("file", "record", "beacon"):
+            with self.subTest(mutate=mutate), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                r1cs, expected = self.fixture(root)
+                if mutate == "file":
+                    (root / "phase1-commons.bin").write_bytes(b"changed")
+                elif mutate == "record":
+                    record = json.loads((root / "05-phase1-verify.json").read_text())
+                    record["verified"] = False
+                    (root / "05-phase1-verify.json").write_text(json.dumps(record))
+                else:
+                    (root / "phase1-beacon.json").write_text(
+                        json.dumps({"round": 10, "randomness": "34" * 32})
+                    )
+                with self.assertRaises(ValueError):
+                    MODULE.verify_checkpoint(root, r1cs, *expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_open_competition_v2_groth16_ceremony.py
+++ b/scripts/verify_open_competition_v2_groth16_ceremony.py
@@ -15,7 +15,11 @@ COMMAND_SCHEMA = "agent-bounties/open-competition-v2-beta3-groth16-mpc-command-v
 TRANSCRIPT_SCHEMA = "agent-bounties/open-competition-v2-beta3-groth16-mpc-transcript-v1"
 EVIDENCE_SCHEMA = "agent-bounties/open-competition-v2-beta3-setup-verification-evidence-v1"
 def sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def inventory(record: dict[str, Any], field: str) -> dict[str, str]:

--- a/scripts/verify_open_competition_v2_groth16_phase1_checkpoint.py
+++ b/scripts/verify_open_competition_v2_groth16_phase1_checkpoint.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Verify a pinned Groth16 Phase 1 checkpoint before resuming Phase 2."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+
+COMMAND_SCHEMA = "agent-bounties/open-competition-v2-beta3-groth16-mpc-command-v1"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def inventory(record: dict[str, Any], field: str) -> dict[str, str]:
+    return {str(item["path"]): str(item["sha256"]) for item in record.get(field, [])}
+
+
+def verify_checkpoint(
+    root: Path,
+    r1cs: Path,
+    expected_r1cs: str,
+    expected_phase1_1: str,
+    expected_phase1_2: str,
+    expected_commons: str,
+    expected_beacon: str,
+) -> None:
+    expected_digests = {
+        r1cs.name: expected_r1cs,
+        "phase1-1.bin": expected_phase1_1,
+        "phase1-2.bin": expected_phase1_2,
+    }
+    for digest in (*expected_digests.values(), expected_commons):
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError("expected Phase 1 digest is invalid")
+    if not re.fullmatch(r"0x[0-9a-f]{64}", expected_beacon):
+        raise ValueError("expected Phase 1 beacon is invalid")
+
+    actual_digests = {
+        r1cs.name: sha256(r1cs),
+        "phase1-1.bin": sha256(root / "phase1-1.bin"),
+        "phase1-2.bin": sha256(root / "phase1-2.bin"),
+    }
+    if actual_digests != expected_digests:
+        raise ValueError("Phase 1 checkpoint input hash mismatch")
+    if sha256(root / "phase1-commons.bin") != expected_commons:
+        raise ValueError("Phase 1 commons hash mismatch")
+
+    record = json.loads((root / "05-phase1-verify.json").read_text(encoding="utf-8"))
+    if record.get("schema_version") != COMMAND_SCHEMA:
+        raise ValueError("Phase 1 checkpoint schema mismatch")
+    if record.get("command") != "verify-phase1" or record.get("verified") is not True:
+        raise ValueError("Phase 1 checkpoint is not a verified Phase 1 record")
+    if inventory(record, "inputs") != expected_digests:
+        raise ValueError("Phase 1 checkpoint record inputs mismatch")
+    if inventory(record, "outputs") != {"phase1-commons.bin": expected_commons}:
+        raise ValueError("Phase 1 checkpoint record output mismatch")
+    if record.get("beacon_hex") != expected_beacon:
+        raise ValueError("Phase 1 checkpoint record beacon mismatch")
+
+    beacon = json.loads((root / "phase1-beacon.json").read_text(encoding="utf-8"))
+    if beacon.get("randomness") != expected_beacon[2:] or int(beacon.get("round", 0)) <= 0:
+        raise ValueError("Phase 1 checkpoint beacon evidence mismatch")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--r1cs", type=Path, required=True)
+    parser.add_argument("--r1cs-sha256", required=True)
+    parser.add_argument("--phase1-1-sha256", required=True)
+    parser.add_argument("--phase1-2-sha256", required=True)
+    parser.add_argument("--commons-sha256", required=True)
+    parser.add_argument("--beacon", required=True)
+    args = parser.parse_args()
+    verify_checkpoint(
+        args.root,
+        args.r1cs,
+        args.r1cs_sha256,
+        args.phase1_1_sha256,
+        args.phase1_2_sha256,
+        args.commons_sha256,
+        args.beacon,
+    )
+    print(json.dumps({"verified": True, "commons_sha256": args.commons_sha256}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/open-competition-v2-ceremony/README.md
+++ b/tools/open-competition-v2-ceremony/README.md
@@ -10,6 +10,12 @@ contribution, use a public 32-byte-or-longer beacon that did not exist when the
 last contributor ran. `verify-phase1` and `finalize` verify the complete chains
 before producing the final PK, VK, and Solidity verifier.
 
+The release runner uses `coordinate-phase2` to retain the exact initialization
+evaluations while two separate networkless contributor containers update the
+transcript. It waits for a durable ready marker created only after the second
+contribution and the next numbered drand round, verifies the same ordered chain
+as `finalize`, and seals the key without recomputing initialization.
+
 Never use `groth16.Setup` output as a mainnet release key. Never reuse a
 contributor environment or claim independent participation when one operator
 controlled every entropy source.

--- a/tools/open-competition-v2-ceremony/main.go
+++ b/tools/open-competition-v2-ceremony/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
@@ -42,7 +43,7 @@ type digest struct {
 
 func main() {
 	if len(os.Args) < 2 {
-		fail(errors.New("usage: ceremony <init-phase1|contribute-phase1|verify-phase1|init-phase2|contribute-phase2|finalize> ..."))
+		fail(errors.New("usage: ceremony <init-phase1|contribute-phase1|verify-phase1|init-phase2|contribute-phase2|coordinate-phase2|finalize> ..."))
 	}
 	command := os.Args[1]
 	var result record
@@ -58,6 +59,8 @@ func main() {
 		result, err = initPhase2(os.Args[2:])
 	case "contribute-phase2":
 		result, err = contributePhase2(os.Args[2:])
+	case "coordinate-phase2":
+		result, err = coordinatePhase2(os.Args[2:])
 	case "finalize":
 		result, err = finalize(os.Args[2:])
 	default:
@@ -71,6 +74,148 @@ func main() {
 		fail(err)
 	}
 	fmt.Println(string(encoded))
+}
+
+func coordinatePhase2(args []string) (record, error) {
+	flags := flag.NewFlagSet("coordinate-phase2", flag.ContinueOnError)
+	r1csPath := flags.String("r1cs", "", "exact Groth16 circuit")
+	commonsPath := flags.String("commons", "", "verified Phase 1 commons")
+	initialPath := flags.String("initial", "", "initial Phase 2 transcript")
+	initialRecordPath := flags.String("initial-record", "", "initial Phase 2 JSON record")
+	inputs := flags.String("inputs", "", "ordered comma-separated Phase 2 contributions")
+	beaconPath := flags.String("beacon-file", "", "post-contribution drand JSON")
+	readyPath := flags.String("ready-file", "", "file created only after contributions and beacon are durable")
+	pkPath := flags.String("pk", "", "output proving key")
+	vkPath := flags.String("vk", "", "output verifying key")
+	solidityPath := flags.String("solidity", "", "output Solidity verifier")
+	timeout := flags.Duration("timeout", 48*time.Hour, "maximum wait for contributions and beacon")
+	if err := flags.Parse(args); err != nil {
+		return record{}, err
+	}
+	if *timeout <= 0 || *timeout > 7*24*time.Hour {
+		return record{}, errors.New("timeout must be positive and no greater than seven days")
+	}
+	paths, err := splitPaths(*inputs)
+	if err != nil {
+		return record{}, err
+	}
+	if len(paths) != 2 {
+		return record{}, errors.New("coordinate-phase2 requires exactly two ordered contributions")
+	}
+	if *readyPath == "" || *beaconPath == "" || *initialRecordPath == "" {
+		return record{}, errors.New("ready-file, beacon-file, and initial-record are required")
+	}
+	r1cs, err := readR1CS(*r1csPath)
+	if err != nil {
+		return record{}, err
+	}
+	commons := new(mpc.SrsCommons)
+	if err := readFrom(*commonsPath, commons); err != nil {
+		return record{}, err
+	}
+	initial := new(mpc.Phase2)
+	evaluations := initial.Initialize(r1cs, commons)
+	if err := writeToExclusive(*initialPath, initial); err != nil {
+		return record{}, err
+	}
+	initialRecord, err := makeRecord(
+		"init-phase2", []string{*r1csPath, *commonsPath}, []string{*initialPath}, 0, 0, "",
+	)
+	if err != nil {
+		return record{}, err
+	}
+	if err := writeJSONExclusive(*initialRecordPath, initialRecord); err != nil {
+		return record{}, err
+	}
+	if err := waitForFile(*readyPath, *timeout); err != nil {
+		return record{}, err
+	}
+	phases := make([]*mpc.Phase2, len(paths))
+	for index, path := range paths {
+		phases[index] = new(mpc.Phase2)
+		if err := readFrom(path, phases[index]); err != nil {
+			return record{}, err
+		}
+	}
+	beaconBytes, canonicalBeacon, err := readDrandBeacon(*beaconPath)
+	if err != nil {
+		return record{}, err
+	}
+	pk, vk, err := sealPhase2(commons, &evaluations, initial, beaconBytes, phases...)
+	if err != nil {
+		return record{}, fmt.Errorf("Phase 2 verification failed: %w", err)
+	}
+	if err := writeDumpExclusive(*pkPath, pk); err != nil {
+		return record{}, err
+	}
+	if err := writeToExclusive(*vkPath, vk); err != nil {
+		return record{}, err
+	}
+	if err := writeSolidity(*solidityPath, vk); err != nil {
+		return record{}, err
+	}
+	return makeRecord(
+		"finalize",
+		append([]string{*r1csPath, *commonsPath}, paths...),
+		[]string{*pkPath, *vkPath, *solidityPath},
+		0,
+		0,
+		canonicalBeacon,
+	)
+}
+
+func sealPhase2(
+	commons *mpc.SrsCommons,
+	evaluations *mpc.Phase2Evaluations,
+	initial *mpc.Phase2,
+	beacon []byte,
+	phases ...*mpc.Phase2,
+) (groth16.ProvingKey, groth16.VerifyingKey, error) {
+	previous := initial
+	for _, phase := range phases {
+		if err := previous.Verify(phase); err != nil {
+			return nil, nil, err
+		}
+		previous = phase
+	}
+	pk, vk := previous.Seal(commons, evaluations, beacon)
+	return pk, vk, nil
+}
+
+func waitForFile(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if info, err := os.Stat(path); err == nil {
+			if !info.IsDir() {
+				return nil
+			}
+			return errors.New("ready-file is a directory")
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		time.Sleep(time.Second)
+	}
+	return errors.New("timed out waiting for Phase 2 contributions and beacon")
+}
+
+func readDrandBeacon(path string) ([]byte, string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, "", err
+	}
+	defer file.Close()
+	var value struct {
+		Round      uint64 `json:"round"`
+		Randomness string `json:"randomness"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(file, 1<<20))
+	if err := decoder.Decode(&value); err != nil {
+		return nil, "", fmt.Errorf("invalid drand beacon: %w", err)
+	}
+	if value.Round == 0 {
+		return nil, "", errors.New("drand beacon round must be positive")
+	}
+	return parseBeacon("0x" + value.Randomness)
 }
 
 func initPhase1(args []string) (record, error) {
@@ -365,6 +510,22 @@ func writeToExclusive(path string, value io.WriterTo) error {
 		return err
 	}
 	return writer.Flush()
+}
+
+func writeJSONExclusive(path string, value any) error {
+	if path == "" {
+		return errors.New("JSON output path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	encoder := json.NewEncoder(file)
+	return encoder.Encode(value)
 }
 
 type dumpWriter interface {

--- a/tools/open-competition-v2-ceremony/main_test.go
+++ b/tools/open-competition-v2-ceremony/main_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend/groth16"
@@ -31,6 +34,47 @@ func TestParseBeaconRequiresCanonicalPublicEntropy(t *testing.T) {
 		if _, _, err := parseBeacon(invalid); err == nil {
 			t.Fatalf("invalid beacon accepted: %q", invalid)
 		}
+	}
+}
+
+func TestDrandBeaconRequiresPositiveRoundAndCanonicalRandomness(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "beacon.json")
+	value := map[string]any{
+		"round": 10, "randomness": string(bytes.Repeat([]byte{'a'}, 64)),
+		"signature": "permitted drand metadata",
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	beacon, canonical, err := readDrandBeacon(path)
+	if err != nil || len(beacon) != 32 || canonical != "0x"+value["randomness"].(string) {
+		t.Fatalf("valid drand beacon rejected: %v", err)
+	}
+	value["round"] = 0
+	encoded, _ = json.Marshal(value)
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := readDrandBeacon(path); err == nil {
+		t.Fatal("zero drand round accepted")
+	}
+}
+
+func TestWaitForFileIsBounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ready")
+	if err := os.WriteFile(path, []byte("ready"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitForFile(path, time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitForFile(filepath.Join(t.TempDir(), "missing"), time.Millisecond); err == nil {
+		t.Fatal("missing ready file did not time out")
 	}
 }
 
@@ -122,18 +166,54 @@ func TestMpcRoundTripAndSp1DumpEncoding(t *testing.T) {
 		t.Fatal(err)
 	}
 	phase2 := new(mpc.Phase2)
-	phase2.Initialize(typed, &commons)
+	evaluations := phase2.Initialize(typed, &commons)
+	initial2 := new(mpc.Phase2)
+	snapshot(phase2, initial2)
 	phase2.Contribute()
 	first2 := new(mpc.Phase2)
 	snapshot(phase2, first2)
 	phase2.Contribute()
 	second2 := new(mpc.Phase2)
 	snapshot(phase2, second2)
-	pk, vk, err := mpc.VerifyPhase2(
-		typed, &commons, []byte("post-phase2-beacon"), first2, second2,
+	canonicalFirst := new(mpc.Phase2)
+	canonicalSecond := new(mpc.Phase2)
+	snapshot(first2, canonicalFirst)
+	snapshot(second2, canonicalSecond)
+	retainedFirst := new(mpc.Phase2)
+	retainedSecond := new(mpc.Phase2)
+	snapshot(first2, retainedFirst)
+	snapshot(second2, retainedSecond)
+	canonicalPK, canonicalVK, err := mpc.VerifyPhase2(
+		typed, &commons, []byte("post-phase2-beacon"), canonicalFirst, canonicalSecond,
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+	pk, vk, err := sealPhase2(
+		&commons, &evaluations, initial2, []byte("post-phase2-beacon"), retainedFirst, retainedSecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalPKDump := new(bytes.Buffer)
+	retainedPKDump := new(bytes.Buffer)
+	if err := canonicalPK.WriteDump(canonicalPKDump); err != nil {
+		t.Fatal(err)
+	}
+	if err := pk.WriteDump(retainedPKDump); err != nil {
+		t.Fatal(err)
+	}
+	canonicalVKBytes := new(bytes.Buffer)
+	retainedVKBytes := new(bytes.Buffer)
+	if _, err := canonicalVK.WriteTo(canonicalVKBytes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vk.WriteTo(retainedVKBytes); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(canonicalPKDump.Bytes(), retainedPKDump.Bytes()) ||
+		!bytes.Equal(canonicalVKBytes.Bytes(), retainedVKBytes.Bytes()) {
+		t.Fatal("retained Phase 2 evaluations changed canonical setup output")
 	}
 	dump := new(bytes.Buffer)
 	if err := pk.WriteDump(dump); err != nil {


### PR DESCRIPTION
## Summary
- verify a Phase 1 checkpoint against pinned R1CS, contribution, commons, record, and beacon hashes before resuming
- retain Phase 2 initialization while two networkless contribution containers run, then verify and seal with a later drand round
- eliminate the duplicate multi-hour initialization formerly performed by `finalize`
- stream hashes for multi-gigabyte ceremony artifacts
- enforce LF for the patch inputs used by the digest-pinned Linux image

## Evidence
- retained-evaluation output is byte-identical to canonical gnark `VerifyPhase2` for both proving and verifying keys
- digest-pinned Docker image builds and runs all Go tests
- `python -m unittest discover -s scripts -p "test_*open_competition_v2*.py"` (107 passed)
- both ceremony scripts pass `bash -n`
- `scripts/preflight.ps1 -Mode core`
- recovered original drand round 6380882 matches immutable `05-phase1-verify.json`; its 2026-08-16 05:18 UTC publication is later than contribution 2 at 05:07 UTC

## Operations
This is the announced recovery change in #888. It does not alter the Beta3 circuit, vkeys, contracts, policies, V1 behavior, or contributor interfaces.