### PR TITLE
Fix Beta3 signed RPC contract destinations

### DIFF
--- a/scripts/run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/run_open_competition_v2_sepolia_rehearsal.py
@@ -12,6 +12,7 @@ import time
 from typing import Any
 
 from eth_account import Account
+from eth_utils import to_checksum_address
 
 import build_open_competition_v2_beta3_release as release
 import open_competition_v2_proof_rehearsal as rehearsal
@@ -162,8 +163,9 @@ class SignedRpc:
             "maxPriorityFeePerGas": hex(priority),
         }
         if to is not None:
-            transaction["to"] = to
-            estimate_request["to"] = to
+            destination = to_checksum_address(to)
+            transaction["to"] = destination
+            estimate_request["to"] = destination
         gas = int(rpc(self.url, "eth_estimateGas", [estimate_request]), 16)
         transaction["gas"] = gas * 5 // 4 + 25_000
         signed = actor.sign_transaction(transaction)

--- a/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
@@ -1,5 +1,6 @@
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
@@ -12,6 +13,37 @@ SPEC.loader.exec_module(MODULE)
 
 
 class SepoliaRehearsalTests(unittest.TestCase):
+    def test_signed_rpc_checksummed_lowercase_contract_destination(self):
+        destination = "0x036cbd53842c5426634e7929541ec2318f3dcf7e"
+
+        class Actor:
+            address = "0xfd7bE4C69541aB297aEcE2a674fc1418b898cC0a"
+
+            def sign_transaction(self, transaction):
+                self.transaction = transaction
+                return SimpleNamespace(raw_transaction=b"signed")
+
+        def rpc_response(_url, method, _params):
+            return {
+                "eth_chainId": hex(MODULE.CHAIN_ID),
+                "eth_getTransactionCount": "0x0",
+                "eth_getBlockByNumber": {"baseFeePerGas": "0x1"},
+                "eth_maxPriorityFeePerGas": "0x1",
+                "eth_estimateGas": "0x5208",
+                "eth_sendRawTransaction": "0x" + "44" * 32,
+            }[method]
+
+        actor = Actor()
+        with patch.object(MODULE, "rpc", side_effect=rpc_response):
+            client = MODULE.SignedRpc("https://base-sepolia.invalid")
+            with patch.object(client, "wait_receipt", return_value={"status": "0x1"}):
+                client.send(actor, to=destination)
+
+        self.assertEqual(
+            actor.transaction["to"],
+            "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        )
+
     def test_prepared_actor_roles_normalize_creator_to_deployer(self):
         actors = {
             "deployer": "0x" + "11" * 20,


### PR DESCRIPTION
## Why\nThe protected Base Sepolia rehearsal generated and self-verified all three real SP1 proofs, then failed before broadcast because th_account rejects lowercase contract destinations during local transaction signing.\n\n## Change\n- normalize every non-creation destination to EIP-55 checksum form before gas estimation and signing\n- cover the exact lowercase Base Sepolia USDC destination with a local signer regression test\n\n## Validation\n- PYTHONPATH=scripts python -m unittest scripts.test_run_open_competition_v2_sepolia_rehearsal -v\n- python -m py_compile scripts/run_open_competition_v2_sepolia_rehearsal.py scripts/test_run_open_competition_v2_sepolia_rehearsal.py\n- scripts/preflight.ps1 -Mode core\n- git diff --check\n\nThe failed run moved no funds. Its retained proof evidence was archived and independently hash-verified, but is not reused because the proof context correctly binds the prior source commit.