### PR TITLE
fix(beta3): normalize prepared rehearsal actor roles

### DIFF
--- a/scripts/run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/run_open_competition_v2_sepolia_rehearsal.py
@@ -313,6 +313,14 @@ def actors_for(
     )
 
 
+def prepared_actor_set(actors: dict[str, str]) -> dict[str, str]:
+    return {
+        "creator": actors["deployer"],
+        "solver_a": actors["solver_a"],
+        "solver_b": actors["solver_b"],
+    }
+
+
 def prepare(args: argparse.Namespace) -> dict[str, Any]:
     raw_key = normalized_key(os.environ.get(args.private_key_env, ""))
     signer = Account.from_key(raw_key)
@@ -415,7 +423,10 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             funding_window=PREPARED_FUNDING_WINDOW,
         )
     context, fixtures = rehearsal.load_context(bundle, prepared)
-    require(context["actors"] == actors, "prepared proof actor set changed")
+    require(
+        context["actors"] == prepared_actor_set(actors),
+        "prepared proof actor set changed",
+    )
     required_proofs = (
         {"plonk_best_a", "plonk_best_b"}
         if args.x402_replaces_first_proven

--- a/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
@@ -12,6 +12,21 @@ SPEC.loader.exec_module(MODULE)
 
 
 class SepoliaRehearsalTests(unittest.TestCase):
+    def test_prepared_actor_roles_normalize_creator_to_deployer(self):
+        actors = {
+            "deployer": "0x" + "11" * 20,
+            "solver_a": "0x" + "22" * 20,
+            "solver_b": "0x" + "33" * 20,
+        }
+        self.assertEqual(
+            MODULE.prepared_actor_set(actors),
+            {
+                "creator": actors["deployer"],
+                "solver_a": actors["solver_a"],
+                "solver_b": actors["solver_b"],
+            },
+        )
+
     def test_sepolia_rebind_deploys_exact_three_component_sequence(self):
         deployer = "0x" + "11" * 20
         predicted = ["0x" + f"{value:040x}" for value in (101, 102, 103)]


### PR DESCRIPTION
## Summary

- translate runtime `deployer` role into the prepared proof context's canonical `creator` role
- keep solver identities exact
- add a regression test for the role mapping

## Verification

- `python -m unittest discover -s scripts -p 'test_*open_competition_v2*py' -v` (116 passed)
- exact local Base Sepolia fork replay using the failed protected run's real Groth16 and PLONK proofs (both winner modes settled; both escrows zero)
- `python -m py_compile scripts/run_open_competition_v2_sepolia_rehearsal.py scripts/test_run_open_competition_v2_sepolia_rehearsal.py`
- `scripts/preflight.ps1 -Mode core`
- `git diff --check`

Fixes the fail-closed actor-role mismatch observed in protected release run 32109120588. No contract, circuit, proof, deployment, or settlement behavior changes.