### PR TITLE
Fix Beta3 broker destination signing

### DIFF
--- a/scripts/fund_open_competition_v2_beta3_broker.py
+++ b/scripts/fund_open_competition_v2_beta3_broker.py
@@ -12,6 +12,7 @@ import time
 from typing import Any
 
 from eth_account import Account
+from eth_utils import to_checksum_address
 
 from _shared.evm import address_word, uint_word
 from _shared.rpc import rpc
@@ -57,6 +58,11 @@ def usdc_balance(url: str, token: str, address: str, block: str) -> int:
     return int(rpc(url, "eth_call", [{"to": token, "data": data}, block]), 16)
 
 
+def signing_address(address: str) -> str:
+    require(ADDRESS.fullmatch(address) is not None, "transaction destination is invalid")
+    return to_checksum_address(address)
+
+
 class SignedRpc:
     def __init__(self, url: str, signer: Any, chain_id: int) -> None:
         self.url = url
@@ -65,6 +71,7 @@ class SignedRpc:
         require(int(rpc(url, "eth_chainId", []), 16) == chain_id, "RPC chain ID mismatch")
 
     def send(self, *, to: str, data: str = "0x", value: int = 0) -> dict[str, Any]:
+        to = signing_address(to)
         nonce = int(rpc(self.url, "eth_getTransactionCount", [self.signer.address, "pending"]), 16)
         block = rpc(self.url, "eth_getBlockByNumber", ["latest", False])
         base_fee = int(block.get("baseFeePerGas", "0x0"), 16)

--- a/scripts/test_fund_open_competition_v2_beta3_broker.py
+++ b/scripts/test_fund_open_competition_v2_beta3_broker.py
@@ -34,6 +34,28 @@ class BrokerFundingTests(unittest.TestCase):
         with self.assertRaisesRegex(MODULE.BrokerFundingError, "are invalid"):
             MODULE.deficits(current_usdc=0, current_eth=0, target_usdc=0, target_eth=0)
 
+    def test_signing_address_accepts_canonical_lowercase_broker(self):
+        destination = MODULE.signing_address("0x176f486a724720c4fdfc920d7c17dd1004c2bfb4")
+        self.assertEqual(destination, "0x176f486A724720C4FDfc920d7c17Dd1004C2bfb4")
+        signer = MODULE.Account.from_key("0x" + "01".zfill(64))
+        signed = signer.sign_transaction(
+            {
+                "chainId": 84532,
+                "to": destination,
+                "nonce": 0,
+                "value": 1,
+                "gas": 21_000,
+                "maxFeePerGas": 2_000_000,
+                "maxPriorityFeePerGas": 1_000_000,
+                "type": 2,
+            }
+        )
+        self.assertTrue(signed.raw_transaction)
+
+    def test_signing_address_rejects_malformed_destination(self):
+        with self.assertRaisesRegex(MODULE.BrokerFundingError, "destination is invalid"):
+            MODULE.signing_address("0x1234")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary\n- checksum EVM destinations only at the th-account signing boundary\n- retain lowercase canonical addresses in release evidence and identity comparisons\n- add a regression using the exact lowercased Sepolia broker address that failed\n\n## Incident\nProtected release run 32087800864 attempt 2 stopped before deployment because th-account rejected the lowercase transaction 	o address. No Sepolia or mainnet Beta3 contract was deployed and no production funds moved.\n\n## Verification\n- python -m unittest scripts.test_fund_open_competition_v2_beta3_broker scripts.test_verify_open_competition_v2_beta3_broker_reserve scripts.test_build_open_competition_v2_beta3_release -v\n- python -m py_compile scripts/fund_open_competition_v2_beta3_broker.py scripts/test_fund_open_competition_v2_beta3_broker.py\n- scripts/preflight.ps1 -Mode core\n- git diff --check\n\nThe regression signs an EIP-1559 transaction with the exact failed lowercase broker address after checksum normalization.