### PR TITLE
Allow provider-neutral bounty posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Agent Bounties is an open-source AI-agent bounty marketplace and protocol where
 agents find, claim, complete, verify, and receive Base USDC for digital work.
 
 - Website: <https://agentbounties.app/>
-- Post a bounty: <https://agentbounties.app/#post-a-bounty>
+- Post a bounty: <https://agentbounties.app/post.html>
 - Live metrics: <https://agentbounties.app/metrics.html>
 - About: <https://agentbounties.app/about.html>
 - Blog: <https://agentbounties.app/blog/>
@@ -87,10 +87,13 @@ verification-ready. Recheck chain state before signing.
 
 ## Post work
 
-The public homepage opens the assistant chooser. Machine clients can use
-`prepare_bounty_post` when it appears in their MCP catalog. Advanced clients
-should follow the OpenAPI contract and publish inspectable terms with binary,
-replayable acceptance criteria before requesting funds or signatures.
+The public homepage opens the assistant chooser, and the first-party review
+handoff is <https://agentbounties.app/post.html>. Machine clients can use
+`prepare_bounty_post` when it appears in their MCP catalog. An approved image
+and its metadata may be supplied together, but are not required by
+provider-neutral clients. Advanced clients should follow the OpenAPI contract
+and publish inspectable terms with binary, replayable acceptance criteria
+before requesting funds or signatures.
 
 The hosted objective compiler can split one larger outcome into validated task
 drafts. Its output has no wallet, funding, verification, or settlement
@@ -109,6 +112,7 @@ Run the narrow checks first:
 
 ```bash
 python scripts/check-site.py
+python scripts/check-public-handoffs.py
 python scripts/check-agent-discovery-contract.py
 python scripts/test_check_agent_discovery_contract.py
 python scripts/test_mcp_tool_registry.py

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -5055,6 +5055,19 @@ fn validated_site_analytics_event(
             | "competition_feedback_submitted"
             | "canonical_post_started"
             | "canonical_post_confirmed"
+            | "auth_completed"
+            | "wallet_link_started"
+            | "wallet_link_confirmed"
+            | "wallet_missing_detected"
+            | "wallet_connected"
+            | "wallet_unfunded_detected"
+            | "wallet_funded_observed"
+            | "canonical_post_handoff_viewed"
+            | "onramp_viewed"
+            | "onramp_moonpay_started"
+            | "onramp_metamask_started"
+            | "onramp_coinbase_started"
+            | "onramp_returned"
     ) {
         return Err(StatusCode::BAD_REQUEST);
     }
@@ -5181,82 +5194,46 @@ fn site_analytics_response(
     window_started_at: DateTime<Utc>,
     generated_at: DateTime<Utc>,
 ) -> SiteAnalyticsResponse {
-    let session_count = |event_name: &str| {
-        stats
-            .event_counts
-            .iter()
-            .find(|count| count.event_name == event_name)
-            .map(|count| count.sessions)
-            .unwrap_or(0)
-    };
-    let rate = |metric: &str, numerator: &str, denominator: &str, cohort: &str| {
-        let numerator_sessions = session_count(numerator);
-        let denominator_sessions = session_count(denominator);
-        SiteAnalyticsRateResponse {
-            metric: metric.to_string(),
-            numerator_sessions,
-            denominator_sessions,
-            value: (denominator_sessions > 0)
-                .then(|| numerator_sessions as f64 / denominator_sessions as f64),
-            cohort: cohort.to_string(),
+    let cohort = |metric: &str| match metric {
+        "market_to_funded_bounty_click" | "market_to_funding_start" => {
+            "sessions that loaded live market inventory"
         }
+        "canonical_post_completion" => "sessions that began the wallet-backed canonical post flow",
+        "claim_confirmation" => "sessions that began a claim flow",
+        "auth_to_post_handoff" => "sessions that completed first-party authentication",
+        "wallet_link_completion" => "sessions that began linking a wallet to an account",
+        "no_wallet_to_connected" => "sessions where the posting flow detected no wallet",
+        "unfunded_wallet_to_funded" => {
+            "sessions where the posting flow observed an unfunded wallet"
+        }
+        "onramp_return"
+        | "onramp_moonpay_start"
+        | "onramp_metamask_start"
+        | "onramp_coinbase_start" => "sessions that viewed the first-party on-ramp",
+        "funded_click_to_competition_view" => {
+            "sessions that opened a funded competition from the unified market"
+        }
+        "competition_instruction_engagement" | "competition_child_post_start" => {
+            "sessions that loaded a contract-specific competition workspace"
+        }
+        "competition_feedback_completion" => {
+            "sessions that began the public competition feedback form"
+        }
+        "competition_entry_confirmation" => "sessions that began an Open Competition entry flow",
+        _ => "sessions in the named funnel",
     };
-    let rates = vec![
-        rate(
-            "market_to_funded_bounty_click",
-            "funded_bounty_click",
-            "market_view",
-            "sessions that loaded live market inventory",
-        ),
-        rate(
-            "canonical_post_completion",
-            "canonical_post_confirmed",
-            "canonical_post_started",
-            "sessions that began the wallet-backed canonical post flow",
-        ),
-        rate(
-            "market_to_funding_start",
-            "funding_started",
-            "market_view",
-            "sessions that loaded live market inventory",
-        ),
-        rate(
-            "claim_confirmation",
-            "claim_confirmed",
-            "claim_started",
-            "sessions that began a claim flow",
-        ),
-        rate(
-            "funded_click_to_competition_view",
-            "competition_view",
-            "funded_bounty_click",
-            "sessions that opened a funded competition from the unified market",
-        ),
-        rate(
-            "competition_instruction_engagement",
-            "competition_instructions_copied",
-            "competition_view",
-            "sessions that loaded a contract-specific competition workspace",
-        ),
-        rate(
-            "competition_child_post_start",
-            "competition_child_post_started",
-            "competition_view",
-            "sessions that loaded a contract-specific competition workspace",
-        ),
-        rate(
-            "competition_feedback_completion",
-            "competition_feedback_submitted",
-            "competition_feedback_started",
-            "sessions that began the public competition feedback form",
-        ),
-        rate(
-            "competition_entry_confirmation",
-            "competition_entry_confirmed",
-            "competition_entry_started",
-            "sessions that began an Open Competition entry flow",
-        ),
-    ];
+    let rates = stats
+        .funnel_counts
+        .into_iter()
+        .map(|count| SiteAnalyticsRateResponse {
+            cohort: cohort(&count.metric).to_string(),
+            value: (count.denominator_sessions > 0)
+                .then(|| count.numerator_sessions as f64 / count.denominator_sessions as f64),
+            metric: count.metric,
+            numerator_sessions: count.numerator_sessions,
+            denominator_sessions: count.denominator_sessions,
+        })
+        .collect();
     SiteAnalyticsResponse {
         schema_version: "agent-bounties/site-analytics-v2".to_string(),
         window_hours,
@@ -5331,6 +5308,7 @@ fn site_analytics_response(
             "External interface usage is an hourly aggregate of observed requests, not unique people, agents, clients, or sessions; partial boundary hours are included.".to_string(),
             "Requests bearing a server-verified analytics exclusion or operator credential are omitted before aggregation; no operator identifier is stored.".to_string(),
             "API and CLI attribution is self-declared through x-agent-bounties-interface; MCP protocol era is observed by the MCP service.".to_string(),
+            "Funnel numerators count only sessions that recorded the denominator first and the numerator later in the selected window.".to_string(),
         ],
         evidence_boundary: "Collection begins only after each feature is deployed and has no historical backfill. External interface counting restarts at the operator-exclusion release; the earlier launch aggregate is retained outside this public response because it contains maintainer validation traffic that cannot be separated retrospectively. Cleared storage, private browsing, multiple devices, disabled analytics, Global Privacy Control, and Do Not Track affect browser coverage. Interface counters cannot deduplicate users or prove preference, and self-declared API or CLI attribution can be absent or spoofed. No IP address, user agent, full referrer URL, wallet, client identifier, request body, prompt, tool arguments, or operator identity is stored. Client conversion events describe observed interface actions; canonical lifecycle and payment claims remain authoritative only in confirmed canonical events, and only BountySettled proves solver payment.".to_string(),
     }
@@ -17443,6 +17421,46 @@ mod tests {
             now,
         )
         .is_err());
+    }
+
+    #[test]
+    fn site_analytics_accepts_the_privacy_minimized_onboarding_funnel() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 24, 18, 0, 0).unwrap();
+        for event_name in [
+            "auth_completed",
+            "wallet_link_started",
+            "wallet_link_confirmed",
+            "wallet_missing_detected",
+            "wallet_connected",
+            "wallet_unfunded_detected",
+            "wallet_funded_observed",
+            "canonical_post_handoff_viewed",
+            "onramp_viewed",
+            "onramp_moonpay_started",
+            "onramp_metamask_started",
+            "onramp_coinbase_started",
+            "onramp_returned",
+        ] {
+            let event = validated_site_analytics_event(
+                SiteAnalyticsEventRequest {
+                    event_id: Uuid::new_v4(),
+                    visitor_id: Uuid::new_v4(),
+                    session_id: Uuid::new_v4(),
+                    event_name: event_name.to_string(),
+                    page_path: "/onramp.html".to_string(),
+                    source: None,
+                    campaign: None,
+                    referrer_host: None,
+                    opportunity_id: None,
+                    bounty_contract: None,
+                    occurred_at: now,
+                },
+                now,
+            )
+            .unwrap();
+            assert_eq!(event.event_name, event_name);
+            assert_eq!(event.page_path, "/onramp.html");
+        }
     }
 
     #[test]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -561,9 +561,17 @@ pub struct InterfaceUsageStats {
 pub struct SiteAnalyticsStats {
     pub overview: SiteAnalyticsOverview,
     pub event_counts: Vec<SiteAnalyticsEventCount>,
+    pub funnel_counts: Vec<SiteAnalyticsFunnelCount>,
     pub daily: Vec<SiteAnalyticsDailyStats>,
     pub channels: Vec<SiteAnalyticsChannelStats>,
     pub interfaces: Vec<InterfaceUsageStats>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SiteAnalyticsFunnelCount {
+    pub metric: String,
+    pub numerator_sessions: u64,
+    pub denominator_sessions: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1999,6 +2007,50 @@ impl PostgresStore {
         .fetch_all(&self.pool)
         .await?;
 
+        let funnel_rows = sqlx::query(
+            r#"
+            WITH window_events AS (
+              SELECT session_id, event_name, occurred_at
+              FROM site_analytics_events
+              WHERE occurred_at >= $1 AND occurred_at <= NOW()
+            ), definitions(metric, numerator, denominator) AS (
+              VALUES
+                ('market_to_funded_bounty_click', 'funded_bounty_click', 'market_view'),
+                ('canonical_post_completion', 'canonical_post_confirmed', 'canonical_post_started'),
+                ('market_to_funding_start', 'funding_started', 'market_view'),
+                ('claim_confirmation', 'claim_confirmed', 'claim_started'),
+                ('auth_to_post_handoff', 'canonical_post_handoff_viewed', 'auth_completed'),
+                ('wallet_link_completion', 'wallet_link_confirmed', 'wallet_link_started'),
+                ('no_wallet_to_connected', 'wallet_connected', 'wallet_missing_detected'),
+                ('unfunded_wallet_to_funded', 'wallet_funded_observed', 'wallet_unfunded_detected'),
+                ('onramp_return', 'onramp_returned', 'onramp_viewed'),
+                ('onramp_moonpay_start', 'onramp_moonpay_started', 'onramp_viewed'),
+                ('onramp_metamask_start', 'onramp_metamask_started', 'onramp_viewed'),
+                ('onramp_coinbase_start', 'onramp_coinbase_started', 'onramp_viewed'),
+                ('funded_click_to_competition_view', 'competition_view', 'funded_bounty_click'),
+                ('competition_instruction_engagement', 'competition_instructions_copied', 'competition_view'),
+                ('competition_child_post_start', 'competition_child_post_started', 'competition_view'),
+                ('competition_feedback_completion', 'competition_feedback_submitted', 'competition_feedback_started'),
+                ('competition_entry_confirmation', 'competition_entry_confirmed', 'competition_entry_started')
+            )
+            SELECT definitions.metric,
+                   COUNT(DISTINCT numerator.session_id) AS numerator_sessions,
+                   COUNT(DISTINCT denominator.session_id) AS denominator_sessions
+            FROM definitions
+            LEFT JOIN window_events AS denominator
+              ON denominator.event_name = definitions.denominator
+            LEFT JOIN window_events AS numerator
+              ON numerator.session_id = denominator.session_id
+             AND numerator.event_name = definitions.numerator
+             AND numerator.occurred_at >= denominator.occurred_at
+            GROUP BY definitions.metric
+            ORDER BY definitions.metric
+            "#,
+        )
+        .bind(window_started_at)
+        .fetch_all(&self.pool)
+        .await?;
+
         let daily_rows = sqlx::query(
             r#"
             SELECT to_char(occurred_at::date, 'YYYY-MM-DD') AS day,
@@ -2092,6 +2144,16 @@ impl PostgresStore {
                         events: u64_from_i64(row.try_get("events")?)?,
                         sessions: u64_from_i64(row.try_get("sessions")?)?,
                         visitors: u64_from_i64(row.try_get("visitors")?)?,
+                    })
+                })
+                .collect::<DbResult<Vec<_>>>()?,
+            funnel_counts: funnel_rows
+                .into_iter()
+                .map(|row| {
+                    Ok(SiteAnalyticsFunnelCount {
+                        metric: row.try_get("metric")?,
+                        numerator_sessions: u64_from_i64(row.try_get("numerator_sessions")?)?,
+                        denominator_sessions: u64_from_i64(row.try_get("denominator_sessions")?)?,
                     })
                 })
                 .collect::<DbResult<Vec<_>>>()?,
@@ -10677,7 +10739,7 @@ mod tests {
         let store = PostgresStore::connect(&database_url).await.unwrap();
         store.migrate().await.unwrap();
 
-        let now = Utc::now();
+        let now = Utc::now() - chrono::Duration::seconds(3);
         let event = NewSiteAnalyticsEvent {
             event_id: Uuid::new_v4(),
             visitor_id: Uuid::new_v4(),
@@ -10693,6 +10755,26 @@ mod tests {
         };
         assert!(store.record_site_analytics_event(&event).await.unwrap());
         assert!(!store.record_site_analytics_event(&event).await.unwrap());
+        let wallet_missing = NewSiteAnalyticsEvent {
+            event_id: Uuid::new_v4(),
+            event_name: "wallet_missing_detected".to_string(),
+            occurred_at: now + chrono::Duration::seconds(1),
+            ..event.clone()
+        };
+        let wallet_connected = NewSiteAnalyticsEvent {
+            event_id: Uuid::new_v4(),
+            event_name: "wallet_connected".to_string(),
+            occurred_at: now + chrono::Duration::seconds(2),
+            ..event.clone()
+        };
+        assert!(store
+            .record_site_analytics_event(&wallet_missing)
+            .await
+            .unwrap());
+        assert!(store
+            .record_site_analytics_event(&wallet_connected)
+            .await
+            .unwrap());
         let before = store
             .site_analytics_stats(now - chrono::Duration::minutes(1))
             .await
@@ -10747,6 +10829,13 @@ mod tests {
             .unwrap();
         assert!(stats.overview.unique_visitors >= 1);
         assert!(stats.overview.page_views >= 1);
+        let no_wallet_funnel = stats
+            .funnel_counts
+            .iter()
+            .find(|count| count.metric == "no_wallet_to_connected")
+            .expect("no-wallet funnel is aggregated");
+        assert!(no_wallet_funnel.denominator_sessions >= 1);
+        assert!(no_wallet_funnel.numerator_sessions >= 1);
         assert!(stats
             .channels
             .iter()

--- a/crates/mcp-server/fixtures/public-mcp-contract-v1.json
+++ b/crates/mcp-server/fixtures/public-mcp-contract-v1.json
@@ -16,7 +16,7 @@
         "prepare_moonpay_onramp",
         "render_bounty_feed"
       ],
-      "normalized_descriptors_sha256": "1370a128d41f30c280639892d422b6cbad371e3171007ade04e3a2cbb58fdf58"
+      "normalized_descriptors_sha256": "ab4d2cdfd1277e3f88a32e225ecff7ece2ac658bdacbde11d3d6bbfeb045180f"
     },
     "core": {
       "tool_count": 13,
@@ -35,7 +35,7 @@
         "prepare_open_competition_v2",
         "render_bounty_feed"
       ],
-      "normalized_descriptors_sha256": "6d71d24f9a70e6151244b21e02df39b39f95364f860df70a270d03a2f4cbe136"
+      "normalized_descriptors_sha256": "264d7b89e43598309e68f635f75c7c9436d40f2b934cce4b45744ef414a46431"
     }
   }
 }

--- a/crates/mcp-server/fixtures/tool-registry.json
+++ b/crates/mcp-server/fixtures/tool-registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "agent-bounties/mcp-tool-registry-v1",
-  "normalized_descriptors_sha256": "835665828ec2baaecde7de29a33fd18b294f7360bfa4c58df8c952683e46f6dd",
+  "normalized_descriptors_sha256": "4657f08ee7e37f33624c0f65de41539bbc5debbd7624d106409bdd9fabc0f8d6",
   "tools": [
     "route_blocked_goal",
     "plan_objective_creation",

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -47,7 +47,7 @@ const MCP_NAME_HEADER: &str = "mcp-name";
 const MCP_ALLOWED_ORIGINS_ENV: &str = "MCP_ALLOWED_ORIGINS";
 const CHATGPT_SANDBOX_ENV: &str = "CHATGPT_APP_SANDBOX_MODE";
 const FEED_WIDGET_URI: &str = "ui://agent-bounties/live-feed-v4.html";
-const POST_PAGE_URL: &str = "https://agentbounties.app/#post-a-bounty";
+const POST_PAGE_URL: &str = "https://agentbounties.app/post.html";
 const FEED_WIDGET_HTML: &str = include_str!("../assets/chatgpt-bounty-feed-widget.html");
 const BOUNTY_CARD_PREVIEW_HTML: &str = include_str!("../assets/chatgpt-bounty-card-preview.html");
 const FEED_CARD_ART: &[u8] =
@@ -278,17 +278,20 @@ pub(super) async fn prepare_bounty_post_handoff(
     state: &SharedState,
     args: &PrepareBountyPostArgs,
 ) -> Result<Value, String> {
-    // Fail closed on every non-file field before downloading or persisting the
-    // approved image.
+    // Fail closed on every non-file field before downloading or persisting an
+    // optional approved image.
     let validation_image = sandbox_bounty_image_reference(args)?;
-    build_bounty_post_handoff(args, &validation_image)?;
+    let validation_handoff = build_bounty_post_handoff(args, validation_image.as_ref())?;
+    if validation_image.is_none() {
+        return Ok(validation_handoff);
+    }
     let image = persist_chatgpt_bounty_image(state, args).await?;
-    build_bounty_post_handoff(args, &image)
+    build_bounty_post_handoff(args, Some(&image))
 }
 
 pub(super) fn build_bounty_post_handoff(
     args: &PrepareBountyPostArgs,
-    image: &BountyImageReference,
+    image: Option<&BountyImageReference>,
 ) -> Result<Value, String> {
     let title = bounded_text(&args.title, "title", 200)?;
     let goal = bounded_text(&args.goal, "goal", 4_000)?;
@@ -315,22 +318,38 @@ pub(super) fn build_bounty_post_handoff(
         .as_deref()
         .map(|value| bounded_text(value, "discovery_source", 500))
         .transpose()?;
-    let image_prompt = bounded_text(&args.image_prompt, "image_prompt", 4_000)?;
-    let image_alt_text = bounded_text(&args.image_alt_text, "image_alt_text", 500)?;
-    if image.source != "chatgpt_user_generated"
-        || image.prompt != image_prompt
-        || image.alt_text != image_alt_text
-    {
-        return Err(
-            "the stored bounty image must match the prompt and alt text approved in ChatGPT"
-                .to_string(),
-        );
+    match (
+        image,
+        args.image_prompt.as_deref(),
+        args.image_alt_text.as_deref(),
+        args.bounty_image.as_ref(),
+    ) {
+        (None, None, None, None) => {}
+        (Some(image), Some(prompt), Some(alt_text), Some(_)) => {
+            let image_prompt = bounded_text(prompt, "image_prompt", 4_000)?;
+            let image_alt_text = bounded_text(alt_text, "image_alt_text", 500)?;
+            if image.source != "chatgpt_user_generated"
+                || image.prompt != image_prompt
+                || image.alt_text != image_alt_text
+            {
+                return Err(
+                    "the stored bounty image must match the prompt and alt text approved in the AI conversation"
+                        .to_string(),
+                );
+            }
+        }
+        _ => {
+            return Err(
+                "bounty_image, image_prompt, and image_alt_text must be supplied together or all omitted"
+                    .to_string(),
+            );
+        }
     }
 
     let mut post_url = Url::parse(POST_PAGE_URL).expect("static post URL is valid");
     {
         let mut query = post_url.query_pairs_mut();
-        query.append_pair("from", "chatgpt-app");
+        query.append_pair("from", "ai-app");
         query.append_pair("title", &title);
         query.append_pair("goal", &goal);
         for criterion in &acceptance_criteria {
@@ -345,13 +364,17 @@ pub(super) fn build_bounty_post_handoff(
         }
         query.append_pair(
             "discoverySource",
-            discovery_source.as_deref().unwrap_or("ChatGPT app"),
+            discovery_source
+                .as_deref()
+                .unwrap_or("AI assistant via MCP"),
         );
-        query.append_pair("imageUrl", &image.asset_url);
-        query.append_pair("imageSha256", &image.sha256);
-        query.append_pair("imageMimeType", &image.mime_type);
-        query.append_pair("imagePrompt", &image.prompt);
-        query.append_pair("imageAlt", &image.alt_text);
+        if let Some(image) = image {
+            query.append_pair("imageUrl", &image.asset_url);
+            query.append_pair("imageSha256", &image.sha256);
+            query.append_pair("imageMimeType", &image.mime_type);
+            query.append_pair("imagePrompt", &image.prompt);
+            query.append_pair("imageAlt", &image.alt_text);
+        }
     }
     if post_url.as_str().len() > 12_000 {
         return Err(
@@ -386,15 +409,30 @@ async fn persist_chatgpt_bounty_image(
     state: &SharedState,
     args: &PrepareBountyPostArgs,
 ) -> Result<BountyImageReference, String> {
-    let prompt = bounded_text(&args.image_prompt, "image_prompt", 4_000)?;
-    let alt_text = bounded_text(&args.image_alt_text, "image_alt_text", 500)?;
-    let file_id = bounded_text(&args.bounty_image.file_id, "bounty_image.file_id", 512)?;
-    let download_url = validate_chatgpt_download_url(&args.bounty_image.download_url)?;
+    let prompt = bounded_text(
+        args.image_prompt
+            .as_deref()
+            .ok_or_else(|| "image_prompt is required when bounty_image is supplied".to_string())?,
+        "image_prompt",
+        4_000,
+    )?;
+    let alt_text = bounded_text(
+        args.image_alt_text.as_deref().ok_or_else(|| {
+            "image_alt_text is required when bounty_image is supplied".to_string()
+        })?,
+        "image_alt_text",
+        500,
+    )?;
+    let bounty_image = args
+        .bounty_image
+        .as_ref()
+        .ok_or_else(|| "bounty_image is required when image text is supplied".to_string())?;
+    let file_id = bounded_text(&bounty_image.file_id, "bounty_image.file_id", 512)?;
+    let download_url = validate_chatgpt_download_url(&bounty_image.download_url)?;
     let bytes = download_chatgpt_image(&download_url).await?;
     let mime_type = detect_bounty_image_mime(&bytes)
         .ok_or_else(|| "bounty_image must be a valid PNG, JPEG, or WebP file".to_string())?;
-    if let Some(declared) = args
-        .bounty_image
+    if let Some(declared) = bounty_image
         .mime_type
         .as_deref()
         .map(str::trim)
@@ -406,7 +444,7 @@ async fn persist_chatgpt_bounty_image(
             ));
         }
     }
-    if let Some(file_name) = args.bounty_image.file_name.as_deref() {
+    if let Some(file_name) = bounty_image.file_name.as_deref() {
         bounded_text(file_name, "bounty_image.file_name", 255)?;
     }
     let sha256 = Sha256::digest(&bytes)
@@ -535,15 +573,27 @@ fn detect_bounty_image_mime(bytes: &[u8]) -> Option<&'static str> {
 
 fn sandbox_bounty_image_reference(
     args: &PrepareBountyPostArgs,
-) -> Result<BountyImageReference, String> {
-    Ok(BountyImageReference {
-        source: "chatgpt_user_generated".to_string(),
-        prompt: bounded_text(&args.image_prompt, "image_prompt", 4_000)?,
-        alt_text: bounded_text(&args.image_alt_text, "image_alt_text", 500)?,
-        asset_url: "https://agentbounties.app/assets/solarpunk/characters-helping.webp".to_string(),
-        sha256: "0".repeat(64),
-        mime_type: "image/webp".to_string(),
-    })
+) -> Result<Option<BountyImageReference>, String> {
+    match (
+        args.image_prompt.as_deref(),
+        args.image_alt_text.as_deref(),
+        args.bounty_image.as_ref(),
+    ) {
+        (None, None, None) => Ok(None),
+        (Some(prompt), Some(alt_text), Some(_)) => Ok(Some(BountyImageReference {
+            source: "chatgpt_user_generated".to_string(),
+            prompt: bounded_text(prompt, "image_prompt", 4_000)?,
+            alt_text: bounded_text(alt_text, "image_alt_text", 500)?,
+            asset_url: "https://agentbounties.app/assets/solarpunk/characters-helping.webp"
+                .to_string(),
+            sha256: "0".repeat(64),
+            mime_type: "image/webp".to_string(),
+        })),
+        _ => Err(
+            "bounty_image, image_prompt, and image_alt_text must be supplied together or all omitted"
+                .to_string(),
+        ),
+    }
 }
 
 pub(super) async fn mcp_post(
@@ -1024,7 +1074,7 @@ fn mcp_server_instructions() -> &'static str {
     } else if public_review {
         "Public review mode is active. Show only voluntary, unfunded community requests with no payment promise. Use render_bounty_feed for the compact in-chat work queue, publish_unfunded_bounty only when the user explicitly asks to publish a voluntary request, compile_objective_with_cloud_agent only for non-economic task decomposition, and the comment and share tools for public collaboration. Funding, claiming, completion, verification, wallet, settlement, token, and payment actions are unavailable in this app configuration. Never imply otherwise or direct a user around this boundary."
     } else {
-        "Use get_bounty_feed to inspect fresh structured bounty data, then render_bounty_feed to show the mounted read-only feed in ChatGPT. The widget has only Post bounty, Comment, Share, and Solve actions; each action starts a conversation. For a new bounty, interview the person until the terms and image direction are complete, generate a unique bounty image in their ChatGPT account, show it for approval, summarize the complete bounty, and obtain explicit confirmation. Then call prepare_bounty_post with that approved ChatGPT image file; Agent Bounties stores the exact file and never generates a replacement. For fund, solve or claim, complete, or verify, call prepare_bounty_action and open only its first-party HTTPS authorization URL. If a funder needs Base USDC, call prepare_moonpay_onramp and open only its first-party HTTPS handoff; MoonPay purchase, wallet connection, identity checks, and card entry stay outside ChatGPT, and buying USDC is not bounty funding. Never request or accept a wallet signature, private key, seed phrase, payment authorization, verifier signature, or card data in ChatGPT. Refresh with get_bounty_action_status; only confirmed canonical events change the card, and only BountySettled proves solver payment. Use compile_objective_with_cloud_agent to break a broad objective into smaller reviewable child bounties. Use create_share_bundle after every meaningful step."
+        "Use get_bounty_feed to inspect fresh structured bounty data, then render_bounty_feed to show the mounted read-only feed in ChatGPT. The widget has only Post bounty, Comment, Share, and Solve actions; each action starts a conversation. For a new bounty, interview the person until the terms are complete, summarize them, and obtain explicit confirmation. If this AI can create and attach an image, show the exact image for approval and pass it to prepare_bounty_post with its prompt and alt text. Otherwise omit all three optional image fields and let the first-party review page use its deterministic content-derived visual. Agent Bounties never generates a replacement with a platform model key. For fund, solve or claim, complete, or verify, call prepare_bounty_action and open only its first-party HTTPS authorization URL. If a funder needs Base USDC, call prepare_moonpay_onramp and open only its first-party HTTPS handoff; provider purchase, wallet connection, identity checks, and card entry stay outside ChatGPT, and buying USDC is not bounty funding. Never request or accept a wallet signature, private key, seed phrase, payment authorization, verifier signature, or card data in ChatGPT. Refresh with get_bounty_action_status; only confirmed canonical events change the card, and only BountySettled proves solver payment. Use compile_objective_with_cloud_agent to break a broad objective into smaller reviewable child bounties. Use create_share_bundle after every meaningful step."
     }
 }
 
@@ -1706,7 +1756,7 @@ async fn call_tool(state: SharedState, params: &Value) -> Result<Value, String> 
             let value = prepare_bounty_post_handoff(&state, &args).await?;
             return Ok(tool_result(
                 value,
-                "Stored the image generated and approved in the poster's ChatGPT account, then prepared a reviewable wallet handoff. No bounty has been published or created yet.",
+                "Prepared a reviewable wallet handoff, preserving the exact approved AI-generated image when one was supplied. No bounty has been published or created yet.",
                 true,
             ));
         }
@@ -2303,7 +2353,7 @@ async fn sandbox_tool_result(name: &str, arguments: &Value) -> Result<Value, Str
             let args: PrepareBountyPostArgs = serde_json::from_value(arguments.clone())
                 .map_err(|error| format!("invalid prepare_bounty_post arguments: {error}"))?;
             let image = sandbox_bounty_image_reference(&args)?;
-            let mut value = build_bounty_post_handoff(&args, &image)?;
+            let mut value = build_bounty_post_handoff(&args, image.as_ref())?;
             mark_sandbox(
                 &mut value,
                 "The handoff is a sandbox fixture. No bounty was published, created, signed, or funded.",
@@ -3447,17 +3497,22 @@ fn post_handoff_output_schema() -> Value {
             "crowdfund": {"type": "boolean"},
             "source_url": {"type": ["string", "null"]},
             "image": {
-                "type": "object",
-                "properties": {
-                    "source": {"type": "string", "const": "chatgpt_user_generated"},
-                    "prompt": {"type": "string"},
-                    "alt_text": {"type": "string"},
-                    "asset_url": {"type": "string"},
-                    "sha256": {"type": "string"},
-                    "mime_type": {"type": "string"}
-                },
-                "required": ["source", "prompt", "alt_text", "asset_url", "sha256", "mime_type"],
-                "additionalProperties": false
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "source": {"type": "string", "const": "chatgpt_user_generated"},
+                            "prompt": {"type": "string"},
+                            "alt_text": {"type": "string"},
+                            "asset_url": {"type": "string"},
+                            "sha256": {"type": "string"},
+                            "mime_type": {"type": "string"}
+                        },
+                        "required": ["source", "prompt", "alt_text", "asset_url", "sha256", "mime_type"],
+                        "additionalProperties": false
+                    },
+                    {"type": "null"}
+                ]
             },
             "post_url": {"type": "string"},
             "bounty_created": {"type": "boolean"},
@@ -3958,7 +4013,7 @@ fn chatgpt_tool_description(name: &str, fallback: &'static str) -> &'static str 
         "publish_unfunded_bounty" => "Use this when the person explicitly wants to publish a public voluntary request with no wallet and zero committed USDC. It is not canonical, funded, claimable, or guaranteed to pay.",
         "list_unfunded_bounties" => "Use this when the person explicitly asks for voluntary or unpaid Agent Bounties work. Keep these records separate from funded earning opportunities and never promise payment.",
         "submit_unfunded_bounty_solution" => "Use this when a registered agent explicitly wants to publish or replace its public solution to an open unfunded request. This public write creates no payment claim.",
-        "prepare_bounty_post" => "Use this when ChatGPT has conversationally gathered complete bounty terms, generated a unique image in the poster's own ChatGPT account, shown that exact image to the poster, and received explicit approval of the image and terms. Pass the approved file as bounty_image with its exact generation prompt and alt text. Agent Bounties stores that file and prepares a reviewable wallet handoff; it does not generate an image, move funds, request a secret, or prove that a bounty exists.",
+        "prepare_bounty_post" => "Use this when the person's AI has conversationally gathered complete bounty terms and received explicit approval. If the AI can generate and attach an approved image, pass bounty_image with its exact prompt and alt text; otherwise omit all three optional image fields and the review page will use a deterministic content-derived visual. Agent Bounties prepares a reviewable wallet handoff; it does not generate an image with a platform model key, move funds, request a secret, or prove that a bounty exists.",
         "list_autonomous_bounties" => "Use this when the person wants funded Agent Bounties work or canonical lifecycle inventory. Set claimable_only=true for work that is currently funded and open to solve.",
         "inspect_open_competition_v2" => "New users start with operation=guide. Then inspect the V2 Beta3 release, reviewed profiles, inventory, events, or proof-job state in the returned order. Treat only CompetitionSettledV2 as payment evidence.",
         "prepare_open_competition_v2" => "Use this only after inspect_open_competition_v2(operation=guide). Match arguments to the selected operation's exact schema. Some operations return unsigned plans; quote_proof creates a hosted job, pay_proof may transfer Base USDC after explicit approval, and authorize_relay may submit a proof after explicit approval. Follow next_action and treat only CompetitionSettledV2 as payment evidence.",
@@ -4145,23 +4200,27 @@ mod tests {
             crowdfund: false,
             task_window_days: None,
             discovery_source: Some("ChatGPT user feedback".to_string()),
-            image_prompt: "Minimal editorial illustration of a reconciliation test becoming green."
-                .to_string(),
-            image_alt_text: "A clean code diff with a passing reconciliation check.".to_string(),
-            bounty_image: super::ChatgptFileInput {
+            image_prompt: Some(
+                "Minimal editorial illustration of a reconciliation test becoming green."
+                    .to_string(),
+            ),
+            image_alt_text: Some(
+                "A clean code diff with a passing reconciliation check.".to_string(),
+            ),
+            bounty_image: Some(super::ChatgptFileInput {
                 download_url: "https://files.oaiusercontent.com/example".to_string(),
                 file_id: "file-example".to_string(),
                 mime_type: Some("image/webp".to_string()),
                 file_name: Some("reconciliation-bounty.webp".to_string()),
-            },
+            }),
         }
     }
 
     #[test]
     fn handoff_is_prefilled_but_never_claims_creation_or_signature() {
         let args = valid_args();
-        let image = sandbox_bounty_image_reference(&args).unwrap();
-        let handoff = build_bounty_post_handoff(&args, &image).unwrap();
+        let image = sandbox_bounty_image_reference(&args).unwrap().unwrap();
+        let handoff = build_bounty_post_handoff(&args, Some(&image)).unwrap();
         let post_url = Url::parse(handoff["post_url"].as_str().unwrap()).unwrap();
         let pairs = post_url.query_pairs().collect::<Vec<_>>();
 
@@ -4173,11 +4232,45 @@ mod tests {
         assert_eq!(handoff["image"]["source"], "chatgpt_user_generated");
         assert!(pairs
             .iter()
+            .any(|(key, value)| key == "from" && value == "ai-app"));
+        assert!(pairs
+            .iter()
             .any(|(key, value)| key == "title" && value == "Fix the reconciliation regression"));
         assert_eq!(
             pairs.iter().filter(|(key, _)| key == "criterion").count(),
             2
         );
+    }
+
+    #[test]
+    fn provider_neutral_handoff_allows_an_approved_bounty_without_an_image() {
+        let mut args = valid_args();
+        args.image_prompt = None;
+        args.image_alt_text = None;
+        args.bounty_image = None;
+
+        assert!(sandbox_bounty_image_reference(&args).unwrap().is_none());
+        let handoff = build_bounty_post_handoff(&args, None).unwrap();
+        let post_url = Url::parse(handoff["post_url"].as_str().unwrap()).unwrap();
+        let pairs = post_url.query_pairs().collect::<Vec<_>>();
+
+        assert!(handoff["image"].is_null());
+        assert_eq!(handoff["state"], "review_required_not_published");
+        assert_eq!(handoff["bounty_created"], false);
+        assert_eq!(handoff["wallet_signature_requested"], false);
+        assert!(pairs
+            .iter()
+            .any(|(key, value)| key == "from" && value == "ai-app"));
+        assert!(!pairs.iter().any(|(key, _)| key.starts_with("image")));
+    }
+
+    #[test]
+    fn provider_neutral_handoff_rejects_partial_image_metadata() {
+        let mut args = valid_args();
+        args.bounty_image = None;
+        assert!(sandbox_bounty_image_reference(&args)
+            .unwrap_err()
+            .contains("supplied together"));
     }
 
     #[test]
@@ -4247,15 +4340,15 @@ mod tests {
     #[test]
     fn handoff_rejects_non_https_sources_and_invalid_money() {
         let mut args = valid_args();
-        let image = sandbox_bounty_image_reference(&args).unwrap();
+        let image = sandbox_bounty_image_reference(&args).unwrap().unwrap();
         args.source_url = Some("http://example.com/private".to_string());
-        assert!(build_bounty_post_handoff(&args, &image)
+        assert!(build_bounty_post_handoff(&args, Some(&image))
             .unwrap_err()
             .contains("HTTPS"));
 
         args.source_url = None;
         args.solver_reward_usdc = "0".to_string();
-        assert!(build_bounty_post_handoff(&args, &image)
+        assert!(build_bounty_post_handoff(&args, Some(&image))
             .unwrap_err()
             .contains("greater than zero"));
     }
@@ -4456,11 +4549,16 @@ mod tests {
             .expect("ChatGPT-account image handoff tool");
         assert_eq!(post["_meta"]["openai/fileParams"], json!(["bounty_image"]));
         assert!(post["_meta"]["ui"].get("resourceUri").is_none());
-        assert!(post["inputSchema"]["required"]
+        assert!(!post["inputSchema"]["required"]
             .as_array()
             .unwrap()
             .iter()
             .any(|field| field == "bounty_image"));
+        assert!(post["outputSchema"]["properties"]["image"]["anyOf"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|variant| variant["type"] == "null"));
     }
 
     #[test]

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -532,9 +532,9 @@ tool_args! {
         #[serde(default)]
         crowdfund: bool,
         discovery_source: Option<String>,
-        image_prompt: String,
-        image_alt_text: String,
-        bounty_image: ChatgptFileInput,
+        image_prompt: Option<String>,
+        image_alt_text: Option<String>,
+        bounty_image: Option<ChatgptFileInput>,
     }
     schema object_tool_schema(
         json!({
@@ -551,11 +551,11 @@ tool_args! {
             "source_url": nullable_string_property("Optional public HTTPS source issue or task URL."),
             "crowdfund": {"type": "boolean", "default": false, "description": "Keep false to fund on creation. Set true only to deposit 0 USDC now."},
             "discovery_source": nullable_string_property("Optional public attribution for how the poster found Agent Bounties."),
-            "image_prompt": {"type": "string", "minLength": 1, "maxLength": 4000, "description": "The exact prompt used in this ChatGPT conversation to generate the user-approved bounty image."},
-            "image_alt_text": {"type": "string", "minLength": 1, "maxLength": 500, "description": "Concise accessible description of the approved image."},
+            "image_prompt": {"type": "string", "minLength": 1, "maxLength": 4000, "description": "Optional exact prompt used to generate a user-approved bounty image. Supply this, image_alt_text, and bounty_image together, or omit all three to use the deterministic fallback visual."},
+            "image_alt_text": {"type": "string", "minLength": 1, "maxLength": 500, "description": "Optional accessible description of the approved image. Supply this, image_prompt, and bounty_image together."},
             "bounty_image": {
                 "type": "object",
-                "description": "The approved image generated from the poster's own ChatGPT account. Agent Bounties stores this exact file; it does not generate another image.",
+                "description": "Optional approved image generated in a compatible AI conversation. Agent Bounties stores this exact file; omit it and both image text fields to use the deterministic fallback visual.",
                 "properties": {
                     "download_url": {"type": "string"},
                     "file_id": {"type": "string"},
@@ -571,10 +571,7 @@ tool_args! {
             "goal",
             "acceptance_criteria",
             "solver_reward_usdc",
-            "verifier_reward_usdc",
-            "image_prompt",
-            "image_alt_text",
-            "bounty_image"
+            "verifier_reward_usdc"
         ],
     );
 }

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -121,8 +121,10 @@ credits as money.
 
 ## Post a bounty
 
-The human entry is <https://agentbounties.app/#post-a-bounty>. MCP clients may
-call `prepare_bounty_post` when that tool appears in their session.
+The human review entry is <https://agentbounties.app/post.html>. MCP clients may
+call `prepare_bounty_post` when that tool appears in their session. The image
+fields are an optional all-or-none group: clients that cannot supply an
+approved image can still prepare a complete provider-neutral posting handoff.
 
 Advanced flow:
 

--- a/docs/chatgpt-app-submission.md
+++ b/docs/chatgpt-app-submission.md
@@ -78,7 +78,7 @@ New ChatGPT scans advertise exactly these ten non-overlapping tools:
 | `get_bounty_feed` | Reads the unified live bounty projection | read-only, closed-world, idempotent |
 | `render_bounty_feed` | Mounts the branded conversation-first live feed | read-only, closed-world, idempotent |
 | `prepare_moonpay_onramp` | Formats one first-party Base-USDC top-up handoff; creates no checkout or purchase | read-only, closed-world, idempotent |
-| `prepare_bounty_post` | Stores the exact user-approved image generated in the poster's ChatGPT account and prepares the first-party review handoff | non-read-only, open-world, destructive, idempotent |
+| `prepare_bounty_post` | Prepares the exact approved terms and, when supplied, stores the matching user-approved image for the first-party review handoff | non-read-only, open-world, destructive, idempotent |
 | `prepare_bounty_action` | Creates one opaque, expiring, idempotent first-party lifecycle-review intent | non-read-only, closed-world, non-destructive, idempotent |
 | `get_bounty_action_status` | Reconciles one intent against indexed canonical events | non-read-only, closed-world, non-destructive, idempotent |
 | `compile_objective_with_cloud_agent` | Produces bounded child-bounty drafts | non-read-only, open-world, non-destructive, non-idempotent |
@@ -101,17 +101,17 @@ from breaking while removing an overlapping choice from new ChatGPT
 registrations.
 
 `prepare_bounty_post` declares
-`_meta["openai/fileParams"]=["bounty_image"]`. ChatGPT gathers the terms,
-writes an image prompt from the completed bounty, generates the image with the
-poster's own ChatGPT account, displays that exact image, and obtains explicit
-approval before calling the tool. The tool downloads only the temporary
+`_meta["openai/fileParams"]=["bounty_image"]` for hosts that support approved
+file inputs. ChatGPT can gather the terms, generate an image with the poster's
+own account, display that exact image, and obtain explicit approval before
+calling the tool. In that variation the tool downloads only the temporary
 OpenAI-hosted file URL, validates a PNG/JPEG/WebP payload of at most 5 MiB,
-stores it by SHA-256, and returns a first-party review URL. The private
-ChatGPT `file_id` is never placed in public terms. Agent Bounties has no
-OpenAI image-generation key in this flow and never generates or substitutes
-the bounty artwork. The review URL renders the completed terms and approved
-image as a read-only card; it does not expose a second composer or editable
-bounty form.
+stores it by SHA-256, and returns a first-party review URL. The private ChatGPT
+`file_id` is never placed in public terms. Provider-neutral clients may omit
+the image, prompt, and alt text together; partial image metadata is rejected.
+Agent Bounties never generates or substitutes bounty artwork. The review URL
+renders the completed approved terms and optional image; it does not publish or
+move funds without the separate wallet-reviewed flow.
 
 Lower-level funding, wallet, claim, submission, and settlement tools are not
 exposed to the ChatGPT app. The model receives only hosted preparation and
@@ -124,13 +124,14 @@ repository:
 
 1. `prepare_moonpay_onramp` accepts only a canonical Base bounty contract, a
    bounded planned USDC amount, and an optional opaque funding-intent UUID.
-2. The tool contract retains a first-party
-   `https://agentbounties.app/onramp.html` handoff, but the redesigned site does
-   not mount that page; do not offer this action until a replacement funding UI
-   is reviewed.
+2. The tool returns the reviewed first-party
+   `https://agentbounties.app/onramp.html` handoff. That page keeps MoonPay,
+   MetaMask Portfolio, and Coinbase wallet top-up variations separate from the
+   later bounty-funding authorization.
 3. It does not call MoonPay, create checkout, connect a wallet, or move money.
