### PR TITLE
fix: retain safe rehearsal sweep gas

### DIFF
--- a/scripts/recover_open_competition_v2_rehearsal_funds.py
+++ b/scripts/recover_open_competition_v2_rehearsal_funds.py
@@ -27,6 +27,7 @@ NETWORK = "base-sepolia"
 USDC = "0x036cbd53842c5426634e7929541ec2318f3dcf7e"
 TRANSFER_SELECTOR = "a9059cbb"
 ADDRESS = re.compile(r"^0x[0-9a-fA-F]{40}$")
+ETH_SWEEP_GAS_RESERVE = 150_000
 
 
 class RecoveryError(RuntimeError):
@@ -84,7 +85,7 @@ def parse_actor_scope(value: str) -> tuple[str, str, int]:
 
 
 def sweepable_eth(balance: int, maximum_fee_per_gas: int) -> int:
-    reserve = 30_000 * maximum_fee_per_gas
+    reserve = ETH_SWEEP_GAS_RESERVE * maximum_fee_per_gas
     return max(balance - reserve, 0)
 
 

--- a/scripts/test_recover_open_competition_v2_rehearsal_funds.py
+++ b/scripts/test_recover_open_competition_v2_rehearsal_funds.py
@@ -19,8 +19,8 @@ class RehearsalRecoveryTests(unittest.TestCase):
         self.assertEqual(Account.from_key(root).address, "0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A")
 
     def test_eth_sweep_keeps_a_conservative_gas_reserve(self) -> None:
-        self.assertEqual(recovery.sweepable_eth(100_000, 2), 40_000)
-        self.assertEqual(recovery.sweepable_eth(59_999, 2), 0)
+        self.assertEqual(recovery.sweepable_eth(400_000, 2), 100_000)
+        self.assertEqual(recovery.sweepable_eth(299_999, 2), 0)
 
     def test_additional_actor_scope_is_explicit_and_validated(self) -> None:
         scope = recovery.parse_actor_scope(


### PR DESCRIPTION
## Summary
- retain a 150,000-gas fee reserve when sweeping generated Base Sepolia actors
- cover the actual 51,250 gas cap plus RPC fee movement between quote and broadcast
- keep recovery idempotent after the already-confirmed competition finalization and USDC transfers

## Verification
- `python scripts/test_recover_open_competition_v2_rehearsal_funds.py`
- `git diff --check`

Base Sepolia test assets only; no mainnet path.