### PR TITLE
release: harden Beta3 self-hosted asset build

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,6 +24,11 @@ runs:
             component_args+=(--component "$component")
           fi
         done
+        if ! command -v rustup >/dev/null 2>&1; then
+          test -x "$HOME/.cargo/bin/rustup"
+          export PATH="$HOME/.cargo/bin:$PATH"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        fi
         export RUSTUP_PERMIT_COPY_RENAME=1
         rustup toolchain install "$toolchain" --profile minimal --no-self-update \
           "${component_args[@]}"

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -120,6 +120,7 @@ jobs:
             scripts.test_verify_open_competition_v2_fresh_agent_flow \
             scripts.test_verify_open_competition_v2_plonk_setup \
             scripts.test_verify_open_competition_v2_wrap_template \
+            scripts.test_normalize_sp1_verifier_vk_root \
             scripts.test_verify_sp1_patched_graph \
             scripts.test_seed_open_competition_v2_discovery \
             scripts.test_publish_open_competition_v2_seed_issues -v
@@ -432,6 +433,10 @@ jobs:
             test -f "$trusted_root/$system/verification-evidence.json"
             cp -a "$trusted_root/$system" ".sp1-safe/crates/prover/build/$system"
           done
+          python scripts/normalize_sp1_verifier_vk_root.py \
+            .sp1-safe/crates/prover/build/groth16/SP1VerifierGroth16.sol \
+            .sp1-safe/crates/prover/build/plonk/SP1VerifierPlonk.sol \
+            --output target/verifier-vk-root-normalization.json
           mkdir -p target/trusted-setup-evidence/groth16 target/trusted-setup-evidence/plonk
           cp "$trusted_root/trusted-setup.json" target/trusted-setup-evidence/
           for system in groth16 plonk; do
@@ -568,6 +573,7 @@ jobs:
             target/structured-artifact-prover-capabilities.json
             target/gnark-image.json
             target/gnark-cli.sha256
+            target/verifier-vk-root-normalization.json
             target/trusted-setup-evidence/**
           if-no-files-found: error
           retention-days: 90

--- a/scripts/normalize_sp1_verifier_vk_root.py
+++ b/scripts/normalize_sp1_verifier_vk_root.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Canonicalize SP1's zero-prefixed BN254 VK root for Solidity bytes32."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+VK_ROOT = re.compile(
+    r"(function\s+VK_ROOT\(\)\s+public\s+pure\s+returns\s+\(bytes32\)\s*\{\s*"
+    r"return\s+0x)([0-9a-fA-F]+)(;\s*\})",
+    re.MULTILINE,
+)
+
+
+def normalize(path: Path) -> str:
+    source = path.read_text(encoding="utf-8")
+    matches = list(VK_ROOT.finditer(source))
+    if len(matches) != 1:
+        raise ValueError(f"{path}: expected exactly one bytes32 VK_ROOT function")
+
+    encoded = matches[0].group(2).lower()
+    if len(encoded) == 64:
+        canonical = encoded
+    elif len(encoded) == 66 and encoded.startswith("00"):
+        canonical = encoded[2:]
+        if int(encoded, 16) != int(canonical, 16):
+            raise ValueError(f"{path}: VK_ROOT normalization changed its value")
+    else:
+        raise ValueError(
+            f"{path}: VK_ROOT must be 32 bytes or one zero-prefixed 33-byte value"
+        )
+
+    rewritten = VK_ROOT.sub(
+        lambda match: f"{match.group(1)}{canonical}{match.group(3)}", source, count=1
+    )
+    if len(canonical) != 64 or not re.fullmatch(r"[0-9a-f]{64}", canonical):
+        raise ValueError(f"{path}: canonical VK_ROOT is not bytes32")
+    path.write_text(rewritten, encoding="utf-8")
+    return f"0x{canonical}"
+
+
+def normalize_all(paths: list[Path]) -> dict[str, object]:
+    if not paths:
+        raise ValueError("at least one verifier source is required")
+    roots = {str(path): normalize(path) for path in paths}
+    if len(set(roots.values())) != 1:
+        raise ValueError("Groth16 and PLONK verifier VK roots differ")
+    return {
+        "schema_version": "agent-bounties/sp1-solidity-vk-root-normalization-v1",
+        "status": "canonical_bytes32",
+        "vk_root": next(iter(roots.values())),
+        "sources": roots,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sources", type=Path, nargs="+")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    evidence = normalize_all(args.sources)
+    rendered = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_normalize_sp1_verifier_vk_root.py
+++ b/scripts/test_normalize_sp1_verifier_vk_root.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("normalize_sp1_verifier_vk_root.py")
+SPEC = importlib.util.spec_from_file_location("normalize_sp1_vk_root", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def verifier(root: str) -> str:
+    return f"""
+contract SP1Verifier {{
+    function VK_ROOT() public pure returns (bytes32) {{
+        return 0x{root};
+    }}
+}}
+"""
+
+
+class NormalizeVkRootTests(unittest.TestCase):
+    def write(self, directory: str, name: str, root: str) -> Path:
+        path = Path(directory) / name
+        path.write_text(verifier(root), encoding="utf-8")
+        return path
+
+    def test_removes_only_redundant_zero_byte(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            expected = "2f" * 32
+            groth = self.write(directory, "groth.sol", "00" + expected)
+            plonk = self.write(directory, "plonk.sol", "00" + expected)
+            result = MODULE.normalize_all([groth, plonk])
+            self.assertEqual(result["vk_root"], "0x" + expected)
+            self.assertIn("return 0x" + expected, groth.read_text(encoding="utf-8"))
+
+    def test_is_idempotent_for_canonical_bytes32(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            expected = "ab" * 32
+            path = self.write(directory, "verifier.sol", expected)
+            self.assertEqual(MODULE.normalize(path), "0x" + expected)
+            self.assertEqual(MODULE.normalize(path), "0x" + expected)
+
+    def test_nonzero_extra_byte_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write(directory, "verifier.sol", "01" + "ab" * 32)
+            with self.assertRaisesRegex(ValueError, "32 bytes"):
+                MODULE.normalize(path)
+
+    def test_proof_system_root_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            groth = self.write(directory, "groth.sol", "11" * 32)
+            plonk = self.write(directory, "plonk.sol", "22" * 32)
+            with self.assertRaisesRegex(ValueError, "VK roots differ"):
+                MODULE.normalize_all([groth, plonk])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make the shared Rust setup action find rustup on self-hosted runners even when the runner snapshot omits Cargo's bin directory
- canonicalize SP1's redundant zero-prefixed 33-byte BN254 VK root to an exact Solidity bytes32
- require Groth16 and PLONK roots to match and emit release evidence
- add fail-closed regression tests

## Validation
- Python unit tests pass
- workflow YAML parses
- exact trusted Groth16 and PLONK sources normalize to the same root
- both normalized immutable verifier sources compile with pinned solc 0.8.26 on the release builder

## Release impact
Beta3 remains blocked until this PR is merged and a new exact-main protected release passes all cryptographic, Sepolia, mainnet canary, x402 refund, indexer, and activation gates.