### PR TITLE
Pin Beta3 proof context to isolated deployer

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -482,10 +482,13 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}/scripts
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_ARCHIVE_RPC_URL || 'https://mainnet.base.org' }}
+          BASE_DEPLOYER_ADDRESS: ${{ vars.BASE_DEPLOYER_ADDRESS }}
           OPEN_COMPETITION_V2_PROVER_BINARY: ${{ github.workspace }}/target/public-vector-metric-v1-script
           SP1_PROVER: cpu
         run: |
           set -euo pipefail
+          test -n "$BASE_DEPLOYER_ADDRESS"
+          DEPLOYER="${BASE_DEPLOYER_ADDRESS,,}"
           export SP1_GROTH16_CIRCUIT_PATH="$HOME/.cache/agent-bounties/$SP1_SAFE_CIRCUIT_VERSION/groth16"
           export SP1_PLONK_CIRCUIT_PATH="$HOME/.cache/agent-bounties/$SP1_SAFE_CIRCUIT_VERSION/plonk"
           forge build --root contracts/base-escrow --force --ast
@@ -511,7 +514,7 @@ jobs:
             "${setup[@]}" \
             --allow-pending-proof-evidence --output target/verifier-assets.pending.json
           python scripts/build_open_competition_v2_beta3_release.py --network base-mainnet \
-            --rpc-url "$BASE_MAINNET_RPC_URL" --source-commit "$GITHUB_SHA" \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --deployer "$DEPLOYER" --source-commit "$GITHUB_SHA" \
             --verifier-assets target/verifier-assets.pending.json --allow-pending-proof-evidence \
             --output target/mainnet.pending.json
           python scripts/run_open_competition_v2_mainnet_fork_replay.py --bundle target/mainnet.pending.json \
@@ -529,7 +532,7 @@ jobs:
             --plonk-proof-evidence-2 target/proofs/plonk_best_b.json \
             --output target/verifier-assets.json
           python scripts/build_open_competition_v2_beta3_release.py --network base-mainnet \
-            --rpc-url "$BASE_MAINNET_RPC_URL" --source-commit "$GITHUB_SHA" \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --deployer "$DEPLOYER" --source-commit "$GITHUB_SHA" \
             --verifier-assets target/verifier-assets.json --output target/mainnet.json
           python scripts/run_open_competition_v2_mainnet_fork_replay.py --bundle target/mainnet.json \
             --rpc-url "$BASE_MAINNET_RPC_URL" --proof-rehearsal \
@@ -563,7 +566,7 @@ jobs:
           record_gate base_mainnet_fork_exact_replay_complete target/mainnet-fork-replay.json
           record_gate critical_and_high_findings_resolved target/prerequisites/patched-source/sp1-patched-graph.json
           python scripts/build_open_competition_v2_beta3_release.py --network base-mainnet \
-            --rpc-url "$BASE_MAINNET_RPC_URL" --source-commit "$GITHUB_SHA" \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --deployer "$DEPLOYER" --source-commit "$GITHUB_SHA" \
             --verifier-assets target/verifier-assets.json --gates target/release-gates.json \
             --output target/mainnet.presepolia.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/scripts/build_open_competition_v2_beta3_release.py
+++ b/scripts/build_open_competition_v2_beta3_release.py
@@ -18,7 +18,7 @@ from _shared.rpc import rpc
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_ROOT = ROOT / "contracts" / "base-escrow"
 OUT = CONTRACT_ROOT / "out"
-DEFAULT_DEPLOYER = "0x884834e884d6e93462655a2820140ad03e6747bc"
+DEFAULT_DEPLOYER = "0xfd7be4c69541ab297aece2a674fc1418b898cc0a"
 PROTOCOL_VERSION = "agent-bounties/open-competition-v2-beta3"
 VERIFIER_ASSETS_PATH = ROOT / "deployments/open-competition-v2-beta3-verifier-assets.json"
 SP1_SAFE_CIRCUIT_VERSION = "agent-bounties-sp1-safe-v5"

--- a/scripts/test_build_open_competition_v2_beta3_release.py
+++ b/scripts/test_build_open_competition_v2_beta3_release.py
@@ -15,6 +15,32 @@ SPEC.loader.exec_module(MODULE)
 class OpenCompetitionV2ReleaseTests(unittest.TestCase):
     subject_hash = "0x" + "33" * 32
 
+    def test_release_builder_defaults_to_the_isolated_deployer(self):
+        self.assertEqual(
+            MODULE.DEFAULT_DEPLOYER,
+            "0xfd7be4c69541ab297aece2a674fc1418b898cc0a",
+        )
+
+    def test_proof_build_pins_every_bundle_to_the_configured_deployer(self):
+        workflow = (
+            MODULE.ROOT / ".github/workflows/open-competition-v2-beta3-release.yml"
+        ).read_text(encoding="utf-8")
+        build = workflow.split("  build-release-assets:", 1)[1].split(
+            "  live-sepolia-rehearsal:", 1
+        )[0]
+        self.assertIn("BASE_DEPLOYER_ADDRESS: ${{ vars.BASE_DEPLOYER_ADDRESS }}", build)
+        self.assertIn('test -n "$BASE_DEPLOYER_ADDRESS"', build)
+        self.assertEqual(
+            build.count(
+                'build_open_competition_v2_beta3_release.py --network base-mainnet'
+            ),
+            3,
+        )
+        self.assertEqual(
+            build.count('--deployer "$DEPLOYER" --source-commit "$GITHUB_SHA"'),
+            3,
+        )
+
     def test_mainnet_workflow_records_the_exact_x402_gate(self):
         workflow = (MODULE.ROOT / ".github/workflows/open-competition-v2-beta3-release.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- bind all Beta3 mainnet release bundles and generated proof context to the configured isolated deployer
- make the isolated deployer the builder fallback instead of the legacy owner wallet
- add regression coverage for all three proof-window bundle builds

## Incident
Protected run 32136610379 proved against a bundle constructed with the legacy owner address while deployment was configured for the isolated signer. Owner-wallet nonce movement during proving then changed the predicted factory and correctly invalidated the proof context before any deployment.

## Verification
- PYTHONPATH=scripts python -m unittest scripts.test_build_open_competition_v2_beta3_release scripts.test_run_open_competition_v2_sepolia_rehearsal (30 passed)
- python -m py_compile ...
- git diff --check
- scripts/preflight.ps1 -Mode core

No contracts, public interfaces, or contributor-owned files change.