### PR TITLE
fix: recover archived Beta3 rehearsal actors

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -38,6 +38,7 @@ jobs:
             --source-commit 4d09d82825c38f2bf93a8ee4375a95b302410c29 \
             --run-id 32147289466 \
             --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 \
+            --additional-actor-scope 5c90f23e6d03157fcd28883874439009419c9938:32136610379:1 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
             --required-actor 0xf723d4ac02331707f39bc9416b11ec25a73743f1 \
             --required-actor 0x300775bb9ae722e94280637c4547260f1708afc3 \

--- a/scripts/recover_open_competition_v2_rehearsal_funds.py
+++ b/scripts/recover_open_competition_v2_rehearsal_funds.py
@@ -73,6 +73,16 @@ def actor_set(root_key: bytes, source_commit: str, run_id: str, attempts: list[i
     return actors
 
 
+def parse_actor_scope(value: str) -> tuple[str, str, int]:
+    parts = value.split(":")
+    require(len(parts) == 3, "actor scope must be SOURCE_COMMIT:RUN_ID:ATTEMPT")
+    source_commit, run_id, attempt_text = parts
+    require(re.fullmatch(r"[0-9a-f]{40}", source_commit) is not None, "actor scope source commit is invalid")
+    require(run_id.isdigit() and int(run_id) > 0, "actor scope run ID is invalid")
+    require(attempt_text.isdigit() and int(attempt_text) > 0, "actor scope attempt is invalid")
+    return source_commit, run_id, int(attempt_text)
+
+
 def sweepable_eth(balance: int, maximum_fee_per_gas: int) -> int:
     reserve = 30_000 * maximum_fee_per_gas
     return max(balance - reserve, 0)
@@ -108,7 +118,15 @@ def recover(args: argparse.Namespace) -> dict[str, Any]:
     require(deployer.address.lower() == args.deployer.lower(), "protected key does not match the expected deployer")
     require(call_address(args.rpc_url, args.competition, "creator()") == deployer.address.lower(), "competition creator mismatch")
 
-    actors = actor_set(root_key, args.source_commit, args.run_id, args.attempts)
+    actor_scopes = [(args.source_commit, args.run_id, attempt) for attempt in args.attempts]
+    actor_scopes.extend(parse_actor_scope(scope) for scope in args.additional_actor_scope)
+    actors: list[Any] = []
+    seen_actors: set[str] = set()
+    for source_commit, run_id, attempt in actor_scopes:
+        for actor in actor_set(root_key, source_commit, run_id, [attempt]):
+            if actor.address.lower() not in seen_actors:
+                actors.append(actor)
+                seen_actors.add(actor.address.lower())
     actor_addresses = {actor.address.lower() for actor in actors}
     missing = sorted(address.lower() for address in args.required_actor if address.lower() not in actor_addresses)
     require(not missing, f"required rehearsal actors were not derived: {missing}")
@@ -175,6 +193,10 @@ def recover(args: argparse.Namespace) -> dict[str, Any]:
         "source_commit": args.source_commit,
         "release_run_id": args.run_id,
         "attempts": args.attempts,
+        "actor_scopes": [
+            {"source_commit": source_commit, "run_id": run_id, "attempt": attempt}
+            for source_commit, run_id, attempt in actor_scopes
+        ],
         "competition": args.competition.lower(),
         "deployer": deployer.address.lower(),
         "derived_actor_addresses": sorted(actor_addresses),
@@ -195,6 +217,7 @@ def main() -> int:
     parser.add_argument("--source-commit", required=True)
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--attempt", dest="attempts", action="append", type=int, required=True)
+    parser.add_argument("--additional-actor-scope", action="append", default=[])
     parser.add_argument("--competition", required=True)
     parser.add_argument("--required-actor", action="append", default=[])
     parser.add_argument("--minimum-usdc", type=int, default=900_000)

--- a/scripts/test_recover_open_competition_v2_rehearsal_funds.py
+++ b/scripts/test_recover_open_competition_v2_rehearsal_funds.py
@@ -22,6 +22,17 @@ class RehearsalRecoveryTests(unittest.TestCase):
         self.assertEqual(recovery.sweepable_eth(100_000, 2), 40_000)
         self.assertEqual(recovery.sweepable_eth(59_999, 2), 0)
 
+    def test_additional_actor_scope_is_explicit_and_validated(self) -> None:
+        scope = recovery.parse_actor_scope(
+            "5c90f23e6d03157fcd28883874439009419c9938:32136610379:1"
+        )
+        self.assertEqual(
+            scope,
+            ("5c90f23e6d03157fcd28883874439009419c9938", "32136610379", 1),
+        )
+        with self.assertRaises(recovery.RecoveryError):
+            recovery.parse_actor_scope("main:32136610379:1")
+
     def test_transfer_calldata_binds_recipient_and_amount(self) -> None:
         data = recovery.transfer_data("0x" + "12" * 20, 525_000)
         self.assertTrue(data.startswith("0xa9059cbb"))


### PR DESCRIPTION
## Summary
- recover deterministic rehearsal actors from both the current and archived Beta3 release scopes
- validate every additional source/run/attempt tuple before key derivation
- preserve a complete actor-scope audit trail in safe-block recovery evidence

## Verification
- `python scripts/test_recover_open_competition_v2_rehearsal_funds.py`
- `python -m py_compile scripts/recover_open_competition_v2_rehearsal_funds.py`
- `git diff --check`

## Operational boundary
Base Sepolia test-token recovery only. No Base-mainnet path and no production wallet change.