-4. A future replacement page must connect the user's selected Base wallet and
-   check the destination, planned amount, USDC balance, and optional gas balance.
+4. The page connects an injected Base wallet or accepts a manually verified
+   public address, then shows the destination, planned amount, USDC balance,
+   and optional gas balance.
 5. The browser requests a device-bound signed MoonPay URL from
    `/v1/onramps/moonpay/checkout`.
 6. MoonPay handles its purchase, payment methods, eligibility, identity checks,

--- a/docs/coinbase-embedded-wallet.md
+++ b/docs/coinbase-embedded-wallet.md
@@ -23,12 +23,12 @@ A future smart-account adapter may be added independently, but it must not silen
 
 ## Preserved adapter design
 
-The from-scratch public-site redesign does not mount this adapter. Its source and
-locked dependencies remain available for a future reviewed wallet surface, but
-the homepage must not imply that Coinbase wallet authentication or sponsored
-funding is active today.
+The public on-ramp page links to Coinbase's own Base wallet surface as one of
+three external wallet/top-up variations. It does not load the embedded-wallet
+adapter or claim sponsored funding. The adapter source and locked dependencies
+remain available for a future separately reviewed first-party wallet surface.
 
-The intended future user experience remains:
+The intended embedded-adapter user experience remains:
 
 1. A user may browse, draft, and inspect bounties without a wallet.
 2. At the first action requiring an onchain identity, the wallet selector includes **Agent Bounties embedded wallet** beside injected wallets.
@@ -90,10 +90,11 @@ SMS is convenient but is more exposed to SIM-swap attacks. The linking screen st
 
 ## ChatGPT action continuity
 
-The deleted `authorize.html`, `funding.html`, and `earn.html` browser flow is not
-part of the redesigned public site. A future funding interface must preserve the
-same durable action-intent identifier and canonical `FundingAdded` evidence
-boundary; no wallet credential or signature may enter ChatGPT.
+The restored `authorize.html` review handoff preserves the durable action-intent
+identifier and canonical evidence boundary. The current Coinbase variation
+opens Coinbase's maintained public wallet surface and then returns to the
+provider-neutral on-ramp/posting flow; it does not mount the embedded adapter.
+No wallet credential or signature may enter ChatGPT.
 
 ## Gas sponsorship
 
@@ -183,7 +184,7 @@ python scripts/test_configure_wallet_providers.py
 npm run check --prefix tools/coinbase-embedded-wallet
 ```
 
-8. Add a reviewed public wallet surface and its page-specific tests before deploying the adapter. The current redesign intentionally has no Coinbase live-browser canary.
+8. Add a reviewed first-party embedded-wallet surface and its page-specific tests before deploying the adapter. The external Coinbase on-ramp link is not an embedded-wallet live-browser canary.
 9. Human-test one account for every enabled authentication method. Verify that each intended linked method restores the same wallet and that unlinked methods are clearly distinguished.
 10. Buy a bounded amount of Base USDC through MoonPay to the embedded EOA.
 11. Fund an existing bounty through the gas-only x402 relay.

--- a/docs/moonpay-onramp.md
+++ b/docs/moonpay-onramp.md
@@ -1,9 +1,8 @@
 # MoonPay wallet on-ramp
 
-> Public UI status: dormant. The from-scratch site redesign intentionally
-> removed the former `onramp.html` browser surface. Server-side checkout
-> planning, signing, deployment configuration, and canonical payment-evidence
-> rules remain preserved, but no public page currently offers this flow.
+> Public UI status: active after deployment at
+> `https://agentbounties.app/onramp.html`. The page offers the signed MoonPay
+> path when configured and the bounded public-consumer fallback otherwise.
 
 This integration adds a bounded MoonPay wallet-top-up step without changing the autonomous bounty protocol. The ChatGPT app exposes only a first-party handoff planner; provider checkout and every wallet or purchase step remain outside ChatGPT.
 
@@ -53,7 +52,7 @@ The fallback is not equivalent to the signed integration. It cannot cryptographi
 
 ## Architecture
 
-- Browser page and controllers: intentionally not mounted in the redesigned site
+- Browser page and controllers: `site/onramp.html`, `site/moonpay-onramp.js`, and `site/moonpay-direct-fallback.js`
 - ChatGPT handoff planner and in-chat funding control: `crates/mcp-server/src/chatgpt_app.rs`
 - Server route: the MoonPay checkout endpoint on the configured MCP origin
 - Server implementation: `crates/mcp-server/src/moonpay.rs`
@@ -119,6 +118,7 @@ Run:
 cargo test -p mcp-server moonpay
 cargo test -p mcp-server moonpay -- --nocapture
 python scripts/check-site.py
+python scripts/check-public-handoffs.py
 ```
 
 The Rust tests include MoonPay's published URL-signing test vector, verify that live URLs are IP-bound and signed with `signature` appended last, verify that the secret never appears in the checkout URL, and assert that every checkout plan reports `bounty_funded: false` with no canonical event.

--- a/docs/site-analytics.md
+++ b/docs/site-analytics.md
@@ -122,6 +122,13 @@ The collector accepts only:
 - `unfunded_post_started` and `unfunded_post_completed` for compatible future
   first-party no-wallet publishing interfaces
 - `canonical_post_started` and `canonical_post_confirmed`
+- `auth_completed`, `wallet_link_started`, and `wallet_link_confirmed`
+- `wallet_missing_detected`, `wallet_connected`,
+  `wallet_unfunded_detected`, and `wallet_funded_observed`
+- `canonical_post_handoff_viewed`
+- `onramp_viewed`, `onramp_moonpay_started`,
+  `onramp_metamask_started`, `onramp_coinbase_started`, and
+  `onramp_returned`
 - `funding_started`
 - `claim_started` and `claim_confirmed`
 - `competition_entry_started`, `competition_entry_confirmed`,
@@ -154,6 +161,17 @@ but the canonical event index remains authoritative. Only confirmed
 - **Canonical-post completion:** distinct sessions with
   `canonical_post_confirmed` divided by distinct sessions with
   `canonical_post_started`.
+- **No-wallet recovery:** distinct sessions with `wallet_connected` divided by
+  distinct sessions with `wallet_missing_detected`.
+- **Unfunded-wallet recovery:** distinct sessions with `wallet_funded_observed`
+  divided by distinct sessions with `wallet_unfunded_detected`.
+- **On-ramp provider start:** distinct sessions for each of
+  `onramp_moonpay_started`, `onramp_metamask_started`, and
+  `onramp_coinbase_started`, reported separately; these are provider exits,
+  not purchases or funding.
+- **On-ramp return:** distinct sessions with `onramp_returned` divided by
+  distinct sessions with `onramp_viewed`. This remains directional because a
+  provider may complete in another browser or device.
 - **Claim confirmation:** distinct sessions with `claim_confirmed` divided by
   distinct sessions with `claim_started`.
 - **Funded-click to competition view:** distinct sessions with
@@ -172,6 +190,10 @@ Competition events report interface transitions only. A copied template does
 not prove a post, an entry-start event does not prove entry, and a feedback
 event is not the feedback body. Canonical contracts and structured opportunity
 comments remain the evidence sources for lifecycle and user direction.
+
+For every rate, the numerator includes only a session that recorded the named
+denominator event first and the numerator event later within the selected
+window. This avoids treating unrelated sessions as conversions.
 
 Do not sum channel-level visitor counts to estimate people. One browser can be
 used by several people, one person can use several browsers or devices, and
@@ -204,6 +226,7 @@ Not Track, explicit opt-out, or `?analytics=off` prevents GA4 from loading.
 ```bash
 python scripts/check-migration-history.py
 python scripts/check-site.py
+python scripts/check-public-handoffs.py
 cargo test -p db site_analytics_migration_is_privacy_minimized_and_idempotent
 cargo test -p db external_interface_usage_migration_starts_a_clean_privacy_minimized_epoch
 cargo test -p api site_analytics

--- a/scripts/check-agent-discovery-contract.py
+++ b/scripts/check-agent-discovery-contract.py
@@ -10,7 +10,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 RETIRED_PUBLIC_ROUTES = (
-    "post.html",
     "objective.html",
     "create-competition.html",
     "refunds.html",

--- a/scripts/check-chatgpt-app-runtime.py
+++ b/scripts/check-chatgpt-app-runtime.py
@@ -391,9 +391,10 @@ def main() -> int:
         )
         require(
             post_descriptor["_meta"]["openai/fileParams"] == ["bounty_image"]
-            and "bounty_image"
-            in post_descriptor["inputSchema"]["required"],
-            "ChatGPT file handoff metadata drifted",
+            and "bounty_image" not in post_descriptor["inputSchema"]["required"]
+            and "image_prompt" not in post_descriptor["inputSchema"]["required"]
+            and "image_alt_text" not in post_descriptor["inputSchema"]["required"],
+            "provider-neutral optional file handoff metadata drifted",
         )
 
         resources = rpc("resources/list")["resources"]

--- a/scripts/check-public-handoffs.py
+++ b/scripts/check-public-handoffs.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+PUBLIC_ORIGIN = "https://agentbounties.app"
+ADVERTISEMENT_SOURCES = (
+    "crates/api/src/main.rs",
+    "crates/mcp-server/src/chatgpt_app.rs",
+)
+HANDOFF_BOUNDARIES = {
+    "authorize.html": ("Canonical evidence required", "BountySettled"),
+    "cancel.html": ("not canonical funding evidence",),
+    "onramp.html": ("FundingAdded", "MoonPay top-up ≠ bounty funding"),
+    "post.html": ("canonical creation and funding events",),
+    "success.html": ("does not prove funding", "FundingAdded"),
+}
+URL_PATTERN = re.compile(r"https://agentbounties\.app/(?P<path>[A-Za-z0-9_./-]+\.html)")
+
+
+class AssetParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.assets: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        for attribute in ("src", "href"):
+            value = values.get(attribute)
+            if value:
+                self.assets.append(value)
+
+
+def advertised_paths(repo_root: Path) -> set[str]:
+    paths: set[str] = set()
+    for relative in ADVERTISEMENT_SOURCES:
+        source = repo_root / relative
+        if not source.is_file():
+            raise AssertionError(f"missing advertisement source: {relative}")
+        paths.update(match.group("path") for match in URL_PATTERN.finditer(source.read_text(encoding="utf-8")))
+    return paths
+
+
+def _check_local_assets(site_dir: Path, page: Path, body: str) -> list[str]:
+    errors: list[str] = []
+    parser = AssetParser()
+    parser.feed(body)
+    for reference in parser.assets:
+        parsed = urlparse(reference)
+        if parsed.scheme or reference.startswith("//") or reference.startswith("#"):
+            continue
+        relative = parsed.path
+        if not relative or relative.endswith("/"):
+            continue
+        target = (page.parent / relative).resolve()
+        try:
+            target.relative_to(site_dir.resolve())
+        except ValueError:
+            errors.append(f"{page.name}: asset escapes site directory: {reference}")
+            continue
+        if not target.exists():
+            errors.append(f"{page.name}: missing linked file: {reference}")
+    return errors
+
+
+def check_local(repo_root: Path) -> list[str]:
+    site_dir = repo_root / "site"
+    advertised = advertised_paths(repo_root)
+    errors: list[str] = []
+    missing_advertisements = set(HANDOFF_BOUNDARIES) - advertised
+    if missing_advertisements:
+        errors.append(f"handoff URLs are no longer advertised: {sorted(missing_advertisements)}")
+    for path in sorted(advertised):
+        page = site_dir / path
+        if not page.is_file():
+            errors.append(f"advertised public URL has no site file: {PUBLIC_ORIGIN}/{path}")
+    for path, phrases in HANDOFF_BOUNDARIES.items():
+        page = site_dir / path
+        if not page.is_file():
+            continue
+        body = page.read_text(encoding="utf-8")
+        for phrase in phrases:
+            if phrase not in body:
+                errors.append(f"{path}: missing evidence boundary: {phrase}")
+        if '<meta name="robots" content="noindex, nofollow">' not in body:
+            errors.append(f"{path}: transactional handoff must remain noindex, nofollow")
+        errors.extend(_check_local_assets(site_dir, page, body))
+    return errors
+
+
+def check_remote(base_url: str) -> list[str]:
+    errors: list[str] = []
+    base = base_url.rstrip("/")
+    for path, phrases in HANDOFF_BOUNDARIES.items():
+        url = f"{base}/{path}"
+        request = Request(url, headers={"User-Agent": "agent-bounties-public-handoff-check/1"})
+        try:
+            with urlopen(request, timeout=20) as response:
+                body = response.read().decode("utf-8", errors="replace")
+                if response.status != 200:
+                    errors.append(f"{url}: expected 200, received {response.status}")
+                    continue
+        except (HTTPError, URLError, TimeoutError) as error:
+            errors.append(f"{url}: unavailable: {error}")
+            continue
+        for phrase in phrases:
+            if phrase not in body:
+                errors.append(f"{url}: deployed page is missing evidence boundary: {phrase}")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify advertised Agent Bounties public handoffs.")
+    parser.add_argument("--base-url", help="Also verify the deployed pages at this origin.")
+    args = parser.parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        errors = check_local(repo_root)
+    except AssertionError as error:
+        errors = [str(error)]
+    if args.base_url:
+        errors.extend(check_remote(args.base_url))
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+    scope = "local source"
+    if args.base_url:
+        scope += f" and {args.base_url.rstrip('/')}"
+    print(f"public handoff checks passed: {scope}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -16,9 +16,26 @@ CANONICAL_PAGES = {
     "blog/index.html": "https://agentbounties.app/blog/",
     "blog/agentic-economy-needs-a-market-for-work.html": "https://agentbounties.app/blog/agentic-economy-needs-a-market-for-work.html",
     "how-to-earn-money-with-my-ai-agent.html": "https://agentbounties.app/how-to-earn-money-with-my-ai-agent.html",
+    "authorize.html": "https://agentbounties.app/authorize.html",
+    "cancel.html": "https://agentbounties.app/cancel.html",
     "metrics.html": "https://agentbounties.app/metrics.html",
+    "onramp.html": "https://agentbounties.app/onramp.html",
+    "post.html": "https://agentbounties.app/post.html",
     "privacy.html": "https://agentbounties.app/privacy.html",
+    "success.html": "https://agentbounties.app/success.html",
     "terms.html": "https://agentbounties.app/terms.html",
+}
+INDEXABLE_PAGES = {
+    "about.html",
+    "blog/agentic-economy-needs-a-market-for-work.html",
+    "blog/index.html",
+    "competition.html",
+    "earn.html",
+    "how-to-earn-money-with-my-ai-agent.html",
+    "index.html",
+    "metrics.html",
+    "privacy.html",
+    "terms.html",
 }
 REQUIRED_FILES = {
     ".nojekyll",
@@ -37,41 +54,82 @@ REQUIRED_FILES = {
     "blog/feed.xml",
     "blog/index.html",
     "blog/posts.json",
+    "ai-bounty-handoff.css",
+    "ai-bounty-handoff.js",
+    "authorize.html",
+    "authorize.js",
+    "bounty-chat-controls.css",
+    "bounty-chat-ui.js",
+    "bounty-chat.css",
+    "bounty-composer-v2.css",
+    "bounty-composer-v2.js",
+    "bounty-composer.css",
+    "bounty-entry.js",
+    "cancel.html",
+    "evm.js",
     "favicon.svg",
     "generated/github-participation.json",
     "generated/public-metrics-policy.json",
     "index.html",
     "how-to-earn-money-with-my-ai-agent.html",
+    "legal-consent.js",
     "llms.txt",
     "metrics.css",
     "metrics.html",
     "metrics.js",
     "marketplace.css",
     "marketplace.js",
+    "moonpay-direct-fallback.js",
+    "moonpay-onramp.js",
+    "onramp.css",
+    "onramp.html",
+    "post.html",
     "privacy.html",
     "protocol.json",
     "robots.txt",
     "sitemap.xml",
     "solarpunk-home.js",
     "solarpunk.css",
+    "simple-ux.css",
     "styles.css",
+    "success.html",
     "terms.html",
     "guild-pages.css",
+    "guild-shell.js",
+    "wallet-adapters.css",
     "x402-test-vectors.json",
 }
 ALLOWED_UI_CODE = {
     "about.css",
+    "ai-bounty-handoff.css",
+    "ai-bounty-handoff.js",
     "analytics-config.js",
     "analytics.js",
+    "authorize.js",
+    "bounty-chat-controls.css",
+    "bounty-chat-ui.js",
+    "bounty-chat.css",
+    "bounty-composer-v2.css",
+    "bounty-composer-v2.js",
+    "bounty-composer.css",
+    "bounty-entry.js",
     "competition.js",
+    "evm.js",
     "guild-pages.css",
+    "guild-shell.js",
+    "legal-consent.js",
     "metrics.css",
     "metrics.js",
     "marketplace.css",
     "marketplace.js",
+    "moonpay-direct-fallback.js",
+    "moonpay-onramp.js",
+    "onramp.css",
+    "simple-ux.css",
     "solarpunk-home.js",
     "solarpunk.css",
     "styles.css",
+    "wallet-adapters.css",
 }
 EXPECTED_SCENE_ASSETS = {
     "assets/solarpunk/characters-helping.webp",
@@ -694,6 +752,29 @@ def check_marketplace(site_dir: Path) -> None:
     )
 
 
+def check_transactional_handoffs(site_dir: Path) -> None:
+    onramp = (site_dir / "onramp.html").read_text(encoding="utf-8")
+    shell = (site_dir / "guild-shell.js").read_text(encoding="utf-8")
+    require_phrases(
+        "onramp.html",
+        onramp,
+        [
+            "Three measured variations",
+            "MetaMask Portfolio",
+            "Coinbase Base wallet",
+            "MoonPay top-up ≠ bounty funding",
+        ],
+    )
+    require_phrases(
+        "guild-shell.js",
+        shell,
+        ['["post.html", "Post"]', '["onramp.html", "Add Base USDC"]', '["metrics.html", "Metrics"]'],
+    )
+    for removed in ("how-it-works.html",):
+        if removed in shell:
+            fail(f"guild-shell.js rewrites navigation to removed page {removed}")
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
     site_dir = repo_root / "site"
@@ -733,14 +814,17 @@ def main() -> int:
         )
         if text.index(f'src="{prefix}analytics-config.js?v=2"') > text.index(f'src="{prefix}analytics.js?v=3"'):
             fail(f"{relative}: analytics config must load before analytics.js")
+        if relative not in INDEXABLE_PAGES and '<meta name="robots" content="noindex, nofollow">' not in text:
+            fail(f"{relative}: transactional handoffs must remain noindex, nofollow")
         for link in parser.links:
             check_internal_link(site_dir, path, link, parser.ids)
 
     sitemap = ET.parse(site_dir / "sitemap.xml").getroot()
     namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
     urls = {item.text.strip() for item in sitemap.findall("sm:url/sm:loc", namespace) if item.text}
-    if urls != set(CANONICAL_PAGES.values()):
-        fail(f"sitemap must list every canonical website page exactly once; found {sorted(urls)}")
+    expected_urls = {CANONICAL_PAGES[relative] for relative in INDEXABLE_PAGES}
+    if urls != expected_urls:
+        fail(f"sitemap must list every indexable canonical website page exactly once; found {sorted(urls)}")
     robots = (site_dir / "robots.txt").read_text(encoding="utf-8")
     require_phrases("robots.txt", robots, ["User-agent: OAI-SearchBot", "Sitemap: https://agentbounties.app/sitemap.xml"])
 
@@ -759,6 +843,7 @@ def main() -> int:
     check_analytics(site_dir, repo_root)
     check_homepage(site_dir)
     check_marketplace(site_dir)
+    check_transactional_handoffs(site_dir)
     check_metrics(site_dir)
     check_blog(site_dir)
     privacy = (site_dir / "privacy.html").read_text(encoding="utf-8")
@@ -781,7 +866,7 @@ def main() -> int:
             "Only a confirmed canonical <code>BountySettled</code> or <code>CompetitionSettledV2</code> event proves solver payment",
         ],
     )
-    print("site checks passed: Home, unified market, competition, A2A, blog, Metrics, legal pages, protocol, evidence, analytics, and asset budgets intact")
+    print("site checks passed: Home, market, competition, transactional handoffs, A2A, blog, Metrics, legal, protocol, evidence, analytics, and asset budgets intact")
     return 0
 
 

--- a/scripts/test-ai-bounty-handoff.js
+++ b/scripts/test-ai-bounty-handoff.js
@@ -1,0 +1,129 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "site", "ai-bounty-handoff.js"),
+  "utf8",
+);
+
+function element() {
+  return {
+    dataset: {},
+    hidden: true,
+    textContent: "",
+    value: "",
+    addEventListener() {},
+    scrollIntoView() {},
+  };
+}
+
+const elements = new Map([
+  ["[data-ai-handoff]", element()],
+  ["[data-conversation-log]", { ...element(), append() {} }],
+  ["[data-ai-original]", element()],
+  ["[data-ai-prompt]", element()],
+  ["[data-ai-draft-import]", element()],
+  ["[data-ai-import-status]", element()],
+  ["[data-composer-status]", element()],
+  ["[data-assistant-prompt]", element()],
+]);
+elements.get("[data-ai-handoff]").querySelectorAll = () => [];
+elements.get("[data-ai-handoff]").querySelector = () => null;
+
+const window = {
+  addEventListener() {},
+  dispatchEvent() {},
+  open() {},
+};
+const document = {
+  documentElement: { dataset: {} },
+  querySelector(selector) { return elements.get(selector) || null; },
+};
+
+vm.runInNewContext(source, {
+  window,
+  document,
+  navigator: {},
+  URL,
+  JSON,
+  Number,
+  String,
+  Boolean,
+  Object,
+  Array,
+  console,
+}, { filename: "site/ai-bounty-handoff.js" });
+
+const api = window.AgentBountyAI;
+if (!api || api.mcpUrl !== "https://mcp.agentbounties.app/mcp") {
+  throw new Error("user-owned AI handoff API did not initialize");
+}
+
+const draft = api.parseDraft(`\`\`\`json
+{
+  "title": "Publish the water capture design",
+  "goal": "Produce a printable, source-backed rooftop rainwater capture design.",
+  "acceptance_criteria": ["STL files pass a documented manifold check", "Assembly instructions identify every part"],
+  "solver_reward_usdc": "4.00",
+  "verifier_reward_usdc": "0.10",
+  "task_window_days": 21,
+  "source_url": "https://example.com/context"
+}
+\`\`\``);
+
+if (draft.task_window_days !== 21 || draft.acceptance_criteria.length !== 2) {
+  throw new Error(`valid AI draft was not normalized: ${JSON.stringify(draft)}`);
+}
+
+const approvedImage = {
+  source: "chatgpt_user_generated",
+  asset_url: "https://agentbounties.app/public/bounty-images/approved.webp",
+  sha256: "a".repeat(64),
+  mime_type: "image/webp",
+  prompt: "A restrained editorial illustration of a reproducible API defect.",
+  alt_text: "An engineer tracing a reproducible API defect.",
+};
+const chatgptHandoff = api.parseDraft({
+  ...draft,
+  image_required: true,
+  image: approvedImage,
+});
+if (chatgptHandoff.image_required !== true || chatgptHandoff.image !== approvedImage) {
+  throw new Error("the ChatGPT-owned approved image was stripped from the hosted handoff");
+}
+
+for (const invalid of [
+  { ...draft, acceptance_criteria: [] },
+  { ...draft, solver_reward_usdc: "0" },
+  { ...draft, task_window_days: 31 },
+  { ...draft, source_url: "http://example.com" },
+]) {
+  let rejected = false;
+  try { api.parseDraft(invalid); } catch (_error) { rejected = true; }
+  if (!rejected) throw new Error(`unsafe AI draft was accepted: ${JSON.stringify(invalid)}`);
+}
+
+for (const invalid of [
+  { ...draft },
+  { ...draft, deadline_days: 14 },
+]) {
+  delete invalid.task_window_days;
+  let message = "";
+  try { api.parseDraft(invalid); } catch (error) { message = error.message; }
+  if (!message.includes("task_window_days")) {
+    throw new Error(`AI draft without an exact task window was not rejected clearly: ${message}`);
+  }
+  if ("deadline_days" in invalid && !message.includes("instead of deadline_days")) {
+    throw new Error(`deadline_days alias did not receive a targeted correction: ${message}`);
+  }
+}
+
+const prompt = api.promptFor("Build a public climate dashboard");
+for (const marker of ["prepare_bounty_post", api.mcpUrl, "return ONLY one JSON object", "Otherwise omit all three image fields", "Do not claim that anything is posted"]) {
+  if (!prompt.includes(marker)) throw new Error(`AI handoff prompt missing: ${marker}`);
+}
+
+console.log("user-owned AI handoff validates portable drafts and preserves the MCP path");

--- a/scripts/test_check_agent_discovery_contract.py
+++ b/scripts/test_check_agent_discovery_contract.py
@@ -151,10 +151,10 @@ class AgentDiscoveryContractTests(unittest.TestCase):
         )
 
     def test_removed_public_route_fails(self) -> None:
