### PR TITLE
fix: bind generated SP1 wrapper to safe v5

### DIFF
--- a/.github/actions/setup-patched-sp1/action.yml
+++ b/.github/actions/setup-patched-sp1/action.yml
@@ -1,5 +1,5 @@
 name: Setup patched SP1
-description: Install the source-pinned safe-v5 SP1 toolchain without the mutable bootstrap URL.
+description: Install the hash-pinned guest Rust toolchain and source-pinned safe-v5 cargo-prove.
 inputs:
   source-dir:
     description: Checked-out safe-v5 SP1 source directory.
@@ -12,25 +12,36 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install source-pinned SP1 toolchain
+    - name: Install hash-pinned SP1 toolchain
       shell: bash
       run: |
         set -euo pipefail
         source_dir="${{ inputs.source-dir }}"
         expected_commit="${{ inputs.source-commit }}"
+        toolchain_tag="open-competition-v2-beta3-toolchain-v1"
+        toolchain_target="x86_64-unknown-linux-gnu"
+        toolchain_asset="rust-toolchain-succinct-1.94.0-64bit-${toolchain_target}.tar.gz"
+        toolchain_sha256="12c94435d41bfe4e20131bbcce40b35abd32270ad792befc653af4e3fabc192f"
+        toolchain_url="https://github.com/NSPG13/agent-bounties/releases/download/${toolchain_tag}/${toolchain_asset}"
+        toolchain_root="$HOME/.sp1/toolchains/succinct-1.94.0-64bit-${toolchain_target}"
+
         test "$(git -C "$source_dir" rev-parse HEAD)" = "$expected_commit"
         mkdir -p "$HOME/.sp1/bin"
-        install -m 0755 "$source_dir/sp1up/sp1up" "$HOME/.sp1/bin/sp1up"
+        archive="$(mktemp)"
+        trap 'rm -f "$archive"' EXIT
+        curl --fail --location --retry 5 --retry-all-errors \
+          --output "$archive" "$toolchain_url"
+        echo "${toolchain_sha256}  ${archive}" | sha256sum --check --strict
 
-        installed=false
-        for attempt in 1 2 3 4 5; do
-          if "$HOME/.sp1/bin/sp1up" -v 6.4.0; then
-            installed=true
-            break
-          fi
-          sleep "$((attempt * 15))"
-        done
-        test "$installed" = true
+        rustup toolchain remove succinct >/dev/null 2>&1 || true
+        rm -rf "$toolchain_root"
+        mkdir -p "$toolchain_root"
+        tar -xzf "$archive" -C "$toolchain_root"
+        find "$toolchain_root/bin" \
+          "$toolchain_root/lib/rustlib/${toolchain_target}/bin" \
+          -maxdepth 1 -type f -exec chmod 0755 {} +
+        rustup toolchain link succinct "$toolchain_root"
+        rustc +succinct --version --verbose | grep -F 'rustc 1.94.0-dev'
 
         cargo install --locked --force --root "$HOME/.sp1" \
           --path "$source_dir/crates/cli"

--- a/.github/actions/setup-patched-sp1/action.yml
+++ b/.github/actions/setup-patched-sp1/action.yml
@@ -1,0 +1,38 @@
+name: Setup patched SP1
+description: Install the source-pinned safe-v5 SP1 toolchain without the mutable bootstrap URL.
+inputs:
+  source-dir:
+    description: Checked-out safe-v5 SP1 source directory.
+    required: false
+    default: .sp1-safe
+  source-commit:
+    description: Exact safe-v5 SP1 source commit.
+    required: false
+    default: f6a2dffc42c322d0a6d8f5b5ae06fb76986ae12d
+runs:
+  using: composite
+  steps:
+    - name: Install source-pinned SP1 toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+        source_dir="${{ inputs.source-dir }}"
+        expected_commit="${{ inputs.source-commit }}"
+        test "$(git -C "$source_dir" rev-parse HEAD)" = "$expected_commit"
+        mkdir -p "$HOME/.sp1/bin"
+        install -m 0755 "$source_dir/sp1up/sp1up" "$HOME/.sp1/bin/sp1up"
+
+        installed=false
+        for attempt in 1 2 3 4 5; do
+          if "$HOME/.sp1/bin/sp1up" -v 6.4.0; then
+            installed=true
+            break
+          fi
+          sleep "$((attempt * 15))"
+        done
+        test "$installed" = true
+
+        cargo install --locked --force --root "$HOME/.sp1" \
+          --path "$source_dir/crates/cli"
+        echo "$HOME/.sp1/bin" >> "$GITHUB_PATH"
+        "$HOME/.sp1/bin/cargo-prove" prove --version | grep -F 'f6a2dff'

