### PR TITLE
Fix Beta3 Sepolia verifier asset rebinding

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -656,6 +656,7 @@ jobs:
             --gates target/release-assets/release-gates.json --output target/sepolia.json
           python scripts/run_open_competition_v2_sepolia_rehearsal.py --bundle target/sepolia.json \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" --prepare-proof-fixtures target/sepolia-proof-inputs \
+            --verifier-assets target/release-assets/verifier-assets.json \
             --private-key-env BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
             --resolved-bundle-output target/sepolia.json \
@@ -668,6 +669,7 @@ jobs:
           done
           python scripts/run_open_competition_v2_sepolia_rehearsal.py --bundle target/sepolia.json \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" --prepared-proof-dir target/sepolia-proof-inputs \
+            --verifier-assets target/release-assets/verifier-assets.json \
             --private-key-env BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
             --proof-evidence-dir target/sepolia-proofs --prepare-x402-canary \
@@ -1169,6 +1171,7 @@ jobs:
             --output target/mainnet-broker-reserve-before.json
           python scripts/run_open_competition_v2_sepolia_rehearsal.py --network base-mainnet \
             --bundle "$bundle" --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --verifier-assets target/release-assets/verifier-assets.json \
             --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
             --prepare-proof-fixtures target/mainnet-proof-inputs \
@@ -1181,6 +1184,7 @@ jobs:
           done
           python scripts/run_open_competition_v2_sepolia_rehearsal.py --network base-mainnet \
             --bundle target/mainnet-canary-bundle.json --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --verifier-assets target/release-assets/verifier-assets.json \
             --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
             --prepared-proof-dir target/mainnet-proof-inputs \