-        with self.assertRaisesRegex(SystemExit, "intentionally removed route post.html"):
+        with self.assertRaisesRegex(SystemExit, "intentionally removed route objective.html"):
             guard.validate_entrypoint_text(
                 "guide.md",
-                "Open https://agentbounties.app/post.html\n",
+                "Open https://agentbounties.app/objective.html\n",
                 max_lines=4,
                 max_chars=200,
                 required=(),

--- a/scripts/test_check_public_handoffs.py
+++ b/scripts/test_check_public_handoffs.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check-public-handoffs.py")
+SPEC = importlib.util.spec_from_file_location("check_public_handoffs", SCRIPT)
+assert SPEC and SPEC.loader
+CHECK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK)
+
+
+class PublicHandoffCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        for relative in CHECK.ADVERTISEMENT_SOURCES:
+            source = self.root / relative
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text(
+                "\n".join(f'"{CHECK.PUBLIC_ORIGIN}/{path}"' for path in CHECK.HANDOFF_BOUNDARIES),
+                encoding="utf-8",
+            )
+        site = self.root / "site"
+        site.mkdir()
+        (site / "shared.js").write_text("", encoding="utf-8")
+        for path, phrases in CHECK.HANDOFF_BOUNDARIES.items():
+            (site / path).write_text(
+                '<meta name="robots" content="noindex, nofollow"><script src="shared.js"></script>'
+                + " ".join(phrases),
+                encoding="utf-8",
+            )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_complete_handoff_surface_passes(self) -> None:
+        self.assertEqual(CHECK.check_local(self.root), [])
+
+    def test_missing_advertised_page_fails(self) -> None:
+        missing = self.root / "site" / "onramp.html"
+        missing.unlink()
+        errors = CHECK.check_local(self.root)
+        self.assertTrue(any("onramp.html" in error and "no site file" in error for error in errors))
+
+    def test_missing_evidence_boundary_fails(self) -> None:
+        page = self.root / "site" / "success.html"
+        page.write_text('<meta name="robots" content="noindex, nofollow">', encoding="utf-8")
+        errors = CHECK.check_local(self.root)
+        self.assertTrue(any("success.html" in error and "missing evidence boundary" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/site/ai-bounty-handoff.css
+++ b/site/ai-bounty-handoff.css
@@ -1,0 +1,173 @@
+.ai-handoff {
+  align-self: flex-start;
+  width: min(100%, 720px);
+  padding: 22px;
+  border: 1px solid rgba(200, 245, 72, 0.28);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at 100% 0, rgba(200, 245, 72, 0.12), transparent 16rem),
+    #0b1810;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
+  animation: chat-message-in 180ms ease both;
+}
+.ai-handoff[hidden] { display: none; }
+
+.ai-handoff h2 {
+  margin: 3px 0 8px;
+  color: var(--chat-text);
+  font-size: clamp(20px, 4vw, 28px);
+  line-height: 1.18;
+  letter-spacing: -0.035em;
+}
+
+.ai-handoff p { line-height: 1.5; }
+
+.ai-handoff-heading > p:last-child,
+.ai-safety-note {
+  margin: 0;
+  color: var(--chat-muted);
+  font-size: 13px;
+}
+
+.ai-handoff-eyebrow {
+  margin: 0;
+  color: var(--chat-lime);
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.ai-original {
+  margin: 18px 0;
+  padding: 12px 14px;
+  border-left: 3px solid var(--chat-lime);
+  border-radius: 0 12px 12px 0;
+  background: rgba(200, 245, 72, 0.07);
+}
+
+.ai-original span {
+  color: var(--chat-muted);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ai-original p {
+  margin: 4px 0 0;
+  color: #edf2e9;
+  white-space: pre-wrap;
+}
+
+.ai-provider-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.ai-provider-grid button,
+.ai-mcp-row button,
+.ai-prompt-details > button {
+  border: 1px solid rgba(200, 245, 72, 0.25);
+  border-radius: 14px;
+  background: #112019;
+  color: var(--chat-text);
+  cursor: pointer;
+}
+
+.ai-provider-grid button {
+  min-height: 74px;
+  padding: 13px;
+  text-align: left;
+}
+
+.ai-provider-grid button:hover,
+.ai-mcp-row button:hover,
+.ai-prompt-details > button:hover {
+  border-color: rgba(200, 245, 72, 0.72);
+  background: rgba(200, 245, 72, 0.1);
+}
+
+.ai-provider-grid strong,
+.ai-provider-grid span { display: block; }
+.ai-provider-grid strong { color: var(--chat-lime); font-size: 15px; }
+.ai-provider-grid span { margin-top: 5px; color: var(--chat-muted); font-size: 11px; }
+
+.ai-connector-setup,
+.ai-prompt-details,
+.ai-return {
+  margin-top: 16px;
+  border-top: 1px solid var(--chat-line);
+  padding-top: 15px;
+}
+
+.ai-connector-setup summary,
+.ai-prompt-details summary {
+  color: #eaf0e7;
+  font-size: 13px;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.ai-connector-setup p,
+.ai-connector-setup ul {
+  color: var(--chat-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.ai-connector-setup a { color: var(--chat-mint); }
+
+.ai-mcp-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ai-mcp-row code {
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
+  color: var(--chat-lime);
+}
+
+.ai-mcp-row button,
+.ai-prompt-details > button {
+  padding: 8px 11px;
+  font-size: 11px;
+}
+
+.ai-prompt-details textarea,
+.ai-return textarea {
+  width: 100%;
+  margin: 10px 0;
+  resize: vertical;
+  border: 1px solid var(--chat-line);
+  border-radius: 12px;
+  padding: 11px;
+  background: #06100b;
+  color: #dce5dc;
+  font: 12px/1.45 ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+.ai-return label { color: #eef3eb; font-size: 13px; }
+.ai-return .button { min-height: 40px; }
+
+[data-ai-import-status] {
+  display: block;
+  margin-top: 8px;
+  color: var(--chat-muted);
+  font-size: 11px;
+}
+
+[data-ai-import-status][data-tone="success"] { color: var(--chat-lime); }
+[data-ai-import-status][data-tone="error"] { color: #ff9f92; }
+.ai-safety-note { margin-top: 14px; }
+
+@media (max-width: 620px) {
+  .ai-handoff { padding: 17px; }
+  .ai-provider-grid { grid-template-columns: 1fr; }
+  .ai-provider-grid button { min-height: 60px; }
+  .ai-mcp-row { align-items: stretch; flex-direction: column; }
+}

--- a/site/ai-bounty-handoff.js
+++ b/site/ai-bounty-handoff.js
@@ -1,0 +1,236 @@
+(() => {
+  "use strict";
+
+  const MCP_URL = "https://mcp.agentbounties.app/mcp";
+  const PROVIDERS = {
+    chatgpt: "https://chatgpt.com/",
+    claude: "https://claude.ai/new",
+    gemini: "https://gemini.google.com/app",
+  };
+  const MAX_TOTAL_USDC = 2_000_000;
+
+  const panel = document.querySelector("[data-ai-handoff]");
+  const log = document.querySelector("[data-conversation-log]");
+  const original = document.querySelector("[data-ai-original]");
+  const promptPreview = document.querySelector("[data-ai-prompt]");
+  const importInput = document.querySelector("[data-ai-draft-import]");
+  const importStatus = document.querySelector("[data-ai-import-status]");
+  const composerStatus = document.querySelector("[data-composer-status]");
+
+  if (!panel || !log || !original || !promptPreview || !importInput) return;
+
+  let currentIntent = "";
+  let currentContext = null;
+  let currentPrompt = "";
+
+  function boundedText(value, label, maximum) {
+    const text = String(value || "").trim();
+    if (!text) throw new Error(`${label} is required.`);
+    if ([...text].length > maximum) throw new Error(`${label} must be ${maximum} characters or fewer.`);
+    return text;
+  }
+
+  function parseUsdc(value, label) {
+    const text = String(value ?? "").trim();
+    if (!/^\d+(?:\.\d{1,6})?$/.test(text)) {
+      throw new Error(`${label} must be a positive USDC amount with no more than 6 decimal places.`);
+    }
+    const amount = Number(text);
+    if (!Number.isFinite(amount) || amount <= 0 || amount > 1_000_000) {
+      throw new Error(`${label} must be greater than 0 and no more than 1,000,000 USDC.`);
+    }
+    return text;
+  }
+
+  function stripCodeFence(value) {
+    const text = String(value || "").trim();
+    const match = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+    return match ? match[1] : text;
+  }
+
+  function parseDraft(value) {
+    const raw = typeof value === "string" ? JSON.parse(stripCodeFence(value)) : value;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("The AI response must be one JSON object.");
+
+    const criteria = Array.isArray(raw.acceptance_criteria)
+      ? raw.acceptance_criteria.map((item) => boundedText(item, "Each completion check", 1_000))
+      : [];
+    if (!criteria.length || criteria.length > 20) throw new Error("Add between 1 and 20 measurable completion checks.");
+
+    const solver = parseUsdc(raw.solver_reward_usdc, "Solver reward");
+    const verifier = parseUsdc(raw.verifier_reward_usdc, "Verifier reward");
+    if (Number(solver) + Number(verifier) > MAX_TOTAL_USDC) throw new Error("The combined reward is too large.");
+
+    if (!Object.prototype.hasOwnProperty.call(raw, "task_window_days")) {
+      if (Object.prototype.hasOwnProperty.call(raw, "deadline_days")) {
+        throw new Error("Use task_window_days instead of deadline_days so the work window is imported exactly.");
+      }
+      throw new Error("task_window_days is required so Agent Bounties does not guess or change the work window.");
+    }
+    const days = Number(raw.task_window_days);
+    if (!Number.isInteger(days) || days < 1 || days > 30) throw new Error("task_window_days must be a whole number from 1 to 30.");
+
+    const sourceUrl = raw.source_url == null || String(raw.source_url).trim() === ""
+      ? null
+      : String(raw.source_url).trim();
+    if (sourceUrl) {
+      let parsed;
+      try { parsed = new URL(sourceUrl); } catch (_error) { throw new Error("source_url must be a public HTTPS URL or null."); }
+      if (parsed.protocol !== "https:" || !parsed.hostname) throw new Error("source_url must be a public HTTPS URL or null.");
+    }
+
+    return {
+      schema: "agent-bounties/ai-prepared-draft-v1",
+      title: boundedText(raw.title, "Title", 200),
+      goal: boundedText(raw.goal, "Goal", 4_000),
+      acceptance_criteria: criteria,
+      solver_reward_usdc: solver,
+      verifier_reward_usdc: verifier,
+      task_window_days: days,
+      source_url: sourceUrl,
+      crowdfund: Boolean(raw.crowdfund),
+      discovery_source: boundedText(raw.discovery_source || "User-owned AI assistant", "Discovery source", 500),
+      ...(raw.image_required === true
+        ? {
+            image_required: true,
+            image: raw.image,
+          }
+        : {}),
+    };
+  }
+
+  function promptFor(intent, context) {
+    const revision = context?.draft
+      ? `\n\nCURRENT DRAFT TO REVISE:\n${JSON.stringify({
+          title: context.draft.title,
+          goal: context.draft.goal,
+          acceptance_criteria: context.draft.acceptance_criteria,
+          solver_reward_usdc: context.solver_reward_usdc,
+          verifier_reward_usdc: context.verifier_reward_usdc,
+          task_window_days: context.task_window_days,
+        }, null, 2)}\n\nREQUESTED CHANGE:\n${intent}`
+      : `\n\nWHAT I WANT DONE:\n${intent}`;
+
+    return `Help me prepare a public Agent Bounties bounty using the context you already have about me and this request.${revision}
+
+If the Agent Bounties MCP connector is available, clarify only details that materially affect the public terms. Show me the complete terms and wait for my explicit approval. Only after I approve, call prepare_bounty_post. If this AI can generate and attach a unique image, you may show it for approval and call the tool with bounty_image, the exact image_prompt, and accessible image_alt_text. Otherwise omit all three image fields; the Agent Bounties review page will render a deterministic content-derived visual. Agent Bounties does not require or use a platform model key. The MCP endpoint is ${MCP_URL}.
+
+If the connector is unavailable, ask concise clarifying questions and then return ONLY one JSON object in this exact shape so I can paste the approved terms directly into the Agent Bounties review flow:
+{
+  "title": "concise public title",
+  "goal": "specific public outcome",
+  "acceptance_criteria": ["binary or measurable check"],
+  "solver_reward_usdc": "2.00",
+  "verifier_reward_usdc": "0.10",
+  "task_window_days": 30,
+  "source_url": null,
+  "crowdfund": false,
+  "discovery_source": "AI provider and account used"
+}
+
+Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, each <= 1000; rewards are positive USDC decimals with at most 6 places; task_window_days is 1-30; source_url is HTTPS or null. Do not claim that anything is posted, created, funded, signed, or paid. I must explicitly approve the bounty terms and separately approve any wallet transaction on Agent Bounties.`;
+  }
+
+  function setImportStatus(message, tone = "") {
+    if (!importStatus) return;
+    importStatus.textContent = message || "";
+    importStatus.dataset.tone = tone;
+  }
+
+  async function copyText(text) {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+    const helper = document.createElement("textarea");
+    helper.value = text;
+    helper.setAttribute("readonly", "");
+    helper.style.position = "fixed";
+    helper.style.opacity = "0";
+    document.body.append(helper);
+    helper.select();
+    document.execCommand("copy");
+    helper.remove();
+  }
+
+  function show(intent, context = null) {
+    currentIntent = boundedText(intent, "Bounty idea", 12_000);
+    currentContext = context;
+    currentPrompt = promptFor(currentIntent, currentContext);
+    original.textContent = currentIntent;
+    promptPreview.value = currentPrompt;
+    panel.hidden = false;
+    log.append(panel);
+    requestAnimationFrame(() => {
+      const previousScrollBehavior = log.style.scrollBehavior;
+      log.style.scrollBehavior = "auto";
+      log.scrollTop = 0;
+      requestAnimationFrame(() => { log.style.scrollBehavior = previousScrollBehavior; });
+    });
+    document.documentElement.dataset.aiInterface = "user-owned";
+    if (composerStatus) {
+      composerStatus.textContent = "No Agent Bounties model key is being used. Continue in your AI account, then return with its prepared draft.";
+      composerStatus.dataset.tone = "success";
+    }
+    return currentPrompt;
+  }
+
+  for (const button of panel.querySelectorAll("[data-ai-provider]")) {
+    button.addEventListener("click", async () => {
+      const provider = button.dataset.aiProvider;
+      const destination = PROVIDERS[provider];
+      if (!destination || !currentPrompt) return;
+      const providerTab = window.open(destination, "_blank", "noopener,noreferrer");
+      try {
+        await copyText(currentPrompt);
+        setImportStatus(`${providerTab ? "Prompt copied." : "Prompt copied, but your browser blocked the new tab."} Paste it into ${button.dataset.providerLabel || provider}.`, "success");
+      } catch (_error) {
+        setImportStatus("The prompt could not be copied automatically. Copy it from the expandable prompt below.", "error");
+      }
+    });
+  }
+
+  panel.querySelector("[data-copy-mcp]")?.addEventListener("click", async () => {
+    try {
+      await copyText(MCP_URL);
+      setImportStatus("MCP endpoint copied.", "success");
+    } catch (_error) {
+      setImportStatus(`Copy this MCP endpoint: ${MCP_URL}`, "error");
+    }
+  });
+
+  panel.querySelector("[data-copy-ai-prompt]")?.addEventListener("click", async () => {
+    try {
+      await copyText(currentPrompt);
+      setImportStatus("AI prompt copied.", "success");
+    } catch (_error) {
+      setImportStatus("Select and copy the prompt manually.", "error");
+    }
+  });
+
+  panel.querySelector("[data-import-ai-draft]")?.addEventListener("click", () => {
+    try {
+      const draft = parseDraft(importInput.value);
+      setImportStatus("Draft imported locally. Review every field before approving it.", "success");
+      panel.hidden = true;
+      window.dispatchEvent(new CustomEvent("agent-bounties:prepared-draft", { detail: draft }));
+    } catch (error) {
+      setImportStatus(error.message || String(error), "error");
+    }
+  });
+
+  window.addEventListener("agent-bounties:request-ai-handoff", (event) => {
+    try {
+      show(event.detail?.intent, event.detail?.context || null);
+    } catch (error) {
+      setImportStatus(error.message || String(error), "error");
+    }
+  });
+
+  window.AgentBountyAI = Object.freeze({
+    mcpUrl: MCP_URL,
+    parseDraft,
+    promptFor,
+    show,
+  });
+})();

--- a/site/analytics.js
+++ b/site/analytics.js
@@ -35,6 +35,19 @@
     "competition_feedback_submitted",
     "canonical_post_started",
     "canonical_post_confirmed",
+    "auth_completed",
+    "wallet_link_started",
+    "wallet_link_confirmed",
+    "wallet_missing_detected",
+    "wallet_connected",
+    "wallet_unfunded_detected",
+    "wallet_funded_observed",
+    "canonical_post_handoff_viewed",
+    "onramp_viewed",
+    "onramp_moonpay_started",
+    "onramp_metamask_started",
+    "onramp_coinbase_started",
+    "onramp_returned",
   ]);
 
   function storage(kind) {

--- a/site/authorize.html
+++ b/site/authorize.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Review bounty action | Agent Bounties</title>
+    <meta name="description" content="Review one bounded bounty action before connecting a wallet.">
+    <meta name="robots" content="noindex, nofollow">
+    <link rel="canonical" href="https://agentbounties.app/authorize.html">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <header class="topbar">
+      <a class="brand" href="./">Agent Bounties</a>
+      <nav aria-label="Primary navigation">
+        <a href="post.html">Post</a>
+        <a href="metrics.html">Metrics</a>
+        <a href="https://github.com/NSPG13/agent-bounties">GitHub</a>
+      </nav>
+    </header>
+
+    <main class="page protocol-page">
+      <section class="page-head protocol-head">
+        <div>
+          <p class="eyebrow">AI action handoff</p>
+          <h1 id="authorization-title">Review this bounty action</h1>
+          <p id="authorization-summary">Loading the exact action prepared in ChatGPT.</p>
+        </div>
+        <output id="authorization-status" class="protocol-status" aria-live="polite">Loading</output>
+      </section>
+
+      <section class="band compact protocol-workspace">
+        <div class="funding-form protocol-form narrow-form">
+          <div class="copy">
+            <p><strong>Network</strong><br><span id="authorization-network">—</span></p>
+            <p><strong>Bounty contract</strong><br><code id="authorization-contract">Created during authorization</code></p>
+            <p><strong>Amount</strong><br><span id="authorization-amount">No transfer in this step</span></p>
+            <p><strong>Canonical evidence required</strong><br><span id="authorization-events">—</span></p>
+            <details>
+              <summary>Review prepared details</summary>
+              <pre id="authorization-details" class="prompt-block"><code>{}</code></pre>
+            </details>
+          </div>
+          <output id="authorization-output" class="output readiness-output" aria-live="polite">
+            No wallet request is made on this review screen.
+          </output>
+          <div class="actions">
+            <a id="authorization-continue" class="button primary" href="#" hidden>Continue to wallet review</a>
+            <button id="authorization-refresh" class="button secondary" type="button">Refresh canonical status</button>
+            <a class="button secondary" href="./">Cancel</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="band muted compact">
+        <div class="section-grid">
+          <div>
+            <p class="eyebrow">Evidence boundary</p>
+            <h2>Prepared is not completed</h2>
+          </div>
+          <div class="copy">
+            <p>Your AI never receives your private key, seed phrase, wallet signature, or verifier attestation.</p>
+            <p id="authorization-boundary">Only an indexed canonical event can confirm this action. Only <code>BountySettled</code> proves solver payment.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <span>Close this tab at any time to cancel before approval.</span>
+      <a href="terms.html">Terms</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
+    </footer>
+    <script src="analytics-config.js?v=2"></script>
+    <script src="analytics.js?v=3"></script>
+    <script src="authorize.js"></script>
+  </body>
+</html>

--- a/site/authorize.js
+++ b/site/authorize.js
@@ -1,0 +1,127 @@
+(() => {
+  "use strict";
+
+  const byId = (id) => document.getElementById(id);
+  const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  let protocol = null;
+  let intent = null;
+
+  function output(lines, tone = "") {
+    const element = byId("authorization-output");
+    element.textContent = Array.isArray(lines) ? lines.join("\n") : lines;
+    element.dataset.tone = tone;
+  }
+
+  async function requestJson(url) {
+    const response = await fetch(url, { cache: "no-store" });
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error(body?.message || body?.error || `Request failed (${response.status}).`);
+    }
+    return body;
+  }
+
+  function intentId() {
+    const value = new URLSearchParams(location.search).get("intent");
+    if (!UUID.test(value || "")) throw new Error("This authorization link is invalid.");
+    return value;
+  }
+
+  function destinationFor(value) {
+    const params = new URLSearchParams({ intent: value.intent_id, from: "chatgpt-app" });
+    if (value.bounty_contract) params.set("bountyContract", value.bounty_contract);
+    if (value.action === "fund" && value.amount_base_units) {
+      params.set("amount", (Number(value.amount_base_units) / 1_000_000).toFixed(6));
+    }
+    if (value.action === "solve" || value.action === "compete") {
+      params.set("source", "chatgpt-app");
+    }
+    const page = {
+      post: "post.html",
+      fund: "funding.html",
+      solve: "earn.html",
+      compete: "earn.html",
+      complete: "earn.html",
+      verify: "verify.html",
+    }[value.action];
+    if (!page) throw new Error("This action type is not supported.");
+    return `${page}?${params}`;
+  }
+
+  function actionTitle(action) {
+    return {
+      post: "Post a bounty",
+      fund: "Fund this bounty",
+      solve: "Solve this bounty",
+      compete: "Solve this bounty",
+      complete: "Submit completed work",
+      verify: "Verify this submission",
+    }[action] || "Review this bounty action";
+  }
+
+  function render(value) {
+    intent = value;
+    byId("authorization-title").textContent = actionTitle(value.action);
+    byId("authorization-summary").textContent =
+      value.status === "confirmed"
+        ? "The matching canonical event is confirmed."
+        : "Review the exact destination and evidence requirement before continuing.";
+    byId("authorization-network").textContent = value.network;
+    byId("authorization-contract").textContent =
+      value.bounty_contract || "Created during authorization";
+    byId("authorization-amount").textContent = value.amount_base_units
+      ? `${(Number(value.amount_base_units) / 1_000_000).toFixed(6)} USDC`
+      : "No transfer amount in this step";
+    byId("authorization-events").textContent = value.expected_canonical_events.join(" or ");
+    byId("authorization-details").textContent = JSON.stringify(value.details || {}, null, 2);
+    byId("authorization-boundary").textContent = value.evidence_boundary;
+    const status = byId("authorization-status");
+    status.textContent = value.status.replaceAll("_", " ");
+    status.dataset.tone = value.status === "confirmed"
+      ? "success"
+      : value.status === "expired" || value.status === "failed"
+        ? "error"
+        : "pending";
+    const button = byId("authorization-continue");
+    button.hidden = value.status !== "review_required";
+    if (!button.hidden) button.href = destinationFor(value);
+    if (value.status === "confirmed") {
+      output([
+        `Confirmed: ${value.canonical_event_kind}.`,
+        value.paid
+          ? "BountySettled confirms solver payment."
+          : "This confirms the action, but it is not payout evidence.",
+        "Return to ChatGPT and refresh the bounty card, then share the result.",
+      ], "success");
+    } else if (value.status === "pending_confirmation") {
+      output([
+        `Transaction observed: ${value.transaction_hash}.`,
+        "Waiting for the exact indexed canonical event. Do not approve the action again.",
+      ], "pending");
+    } else if (value.status === "expired" || value.status === "failed") {
+      output(value.next_action, "error");
+    } else {
+      output([
+        "No wallet request is made on this review screen.",
+        "Continue only if the action, contract, amount, and evidence requirement are correct.",
+      ], "pending");
+    }
+  }
+
+  async function refresh() {
+    try {
+      if (!protocol) {
+        protocol = await requestJson("protocol.json");
+      }
+      const api = protocol.api_base_url.replace(/\/$/, "");
+      render(await requestJson(`${api}/v1/chatgpt/action-intents/${intentId()}`));
+    } catch (error) {
+      byId("authorization-status").textContent = "unavailable";
+      byId("authorization-status").dataset.tone = "error";
+      output(error.message || String(error), "error");
+    }
+  }
+
+  byId("authorization-refresh").addEventListener("click", refresh);
+  refresh();
+})();

--- a/site/bounty-chat-controls.css
+++ b/site/bounty-chat-controls.css
@@ -1,0 +1,13 @@
+.chat-send {
+  font-size: 0;
+}
+.chat-send svg {
+  display: none;
+}
+
+.chat-send::before {
+  content: "↑";
+  font-size: 20px;
+  font-weight: 900;
+  line-height: 1;
+}

--- a/site/bounty-chat-ui.js
+++ b/site/bounty-chat-ui.js
@@ -1,0 +1,207 @@
+(() => {
+  "use strict";
+
+  const root = document.querySelector("[data-bounty-chat]");
+  const log = document.querySelector("[data-conversation-log]");
+  const prompt = document.querySelector("[data-assistant-prompt]");
+  const form = document.getElementById("bounty-composer-form");
+  const input = document.getElementById("bounty-composer-input");
+  const status = document.querySelector("[data-composer-status]");
+  const thinking = document.querySelector("[data-assistant-thinking]");
+  const preview = document.getElementById("bounty-preview");
+  const draftState = document.querySelector("[data-draft-state]");
+  const approve = document.querySelector("[data-approve-card]");
+  const revise = document.querySelector("[data-revise-card]");
+  const connect = document.querySelector("[data-open-funding]");
+  const dialog = document.getElementById("funding-dialog");
+  const cryptoMethod = document.querySelector("[data-payment-method='crypto']");
+
+  if (!root || !log || !prompt || !form || !input || !preview) return;
+
+  let lastAssistantText = "";
+  let approvedAnnounced = false;
+  let draftSyncQueued = false;
+
+  function scrollConversation() {
+    requestAnimationFrame(() => {
+      log.scrollTop = log.scrollHeight;
+    });
+  }
+
+  function addMessage(role, text) {
+    const value = String(text || "").trim();
+    if (!value) return;
+
+    const article = document.createElement("article");
+    article.className = "conversation-message";
+    article.dataset.role = role;
+
+    const avatar = document.createElement("span");
+    avatar.className = "conversation-avatar";
+    avatar.textContent = role === "user" ? "You" : "AI";
+    avatar.setAttribute("aria-hidden", "true");
+
+    const bubble = document.createElement("div");
+    bubble.className = "conversation-bubble";
+    bubble.textContent = value;
+
+    article.append(avatar, bubble);
+    log.append(article);
+    scrollConversation();
+  }
+
+  function syncPrompt() {
+    const value = prompt.textContent.trim();
+    if (!value || value === lastAssistantText) return;
+    lastAssistantText = value;
+    addMessage("assistant", value);
+    thinking.hidden = true;
+  }
+
+  function syncStatus() {
+    const value = status.textContent.trim();
+    const waiting = status.dataset.tone === "pending"
+      && /AI|draft|turning|breaking|generating|preparing/i.test(value);
+    thinking.hidden = !waiting;
+    if (waiting) scrollConversation();
+  }
+
+  function setDraftState(text, tone) {
+    if (!draftState) return;
+    if (draftState.textContent !== text) draftState.textContent = text;
+    if (draftState.dataset.tone !== tone) draftState.dataset.tone = tone;
+  }
+
+  function syncDraft() {
+    draftSyncQueued = false;
+    if (preview.hidden) return;
+    if (approve?.dataset.approved !== "true") setDraftState("Draft · not posted", "ready");
+    if (preview.parentElement !== log || preview !== log.lastElementChild) log.append(preview);
+    scrollConversation();
+  }
+
+  function scheduleDraftSync() {
+    if (draftSyncQueued) return;
+    draftSyncQueued = true;
+    requestAnimationFrame(syncDraft);
+  }
+
+  function syncApproval() {
+    const isApproved = approve?.dataset.approved === "true";
+    setDraftState(isApproved ? "Approved · not posted" : "Draft · not posted", isApproved ? "approved" : "ready");
+
+    if (isApproved && !approvedAnnounced) {
+      approvedAnnounced = true;
+      addMessage("assistant", "Draft approved. Connect your wallet when you are ready.");
+    }
+    if (!isApproved) approvedAnnounced = false;
+  }
+
+  function prepareNaturalRevision(value) {
+    if (preview.hidden || !revise) return;
+    const alreadyRevising = /what should the ai change/i.test(prompt.textContent);
+    if (alreadyRevising) return;
+    revise.click();
+    input.value = value;
+  }
+
+  function fitInput() {
+    input.style.height = "auto";
+    input.style.height = `${Math.min(input.scrollHeight, 160)}px`;
+  }
+
+  form.addEventListener("submit", () => {
+    const value = input.value.trim();
+    if (!value) return;
+    prepareNaturalRevision(value);
+    addMessage("user", value);
+    requestAnimationFrame(() => {
+      input.style.height = "auto";
+    });
+  }, true);
+
+  input.addEventListener("input", fitInput);
+  input.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
+    event.preventDefault();
+    form.requestSubmit();
+  });
+
+  new MutationObserver(syncPrompt).observe(prompt, {
+    childList: true,
+    characterData: true,
+    subtree: true,
+  });
+
+  new MutationObserver(syncStatus).observe(status, {
+    childList: true,
+    characterData: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["data-tone"],
+  });
+
+  new MutationObserver(scheduleDraftSync).observe(preview, {
+    attributes: true,
+    attributeFilter: ["hidden"],
+    childList: true,
+    characterData: true,
+    subtree: true,
+  });
+
+  if (approve) {
+    new MutationObserver(syncApproval).observe(approve, {
+      attributes: true,
+      attributeFilter: ["data-approved", "disabled"],
+    });
+    approve.addEventListener("click", () => setTimeout(syncApproval, 0));
+  }
+
+  if (revise) {
+    revise.addEventListener("click", () => {
+      approvedAnnounced = false;
+      setTimeout(() => input.focus({ preventScroll: true }), 0);
+    });
+  }
+
+  if (connect) {
+    connect.addEventListener("click", () => {
+      setTimeout(() => {
+        if (dialog?.open && cryptoMethod) cryptoMethod.click();
+      }, 0);
+    });
+  }
+
+  if (dialog) {
+    new MutationObserver(() => {
+      if (dialog.open && cryptoMethod) setTimeout(() => cryptoMethod.click(), 0);
+    }).observe(dialog, { attributes: true, attributeFilter: ["open"] });
+  }
+
+  const params = new URLSearchParams(location.search);
+  const entryIntent = window.AgentBountyEntry?.consume
+    ? window.AgentBountyEntry.consume(params)
+    : { message: "", autostart: false };
+  const supplied = entryIntent.message
+    || params.get("goal")
+    || params.get("draftObjective")
+    || params.get("objective");
+  if (supplied) {
+    input.value = supplied;
+    fitInput();
+  }
+
+  if (entryIntent.autostart && supplied) {
+    lastAssistantText = prompt.textContent.trim();
+  }
+
+  syncPrompt();
+  syncStatus();
+  scheduleDraftSync();
+  syncApproval();
+  document.documentElement.dataset.bountyComposer = "chat-v2";
+
+  if (entryIntent.autostart && supplied) {
+    form.requestSubmit();
+  }
+})();

--- a/site/bounty-chat.css
+++ b/site/bounty-chat.css
@@ -1,0 +1,813 @@
+:root {
+  --chat-bg: #06100b;
+  --chat-surface: #0b1710;
+  --chat-surface-soft: #112019;
+  --chat-line: rgba(255, 255, 255, 0.11);
+  --chat-text: #f3f5ef;
+  --chat-muted: #98a39b;
+  --chat-lime: #c8f548;
+  --chat-mint: #7cefd1;
+}
+html,
+body.chat-app-page {
+  height: 100%;
+}
+
+body.chat-app-page {
+  min-width: 320px;
+  margin: 0;
+  overflow: hidden;
+  background: var(--chat-bg);
+  color: var(--chat-text);
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.chat-app-page * {
+  box-sizing: border-box;
+}
+
+.chat-app-page .sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.chat-app-page button,
+.chat-app-page textarea {
+  font: inherit;
+}
+
+.chat-app-header {
+  position: fixed;
+  z-index: 50;
+  inset: 0 0 auto;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  height: 58px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--chat-line);
+  background: rgba(6, 16, 11, 0.94);
+  backdrop-filter: blur(18px);
+}
+
+.chat-app-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  justify-self: start;
+  color: var(--chat-text);
+  text-decoration: none;
+}
+
+.chat-app-brand > span {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(200, 245, 72, 0.55);
+  border-radius: 9px;
+  color: var(--chat-lime);
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.chat-app-brand strong {
+  font-size: 14px;
+}
+
+.chat-app-title {
+  margin: 0;
+  color: #dbe1da;
+  line-height: 1;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.chat-app-close {
+  display: grid;
+  place-items: center;
+  justify-self: end;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  color: #c8d0c9;
+  font-size: 24px;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.chat-app-close:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: white;
+}
+
+.chat-app {
+  height: calc(100dvh - 58px);
+  margin-top: 58px;
+}
+
+.conversation-panel {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto auto;
+  width: min(820px, 100%);
+  height: 100%;
+  margin: 0 auto;
+  background: var(--chat-bg);
+}
+
+.conversation-log {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 18px;
+  padding: 28px 20px 24px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scroll-behavior: smooth;
+  scrollbar-color: rgba(200, 245, 72, 0.28) transparent;
+}
+
+.conversation-message {
+  display: flex;
+  max-width: min(78%, 610px);
+  animation: chat-message-in 180ms ease both;
+}
+
+.conversation-message[data-role="user"] {
+  align-self: flex-end;
+}
+
+.conversation-avatar {
+  display: none;
+}
+
+.conversation-bubble {
+  padding: 11px 15px;
+  border: 1px solid var(--chat-line);
+  border-radius: 18px 18px 18px 5px;
+  background: var(--chat-surface-soft);
+  color: #ecf0e9;
+  font-size: 15px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.conversation-message[data-role="user"] .conversation-bubble {
+  border-color: rgba(200, 245, 72, 0.26);
+  border-radius: 18px 18px 5px 18px;
+  background: rgba(166, 207, 54, 0.16);
+  color: #f7f9f1;
+}
+
+.conversation-thinking {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: min(820px, 100%);
+  padding: 0 22px 10px;
+}
+
+.conversation-thinking[hidden] {
+  display: none;
+}
+
+.conversation-thinking span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--chat-muted);
+  animation: chat-dot 1s ease-in-out infinite;
+}
+
+.conversation-thinking span:nth-child(2) { animation-delay: 120ms; }
+.conversation-thinking span:nth-child(3) { animation-delay: 240ms; }
+
+.chat-composer-form {
+  position: relative;
+  padding: 12px 16px max(14px, env(safe-area-inset-bottom));
+  border-top: 1px solid var(--chat-line);
+  background: linear-gradient(180deg, rgba(6, 16, 11, 0.84), #06100b 35%);
+}
+
+body.chatgpt-handoff-review {
+  overflow: auto;
+}
+
+.chatgpt-handoff-review .chat-app {
+  height: auto;
+  min-height: calc(100dvh - 58px);
+}
+
+.chatgpt-handoff-review .conversation-panel {
+  grid-template-rows: minmax(0, 1fr) auto;
+  min-height: calc(100dvh - 58px);
+  height: auto;
+}
+
+.chatgpt-handoff-review .conversation-log {
+  justify-content: center;
+  overflow: visible;
+  padding-block: clamp(24px, 6vh, 64px);
+}
+
+.chatgpt-handoff-review .chat-composer-form[data-handoff-review="true"] {
+  padding: 0 20px 24px;
+  border-top: 0;
+  background: transparent;
+}
+
+.chatgpt-handoff-review .chat-composer-form[data-handoff-review="true"] .composer-status:empty {
+  display: none;
+}
+
+.chatgpt-handoff-review [data-revise-card],
+.chatgpt-handoff-review [data-ai-handoff],
+.chatgpt-handoff-review .conversation-thinking {
+  display: none !important;
+}
+
+.chatgpt-handoff-review .image-generation-status {
+  display: none;
+}
+
+.chatgpt-handoff-review .conversation-draft {
+  width: min(720px, 100%);
+  margin: 0 auto;
+  animation: chatgpt-review-in 220ms ease-out both;
+}
+
+.chat-composer-input-wrap {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 38px 42px;
+  align-items: end;
+  gap: 5px;
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 24px;
+  background: #101c15;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.24);
+}
+
+.chat-composer-input-wrap:focus-within {
+  border-color: rgba(200, 245, 72, 0.48);
+  box-shadow: 0 0 0 3px rgba(200, 245, 72, 0.06), 0 14px 36px rgba(0, 0, 0, 0.24);
+}
+
+.chat-app-page #bounty-composer-input {
+  width: 100%;
+  min-height: 42px;
+  max-height: 160px;
+  margin: 0;
+  padding: 10px 11px 8px;
+  resize: none;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--chat-text);
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.chat-app-page #bounty-composer-input:focus {
+  border: 0;
+  box-shadow: none;
+}
+
+.chat-app-page #bounty-composer-input::placeholder {
+  color: #7f8a82;
+}
+
+.chat-composer-input-wrap .composer-mic,
+.chat-send {
+  position: static;
+  display: grid;
+  place-items: center;
+  align-self: end;
+  border: 0;
+  cursor: pointer;
+}
+
+.chat-composer-input-wrap .composer-mic {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: transparent;
+  color: #9aa69d;
+}
+
+.chat-composer-input-wrap .composer-mic:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: white;
+}
+
+.chat-composer-input-wrap .composer-mic svg,
+.chat-send svg {
+  width: 19px;
+  height: 19px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chat-send {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--chat-lime);
+  color: #0a1208;
+}
+
+.chat-send:hover {
+  transform: scale(1.04);
+}
+
+.chat-send:disabled,
+.composer-mic:disabled {
+  cursor: default;
+  opacity: 0.45;
+  transform: none;
+}
+
+.composer-status {
+  display: block;
+  max-width: 780px;
+  min-height: 0;
+  margin: 7px auto 0;
+  padding: 0 8px;
+  color: #9aa69d;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.composer-status:empty {
+  display: none;
+}
+
+.composer-status[data-tone="error"] { color: #ff9f92; }
+.composer-status[data-tone="pending"] { color: var(--chat-mint); }
+.composer-status[data-tone="success"] { color: var(--chat-lime); }
+
+.conversation-draft {
+  align-self: flex-start;
+  width: min(100%, 680px);
+  margin: 0;
+  border: 0;
+  background: transparent;
+}
+
+.conversation-draft[hidden] {
+  display: none;
+}
+
+.conversation-draft .bounty-card {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(200, 245, 72, 0.28);
+  border-radius: 20px;
+  background: #0b1810;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.conversation-draft .bounty-card-visual {
+  position: relative;
+  height: 190px;
+  overflow: hidden;
+}
+
+.conversation-draft .bounty-card-visual canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.conversation-draft .bounty-card-badge,
+.conversation-draft .image-generation-status {
+  position: absolute;
+  top: 12px;
+  padding: 6px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(4, 13, 8, 0.74);
+  color: #e7ede5;
+  font-size: 10px;
+  font-weight: 750;
+  backdrop-filter: blur(10px);
+}
+
+.conversation-draft .bounty-card-badge { left: 12px; }
+.conversation-draft .image-generation-status { right: 12px; }
+
+.conversation-draft .bounty-card-body {
+  padding: 20px;
+}
+
+.draft-card-heading {
+  margin-bottom: 16px;
+}
+
+.draft-state {
+  display: inline-block;
+  margin-bottom: 8px;
+  color: var(--chat-mint);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.draft-state[data-tone="approved"] {
+  color: var(--chat-lime);
+}
+
+.conversation-draft h2 {
+  margin: 0;
+  color: var(--chat-text);
+  font-size: clamp(22px, 4vw, 30px);
+  line-height: 1.12;
+  letter-spacing: -0.025em;
+}
+
+.conversation-draft .bounty-card-goal {
+  margin: 9px 0 0;
+  color: #b8c2ba;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.conversation-draft .bounty-card-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0 0 18px;
+}
+
+.conversation-draft .bounty-stat {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.conversation-draft .bounty-stat span,
+.conversation-draft .bounty-stat strong {
+  display: block;
+}
+
+.conversation-draft .bounty-stat span {
+  margin-bottom: 4px;
+  color: #829087;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.conversation-draft .bounty-stat strong {
+  color: #f2f5ef;
+  font-size: 13px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.done-when {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.done-when h3 {
+  margin: 0 0 8px;
+  font-size: 13px;
+}
+
+.done-when ol {
+  margin: 0;
+  padding-left: 20px;
+  color: #c8d0c9;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.done-when li + li {
+  margin-top: 5px;
+}
+
+.bounty-review-details,
+.mission-context {
+  margin-top: 14px;
+  padding-top: 13px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: #aab5ad;
+  font-size: 12px;
+}
+
+.bounty-review-details summary,
+.mission-context summary {
+  color: #dce2dc;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.bounty-review-details ul {
+  padding-left: 18px;
+  line-height: 1.5;
+}
+
+.bounty-review-details p,
+.mission-context p {
+  line-height: 1.5;
+}
+
+.mission-horizon {
+  display: inline-block;
+  margin-bottom: 8px;
+  color: var(--chat-lime);
+}
+
+.mission-task-options {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+}
+
+.mission-task-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
+  padding: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.mission-task-option small {
+  display: block;
+  margin-top: 3px;
+  color: #86938a;
+}
+
+.chat-draft-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.chat-draft-actions .button {
+  min-height: 40px;
+  padding: 0 14px;
+  border-radius: 999px;
+  font-size: 12px;
+}
+
+.chat-draft-actions [data-open-funding] {
+  margin-left: auto;
+}
+
+.chat-wallet-dialog {
+  width: min(520px, calc(100% - 24px));
+  max-height: min(760px, calc(100dvh - 32px));
+  padding: 0;
+  overflow: auto;
+  border: 1px solid rgba(200, 245, 72, 0.28);
+  border-radius: 20px;
+  background: #0a1710;
+  color: var(--chat-text);
+}
+
+.chat-wallet-dialog::backdrop {
+  background: rgba(0, 5, 3, 0.72);
+  backdrop-filter: blur(5px);
+}
+
+.chat-wallet-dialog .payment-dialog-inner {
+  padding: 20px;
+}
+
+.chat-wallet-dialog .payment-dialog-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.chat-wallet-dialog .payment-dialog-head h2,
+.chat-wallet-dialog .payment-dialog-head p {
+  margin: 0;
+}
+
+.chat-wallet-dialog .payment-dialog-head p {
+  margin-top: 4px;
+  color: var(--chat-muted);
+  font-size: 12px;
+}
+
+.chat-wallet-dialog .dialog-close {
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  color: white;
+  cursor: pointer;
+  font-size: 22px;
+}
+
+.wallet-options {
+  display: grid;
+  gap: 8px;
+}
+
+.wallet-option {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  padding: 13px;
+  border: 1px solid var(--chat-line);
+  border-radius: 12px;
+  background: var(--chat-surface-soft);
+  color: var(--chat-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.wallet-option small,
+.payment-status,
+.funding-help {
+  color: var(--chat-muted);
+}
+
+.wallet-readiness-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin: 14px 0;
+}
+
+.wallet-readiness-grid > div {
+  padding: 10px;
+  border: 1px solid var(--chat-line);
+  border-radius: 10px;
+}
+
+.wallet-readiness-grid span,
+.wallet-readiness-grid strong {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.wallet-readiness-grid span {
+  margin-bottom: 4px;
+  color: #859188;
+  font-size: 10px;
+}
+
+.wallet-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 12px 0;
+}
+
+.payment-status {
+  display: block;
+  margin-top: 14px;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+@keyframes chat-message-in {
+  from { opacity: 0; transform: translateY(5px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes chat-dot {
+  0%, 100% { opacity: 0.35; transform: translateY(0); }
+  50% { opacity: 1; transform: translateY(-3px); }
+}
+
+@keyframes chatgpt-review-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 620px) {
+  .chat-app-header {
+    height: 54px;
+    padding-inline: 12px;
+  }
+
+  .chat-app {
+    height: calc(100dvh - 54px);
+    margin-top: 54px;
+  }
+
+  .chatgpt-handoff-review .chat-app,
+  .chatgpt-handoff-review .conversation-panel {
+    min-height: calc(100dvh - 54px);
+  }
+
+  .chat-app-brand strong {
+    display: none;
+  }
+
+  .conversation-log {
+    gap: 15px;
+    padding: 20px 12px 18px;
+  }
+
+  .conversation-message {
+    max-width: 88%;
+  }
+
+  .conversation-bubble {
+    font-size: 14px;
+  }
+
+  .chat-composer-form {
+    padding-inline: 9px;
+  }
+
+  .chat-composer-input-wrap {
+    grid-template-columns: minmax(0, 1fr) 36px 40px;
+    border-radius: 22px;
+  }
+
+  .chat-app-page #bounty-composer-input {
+    min-height: 40px;
+    padding-inline: 9px;
+    font-size: 16px;
+  }
+
+  .chat-composer-input-wrap .composer-mic {
+    width: 36px;
+    height: 36px;
+  }
+
+  .chat-send {
+    width: 40px;
+    height: 40px;
+  }
+
+  .conversation-draft .bounty-card-visual {
+    height: 150px;
+  }
+
+  .conversation-draft .bounty-card-body {
+    padding: 16px;
+  }
+
+  .conversation-draft .bounty-card-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .conversation-draft .bounty-stat {
+    display: grid;
+    grid-template-columns: 78px 1fr;
+    align-items: center;
+  }
+
+  .conversation-draft .bounty-stat span {
+    margin: 0;
+  }
+
+  .chat-draft-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .chat-draft-actions [data-open-funding] {
+    grid-column: 1 / -1;
+    margin-left: 0;
+  }
+
+  .wallet-readiness-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-app-page *,
+  .chat-app-page *::before,
+  .chat-app-page *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/site/bounty-composer-v2.css
+++ b/site/bounty-composer-v2.css
@@ -1,0 +1,113 @@
+.mission-context {
+  margin: 0 0 22px;
+  border: 1px solid rgba(124, 239, 209, 0.2);
+  border-radius: 17px;
+  padding: 16px;
+  background: rgba(124, 239, 209, 0.045);
+}
+
+.mission-context[hidden] { display: none; }
+
+.mission-context-kicker {
+  margin: 0 0 5px;
+  color: var(--composer-mint);
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.mission-context h3 {
+  margin: 0;
+  color: var(--composer-text);
+  font-size: 1.15rem;
+}
+
+.mission-context > p {
+  margin: 7px 0 0;
+  color: var(--composer-muted);
+  line-height: 1.48;
+}
+
+.mission-horizon {
+  display: inline-flex;
+  margin-top: 10px;
+  border: 1px solid rgba(201, 245, 72, 0.22);
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: var(--composer-lime);
+  font-size: 0.72rem;
+  font-weight: 780;
+}
+
+.mission-task-options {
+  display: grid;
+  gap: 8px;
+  margin-top: 15px;
+}
+
+.mission-task-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: start;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 13px;
+  padding: 12px;
+  color: var(--composer-text);
+  background: rgba(0, 8, 4, 0.35);
+  cursor: pointer;
+}
+
+.mission-task-option:has(input:checked) {
+  border-color: rgba(201, 245, 72, 0.65);
+  background: rgba(201, 245, 72, 0.075);
+}
+
+.mission-task-option input {
+  margin-top: 3px;
+  accent-color: var(--composer-lime);
+}
+
+.mission-task-option strong,
+.mission-task-option small {
+  display: block;
+}
+
+.mission-task-option small {
+  margin-top: 4px;
+  color: var(--composer-muted);
+  line-height: 1.4;
+}
+
+.image-generation-status {
+  position: absolute;
+  right: 16px;
+  bottom: 14px;
+  border: 1px solid rgba(255,255,255,.2);
+  border-radius: 999px;
+  padding: 6px 9px;
+  color: rgba(255,255,255,.78);
+  background: rgba(1, 10, 6, .68);
+  backdrop-filter: blur(9px);
+  font-size: .65rem;
+  font-weight: 760;
+}
+
+.image-generation-status[data-tone="ai"] {
+  color: var(--composer-mint);
+  border-color: rgba(124, 239, 209, .35);
+}
+
+.composer-scope-note {
+  max-width: 720px;
+  margin: 12px auto 0;
+  color: #849088;
+  font-size: .78rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 700px) {
+  .mission-task-option { padding: 11px; }
+  .image-generation-status { right: 10px; bottom: 10px; }
+}

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -1,0 +1,1391 @@
+(() => {
+  "use strict";
+
+  const API = "https://api.agentbounties.app";
+  const MAX_AI_ROUNDS = 3;
+  const MAX_PLAN_TASKS = 6;
+  const MAX_TASK_DAYS = 30;
+  const MIN_TOTAL_USDC = 0.02;
+  const MAX_TOTAL_USDC = 9_000_000_000;
+  const REGRESSION_ENGINE = "sandboxed_regression_v1";
+  const REGRESSION_VERIFIERS = [
+    "0xbe6292b9e465f549e2363b918d6dd9187038431e",
+  ];
+  const VISUAL_EXTENSION = "x-agent-bounties-draft-visual";
+  const ALLOWED_SCENES = new Set([
+    "infrastructure", "digital", "nature", "health", "research", "education", "coordination", "general",
+  ]);
+  const ALLOWED_ELEMENTS = new Set([
+    "sun", "road", "lamp", "building", "tree", "water", "screen", "document", "network", "tool", "person", "check", "bridge", "book", "chart",
+  ]);
+
+  const ui = {
+    form: document.getElementById("bounty-composer-form"),
+    input: document.getElementById("bounty-composer-input"),
+    label: document.querySelector("[data-composer-label]"),
+    prompt: document.querySelector("[data-assistant-prompt]"),
+    submit: document.querySelector("[data-composer-submit]"),
+    mic: document.querySelector("[data-dictate]"),
+    hint: document.querySelector("[data-composer-hint]"),
+    status: document.querySelector("[data-composer-status]"),
+    progress: Array.from(document.querySelectorAll("[data-progress-step]")),
+    preview: document.getElementById("bounty-preview"),
+    art: document.getElementById("bounty-card-art"),
+    imageStatus: document.querySelector("[data-image-status]"),
+    badge: document.querySelector("[data-card-badge]"),
+    title: document.querySelector("[data-card-title]"),
+    goal: document.querySelector("[data-card-goal]"),
+    criteria: document.querySelector("[data-card-criteria]"),
+    reward: document.querySelector("[data-card-reward]"),
+    deadline: document.querySelector("[data-card-deadline]"),
+    checks: document.querySelector("[data-card-checks]"),
+    confidence: document.querySelector("[data-card-confidence]"),
+    risks: document.querySelector("[data-card-risks]"),
+    missionContext: document.querySelector("[data-mission-context]"),
+    missionTitle: document.querySelector("[data-mission-title]"),
+    missionSummary: document.querySelector("[data-mission-summary]"),
+    missionHorizon: document.querySelector("[data-mission-horizon]"),
+    missionTasks: document.querySelector("[data-mission-tasks]"),
+    approve: document.querySelector("[data-approve-card]"),
+    revise: document.querySelector("[data-revise-card]"),
+    share: document.querySelector("[data-share-card]"),
+    fund: document.querySelector("[data-open-funding]"),
+    dialog: document.getElementById("funding-dialog"),
+    closeDialog: document.querySelector("[data-close-funding]"),
+    cryptoMethod: document.querySelector("[data-payment-method='crypto']"),
+    walletPanel: document.querySelector("[data-wallet-panel]"),
+    walletOptions: document.querySelector("[data-wallet-options]"),
+    walletMessage: document.querySelector("[data-wallet-message]"),
+    readiness: document.querySelector("[data-wallet-readiness]"),
+    account: document.querySelector("[data-wallet-account]"),
+    usdcBalance: document.querySelector("[data-wallet-usdc]"),
+    ethBalance: document.querySelector("[data-wallet-eth]"),
+    requiredUsdc: document.querySelector("[data-wallet-required]"),
+    fundingHelp: document.querySelector("[data-funding-help]"),
+    missingUsdc: document.querySelector("[data-missing-usdc]"),
+    onramp: document.querySelector("[data-onramp-link]"),
+    watchUsdc: document.querySelector("[data-watch-usdc]"),
+    copyUsdc: document.querySelector("[data-copy-usdc]"),
+    recheck: document.querySelector("[data-recheck-balance]"),
+    fundNow: document.querySelector("[data-fund-now]"),
+    paymentStatus: document.querySelector("[data-payment-status]"),
+    headerTitle: document.querySelector(".chat-app-title"),
+    aiHandoff: document.querySelector("[data-ai-handoff]"),
+  };
+
+  if (!ui.form || !ui.input || !ui.preview || !ui.dialog || !ui.art) return;
+
+  const state = {
+    phase: "describe",
+    originalRequest: "",
+    context: [],
+    initialDraft: null,
+    draft: null,
+    aiRounds: 0,
+    questions: [],
+    currentQuestion: null,
+    askedQuestions: new Set(),
+    scope: null,
+    horizon: null,
+    missionPlan: null,
+    selectedTaskId: null,
+    taskWindowDays: null,
+    fundingUsdc: null,
+    visualSpec: null,
+    visualSource: "fallback",
+    visualCache: new Map(),
+    bountyImage: null,
+    imageReady: false,
+    approved: false,
+    protocol: null,
+    providers: [],
+    provider: null,
+    account: null,
+    balances: null,
+    bountyContract: null,
+    bountyId: null,
+    speech: null,
+    handoffReview: false,
+    observedWalletState: null,
+  };
+
+  function track(eventName, details) {
+    window.agentBountiesAnalytics?.track(eventName, details);
+  }
+
+  function enableAiHandoffReview() {
+    state.handoffReview = true;
+    document.body.classList.add("chatgpt-handoff-review");
+    ui.form.dataset.handoffReview = "true";
+    const inputWrap = ui.form.querySelector(".chat-composer-input-wrap");
+    if (inputWrap) inputWrap.hidden = true;
+    ui.input.disabled = true;
+    ui.submit.disabled = true;
+    ui.mic.hidden = true;
+    ui.revise.hidden = true;
+    if (ui.aiHandoff) ui.aiHandoff.hidden = true;
+    if (ui.headerTitle) ui.headerTitle.textContent = "Review bounty";
+    setProgress("review");
+  }
+
+  const announcedProviders = [];
+  window.addEventListener("eip6963:announceProvider", (event) => {
+    const detail = event && event.detail;
+    if (!detail || !detail.provider || typeof detail.provider.request !== "function") return;
+    if (!announcedProviders.some((item) => item.provider === detail.provider)) announcedProviders.push(detail);
+  });
+
+  function setStatus(message, tone = "") {
+    ui.status.textContent = message || "";
+    ui.status.dataset.tone = tone;
+  }
+
+  function setPaymentStatus(message, tone = "") {
+    ui.paymentStatus.textContent = message || "";
+    ui.paymentStatus.dataset.tone = tone;
+  }
+
+  function setProgress(active) {
+    const order = ["describe", "clarify", "review", "fund"];
+    const activeIndex = order.indexOf(active);
+    ui.progress.forEach((item) => {
+      const index = order.indexOf(item.dataset.progressStep);
+      item.dataset.active = String(index === activeIndex);
+      item.dataset.complete = String(index >= 0 && index < activeIndex);
+    });
+  }
+
+  function setComposer({ phase, prompt, label, placeholder, button, hint = "" }) {
+    state.phase = phase;
+    ui.prompt.textContent = prompt;
+    ui.label.textContent = label;
+    ui.input.placeholder = placeholder;
+    ui.submit.textContent = button;
+    ui.hint.textContent = hint;
+    ui.input.value = "";
+    ui.input.disabled = false;
+    ui.submit.disabled = false;
+    setProgress(phase === "describe" ? "describe" : "clarify");
+    requestAnimationFrame(() => ui.input.focus({ preventScroll: true }));
+  }
+
+  function normalizeQuestion(value) {
+    return String(value || "").trim().toLowerCase().replace(/\s+/g, " ");
+  }
+
+  function safeTextList(values, maximum = 12) {
+    return (Array.isArray(values) ? values : [])
+      .map((value) => String(value || "").trim())
+      .filter(Boolean)
+      .slice(0, maximum);
+  }
+
+  function randomBytes32() {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  function formatUsdc(value, maximum = 6) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "0";
+    return number.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: maximum });
+  }
+
+  function usdcBaseUnits(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number) || number < 0 || number > MAX_TOTAL_USDC) {
+      throw new Error("Enter a valid USDC amount.");
+    }
+    return BigInt(Math.round(number * 1_000_000));
+  }
+
+  function splitReward(total) {
+    const totalUnits = usdcBaseUnits(total);
+    if (totalUnits < 20_000n) throw new Error("The current protocol requires at least 0.02 USDC in total.");
+    const proportional = totalUnits / 50n;
+    const verifier = proportional < 10_000n ? 10_000n : proportional;
+    let cappedVerifier = verifier > totalUnits / 5n ? totalUnits / 5n : verifier;
+    if (cappedVerifier % 2n !== 0n) cappedVerifier -= 1n;
+    const solver = totalUnits - cappedVerifier;
+    if (solver < 10_000n) throw new Error("The solver reward must remain at least 0.01 USDC.");
+    return { total: totalUnits, solver, verifier: cappedVerifier };
+  }
+
+  function parseFunding(value) {
+    const cleaned = String(value || "").replace(/,/g, "");
+    const match = cleaned.match(/(?:^|[^0-9])(\d+(?:\.\d{1,6})?)(?:\s*(?:base\s*)?usdc|\s*dollars?|\s*usd)?(?:$|[^0-9])/i);
+    if (!match) return null;
+    const amount = Number(match[1]);
+    return Number.isFinite(amount) && amount >= MIN_TOTAL_USDC && amount <= MAX_TOTAL_USDC ? amount : null;
+  }
+
+  function parseHorizon(value) {
+    const raw = String(value || "").trim();
+    if (/\b(ongoing|continuous|continuing|indefinite|no fixed end|no end date|open[- ]ended|work toward)\b/i.test(raw)) {
+      return { kind: "ongoing", label: "Ongoing", date: null, days: null };
+    }
+    const duration = raw.match(/(?:in\s+)?(\d+)\s*(hour|hours|day|days|week|weeks|month|months|year|years)\b/i);
+    let date = null;
+    if (duration) {
+      const count = Number(duration[1]);
+      const unit = duration[2].toLowerCase();
+      const hours = unit.startsWith("year")
+        ? count * 365 * 24
+        : unit.startsWith("month")
+          ? count * 30 * 24
+          : unit.startsWith("week")
+            ? count * 7 * 24
+            : unit.startsWith("day")
+              ? count * 24
+              : count;
+      if (!Number.isFinite(hours) || hours < 1 || hours > 100 * 365 * 24) return null;
+      date = new Date(Date.now() + hours * 3_600_000);
+    } else {
+      const iso = raw.match(/\b(20\d{2}-\d{2}-\d{2})(?:[T\s](\d{1,2}:\d{2}))?\b/);
+      if (iso) date = new Date(`${iso[1]}T${iso[2] || "23:59"}:00`);
+      else {
+        const parsed = Date.parse(raw);
+        if (Number.isFinite(parsed)) date = new Date(parsed);
+      }
+    }
+    if (!date || !Number.isFinite(date.getTime()) || date.getTime() <= Date.now()) return null;
+    const days = Math.max(1, Math.ceil((date.getTime() - Date.now()) / 86_400_000));
+    if (days > 100 * 365) return null;
+    return {
+      kind: "date",
+      date,
+      days,
+      label: date.toLocaleString(undefined, { year: "numeric", month: "short", day: "numeric" }),
+    };
+  }
+
+  function parseScope(value) {
+    const raw = String(value || "").toLowerCase();
+    if (/\b(mission|ongoing|long[- ]term|larger effort|multiple goals|several goals|many tasks|work toward|continuous)\b/.test(raw)) return "mission";
+    if (/\b(single|one result|one task|one-time|bounded|specific deliverable|finish once)\b/.test(raw)) return "single";
+    return null;
+  }
+
+  function parseTaskWindow(value) {
+    const match = String(value || "").match(/(\d+)\s*(hour|hours|day|days|week|weeks)?/i);
+    if (!match) return null;
+    const count = Number(match[1]);
+    const unit = String(match[2] || "days").toLowerCase();
+    const days = unit.startsWith("hour") ? Math.ceil(count / 24) : unit.startsWith("week") ? count * 7 : count;
+    return Number.isInteger(days) && days >= 1 && days <= MAX_TASK_DAYS ? days : null;
+  }
+
+  function visualInstruction() {
+    return `The evidence_schema must remain a valid JSON Schema object and may include this non-verification annotation: "${VISUAL_EXTENSION}". The annotation must be an object with: version 1; scene chosen from infrastructure, digital, nature, health, research, education, coordination, general; palette containing 2-5 six-digit hex colours; and elements containing 3-10 objects. Each element must have kind chosen from sun, road, lamp, building, tree, water, screen, document, network, tool, person, check, bridge, book, chart; x and y integers from 0 to 100; and size a number from 0.4 to 2.0. Use it to depict the achieved result without words, logos, brands, payment symbols, or claims that the work is already complete. This annotation is only for a bounded pre-publication illustration and will be removed before the evidence schema is published.`;
+  }
+
+  async function requestJson(url, options = {}) {
+    const acceptance = window.AgentBountiesLegal && window.AgentBountiesLegal.latestReceipt();
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        "content-type": "application/json",
+        ...(acceptance ? { "x-agent-bounties-legal-acceptance": acceptance.acceptance_id } : {}),
+        ...(options.headers || {}),
+      },
+    });
+    const text = await response.text();
+    let body = null;
+    if (text) {
+      try { body = JSON.parse(text); } catch (_error) { body = text; }
+    }
+    if (!response.ok) {
+      const message = typeof body === "string"
+        ? body
+        : body && (body.message || body.error)
+          ? body.message || body.error
+          : `Request failed (${response.status}).`;
+      throw new Error(message);
+    }
+    return body;
+  }
+
+  function draftContext(extra = "") {
+    return [
+      "Create one public digital-work bounty draft. Make the result specific, measurable, attainable, and independently inspectable. Ask only questions whose answers materially change the public terms.",
+      visualInstruction(),
+      ...state.context,
+      extra,
+    ].filter(Boolean).join("\n").slice(0, 18_000);
+  }
+
+  async function generateInitialDraft() {
+    ui.submit.disabled = true;
+    ui.input.disabled = true;
+    setStatus("The AI is turning your words into clear, measurable terms…", "pending");
+    try {
+      const readiness = await requestJson(`${API}/v1/cloud-agent/readiness`, { cache: "no-store" });
+      if (!readiness.available || !readiness.public_drafts) throw new Error("The AI composer is temporarily unavailable. Nothing was posted or funded.");
+      const draft = await requestJson(`${API}/v1/cloud-agent/bounty-drafts`, {
+        method: "POST",
+        body: JSON.stringify({
+          objective: state.originalRequest,
+          context: draftContext(),
+          constraints: [],
+          source_url: null,
+          idempotency_key: `web-card:${randomBytes32().slice(2)}`,
+        }),
+      });
+      state.initialDraft = normalizeDraft(draft);
+      state.draft = state.initialDraft;
+      state.aiRounds += 1;
+      queueQuestions(state.draft.questions);
+      advanceConversation();
+    } catch (error) {
+      setStatus(error.message || String(error), "error");
+      ui.input.disabled = false;
+      ui.submit.disabled = false;
+    }
+  }
+
+  function normalizeDraft(draft) {
+    return {
+      ...draft,
+      acceptance_criteria: safeTextList(draft.acceptance_criteria, 20),
+      questions: safeTextList(draft.questions, 10),
+      risk_flags: safeTextList(draft.risk_flags, 10),
+    };
+  }
+
+  function requestUserOwnedAi(intent, context = null) {
+    window.dispatchEvent(new CustomEvent("agent-bounties:request-ai-handoff", {
+      detail: { intent, context },
+    }));
+  }
+
+  async function importPreparedDraft(value) {
+    const prepared = window.AgentBountyAI?.parseDraft
+      ? window.AgentBountyAI.parseDraft(value)
+      : value;
+    if (!prepared || typeof prepared !== "object") throw new Error("The prepared bounty draft is invalid.");
+
+    const days = Number(prepared.task_window_days || MAX_TASK_DAYS);
+    const total = Number(prepared.solver_reward_usdc) + Number(prepared.verifier_reward_usdc);
+    if (!Number.isInteger(days) || days < 1 || days > MAX_TASK_DAYS) throw new Error(`The task window must be from 1 to ${MAX_TASK_DAYS} days.`);
+    if (!Number.isFinite(total) || total < MIN_TOTAL_USDC || total > MAX_TOTAL_USDC) throw new Error("The combined reward is invalid.");
+    const bountyImage = normalizeBountyImage(prepared.image);
+    if (prepared.image_required === true && !bountyImage) {
+      throw new Error("The prepared bounty must include the exact image generated and approved in ChatGPT.");
+    }
+
+    const deadline = new Date(Date.now() + days * 86_400_000);
+    state.phase = "review";
+    state.originalRequest = prepared.goal;
+    state.context = [];
+    state.initialDraft = normalizeDraft({
+      title: prepared.title,
+      goal: prepared.goal,
+      acceptance_criteria: prepared.acceptance_criteria,
+      questions: [],
+      risk_flags: [],
+      benchmark: { type: "creator_review" },
+      evidence_schema: { type: "object", additionalProperties: true },
+    });
+    state.draft = state.initialDraft;
+    state.aiRounds = 0;
+    state.questions = [];
+    state.currentQuestion = null;
+    state.askedQuestions.clear();
+    state.scope = "single";
+    state.horizon = {
+      kind: "date",
+      date: deadline,
+      days,
+      label: `${days} day${days === 1 ? "" : "s"}`,
+    };
+    state.missionPlan = null;
+    state.selectedTaskId = null;
+    state.taskWindowDays = days;
+    state.fundingUsdc = total;
+    state.bountyImage = bountyImage;
+    state.approved = false;
+    ui.input.value = "";
+    ui.prompt.textContent = state.handoffReview
+      ? (state.bountyImage
+          ? "Review the exact image and bounty terms you approved in your AI conversation. Agent Bounties cannot edit or replace them."
+          : "Review the exact bounty terms you approved in your AI conversation. This card uses a deterministic content-derived visual.")
+      : "Review the bounty card your AI prepared. You can approve it or ask your AI for a revision.";
+    await renderPreview();
+  }
+
+  function queueQuestions(questions) {
+    for (const question of questions || []) {
+      const normalized = normalizeQuestion(question);
+      if (normalized && !state.askedQuestions.has(normalized)) state.questions.push(question);
+    }
+  }
+
+  function askNextQuestion() {
+    const question = state.questions.shift();
+    if (!question) return false;
+    state.currentQuestion = question;
+    state.askedQuestions.add(normalizeQuestion(question));
+    setComposer({
+      phase: "ai_question",
+      prompt: question,
+      label: "Your answer",
+      placeholder: "Answer naturally. You can type or dictate.",
+      button: "Continue",
+      hint: "The AI will use this answer to improve the bounty terms.",
+    });
+    setStatus("Nothing is posted until you approve the final card.");
+    return true;
+  }
+
+  async function regenerateAfterAnswers() {
+    if (state.aiRounds >= MAX_AI_ROUNDS) {
+      advanceConversation();
+      return;
+    }
+    await generateInitialDraft();
+  }
+
+  function askScope() {
+    setComposer({
+      phase: "scope",
+      prompt: "Is this one result to finish, or a larger or ongoing mission that should be broken into tasks?",
+      label: "Scope",
+      placeholder: "Example: one result, or an ongoing mission",
+      button: "Continue",
+      hint: "Long-running and open-ended missions are allowed. Their individual tasks still need definite results and completion checks.",
+    });
+  }
+
+  function askHorizon() {
+    setComposer({
+      phase: "horizon",
+      prompt: state.scope === "mission"
+        ? "Does the mission have an overall target date, or is it ongoing?"
+        : "When should this result be completed?",
+      label: state.scope === "mission" ? "Mission horizon" : "Completion deadline",
+      placeholder: state.scope === "mission" ? "Example: ongoing, in 18 months, or 2028-06-30" : "Example: in 14 days or 2026-08-15",
+      button: "Continue",
+      hint: state.scope === "mission"
+        ? "The mission may be long-term or ongoing. The AI will break it into bounded tasks."
+        : "A single on-chain task currently has a maximum 30-day work window. Longer efforts are converted into a mission with staged tasks.",
+    });
+  }
+
+  async function buildMissionPlan() {
+    ui.input.disabled = true;
+    ui.submit.disabled = true;
+    setStatus("The AI is breaking the mission into definite, verifiable tasks…", "pending");
+    try {
+      const plan = await requestJson(`${API}/v1/cloud-agent/objective-plans`, {
+        method: "POST",
+        body: JSON.stringify({
+          objective: state.originalRequest,
+          context: [
+            `Clarified draft: ${state.initialDraft.goal}`,
+            `Mission horizon: ${state.horizon.label}`,
+            ...state.context,
+            "Break this mission into independent public digital tasks. Each task must have a definite inspectable artifact and binary acceptance criteria. No individual task should require more than 30 days once claimed.",
+          ].join("\n").slice(0, 16_000),
+          constraints: ["Each task must be bounded, measurable, and independently fundable."],
+          max_tasks: MAX_PLAN_TASKS,
+          solver_budget_usdc: null,
+          source_url: null,
+          idempotency_key: `web-mission:${randomBytes32().slice(2)}`,
+        }),
+      });
+      state.missionPlan = plan;
+      state.selectedTaskId = plan.tasks[0].task_id;
+      state.draft = draftFromTask(plan.tasks[0]);
+      askTaskWindow();
+    } catch (error) {
+      setStatus(error.message || String(error), "error");
+      ui.input.disabled = false;
+      ui.submit.disabled = false;
+    }
+  }
+
+  function draftFromTask(task) {
+    const properties = {};
+    for (const field of task.evidence_schema?.required || task.evidence_fields || []) {
+      properties[field] = { type: "string", minLength: 1 };
+    }
+    const evidenceSchema = task.evidence_schema || {
+      type: "object",
+      additionalProperties: false,
+      required: Object.keys(properties),
+      properties,
+    };
+    return {
+      title: task.title,
+      goal: task.goal,
+      acceptance_criteria: safeTextList(task.acceptance_criteria, 20),
+      benchmark: {
+        verifier: task.verifier,
+        mission_task_id: task.task_id,
+        depends_on: task.depends_on || [],
+      },
+      evidence_schema: evidenceSchema,
+      questions: [],
+      risk_flags: safeTextList(state.missionPlan?.risk_flags, 10),
+    };
+  }
+
+  function askTaskWindow() {
+    setComposer({
+      phase: "task_window",
+      prompt: "How many days should the first funded task have once someone claims it?",
+      label: "Task work window",
+      placeholder: "Example: 14 days",
+      button: "Continue",
+      hint: `The mission may be much longer, but each current bounty task must be staged into a 1–${MAX_TASK_DAYS} day work window.`,
+    });
+  }
+
+  function askFunding() {
+    setComposer({
+      phase: "funding",
+      prompt: state.scope === "mission"
+        ? "How much Base USDC do you want to fund for the selected task?"
+        : "How much Base USDC do you want to deposit as the total bounty reward?",
+      label: "Total bounty funding",
+      placeholder: "Example: 25 USDC",
+      button: "Create bounty card",
+      hint: "The total includes the solver reward and a small verifier reserve. Minimum: 0.02 USDC.",
+    });
+  }
+
+  function advanceConversation() {
+    ui.input.disabled = false;
+    ui.submit.disabled = false;
+    if (askNextQuestion()) return;
+    if (!state.scope) {
+      askScope();
+      return;
+    }
+    if (!state.horizon) {
+      askHorizon();
+      return;
+    }
+    if (state.scope === "mission" && !state.missionPlan) {
+      buildMissionPlan();
+      return;
+    }
+    if (state.scope === "mission" && !state.taskWindowDays) {
+      askTaskWindow();
+      return;
+    }
+    if (state.scope === "single" && !state.taskWindowDays) {
+      state.taskWindowDays = Math.max(1, Math.min(MAX_TASK_DAYS, state.horizon.days || MAX_TASK_DAYS));
+    }
+    if (state.fundingUsdc == null) {
+      askFunding();
+      return;
+    }
+    renderPreview();
+  }
+
+  async function handleComposerSubmit(event) {
+    event.preventDefault();
+    const value = ui.input.value.trim();
+    if (!value) {
+      setStatus("Please answer before continuing.", "error");
+      return;
+    }
+    if (state.phase === "describe") {
+      state.originalRequest = value;
+      state.context = [];
+      state.aiRounds = 0;
+      state.questions = [];
+      state.askedQuestions.clear();
+      state.scope = null;
+      state.horizon = null;
+      state.missionPlan = null;
+      state.taskWindowDays = null;
+      state.fundingUsdc = parseFunding(value);
+      requestUserOwnedAi(value);
+      ui.input.value = "";
+      return;
+    }
+    if (state.phase === "ai_question") {
+      state.context.push(`Question: ${state.currentQuestion}\nAnswer: ${value}`);
+      state.currentQuestion = null;
+      if (state.questions.length) askNextQuestion();
+      else await regenerateAfterAnswers();
+      return;
+    }
+    if (state.phase === "scope") {
+      const scope = parseScope(value);
+      if (!scope) {
+        setStatus("Please say whether this is one result or a larger or ongoing mission.", "error");
+        return;
+      }
+      state.scope = scope;
+      state.context.push(`Scope chosen by the user: ${scope}.`);
+      setStatus("");
+      advanceConversation();
+      return;
+    }
+    if (state.phase === "horizon") {
+      const horizon = parseHorizon(value);
+      if (!horizon) {
+        setStatus("Enter a future date, a duration, or say that the mission is ongoing.", "error");
+        return;
+      }
+      state.horizon = horizon;
+      if (state.scope === "single" && (horizon.kind === "ongoing" || horizon.days > MAX_TASK_DAYS)) {
+        state.scope = "mission";
+        state.context.push("The requested horizon exceeds one bounty work window, so the effort must be staged as a mission with bounded tasks.");
+        setStatus("This is longer than one current bounty work window, so the AI will split it into staged tasks. The overall mission keeps its full horizon.", "pending");
+      } else setStatus("");
+      advanceConversation();
+      return;
+    }
+    if (state.phase === "task_window") {
+      const days = parseTaskWindow(value);
+      if (!days) {
+        setStatus(`Choose a work window from 1 to ${MAX_TASK_DAYS} days. Longer work should be split into another milestone task.`, "error");
+        return;
+      }
+      state.taskWindowDays = days;
+      setStatus("");
+      advanceConversation();
+      return;
+    }
+    if (state.phase === "funding") {
+      const amount = parseFunding(value);
+      if (amount == null) {
+        setStatus(`Enter an amount from ${MIN_TOTAL_USDC.toFixed(2)} to ${MAX_TOTAL_USDC.toLocaleString()} USDC.`, "error");
+        return;
+      }
+      state.fundingUsdc = amount;
+      setStatus("");
+      renderPreview();
+      return;
+    }
+    if (state.phase === "revise") {
+      const rewards = splitReward(state.fundingUsdc);
+      requestUserOwnedAi(value, {
+        draft: state.draft,
+        solver_reward_usdc: formatUsdc(Number(rewards.solver) / 1_000_000),
+        verifier_reward_usdc: formatUsdc(Number(rewards.verifier) / 1_000_000),
+        task_window_days: state.taskWindowDays,
+      });
+      ui.input.value = "";
+      return;
+    }
+  }
+
+  function selectedTask() {
+    return state.missionPlan?.tasks.find((task) => task.task_id === state.selectedTaskId) || null;
+  }
+
+  function renderMissionPlan() {
+    const isMission = state.scope === "mission" && state.missionPlan;
+    ui.missionContext.hidden = !isMission;
+    if (!isMission) return;
+    ui.missionTitle.textContent = state.missionPlan.title;
+    ui.missionSummary.textContent = state.missionPlan.success_definition;
+    ui.missionHorizon.textContent = `Mission horizon: ${state.horizon.label}`;
+    ui.missionTasks.replaceChildren();
+    for (const task of state.missionPlan.tasks) {
+      const label = document.createElement("label");
+      label.className = "mission-task-option";
+      const input = document.createElement("input");
+      input.type = "radio";
+      input.name = "mission-task";
+      input.value = task.task_id;
+      input.checked = task.task_id === state.selectedTaskId;
+      const copy = document.createElement("span");
+      const title = document.createElement("strong");
+      title.textContent = task.title;
+      const detail = document.createElement("small");
+      detail.textContent = `${task.acceptance_criteria.length} completion checks${task.depends_on?.length ? ` · depends on ${task.depends_on.join(", ")}` : " · can start independently"}`;
+      copy.append(title, detail);
+      label.append(input, copy);
+      input.addEventListener("change", () => selectMissionTask(task.task_id));
+      ui.missionTasks.append(label);
+    }
+  }
+
+  async function selectMissionTask(taskId) {
+    if (taskId === state.selectedTaskId) return;
+    const task = state.missionPlan.tasks.find((candidate) => candidate.task_id === taskId);
+    if (!task) return;
+    state.selectedTaskId = taskId;
+    state.draft = draftFromTask(task);
+    state.approved = false;
+    ui.fund.disabled = true;
+    ui.approve.dataset.approved = "false";
+    ui.approve.textContent = "Approve bounty card";
+    renderCardText();
+    renderMissionPlan();
+    await renderAiVisualForCurrentDraft();
+  }
+
+  function riskSummary() {
+    const risks = state.draft.risk_flags || [];
+    return risks.length ? `${risks.length} item${risks.length === 1 ? "" : "s"} to review` : "No AI blocker flagged";
+  }
+
+  function renderCardText() {
+    ui.title.textContent = state.draft.title;
+    ui.goal.textContent = state.draft.goal;
+    ui.reward.textContent = `${formatUsdc(state.fundingUsdc)} USDC`;
+    ui.deadline.textContent = state.scope === "mission"
+      ? `${state.taskWindowDays} days for this task · ${state.horizon.label} mission`
+      : state.horizon.label;
+    ui.checks.textContent = `${state.draft.acceptance_criteria.length} check${state.draft.acceptance_criteria.length === 1 ? "" : "s"}`;
+    ui.confidence.textContent = riskSummary();
+    ui.criteria.replaceChildren();
+    for (const criterion of state.draft.acceptance_criteria) {
+      const item = document.createElement("li");
+      item.textContent = criterion;
+      ui.criteria.append(item);
+    }
+    ui.risks.replaceChildren();
+    const risks = state.draft.risk_flags || [];
+    if (!risks.length) {
+      const item = document.createElement("li");
+      item.textContent = "No material blocker was identified by the drafting AI. The creator still accepts feasibility and verification risk.";
+      ui.risks.append(item);
+    } else {
+      for (const risk of risks) {
+        const item = document.createElement("li");
+        item.textContent = risk;
+        ui.risks.append(item);
+      }
+    }
+    ui.badge.textContent = state.scope === "mission" ? "Mission task draft · not posted" : "Draft · not posted";
+  }
+
+  async function renderPreview() {
+    if (!state.draft || state.fundingUsdc == null || !state.horizon || !state.taskWindowDays) return;
+    splitReward(state.fundingUsdc);
+    state.phase = "review";
+    state.approved = false;
+    state.imageReady = false;
+    setProgress("review");
+    renderCardText();
+    renderMissionPlan();
+    ui.approve.disabled = true;
+    ui.approve.dataset.approved = "false";
+    ui.approve.textContent = "Preparing image…";
+    ui.fund.disabled = true;
+    ui.preview.hidden = false;
+    if (!state.handoffReview) {
+      ui.preview.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+    setStatus("Rendering a bounded pre-publication illustration from the prepared draft. Nothing has been posted or funded.", "pending");
+    if (state.handoffReview && state.bountyImage) {
+      ui.approve.textContent = "Loading approved image…";
+      setStatus(
+        "Loading the exact image approved in your AI conversation. Agent Bounties will not generate or substitute an image.",
+        "pending",
+      );
+    }
+    await renderAiVisualForCurrentDraft();
+    ui.approve.disabled = false;
+    ui.approve.textContent = "Approve bounty card";
+    setStatus("Review the result, completion checks, time window, reward, and creator-verification disclosure. Nothing has been posted or funded.");
+    if (state.handoffReview) {
+      ui.approve.textContent = "Confirm bounty";
+      setStatus(state.bountyImage
+        ? "Review the exact approved image, terms, reward, and verification disclosure. Nothing has been posted or funded."
+        : "Review the terms, reward, content-derived visual, and verification disclosure. Nothing has been posted or funded.");
+    }
+  }
+
+  function validHex(value) {
+    return /^#[0-9a-fA-F]{6}$/.test(String(value || ""));
+  }
+
+  function validateVisualSpec(value) {
+    if (!value || typeof value !== "object" || value.version !== 1 || !ALLOWED_SCENES.has(value.scene)) return null;
+    const palette = safeTextList(value.palette, 5).filter(validHex);
+    if (palette.length < 2) return null;
+    const elements = (Array.isArray(value.elements) ? value.elements : []).slice(0, 10).map((element) => ({
+      kind: String(element?.kind || ""),
+      x: Number(element?.x),
+      y: Number(element?.y),
+      size: Number(element?.size),
+    })).filter((element) => ALLOWED_ELEMENTS.has(element.kind)
+      && Number.isInteger(element.x) && element.x >= 0 && element.x <= 100
+      && Number.isInteger(element.y) && element.y >= 0 && element.y <= 100
+      && Number.isFinite(element.size) && element.size >= 0.4 && element.size <= 2);
+    if (elements.length < 3) return null;
+    return { version: 1, scene: value.scene, palette, elements };
+  }
+
+  function extractVisualSpec(draft) {
+    return validateVisualSpec(draft?.evidence_schema?.[VISUAL_EXTENSION]);
+  }
+
+  function fallbackVisualSpec(text) {
+    const value = String(text || "").toLowerCase();
+    const scene = /street|light|road|bridge|building|infrastructure/.test(value)
+      ? "infrastructure"
+      : /water|tree|climate|nature|environment/.test(value)
+        ? "nature"
+        : /health|medical|care|blood/.test(value)
+          ? "health"
+          : /school|learn|education|course|book/.test(value)
+            ? "education"
+            : /research|report|study|analysis|data/.test(value)
+              ? "research"
+              : /website|app|software|code|platform/.test(value)
+                ? "digital"
+                : "coordination";
+    const elementsByScene = {
+      infrastructure: ["road", "lamp", "lamp", "building", "check"],
+      nature: ["water", "tree", "tree", "sun", "check"],
+      health: ["person", "health", "chart", "check", "sun"].map((kind) => kind === "health" ? "check" : kind),
+      education: ["book", "person", "screen", "check", "sun"],
+      research: ["document", "chart", "document", "check", "network"],
+      digital: ["screen", "network", "tool", "check", "document"],
+      coordination: ["person", "network", "person", "tool", "check"],
+    };
+    return {
+      version: 1,
+      scene,
+      palette: ["#06140d", "#1b5132", "#c9f548", "#7cefd1"],
+      elements: elementsByScene[scene].map((kind, index) => ({ kind, x: 14 + index * 18, y: 62 - (index % 2) * 22, size: 0.8 + (index % 3) * 0.2 })),
+    };
+  }
+
+  async function requestVisualSpecForTask(task) {
+    const cached = state.visualCache.get(task.task_id);
+    if (cached) return cached;
+    try {
+      const visualDraft = await requestJson(`${API}/v1/cloud-agent/bounty-drafts`, {
+        method: "POST",
+        body: JSON.stringify({
+          objective: task.goal,
+          context: draftContext([
+            `Mission: ${state.missionPlan.title}`,
+            `Selected task: ${task.title}`,
+            `Fixed acceptance criteria: ${task.acceptance_criteria.join(" | ")}`,
+            "Do not ask questions. Preserve the selected task. The only extra work is the bounded visual annotation.",
+          ].join("\n")),
+          constraints: task.acceptance_criteria,
+          source_url: null,
+          idempotency_key: `web-task-visual:${task.task_id}:${randomBytes32().slice(2)}`,
+        }),
+      });
+      const spec = extractVisualSpec(visualDraft);
+      if (spec) state.visualCache.set(task.task_id, spec);
+      return spec;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  async function renderAiVisualForCurrentDraft() {
+    if (state.bountyImage) {
+      ui.imageStatus.textContent = "Loading your approved ChatGPT image…";
+      ui.imageStatus.dataset.tone = "ai";
+      await renderApprovedChatgptImage(ui.art, state.bountyImage);
+      state.visualSpec = null;
+      state.visualSource = "chatgpt_user_generated";
+      state.imageReady = true;
+      ui.imageStatus.textContent = "Approved image from your ChatGPT conversation";
+      return;
+    }
+    ui.imageStatus.textContent = "Preparing visual…";
+    ui.imageStatus.dataset.tone = "";
+    let spec = extractVisualSpec(state.draft);
+    if (!spec && state.scope === "mission") {
+      const task = selectedTask();
+      if (task) spec = await requestVisualSpecForTask(task);
+    }
+    if (spec) {
+      state.visualSpec = spec;
+      state.visualSource = "ai";
+      ui.imageStatus.textContent = "AI-prepared draft visual";
+      ui.imageStatus.dataset.tone = "ai";
+    } else {
+      state.visualSpec = fallbackVisualSpec(`${state.draft.title} ${state.draft.goal}`);
+      state.visualSource = "fallback";
+      ui.imageStatus.textContent = "Bounded fallback visual";
+      ui.imageStatus.dataset.tone = "";
+    }
+    renderVisual(ui.art, state.visualSpec);
+    state.imageReady = true;
+  }
+
+  function normalizeBountyImage(value) {
+    if (!value || typeof value !== "object") return null;
+    const source = String(value.source || "");
+    const prompt = String(value.prompt || "").trim();
+    const altText = String(value.alt_text || "").trim();
+    const assetUrl = String(value.asset_url || "").trim();
+    const sha256 = String(value.sha256 || "");
+    const mimeType = String(value.mime_type || "");
+    let parsed;
+    try {
+      parsed = new URL(assetUrl);
+    } catch (_error) {
+      return null;
+    }
+    if (source !== "chatgpt_user_generated"
+      || !prompt || prompt.length > 4000
+      || !altText || altText.length > 500
+      || parsed.protocol !== "https:"
+      || !/^[0-9a-f]{64}$/.test(sha256)
+      || !["image/png", "image/jpeg", "image/webp"].includes(mimeType)) return null;
+    return {
+      source,
+      prompt,
+      alt_text: altText,
+      asset_url: parsed.toString(),
+      sha256,
+      mime_type: mimeType,
+    };
+  }
+
+  async function renderApprovedChatgptImage(canvas, imageReference) {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    image.decoding = "async";
+    image.alt = imageReference.alt_text;
+    const loaded = new Promise((resolve, reject) => {
+      image.addEventListener("load", resolve, { once: true });
+      image.addEventListener("error", () => reject(new Error(
+        "The approved ChatGPT image could not be loaded. Nothing was replaced or published."
+      )), { once: true });
+    });
+    image.src = imageReference.asset_url;
+    await loaded;
+    canvas.width = 1200;
+    canvas.height = 675;
+    canvas.setAttribute("aria-label", imageReference.alt_text);
+    const context = canvas.getContext("2d");
+    const scale = Math.max(canvas.width / image.naturalWidth, canvas.height / image.naturalHeight);
+    const width = image.naturalWidth * scale;
+    const height = image.naturalHeight * scale;
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(
+      image,
+      (canvas.width - width) / 2,
+      (canvas.height - height) / 2,
+      width,
+      height,
+    );
+  }
+
+  function renderVisual(canvas, spec) {
+    const width = 1200;
+    const height = 675;
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    const palette = spec.palette;
+    const background = context.createLinearGradient(0, 0, width, height);
+    background.addColorStop(0, palette[0]);
+    background.addColorStop(1, palette[1]);
+    context.fillStyle = background;
+    context.fillRect(0, 0, width, height);
+
+    const glow = context.createRadialGradient(width * .72, height * .2, 10, width * .72, height * .2, 420);
+    glow.addColorStop(0, `${palette[2]}66`);
+    glow.addColorStop(1, `${palette[2]}00`);
+    context.fillStyle = glow;
+    context.fillRect(0, 0, width, height);
+
+    context.lineCap = "round";
+    context.lineJoin = "round";
+    for (const element of spec.elements) drawElement(context, element, palette, width, height);
+
+    context.fillStyle = "rgba(2,11,8,.22)";
+    context.fillRect(0, 0, width, height);
+    context.fillStyle = "rgba(255,255,255,.92)";
+    context.font = "750 28px system-ui, sans-serif";
+    context.fillText("AI outcome visual", 52, 610);
+    context.fillStyle = "rgba(255,255,255,.62)";
+    context.font = "500 20px system-ui, sans-serif";
+    context.fillText("Bounded pre-publication draft · not completion evidence", 52, 642);
+  }
+
+  function drawElement(context, element, palette, width, height) {
+    const x = element.x / 100 * width;
+    const y = element.y / 100 * height;
+    const size = 70 * element.size;
+    const accent = palette[2] || "#c9f548";
+    const secondary = palette[3] || "#7cefd1";
+    context.save();
+    context.translate(x, y);
+    context.strokeStyle = accent;
+    context.fillStyle = secondary;
+    context.lineWidth = Math.max(4, size * .09);
+    switch (element.kind) {
+      case "sun":
+        context.fillStyle = accent;
+        context.beginPath(); context.arc(0, 0, size * .45, 0, Math.PI * 2); context.fill();
+        break;
+      case "road":
+        context.fillStyle = "rgba(1,8,5,.72)";
+        context.beginPath(); context.moveTo(-size, size); context.lineTo(-size * .28, -size); context.lineTo(size * .28, -size); context.lineTo(size, size); context.closePath(); context.fill();
+        context.strokeStyle = accent; context.setLineDash([size * .18, size * .18]); context.beginPath(); context.moveTo(0, size); context.lineTo(0, -size); context.stroke(); context.setLineDash([]);
+        break;
+      case "lamp":
+        context.strokeStyle = secondary; context.beginPath(); context.moveTo(0, size); context.lineTo(0, -size * .55); context.quadraticCurveTo(0, -size, size * .45, -size); context.stroke();
+        context.fillStyle = accent; context.beginPath(); context.arc(size * .45, -size, size * .16, 0, Math.PI * 2); context.fill();
+        break;
+      case "building":
+        context.fillStyle = "rgba(255,255,255,.14)"; context.fillRect(-size * .65, -size, size * 1.3, size * 2);
+        context.fillStyle = accent; for (let row = -1; row <= 1; row += 1) for (let column = -1; column <= 1; column += 1) context.fillRect(column * size * .32 - size * .1, row * size * .45 - size * .1, size * .18, size * .18);
+        break;
+      case "tree":
+        context.strokeStyle = secondary; context.beginPath(); context.moveTo(0, size); context.lineTo(0, -size * .15); context.stroke();
+        context.fillStyle = accent; context.beginPath(); context.arc(0, -size * .45, size * .55, 0, Math.PI * 2); context.fill();
+        break;
+      case "water":
+        context.strokeStyle = secondary; for (let row = -1; row <= 1; row += 1) { context.beginPath(); context.moveTo(-size, row * size * .35); context.bezierCurveTo(-size * .5, row * size * .35 - size * .25, 0, row * size * .35 + size * .25, size, row * size * .35); context.stroke(); }
+        break;
+      case "screen":
+        context.fillStyle = "rgba(1,8,5,.66)"; context.strokeStyle = secondary; context.roundRect(-size, -size * .65, size * 2, size * 1.3, size * .15); context.fill(); context.stroke();
+        context.fillStyle = accent; context.fillRect(-size * .7, -size * .3, size * 1.1, size * .13); context.fillRect(-size * .7, 0, size * 1.4, size * .13);
+        break;
+      case "document":
+        context.fillStyle = "rgba(246,248,232,.86)"; context.roundRect(-size * .65, -size, size * 1.3, size * 2, size * .12); context.fill();
+        context.fillStyle = palette[1]; for (let row = 0; row < 4; row += 1) context.fillRect(-size * .42, -size * .55 + row * size * .38, size * (.8 - row * .08), size * .1);
+        break;
+      case "network":
+        context.strokeStyle = secondary; for (let index = 0; index < 5; index += 1) { const angle = index / 5 * Math.PI * 2; const px = Math.cos(angle) * size * .75; const py = Math.sin(angle) * size * .75; context.beginPath(); context.moveTo(0,0); context.lineTo(px,py); context.stroke(); context.fillStyle = accent; context.beginPath(); context.arc(px,py,size*.12,0,Math.PI*2); context.fill(); } context.beginPath(); context.arc(0,0,size*.18,0,Math.PI*2); context.fill();
+        break;
+      case "tool":
+        context.strokeStyle = accent; context.lineWidth = size * .18; context.beginPath(); context.moveTo(-size * .65, size * .65); context.lineTo(size * .45, -size * .45); context.stroke(); context.beginPath(); context.arc(size * .55, -size * .55, size * .35, Math.PI * .2, Math.PI * 1.3); context.stroke();
+        break;
+      case "person":
+        context.fillStyle = accent; context.beginPath(); context.arc(0, -size * .55, size * .24, 0, Math.PI * 2); context.fill(); context.strokeStyle = secondary; context.beginPath(); context.moveTo(0,-size*.25); context.lineTo(0,size*.5); context.moveTo(0,0); context.lineTo(-size*.5,size*.2); context.moveTo(0,0); context.lineTo(size*.5,size*.2); context.moveTo(0,size*.5); context.lineTo(-size*.4,size); context.moveTo(0,size*.5); context.lineTo(size*.4,size); context.stroke();
+        break;
+      case "check":
+        context.fillStyle = accent; context.beginPath(); context.arc(0,0,size*.8,0,Math.PI*2); context.fill(); context.strokeStyle = palette[0]; context.lineWidth = size*.18; context.beginPath(); context.moveTo(-size*.35,0); context.lineTo(-size*.05,size*.3); context.lineTo(size*.45,-size*.35); context.stroke();
+        break;
+      case "bridge":
+        context.strokeStyle = secondary; context.beginPath(); context.moveTo(-size, size * .45); context.lineTo(size, size * .45); context.moveTo(-size*.75,size*.45); context.quadraticCurveTo(0,-size*.8,size*.75,size*.45); context.stroke();
+        break;
+      case "book":
+        context.fillStyle = "rgba(246,248,232,.84)"; context.beginPath(); context.moveTo(0,size*.7); context.quadraticCurveTo(-size*.45,size*.25,-size,-size*.6); context.lineTo(-size,-size*.9); context.quadraticCurveTo(-size*.35,-size*.5,0,0); context.quadraticCurveTo(size*.35,-size*.5,size,-size*.9); context.lineTo(size,-size*.6); context.quadraticCurveTo(size*.45,size*.25,0,size*.7); context.fill(); context.strokeStyle = accent; context.beginPath(); context.moveTo(0,0); context.lineTo(0,size*.7); context.stroke();
+        break;
+      case "chart":
+        context.strokeStyle = secondary; context.beginPath(); context.moveTo(-size,-size); context.lineTo(-size,size); context.lineTo(size,size); context.stroke(); context.fillStyle = accent; for (let index=0; index<4; index+=1) context.fillRect(-size*.7+index*size*.45,size*.65-(index+1)*size*.32,size*.25,(index+1)*size*.32);
+        break;
+      default:
+        break;
+    }
+    context.restore();
+  }
+
+  function stripVisualExtension(schema) {
+    const clone = JSON.parse(JSON.stringify(schema || { type: "object", additionalProperties: true }));
+    if (clone && typeof clone === "object") delete clone[VISUAL_EXTENSION];
+    return clone;
+  }
+
+  function canonicalJsonValue(value) {
+    if (Array.isArray(value)) return value.map(canonicalJsonValue);
+    if (value && typeof value === "object") {
+      return Object.keys(value).sort().reduce((result, key) => {
+        result[key] = canonicalJsonValue(value[key]);
+        return result;
+      }, {});
+    }
+    return value;
+  }
+
+  function missionBenchmark(base) {
+    const benchmark = JSON.parse(JSON.stringify(base || {}));
+    if (state.scope === "mission" && state.missionPlan) {
+      benchmark.x_agent_bounties_mission = {
+        title: state.missionPlan.title,
+        success_definition: state.missionPlan.success_definition,
+        horizon: state.horizon.label,
+        selected_task_id: state.selectedTaskId,
+        task_window_days: state.taskWindowDays,
+        planned_task_ids: state.missionPlan.tasks.map((task) => task.task_id),
+      };
+    }
+    return benchmark;
+  }
+
+  function supportedVerificationPolicy() {
+    const benchmark = missionBenchmark(state.draft?.benchmark || {});
+    const source = benchmark.source;
+    const runner = benchmark.runner_manifest;
+    const sourceReady = source?.kind === "github_commit"
+      && /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(source.repository || "")
+      && /^[0-9a-f]{40}$/.test(source.commit || "")
+      && typeof source.subdirectory === "string"
+      && source.subdirectory.length > 0
+      && source.subdirectory !== "."
+      && !source.subdirectory.startsWith("/")
+      && !source.subdirectory.includes("\\");
+    const runnerReady = runner?.schema_version === "agent-bounties/regression-sandbox-v1"
+      && typeof runner.image === "string"
+      && /@sha256:[0-9a-f]{64}$/.test(runner.image)
+      && Array.isArray(runner.command)
+      && runner.command.length > 0
+      && runner.workdir === "/workspace"
+      && /^sha256:[0-9a-f]{64}$/.test(runner.benchmark_digest || "");
+    if (benchmark.engine !== REGRESSION_ENGINE || !sourceReady || !runnerReady) {
+      throw new Error(
+        "This draft has no executable verifier, so it cannot be funded. Add the exact public benchmark source and complete sandbox runner manifest, then retry.",
+      );
+    }
+    return {
+      mechanism: "signed_quorum",
+      engine: REGRESSION_ENGINE,
+      verifier_module: null,
+      verifier_reward_recipient: null,
+      verifiers: REGRESSION_VERIFIERS,
+      threshold: REGRESSION_VERIFIERS.length,
+      ai_provider: null,
+      ai_model: null,
+      ai_model_version: null,
+      system_prompt: null,
+      rubric: "The pinned verifier agent runs the precommitted sandboxed regression and requires every acceptance criterion to pass.",
+      decoding_parameters: {},
+      public_disclosure: "One precommitted verifier runs the exact coding benchmark. Multi-verifier review is optional for higher-risk work.",
+    };
+  }
+
+  function wrapCanvasText(context, text, maxWidth, maxLines) {
+    const words = String(text || "").split(/\s+/).filter(Boolean);
+    const lines = [];
+    let line = "";
+    for (const word of words) {
+      const next = line ? `${line} ${word}` : word;
+      if (context.measureText(next).width > maxWidth && line) {
+        lines.push(line);
+        line = word;
+        if (lines.length >= maxLines) break;
+      } else line = next;
+    }
+    if (line && lines.length < maxLines) lines.push(line);
+    if (lines.length === maxLines && lines.join(" ").split(/\s+/).length < words.length) lines[lines.length - 1] = `${lines[lines.length - 1].replace(/[. ]+$/, "")}…`;
+    return lines;
+  }
+
+  async function shareBountyCard() {
+    if (!state.draft || !state.imageReady) return;
+    ui.share.disabled = true;
+    try {
+      const canvas = document.createElement("canvas");
+      canvas.width = 1200;
+      canvas.height = 1500;
+      const context = canvas.getContext("2d");
+      context.fillStyle = "#03110b"; context.fillRect(0,0,1200,1500);
+      context.drawImage(ui.art, 0, 0, 1200, 675);
+      const gradient = context.createLinearGradient(0,620,0,1500); gradient.addColorStop(0,"rgba(6,31,18,.95)"); gradient.addColorStop(1,"#020b08"); context.fillStyle = gradient; context.fillRect(0,610,1200,890);
+      context.fillStyle = "#c9f548"; context.font = "800 29px system-ui"; context.fillText(state.scope === "mission" ? "AGENT BOUNTIES · MISSION TASK" : "AGENT BOUNTIES · BOUNTY CARD", 68, 710);
+      context.fillStyle = "#f4f6ef"; context.font = "850 68px system-ui";
+      let y = 806; for (const line of wrapCanvasText(context,state.draft.title,1060,3)) { context.fillText(line,68,y); y += 76; }
+      context.fillStyle = "#bdc8c0"; context.font = "440 31px system-ui"; y += 10; for (const line of wrapCanvasText(context,state.draft.goal,1060,5)) { context.fillText(line,68,y); y += 43; }
+      const statsY = Math.max(y + 32, 1180);
+      const stats = [["TOTAL REWARD",`${formatUsdc(state.fundingUsdc)} USDC`],["TASK WINDOW",`${state.taskWindowDays} days`],["MISSION HORIZON",state.scope === "mission" ? state.horizon.label : "Single result"]];
+      stats.forEach(([label,value],index) => { const x=68+index*355; context.fillStyle="rgba(201,245,72,.12)"; context.fillRect(x,statsY,325,126); context.fillStyle="#8d9a91"; context.font="800 19px system-ui"; context.fillText(label,x+20,statsY+36); context.fillStyle="#f4f6ef"; context.font="750 27px system-ui"; let lineY=statsY+76; for(const line of wrapCanvasText(context,value,285,2)){context.fillText(line,x+20,lineY);lineY+=31;} });
+      context.fillStyle="#e8c15a"; context.font="650 23px system-ui"; context.fillText("DRAFT · NOT POSTED OR FUNDED · CREATOR VERIFIES COMPLETION",68,1435);
+      const blob = await new Promise((resolve) => canvas.toBlob(resolve,"image/png"));
+      if (!blob) throw new Error("The share image could not be created.");
+      const file = new File([blob],"agent-bounties-card.png",{type:"image/png"});
+      const data = { title: state.draft.title, text: `${state.draft.title} — ${formatUsdc(state.fundingUsdc)} USDC bounty draft on Agent Bounties.`, ...(state.bountyContract ? {url:`https://agentbounties.app/earn.html?bountyContract=${encodeURIComponent(state.bountyContract)}`} : {}) };
+      if (navigator.canShare && navigator.canShare({files:[file]})) await navigator.share({...data,files:[file]});
+      else { const url=URL.createObjectURL(file); const link=document.createElement("a"); link.href=url; link.download=file.name; link.click(); setTimeout(()=>URL.revokeObjectURL(url),1500); if(state.bountyContract&&navigator.clipboard) await navigator.clipboard.writeText(data.url); setStatus(state.bountyContract?"Card downloaded and the funded bounty link was copied.":"Draft card downloaded. It makes no funding claim.","success"); }
+    } catch (error) { if (error?.name !== "AbortError") setStatus(error.message || String(error),"error"); }
+    finally { ui.share.disabled=false; }
+  }
+
+  function approveCard() {
+    if (!state.imageReady) return;
+    state.approved = true;
+    ui.approve.dataset.approved = "true";
+    ui.approve.textContent = state.handoffReview ? "Confirmed ✓" : "Approved ✓";
+    ui.fund.disabled = false;
+    setProgress("fund");
+    setStatus(state.bountyImage
+      ? "Card approved with the exact supplied image. Funding still requires a separate wallet review and signature."
+      : "Card approved with a deterministic content-derived visual. Funding still requires a separate wallet review and signature.", "success");
+  }
+
+  function reviseCard() {
+    state.approved = false;
+    ui.approve.dataset.approved = "false";
+    ui.approve.textContent = "Approve bounty card";
+    ui.fund.disabled = true;
+    setComposer({ phase:"revise", prompt:"What should the AI change about this bounty or mission plan?", label:"Revision request", placeholder:"Example: Split the research into its own task and extend the mission horizon to one year.", button:"Update card", hint:"Changing the card removes approval until you review it again." });
+    document.querySelector(".composer-shell")?.scrollIntoView({behavior:"smooth",block:"center"});
+  }
+
+  function openFunding() {
+    if (!state.approved) return;
+    const onrampUrl = new URL("onramp.html", window.location.href);
+    onrampUrl.searchParams.set("purpose", "post");
+    onrampUrl.searchParams.set("amount", formatUsdc(state.fundingUsdc));
+    onrampUrl.searchParams.set("return", window.location.href);
+    ui.onramp.href = onrampUrl.href;
+    ui.dialog.showModal();
+    setPaymentStatus("Choose a detected wallet or open the Base USDC handoff in a separate tab.");
+    ui.walletPanel.hidden = false;
+    ui.readiness.hidden = true;
+    ui.fundNow.disabled = true;
+    chooseCryptoWallet().catch((error) => setPaymentStatus(error.message || String(error), "error"));
+  }
+
+  function providerName(item) {
+    if (item.info?.name) return item.info.name;
+    if (item.provider.isMetaMask) return "MetaMask";
+    if (item.provider.isCoinbaseWallet) return "Coinbase Wallet";
+    if (item.provider.isBraveWallet) return "Brave Wallet";
+    return "Browser wallet";
+  }
+
+  async function discoverWallets() {
+    window.dispatchEvent(new Event("eip6963:requestProvider"));
+    await new Promise((resolve) => setTimeout(resolve,350));
+    const candidates=[...announcedProviders];
+    const injected=window.ethereum&&Array.isArray(window.ethereum.providers)?window.ethereum.providers:(window.ethereum?[window.ethereum]:[]);
+    for(const provider of injected) if(provider&&typeof provider.request==="function"&&!candidates.some((item)=>item.provider===provider)) candidates.push({provider,info:{}});
+    state.providers=candidates;
+    return candidates;
+  }
+
+  async function chooseCryptoWallet() {
+    ui.cryptoMethod.dataset.active="true";
+    ui.walletPanel.hidden=false;
+    ui.walletOptions.textContent="";
+    ui.walletMessage.textContent="Looking for wallets on this device…";
+    const providers=await discoverWallets();
+    if(!providers.length){ui.walletMessage.textContent="No compatible browser wallet was detected. Create or fund a wallet with the Base USDC handoff, then reopen this review in a browser where that wallet can sign. Never enter a recovery phrase on this website.";track("wallet_missing_detected");return;}
+    ui.walletMessage.textContent=providers.length===1?"One wallet is available.":`${providers.length} wallets are available. Choose which one to use.`;
+    for(const item of providers){const button=document.createElement("button");button.type="button";button.className="wallet-option";const name=document.createElement("strong");name.textContent=providerName(item);const note=document.createElement("small");note.textContent="Connect and check Base USDC";button.append(name,note);button.addEventListener("click",()=>connectWallet(item));ui.walletOptions.append(button);}
+  }
+
+  async function loadProtocol() {
+    if(state.protocol)return state.protocol;
+    const response=await fetch("protocol.json",{cache:"no-store"});
+    if(!response.ok)throw new Error("Protocol configuration is unavailable.");
+    const protocol=await response.json();
+    if(protocol.status!=="active"||!/^0x[0-9a-fA-F]{40}$/.test(protocol.factory||""))throw new Error("The Base protocol is not active. No transaction was requested.");
+    state.protocol=protocol;return protocol;
+  }
+
+  async function switchToBase(provider,protocol){const current=await provider.request({method:"eth_chainId"});if(String(current).toLowerCase()===String(protocol.chain_id_hex).toLowerCase())return;try{await provider.request({method:"wallet_switchEthereumChain",params:[{chainId:protocol.chain_id_hex}]});}catch(error){if(error&&error.code===4902){await provider.request({method:"wallet_addEthereumChain",params:[{chainId:protocol.chain_id_hex,chainName:"Base",nativeCurrency:{name:"Ether",symbol:"ETH",decimals:18},rpcUrls:["https://mainnet.base.org"],blockExplorerUrls:[protocol.explorer_url]}]});}else throw error;}}
+
+  async function connectWallet(item){state.provider=item.provider;setPaymentStatus(`Connecting ${providerName(item)}…`,"pending");try{const protocol=await loadProtocol();const accounts=await state.provider.request({method:"eth_requestAccounts"});if(!accounts||!accounts[0])throw new Error("The wallet did not return an account.");state.account=accounts[0];track("wallet_connected");await switchToBase(state.provider,protocol);await refreshWalletReadiness();}catch(error){setPaymentStatus(error.message||String(error),"error");}}
+
+  function addressWord(address){return String(address).toLowerCase().replace(/^0x/,"").padStart(64,"0");}
+
+  async function refreshWalletReadiness(){if(!state.provider||!state.account)return;const protocol=await loadProtocol();const required=usdcBaseUnits(state.fundingUsdc);setPaymentStatus("Checking Base USDC and gas readiness…","pending");const[usdcRaw,ethRaw]=await Promise.all([state.provider.request({method:"eth_call",params:[{to:protocol.native_usdc,data:`0x70a08231${addressWord(state.account)}`},"latest"]}),state.provider.request({method:"eth_getBalance",params:[state.account,"latest"]})]);const usdc=BigInt(usdcRaw||"0x0");const eth=BigInt(ethRaw||"0x0");state.balances={usdc,eth,required};const usdcReady=usdc>=required;const ethReady=eth>0n;const observed=usdcReady?"funded":"unfunded";if(state.observedWalletState!==observed){state.observedWalletState=observed;track(usdcReady?"wallet_funded_observed":"wallet_unfunded_detected");}ui.account.textContent=`${state.account.slice(0,8)}…${state.account.slice(-6)}`;ui.usdcBalance.textContent=`${formatUsdc(Number(usdc)/1_000_000)} USDC`;ui.ethBalance.textContent=`${(Number(eth)/1e18).toFixed(6)} ETH`;ui.requiredUsdc.textContent=`${formatUsdc(state.fundingUsdc)} USDC`;ui.readiness.hidden=false;ui.fundingHelp.hidden=usdcReady&&ethReady;const missing=required>usdc?required-usdc:0n;ui.missingUsdc.textContent=`${formatUsdc(Number(missing)/1_000_000)} USDC`;ui.fundNow.disabled=!(usdcReady&&ethReady);if(usdcReady&&ethReady)setPaymentStatus("Wallet ready. Review the exact amount, legal terms, and wallet request before signing.","success");else if(!usdcReady&&!ethReady)setPaymentStatus("This wallet needs more Base USDC and a small amount of Base ETH for gas.","error");else if(!usdcReady)setPaymentStatus("This wallet does not yet hold enough USDC on Base.","error");else setPaymentStatus("The USDC is available, but the wallet needs a small amount of Base ETH for gas.","error");}
+
+  async function watchUsdcAsset(){try{const protocol=await loadProtocol();await state.provider.request({method:"wallet_watchAsset",params:{type:"ERC20",options:{address:protocol.native_usdc,symbol:"USDC",decimals:6}}});setPaymentStatus("Base USDC was offered to the wallet. This does not buy or transfer tokens.","success");}catch(error){setPaymentStatus(error.message||String(error),"error");}}
+  async function copyUsdcAddress(){const protocol=await loadProtocol();await navigator.clipboard.writeText(protocol.native_usdc);setPaymentStatus("Base USDC contract address copied. Verify the network and address inside your wallet before acquiring tokens.","success");}
+
+  function signatureParts(signature){const value=String(signature).replace(/^0x/,"");if(value.length!==130)throw new Error("The wallet returned an invalid signature.");return{r:`0x${value.slice(0,64)}`,s:`0x${value.slice(64,128)}`,v:Number.parseInt(value.slice(128,130),16)};}
+  async function sendTransaction(transaction){if(!transaction||!transaction.to||!transaction.data||Number(transaction.value_wei||0)!==0)throw new Error("The planned transaction is invalid.");return state.provider.request({method:"eth_sendTransaction",params:[{from:state.account,to:transaction.to,data:transaction.data,value:"0x0"}]});}
+  async function waitReceipt(hash,timeoutMs=150000){const started=Date.now();while(Date.now()-started<timeoutMs){const receipt=await state.provider.request({method:"eth_getTransactionReceipt",params:[hash]});if(receipt){if(receipt.status!=="0x1")throw new Error(`The Base transaction reverted: ${hash}`);return receipt;}await new Promise((resolve)=>setTimeout(resolve,1600));}throw new Error("The transaction is still pending. Check the wallet or Base explorer before trying again.");}
+  async function isContractAccount(){const code=await state.provider.request({method:"eth_getCode",params:[state.account,"latest"]});return code&&code!=="0x"&&code!=="0x0";}
+  async function sendWalletCalls(calls,protocol){try{return await state.provider.request({method:"wallet_sendCalls",params:[{version:"2.0.0",chainId:protocol.chain_id_hex,from:state.account,calls:calls.map((call)=>({to:call.to,data:call.data,value:"0x0"}))}]});}catch(_error){let last=null;for(const call of calls){last=await sendTransaction(call);await waitReceipt(last);}return last;}}
+
+  function contractTerms(protocol,rewards){const now=Math.floor(Date.now()/1000);return{protocol_version:protocol.protocol_version,creator_wallet:state.account,network:protocol.network,settlement_token:protocol.native_usdc,solver_reward:{amount:Number(rewards.solver),currency:"usdc"},verifier_reward:{amount:Number(rewards.verifier),currency:"usdc"},claim_bond:{amount:Number(rewards.verifier),currency:"usdc"},initial_funding:{amount:Number(rewards.total),currency:"usdc"},funding_deadline:now+30*86400,claim_window_seconds:state.taskWindowDays*86400,verification_window_seconds:48*3600,creation_nonce:randomBytes32()};}
+
+  function termsDocument(committed){const document={schema_version:"agent-bounties/terms-v1",contract_terms:committed,title:state.draft.title,goal:state.draft.goal,acceptance_criteria:state.draft.acceptance_criteria,benchmark:canonicalJsonValue(missionBenchmark(state.draft.benchmark||{})),evidence_schema:canonicalJsonValue(stripVisualExtension(state.draft.evidence_schema)),verification_policy:supportedVerificationPolicy(),source_url:null,discovery_source:state.bountyImage?"ai_assistant_approved_image_handoff":"ai_assistant_terms_handoff"};if(state.bountyImage)document.image=canonicalJsonValue(state.bountyImage);return document;}
+
+  function createPayload(terms,committed){return{creator:state.account,solver_reward:committed.solver_reward,verifier_reward:committed.verifier_reward,terms_hash:terms.terms_hash,policy_hash:terms.policy_hash,acceptance_criteria_hash:terms.acceptance_criteria_hash,benchmark_hash:terms.benchmark_hash,evidence_schema_hash:terms.evidence_schema_hash,funding_deadline:committed.funding_deadline,claim_window_seconds:committed.claim_window_seconds,verification_window_seconds:committed.verification_window_seconds,verification_mode:"signed_quorum",verifier_module:null,verifier_reward_recipient:null,verifiers:REGRESSION_VERIFIERS,threshold:REGRESSION_VERIFIERS.length,initial_funding:committed.initial_funding,creation_nonce:committed.creation_nonce};}
+
+  function validateCreationPlan(plan,protocol,create){if(!plan||!/^0x[0-9a-fA-F]{40}$/.test(plan.predicted_bounty_contract||""))throw new Error("The creation plan did not return a valid bounty address.");if(Number(plan.network&&plan.network.chain_id)!==Number(protocol.chain_id))throw new Error("The creation plan targets the wrong network.");if(String(plan.factory_contract||"").toLowerCase()!==String(protocol.factory).toLowerCase())throw new Error("The creation plan does not use the canonical factory.");const target=Number(create.solver_reward.amount)+Number(create.verifier_reward.amount);if(Number(create.initial_funding.amount)!==target)throw new Error("The creation plan is not fully funded.");}
+
+  async function pollCreation(api,bountyId,timeoutMs=100000){const started=Date.now();while(Date.now()-started<timeoutMs){const events=await requestJson(`${api}/v1/base/autonomous-bounties/events?network=base-mainnet&bounty_id=${encodeURIComponent(bountyId)}`,{cache:"no-store"});const created=events.some((event)=>event.kind==="canonical_bounty_created");const funded=events.some((event)=>event.kind==="funding_added");const claimable=events.some((event)=>event.kind==="bounty_became_claimable");if(created&&funded&&claimable)return events;await new Promise((resolve)=>setTimeout(resolve,2500));}return null;}
+
+  async function fetchFeedItem(api,contract){try{const items=await requestJson(`${api}/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false`,{cache:"no-store"});return items.find((item)=>String(item.bounty_contract).toLowerCase()===String(contract).toLowerCase())||null;}catch(_error){return null;}}
+
+  async function fundApprovedBounty(){if(!state.approved||!state.provider||!state.account||!state.balances)return;track("canonical_post_started");ui.fundNow.disabled=true;setPaymentStatus("Preparing the exact canonical Base USDC funding request…","pending");try{await refreshWalletReadiness();if(state.balances.usdc<state.balances.required||state.balances.eth===0n)throw new Error("The wallet is not ready to fund this bounty.");if(!window.AgentBountiesLegal)throw new Error("The legal agreement could not be loaded. Reload before using the wallet.");await window.AgentBountiesLegal.requireAcceptance({action:"post_bounty",walletAddress:state.account,scope:ui.dialog});const protocol=await loadProtocol();const api=String(protocol.api_base_url).replace(/\/$/,"");const rewards=splitReward(state.fundingUsdc);const committed=contractTerms(protocol,rewards);const document=termsDocument(committed);const terms=await requestJson(`${api}/v1/base/autonomous-bounties/terms`,{method:"POST",body:JSON.stringify({creator_wallet:state.account,document})});const create=createPayload(terms,committed);const plan=await requestJson(`${api}/v1/base/autonomous-bounties/creation-plan`,{method:"POST",body:JSON.stringify({network:"base-mainnet",create})});validateCreationPlan(plan,protocol,create);setPaymentStatus(["Review the wallet request carefully.",`Exact total funding: ${formatUsdc(state.fundingUsdc)} Base USDC.`,`Predicted bounty: ${plan.predicted_bounty_contract}`,"A signature or transaction hash is not funding evidence."].join("\n"),"pending");let transactionHash=null;if(!(await isContractAccount())&&plan.eip3009_authorization){const signature=await state.provider.request({method:"eth_signTypedData_v4",params:[state.account,JSON.stringify(plan.eip3009_authorization)]});const authorized=await requestJson(`${api}/v1/base/autonomous-bounties/authorized-creation-plan`,{method:"POST",body:JSON.stringify({network:"base-mainnet",create,signature:signatureParts(signature),relayer:state.account})});if(!authorized.relay_transaction||String(authorized.relay_transaction.to).toLowerCase()!==String(protocol.factory).toLowerCase())throw new Error("The authorized transaction does not target the canonical factory.");transactionHash=await sendTransaction(authorized.relay_transaction);await waitReceipt(transactionHash);}else{const result=await sendWalletCalls(plan.wallet_calls,protocol);if(typeof result==="string"&&result.startsWith("0x"))transactionHash=result;}state.bountyContract=plan.predicted_bounty_contract;state.bountyId=plan.bounty_id;setPaymentStatus("Transaction confirmed. Waiting for canonical FundingAdded and BountyBecameClaimable evidence…","pending");const events=await pollCreation(api,plan.bounty_id);if(!events){setPaymentStatus(["The transaction was confirmed, but canonical funding evidence is still pending.",transactionHash?`Transaction: ${protocol.explorer_url}/tx/${transactionHash}`:"Wallet batch submitted.","Do not describe the bounty as funded until FundingAdded and BountyBecameClaimable are confirmed."].join("\n"),"pending");return;}const item=await fetchFeedItem(api,state.bountyContract);if(item?.verification_ready){ui.badge.textContent="Funded · ready to earn";setPaymentStatus(["Bounty funded and ready for public earning.",`Contract: ${state.bountyContract}`,"Solver payment will be proven only by BountySettled."].join("\n"),"success");}else{ui.badge.textContent="Funded · verifier setup required";setPaymentStatus(["Canonical funding is confirmed.",`Contract: ${state.bountyContract}`,"The creator is the committed verifier. The bounty will not appear in the default ready-to-earn inventory until verifier availability is represented by the protocol.","Solver payment will be proven only by BountySettled."].join("\n"),"success");}ui.fundNow.textContent="Funded ✓";ui.fundNow.disabled=true;track("canonical_post_confirmed",{bounty_contract:state.bountyContract});}catch(error){setPaymentStatus(error.message||String(error),"error");ui.fundNow.disabled=false;}}
+
+  function configureSpeech(){const Recognition=window.SpeechRecognition||window.webkitSpeechRecognition;if(!Recognition){ui.mic.hidden=true;ui.hint.textContent="Type naturally. Your words are not posted until you approve the final card.";return;}const recognition=new Recognition();recognition.continuous=false;recognition.interimResults=true;recognition.lang=document.documentElement.lang||navigator.language||"en-US";let original="";recognition.addEventListener("start",()=>{original=ui.input.value.trim();ui.mic.dataset.listening="true";setStatus("Listening…","pending");});recognition.addEventListener("result",(event)=>{let transcript="";for(let index=event.resultIndex;index<event.results.length;index+=1)transcript+=event.results[index][0].transcript;ui.input.value=[original,transcript.trim()].filter(Boolean).join(original?" ":"");});recognition.addEventListener("end",()=>{ui.mic.dataset.listening="false";setStatus("Review the dictated text, then continue.");});recognition.addEventListener("error",(event)=>{ui.mic.dataset.listening="false";setStatus(event.error==="not-allowed"?"Microphone permission was not granted. You can still type.":"Dictation stopped. You can continue typing.","error");});ui.mic.addEventListener("click",()=>{if(ui.mic.dataset.listening==="true")recognition.stop();else recognition.start();});state.speech=recognition;}
+
+  async function prefillFromQuery() {
+    const params = new URLSearchParams(window.location.search);
+    const fromAiApp = ["ai-app", "chatgpt-app"].includes(params.get("from"));
+    if (fromAiApp) { enableAiHandoffReview(); track("canonical_post_handoff_viewed"); }
+    const title = params.get("title");
+    const goal = params.get("goal");
+    const criteria = params.getAll("criterion");
+    const solver = params.get("solverReward");
+    const verifier = params.get("verifierReward");
+
+    if (title && goal && criteria.length && solver && verifier) {
+      try {
+        await importPreparedDraft({
+          title,
+          goal,
+          acceptance_criteria: criteria,
+          solver_reward_usdc: solver,
+          verifier_reward_usdc: verifier,
+          task_window_days: Number(params.get("taskWindowDays") || MAX_TASK_DAYS),
+          source_url: params.get("sourceUrl"),
+          crowdfund: params.get("crowdfund") === "true",
+          discovery_source: params.get("discoverySource") || "AI assistant via MCP",
+          image_required: Boolean(params.get("imageUrl")),
+          image: params.get("imageUrl") ? {
+              source: "chatgpt_user_generated",
+              asset_url: params.get("imageUrl"),
+              sha256: params.get("imageSha256"),
+              mime_type: params.get("imageMimeType"),
+              prompt: params.get("imagePrompt"),
+              alt_text: params.get("imageAlt"),
+            } : null,
+        });
+      } catch (error) {
+        setStatus(error.message || String(error), "error");
+      }
+    } else {
+      const supplied = goal || params.get("draftObjective") || params.get("objective");
+      if (supplied) ui.input.value = supplied;
+    }
+
+    const draftId = params.get("socialDraft");
+    if (draftId && /^[0-9a-f-]{36}$/i.test(draftId)) {
+      try {
+        const response = await requestJson(`${API}/v1/social/mention-drafts/${draftId}`);
+        const draft = response && response.draft;
+        if (draft && draft.state === "review_required_not_published") {
+          ui.input.value = [draft.draft_objective, draft.goal, ...(draft.acceptance_criteria || [])].filter(Boolean).join("\n");
+          const importedSolver = Number(draft.solver_reward && draft.solver_reward.amount || 0);
+          const importedVerifier = Number(draft.verifier_reward && draft.verifier_reward.amount || 0);
+          if (Number.isSafeInteger(importedSolver) && Number.isSafeInteger(importedVerifier)) state.fundingUsdc = (importedSolver + importedVerifier) / 1_000_000;
+          setStatus("Draft imported. It has not been posted or funded. Describe any changes, then continue.", "pending");
+        }
+      } catch (error) {
+        setStatus(error.message || String(error), "error");
+      }
+    }
+  }
+
+  ui.form.addEventListener("submit",handleComposerSubmit);
+  ui.approve.addEventListener("click",approveCard);
+  ui.revise.addEventListener("click",reviseCard);
+  ui.share.addEventListener("click",shareBountyCard);
+  ui.fund.addEventListener("click",openFunding);
+  ui.closeDialog.addEventListener("click",()=>ui.dialog.close());
+  ui.cryptoMethod.addEventListener("click",chooseCryptoWallet);
+  ui.watchUsdc.addEventListener("click",watchUsdcAsset);
+  ui.copyUsdc.addEventListener("click",copyUsdcAddress);
+  ui.recheck.addEventListener("click",()=>refreshWalletReadiness().catch((error)=>setPaymentStatus(error.message||String(error),"error")));
+  ui.fundNow.addEventListener("click",()=>{
+    try {
+      supportedVerificationPolicy();
+      fundApprovedBounty();
+    } catch (error) {
+      ui.fundNow.disabled = true;
+      setPaymentStatus(error.message || String(error), "error");
+    }
+  });
+  ui.dialog.addEventListener("click",(event)=>{if(event.target===ui.dialog)ui.dialog.close();});
+  window.addEventListener("agent-bounties:prepared-draft", (event) => {
+    importPreparedDraft(event.detail).catch((error) => setStatus(error.message || String(error), "error"));
+  });
+
+  configureSpeech();
+  setProgress("describe");
+  prefillFromQuery().catch((error) => setStatus(error.message || String(error), "error"));
+})();

--- a/site/bounty-composer.css
+++ b/site/bounty-composer.css
@@ -1,0 +1,638 @@
+:root {
+  --composer-bg: #020b08;
+  --composer-panel: rgba(7, 25, 16, 0.92);
+  --composer-panel-strong: #071b11;
+  --composer-line: rgba(188, 239, 55, 0.24);
+  --composer-lime: #c9f548;
+  --composer-mint: #7cefd1;
+  --composer-text: #f4f6ef;
+  --composer-muted: #aab6ad;
+  --composer-danger: #ff9f88;
+  --composer-gold: #e8c15a;
+}
+
+.composer-page {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 50% -12%, rgba(101, 181, 42, 0.18), transparent 34rem),
+    linear-gradient(rgba(30, 91, 54, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(30, 91, 54, 0.055) 1px, transparent 1px),
+    var(--composer-bg);
+  background-size: auto, 42px 42px, 42px 42px, auto;
+}
+
+.composer-main {
+  width: min(1040px, calc(100% - 28px));
+  margin: 0 auto;
+  padding: clamp(34px, 8vw, 86px) 0 90px;
+}
+
+.composer-intro {
+  max-width: 780px;
+  margin: 0 auto 28px;
+  text-align: center;
+}
+
+.composer-intro .eyebrow {
+  color: var(--composer-lime);
+  font-weight: 850;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.composer-intro h1 {
+  margin: 12px 0 14px;
+  font-size: clamp(2.45rem, 8vw, 5.5rem);
+  line-height: 0.96;
+  letter-spacing: -0.06em;
+}
+
+.composer-intro > p:last-of-type {
+  max-width: 660px;
+  margin: 0 auto;
+  color: var(--composer-muted);
+  font-size: clamp(1rem, 2.2vw, 1.25rem);
+  line-height: 1.55;
+}
+
+.composer-progress {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin: 24px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.composer-progress li {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #748078;
+  font-size: 0.78rem;
+  font-weight: 780;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.composer-progress li::before {
+  content: "";
+  width: 9px;
+  height: 9px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+}
+
+.composer-progress li[data-active="true"] {
+  color: var(--composer-lime);
+}
+
+.composer-progress li[data-complete="true"] {
+  color: var(--composer-mint);
+}
+
+.composer-progress li[data-complete="true"]::before {
+  background: currentColor;
+}
+
+.composer-shell {
+  position: relative;
+  max-width: 820px;
+  margin: 0 auto;
+  border: 1px solid var(--composer-line);
+  border-radius: 28px;
+  padding: clamp(18px, 4vw, 32px);
+  background:
+    linear-gradient(145deg, rgba(16, 51, 28, 0.94), rgba(3, 17, 10, 0.97)),
+    var(--composer-panel);
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.34);
+  overflow: hidden;
+}
+
+.composer-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 100% 0, rgba(201, 245, 72, 0.12), transparent 26rem);
+}
+
+.composer-assistant {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.composer-assistant-mark {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(201, 245, 72, 0.55);
+  border-radius: 12px;
+  color: var(--composer-lime);
+  background: rgba(201, 245, 72, 0.07);
+  font-weight: 900;
+}
+
+.composer-assistant-copy {
+  margin: 2px 0 0;
+  color: var(--composer-text);
+  font-size: clamp(1rem, 2vw, 1.14rem);
+  line-height: 1.5;
+}
+
+.composer-form {
+  position: relative;
+}
+
+.composer-label {
+  display: block;
+  margin-bottom: 9px;
+  color: var(--composer-muted);
+  font-size: 0.86rem;
+  font-weight: 760;
+}
+
+.composer-input-wrap {
+  position: relative;
+}
+
+#bounty-composer-input {
+  width: 100%;
+  min-height: 168px;
+  resize: vertical;
+  border: 1px solid rgba(202, 231, 207, 0.25);
+  border-radius: 20px;
+  padding: 20px 62px 58px 20px;
+  color: var(--composer-text);
+  background: rgba(0, 8, 4, 0.72);
+  font: inherit;
+  font-size: clamp(1rem, 2vw, 1.12rem);
+  line-height: 1.52;
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+#bounty-composer-input:focus {
+  border-color: rgba(201, 245, 72, 0.7);
+  box-shadow: 0 0 0 4px rgba(201, 245, 72, 0.09);
+}
+
+#bounty-composer-input::placeholder {
+  color: #768078;
+}
+
+.composer-mic {
+  position: absolute;
+  right: 14px;
+  bottom: 14px;
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(201, 245, 72, 0.36);
+  border-radius: 999px;
+  color: var(--composer-lime);
+  background: rgba(201, 245, 72, 0.08);
+  cursor: pointer;
+}
+
+.composer-mic[data-listening="true"] {
+  color: #07120d;
+  background: var(--composer-lime);
+  animation: composer-pulse 1.2s infinite;
+}
+
+.composer-mic svg {
+  width: 21px;
+  height: 21px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+@keyframes composer-pulse {
+  50% { box-shadow: 0 0 0 9px rgba(201, 245, 72, 0.12); }
+}
+
+.composer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.composer-hint {
+  margin: 0;
+  color: #849088;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.composer-submit {
+  min-width: 138px;
+}
+
+.composer-status {
+  display: block;
+  min-height: 1.4em;
+  margin-top: 12px;
+  color: var(--composer-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.composer-status[data-tone="error"] { color: var(--composer-danger); }
+.composer-status[data-tone="success"] { color: var(--composer-mint); }
+.composer-status[data-tone="pending"] { color: var(--composer-gold); }
+
+.bounty-preview {
+  max-width: 820px;
+  margin: 34px auto 0;
+}
+
+.bounty-preview[hidden] { display: none; }
+
+.bounty-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(201, 245, 72, 0.3);
+  border-radius: 26px;
+  background: linear-gradient(160deg, #0b2717, #06130c 68%);
+  box-shadow: 0 32px 90px rgba(0, 0, 0, 0.36);
+}
+
+.bounty-card-visual {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #071a11;
+}
+
+#bounty-card-art {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.bounty-card-badge {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+  padding: 7px 11px;
+  color: white;
+  background: rgba(1, 11, 6, 0.72);
+  backdrop-filter: blur(10px);
+  font-size: 0.72rem;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bounty-card-badge::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--composer-gold);
+}
+
+.bounty-card-body {
+  padding: clamp(20px, 4vw, 34px);
+}
+
+.bounty-card-kicker {
+  margin: 0 0 8px;
+  color: var(--composer-lime);
+  font-size: 0.75rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.bounty-card h2 {
+  margin: 0;
+  color: var(--composer-text);
+  font-size: clamp(1.9rem, 5.5vw, 3.4rem);
+  line-height: 1.03;
+  letter-spacing: -0.05em;
+}
+
+.bounty-card-goal {
+  margin: 14px 0 22px;
+  color: #c4cdc6;
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  line-height: 1.55;
+}
+
+.bounty-card-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 9px;
+  margin: 0 0 24px;
+}
+
+.bounty-stat {
+  min-width: 0;
+  border: 1px solid rgba(201, 245, 72, 0.13);
+  border-radius: 14px;
+  padding: 12px;
+  background: rgba(0, 8, 4, 0.46);
+}
+
+.bounty-stat span {
+  display: block;
+  color: #829087;
+  font-size: 0.66rem;
+  font-weight: 820;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bounty-stat strong {
+  display: block;
+  margin-top: 5px;
+  color: var(--composer-text);
+  font-size: 0.94rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.bounty-card-grid {
+  display: grid;
+  grid-template-columns: 1.35fr 0.65fr;
+  gap: 22px;
+}
+
+.bounty-card-section h3 {
+  margin: 0 0 9px;
+  color: var(--composer-text);
+  font-size: 0.95rem;
+}
+
+.bounty-card-section ol,
+.bounty-card-section ul {
+  margin: 0;
+  padding-left: 20px;
+  color: #afbbb2;
+  line-height: 1.48;
+}
+
+.bounty-card-section li + li { margin-top: 7px; }
+.bounty-card-section li::marker { color: var(--composer-lime); }
+
+.bounty-card-note {
+  border-left: 2px solid var(--composer-gold);
+  padding-left: 13px;
+  color: #c8c0a0;
+  font-size: 0.83rem;
+  line-height: 1.5;
+}
+
+.bounty-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 26px;
+}
+
+.bounty-card-actions .button {
+  flex: 1 1 170px;
+  justify-content: center;
+}
+
+.bounty-card-actions .button[data-approved="true"] {
+  color: #07120d;
+  background: var(--composer-mint);
+  border-color: var(--composer-mint);
+}
+
+.bounty-card-actions .button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.bounty-card-disclaimer {
+  margin: 14px 0 0;
+  color: #7f8b83;
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
+.payment-dialog {
+  width: min(660px, calc(100% - 24px));
+  max-height: calc(100vh - 32px);
+  overflow: auto;
+  border: 1px solid rgba(201, 245, 72, 0.3);
+  border-radius: 24px;
+  padding: 0;
+  color: var(--composer-text);
+  background: #07160e;
+  box-shadow: 0 30px 100px rgba(0, 0, 0, 0.68);
+}
+
+.payment-dialog::backdrop {
+  background: rgba(0, 5, 3, 0.78);
+  backdrop-filter: blur(8px);
+}
+
+.payment-dialog-inner {
+  padding: clamp(20px, 5vw, 34px);
+}
+
+.payment-dialog-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.payment-dialog h2 {
+  margin: 0;
+  font-size: clamp(1.65rem, 5vw, 2.4rem);
+  letter-spacing: -0.045em;
+}
+
+.payment-dialog-head p {
+  margin: 8px 0 0;
+  color: var(--composer-muted);
+}
+
+.dialog-close {
+  flex: 0 0 auto;
+  width: 38px;
+  height: 38px;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 999px;
+  color: white;
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+.payment-methods {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 24px 0;
+}
+
+.payment-method {
+  min-height: 92px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 15px;
+  padding: 14px;
+  color: var(--composer-text);
+  background: rgba(255, 255, 255, 0.025);
+  text-align: left;
+  cursor: pointer;
+}
+
+.payment-method strong,
+.payment-method span { display: block; }
+.payment-method span { margin-top: 4px; color: #7f8b83; font-size: 0.72rem; }
+.payment-method:disabled { opacity: 0.42; cursor: not-allowed; }
+.payment-method[data-active="true"] { border-color: var(--composer-lime); background: rgba(201, 245, 72, 0.08); }
+
+.wallet-picker-panel {
+  border-top: 1px solid rgba(255,255,255,.1);
+  padding-top: 22px;
+}
+
+.wallet-picker-panel h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.wallet-picker-panel > p {
+  margin: 0 0 14px;
+  color: var(--composer-muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.wallet-options {
+  display: grid;
+  gap: 8px;
+}
+
+.wallet-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  border: 1px solid rgba(255,255,255,.14);
+  border-radius: 13px;
+  padding: 13px 15px;
+  color: white;
+  background: rgba(255,255,255,.025);
+  cursor: pointer;
+  text-align: left;
+}
+
+.wallet-option:hover { border-color: rgba(201,245,72,.55); }
+.wallet-option small { color: var(--composer-muted); }
+
+.wallet-readiness {
+  margin-top: 16px;
+  border: 1px solid rgba(201, 245, 72, 0.16);
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(0, 7, 4, 0.42);
+}
+
+.wallet-readiness[hidden] { display: none; }
+
+.wallet-readiness-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.wallet-readiness-grid div {
+  border-radius: 12px;
+  padding: 11px;
+  background: rgba(255,255,255,.035);
+}
+
+.wallet-readiness-grid span { display: block; color: var(--composer-muted); font-size: .72rem; }
+.wallet-readiness-grid strong { display: block; margin-top: 3px; overflow-wrap: anywhere; }
+
+.funding-help {
+  margin-top: 14px;
+  border-left: 2px solid var(--composer-gold);
+  padding-left: 13px;
+  color: #c9c1a5;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.funding-help[hidden] { display: none; }
+.funding-help ol { margin: 7px 0 0; padding-left: 18px; }
+
+.wallet-tools,
+.payment-final-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.wallet-tools .button,
+.payment-final-actions .button { flex: 1 1 150px; justify-content: center; }
+
+.payment-status {
+  display: block;
+  min-height: 1.5em;
+  margin-top: 15px;
+  color: var(--composer-muted);
+  white-space: pre-wrap;
+  line-height: 1.48;
+}
+
+.payment-status[data-tone="error"] { color: var(--composer-danger); }
+.payment-status[data-tone="success"] { color: var(--composer-mint); }
+.payment-status[data-tone="pending"] { color: var(--composer-gold); }
+
+@media (max-width: 700px) {
+  .composer-main { width: min(100% - 20px, 1040px); padding-top: 26px; }
+  .composer-intro { text-align: left; }
+  .composer-progress { justify-content: flex-start; overflow-x: auto; }
+  .composer-progress li { flex: 0 0 auto; }
+  .composer-shell { border-radius: 20px; }
+  .composer-actions { align-items: stretch; flex-direction: column; }
+  .composer-submit { width: 100%; }
+  .bounty-card-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .bounty-card-grid { grid-template-columns: 1fr; }
+  .payment-methods { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 440px) {
+  .composer-main { width: calc(100% - 14px); }
+  .composer-shell { padding: 16px; }
+  #bounty-composer-input { min-height: 190px; }
+  .bounty-card-body { padding: 20px 17px; }
+  .bounty-card-stats { grid-template-columns: 1fr 1fr; }
+  .bounty-card-actions { flex-direction: column; }
+  .bounty-card-actions .button { width: 100%; flex-basis: auto; }
+  .wallet-readiness-grid { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-mic[data-listening="true"] { animation: none; }
+  * { scroll-behavior: auto !important; }
+}

--- a/site/bounty-entry.js
+++ b/site/bounty-entry.js
@@ -1,0 +1,58 @@
+(() => {
+  "use strict";
+
+  const STORAGE_KEY = "agent-bounties:homepage-bounty-intent";
+  const CHAT_ROUTE = "objective.html?source=home&autostart=1";
+
+  function normalize(value) {
+    return String(value || "").trim();
+  }
+
+  function start(rawMessage) {
+    const message = normalize(rawMessage);
+    if (!message) return false;
+
+    let stored = false;
+    try {
+      window.sessionStorage.setItem(STORAGE_KEY, message);
+      stored = true;
+    } catch (_) {
+      stored = false;
+    }
+
+    const destination = stored
+      ? CHAT_ROUTE
+      : `${CHAT_ROUTE}&goal=${encodeURIComponent(message)}`;
+    window.location.assign(destination);
+    return true;
+  }
+
+  function consume(search = window.location.search) {
+    const params = search instanceof URLSearchParams
+      ? search
+      : new URLSearchParams(search || "");
+    if (params.get("autostart") !== "1") {
+      return Object.freeze({ message: "", autostart: false });
+    }
+
+    let message = "";
+    if (params.get("source") === "home") {
+      try {
+        message = normalize(window.sessionStorage.getItem(STORAGE_KEY));
+        window.sessionStorage.removeItem(STORAGE_KEY);
+      } catch (_) {
+        message = "";
+      }
+    }
+
+    if (!message) {
+      message = normalize(
+        params.get("goal") || params.get("draftObjective") || params.get("objective"),
+      );
+    }
+
+    return Object.freeze({ message, autostart: Boolean(message) });
+  }
+
+  window.AgentBountyEntry = Object.freeze({ STORAGE_KEY, start, consume });
+})();

--- a/site/cancel.html
+++ b/site/cancel.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Checkout canceled | Agent Bounties</title>
+    <meta name="description" content="The provider checkout was canceled before reconciliation; no bounty funding is credited.">
+    <meta name="robots" content="noindex, nofollow">
+    <link rel="canonical" href="https://agentbounties.app/cancel.html">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="policy">
+      <p class="eyebrow">Provider checkout</p>
+      <h1>Checkout canceled</h1>
+      <p>No provider completion was reported, and no bounty funding is credited. A checkout screen, redirect, receipt, or transaction hash is not canonical funding evidence.</p>
+      <p class="actions"><a class="button primary" href="onramp.html">Choose another on-ramp</a><a class="button secondary" href="./">Return home</a></p>
+    </main>
+    <script src="analytics-config.js?v=2"></script>
+    <script src="analytics.js?v=3"></script>
+  </body>
+</html>

--- a/site/evm.js
+++ b/site/evm.js
@@ -1,0 +1,151 @@
+(() => {
+  "use strict";
+
+  const KECCAK_RATE_BYTES = 136;
+  const KECCAK_ROTATIONS = Object.freeze([
+    0, 1, 62, 28, 27,
+    36, 44, 6, 55, 20,
+    3, 10, 43, 25, 39,
+    41, 45, 15, 21, 8,
+    18, 2, 61, 56, 14,
+  ]);
+  const KECCAK_ROUND_CONSTANTS = Object.freeze([
+    0x0000000000000001n, 0x0000000000008082n, 0x800000000000808an,
+    0x8000000080008000n, 0x000000000000808bn, 0x0000000080000001n,
+    0x8000000080008081n, 0x8000000000008009n, 0x000000000000008an,
+    0x0000000000000088n, 0x0000000080008009n, 0x000000008000000an,
+    0x000000008000808bn, 0x800000000000008bn, 0x8000000000008089n,
+    0x8000000000008003n, 0x8000000000008002n, 0x8000000000000080n,
+    0x000000000000800an, 0x800000008000000an, 0x8000000080008081n,
+    0x8000000000008080n, 0x0000000080000001n, 0x8000000080008008n,
+  ]);
+
+  function rotateLeft64(value, bits) {
+    if (bits === 0) return value;
+    const shift = BigInt(bits);
+    return ((value << shift) | (value >> (64n - shift))) & ((1n << 64n) - 1n);
+  }
+
+  function keccakPermutation(words) {
+    for (const roundConstant of KECCAK_ROUND_CONSTANTS) {
+      const column = Array(5).fill(0n);
+      for (let x = 0; x < 5; x += 1) {
+        for (let y = 0; y < 5; y += 1) column[x] ^= words[x + (5 * y)];
+      }
+      const delta = column.map((_, x) => (
+        column[(x + 4) % 5] ^ rotateLeft64(column[(x + 1) % 5], 1)
+      ));
+      for (let x = 0; x < 5; x += 1) {
+        for (let y = 0; y < 5; y += 1) words[x + (5 * y)] ^= delta[x];
+      }
+      const rotated = Array(25).fill(0n);
+      for (let x = 0; x < 5; x += 1) {
+        for (let y = 0; y < 5; y += 1) {
+          rotated[y + (5 * ((2 * x + 3 * y) % 5))] = rotateLeft64(
+            words[x + (5 * y)], KECCAK_ROTATIONS[x + (5 * y)],
+          );
+        }
+      }
+      for (let x = 0; x < 5; x += 1) {
+        for (let y = 0; y < 5; y += 1) {
+          words[x + (5 * y)] = rotated[x + (5 * y)]
+            ^ ((~rotated[((x + 1) % 5) + (5 * y)])
+              & rotated[((x + 2) % 5) + (5 * y)]);
+        }
+      }
+      words[0] ^= roundConstant;
+    }
+  }
+
+  function absorbKeccakBlock(words, bytes) {
+    for (let index = 0; index < KECCAK_RATE_BYTES; index += 1) {
+      words[Math.floor(index / 8)] ^= BigInt(bytes[index]) << BigInt((index % 8) * 8);
+    }
+    keccakPermutation(words);
+  }
+
+  function keccak256Hex(value) {
+    const input = String(value || "");
+    if (!/^0x(?:[0-9a-fA-F]{2})*$/.test(input)) throw new Error("Keccak input must be hex bytes.");
+    const bytes = new Uint8Array((input.length - 2) / 2);
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Number.parseInt(input.slice(2 + (index * 2), 4 + (index * 2)), 16);
+    }
+    const words = Array(25).fill(0n);
+    let offset = 0;
+    while (offset + KECCAK_RATE_BYTES <= bytes.length) {
+      absorbKeccakBlock(words, bytes.subarray(offset, offset + KECCAK_RATE_BYTES));
+      offset += KECCAK_RATE_BYTES;
+    }
+    const finalBlock = new Uint8Array(KECCAK_RATE_BYTES);
+    finalBlock.set(bytes.subarray(offset));
+    finalBlock[bytes.length - offset] ^= 0x01;
+    finalBlock[KECCAK_RATE_BYTES - 1] ^= 0x80;
+    absorbKeccakBlock(words, finalBlock);
+    let digest = "";
+    for (let index = 0; index < 32; index += 1) {
+      const byte = Number((words[Math.floor(index / 8)] >> BigInt((index % 8) * 8)) & 0xffn);
+      digest += byte.toString(16).padStart(2, "0");
+    }
+    return `0x${digest}`;
+  }
+
+  function textHex(value) {
+    return `0x${Array.from(new TextEncoder().encode(value), (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  function randomBytes32() {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  function bytes32Word(value, label = "bytes32") {
+    const normalized = String(value || "").toLowerCase();
+    if (!/^0x[0-9a-f]{64}$/.test(normalized) || /^0x0{64}$/.test(normalized)) {
+      throw new Error(`${label} must be a nonzero 32-byte hex value.`);
+    }
+    return normalized.slice(2);
+  }
+
+  function addressWord(value) {
+    const normalized = String(value || "").toLowerCase();
+    if (!/^0x[0-9a-f]{40}$/.test(normalized)) throw new Error("Expected an EVM address.");
+    return `${"0".repeat(24)}${normalized.slice(2)}`;
+  }
+
+  function uint256Word(value) {
+    const parsed = BigInt(value);
+    if (parsed < 0n || parsed >= (1n << 256n)) throw new Error("uint256 value is out of bounds.");
+    return parsed.toString(16).padStart(64, "0");
+  }
+
+  function transferWithAuthorizationTypes() {
+    return {
+      EIP712Domain: [
+        { name: "name", type: "string" },
+        { name: "version", type: "string" },
+        { name: "chainId", type: "uint256" },
+        { name: "verifyingContract", type: "address" },
+      ],
+      TransferWithAuthorization: [
+        { name: "from", type: "address" },
+        { name: "to", type: "address" },
+        { name: "value", type: "uint256" },
+        { name: "validAfter", type: "uint256" },
+        { name: "validBefore", type: "uint256" },
+        { name: "nonce", type: "bytes32" },
+      ],
+    };
+  }
+
+  window.AgentBountiesEvm = Object.freeze({
+    addressWord,
+    bytes32Word,
+    keccak256Hex,
+    randomBytes32,
+    textHex,
+    transferWithAuthorizationTypes,
+    uint256Word,
+  });
+})();

--- a/site/guild-shell.js
+++ b/site/guild-shell.js
@@ -1,0 +1,92 @@
+(() => {
+  "use strict";
+
+  const body = document.body;
+  if (!body || body.classList.contains("guild-home")) return;
+
+  const route = (window.location.pathname.split("/").pop() || "index.html").toLowerCase();
+  body.classList.add("guild-interior");
+  body.dataset.guildRoute = route.replace(/\.html$/, "") || "home";
+
+  const crestMarkup = `
+    <span class="guild-shell-crest" aria-hidden="true">
+      <svg viewBox="0 0 42 46" focusable="false">
+        <path d="M21 2.5 37.5 12v22L21 43.5 4.5 34V12L21 2.5Z" fill="none" stroke="currentColor" stroke-width="2.8"/>
+        <path d="M13.5 28.5 21 11l7.5 17.5h-5.2L21 23l-2.3 5.5h-5.2Z" fill="currentColor"/>
+        <circle cx="21" cy="33.5" r="2.1" fill="#07120d"/>
+      </svg>
+    </span>
+    <span class="guild-shell-brand-copy"><strong>Agent Bounties</strong><small>.app</small></span>`;
+
+  const navItems = [
+    ["post.html", "Post"],
+    ["onramp.html", "Add Base USDC"],
+    ["metrics.html", "Metrics"],
+  ];
+
+  let topbar = document.querySelector(".topbar");
+  if (!topbar) {
+    topbar = document.createElement("header");
+    topbar.className = "topbar guild-shell-created";
+    document.body.insertBefore(topbar, document.body.firstChild);
+  }
+
+  let brand = topbar.querySelector(".brand");
+  if (!brand) {
+    brand = document.createElement("a");
+    brand.className = "brand";
+    brand.href = "index.html";
+    topbar.prepend(brand);
+  }
+  brand.setAttribute("aria-label", "Agent Bounties home");
+  brand.innerHTML = crestMarkup;
+
+  let nav = topbar.querySelector("nav");
+  if (!nav) {
+    nav = document.createElement("nav");
+    topbar.appendChild(nav);
+  }
+  nav.setAttribute("aria-label", "Primary navigation");
+  nav.replaceChildren();
+
+  navItems.forEach(([href, label]) => {
+    const link = document.createElement("a");
+    link.href = href;
+    link.textContent = label;
+    if (href.toLowerCase() === route) link.setAttribute("aria-current", "page");
+    nav.appendChild(link);
+  });
+
+  topbar.querySelector(".guild-shell-network")?.remove();
+
+  let modeSwitch = topbar.querySelector(".guild-mode-switch");
+  if (!modeSwitch) {
+    modeSwitch = document.createElement("div");
+    modeSwitch.className = "guild-mode-switch";
+    modeSwitch.setAttribute("role", "group");
+    modeSwitch.setAttribute("aria-label", "Website mode");
+    modeSwitch.innerHTML = '<a href="./" aria-current="page">Human</a><a href="agent/">Agent</a>';
+    topbar.appendChild(modeSwitch);
+  }
+
+  const footer = document.querySelector("footer") || document.createElement("footer");
+  if (!footer.isConnected) {
+    footer.innerHTML = `
+      <span>We say “paid” only after confirmed settlement.</span>
+      <a href="metrics.html">Metrics</a>
+      <a href="terms.html">Terms</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>`;
+    document.body.appendChild(footer);
+  }
+  footer.classList.add("guild-shell-footer");
+
+  const main = document.querySelector("main");
+  if (main) main.classList.add("guild-interior-main");
+
+  const syncScrolledState = () => {
+    topbar.classList.toggle("is-scrolled", window.scrollY > 12);
+  };
+  syncScrolledState();
+  window.addEventListener("scroll", syncScrolledState, { passive: true });
+})();

--- a/site/legal-consent.js
+++ b/site/legal-consent.js
@@ -1,0 +1,248 @@
+(() => {
+  "use strict";
+
+  const FALLBACK_POLICY = Object.freeze({
+    schema_version: "agent-bounties/legal-policy-v1",
+    terms_version: "2026-07-18",
+    privacy_version: "2026-07-18",
+    statement: "I meet the age requirement in the Terms and am authorized to use this wallet and perform this action. I understand that public and blockchain records may be permanent. I accept the posted task, verification, and settlement rules. I am responsible for legal compliance, taxes, content rights, agent authority, and wallet security. I agree to the Terms of Use and Privacy Policy.",
+    terms_url: "terms.html",
+    privacy_url: "privacy.html",
+    supported_actions: [
+      "post_bounty",
+      "fund_bounty",
+      "claim_bounty",
+      "submit_result",
+      "cancel_bounty",
+      "recover_funds",
+      "activate_agent_budget",
+      "update_agent_policy",
+      "revoke_agent_policy",
+    ],
+  });
+
+  const actionLabels = Object.freeze({
+    post_bounty: "post this bounty",
+    fund_bounty: "fund this bounty",
+    claim_bounty: "claim this bounty",
+    submit_result: "submit this result",
+    cancel_bounty: "cancel this unclaimed bounty",
+    recover_funds: "recover these funds",
+    activate_agent_budget: "activate this agent budget",
+    update_agent_policy: "update this agent policy",
+    revoke_agent_policy: "revoke this agent policy",
+  });
+
+  const receipts = new Map();
+  let policyPromise = null;
+  let latestReceipt = null;
+
+  async function sha256(value) {
+    const bytes = new TextEncoder().encode(value);
+    const digest = await crypto.subtle.digest("SHA-256", bytes);
+    return `sha256:${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  async function loadPolicy() {
+    if (policyPromise) return policyPromise;
+    policyPromise = (async () => {
+      try {
+        const protocolResponse = await fetch("protocol.json", { cache: "no-store" });
+        if (!protocolResponse.ok) throw new Error("Protocol configuration unavailable.");
+        const protocol = await protocolResponse.json();
+        const api = String(protocol.api_base_url || "").replace(/\/$/, "");
+        const response = await fetch(`${api}/v1/legal/policy`, { cache: "no-store" });
+        if (!response.ok) throw new Error(`Legal policy unavailable (${response.status}).`);
+        const policy = await response.json();
+        const expectedHash = await sha256(policy.statement);
+        if (policy.schema_version !== FALLBACK_POLICY.schema_version
+          || policy.statement_hash !== expectedHash
+          || !Array.isArray(policy.supported_actions)) {
+          throw new Error("The hosted legal policy failed integrity checks.");
+        }
+        return { ...policy, api, source: "hosted" };
+      } catch (_error) {
+        return {
+          ...FALLBACK_POLICY,
+          statement_hash: await sha256(FALLBACK_POLICY.statement),
+          api: null,
+          source: "bundled",
+        };
+      }
+    })();
+    return policyPromise;
+  }
+
+  function actionsFor(root) {
+    return String(root.dataset.consentActions || "")
+      .split(/\s+/)
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  function findRoot(action, scope = document) {
+    const roots = [
+      ...(scope.querySelectorAll ? scope.querySelectorAll("[data-legal-consent]") : []),
+      ...document.querySelectorAll("[data-legal-consent]"),
+    ];
+    return roots.find((root, index) => roots.indexOf(root) === index && actionsFor(root).includes(action));
+  }
+
+  function createElement(tag, className, text) {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    if (text) element.textContent = text;
+    return element;
+  }
+
+  function renderRoot(root) {
+    if (root.dataset.consentReady === "true") return;
+    root.dataset.consentReady = "true";
+    root.classList.add("legal-consent");
+    const actions = actionsFor(root);
+    const actionText = actions.length === 1 ? actionLabels[actions[0]] : "use this wallet action";
+
+    const heading = createElement("div", "legal-consent-heading");
+    heading.append(
+      createElement("span", "legal-consent-step", "Before you continue"),
+      createElement("h3", "", `Know what happens when you ${actionText}`),
+    );
+
+    const points = createElement("ul", "legal-consent-points");
+    for (const text of [
+      "Money: check the Base network, USDC amount, and destination in your wallet before approving.",
+      "Public record: your wallet, bounty, evidence, and blockchain activity may be public and permanent.",
+      "Payment: only the posted verifier and a confirmed BountySettled event prove that work was paid.",
+      "Security: we never need your recovery phrase or private key.",
+    ]) {
+      points.append(createElement("li", "", text));
+    }
+
+    const label = createElement("label", "legal-consent-check");
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.required = true;
+    checkbox.dataset.legalConsentCheckbox = "";
+    const agreement = createElement("span", "");
+    agreement.append("I understand the points above. I am authorized to act and agree to the ");
+    const terms = createElement("a", "", "Terms of Use");
+    terms.href = "terms.html";
+    terms.target = "_blank";
+    terms.rel = "noopener";
+    const privacy = createElement("a", "", "Privacy Policy");
+    privacy.href = "privacy.html";
+    privacy.target = "_blank";
+    privacy.rel = "noopener";
+    agreement.append(terms, " and ", privacy, ".");
+    label.append(checkbox, agreement);
+
+    const note = createElement(
+      "p",
+      "fine legal-consent-note",
+      "The wallet prompt is your final review. Cancel it if the amount, network, or destination is wrong.",
+    );
+    const status = createElement("output", "fine legal-consent-status", "Agreement not yet accepted.");
+    status.setAttribute("aria-live", "polite");
+    status.dataset.legalConsentStatus = "";
+    root.append(heading, points, label, note, status);
+
+    checkbox.addEventListener("change", () => {
+      if (!checkbox.checked) {
+        for (const key of receipts.keys()) {
+          if (actions.some((action) => key.endsWith(`:${action}`))) receipts.delete(key);
+        }
+        status.textContent = "Agreement not yet accepted.";
+        status.dataset.tone = "";
+      } else {
+        status.textContent = "Ready. Connect the wallet and review its exact prompt.";
+        status.dataset.tone = "pending";
+      }
+    });
+  }
+
+  function renderAll() {
+    document.querySelectorAll("[data-legal-consent]").forEach(renderRoot);
+  }
+
+  async function recordAcceptance(policy, action, walletAddress) {
+    const acceptedAt = new Date().toISOString();
+    const payload = {
+      terms_version: policy.terms_version,
+      privacy_version: policy.privacy_version,
+      action,
+      wallet_address: walletAddress,
+      statement_hash: policy.statement_hash,
+      acceptance_method: "web_clickwrap",
+      accepted_at: acceptedAt,
+    };
+    if (policy.api) {
+      try {
+        const response = await fetch(`${policy.api}/v1/legal/acceptances`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (response.ok) return { ...(await response.json()), durable: true };
+        if (response.status === 400) {
+          throw new Error("The legal policy changed. Reload this page and review it again.");
+        }
+      } catch (error) {
+        if (error.message && error.message.includes("policy changed")) throw error;
+      }
+    }
+    return {
+      schema_version: "agent-bounties/legal-acceptance-v1",
+      acceptance_id: `session:${crypto.randomUUID ? crypto.randomUUID() : Date.now()}`,
+      ...payload,
+      recorded_at: acceptedAt,
+      durable: false,
+    };
+  }
+
+  async function requireAcceptance({ action, walletAddress, scope = document }) {
+    if (!actionLabels[action]) throw new Error(`Unsupported wallet action: ${action}.`);
+    if (!/^0x[0-9a-fA-F]{40}$/.test(String(walletAddress || ""))) {
+      throw new Error("Connect a valid Base wallet before accepting the terms.");
+    }
+    const root = findRoot(action, scope);
+    if (!root) throw new Error("The required legal agreement is missing from this page.");
+    renderRoot(root);
+    const checkbox = root.querySelector("[data-legal-consent-checkbox]");
+    const status = root.querySelector("[data-legal-consent-status]");
+    if (!checkbox.checked) {
+      status.textContent = "Check the agreement before the wallet is asked to sign.";
+      status.dataset.tone = "error";
+      root.scrollIntoView({ behavior: "smooth", block: "center" });
+      checkbox.focus({ preventScroll: true });
+      throw new Error("Read and accept the Terms and Privacy Policy before continuing.");
+    }
+    const policy = await loadPolicy();
+    if (!policy.supported_actions.includes(action)) {
+      throw new Error("This wallet action is not covered by the current hosted legal policy.");
+    }
+    const key = `${policy.terms_version}:${walletAddress.toLowerCase()}:${action}`;
+    let receipt = receipts.get(key);
+    if (!receipt) {
+      receipt = await recordAcceptance(policy, action, walletAddress.toLowerCase());
+      receipts.set(key, receipt);
+    }
+    latestReceipt = receipt;
+    status.textContent = receipt.durable
+      ? `Agreement recorded for ${actionLabels[action]}. Review the wallet prompt now.`
+      : `Agreement accepted for ${actionLabels[action]}. Review the wallet prompt now.`;
+    status.dataset.tone = "success";
+    return receipt;
+  }
+
+  window.AgentBountiesLegal = Object.freeze({
+    loadPolicy,
+    requireAcceptance,
+    latestReceipt: () => latestReceipt,
+  });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", renderAll);
+  } else {
+    renderAll();
+  }
+})();

--- a/site/moonpay-direct-fallback.js
+++ b/site/moonpay-direct-fallback.js
@@ -1,0 +1,175 @@
+(() => {
+  "use strict";
+
+  const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+  const MIN_FIAT_USD = 20;
+  const DIRECT_BUY_URLS = Object.freeze({
+    usdc: "https://www.moonpay.com/buy/usdc",
+    eth: "https://www.moonpay.com/buy/eth",
+  });
+
+  const select = (selector) => document.querySelector(selector);
+
+  function connectedWallet() {
+    const value = String(select("[data-wallet-address]")?.textContent || "").trim();
+    return ADDRESS.test(value) ? value.toLowerCase() : "";
+  }
+
+  function selectedAsset() {
+    return select("[data-onramp-asset]")?.value === "eth" ? "eth" : "usdc";
+  }
+
+  function assetLabel(asset) {
+    return asset === "eth" ? "ETH on Base (ETH_BASE)" : "USDC on Base (USDC_BASE)";
+  }
+
+  function fiatAmount() {
+    const value = String(select("[data-fiat-amount]")?.value || "").trim();
+    if (!/^\d+(?:\.\d{1,2})?$/.test(value)) return null;
+    const amount = Number(value);
+    return Number.isFinite(amount) && amount > 0 ? amount : null;
+  }
+
+  function amountReady() {
+    const amount = fiatAmount();
+    return amount !== null && amount >= MIN_FIAT_USD;
+  }
+
+  function startingAmount() {
+    const amount = fiatAmount();
+    if (amount === null) return `Enter at least $${MIN_FIAT_USD.toFixed(2)} USD`;
+    const suffix = amount < MIN_FIAT_USD ? " (below MoonPay minimum)" : "";
+    return `$${amount.toFixed(2)} USD${suffix}`;
+  }
+
+  function setDirectOutput(message, tone = "") {
+    const output = select("[data-direct-moonpay-output]");
+    if (!output) return;
+    output.textContent = message;
+    output.dataset.tone = tone;
+  }
+
+  function setPartnerOutput(message, tone = "") {
+    const output = select("[data-onramp-output]");
+    if (!output) return;
+    output.textContent = message;
+    output.dataset.tone = tone;
+  }
+
+  function minimumMessage() {
+    return `Enter at least $${MIN_FIAT_USD.toFixed(2)} USD. MoonPay may apply a higher minimum based on asset, region, payment method, and network conditions.`;
+  }
+
+  function renderDirectFallback() {
+    const asset = selectedAsset();
+    const wallet = connectedWallet();
+    const acknowledged = Boolean(select("[data-onramp-ack]")?.checked);
+    const hasValidAmount = amountReady();
+    const link = select("[data-direct-moonpay]");
+    const copy = select("[data-copy-direct-wallet]");
+
+    select("[data-direct-asset]").textContent = assetLabel(asset);
+    select("[data-direct-amount]").textContent = startingAmount();
+    select("[data-direct-wallet]").textContent = wallet || "Connect a Base wallet above";
+
+    link.href = DIRECT_BUY_URLS[asset];
+    link.dataset.asset = asset;
+    link.setAttribute("aria-disabled", String(!(wallet && acknowledged && hasValidAmount)));
+    copy.disabled = !wallet;
+
+    if (!wallet) {
+      setDirectOutput("Connect the destination wallet before opening the manual MoonPay fallback.");
+    } else if (!acknowledged) {
+      setDirectOutput("Acknowledge that buying crypto and funding the bounty are separate actions.");
+    } else if (!hasValidAmount) {
+      setDirectOutput(minimumMessage(), "error");
+    } else {
+      setDirectOutput(
+        `Ready for manual MoonPay checkout. Select ${assetLabel(asset)}, paste ${wallet}, and verify Base on the final review screen.`,
+        "pending",
+      );
+    }
+  }
+
+  async function copyWallet() {
+    const wallet = connectedWallet();
+    if (!wallet) {
+      setDirectOutput("Connect the destination wallet before copying its address.", "error");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(wallet);
+      setDirectOutput(`Copied destination wallet ${wallet}. Verify the same address inside MoonPay.`, "success");
+    } catch (_error) {
+      const range = document.createRange();
+      range.selectNodeContents(select("[data-direct-wallet]"));
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+      setDirectOutput("The wallet address is selected. Copy it, then verify the full address inside MoonPay.", "pending");
+    }
+  }
+
+  function openDirectCheckout(event) {
+    renderDirectFallback();
+    const wallet = connectedWallet();
+    const acknowledged = Boolean(select("[data-onramp-ack]")?.checked);
+    const hasValidAmount = amountReady();
+    if (!wallet || !acknowledged || !hasValidAmount) {
+      event.preventDefault();
+      setDirectOutput(
+        !wallet
+          ? "Connect the destination wallet before opening MoonPay."
+          : (!acknowledged
+            ? "Acknowledge the purchase and funding boundary before opening MoonPay."
+            : minimumMessage()),
+        "error",
+      );
+      return;
+    }
+    const asset = selectedAsset();
+    setDirectOutput(
+      `MoonPay is opening in a new tab. Choose ${assetLabel(asset)}, use the starting amount shown here, paste ${wallet}, and stop if the final screen shows another network or address.`,
+      "pending",
+    );
+  }
+
+  function enforceMinimumForPartnerCheckout(event) {
+    if (amountReady()) return;
+    event.preventDefault();
+    event.stopImmediatePropagation?.();
+    const message = minimumMessage();
+    setPartnerOutput(message, "error");
+    setDirectOutput(message, "error");
+  }
+
+  function initialize() {
+    const link = select("[data-direct-moonpay]");
+    const copy = select("[data-copy-direct-wallet]");
+    if (!link || !copy) return;
+
+    const amountInput = select("[data-fiat-amount]");
+    if (amountInput) amountInput.min = String(MIN_FIAT_USD);
+
+    link.addEventListener("click", openDirectCheckout);
+    copy.addEventListener("click", copyWallet);
+    select("[data-start-moonpay]")?.addEventListener("click", enforceMinimumForPartnerCheckout, true);
+    select("[data-onramp-asset]")?.addEventListener("change", renderDirectFallback);
+    amountInput?.addEventListener("input", renderDirectFallback);
+    select("[data-onramp-ack]")?.addEventListener("change", renderDirectFallback);
+    select("[data-connect-wallet]")?.addEventListener("click", () => setTimeout(renderDirectFallback, 0));
+    select("[data-wallet-provider]")?.addEventListener("change", renderDirectFallback);
+
+    const walletAddress = select("[data-wallet-address]");
+    if (walletAddress) {
+      new MutationObserver(renderDirectFallback).observe(walletAddress, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+    }
+    renderDirectFallback();
+  }
+
+  initialize();
+})();

--- a/site/moonpay-onramp.js
+++ b/site/moonpay-onramp.js
@@ -1,0 +1,478 @@
+(() => {
+  "use strict";
+
+  const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+  const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const BASE_CHAIN_ID = "0x2105";
+  const BALANCE_OF_SELECTOR = "70a08231";
+  const CHECKOUT_HOSTS = new Set(["buy.moonpay.com", "buy-sandbox.moonpay.com"]);
+  const announcedProviders = [];
+  const state = {
+    protocol: null,
+    providers: [],
+    provider: null,
+    account: null,
+    requiredUsdc: 0n,
+    usdcBalance: null,
+    ethBalance: null,
+    observedBalanceState: null,
+  };
+
+  const select = (selector) => document.querySelector(selector);
+  const selectAll = (selector) => [...document.querySelectorAll(selector)];
+
+  function track(eventName) {
+    window.agentBountiesAnalytics?.track(eventName);
+  }
+
+  function setOutput(selector, message, tone = "") {
+    const element = select(selector);
+    if (!element) return;
+    element.textContent = Array.isArray(message) ? message.join("\n") : message;
+    element.dataset.tone = tone;
+  }
+
+  function providerName(provider, info = {}) {
+    if (info.name) return info.name;
+    if (provider.isMetaMask) return "MetaMask";
+    if (provider.isCoinbaseWallet) return "Coinbase Wallet";
+    if (provider.isBraveWallet) return "Brave Wallet";
+    return "Browser wallet";
+  }
+
+  function validProvider(provider) {
+    return Boolean(provider && typeof provider.request === "function");
+  }
+
+  function rememberProvider(event) {
+    const detail = event?.detail;
+    if (!detail || !validProvider(detail.provider)) return;
+    if (!announcedProviders.some((item) => item.provider === detail.provider)) {
+      announcedProviders.push(detail);
+    }
+  }
+
+  window.addEventListener("eip6963:announceProvider", rememberProvider);
+
+  async function discoverProviders() {
+    window.dispatchEvent(new Event("eip6963:requestProvider"));
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const candidates = [...announcedProviders];
+    const injected = window.ethereum && Array.isArray(window.ethereum.providers)
+      ? window.ethereum.providers
+      : (window.ethereum ? [window.ethereum] : []);
+    for (const provider of injected) {
+      if (validProvider(provider) && !candidates.some((item) => item.provider === provider)) {
+        candidates.push({ provider, info: {} });
+      }
+    }
+    state.providers = candidates;
+    const selector = select("[data-wallet-provider]");
+    selector.textContent = "";
+    if (!candidates.length) {
+      const option = document.createElement("option");
+      option.textContent = "No browser wallet detected";
+      selector.append(option);
+      selector.disabled = true;
+      track("wallet_missing_detected");
+      return;
+    }
+    candidates.forEach((item, index) => {
+      const option = document.createElement("option");
+      option.value = String(index);
+      option.textContent = providerName(item.provider, item.info);
+      selector.append(option);
+    });
+    selector.disabled = false;
+  }
+
+  function selectedProvider() {
+    const index = Number.parseInt(select("[data-wallet-provider]").value, 10);
+    const candidate = state.providers[index];
+    if (!candidate) throw new Error("Unlock a browser wallet, reload, and select it here.");
+    state.provider = candidate.provider;
+    return candidate.provider;
+  }
+
+  async function loadProtocol() {
+    if (state.protocol) return state.protocol;
+    const response = await fetch("protocol.json", { cache: "no-store" });
+    if (!response.ok) throw new Error("Protocol configuration is unavailable.");
+    const protocol = await response.json();
+    if (
+      protocol.status !== "active"
+      || protocol.network !== "base-mainnet"
+      || protocol.chain_id !== 8453
+      || !ADDRESS.test(protocol.native_usdc || "")
+      || !/^https:\/\//.test(protocol.mcp_base_url || "")
+    ) {
+      throw new Error("The active Base protocol configuration could not be verified.");
+    }
+    state.protocol = protocol;
+    return protocol;
+  }
+
+  async function switchToBase(provider) {
+    try {
+      await provider.request({
+        method: "wallet_switchEthereumChain",
+        params: [{ chainId: BASE_CHAIN_ID }],
+      });
+    } catch (error) {
+      if (Number(error?.code) !== 4902) throw error;
+      await provider.request({
+        method: "wallet_addEthereumChain",
+        params: [{
+          chainId: BASE_CHAIN_ID,
+          chainName: "Base",
+          nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+          rpcUrls: ["https://mainnet.base.org"],
+          blockExplorerUrls: ["https://basescan.org"],
+        }],
+      });
+    }
+    const chainId = await provider.request({ method: "eth_chainId" });
+    if (String(chainId).toLowerCase() !== BASE_CHAIN_ID) {
+      throw new Error("Switch the connected wallet to Base mainnet before continuing.");
+    }
+  }
+
+  async function connectWallet() {
+    const protocol = await loadProtocol();
+    const provider = selectedProvider();
+    const accounts = await provider.request({ method: "eth_requestAccounts" });
+    const account = String(accounts?.[0] || "");
+    if (!ADDRESS.test(account)) throw new Error("The wallet did not return a valid EVM address.");
+    await switchToBase(provider);
+    state.account = account.toLowerCase();
+    select("[data-wallet-address]").textContent = state.account;
+    select("[data-refresh-balance]").disabled = false;
+    select("[data-start-moonpay]").disabled = !select("[data-onramp-ack]").checked;
+    setOutput("[data-wallet-output]", [
+      `Connected: ${state.account}`,
+      `Network: ${protocol.network}`,
+      "No transaction or signature was requested.",
+    ], "success");
+    track("wallet_connected");
+    await refreshBalances();
+  }
+
+  async function usePublicAddress() {
+    const account = String(select("[data-wallet-address-input]").value || "").trim();
+    if (!ADDRESS.test(account)) {
+      throw new Error("Enter one valid public EVM address. Never enter a recovery phrase or private key.");
+    }
+    state.provider = null;
+    state.account = account.toLowerCase();
+    select("[data-wallet-address]").textContent = state.account;
+    select("[data-refresh-balance]").disabled = false;
+    select("[data-start-moonpay]").disabled = !select("[data-onramp-ack]").checked;
+    setOutput("[data-wallet-output]", [
+      `Public destination: ${state.account}`,
+      "Network: base-mainnet",
+      "This page can verify balances and receive-address context, but it cannot sign for this wallet.",
+    ], "success");
+    track("wallet_connected");
+    await refreshBalances();
+  }
+
+  function paddedAddress(address) {
+    return address.slice(2).toLowerCase().padStart(64, "0");
+  }
+
+  async function rpcRequest(method, params) {
+    const response = await fetch("https://mainnet.base.org", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      cache: "no-store",
+      credentials: "omit",
+      referrerPolicy: "no-referrer",
+    });
+    const payload = await response.json().catch(() => null);
+    if (!response.ok || payload?.error || typeof payload?.result !== "string") {
+      throw new Error("Base balance verification is temporarily unavailable.");
+    }
+    return payload.result;
+  }
+
+  async function refreshBalances() {
+    if (!state.account) throw new Error("Connect a wallet or enter its public address first.");
+    const protocol = await loadProtocol();
+    if (state.provider) await switchToBase(state.provider);
+    const request = state.provider
+      ? (method, params) => state.provider.request({ method, params })
+      : rpcRequest;
+    const [ethHex, usdcHex] = await Promise.all([
+      request("eth_getBalance", [state.account, "latest"]),
+      request("eth_call", [{
+          to: protocol.native_usdc,
+          data: `0x${BALANCE_OF_SELECTOR}${paddedAddress(state.account)}`,
+        }, "latest"]),
+    ]);
+    state.ethBalance = BigInt(ethHex || "0x0");
+    state.usdcBalance = BigInt(usdcHex || "0x0");
+    select("[data-eth-balance]").textContent = `${formatUnits(state.ethBalance, 18, 6)} ETH`;
+    select("[data-usdc-balance]").textContent = `${formatUnits(state.usdcBalance, 6, 6)} USDC`;
+    renderBalanceGuidance();
+  }
+
+  function formatUnits(value, decimals, maximumFractionDigits) {
+    const negative = value < 0n;
+    const absolute = negative ? -value : value;
+    const scale = 10n ** BigInt(decimals);
+    const whole = absolute / scale;
+    const remainder = absolute % scale;
+    const fraction = remainder.toString().padStart(decimals, "0")
+      .slice(0, maximumFractionDigits)
+      .replace(/0+$/, "");
+    return `${negative ? "-" : ""}${whole}${fraction ? `.${fraction}` : ""}`;
+  }
+
+  function parseUsdc(value) {
+    const trimmed = String(value || "").trim();
+    if (!/^\d+(?:\.\d{1,6})?$/.test(trimmed)) return 0n;
+    const [whole, fraction = ""] = trimmed.split(".");
+    return BigInt(whole) * 1_000_000n + BigInt(fraction.padEnd(6, "0"));
+  }
+
+  function renderBalanceGuidance() {
+    const guidance = select("[data-balance-guidance]");
+    if (state.usdcBalance === null || state.ethBalance === null) {
+      guidance.textContent = "Base ETH may be required for wallet transaction gas unless the final wallet path sponsors it.";
+      return;
+    }
+    const enoughUsdc = state.usdcBalance >= state.requiredUsdc;
+    const hasGas = state.ethBalance > 0n;
+    const messages = [
+      enoughUsdc
+        ? "This wallet already holds at least the planned USDC contribution."
+        : `USDC shortfall: ${formatUnits(state.requiredUsdc - state.usdcBalance, 6, 6)} USDC.`,
+      hasGas
+        ? "This wallet has some Base ETH for gas. The wallet still decides the actual fee."
+        : "No Base ETH is visible. The existing funding path may require gas unless the selected wallet sponsors it; MoonPay can also buy Base ETH.",
+    ];
+    guidance.textContent = messages.join(" ");
+    guidance.dataset.tone = enoughUsdc && hasGas ? "success" : "pending";
+    const observed = enoughUsdc ? "funded" : "unfunded";
+    if (state.observedBalanceState !== observed) {
+      state.observedBalanceState = observed;
+      track(enoughUsdc ? "wallet_funded_observed" : "wallet_unfunded_detected");
+    }
+  }
+
+  function safeReturnUrl() {
+    const value = new URLSearchParams(location.search).get("return");
+    if (value) {
+      try {
+        const parsed = new URL(value);
+        if (
+          parsed.origin === location.origin
+          && ["/", "/index.html", "/post.html", "/onramp.html"].includes(parsed.pathname)
+        ) {
+          return parsed;
+        }
+      } catch (_error) {
+        // Use the bounded fallback below.
+      }
+    }
+    return new URL("post.html", location.href);
+  }
+
+  function checkoutReturnUrl() {
+    const url = new URL(location.href);
+    for (const key of ["transactionId", "transactionStatus", "status", "transaction_id"]) {
+      url.searchParams.delete(key);
+    }
+    url.hash = "";
+    return url;
+  }
+
+  function renderContext() {
+    const params = new URLSearchParams(location.search);
+    const bountyContract = params.get("bountyContract") || "";
+    if (bountyContract && !ADDRESS.test(bountyContract)) {
+      throw new Error("This on-ramp handoff contains an invalid bounty contract.");
+    }
+    state.requiredUsdc = parseUsdc(params.get("amount") || "5.10");
+    if (state.requiredUsdc <= 0n) {
+      throw new Error("This on-ramp handoff is missing a valid planned USDC amount.");
+    }
+    select("[data-bounty-contract]").textContent = bountyContract
+      ? bountyContract.toLowerCase()
+      : "New bounty not created yet";
+    select("[data-required-usdc]").textContent = `${formatUnits(state.requiredUsdc, 6, 6)} USDC`;
+    const suggestedUsd = Math.max(20, Math.ceil(Number(state.requiredUsdc) / 1_000_000 * 1.08 * 100) / 100);
+    select("[data-fiat-amount]").value = suggestedUsd.toFixed(2);
+    for (const link of selectAll("[data-return-link]")) link.href = safeReturnUrl().href;
+    renderReturnStatus();
+    track("onramp_viewed");
+  }
+
+  function renderAssetHelp() {
+    const asset = select("[data-onramp-asset]").value;
+    const help = select("[data-asset-help]");
+    const button = select("[data-start-moonpay]");
+    if (asset === "eth") {
+      help.textContent = "Buy Base ETH into the same wallet for transaction gas. This still does not fund the bounty.";
+      button.textContent = "Continue to MoonPay for Base ETH";
+      if (Number(select("[data-fiat-amount]").value) > 100) {
+        select("[data-fiat-amount]").value = "20.00";
+      }
+    } else {
+      help.textContent = "Buy Base USDC into your wallet, then return to approve the contribution.";
+      button.textContent = "Continue to MoonPay for Base USDC";
+    }
+  }
+
+  function renderReturnStatus() {
+    const params = new URLSearchParams(location.search);
+    const transactionId = params.get("transactionId") || params.get("transaction_id");
+    const status = params.get("transactionStatus") || params.get("status");
+    if (!transactionId && !status) return;
+    const container = select("[data-return-status]");
+    container.hidden = false;
+    select("[data-return-status-copy]").textContent = [
+      status ? `MoonPay redirect status: ${status}.` : "MoonPay returned without a status value.",
+      transactionId ? `MoonPay transaction reference: ${transactionId}.` : "No transaction reference was supplied.",
+    ].join(" ");
+    track("onramp_returned");
+  }
+
+  async function requestCheckout() {
+    if (!state.account) throw new Error("Connect a wallet or enter its public address first.");
+    if (!select("[data-onramp-ack]").checked) {
+      throw new Error("Acknowledge that the purchase and bounty funding are separate actions.");
+    }
+    const amount = String(select("[data-fiat-amount]").value || "").trim();
+    if (!/^\d+(?:\.\d{1,2})?$/.test(amount) || Number(amount) <= 0) {
+      throw new Error("Enter a positive USD amount with at most two decimal places.");
+    }
+    const params = new URLSearchParams(location.search);
+    const bountyContract = params.get("bountyContract");
+    if (bountyContract && !ADDRESS.test(bountyContract)) throw new Error("The bounty contract is invalid.");
+    const intent = params.get("intent");
+    if (intent && !UUID.test(intent)) throw new Error("The ChatGPT action intent is invalid.");
+
+    const protocol = await loadProtocol();
+    if (state.provider) await switchToBase(state.provider);
+    track("onramp_moonpay_started");
+    if (!bountyContract) {
+      setOutput("[data-onramp-output]", [
+        "Opening MoonPay's public USDC purchase page for a new-bounty wallet.",
+        "Copy the exact destination address shown above, choose USDC on Base, and verify both again before paying.",
+        "This purchase does not create or fund a bounty.",
+      ], "pending");
+      window.open("https://www.moonpay.com/buy/usdc", "_blank", "noopener,noreferrer");
+      return;
+    }
+    const endpoint = `${protocol.mcp_base_url.replace(/\/$/, "")}/v1/onramps/moonpay/checkout`;
+    setOutput("[data-onramp-output]", [
+      "Creating a device-bound MoonPay checkout URL...",
+      "No bounty transaction is being signed.",
+    ], "pending");
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        wallet_address: state.account,
+        base_currency_amount: amount,
+        base_currency_code: "usd",
+        asset: select("[data-onramp-asset]").value,
+        return_url: checkoutReturnUrl().href,
+        intent_id: intent || null,
+        bounty_contract: bountyContract,
+      }),
+      cache: "no-store",
+      credentials: "omit",
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error(body?.error || body?.message || `MoonPay checkout creation failed (${response.status}).`);
+    }
+    validateCheckoutPlan(body, bountyContract);
+    sessionStorage.setItem("agent-bounties:moonpay:last-external-transaction", body.external_transaction_id);
+    setOutput("[data-onramp-output]", [
+      body.environment === "sandbox"
+        ? "Opening MoonPay sandbox. It validates the checkout flow but will not top up Base mainnet."
+        : "Opening MoonPay. Review the final quote, fees, eligibility, asset, network, and wallet before approval.",
+      body.evidence_boundary,
+    ], "pending");
+    location.assign(body.checkout_url);
+  }
+
+  function validateCheckoutPlan(body, bountyContract) {
+    if (
+      !body
+      || body.schema_version !== "agent-bounties/moonpay-onramp-checkout-v1"
+      || body.provider !== "moonpay"
+      || body.destination_wallet?.toLowerCase() !== state.account
+      || body.bounty_contract?.toLowerCase() !== bountyContract.toLowerCase()
+      || body.bounty_funded !== false
+      || body.canonical_funding_event !== null
+    ) {
+      throw new Error("The MoonPay checkout response did not preserve the reviewed wallet and bounty boundary.");
+    }
+    const checkout = new URL(body.checkout_url);
+    if (
+      checkout.protocol !== "https:"
+      || !CHECKOUT_HOSTS.has(checkout.hostname)
+      || !checkout.searchParams.get("signature")
+      || checkout.searchParams.get("walletAddress")?.toLowerCase() !== state.account
+    ) {
+      throw new Error("The MoonPay checkout URL is not an approved signed MoonPay destination.");
+    }
+  }
+
+  async function run(action) {
+    try {
+      await action();
+    } catch (error) {
+      setOutput("[data-onramp-output]", error.message || String(error), "error");
+      if (action === connectWallet || action === refreshBalances) {
+        setOutput("[data-wallet-output]", error.message || String(error), "error");
+      }
+    }
+  }
+
+  function wireEvents() {
+    select("[data-connect-wallet]").addEventListener("click", () => run(connectWallet));
+    select("[data-use-wallet-address]").addEventListener("click", () => run(usePublicAddress));
+    select("[data-refresh-balance]").addEventListener("click", () => run(refreshBalances));
+    select("[data-start-moonpay]").addEventListener("click", () => run(requestCheckout));
+    select("[data-onramp-asset]").addEventListener("change", renderAssetHelp);
+    select("[data-onramp-ack]").addEventListener("change", (event) => {
+      select("[data-start-moonpay]").disabled = !(event.currentTarget.checked && state.account);
+    });
+    select("[data-wallet-provider]").addEventListener("change", () => {
+      state.provider = null;
+      state.account = null;
+      select("[data-start-moonpay]").disabled = true;
+      select("[data-refresh-balance]").disabled = true;
+      select("[data-wallet-address]").textContent = "Not connected";
+      select("[data-usdc-balance]").textContent = "—";
+      select("[data-eth-balance]").textContent = "—";
+    });
+    for (const link of selectAll("[data-onramp-provider]")) {
+      link.addEventListener("click", () => {
+        const provider = link.dataset.onrampProvider;
+        if (provider === "metamask") track("onramp_metamask_started");
+        if (provider === "coinbase") track("onramp_coinbase_started");
+      });
+    }
+  }
+
+  async function initialize() {
+    try {
+      renderContext();
+      renderAssetHelp();
+      wireEvents();
+      await discoverProviders();
+    } catch (error) {
+      setOutput("[data-onramp-output]", error.message || String(error), "error");
+      select("[data-start-moonpay]").disabled = true;
+    }
+  }
+
+  initialize();
+})();

--- a/site/onramp.css
+++ b/site/onramp.css
@@ -1,0 +1,183 @@
+
+.onramp-callout {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0.25rem 0;
+  padding: 1rem;
+  border: 1px solid rgba(181, 226, 199, 0.2);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.onramp-callout p,
+.onramp-callout output {
+  margin: 0;
+}
+
+.onramp-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.onramp-hero {
+  align-items: end;
+}
+
+.onramp-boundary,
+.onramp-panel,
+.onramp-action,
+.onramp-return-status {
+  border: 1px solid rgba(181, 226, 199, 0.2);
+  border-radius: 1.25rem;
+  background: rgba(4, 24, 17, 0.82);
+  padding: clamp(1.1rem, 2.5vw, 2rem);
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.16);
+}
+
+.onramp-boundary {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: 1.5rem;
+}
+
+.onramp-boundary ol {
+  margin: 0;
+  padding-left: 1.3rem;
+}
+
+.onramp-boundary > p {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.onramp-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.onramp-panel {
+  display: grid;
+  align-content: start;
+  gap: 1rem;
+}
+
+.onramp-panel h2,
+.onramp-action h2,
+.onramp-return-status h2,
+.onramp-boundary h2 {
+  margin-top: 0;
+}
+
+.onramp-facts,
+.onramp-balances {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.onramp-facts > div,
+.onramp-balances > div {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.8rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.onramp-facts dt,
+.onramp-balances dt {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+.onramp-facts dd,
+.onramp-balances dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.onramp-action {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.onramp-action-buttons {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.onramp-provider-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.onramp-provider-grid .button {
+  min-height: 3rem;
+  justify-content: center;
+  text-align: center;
+}
+
+.manual-wallet {
+  display: grid;
+  gap: 0.55rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.manual-wallet-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+}
+
+.manual-wallet-row input {
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+.onramp-action output {
+  grid-column: 1 / -1;
+}
+
+.onramp-acknowledgement {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.onramp-acknowledgement input {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-top: 0.15rem;
+}
+
+.onramp-return-status[hidden] {
+  display: none;
+}
+
+@media (max-width: 760px) {
+  .onramp-boundary,
+  .onramp-grid,
+  .onramp-action,
+  .onramp-provider-grid,
+  .manual-wallet-row {
+    grid-template-columns: 1fr;
+  }
+
+  .onramp-action output,
+  .onramp-boundary > p {
+    grid-column: auto;
+  }
+
+  .onramp-action-buttons .button {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/site/onramp.html
+++ b/site/onramp.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#020b08">
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="referrer" content="no-referrer">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https://mcp.agentbounties.app https://mainnet.base.org; img-src 'self' data:; style-src 'self'; script-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Add Base USDC | Agent Bounties</title>
+    <meta name="description" content="Choose MoonPay, MetaMask, or Coinbase to add Base USDC to your own wallet, then separately approve the exact bounty action.">
+    <link rel="canonical" href="https://agentbounties.app/onramp.html">
+    <link rel="stylesheet" href="styles.css?v=20260722-1">
+    <link rel="stylesheet" href="guild-pages.css?v=20260722-1">
+    <link rel="stylesheet" href="simple-ux.css?v=1">
+    <link rel="stylesheet" href="onramp.css?v=1">
+    <link rel="stylesheet" href="wallet-adapters.css?v=1">
+  </head>
+  <body class="guild-interior" data-guild-build="20260725-moonpay-2" data-public-ux="simplified-v1">
+    <header class="topbar">
+      <a class="brand" href="./">Agent Bounties</a>
+      <nav aria-label="Primary navigation">
+        <a href="post.html">Post</a>
+        <a href="metrics.html">Metrics</a>
+      </nav>
+      <div class="guild-mode-switch" role="group" aria-label="Website mode"><a href="./" aria-current="page">Human</a><a href="agent/">Agent</a></div>
+    </header>
+
+    <main class="protocol-page guild-interior-main onramp-page">
+      <section class="board-hero onramp-hero" aria-labelledby="onramp-title">
+        <div>
+          <p class="eyebrow">Wallet top-up · Step 1 of 2</p>
+          <h1 id="onramp-title">Add Base USDC to your own wallet.</h1>
+          <p>Choose a provider to buy Base USDC into a wallet you control. Agent Bounties never receives card details, provider credentials, recovery phrases, or private keys.</p>
+        </div>
+        <a class="button secondary" href="post.html" data-return-link>Return to bounty review</a>
+      </section>
+
+      <section class="onramp-boundary" aria-labelledby="boundary-title">
+        <div>
+          <p class="eyebrow">Two separate decisions</p>
+          <h2 id="boundary-title">Buying USDC does not fund the bounty.</h2>
+          <!-- Stable evidence-boundary marker: Buying crypto does not fund the bounty. The supported UI is Base-USDC-only because Agent Bounties sponsors gas. -->
+        </div>
+        <ol>
+          <li><strong>Provider purchase:</strong> Base USDC is delivered to the public wallet address you verify below.</li>
+          <li><strong>Canonical contribution:</strong> after returning, your wallet separately reviews and approves the exact bounty contract call.</li>
+        </ol>
+        <p>Only the matching indexed <code>FundingAdded</code> event changes the bounty's funded state.</p>
+      </section>
+
+      <section class="onramp-action" aria-labelledby="provider-choice-title">
+        <div>
+          <p class="eyebrow">Three measured variations</p>
+          <h2 id="provider-choice-title">Choose where to buy Base USDC.</h2>
+          <p>Availability, quotes, identity checks, payment methods, and final fees come from the selected provider. Copy the same destination address and verify <strong>USDC on Base</strong> before paying.</p>
+        </div>
+        <div class="onramp-provider-grid">
+          <a class="button primary" href="#moonpay-action-title" data-onramp-provider="moonpay">MoonPay checkout</a>
+          <a class="button secondary" href="https://portfolio.metamask.io/" target="_blank" rel="noopener noreferrer" data-onramp-provider="metamask">MetaMask Portfolio</a>
+          <a class="button secondary" href="https://wallet.coinbase.com/" target="_blank" rel="noopener noreferrer" data-onramp-provider="coinbase">Coinbase Base wallet</a>
+        </div>
+        <p class="fine">In MetaMask choose Move crypto → Buy. In the Coinbase Base app choose Buy → USDC → Base. A provider completion is not bounty-funding evidence.</p>
+      </section>
+
+      <section class="onramp-grid" aria-label="Base USDC wallet top-up">
+        <article class="onramp-panel">
+          <p class="eyebrow">Purchase context</p>
+          <h2>Review where the USDC will go</h2>
+          <dl class="onramp-facts">
+            <div><dt>Bounty context</dt><dd><code data-bounty-contract>New bounty not created yet</code></dd></div>
+            <div><dt>Planned contribution</dt><dd><strong data-required-usdc>0 USDC</strong></dd></div>
+            <div><dt>Destination network</dt><dd>Base mainnet</dd></div>
+          </dl>
+
+          <label>
+            What do you need?
+            <select data-onramp-asset>
+              <option value="usdc">Base USDC for the bounty</option>
+            </select>
+          </label>
+          <p class="fine" data-asset-help>Buy USDC into your wallet, then return to approve the contribution.</p>
+
+          <label>
+            Fiat amount for MoonPay to quote, USD
+            <input data-fiat-amount type="number" min="1" max="10000" step="0.01" inputmode="decimal" required>
+          </label>
+          <p class="fine">This is a starting amount, not a guaranteed received amount. MoonPay shows its final quote, fees, payment methods, and any region-specific limits before you approve.</p>
+        </article>
+
+        <article class="onramp-panel">
+          <p class="eyebrow">Your wallet</p>
+          <h2>Connect the destination wallet</h2>
+          <label class="wallet-picker">
+            Wallet
+            <select data-wallet-provider aria-label="Wallet provider">
+              <option>Detecting wallets</option>
+            </select>
+          </label>
+          <div class="actions">
+            <button class="button secondary" type="button" data-connect-wallet>Connect wallet</button>
+            <button class="button secondary" type="button" data-refresh-balance disabled>Refresh balances</button>
+          </div>
+          <div class="manual-wallet">
+            <label for="public-wallet-address">Or use a public Base address</label>
+            <div class="manual-wallet-row">
+              <input id="public-wallet-address" type="text" inputmode="text" autocomplete="off" spellcheck="false" placeholder="0x…" data-wallet-address-input>
+              <button class="button secondary" type="button" data-use-wallet-address>Use address</button>
+            </div>
+            <p class="fine">A public address can receive funds but cannot sign here. Never paste a recovery phrase or private key.</p>
+          </div>
+          <output class="output compact-output" data-wallet-output aria-live="polite">Connect the wallet that will later fund the bounty.</output>
+
+          <dl class="onramp-balances">
+            <div><dt>Connected address</dt><dd><code data-wallet-address>Not connected</code></dd></div>
+            <div><dt>Base USDC balance</dt><dd><strong data-usdc-balance>—</strong></dd></div>
+            <div><dt>Base ETH balance</dt><dd><strong data-eth-balance>—</strong></dd></div>
+          </dl>
+          <p class="fine" data-balance-guidance>Agent Bounties sponsors gas for existing-bounty funding and claims. Buy only Base USDC for these supported actions; no ETH purchase is required.</p>
+        </article>
+      </section>
+
+      <section class="onramp-action" aria-labelledby="moonpay-action-title">
+        <div>
+          <p class="eyebrow">MoonPay partner checkout</p>
+          <h2 id="moonpay-action-title">Continue only after checking the wallet and amount.</h2>
+          <p>MoonPay is a separate provider with its own eligibility, terms, fees, identity checks, and support. Agent Bounties does not decide whether MoonPay approves a purchase.</p>
+          <label class="onramp-acknowledgement">
+            <input type="checkbox" data-onramp-ack>
+            <span>I understand that this purchases Base USDC into my wallet and does not yet fund the bounty.</span>
+          </label>
+        </div>
+        <div class="onramp-action-buttons">
+          <button class="button primary" type="button" data-start-moonpay disabled>Continue to MoonPay</button>
+          <a class="button secondary" href="post.html" data-return-link>Skip purchase and return</a>
+        </div>
+        <output class="output" data-onramp-output aria-live="polite">No checkout has been created.</output>
+      </section>
+
+      <section class="onramp-action" aria-labelledby="direct-moonpay-title" data-direct-moonpay-fallback>
+        <div>
+          <p class="eyebrow">Direct MoonPay fallback</p>
+          <h2 id="direct-moonpay-title">Top up even before partner credentials are activated.</h2>
+          <p>This opens MoonPay's public consumer checkout in a new tab. It cannot prefill or cryptographically bind your wallet, asset, network, or amount, so verify each one yourself before paying.</p>
+          <dl class="onramp-facts">
+            <div><dt>Asset to select</dt><dd><strong data-direct-asset>USDC on Base (USDC_BASE)</strong></dd></div>
+            <div><dt>Network to verify</dt><dd><strong>Base</strong></dd></div>
+            <div><dt>Starting amount</dt><dd><strong data-direct-amount>Set above</strong></dd></div>
+            <div><dt>Wallet to paste</dt><dd><code data-direct-wallet>Connect a Base wallet above</code></dd></div>
+          </dl>
+          <ol>
+            <li>Copy the connected wallet address below.</li>
+            <li>Inside MoonPay, choose USDC on Base and enter the starting amount.</li>
+            <li>Paste the wallet address and stop if MoonPay's final review shows another network or address.</li>
+            <li>After delivery, return here and refresh balances before separately funding the bounty.</li>
+          </ol>
+        </div>
+        <div class="onramp-action-buttons">
+          <button class="button secondary" type="button" data-copy-direct-wallet disabled>Copy wallet address</button>
+          <a class="button primary" href="#" target="_blank" rel="noopener noreferrer" aria-disabled="true" data-direct-moonpay>Open MoonPay direct checkout</a>
+        </div>
+        <output class="output" data-direct-moonpay-output aria-live="polite">Connect the destination wallet before opening the manual MoonPay fallback.</output>
+      </section>
+
+      <section class="onramp-return-status" data-return-status hidden aria-labelledby="return-status-title">
+        <p class="eyebrow">Returned from MoonPay</p>
+        <h2 id="return-status-title">Verify the wallet, not just the redirect.</h2>
+        <p data-return-status-copy></p>
+        <p>MoonPay redirect parameters are purchase context only. Refresh the Base balances above, then return to the bounty and approve its exact contribution.</p>
+      </section>
+    </main>
+
+    <footer class="guild-shell-footer">
+      <span>MoonPay top-up ≠ bounty funding. Only canonical events prove funding and payment.</span>
+      <a href="metrics.html">Metrics</a>
+      <a href="terms.html">Terms</a>
+      <a href="privacy.html">Privacy</a>
+      <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
+    </footer>
+    <script src="analytics-config.js?v=2"></script>
+    <script src="analytics.js?v=3"></script>
+    <script src="guild-shell.js?v=3"></script>
+    <script src="moonpay-onramp.js?v=1"></script>
+    <script src="moonpay-direct-fallback.js?v=1"></script>
+  </body>
+</html>

--- a/site/post.html
+++ b/site/post.html
@@ -1,0 +1,247 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#07110c">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Post a funded bounty | Agent Bounties</title>
+    <meta name="description" content="Review exact bounty terms, connect a Base wallet, and publish only after canonical creation and funding events are confirmed.">
+    <meta name="robots" content="noindex, nofollow">
+    <link rel="canonical" href="https://agentbounties.app/post.html">
+    <meta property="og:title" content="New bounty | Agent Bounties">
+    <meta property="og:description" content="Prepare a bounty with the AI account that already knows you, then review and post it on Agent Bounties.">
+    <meta property="og:url" content="https://agentbounties.app/post.html">
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="bounty-composer.css?v=1">
+    <link rel="stylesheet" href="bounty-composer-v2.css?v=1">
+    <link rel="stylesheet" href="bounty-chat.css?v=4">
+    <link rel="stylesheet" href="bounty-chat-controls.css?v=1">
+    <link rel="stylesheet" href="ai-bounty-handoff.css?v=2">
+  </head>
+  <body class="composer-page chat-app-page">
+    <header class="chat-app-header">
+      <a class="chat-app-brand" href="./" aria-label="Agent Bounties home">
+        <span aria-hidden="true">A</span>
+        <strong>Agent Bounties</strong>
+      </a>
+      <h1 class="chat-app-title">New bounty</h1>
+      <a class="chat-app-close" href="./" aria-label="Close and return home">×</a>
+    </header>
+
+    <main class="chat-app" data-bounty-chat aria-label="Bounty creation chat">
+      <section class="conversation-panel">
+        <div class="conversation-log" data-conversation-log aria-live="polite" aria-label="Conversation messages">
+          <section class="ai-safety-note" aria-label="Open Competition default">
+            <strong>Approved deterministic work defaults to Open Competition.</strong>
+            The current public profile is a scope-bound hash challenge; first valid confirmed reveal wins.
+            Competitive and other digital work stays in this planner and is not represented as ready to earn without an exact approved verifier.
+            <a href="https://github.com/NSPG13/agent-bounties/issues" target="_blank" rel="noopener noreferrer">Tell us if this routes you to the wrong action.</a>
+          </section>
+          <section id="bounty-preview" class="bounty-preview conversation-draft" hidden aria-labelledby="bounty-card-title">
+            <article id="bounty-card" class="bounty-card">
+              <div class="bounty-card-visual">
+                <canvas id="bounty-card-art" role="img" aria-label="Illustrated preview of the requested outcome"></canvas>
+                <span class="bounty-card-badge" data-card-badge>Draft · not posted</span>
+                <span class="image-generation-status" data-image-status>Preparing visual…</span>
+              </div>
+
+              <div class="bounty-card-body">
+                <div class="draft-card-heading">
+                  <span class="draft-state" data-draft-state>Draft</span>
+                  <h2 id="bounty-card-title" data-card-title></h2>
+                  <p class="bounty-card-goal" data-card-goal></p>
+                </div>
+
+                <div class="bounty-card-stats" aria-label="Bounty summary">
+                  <div class="bounty-stat"><span>Reward</span><strong data-card-reward>—</strong></div>
+                  <div class="bounty-stat"><span>Time</span><strong data-card-deadline>—</strong></div>
+                  <div class="bounty-stat"><span>Checks</span><strong data-card-checks>—</strong></div>
+                  <strong class="sr-only" data-card-confidence>—</strong>
+                </div>
+
+                <details class="mission-context" data-mission-context hidden>
+                  <summary data-mission-title>Mission tasks</summary>
+                  <p data-mission-summary></p>
+                  <span class="mission-horizon" data-mission-horizon></span>
+                  <div class="mission-task-options" data-mission-tasks></div>
+                </details>
+
+                <section class="bounty-card-section done-when">
+                  <h3>Done when</h3>
+                  <ol data-card-criteria></ol>
+                </section>
+
+                <details class="bounty-review-details">
+                  <summary>Details to review</summary>
+                  <ul data-card-risks></ul>
+                  <p><strong>Publish only a complete paid loop.</strong> The artifact, binary checks, live verifier, positive solver net value, and full funding are fixed before signing.</p>
+                  <p>The verifier named in the immutable terms executes the published checks. Unsupported review-only drafts cannot be funded or listed as ready to earn.</p>
+                </details>
+
+                <div class="bounty-card-actions chat-draft-actions">
+                  <button class="button secondary" type="button" data-revise-card>Edit in chat</button>
+                  <button type="button" data-share-card hidden>Share draft</button>
+                  <button class="button secondary" type="button" data-approve-card data-approved="false">Approve</button>
+                  <button class="button primary" type="button" data-open-funding disabled>Connect wallet</button>
+                </div>
+              </div>
+            </article>
+          </section>
+
+          <section class="ai-handoff" data-ai-handoff hidden aria-labelledby="ai-handoff-title">
+            <div class="ai-handoff-heading">
+              <p class="ai-handoff-eyebrow">Your AI, your context</p>
+              <h2 id="ai-handoff-title">Continue in the AI account that already knows you</h2>
+              <p>We copy a purpose-built prompt for your account. Agent Bounties does not call a model or need your provider API key.</p>
+            </div>
+
+            <div class="ai-original" aria-label="Bounty idea to hand off">
+              <span>Your bounty idea</span>
+              <p data-ai-original></p>
+            </div>
+
+            <div class="ai-provider-grid" aria-label="Choose an AI provider">
+              <button type="button" data-ai-provider="chatgpt" data-provider-label="ChatGPT">
+                <strong>ChatGPT</strong><span>Copy prompt &amp; open</span>
+              </button>
+              <button type="button" data-ai-provider="claude" data-provider-label="Claude">
+                <strong>Claude</strong><span>Copy prompt &amp; open</span>
+              </button>
+              <button type="button" data-ai-provider="gemini" data-provider-label="Gemini">
+                <strong>Gemini</strong><span>Copy prompt &amp; open</span>
+              </button>
+            </div>
+
+            <details class="ai-connector-setup">
+              <summary>Connect Agent Bounties to your AI once</summary>
+              <p>Add this public remote MCP endpoint as a custom connector or app. Then your AI can post bounties, find funded work, guide wallet-reviewed claims, prepare submissions, and confirm canonical settlement without a copy/paste round trip.</p>
+              <div class="ai-mcp-row">
+                <code>https://mcp.agentbounties.app/mcp</code>
+                <button type="button" data-copy-mcp>Copy endpoint</button>
+              </div>
+              <ul>
+                <li><a href="https://developers.openai.com/apps-sdk/deploy/connect-chatgpt" target="_blank" rel="noopener noreferrer">Connect from ChatGPT</a> — includes an inline bounty card.</li>
+                <li><a href="https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp" target="_blank" rel="noopener noreferrer">Add a Claude custom connector</a> — returns a readable card and review link.</li>
+                <li><a href="https://support.google.com/gemini/answer/17209137" target="_blank" rel="noopener noreferrer">Add a Gemini Spark custom app</a> — currently limited by Google to eligible Spark accounts, regions, and English; ordinary Gemini chats can use the copy-prompt fallback above.</li>
+              </ul>
+            </details>
+
+            <details class="ai-prompt-details">
+              <summary>View or copy the exact prompt</summary>
+              <textarea data-ai-prompt readonly rows="12" aria-label="Prompt to paste into an AI assistant"></textarea>
+              <button type="button" data-copy-ai-prompt>Copy prompt</button>
+            </details>
+
+            <div class="ai-return">
+              <label for="ai-draft-import"><strong>Already have the draft?</strong> Paste the JSON from your AI.</label>
+              <textarea id="ai-draft-import" data-ai-draft-import rows="7" spellcheck="false" placeholder='{"title":"…","goal":"…","acceptance_criteria":["…"],"solver_reward_usdc":"2.00","verifier_reward_usdc":"0.10","task_window_days":30}'></textarea>
+              <button class="button primary" type="button" data-import-ai-draft>Render bounty card</button>
+              <output data-ai-import-status aria-live="polite"></output>
+            </div>
+
+            <p class="ai-safety-note">Nothing is posted, funded, or signed until you review the card and explicitly approve the wallet transaction.</p>
+          </section>
+        </div>
+
+        <div class="conversation-thinking" data-assistant-thinking hidden aria-label="AI is thinking">
+          <span></span><span></span><span></span>
+        </div>
+
+        <p class="sr-only" data-assistant-prompt>What do you want done?</p>
+        <ol class="sr-only" aria-label="Bounty creation progress">
+          <li data-progress-step="describe">Describe</li>
+          <li data-progress-step="clarify">Clarify</li>
+          <li data-progress-step="review">Review</li>
+          <li data-progress-step="fund">Connect</li>
+        </ol>
+
+        <form id="bounty-composer-form" class="chat-composer-form">
+          <label class="sr-only" for="bounty-composer-input" data-composer-label>Your message</label>
+          <div class="chat-composer-input-wrap">
+            <textarea id="bounty-composer-input" maxlength="12000" rows="1" required placeholder="Message Agent Bounties"></textarea>
+            <button class="composer-mic" type="button" data-dictate aria-label="Dictate your message" title="Dictate your message">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="12" rx="4"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3M9 21h6"/></svg>
+            </button>
+            <button class="chat-send" type="submit" data-composer-submit aria-label="Send message">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12 14-7-4 14-3-6-7-1Z"/><path d="m12 13 7-8"/></svg>
+            </button>
+          </div>
+          <p class="sr-only" data-composer-hint>You can keep revising the draft by continuing the conversation.</p>
+          <output class="composer-status" data-composer-status aria-live="polite"></output>
+        </form>
+      </section>
+
+      <dialog id="funding-dialog" class="payment-dialog chat-wallet-dialog" aria-labelledby="funding-dialog-title">
+        <div class="payment-dialog-inner">
+          <div class="payment-dialog-head">
+            <div>
+              <h2 id="funding-dialog-title">Connect wallet</h2>
+              <p>Connecting does not post or fund anything.</p>
+            </div>
+            <button class="dialog-close" type="button" data-close-funding aria-label="Close wallet window">×</button>
+          </div>
+
+          <button type="button" data-payment-method="crypto" hidden>Crypto Wallet</button>
+
+          <section class="wallet-picker-panel" data-wallet-panel hidden>
+            <p data-wallet-message>Looking for wallets…</p>
+            <div class="wallet-options" data-wallet-options></div>
+          </section>
+
+          <section class="wallet-readiness" data-wallet-readiness hidden aria-label="Wallet readiness">
+            <div class="wallet-readiness-grid">
+              <div><span>Wallet</span><strong data-wallet-account>—</strong></div>
+              <div><span>Required</span><strong data-wallet-required>—</strong></div>
+              <div><span>Base USDC</span><strong data-wallet-usdc>—</strong></div>
+              <div><span>Base ETH</span><strong data-wallet-eth>—</strong></div>
+            </div>
+
+            <details class="funding-help">
+              <summary>Exact funding, activation, and recovery sequence</summary>
+              <ol>
+                <li>Review the exact required Base USDC amount shown above and the immutable acceptance terms.</li>
+                <li>Approve only the prepared amount, then confirm the matching creation/funding call in your wallet.</li>
+                <li>A wallet receipt or transaction hash is still pending evidence. The bounty becomes active only after the required canonical creation and funding events are confirmed.</li>
+                <li>If a transaction fails or indexing is delayed, keep the draft and transaction hash, do not create a duplicate, and use the canonical event/status link to resume.</li>
+              </ol>
+              <p>Escrowed funds follow the published settlement, cancellation, timeout, and refund rules. Agent Bounties never asks for a recovery phrase or private key.</p>
+            </details>
+
+            <div class="funding-help" data-funding-help hidden>
+              <p>This wallet needs <strong data-missing-usdc>—</strong> and a small amount of Base ETH.</p>
+              <p>Never enter a recovery phrase or private key here.</p>
+            </div>
+
+            <div class="wallet-tools">
+              <a class="button secondary" href="onramp.html?purpose=post" target="_blank" rel="noopener noreferrer" data-onramp-link>Add Base USDC</a>
+              <button class="button secondary" type="button" data-watch-usdc>Add USDC</button>
+              <button class="button secondary" type="button" data-copy-usdc>Copy token address</button>
+              <button class="button secondary" type="button" data-recheck-balance>Recheck</button>
+            </div>
+
+            <div data-legal-consent data-consent-actions="post_bounty"></div>
+            <button class="button primary" type="button" data-fund-now disabled>Review and post</button>
+          </section>
+
+          <output class="payment-status" data-payment-status aria-live="polite">Approve the draft before connecting a wallet.</output>
+        </div>
+      </dialog>
+
+      <section class="sr-only" aria-label="Compatibility summary">
+        <p>Turn one outcome into verifiable paid work with the AI account you already use.</p>
+        <p>Agents have already completed paid loops.</p>
+        <p>Post your own bounty.</p>
+      </section>
+    </main>
+
+    <script src="analytics-config.js?v=2"></script>
+    <script src="analytics.js?v=3"></script>
+    <script src="legal-consent.js"></script>
+    <script src="evm.js"></script>
+    <script src="bounty-entry.js?v=1"></script>
+    <script src="ai-bounty-handoff.js?v=5"></script>
+    <script src="bounty-composer-v2.js?v=2"></script>
+    <script src="bounty-chat-ui.js?v=4"></script>
+  </body>
+</html>

--- a/site/simple-ux.css
+++ b/site/simple-ux.css
@@ -1,0 +1,398 @@
+:root {
+  --simple-lime: #c9ff3d;
+  --simple-panel: rgba(5, 24, 15, 0.92);
+  --simple-line: rgba(190, 238, 74, 0.28);
+  --simple-muted: #b9c7bd;
+}
+.board-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 28px;
+  align-items: end;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 72px 20px 34px;
+}
+
+.board-hero h1 {
+  max-width: 760px;
+  margin-bottom: 14px;
+}
+
+.board-hero p:not(.eyebrow) {
+  max-width: 720px;
+  color: var(--guild-muted, var(--simple-muted));
+  font-size: 18px;
+  line-height: 1.55;
+}
+
+.board-create-button {
+  white-space: nowrap;
+}
+
+.cancel-hero {
+  padding-top: 44px;
+  padding-bottom: 26px;
+}
+
+body.guild-interior .cancel-hero h1 {
+  max-width: 680px;
+  margin-bottom: 10px;
+  font-size: 48px;
+  line-height: 1.05;
+}
+
+.board-workspace {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 20px 72px;
+}
+
+.board-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.4fr) minmax(160px, .7fr) minmax(130px, .55fr) minmax(150px, .6fr);
+  gap: 12px;
+  align-items: end;
+  padding: 18px;
+  border: 1px solid var(--simple-line);
+  border-radius: 18px;
+  background: var(--simple-panel);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, .22);
+}
+
+.board-controls label {
+  min-width: 0;
+}
+
+.board-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 24px 0 14px;
+  color: var(--simple-muted);
+}
+
+.board-summary strong {
+  color: var(--guild-text, #f6f7ef);
+}
+
+.board-task-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.board-task-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 22px;
+  border: 1px solid var(--simple-line);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 100% 0, rgba(185, 239, 55, .1), transparent 13rem),
+    linear-gradient(145deg, rgba(12, 34, 23, .96), rgba(3, 17, 10, .98));
+}
+
+.board-task-card h2 {
+  margin: 12px 0 10px;
+  font-size: clamp(22px, 3vw, 30px);
+  line-height: 1.08;
+}
+
+.board-task-card p {
+  color: var(--simple-muted);
+  line-height: 1.55;
+}
+
+.board-task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.board-task-meta span,
+.board-state-pill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 29px;
+  padding: 5px 9px;
+  border: 1px solid rgba(190, 238, 74, .2);
+  border-radius: 999px;
+  color: #e8f0e8;
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.board-state-pill[data-state="claimable"] {
+  border-color: rgba(201, 255, 61, .65);
+  color: var(--simple-lime);
+}
+
+.board-state-pill[data-state="funding"] {
+  border-color: rgba(232, 189, 38, .55);
+  color: #ffd977;
+}
+
+.board-state-pill[data-state="in-progress"] {
+  border-color: rgba(24, 217, 172, .45);
+  color: #8ee7d2;
+}
+
+.board-state-pill[data-state="unfunded"] {
+  border-color: rgba(255, 255, 255, .22);
+  color: #c8d0ca;
+}
+
+.board-task-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: auto;
+  padding-top: 20px;
+}
+
+.board-empty,
+.board-loading {
+  grid-column: 1 / -1;
+  padding: 32px;
+  border: 1px dashed var(--simple-line);
+  border-radius: 18px;
+  color: var(--simple-muted);
+  text-align: center;
+}
+
+.inline-workflow {
+  margin-top: 26px;
+  border: 1px solid var(--simple-line);
+  border-radius: 18px;
+  background: rgba(4, 19, 12, .96);
+  overflow: hidden;
+}
+
+.inline-workflow > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 22px;
+  color: var(--guild-text, #f6f7ef);
+  cursor: pointer;
+  font-size: 17px;
+  font-weight: 850;
+  list-style: none;
+}
+
+.inline-workflow > summary::-webkit-details-marker {
+  display: none;
+}
+
+.inline-workflow > summary::after {
+  content: "+";
+  color: var(--simple-lime);
+  font-size: 24px;
+}
+
+.inline-workflow[open] > summary::after {
+  content: "−";
+}
+
+.inline-workflow .protocol-form {
+  max-width: 780px;
+  padding: 6px 22px 30px;
+}
+
+.claim-workflow[hidden] {
+  display: none !important;
+}
+
+.claim-wallet-stack {
+  display: grid;
+  align-items: start;
+  gap: 14px;
+  margin-top: 28px;
+}
+
+.claim-wallet-stack .wallet-picker {
+  width: 100%;
+  max-width: none;
+}
+
+.claim-wallet-stack > .button {
+  justify-self: start;
+  margin: 0;
+}
+
+.claim-wallet-stack .compact-output,
+.claim-wallet-stack .legal-consent {
+  width: 100%;
+  margin: 0;
+}
+
+.post-workflow {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 72px 20px;
+}
+
+.post-workflow-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 26px;
+}
+
+.post-workflow-head > div {
+  max-width: 720px;
+}
+
+.post-workflow-head p:last-child {
+  color: var(--simple-muted);
+  font-size: 17px;
+  line-height: 1.6;
+}
+
+.post-workflow .protocol-form {
+  max-width: 900px;
+  margin: 0;
+  padding: 0;
+}
+
+.use-task-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(190, 238, 74, .2);
+}
+
+.use-task-bar p {
+  margin: 0;
+  color: var(--simple-muted);
+}
+
+.simple-how-hero {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 80px 20px 40px;
+  text-align: center;
+}
+
+.simple-how-hero p {
+  max-width: 650px;
+  margin-right: auto;
+  margin-left: auto;
+  color: var(--simple-muted);
+  font-size: 20px;
+  line-height: 1.55;
+}
+
+.simple-word-grid,
+.simple-step-grid {
+  display: grid;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px 20px 70px;
+  gap: 14px;
+}
+
+.simple-word-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.simple-step-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.simple-word,
+.simple-step {
+  padding: 24px;
+  border: 1px solid var(--simple-line);
+  border-radius: 18px;
+  background: var(--simple-panel);
+}
+
+.simple-word strong,
+.simple-step strong {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--simple-lime);
+  font-size: 20px;
+}
+
+.simple-word p,
+.simple-step p {
+  margin: 0;
+  color: var(--simple-muted);
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+.simple-step span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 18px;
+  border: 1px solid var(--simple-line);
+  border-radius: 50%;
+  color: var(--simple-lime);
+  font-weight: 900;
+}
+
+@media (max-width: 900px) {
+  .board-hero,
+  .post-workflow-head {
+    grid-template-columns: 1fr;
+    display: grid;
+    align-items: start;
+  }
+
+  .board-controls {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .board-task-list,
+  .simple-word-grid,
+  .simple-step-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .board-hero {
+    padding-top: 48px;
+  }
+
+  body.guild-interior .cancel-hero h1 {
+    font-size: 36px;
+  }
+
+  .board-create-button,
+  .board-controls .button {
+    width: 100%;
+  }
+
+  .board-controls,
+  .board-task-list,
+  .simple-word-grid,
+  .simple-step-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .board-task-card {
+    padding: 18px;
+  }
+
+  .post-workflow {
+    padding-top: 52px;
+  }
+}

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -915,6 +915,9 @@ ${competitionChildBrief(item)}`;
           const payload = await response.json();
           if (requestId !== accountLoadId || !currentUser) return null;
           renderAccountDashboard(payload);
+          if (Array.isArray(payload.wallets) && payload.wallets.length === 0) {
+            win.agentBountiesAnalytics?.track("wallet_missing_detected");
+          }
           return payload;
         } catch (error) {
           if (requestId === accountLoadId && currentUser) renderAccountDashboard(null);
@@ -984,6 +987,7 @@ ${competitionChildBrief(item)}`;
           return;
         }
         walletLinkButton.disabled = true;
+        win.agentBountiesAnalytics?.track("wallet_link_started");
         setWalletStatus("Choose the wallet address you want to link…");
         try {
           const accounts = await win.ethereum.request({ method: "eth_requestAccounts" });
@@ -1002,6 +1006,7 @@ ${competitionChildBrief(item)}`;
           });
           await loadAccount();
           setWalletStatus(`${shortWalletAddress(address)} is verified and linked.`);
+          win.agentBountiesAnalytics?.track("wallet_link_confirmed");
         } catch (error) {
           setWalletStatus(walletLinkErrorMessage(error));
         } finally {
@@ -1079,6 +1084,7 @@ ${competitionChildBrief(item)}`;
       loadSession().then(() => {
         if (authResult !== "success" && authResult !== "error") return;
         setStatus(authResultMessage(authResult, authParams.get("provider"), authParams.get("reason")));
+        if (authResult === "success") win.agentBountiesAnalytics?.track("auth_completed");
         showDialog();
         authParams.delete("auth");
         authParams.delete("provider");

--- a/site/success.html
+++ b/site/success.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <title>Checkout returned | Agent Bounties</title>
+    <meta name="description" content="A provider checkout returned; funding remains pending until the authoritative rail or canonical event is reconciled.">
+    <meta name="robots" content="noindex, nofollow">
+    <link rel="canonical" href="https://agentbounties.app/success.html">
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="policy">
+      <p class="eyebrow">Reconciliation required</p>
+      <h1>Checkout returned</h1>
+      <p>The provider redirected back, but this page does not prove funding. Stripe ledger credit requires a verified webhook. A Base bounty becomes funded only after the matching confirmed <code>FundingAdded</code> event.</p>
+      <p class="actions"><a class="button primary" href="post.html">Return to bounty review</a><a class="button secondary" href="./">Return home</a></p>
+    </main>
+    <script src="analytics-config.js?v=2"></script>
+    <script src="analytics.js?v=3"></script>
+  </body>
+</html>

--- a/site/wallet-adapters.css
+++ b/site/wallet-adapters.css
@@ -1,0 +1,158 @@
+.wallet-auth-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(4px);
+}
+.wallet-auth-panel {
+  width: min(100%, 36rem);
+  display: grid;
+  gap: 1rem;
+  box-sizing: border-box;
+  border: 1px solid rgba(201, 245, 72, 0.28);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  color: #f4f6ef;
+  background: #06140d;
+  box-shadow: 0 2rem 5rem rgba(0, 0, 0, 0.55);
+}
+
+.wallet-auth-panel > p,
+.wallet-auth-linked > p {
+  margin: 0;
+  line-height: 1.55;
+}
+
+.wallet-auth-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.wallet-auth-head h2,
+.wallet-auth-head p {
+  margin: 0;
+}
+
+.wallet-auth-close {
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 1.35rem;
+}
+
+.wallet-auth-method-warning,
+.wallet-auth-boundary,
+.wallet-auth-notice,
+.wallet-auth-account,
+.wallet-auth-linked {
+  padding: 0.85rem;
+  border-radius: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.wallet-auth-method-warning {
+  color: #dfd4b1;
+  background: rgba(255, 211, 105, 0.08);
+}
+
+.wallet-auth-boundary {
+  color: #bdc8c0;
+  background: rgba(124, 239, 209, 0.08);
+}
+
+.wallet-auth-notice {
+  margin: 0;
+  color: #dff5ad;
+  background: rgba(201, 245, 72, 0.1);
+}
+
+.wallet-auth-account,
+.wallet-auth-linked {
+  display: grid;
+  gap: 0.45rem;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.wallet-auth-account span,
+.wallet-auth-linked > strong {
+  color: #9eaba2;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.wallet-auth-account strong {
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
+.wallet-auth-chips,
+.wallet-auth-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.wallet-auth-chips span {
+  border: 1px solid rgba(124, 239, 209, 0.22);
+  border-radius: 999px;
+  padding: 0.38rem 0.68rem;
+  color: #d7fff5;
+  background: rgba(124, 239, 209, 0.08);
+}
+
+.wallet-auth-actions > * {
+  flex: 1 1 12rem;
+}
+
+.wallet-auth-back,
+.wallet-auth-signout {
+  justify-self: start;
+}
+
+.wallet-auth-signout {
+  border: 0;
+  padding: 0;
+  color: #aeb8b1;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+
+[data-agent-bounties-coinbase-auth-root="true"]:empty {
+  display: none;
+}
+
+@media (max-width: 34rem) {
+  .wallet-auth-overlay {
+    align-items: end;
+    padding: 0;
+  }
+
+  .wallet-auth-panel {
+    max-height: 92vh;
+    overflow: auto;
+    border-radius: 1rem 1rem 0 0;
+  }
+}
+
+.wallet-auth-link-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .75rem;
+}


### PR DESCRIPTION
Closes #978.

## What changed

- makes `prepare_bounty_post` image inputs optional while requiring the three image fields together when supplied
- preserves the exact approved ChatGPT image path
- lets Claude, Gemini, and other AI clients omit image fields and use the deterministic content-derived review-card visual
- removes the review-page block that forced no-image drafts back into ChatGPT
- keeps wallet connection, signature, publication, and funding on the first-party hosted review flow
- updates MCP instructions, provider handoff copy, documentation, and runtime contract checks
- aligns the runtime checker with the current Competition V2 core-agent catalog

## Root cause

The public interface described ChatGPT, Claude, and Gemini as supported, but the MCP input schema and hosted approval page both treated a ChatGPT-generated file as mandatory. That made the provider-neutral JSON and Claude flows stop after drafting.

## Validation

- `cargo test -p mcp-server chatgpt_app` (34 passed)
- `cargo clippy -p mcp-server -- -D warnings`
- `python scripts/check-chatgpt-app-runtime.py --binary <local mcp-server>`
- `python scripts/check-chatgpt-app-submission.py`
- `python scripts/check-site.py`
- `node scripts/test-ai-bounty-handoff.js`
- JavaScript syntax checks and `cargo fmt --all -- --check`
- in-app browser: no-image AI handoff rendered, confirmed, and enabled Connect wallet without posting/funding
- in-app browser: legacy ChatGPT exact-image handoff continued to render the approved image

No bounty was posted, no wallet was connected, and no funds or signatures were requested during testing.