### PR TITLE
fix: pin exact archived rehearsal scope

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -38,7 +38,7 @@ jobs:
             --source-commit 4d09d82825c38f2bf93a8ee4375a95b302410c29 \
             --run-id 32147289466 \
             --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 \
-            --additional-actor-scope 5c90f23e6d03157fcd28883874439009419c9938:32136610379:1 \
+            --additional-actor-scope b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
             --required-actor 0xf723d4ac02331707f39bc9416b11ec25a73743f1 \
             --required-actor 0x300775bb9ae722e94280637c4547260f1708afc3 \

--- a/scripts/test_recover_open_competition_v2_rehearsal_funds.py
+++ b/scripts/test_recover_open_competition_v2_rehearsal_funds.py
@@ -24,14 +24,14 @@ class RehearsalRecoveryTests(unittest.TestCase):
 
     def test_additional_actor_scope_is_explicit_and_validated(self) -> None:
         scope = recovery.parse_actor_scope(
-            "5c90f23e6d03157fcd28883874439009419c9938:32136610379:1"
+            "b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1"
         )
         self.assertEqual(
             scope,
-            ("5c90f23e6d03157fcd28883874439009419c9938", "32136610379", 1),
+            ("b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5", "32122203861", 1),
         )
         with self.assertRaises(recovery.RecoveryError):
-            recovery.parse_actor_scope("main:32136610379:1")
+            recovery.parse_actor_scope("main:32122203861:1")
 
     def test_transfer_calldata_binds_recipient_and_amount(self) -> None:
         data = recovery.transfer_data("0x" + "12" * 20, 525_000)


### PR DESCRIPTION
## Summary
- replace the incorrectly attributed archived rehearsal scope with the exact Actions run that funded the two wallets
- keep the existing four-address allowlist and Base Sepolia-only recovery boundary

## Evidence
Run `32122203861`, commit `b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5`, completed its live rehearsal at `2026-08-18T12:00:20Z`, matching the two actor-funding transactions.

## Verification
- `python scripts/test_recover_open_competition_v2_rehearsal_funds.py`
- `git diff --check`