### PR TITLE
Recover Beta3 Sepolia attempt 7 assets

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -37,13 +37,15 @@ jobs:
             --deployer "$BASE_DEPLOYER_ADDRESS" \
             --source-commit 4d09d82825c38f2bf93a8ee4375a95b302410c29 \
             --run-id 32147289466 \
-            --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 \
+            --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 --attempt 7 \
             --additional-actor-scope b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
             --required-actor 0xf723d4ac02331707f39bc9416b11ec25a73743f1 \
             --required-actor 0x300775bb9ae722e94280637c4547260f1708afc3 \
             --required-actor 0xfe9ba5613c36365fdeed32cbe92b2a644fa0f2a3 \
             --required-actor 0xdecc449c2af3ec13e348fc920451afa770eee2b5 \
+            --required-actor 0xc4d6fa88149d31f6e5f8e46cd71f4c814ffe8526 \
+            --required-actor 0xa62a0da47f22e85d688d101ecfc0220f338f5527 \
             --output target/beta3-sepolia-rehearsal-recovery.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:


### PR DESCRIPTION
## Summary
- include release attempt 7 in the exact Sepolia recovery scope
- require the two derived attempt-7 actors before recovery can pass

## Evidence
- python scripts/test_recover_open_competition_v2_rehearsal_funds.py`n- git diff --check`n
Operational recovery only; no protocol or contributor interface changes.