### PR TITLE
feat: read-only bounded-wallet liquidity report (closes #871)

### DIFF
--- a/scripts/bounded_wallet_liquidity.py
+++ b/scripts/bounded_wallet_liquidity.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Read-only Base-mainnet liquidity report for the configured bounded wallet.
+
+Reports actual spendable USDC (liquid balance) separately from remaining
+policy authority and from escrowed bounty inventory. The report is
+read-only: it never signs, never broadcasts, and never moves funds.
+
+Fail-closed contract: on wrong chain, wrong token, wrong bytecode, wrong
+owner, policy drift, or RPC unavailability, no spendable quantity is ever
+reported from unverified state -- the report raises ``LiquidityReportError``
+instead of inventing balances.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Canonical Base mainnet anchors used for fail-closed validation.
+BASE_CHAIN_ID = 8453
+# Canonical USDC on Base mainnet.
+BASE_USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+# Canonical bounded-wallet bytecode hash (shared with bounty_inventory_guard.py).
+BOUNDED_WALLET_BYTECODE_HASH = (
+    "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54"
+)
+
+REPORT_VERSION = "bounded-wallet-liquidity-v1"
+
+
+class LiquidityReportError(RuntimeError):
+    """Raised when a fail-closed condition makes spendable balances unknowable."""
+
+
+@dataclass(frozen=True)
+class WalletSnapshot:
+    """Raw, unverified observation of the bounded wallet at one block.
+
+    Every field mirrors one RPC or policy-source read; nothing here is
+    inferred. ``rpc_available`` must be false whenever the observation
+    could not be produced from a live canonical RPC response.
+    """
+
+    chain_id: int
+    token_address: str
+    wallet_address: str
+    owner_address: str
+    bytecode_hash: str
+    usdc_balance: float
+    lifetime_spent: float
+    max_lifetime: float
+    period_spent: float
+    max_per_period: float
+    period_started_at: str
+    policy_version: str
+    policy_hash: str
+    observed_block: int
+    rpc_available: bool
+
+
+@dataclass(frozen=True)
+class WalletPolicy:
+    """Expected policy anchor used to detect policy drift."""
+
+    policy_version: str
+    policy_hash: str
+    expected_owner_address: str
+
+
+def _fail(reason: str) -> None:
+    raise LiquidityReportError(reason)
+
+
+def build_liquidity_report(
+    snapshot: WalletSnapshot, policy: WalletPolicy | None = None
+) -> dict[str, Any]:
+    """Build the read-only liquidity report, failing closed on any drift.
+
+    The three spendable-adjacent quantities are reported as *different*
+    labeled quantities:
+
+    - ``liquid_usdc_balance`` -- actual USDC held by the bounded wallet now;
+    - ``remaining_lifetime_authority`` -- ``max_lifetime - lifetime_spent``;
+    - ``remaining_period_authority`` -- ``max_per_period - period_spent``.
+
+    Currently claimable escrow is a fourth, distinct quantity that this
+    report deliberately does NOT estimate: it is only ever reported by the
+    canonical inventory verifier after on-chain verification.
+    """
+
+    if not snapshot.rpc_available:
+        _fail(
+            "rpc_unavailable: refusing to report spendable balances from "
+            "unverified RPC state"
+        )
+    if snapshot.chain_id != BASE_CHAIN_ID:
+        _fail(f"wrong chain: expected {BASE_CHAIN_ID}, got {snapshot.chain_id}")
+    if snapshot.token_address.lower() != BASE_USDC_ADDRESS.lower():
+        _fail(f"wrong token: expected Base USDC, got {snapshot.token_address}")
+    if snapshot.bytecode_hash.lower() != BOUNDED_WALLET_BYTECODE_HASH.lower():
+        _fail("wrong bytecode: bounded-wallet bytecode hash mismatch")
+    if policy is not None:
+        if snapshot.owner_address.lower() != policy.expected_owner_address.lower():
+            _fail(
+                f"wrong owner: expected {policy.expected_owner_address}, "
+                f"got {snapshot.owner_address}"
+            )
+        if (
+            snapshot.policy_version != policy.policy_version
+            or snapshot.policy_hash.lower() != policy.policy_hash.lower()
+        ):
+            _fail(
+                "policy drift: observed policy version/hash does not match "
+                "the expected policy anchor"
+            )
+
+    remaining_lifetime_authority = max(0.0, snapshot.max_lifetime - snapshot.lifetime_spent)
+    remaining_period_authority = max(0.0, snapshot.max_per_period - snapshot.period_spent)
+
+    return {
+        "report_version": REPORT_VERSION,
+        "status": "ok",
+        "observed_block": snapshot.observed_block,
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "wallet_address": snapshot.wallet_address,
+        "quantities": {
+            "liquid_usdc_balance": snapshot.usdc_balance,
+            "remaining_lifetime_authority": remaining_lifetime_authority,
+            "remaining_period_authority": remaining_period_authority,
+            "claimable_escrow": None,
+        },
+        "authority": {
+            "lifetime_spent": snapshot.lifetime_spent,
+            "max_lifetime": snapshot.max_lifetime,
+            "period_spent": snapshot.period_spent,
+            "max_per_period": snapshot.max_per_period,
+            "period_started_at": snapshot.period_started_at,
+        },
+        "policy": {
+            "policy_version": snapshot.policy_version,
+            "policy_hash": snapshot.policy_hash,
+        },
+        "notes": {
+            "claimable_escrow": (
+                "escrowed bounty inventory is a different quantity, reported "
+                "only by the canonical inventory verifier"
+            )
+        },
+    }
+
+
+def snapshot_from_dict(raw: dict[str, Any]) -> WalletSnapshot:
+    return WalletSnapshot(
+        chain_id=int(raw["chain_id"]),
+        token_address=str(raw["token_address"]),
+        wallet_address=str(raw["wallet_address"]),
+        owner_address=str(raw["owner_address"]),
+        bytecode_hash=str(raw["bytecode_hash"]),
+        usdc_balance=float(raw["usdc_balance"]),
+        lifetime_spent=float(raw["lifetime_spent"]),
+        max_lifetime=float(raw["max_lifetime"]),
+        period_spent=float(raw["period_spent"]),
+        max_per_period=float(raw["max_per_period"]),
+        period_started_at=str(raw["period_started_at"]),
+        policy_version=str(raw["policy_version"]),
+        policy_hash=str(raw["policy_hash"]),
+        observed_block=int(raw["observed_block"]),
+        rpc_available=bool(raw["rpc_available"]),
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--snapshot",
+        required=True,
+        help="path to a wallet snapshot JSON (see scripts/fixtures/bounded-wallet-liquidity/)",
+    )
+    parser.add_argument(
+        "--policy",
+        default=None,
+        help="optional expected policy anchor JSON (policy_version, policy_hash, expected_owner_address)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    raw = json.loads(Path(args.snapshot).read_text(encoding="utf-8"))
+    snapshot = snapshot_from_dict(raw)
+    policy: WalletPolicy | None = None
+    if args.policy:
+        p = json.loads(Path(args.policy).read_text(encoding="utf-8"))
+        policy = WalletPolicy(
+            policy_version=str(p["policy_version"]),
+            policy_hash=str(p["policy_hash"]),
+            expected_owner_address=str(p["expected_owner_address"]),
+        )
+    try:
+        report = build_liquidity_report(snapshot, policy)
+    except LiquidityReportError as exc:
+        print(
+            json.dumps(
+                {
+                    "report_version": REPORT_VERSION,
+                    "status": "fail_closed",
+                    "reason": str(exc),
+                },
+                indent=2,
+            )
+        )
+        return 1
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fixtures/bounded-wallet-liquidity/cap-exhausted.json
+++ b/scripts/fixtures/bounded-wallet-liquidity/cap-exhausted.json
@@ -1,0 +1,17 @@
+{
+  "chain_id": 8453,
+  "token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "wallet_address": "0x1111111111111111111111111111111111111111",
+  "owner_address": "0x2222222222222222222222222222222222222222",
+  "bytecode_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
+  "usdc_balance": 0.0,
+  "lifetime_spent": 5000.0,
+  "max_lifetime": 5000.0,
+  "period_spent": 500.0,
+  "max_per_period": 500.0,
+  "period_started_at": "2026-08-01T00:00:00Z",
+  "policy_version": "v1",
+  "policy_hash": "0xabababababababababababababababababababababababababababababababab",
+  "observed_block": 28123456,
+  "rpc_available": true
+}

--- a/scripts/fixtures/bounded-wallet-liquidity/empty.json
+++ b/scripts/fixtures/bounded-wallet-liquidity/empty.json
@@ -1,0 +1,17 @@
+{
+  "chain_id": 8453,
+  "token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "wallet_address": "0x1111111111111111111111111111111111111111",
+  "owner_address": "0x2222222222222222222222222222222222222222",
+  "bytecode_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
+  "usdc_balance": 0.0,
+  "lifetime_spent": 0.0,
+  "max_lifetime": 5000.0,
+  "period_spent": 0.0,
+  "max_per_period": 500.0,
+  "period_started_at": "2026-08-01T00:00:00Z",
+  "policy_version": "v1",
+  "policy_hash": "0xabababababababababababababababababababababababababababababababab",
+  "observed_block": 28123456,
+  "rpc_available": true
+}

--- a/scripts/fixtures/bounded-wallet-liquidity/healthy.json
+++ b/scripts/fixtures/bounded-wallet-liquidity/healthy.json
@@ -1,0 +1,17 @@
+{
+  "chain_id": 8453,
+  "token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "wallet_address": "0x1111111111111111111111111111111111111111",
+  "owner_address": "0x2222222222222222222222222222222222222222",
+  "bytecode_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
+  "usdc_balance": 1200.0,
+  "lifetime_spent": 200.0,
+  "max_lifetime": 5000.0,
+  "period_spent": 200.0,
+  "max_per_period": 500.0,
+  "period_started_at": "2026-08-01T00:00:00Z",
+  "policy_version": "v1",
+  "policy_hash": "0xabababababababababababababababababababababababababababababababab",
+  "observed_block": 28123456,
+  "rpc_available": true
+}

--- a/scripts/fixtures/bounded-wallet-liquidity/policy-drift.json
+++ b/scripts/fixtures/bounded-wallet-liquidity/policy-drift.json
@@ -1,0 +1,17 @@
+{
+  "chain_id": 8453,
+  "token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "wallet_address": "0x1111111111111111111111111111111111111111",
+  "owner_address": "0x2222222222222222222222222222222222222222",
+  "bytecode_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
+  "usdc_balance": 1000.0,
+  "lifetime_spent": 200.0,
+  "max_lifetime": 5000.0,
+  "period_spent": 200.0,
+  "max_per_period": 500.0,
+  "period_started_at": "2026-08-01T00:00:00Z",
+  "policy_version": "v0",
+  "policy_hash": "0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+  "observed_block": 28123456,
+  "rpc_available": true
+}

--- a/scripts/fixtures/bounded-wallet-liquidity/rpc-unavailable.json
+++ b/scripts/fixtures/bounded-wallet-liquidity/rpc-unavailable.json
@@ -1,0 +1,17 @@
+{
+  "chain_id": 8453,
+  "token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "wallet_address": "0x1111111111111111111111111111111111111111",
+  "owner_address": "0x2222222222222222222222222222222222222222",
+  "bytecode_hash": "0x25c41d7d51e2c807754b901733de17cdb1778dbd353f86347ff33e10289fcb54",
+  "usdc_balance": 1200.0,
+  "lifetime_spent": 200.0,
+  "max_lifetime": 5000.0,
+  "period_spent": 200.0,
+  "max_per_period": 500.0,
+  "period_started_at": "2026-08-01T00:00:00Z",
+  "policy_version": "v1",
+  "policy_hash": "0xabababababababababababababababababababababababababababababababab",
+  "observed_block": 28123456,
+  "rpc_available": false
+}

--- a/scripts/test_bounded_wallet_liquidity.py
+++ b/scripts/test_bounded_wallet_liquidity.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Deterministic tests for the bounded-wallet liquidity report (#871).
+
+Covers the five required fixture families: healthy, empty, cap-exhausted,
+policy-drift, and RPC-unavailable, plus wrong-chain fail-closed behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from bounded_wallet_liquidity import (
+    BASE_CHAIN_ID,
+    LiquidityReportError,
+    WalletPolicy,
+    build_liquidity_report,
+    snapshot_from_dict,
+)
+
+FIXTURES = SCRIPTS / "fixtures" / "bounded-wallet-liquidity"
+
+
+def load_snapshot(name: str) -> dict:
+    return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+
+
+class LiquidityReportTest(unittest.TestCase):
+    def test_healthy_fixture_reports_all_quantities(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("healthy"))
+        report = build_liquidity_report(snapshot)
+        self.assertEqual(report["status"], "ok")
+        q = report["quantities"]
+        self.assertEqual(q["liquid_usdc_balance"], 1200.0)
+        self.assertEqual(q["remaining_lifetime_authority"], 4800.0)
+        self.assertEqual(q["remaining_period_authority"], 300.0)
+        self.assertEqual(report["observed_block"], 28123456)
+        # Escrow is deliberately a separate, unreported quantity.
+        self.assertIsNone(q["claimable_escrow"])
+
+    def test_empty_snapshot_reports_zero_balance(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("empty"))
+        report = build_liquidity_report(snapshot)
+        self.assertEqual(report["status"], "ok")
+        self.assertEqual(report["quantities"]["liquid_usdc_balance"], 0.0)
+        self.assertEqual(report["quantities"]["remaining_lifetime_authority"], 5000.0)
+
+    def test_cap_exhausted_reports_zero_authority(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("cap-exhausted"))
+        report = build_liquidity_report(snapshot)
+        self.assertEqual(report["status"], "ok")
+        self.assertEqual(report["quantities"]["remaining_period_authority"], 0.0)
+        self.assertEqual(report["quantities"]["remaining_lifetime_authority"], 0.0)
+
+    def test_policy_drift_fails_closed(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("policy-drift"))
+        policy = WalletPolicy(
+            policy_version="v1",
+            policy_hash="0x" + "ab" * 32,
+            expected_owner_address=snapshot.owner_address,
+        )
+        with self.assertRaises(LiquidityReportError) as ctx:
+            build_liquidity_report(snapshot, policy)
+        self.assertIn("policy drift", str(ctx.exception))
+
+    def test_policy_owner_mismatch_fails_closed(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("healthy"))
+        policy = WalletPolicy(
+            policy_version=snapshot.policy_version,
+            policy_hash=snapshot.policy_hash,
+            expected_owner_address="0x0000000000000000000000000000000000000000",
+        )
+        with self.assertRaises(LiquidityReportError) as ctx:
+            build_liquidity_report(snapshot, policy)
+        self.assertIn("wrong owner", str(ctx.exception))
+
+    def test_wrong_chain_fails_closed(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("healthy"))
+        snapshot = snapshot_from_dict({**snapshot.__dict__, "chain_id": 1})
+        with self.assertRaises(LiquidityReportError) as ctx:
+            build_liquidity_report(snapshot)
+        self.assertIn("wrong chain", str(ctx.exception))
+        self.assertIn(str(BASE_CHAIN_ID), str(ctx.exception))
+
+    def test_rpc_unavailable_fails_closed(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("rpc-unavailable"))
+        with self.assertRaises(LiquidityReportError) as ctx:
+            build_liquidity_report(snapshot)
+        self.assertIn("rpc_unavailable", str(ctx.exception))
+
+    def test_wrong_token_fails_closed(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("healthy"))
+        snapshot = snapshot_from_dict(
+            {**snapshot.__dict__, "token_address": "0x" + "11" * 20}
+        )
+        with self.assertRaises(LiquidityReportError) as ctx:
+            build_liquidity_report(snapshot)
+        self.assertIn("wrong token", str(ctx.exception))
+
+    def test_wrong_bytecode_fails_closed(self) -> None:
+        snapshot = snapshot_from_dict(load_snapshot("healthy"))
+        snapshot = snapshot_from_dict(
+            {**snapshot.__dict__, "bytecode_hash": "0x" + "22" * 32}
+        )
+        with self.assertRaises(LiquidityReportError) as ctx:
+            build_liquidity_report(snapshot)
+        self.assertIn("wrong bytecode", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #871: read-only Base-mainnet liquidity report for the configured bounded wallet.

- Reports `liquid_usdc_balance`, `remaining_lifetime_authority`, `remaining_period_authority` as separate labeled quantities; escrowed inventory is explicitly reported as a different quantity by the canonical inventory verifier.
- Fails closed on wrong chain, wrong token, wrong bytecode, wrong owner, policy drift, and RPC unavailability — never fabricates spendable balances.
- Deterministic fixtures: healthy, empty, cap-exhausted, policy-drift, rpc-unavailable.

Benchmark: `WORKSPACE_ROOT=$PWD python3 benchmarks/direct-inventory-v1/wallet-liquidity/check.py` → `bounded-wallet liquidity acceptance checks passed` (EXIT=0).

Closes #871