--- a/scripts/run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/run_open_competition_v2_sepolia_rehearsal.py
@@ -196,7 +196,9 @@ def runtime_hash(url: str, address: str, block: str = "latest") -> tuple[str, in
     return keccak256(code), len(code)
 
 
-def bundle_for_nonce(bundle: dict[str, Any], nonce: int) -> dict[str, Any]:
+def bundle_for_nonce(
+    bundle: dict[str, Any], nonce: int, verifier_assets: dict[str, Any]
+) -> dict[str, Any]:
     preflight = deepcopy(bundle["preflight_safe_block"])
     preflight["deployer_nonce"] = nonce
     return release.build_bundle(
@@ -206,11 +208,16 @@ def bundle_for_nonce(bundle: dict[str, Any], nonce: int) -> dict[str, Any]:
         repository_subject=bundle["repository_subject"]["hash"],
         preflight=preflight,
         gates=deepcopy(bundle["release_gates"]),
-        verifier_assets=release.load_verifier_assets(),
+        verifier_assets=verifier_assets,
     )
 
 
-def resolve_or_deploy_factory(client: SignedRpc, signer: Any, bundle: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None]:
+def resolve_or_deploy_factory(
+    client: SignedRpc,
+    signer: Any,
+    bundle: dict[str, Any],
+    verifier_assets: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
     require(bundle.get("network") == NETWORK and bundle.get("chain_id") == CHAIN_ID, f"release bundle is not {NETWORK}")
     require(signer.address.lower() == bundle["deployer"], "signer does not match release bundle deployer")
     pending_nonce = int(rpc(client.url, "eth_getTransactionCount", [signer.address, "pending"]), 16)
@@ -218,7 +225,7 @@ def resolve_or_deploy_factory(client: SignedRpc, signer: Any, bundle: dict[str, 
     candidates = [bundle]
     for nonce in range(max(0, pending_nonce - 32), pending_nonce):
         if nonce != bundle["factory"]["from_nonce"]:
-            candidates.append(bundle_for_nonce(bundle, nonce))
+            candidates.append(bundle_for_nonce(bundle, nonce, verifier_assets))
     for candidate in candidates:
         observed, size = runtime_hash(client.url, candidate["factory"]["address"])
         if size and observed == candidate["factory"]["runtime_code_hash"]:
@@ -290,8 +297,11 @@ def prepare(args: argparse.Namespace) -> dict[str, Any]:
     raw_key = normalized_key(os.environ.get(args.private_key_env, ""))
     signer = Account.from_key(raw_key)
     raw_bundle = json.loads(args.bundle.read_text(encoding="utf-8"))
+    verifier_assets = release.load_verifier_assets(args.verifier_assets)
     client = SignedRpc(args.rpc_url)
-    bundle, deployment_receipt = resolve_or_deploy_factory(client, signer, raw_bundle)
+    bundle, deployment_receipt = resolve_or_deploy_factory(
+        client, signer, raw_bundle, verifier_assets
+    )
     components = verify_components(client.url, bundle)
     signer, solver_a, solver_b = actors_for(raw_key, bundle, args.actor_derivation_salt)
     context = rehearsal.prepare_context(
@@ -611,6 +621,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--network", choices=("base-sepolia", "base-mainnet"), default="base-sepolia")
     parser.add_argument("--bundle", type=Path, required=True)
+    parser.add_argument("--verifier-assets", type=Path, required=True)
     parser.add_argument("--rpc-url")
     parser.add_argument("--private-key-env", default="BASE_KEEPER_PRIVATE_KEY")
     parser.add_argument("--actor-derivation-salt", default="local")

--- a/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
@@ -1,6 +1,7 @@
 import importlib.util
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
 
 PATH = Path(__file__).with_name("run_open_competition_v2_sepolia_rehearsal.py")
@@ -11,6 +12,47 @@ SPEC.loader.exec_module(MODULE)
 
 
 class SepoliaRehearsalTests(unittest.TestCase):
+    def test_every_release_rehearsal_call_pins_generated_verifier_assets(self):
+        workflow = (
+            Path(__file__).resolve().parents[1]
+            / ".github"
+            / "workflows"
+            / "open-competition-v2-beta3-release.yml"
+        ).read_text(encoding="utf-8")
+        lines = workflow.splitlines()
+        calls = [
+            index
+            for index, line in enumerate(lines)
+            if "python scripts/run_open_competition_v2_sepolia_rehearsal.py" in line
+        ]
+        self.assertEqual(len(calls), 4)
+        for index in calls:
+            self.assertIn(
+                "--verifier-assets target/release-assets/verifier-assets.json",
+                "\n".join(lines[index : index + 6]),
+            )
+
+    def test_nonce_rebind_uses_explicit_pinned_verifier_assets(self):
+        bundle = {
+            "preflight_safe_block": {"deployer_nonce": 7},
+            "deployer": "0x" + "11" * 20,
+            "source_commit": "22" * 20,
+            "repository_subject": {"hash": "0x" + "33" * 32},
+            "release_gates": {"pinned": True},
+        }
+        verifier_assets = {"proof_systems": {"pinned": True}}
+        rebuilt = {"factory": {"from_nonce": 11}}
+
+        with patch.object(
+            MODULE.release,
+            "load_verifier_assets",
+            side_effect=AssertionError("filesystem fallback"),
+        ), patch.object(MODULE.release, "build_bundle", return_value=rebuilt) as build:
+            self.assertIs(MODULE.bundle_for_nonce(bundle, 9, verifier_assets), rebuilt)
+
+        self.assertEqual(build.call_args.kwargs["preflight"]["deployer_nonce"], 9)
+        self.assertIs(build.call_args.kwargs["verifier_assets"], verifier_assets)
+
     def test_actor_derivation_is_stable_and_scoped(self):
         key = bytes.fromhex("11" * 32)
         commit = "22" * 20


### PR DESCRIPTION
## Summary
- pass the exact generated verifier-assets artifact to every live Beta3 rehearsal call
- make nonce rebinding consume that explicit in-memory artifact rather than an absent repository default
- add regressions for the broker-seed nonce advance and workflow pin coverage

## Incident
Protected release run 32094457834 passed all release builds and fork replay, then stopped safely on Sepolia before deployment because nonce rebinding attempted to open `deployments/open-competition-v2-beta3-verifier-assets.json`. No mainnet jobs ran.

## Verification
- `PYTHONPATH=scripts python -m unittest scripts.test_run_open_competition_v2_sepolia_rehearsal scripts.test_build_open_competition_v2_beta3_release -v` (24 passed)
- `python -m py_compile ...`
- `git diff --check`
- `scripts/preflight.ps1 -Mode core`