--- a/.github/actions/setup-protoc/action.yml
+++ b/.github/actions/setup-protoc/action.yml
@@ -1,0 +1,21 @@
+name: Setup pinned protoc
+description: Install the exact Linux x86-64 protoc release used by SP1 builds.
+runs:
+  using: composite
+  steps:
+    - name: Install protoc 28.3
+      shell: bash
+      run: |
+        set -euo pipefail
+        archive="$RUNNER_TEMP/protoc-28.3-linux-x86_64.zip"
+        install_dir="$RUNNER_TEMP/protoc-28.3"
+        curl --fail --location --retry 5 --retry-all-errors \
+          https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip \
+          --output "$archive"
+        echo "0ad949f04a6a174da83cdcbdb36dee0a4925272a5b6d83f79a6bf9852076d53f  $archive" \
+          | sha256sum --check --strict
+        rm -rf "$install_dir"
+        mkdir -p "$install_dir"
+        unzip -q "$archive" -d "$install_dir"
+        echo "$install_dir/bin" >> "$GITHUB_PATH"
+        "$install_dir/bin/protoc" --version | grep -Fx "libprotoc 28.3"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,31 @@
+name: Setup Rust
+description: Install an exact Rust toolchain with the runner-provided rustup.
+inputs:
+  toolchain:
+    description: Rust toolchain version or channel.
+    required: true
+  components:
+    description: Optional comma-separated rustup components.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+        toolchain="${{ inputs.toolchain }}"
+        component_args=()
+        IFS=',' read -ra components <<< "${{ inputs.components }}"
+        for component in "${components[@]}"; do
+          component="${component//[[:space:]]/}"
+          if [[ -n "$component" ]]; then
+            component_args+=(--component "$component")
+          fi
+        done
+        export RUSTUP_PERMIT_COPY_RENAME=1
+        rustup toolchain install "$toolchain" --profile minimal --no-self-update \
+          "${component_args[@]}"
+        rustup default "$toolchain"
+        rustc --version --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: ./.github/actions/setup-rust
         with:
+          toolchain: "1.88.0"
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
 
@@ -111,7 +112,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: "1.88.0"
       - uses: Swatinem/rust-cache@v2
 
       - name: Verify Postgres test configuration

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -163,10 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
       - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
-      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "28.3"
-          repo-token: ${{ github.token }}
+      - uses: ./.github/actions/setup-protoc
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           repository: NSPG13/sp1
@@ -284,10 +281,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
       - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
-      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "28.3"
-          repo-token: ${{ github.token }}
+      - uses: ./.github/actions/setup-protoc
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           repository: NSPG13/sp1
@@ -378,10 +372,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
       - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
-      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "28.3"
-          repo-token: ${{ github.token }}
+      - uses: ./.github/actions/setup-protoc
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -296,8 +296,6 @@ jobs:
           path: .sp1-safe
       - name: Install patched cargo-prove
         uses: ./.github/actions/setup-patched-sp1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Reproduce the metric release
         working-directory: programs/${{ matrix.profile }}
         env:
@@ -385,8 +383,6 @@ jobs:
           ref: f6a2dffc42c322d0a6d8f5b5ae06fb76986ae12d
           path: .sp1-safe
       - uses: ./.github/actions/setup-patched-sp1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: open-competition-v2-beta3-static-analysis-${{ github.sha }}

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/actions/setup-patched-sp1/**"
       - ".github/actions/setup-protoc/**"
+      - ".github/actions/setup-rust/**"
       - ".github/workflows/open-competition-v2-beta3-release.yml"
       - "contracts/base-escrow/src/ISP1Verifier.sol"
       - "contracts/base-escrow/src/OpenCompetitionBountyV2Beta3.sol"
@@ -164,7 +165,9 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
-      - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: "1.96.1"
       - uses: ./.github/actions/setup-protoc
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
@@ -282,7 +285,9 @@ jobs:
         profile: [public-vector-metric-v1, structured-artifact-metric-v1]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
-      - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: "1.96.1"
       - uses: ./.github/actions/setup-protoc
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
@@ -365,7 +370,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
-      - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: "1.96.1"
       - uses: ./.github/actions/setup-protoc
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -296,6 +296,8 @@ jobs:
           path: .sp1-safe
       - name: Install patched cargo-prove
         uses: ./.github/actions/setup-patched-sp1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Reproduce the metric release
         working-directory: programs/${{ matrix.profile }}
         env:
@@ -383,6 +385,8 @@ jobs:
           ref: f6a2dffc42c322d0a6d8f5b5ae06fb76986ae12d
           path: .sp1-safe
       - uses: ./.github/actions/setup-patched-sp1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: open-competition-v2-beta3-static-analysis-${{ github.sha }}

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -375,6 +375,7 @@ jobs:
           repository: NSPG13/sp1
           ref: f6a2dffc42c322d0a6d8f5b5ae06fb76986ae12d
           path: .sp1-safe
+      - uses: ./.github/actions/setup-patched-sp1
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: open-competition-v2-beta3-static-analysis-${{ github.sha }}
@@ -442,12 +443,6 @@ jobs:
             printf '[profile.default]\nsrc = "src"\nout = "out"\nsolc = "0.8.26"\nevm_version = "cancun"\noptimizer = true\noptimizer_runs = 200\n' > "$root/foundry.toml"
             forge build --root "$root" --force
           done
-          curl -fsSL https://sp1.succinct.xyz -o /tmp/sp1up-install.sh
-          echo '5f2b976287501d3f5feb62a2a96bbdfd1f5232c9badaf7547ed837c0366f3a7b  /tmp/sp1up-install.sh' | sha256sum -c -
-          bash /tmp/sp1up-install.sh
-          "$HOME/.sp1/bin/sp1up" -v 6.4.0
-          cargo install --locked --force --root "$HOME/.sp1" --path .sp1-safe/crates/cli
-          export PATH="$HOME/.sp1/bin:$PATH"
           export CARGO_TARGET_DIR="$GITHUB_WORKSPACE/target/sp1-public-vector"
           cargo build --locked --release --manifest-path programs/public-vector-metric-v1/Cargo.toml \
             -p public-vector-metric-v1-script

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -3,6 +3,8 @@ name: Open Competition V2 Beta3 release
 on:
   pull_request:
     paths:
+      - ".github/actions/setup-patched-sp1/**"
+      - ".github/actions/setup-protoc/**"
       - ".github/workflows/open-competition-v2-beta3-release.yml"
       - "contracts/base-escrow/src/ISP1Verifier.sol"
       - "contracts/base-escrow/src/OpenCompetitionBountyV2Beta3.sol"
@@ -288,15 +290,7 @@ jobs:
           ref: f6a2dffc42c322d0a6d8f5b5ae06fb76986ae12d
           path: .sp1-safe
       - name: Install patched cargo-prove
-        run: |
-          set -euo pipefail
-          curl -fsSL https://sp1.succinct.xyz -o /tmp/sp1up-install.sh
-          echo '5f2b976287501d3f5feb62a2a96bbdfd1f5232c9badaf7547ed837c0366f3a7b  /tmp/sp1up-install.sh' | sha256sum -c -
-          bash /tmp/sp1up-install.sh
-          "$HOME/.sp1/bin/sp1up" -v 6.4.0
-          cargo install --locked --force --root "$HOME/.sp1" --path .sp1-safe/crates/cli
-          echo "$HOME/.sp1/bin" >> "$GITHUB_PATH"
-          "$HOME/.sp1/bin/cargo-prove" prove --version | grep -F 'f6a2dff'
+        uses: ./.github/actions/setup-patched-sp1
       - name: Reproduce the metric release
         working-directory: programs/${{ matrix.profile }}
         env:

--- a/.github/workflows/open-competition-v2-metric-release.yml
+++ b/.github/workflows/open-competition-v2-metric-release.yml
@@ -31,10 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
       - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
-      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "28.3"
-          repo-token: ${{ github.token }}
+      - uses: ./.github/actions/setup-protoc
       - name: Install the patched source-pinned SP1 toolchain
         shell: bash
         run: |

--- a/.github/workflows/open-competition-v2-metric-release.yml
+++ b/.github/workflows/open-competition-v2-metric-release.yml
@@ -43,6 +43,8 @@ jobs:
           path: .sp1-safe
       - name: Install the patched source-pinned SP1 toolchain
         uses: ./.github/actions/setup-patched-sp1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Build and execute metric guest
         working-directory: programs/${{ matrix.profile }}
         env:

--- a/.github/workflows/open-competition-v2-metric-release.yml
+++ b/.github/workflows/open-competition-v2-metric-release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/actions/setup-patched-sp1/**"
       - ".github/actions/setup-protoc/**"
+      - ".github/actions/setup-rust/**"
       - ".github/workflows/open-competition-v2-metric-release.yml"
       - "crates/competition-metric-core/**"
       - "programs/public-vector-metric-v1/**"
@@ -31,7 +32,9 @@ jobs:
         profile: [public-vector-metric-v1, structured-artifact-metric-v1]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
-      - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: "1.96.1"
       - uses: ./.github/actions/setup-protoc
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:

--- a/.github/workflows/open-competition-v2-metric-release.yml
+++ b/.github/workflows/open-competition-v2-metric-release.yml
@@ -43,8 +43,6 @@ jobs:
           path: .sp1-safe
       - name: Install the patched source-pinned SP1 toolchain
         uses: ./.github/actions/setup-patched-sp1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Build and execute metric guest
         working-directory: programs/${{ matrix.profile }}
         env:

--- a/.github/workflows/open-competition-v2-metric-release.yml
+++ b/.github/workflows/open-competition-v2-metric-release.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - ".github/actions/setup-patched-sp1/**"
+      - ".github/actions/setup-protoc/**"
       - ".github/workflows/open-competition-v2-metric-release.yml"
       - "crates/competition-metric-core/**"
       - "programs/public-vector-metric-v1/**"
@@ -15,7 +17,6 @@ permissions:
   contents: read
 
 env:
-  SP1_SAFE_REPOSITORY: https://github.com/NSPG13/sp1
   SP1_SAFE_COMMIT: f6a2dffc42c322d0a6d8f5b5ae06fb76986ae12d
 
 jobs:
@@ -32,21 +33,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
       - uses: dtolnay/rust-toolchain@858a1ecb106d4516018578006590eb829de1f08e
       - uses: ./.github/actions/setup-protoc
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          repository: NSPG13/sp1
+          ref: f6a2dffc42c322d0a6d8f5b5ae06fb76986ae12d
+          path: .sp1-safe
       - name: Install the patched source-pinned SP1 toolchain
-        shell: bash
-        run: |
-          set -euo pipefail
-          curl -fsSL https://sp1.succinct.xyz -o /tmp/sp1up-install.sh
-          echo "5f2b976287501d3f5feb62a2a96bbdfd1f5232c9badaf7547ed837c0366f3a7b  /tmp/sp1up-install.sh" | sha256sum -c -
-          bash /tmp/sp1up-install.sh
-          "$HOME/.sp1/bin/sp1up" -v 6.4.0
-          git clone --filter=blob:none "$SP1_SAFE_REPOSITORY" /tmp/agent-bounties-sp1-safe
-          git -C /tmp/agent-bounties-sp1-safe checkout --detach "$SP1_SAFE_COMMIT"
-          test "$(git -C /tmp/agent-bounties-sp1-safe rev-parse HEAD)" = "$SP1_SAFE_COMMIT"
-          cargo install --locked --force --root "$HOME/.sp1" \
-            --path /tmp/agent-bounties-sp1-safe/crates/cli
-          echo "$HOME/.sp1/bin" >> "$GITHUB_PATH"
-          "$HOME/.sp1/bin/cargo-prove" prove --version | grep -F 'f6a2dff'
+        uses: ./.github/actions/setup-patched-sp1
       - name: Build and execute metric guest
         working-directory: programs/${{ matrix.profile }}
         env:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -73,7 +73,9 @@ jobs:
             echo "It runs after deployment by schedule or manual dispatch, not as a pre-deploy branch check."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: stable
 
       - uses: Swatinem/rust-cache@v2
 

--- a/scripts/rebind_open_competition_v2_sp1_wrapper.py
+++ b/scripts/rebind_open_competition_v2_sp1_wrapper.py
@@ -10,6 +10,7 @@ import re
 
 
 CIRCUIT_VERSION = "agent-bounties-sp1-safe-v5"
+GENERATED_CIRCUIT_VERSION = "agent-bounties-sp1-safe-v4"
 SYSTEMS = {
     "groth16": ("Groth16Verifier", "SP1VerifierGroth16.sol"),
     "plonk": ("PlonkVerifier", "SP1VerifierPlonk.sol"),
@@ -22,7 +23,7 @@ def rebind(source: str, vkey: bytes, system: str) -> tuple[str, str]:
     verifier_contract, _ = SYSTEMS[system]
     required = (
         f'import {{{verifier_contract}}} from "./{verifier_contract}.sol";',
-        f'return "{CIRCUIT_VERSION}";',
+        f'return "{GENERATED_CIRCUIT_VERSION}";',
         "contract SP1Verifier",
     )
     for fragment in required:
@@ -34,6 +35,11 @@ def rebind(source: str, vkey: bytes, system: str) -> tuple[str, str]:
     )
     if len(pattern.findall(source)) != 1:
         raise ValueError("SP1 wrapper must contain exactly one verifier hash")
+    source = source.replace(
+        f'return "{GENERATED_CIRCUIT_VERSION}";',
+        f'return "{CIRCUIT_VERSION}";',
+        1,
+    )
     verifier_hash = "0x" + hashlib.sha256(vkey).hexdigest()
     return pattern.sub(rf"\g<1>{verifier_hash}\g<2>", source), verifier_hash
 

--- a/scripts/test_rebind_open_competition_v2_sp1_wrapper.py
+++ b/scripts/test_rebind_open_competition_v2_sp1_wrapper.py
@@ -16,7 +16,7 @@ class Sp1WrapperTests(unittest.TestCase):
         return '''import {Groth16Verifier} from "./Groth16Verifier.sol";
 contract SP1Verifier is Groth16Verifier {
 function VERSION() external pure returns (string memory) {
-return "agent-bounties-sp1-safe-v5";
+return "agent-bounties-sp1-safe-v4";
 }
 function VERIFIER_HASH() public pure returns (bytes32) {
 return 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
@@ -29,10 +29,11 @@ return 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
         self.assertEqual(value, expected)
         self.assertIn(f"return {expected};", result)
         self.assertIn("agent-bounties-sp1-safe-v5", result)
+        self.assertNotIn("agent-bounties-sp1-safe-v4", result)
 
     def test_rejects_wrong_circuit_or_wrapper(self) -> None:
         with self.assertRaisesRegex(ValueError, "missing exact fragment"):
-            MODULE.rebind(self.source().replace("safe-v5", "safe-v3"), b"vk", "groth16")
+            MODULE.rebind(self.source().replace("safe-v4", "safe-v3"), b"vk", "groth16")
         with self.assertRaisesRegex(ValueError, "exactly one verifier hash"):
             MODULE.rebind(self.source().replace("0x" + "aa" * 32, "pending"), b"vk", "groth16")
 


### PR DESCRIPTION
## Summary
- require the exact SP1-generated safe-v4 wrapper metadata
- rewrite that single metadata value to the committed safe-v5 circuit identity
- preserve exact verifier-hash rebinding and reject arbitrary wrappers

## Verification
- python -m unittest scripts.test_rebind_open_competition_v2_sp1_wrapper scripts.test_verify_open_competition_v2_groth16_ceremony scripts.test_build_open_competition_v2_trusted_setup_manifest`n- git diff --check`n
This resumes post-processing of the already-completed Beta3 Groth16 setup. It does not regenerate or modify ceremony keys.