### PR TITLE
feat: deterministic inventory replenishment planner (closes #872)

### DIFF
--- a/scripts/fixtures/inventory-replenishment/duplicate.json
+++ b/scripts/fixtures/inventory-replenishment/duplicate.json
@@ -1,0 +1,36 @@
+{
+  "guard_report": {
+    "repository": "NSPG13/agent-bounties",
+    "meta_replenishment_target": 2,
+    "meta_claimable_bounty_ids": ["meta-01"],
+    "meta_replenishment_count": 1,
+    "inventory_evidence_valid": true
+  },
+  "candidate_tasks": [
+    {
+      "task_id": "task-dup",
+      "title": "Duplicate candidate (first)",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/replenishment-plan/check.py"
+    },
+    {
+      "task_id": "task-dup",
+      "title": "Duplicate candidate (second)",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/replenishment-plan/check.py"
+    }
+  ],
+  "wallet": {
+    "wallet_balance": 100.0,
+    "period_spent": 0.0,
+    "max_per_period": 500.0,
+    "lifetime_spent": 0.0,
+    "max_lifetime": 5000.0
+  }
+}

--- a/scripts/fixtures/inventory-replenishment/five.json
+++ b/scripts/fixtures/inventory-replenishment/five.json
@@ -1,0 +1,63 @@
+{
+  "guard_report": {
+    "repository": "NSPG13/agent-bounties",
+    "meta_replenishment_target": 5,
+    "meta_claimable_bounty_ids": [],
+    "meta_replenishment_count": 5,
+    "inventory_evidence_valid": true
+  },
+  "candidate_tasks": [
+    {
+      "task_id": "task-05",
+      "title": "Fifth child bounty",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/replenishment-plan/check.py"
+    },
+    {
+      "task_id": "task-04",
+      "title": "Fourth child bounty",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/replenishment-plan/check.py"
+    },
+    {
+      "task_id": "task-03",
+      "title": "Third child bounty",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/replenishment-plan/check.py"
+    },
+    {
+      "task_id": "task-02",
+      "title": "Second child bounty",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/replenishment-plan/check.py"
+    },
+    {
+      "task_id": "task-01",
+      "title": "First child bounty",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/replenishment-plan/check.py"
+    }
+  ],
+  "wallet": {
+    "wallet_balance": 100.0,
+    "period_spent": 0.0,
+    "max_per_period": 500.0,
+    "lifetime_spent": 0.0,
+    "max_lifetime": 5000.0
+  }
+}

--- a/scripts/fixtures/inventory-replenishment/insufficient.json
+++ b/scripts/fixtures/inventory-replenishment/insufficient.json
@@ -1,0 +1,36 @@
+{
+  "guard_report": {
+    "repository": "NSPG13/agent-bounties",
+    "meta_replenishment_target": 2,
+    "meta_claimable_bounty_ids": [],
+    "meta_replenishment_count": 2,
+    "inventory_evidence_valid": true
+  },
+  "candidate_tasks": [
+    {
+      "task_id": "task-01",
+      "title": "Add wallet liquidity report",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/wallet-liquidity/check.py"
+    },
+    {
+      "task_id": "task-02",
+      "title": "Fix verifier preflight inputs",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/rpc-failover/check.py"
+    }
+  ],
+  "wallet": {
+    "wallet_balance": 0.5,
+    "period_spent": 0.0,
+    "max_per_period": 500.0,
+    "lifetime_spent": 0.0,
+    "max_lifetime": 5000.0
+  }
+}

--- a/scripts/fixtures/inventory-replenishment/period-cap.json
+++ b/scripts/fixtures/inventory-replenishment/period-cap.json
@@ -1,0 +1,36 @@
+{
+  "guard_report": {
+    "repository": "NSPG13/agent-bounties",
+    "meta_replenishment_target": 2,
+    "meta_claimable_bounty_ids": [],
+    "meta_replenishment_count": 2,
+    "inventory_evidence_valid": true
+  },
+  "candidate_tasks": [
+    {
+      "task_id": "task-01",
+      "title": "Add wallet liquidity report",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/wallet-liquidity/check.py"
+    },
+    {
+      "task_id": "task-02",
+      "title": "Fix verifier preflight inputs",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/rpc-failover/check.py"
+    }
+  ],
+  "wallet": {
+    "wallet_balance": 100.0,
+    "period_spent": 499.0,
+    "max_per_period": 500.0,
+    "lifetime_spent": 0.0,
+    "max_lifetime": 5000.0
+  }
+}

--- a/scripts/fixtures/inventory-replenishment/stale.json
+++ b/scripts/fixtures/inventory-replenishment/stale.json
@@ -1,0 +1,27 @@
+{
+  "guard_report": {
+    "repository": "NSPG13/agent-bounties",
+    "meta_replenishment_target": 2,
+    "meta_claimable_bounty_ids": ["meta-01"],
+    "meta_replenishment_count": 1,
+    "inventory_evidence_valid": true
+  },
+  "candidate_tasks": [
+    {
+      "task_id": "task-stale",
+      "title": "Old evidence task",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-07-01T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/replenishment-plan/check.py"
+    }
+  ],
+  "wallet": {
+    "wallet_balance": 100.0,
+    "period_spent": 0.0,
+    "max_per_period": 500.0,
+    "lifetime_spent": 0.0,
+    "max_lifetime": 5000.0
+  }
+}

--- a/scripts/fixtures/inventory-replenishment/sufficient.json
+++ b/scripts/fixtures/inventory-replenishment/sufficient.json
@@ -1,0 +1,36 @@
+{
+  "guard_report": {
+    "repository": "NSPG13/agent-bounties",
+    "meta_replenishment_target": 2,
+    "meta_claimable_bounty_ids": [],
+    "meta_replenishment_count": 2,
+    "inventory_evidence_valid": true
+  },
+  "candidate_tasks": [
+    {
+      "task_id": "task-02",
+      "title": "Fix verifier preflight inputs",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/rpc-failover/check.py"
+    },
+    {
+      "task_id": "task-01",
+      "title": "Add wallet liquidity report",
+      "funding_usdc": 1.0,
+      "solver_margin_usdc": 0.25,
+      "verifier_ready": true,
+      "evidence_updated_at": "2026-08-15T00:00:00Z",
+      "evidence_ref": "benchmarks/direct-inventory-v1/wallet-liquidity/check.py"
+    }
+  ],
+  "wallet": {
+    "wallet_balance": 100.0,
+    "period_spent": 0.0,
+    "max_per_period": 500.0,
+    "lifetime_spent": 0.0,
+    "max_lifetime": 5000.0
+  }
+}

--- a/scripts/plan_inventory_replenishment.py
+++ b/scripts/plan_inventory_replenishment.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Deterministic, non-financial inventory replenishment planning (#872).
+
+Converts an inventory-guard deficit into an idempotent replenishment plan
+that names exact candidate tasks, per-task funding, total funding, wallet
+sufficiency, policy sufficiency, and blockers.
+
+Hard constraints:
+
+- The plan is a *plan only*: it never signs, never broadcasts, never labels
+  an issue funded, and never calls a transaction paid
+  (``financial_action_taken`` is always false).
+- Identical inputs produce the identical plan and the identical
+  ``idempotency_key`` (canonical SHA-256 over the normalized inputs).
+- Duplicate tasks, unverifiable tasks, non-positive solver margin, stale
+  evidence, and totals above wallet balance or policy limits are rejected
+  and surfaced as blockers, never silently dropped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PLAN_VERSION = "inventory-replenishment-plan-v1"
+
+
+@dataclass(frozen=True)
+class CandidateTask:
+    """One candidate task that could absorb replenishment funding."""
+
+    task_id: str
+    title: str
+    funding_usdc: float
+    solver_margin_usdc: float
+    verifier_ready: bool
+    evidence_updated_at: str
+    evidence_ref: str
+
+
+@dataclass(frozen=True)
+class WalletState:
+    """Bounded-wallet state used for sufficiency checks."""
+
+    wallet_balance: float
+    period_spent: float
+    max_per_period: float
+    lifetime_spent: float
+    max_lifetime: float
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _idempotency_key(guard_report: dict, tasks: list[dict], wallet: dict) -> str:
+    canonical = _canonical_json(
+        {
+            "guard_report": guard_report,
+            "candidate_tasks": tasks,
+            "wallet": wallet,
+            "plan_version": PLAN_VERSION,
+        }
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _parse_ts(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def compute_deficit(guard_report: dict[str, Any]) -> int:
+    """Number of missing meta-bounties versus the replenishment target."""
+    if "meta_replenishment_count" in guard_report:
+        return max(0, int(guard_report["meta_replenishment_count"]))
+    target = int(guard_report.get("meta_replenishment_target", 2))
+    held = len(guard_report.get("meta_claimable_bounty_ids", []))
+    return max(0, target - held)
+
+
+def plan_replenishment(
+    guard_report: dict[str, Any],
+    candidate_tasks: list[dict[str, Any]],
+    wallet: dict[str, Any],
+    *,
+    max_evidence_age_days: int = 7,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """Build the deterministic replenishment plan for one deficit window.
+
+    ``now`` is injectable so callers and tests get fully deterministic
+    output; it defaults to the current UTC time.
+    """
+
+    now_dt = _parse_ts(now) if now else datetime.now(timezone.utc)
+    wallet_state = WalletState(
+        wallet_balance=float(wallet["wallet_balance"]),
+        period_spent=float(wallet.get("period_spent", 0.0)),
+        max_per_period=float(wallet["max_per_period"]),
+        lifetime_spent=float(wallet.get("lifetime_spent", 0.0)),
+        max_lifetime=float(wallet["max_lifetime"]),
+    )
+
+    deficit = compute_deficit(guard_report)
+    blockers: list[str] = []
+
+    # --- Validation pass -------------------------------------------------
+    seen_ids: set[str] = set()
+    valid: list[CandidateTask] = []
+    for raw in candidate_tasks:
+        task = CandidateTask(
+            task_id=str(raw["task_id"]),
+            title=str(raw["title"]),
+            funding_usdc=float(raw["funding_usdc"]),
+            solver_margin_usdc=float(raw["solver_margin_usdc"]),
+            verifier_ready=bool(raw.get("verifier_ready", False)),
+            evidence_updated_at=str(raw["evidence_updated_at"]),
+            evidence_ref=str(raw.get("evidence_ref", "")),
+        )
+        if task.task_id in seen_ids:
+            blockers.append(f"duplicate task: {task.task_id}")
+            continue
+        seen_ids.add(task.task_id)
+        if not task.verifier_ready:
+            blockers.append(f"unverifiable task: {task.task_id} (verifier not ready)")
+            continue
+        if task.solver_margin_usdc <= 0:
+            blockers.append(
+                f"non-positive solver margin: {task.task_id} "
+                f"({task.solver_margin_usdc} USDC)"
+            )
+            continue
+        evidence_age = now_dt - _parse_ts(task.evidence_updated_at)
+        if evidence_age.days > max_evidence_age_days:
+            blockers.append(f"stale evidence: {task.task_id} ({evidence_age.days}d old)")
+            continue
+        valid.append(task)
+
+    # Deterministic selection order: task_id ascending.
+    valid.sort(key=lambda t: t.task_id)
+    selected = valid[:deficit]
+    per_task_funding = {t.task_id: t.funding_usdc for t in selected}
+    total_funding = sum(t.funding_usdc for t in selected)
+
+    # --- Sufficiency checks ----------------------------------------------
+    wallet_sufficient = wallet_state.wallet_balance >= total_funding
+    if not wallet_sufficient:
+        blockers.append(
+            f"insufficient balance: need {total_funding} USDC, "
+            f"wallet_balance is {wallet_state.wallet_balance} USDC"
+        )
+    period_ok = (
+        wallet_state.period_spent + total_funding <= wallet_state.max_per_period
+    )
+    lifetime_ok = (
+        wallet_state.lifetime_spent + total_funding <= wallet_state.max_lifetime
+    )
+    policy_sufficient = period_ok and lifetime_ok
+    if not period_ok:
+        blockers.append(
+            "period cap exceeded: "
+            f"{wallet_state.period_spent + total_funding} > {wallet_state.max_per_period}"
+        )
+    if not lifetime_ok:
+        blockers.append(
+            "lifetime cap exceeded: "
+            f"{wallet_state.lifetime_spent + total_funding} > {wallet_state.max_lifetime}"
+        )
+
+    return {
+        "plan_version": PLAN_VERSION,
+        "generated_at": now_dt.isoformat(),
+        "deficit": deficit,
+        "selected_candidates": [t.task_id for t in selected],
+        "per_task_funding": per_task_funding,
+        "total_funding": total_funding,
+        "wallet": {
+            "wallet_balance": wallet_state.wallet_balance,
+            "wallet_sufficient": wallet_sufficient,
+        },
+        "policy": {
+            "period_spent": wallet_state.period_spent,
+            "max_per_period": wallet_state.max_per_period,
+            "lifetime_spent": wallet_state.lifetime_spent,
+            "max_lifetime": wallet_state.max_lifetime,
+            "policy_sufficient": policy_sufficient,
+        },
+        "blockers": blockers,
+        "financial_action_taken": False,
+        "idempotency_key": _idempotency_key(
+            guard_report,
+            sorted(candidate_tasks, key=lambda t: str(t["task_id"])),
+            wallet,
+        ),
+        "disclaimer": (
+            "plan only: no signing, no broadcast, no funding label, and no "
+            "payment claim is implied by this document"
+        ),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--guard-report", required=True, help="inventory-guard report JSON")
+    parser.add_argument("--tasks", required=True, help="candidate task manifest JSON")
+    parser.add_argument("--wallet", required=True, help="bounded-wallet state JSON")
+    parser.add_argument("--max-evidence-age-days", type=int, default=7)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    guard = json.loads(Path(args.guard_report).read_text(encoding="utf-8"))
+    tasks = json.loads(Path(args.tasks).read_text(encoding="utf-8"))
+    wallet = json.loads(Path(args.wallet).read_text(encoding="utf-8"))
+    plan = plan_replenishment(
+        guard, tasks, wallet, max_evidence_age_days=args.max_evidence_age_days
+    )
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_plan_inventory_replenishment.py
+++ b/scripts/test_plan_inventory_replenishment.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Deterministic tests for inventory replenishment planning (#872).
+
+Required fixture families: sufficient inventory, insufficient balance,
+period cap, stale evidence, duplicate candidates, and exact five-task
+replenishment.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from plan_inventory_replenishment import plan_replenishment
+
+FIXTURES = SCRIPTS / "fixtures" / "inventory-replenishment"
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+
+
+NOW = "2026-08-17T00:00:00+00:00"
+
+
+class ReplenishmentPlanTest(unittest.TestCase):
+    def test_five_task_replenishment_plan(self) -> None:
+        fx = load_fixture("five")
+        plan = plan_replenishment(
+            fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+        )
+        self.assertEqual(plan["deficit"], 5)
+        self.assertEqual(len(plan["selected_candidates"]), 5)
+        self.assertEqual(plan["total_funding"], 5.0)
+        self.assertTrue(plan["wallet"]["wallet_sufficient"])
+        self.assertTrue(plan["policy"]["policy_sufficient"])
+        self.assertEqual(plan["blockers"], [])
+        self.assertEqual(plan["financial_action_taken"], False)
+
+    def test_sufficient_inventory_selects_exact_deficit(self) -> None:
+        fx = load_fixture("sufficient")
+        plan = plan_replenishment(
+            fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+        )
+        self.assertEqual(plan["deficit"], 2)
+        self.assertEqual(plan["selected_candidates"], ["task-01", "task-02"])
+        self.assertEqual(plan["total_funding"], 2.0)
+
+    def test_insufficient_balance_is_blocked(self) -> None:
+        fx = load_fixture("insufficient")
+        plan = plan_replenishment(
+            fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+        )
+        self.assertFalse(plan["wallet"]["wallet_sufficient"])
+        self.assertTrue(any("insufficient balance" in b for b in plan["blockers"]))
+
+    def test_period_cap_exceeded_is_blocked(self) -> None:
+        fx = load_fixture("period-cap")
+        plan = plan_replenishment(
+            fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+        )
+        self.assertFalse(plan["policy"]["policy_sufficient"])
+        self.assertTrue(any("period cap exceeded" in b for b in plan["blockers"]))
+
+    def test_stale_evidence_is_blocked(self) -> None:
+        fx = load_fixture("stale")
+        plan = plan_replenishment(
+            fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+        )
+        self.assertTrue(any("stale evidence" in b for b in plan["blockers"]))
+        self.assertNotIn("task-stale", plan["selected_candidates"])
+
+    def test_duplicate_candidates_are_blocked(self) -> None:
+        fx = load_fixture("duplicate")
+        plan = plan_replenishment(
+            fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+        )
+        duplicates = [b for b in plan["blockers"] if "duplicate task" in b]
+        self.assertEqual(len(duplicates), 1)
+        # The deduplicated task is still eligible.
+        self.assertIn("task-dup", plan["selected_candidates"])
+
+    def test_idempotency_same_inputs_same_plan_and_key(self) -> None:
+        fx = load_fixture("five")
+        first = plan_replenishment(
+            fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+        )
+        second = plan_replenishment(
+            fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+        )
+        self.assertEqual(first["idempotency_key"], second["idempotency_key"])
+        self.assertEqual(first["selected_candidates"], second["selected_candidates"])
+        self.assertEqual(first["per_task_funding"], second["per_task_funding"])
+
+    def test_plan_never_takes_financial_action(self) -> None:
+        for name in ("sufficient", "insufficient", "period-cap", "stale", "duplicate", "five"):
+            fx = load_fixture(name)
+            plan = plan_replenishment(
+                fx["guard_report"], fx["candidate_tasks"], fx["wallet"], now=NOW
+            )
+            self.assertFalse(plan["financial_action_taken"], name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #872: convert an inventory-guard deficit into an idempotent, non-financial replenishment plan.

- Deterministic plan: deficit, selected candidates, per-task funding, total funding, wallet sufficiency, policy sufficiency, blockers.
- Rejects duplicate tasks, unverifiable tasks, non-positive solver margin, stale evidence, totals above balance or policy limits.
- Same inputs → same plan and same canonical `idempotency_key` (SHA-256); `financial_action_taken` is always false (never signs, broadcasts, labels funded, or claims payment).
- Deterministic fixtures: sufficient, insufficient, period-cap, stale, duplicate, exact five-task replenishment.

Benchmark: `WORKSPACE_ROOT=$PWD python3 benchmarks/direct-inventory-v1/replenishment-plan/check.py` → `inventory replenishment-plan acceptance checks passed` (EXIT=0).

Closes #872