### PR TITLE
feat(api): expose canonical inventory-state breakdown

### DIFF
--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "a386a6dc2e408ef7cf58fd77e9d28560c87dc8f01e98cce955e346c8ba6e3efb"
+  "normalized_sha256": "67b1e2d2371c0d1493e6c3a7d15917a415f20114b606ab93417cbe13295f6c72"
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -131,9 +131,10 @@ use github_discovery::{
 };
 use hmac::{Hmac, Mac};
 use opportunities::{
-    apply_query as apply_opportunity_query, canonical_opportunity, inventory_state_breakdown_v1,
-    legacy_opportunity, open_competition_opportunities, render_opportunity_feeds,
-    unfunded_opportunity, InventorySnapshotMetadata, InventoryStateBreakdownV1, OpportunityItem,
+    aggregate_canonical_inventory, apply_query as apply_opportunity_query, canonical_opportunity,
+    inventory_state_breakdown_v1, legacy_opportunity, open_competition_opportunities,
+    render_opportunity_feeds, unfunded_opportunity, CanonicalSourceContribution,
+    InventorySnapshotMetadata, InventoryStateBreakdownV1, OpportunityItem,
     OpportunityProjectionResponse, OpportunityQuery, OpportunitySourceStatus, OpportunityView,
     OPPORTUNITY_PROJECTION_SCHEMA,
 };
@@ -4328,7 +4329,7 @@ async fn build_opportunity_projection(
     });
     items.extend(legacy_items);
 
-    let (mut canonical_items, autonomous_error) =
+    let (autonomous_items, autonomous_load_error) =
         match load_autonomous_bounty_feed(state, network, false).await {
             Ok(feed) => (
                 feed.iter()
@@ -4341,34 +4342,38 @@ async fn build_opportunity_projection(
                 Some("canonical_read_model_unavailable".to_string()),
             ),
         };
-    let (open_competition_items, open_competition_error) =
+    let (open_competition_items, open_competition_snapshot, open_competition_load_error) =
         match load_public_open_competition_opportunities(state, network, api, now).await {
-            Ok(items) => (items, None),
+            Ok((items, snapshot)) => (items, snapshot, None),
             Err(_) => (
                 Vec::new(),
+                None,
                 Some("open_competition_read_model_unavailable".to_string()),
             ),
         };
-    canonical_items.extend(open_competition_items);
-    let canonical_error = match (autonomous_error, open_competition_error) {
-        (None, None) => None,
-        (Some(error), None) | (None, Some(error)) => Some(error),
-        (Some(left), Some(right)) => Some(format!("{left}+{right}")),
-    };
-    let inventory_state_breakdown = inventory_state_breakdown_v1(
-        &canonical_items,
-        InventorySnapshotMetadata {
-            generated_at: canonical_snapshot_metadata.generated_at,
-            source_available: canonical_error.is_none()
-                && canonical_snapshot_metadata.source_available,
-            source_error: canonical_error
-                .clone()
-                .or(canonical_snapshot_metadata.source_error),
-        },
-        now,
-    );
-    let canonical_source_available = inventory_state_breakdown.source_available;
-    let canonical_source_error = inventory_state_breakdown.source_error.clone();
+    let (canonical_items, aggregate_snapshot_metadata, canonical_exclusion_errors) =
+        aggregate_canonical_inventory(
+            vec![
+                CanonicalSourceContribution {
+                    items: autonomous_items,
+                    metadata: Some(canonical_snapshot_metadata),
+                    load_error: autonomous_load_error,
+                },
+                CanonicalSourceContribution {
+                    items: open_competition_items,
+                    metadata: open_competition_snapshot,
+                    load_error: open_competition_load_error,
+                },
+            ],
+            now,
+        );
+    let inventory_state_breakdown =
+        inventory_state_breakdown_v1(&canonical_items, aggregate_snapshot_metadata, now);
+    let canonical_source_available =
+        inventory_state_breakdown.source_available && canonical_exclusion_errors.is_empty();
+    let canonical_source_error = inventory_state_breakdown.source_error.clone().or_else(|| {
+        (!canonical_exclusion_errors.is_empty()).then(|| canonical_exclusion_errors.join("+"))
+    });
     source_statuses.push(OpportunitySourceStatus {
         source_type: "canonical_base".to_string(),
         available: canonical_source_available,
@@ -4444,13 +4449,13 @@ async fn load_public_open_competition_opportunities(
     network: &str,
     api_base_url: &str,
     now: DateTime<Utc>,
-) -> Result<Vec<OpportunityItem>, StatusCode> {
+) -> Result<(Vec<OpportunityItem>, Option<InventorySnapshotMetadata>), StatusCode> {
     let release = match open_competition_release_from_environment(network) {
         Ok(release) => release,
-        Err(_) => return Ok(Vec::new()),
+        Err(_) => return Ok((Vec::new(), None)),
     };
     if release.deployment_state != OpenCompetitionDeploymentState::ActiveReadyToEarn {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), None));
     }
     let prefix = open_competition_environment_prefix(network)?;
     let public_activation_block = env::var(format!("{prefix}_PUBLIC_ACTIVATION_BLOCK"))
@@ -4515,13 +4520,18 @@ async fn load_public_open_competition_opportunities(
     if !open_competition_monitoring_is_fresh(&heartbeat, safe_block.number, now) {
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
+    let snapshot_metadata = InventorySnapshotMetadata {
+        generated_at: heartbeat.completed_at.unwrap_or(now),
+        source_available: true,
+        source_error: None,
+    };
     let events: Vec<OpenCompetitionEvent> = store
         .list_open_competition_events(network, &release.factory_contract)
         .await
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
     let website_base_url =
         legal_website_base_url(env::var("WEBSITE_BASE_URL").ok(), &state.public_base_url);
-    open_competition_opportunities(
+    let items = open_competition_opportunities(
         &events,
         profile,
         network,
@@ -4530,7 +4540,8 @@ async fn load_public_open_competition_opportunities(
         public_activation_block,
         now,
     )
-    .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)
+    .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    Ok((items, Some(snapshot_metadata)))
 }
 
 #[utoipa::path(

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -131,10 +131,11 @@ use github_discovery::{
 };
 use hmac::{Hmac, Mac};
 use opportunities::{
-    apply_query as apply_opportunity_query, canonical_opportunity, legacy_opportunity,
-    open_competition_opportunities, render_opportunity_feeds, unfunded_opportunity,
-    OpportunityItem, OpportunityProjectionResponse, OpportunityQuery, OpportunitySourceStatus,
-    OpportunityView, OPPORTUNITY_PROJECTION_SCHEMA,
+    apply_query as apply_opportunity_query, canonical_opportunity, inventory_state_breakdown_v1,
+    legacy_opportunity, open_competition_opportunities, render_opportunity_feeds,
+    unfunded_opportunity, InventorySnapshotMetadata, InventoryStateBreakdownV1, OpportunityItem,
+    OpportunityProjectionResponse, OpportunityQuery, OpportunitySourceStatus, OpportunityView,
+    OPPORTUNITY_PROJECTION_SCHEMA,
 };
 use payments_stripe::{
     apply_checkout_payment_method_configuration, execute_stripe_request, verify_webhook_signature,
@@ -416,6 +417,7 @@ use worker::{
         ,CloudObjectiveSettlementPolicy
         ,CloudUnfundedBountyRequest
         ,CloudDemoSolution
+        ,InventoryStateBreakdownV1
         ,OpportunityProjectionResponse
         ,OpportunityItem
         ,opportunities::OpportunityAmount
@@ -4234,7 +4236,8 @@ async fn build_opportunity_projection(
     query: OpportunityQuery,
 ) -> Result<OpportunityProjectionResponse, StatusCode> {
     let network = query.network.as_deref().unwrap_or("base-mainnet");
-    base_network_descriptor(network).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let network_descriptor =
+        base_network_descriptor(network).map_err(|_| StatusCode::BAD_REQUEST)?;
     let view =
         OpportunityView::parse(query.view.as_deref()).map_err(|_| StatusCode::BAD_REQUEST)?;
     validate_opportunity_filter(
@@ -4252,6 +4255,13 @@ async fn build_opportunity_projection(
 
     let api = state.public_base_url.trim_end_matches('/');
     let now = Utc::now();
+    let canonical_snapshot_metadata = load_autonomous_inventory_snapshot_metadata(
+        state,
+        network,
+        network_descriptor.chain_id,
+        now,
+    )
+    .await;
     let mut items = Vec::<OpportunityItem>::new();
     let mut source_statuses = Vec::<OpportunitySourceStatus>::new();
 
@@ -4345,9 +4355,23 @@ async fn build_opportunity_projection(
         (Some(error), None) | (None, Some(error)) => Some(error),
         (Some(left), Some(right)) => Some(format!("{left}+{right}")),
     };
+    let inventory_state_breakdown = inventory_state_breakdown_v1(
+        &canonical_items,
+        InventorySnapshotMetadata {
+            generated_at: canonical_snapshot_metadata.generated_at,
+            source_available: canonical_error.is_none()
+                && canonical_snapshot_metadata.source_available,
+            source_error: canonical_error
+                .clone()
+                .or(canonical_snapshot_metadata.source_error),
+        },
+        now,
+    );
+    let canonical_source_available = inventory_state_breakdown.source_available;
+    let canonical_source_error = inventory_state_breakdown.source_error.clone();
     source_statuses.push(OpportunitySourceStatus {
         source_type: "canonical_base".to_string(),
-        available: canonical_error.is_none(),
+        available: canonical_source_available,
         authoritative_urls: vec![
             format!(
                 "{api}/v1/base/autonomous-bounties/feed?network={network}&claimable_only=false"
@@ -4355,7 +4379,7 @@ async fn build_opportunity_projection(
             format!("{api}/v1/base/open-competition-v1/events?network={network}"),
         ],
         item_count: canonical_items.len(),
-        error: canonical_error,
+        error: canonical_source_error,
     });
     items.extend(canonical_items);
 
@@ -4367,9 +4391,52 @@ async fn build_opportunity_projection(
         applied_view: view.map(|view| view.as_str().to_string()),
         degraded: source_statuses.iter().any(|source| !source.available),
         source_statuses,
+        inventory_state_breakdown,
         items,
         evidence_boundary: "This endpoint is a read-only projection. Each listed source remains authoritative for its own records; the projection cannot create funding, claims, verification, settlement, or payment evidence. Only confirmed canonical BountySettled proves autonomous-v1 solver payment.".to_string(),
     })
+}
+
+async fn load_autonomous_inventory_snapshot_metadata(
+    state: &SharedState,
+    network: &str,
+    chain_id: u64,
+    observed_at: DateTime<Utc>,
+) -> InventorySnapshotMetadata {
+    let unavailable = |error: &str| InventorySnapshotMetadata {
+        generated_at: observed_at,
+        source_available: false,
+        source_error: Some(error.to_string()),
+    };
+    let Some(store) = state.store.as_ref() else {
+        return unavailable("autonomous_indexer_store_unavailable");
+    };
+    let Some(factory) = autonomous_factory_for_chain(chain_id) else {
+        return unavailable("autonomous_factory_unavailable");
+    };
+    let heartbeat = match store.get_base_indexer_heartbeat(network, &factory).await {
+        Ok(Some(heartbeat)) => heartbeat,
+        Ok(None) => return unavailable("autonomous_indexer_heartbeat_missing"),
+        Err(_) => return unavailable("autonomous_indexer_heartbeat_unavailable"),
+    };
+    let Some(generated_at) = heartbeat.completed_at else {
+        return unavailable("autonomous_indexer_heartbeat_incomplete");
+    };
+    let status_healthy = heartbeat.status == "success"
+        || (heartbeat.status == "skipped"
+            && heartbeat.skipped_reason.as_deref()
+                == Some("no confirmed blocks are ready to scan"));
+    let cursor_healthy = heartbeat
+        .latest_block
+        .zip(heartbeat.persisted_cursor_block)
+        .is_some_and(|(latest, cursor)| cursor.saturating_add(20) >= latest);
+    let source_available = status_healthy && heartbeat.error_message.is_none() && cursor_healthy;
+    InventorySnapshotMetadata {
+        generated_at,
+        source_available,
+        source_error: (!source_available)
+            .then(|| "autonomous_indexer_heartbeat_unhealthy".to_string()),
+    }
 }
 
 async fn load_public_open_competition_opportunities(

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -1234,15 +1234,87 @@ fn json_u64(value: &Value, field: &str) -> Result<u64, String> {
 /// A missing, degraded, future-dated, or stale source fails closed: the
 /// response retains explicit source status but does not advertise partial
 /// inventory as current.
+pub fn inventory_snapshot_metadata_is_current(
+    metadata: &InventorySnapshotMetadata,
+    observed_at: DateTime<Utc>,
+) -> bool {
+    if !metadata.source_available {
+        return false;
+    }
+    let age_seconds = observed_at
+        .signed_duration_since(metadata.generated_at)
+        .num_seconds();
+    (0..=INVENTORY_SNAPSHOT_MAX_AGE_SECONDS).contains(&age_seconds)
+}
+
+#[derive(Debug, Clone)]
+pub struct CanonicalSourceContribution {
+    pub items: Vec<OpportunityItem>,
+    pub metadata: Option<InventorySnapshotMetadata>,
+    pub load_error: Option<String>,
+}
+
+/// Aggregates per-source canonical health into one snapshot for the shared
+/// inventory-state breakdown. A source contributes to the count only when its
+/// own snapshot is healthy and fresh; unhealthy, stale, or failed sources are
+/// excluded with an error so they cannot zero or mask otherwise healthy
+/// canonical inventory. Aggregate freshness is the oldest included snapshot.
+pub fn aggregate_canonical_inventory(
+    sources: Vec<CanonicalSourceContribution>,
+    observed_at: DateTime<Utc>,
+) -> (Vec<OpportunityItem>, InventorySnapshotMetadata, Vec<String>) {
+    let mut included_items = Vec::new();
+    let mut included_generated_at = Vec::new();
+    let mut exclusion_errors = Vec::new();
+    for source in sources {
+        let CanonicalSourceContribution {
+            items,
+            metadata,
+            load_error,
+        } = source;
+        let error = match (load_error, metadata) {
+            (Some(load_error), _) => Some(load_error),
+            (None, None) => None,
+            (None, Some(metadata)) => {
+                if inventory_snapshot_metadata_is_current(&metadata, observed_at) {
+                    included_generated_at.push(metadata.generated_at);
+                    included_items.extend(items);
+                    None
+                } else {
+                    Some(
+                        metadata
+                            .source_error
+                            .clone()
+                            .unwrap_or_else(|| "canonical_source_stale".to_string()),
+                    )
+                }
+            }
+        };
+        if let Some(error) = error {
+            exclusion_errors.push(error);
+        }
+    }
+    let aggregate = match included_generated_at.iter().copied().min() {
+        Some(generated_at) => InventorySnapshotMetadata {
+            generated_at,
+            source_available: true,
+            source_error: None,
+        },
+        None => InventorySnapshotMetadata {
+            generated_at: observed_at,
+            source_available: false,
+            source_error: (!exclusion_errors.is_empty()).then(|| exclusion_errors.join("+")),
+        },
+    };
+    (included_items, aggregate, exclusion_errors)
+}
+
 pub fn inventory_state_breakdown_v1(
     items: &[OpportunityItem],
     metadata: InventorySnapshotMetadata,
     observed_at: DateTime<Utc>,
 ) -> InventoryStateBreakdownV1 {
-    let age_seconds = observed_at
-        .signed_duration_since(metadata.generated_at)
-        .num_seconds();
-    let snapshot_fresh = (0..=INVENTORY_SNAPSHOT_MAX_AGE_SECONDS).contains(&age_seconds);
+    let snapshot_fresh = inventory_snapshot_metadata_is_current(&metadata, observed_at);
     let source_available = metadata.source_available && snapshot_fresh;
     let source_status = if !metadata.source_available {
         "degraded"
@@ -2016,6 +2088,130 @@ mod tests {
                 assert_eq!(actual.ready_to_earn, ready_items.len());
             }
         }
+    }
+
+    #[test]
+    fn aggregate_canonical_inventory_counts_only_current_per_source_snapshots() {
+        let observed_at = DateTime::<Utc>::from_timestamp(1_800_000_300, 0).unwrap();
+        let fresh_generated_at = DateTime::<Utc>::from_timestamp(1_800_000_100, 0).unwrap();
+        let stale_generated_at = DateTime::<Utc>::from_timestamp(1_799_990_000, 0).unwrap();
+        let healthy_open_competition = {
+            let (events, profile) = open_competition_fixture();
+            open_competition_opportunities(
+                &events,
+                &profile,
+                "base-mainnet",
+                "https://api.example",
+                "https://www.example",
+                100,
+                observed_at,
+            )
+            .unwrap()
+            .remove(0)
+        };
+
+        let (included, aggregate, errors) = aggregate_canonical_inventory(
+            vec![
+                CanonicalSourceContribution {
+                    items: vec![canonical_opportunity(
+                        &canonical("claimable", "1000000", true),
+                        "base-mainnet",
+                        "https://api.example",
+                    )
+                    .unwrap()],
+                    metadata: Some(InventorySnapshotMetadata {
+                        generated_at: stale_generated_at,
+                        source_available: false,
+                        source_error: Some("autonomous_indexer_heartbeat_unhealthy".to_string()),
+                    }),
+                    load_error: None,
+                },
+                CanonicalSourceContribution {
+                    items: vec![healthy_open_competition],
+                    metadata: Some(InventorySnapshotMetadata {
+                        generated_at: fresh_generated_at,
+                        source_available: true,
+                        source_error: None,
+                    }),
+                    load_error: None,
+                },
+            ],
+            observed_at,
+        );
+        assert_eq!(errors, vec!["autonomous_indexer_heartbeat_unhealthy"]);
+        assert!(aggregate.source_available);
+        assert_eq!(aggregate.generated_at, fresh_generated_at);
+        assert_eq!(included.len(), 1);
+        let breakdown = inventory_state_breakdown_v1(&included, aggregate, observed_at);
+        assert!(breakdown.source_available);
+    }
+
+    #[test]
+    fn aggregate_canonical_inventory_reports_joined_errors_when_no_source_is_current() {
+        let observed_at = DateTime::<Utc>::from_timestamp(1_800_000_300, 0).unwrap();
+        let (included, aggregate, errors) = aggregate_canonical_inventory(
+            vec![
+                CanonicalSourceContribution {
+                    items: Vec::new(),
+                    metadata: Some(InventorySnapshotMetadata {
+                        generated_at: observed_at,
+                        source_available: false,
+                        source_error: Some("autonomous_indexer_heartbeat_unhealthy".to_string()),
+                    }),
+                    load_error: None,
+                },
+                CanonicalSourceContribution {
+                    items: Vec::new(),
+                    metadata: None,
+                    load_error: Some("open_competition_read_model_unavailable".to_string()),
+                },
+            ],
+            observed_at,
+        );
+        assert!(included.is_empty());
+        assert!(!aggregate.source_available);
+        assert_eq!(
+            aggregate.source_error.as_deref(),
+            Some("autonomous_indexer_heartbeat_unhealthy+open_competition_read_model_unavailable")
+        );
+        assert_eq!(errors.len(), 2);
+        let breakdown = inventory_state_breakdown_v1(&included, aggregate, observed_at);
+        assert!(!breakdown.source_available);
+        assert_eq!(breakdown.ready_to_earn, 0);
+    }
+
+    #[test]
+    fn aggregate_canonical_inventory_skips_disabled_sources_without_masking_health() {
+        let observed_at = DateTime::<Utc>::from_timestamp(1_800_000_300, 0).unwrap();
+        let generated_at = DateTime::<Utc>::from_timestamp(1_800_000_250, 0).unwrap();
+        let (included, aggregate, errors) = aggregate_canonical_inventory(
+            vec![
+                CanonicalSourceContribution {
+                    items: vec![canonical_opportunity(
+                        &canonical("claimable", "1000000", true),
+                        "base-mainnet",
+                        "https://api.example",
+                    )
+                    .unwrap()],
+                    metadata: Some(InventorySnapshotMetadata {
+                        generated_at,
+                        source_available: true,
+                        source_error: None,
+                    }),
+                    load_error: None,
+                },
+                CanonicalSourceContribution {
+                    items: Vec::new(),
+                    metadata: None,
+                    load_error: None,
+                },
+            ],
+            observed_at,
+        );
+        assert!(errors.is_empty());
+        assert!(aggregate.source_available);
+        assert_eq!(aggregate.generated_at, generated_at);
+        assert_eq!(included.len(), 1);
     }
 
     #[test]

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -14,6 +14,8 @@ use utoipa::ToSchema;
 use web_public::escape_html;
 
 pub const OPPORTUNITY_PROJECTION_SCHEMA: &str = "agent-bounties/opportunity-projection-v1";
+pub const INVENTORY_STATE_BREAKDOWN_SCHEMA: &str = "agent-bounties/inventory-state-breakdown-v1";
+const INVENTORY_SNAPSHOT_MAX_AGE_SECONDS: i64 = 300;
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct OpportunityQuery {
@@ -221,6 +223,30 @@ pub struct OpportunitySourceStatus {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct InventoryStateBreakdownV1 {
+    pub schema_version: String,
+    pub generated_at: String,
+    pub observed_at: String,
+    pub source: String,
+    pub source_available: bool,
+    pub source_degraded: bool,
+    pub source_status: String,
+    pub source_error: Option<String>,
+    pub ready_to_earn: usize,
+    pub in_progress: usize,
+    pub submitted: usize,
+    pub paid: usize,
+    pub verification_unavailable: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InventorySnapshotMetadata {
+    pub generated_at: DateTime<Utc>,
+    pub source_available: bool,
+    pub source_error: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct OpportunityProjectionResponse {
     pub schema_version: String,
@@ -229,6 +255,7 @@ pub struct OpportunityProjectionResponse {
     pub applied_view: Option<String>,
     pub degraded: bool,
     pub source_statuses: Vec<OpportunitySourceStatus>,
+    pub inventory_state_breakdown: InventoryStateBreakdownV1,
     pub items: Vec<OpportunityItem>,
     pub evidence_boundary: String,
 }
@@ -1202,6 +1229,77 @@ fn json_u64(value: &Value, field: &str) -> Result<u64, String> {
         .map_err(|_| format!("open-competition event field {field} is out of range"))
 }
 
+/// Derive every lifecycle count from one unfiltered canonical projection.
+///
+/// A missing, degraded, future-dated, or stale source fails closed: the
+/// response retains explicit source status but does not advertise partial
+/// inventory as current.
+pub fn inventory_state_breakdown_v1(
+    items: &[OpportunityItem],
+    metadata: InventorySnapshotMetadata,
+    observed_at: DateTime<Utc>,
+) -> InventoryStateBreakdownV1 {
+    let age_seconds = observed_at
+        .signed_duration_since(metadata.generated_at)
+        .num_seconds();
+    let snapshot_fresh = (0..=INVENTORY_SNAPSHOT_MAX_AGE_SECONDS).contains(&age_seconds);
+    let source_available = metadata.source_available && snapshot_fresh;
+    let source_status = if !metadata.source_available {
+        "degraded"
+    } else if !snapshot_fresh {
+        "stale"
+    } else {
+        "current"
+    };
+    let source_error = if !metadata.source_available {
+        metadata
+            .source_error
+            .or_else(|| Some("canonical_source_unavailable".to_string()))
+    } else if !snapshot_fresh {
+        Some("canonical_snapshot_stale".to_string())
+    } else {
+        None
+    };
+
+    let mut breakdown = InventoryStateBreakdownV1 {
+        schema_version: INVENTORY_STATE_BREAKDOWN_SCHEMA.to_string(),
+        generated_at: metadata.generated_at.to_rfc3339(),
+        observed_at: observed_at.to_rfc3339(),
+        source: "canonical_base".to_string(),
+        source_available,
+        source_degraded: !source_available,
+        source_status: source_status.to_string(),
+        source_error,
+        ready_to_earn: 0,
+        in_progress: 0,
+        submitted: 0,
+        paid: 0,
+        verification_unavailable: 0,
+    };
+    if !source_available {
+        return breakdown;
+    }
+
+    for item in items
+        .iter()
+        .filter(|item| item.source_type == "canonical_base")
+    {
+        if is_ready_to_earn_item(item) {
+            breakdown.ready_to_earn += 1;
+        }
+        match item.work_state.as_str() {
+            "in_progress" => breakdown.in_progress += 1,
+            "submitted" => breakdown.submitted += 1,
+            "completed" if item.payment_state == "paid" => breakdown.paid += 1,
+            _ => {}
+        }
+        if !item.verification_ready && item.work_state != "completed" {
+            breakdown.verification_unavailable += 1;
+        }
+    }
+    breakdown
+}
+
 pub fn apply_query(
     mut items: Vec<OpportunityItem>,
     query: &OpportunityQuery,
@@ -1259,15 +1357,7 @@ fn apply_view(item: &mut OpportunityItem, view: OpportunityView, now: DateTime<U
             matches
         }
         OpportunityView::ReadyToEarn => {
-            let matches = item.work_state == "claimable"
-                && item.payment_state == "escrowed"
-                && item.payment_committed
-                && item.verification_ready
-                && (item.source_type != "canonical_base"
-                    || item
-                        .cash_economics
-                        .as_ref()
-                        .is_some_and(|economics| economics.gross_cash_margin_positive));
+            let matches = is_ready_to_earn_item(item);
             if matches {
                 item.discovery_factors.push(
                     "view:ready_to_earn;factors=claimable+escrowed+verification_ready+positive_gross_cash_margin".to_string(),
@@ -1276,6 +1366,18 @@ fn apply_view(item: &mut OpportunityItem, view: OpportunityView, now: DateTime<U
             matches
         }
     }
+}
+
+fn is_ready_to_earn_item(item: &OpportunityItem) -> bool {
+    item.work_state == "claimable"
+        && item.payment_state == "escrowed"
+        && item.payment_committed
+        && item.verification_ready
+        && (item.source_type != "canonical_base"
+            || item
+                .cash_economics
+                .as_ref()
+                .is_some_and(|economics| economics.gross_cash_margin_positive))
 }
 
 fn taxonomy_view(item: &mut OpportunityItem, view: &str) -> bool {
@@ -1543,6 +1645,36 @@ mod tests {
     };
     use uuid::Uuid;
 
+    #[derive(serde::Deserialize)]
+    struct InventoryFixture {
+        generated_at: String,
+        observed_at: String,
+        source_available: bool,
+        source_error: Option<String>,
+        items: Vec<InventoryFixtureItem>,
+        expected: InventoryFixtureExpected,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct InventoryFixtureItem {
+        status: String,
+        funded: String,
+        verification_ready: bool,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct InventoryFixtureExpected {
+        source_available: bool,
+        source_degraded: bool,
+        source_status: String,
+        source_error: Option<String>,
+        ready_to_earn: usize,
+        in_progress: usize,
+        submitted: usize,
+        paid: usize,
+        verification_unavailable: usize,
+    }
+
     fn trial() -> TrialBounty {
         let created_at = DateTime::<Utc>::from_timestamp(1_800_000_000, 0).unwrap();
         TrialBounty {
@@ -1802,6 +1934,91 @@ mod tests {
     }
 
     #[test]
+    fn inventory_state_breakdown_uses_production_projector_for_all_fixtures() {
+        let fixtures = [
+            (
+                "empty",
+                include_str!("../../../scripts/fixtures/inventory-state-breakdown/empty.json"),
+            ),
+            (
+                "mixed",
+                include_str!("../../../scripts/fixtures/inventory-state-breakdown/mixed.json"),
+            ),
+            (
+                "degraded",
+                include_str!("../../../scripts/fixtures/inventory-state-breakdown/degraded.json"),
+            ),
+            (
+                "stale",
+                include_str!("../../../scripts/fixtures/inventory-state-breakdown/stale.json"),
+            ),
+        ];
+
+        for (name, fixture) in fixtures {
+            let fixture: InventoryFixture = serde_json::from_str(fixture).unwrap();
+            let items = fixture
+                .items
+                .iter()
+                .map(|item| {
+                    canonical_opportunity(
+                        &canonical(&item.status, &item.funded, item.verification_ready),
+                        "base-mainnet",
+                        "https://api.example",
+                    )
+                    .unwrap()
+                })
+                .collect::<Vec<_>>();
+            let generated_at = DateTime::parse_from_rfc3339(&fixture.generated_at)
+                .unwrap()
+                .with_timezone(&Utc);
+            let observed_at = DateTime::parse_from_rfc3339(&fixture.observed_at)
+                .unwrap()
+                .with_timezone(&Utc);
+            let actual = inventory_state_breakdown_v1(
+                &items,
+                InventorySnapshotMetadata {
+                    generated_at,
+                    source_available: fixture.source_available,
+                    source_error: fixture.source_error,
+                },
+                observed_at,
+            );
+            let expected = fixture.expected;
+
+            assert_eq!(
+                actual.schema_version, INVENTORY_STATE_BREAKDOWN_SCHEMA,
+                "{name}"
+            );
+            assert_eq!(actual.source_available, expected.source_available, "{name}");
+            assert_eq!(actual.source_degraded, expected.source_degraded, "{name}");
+            assert_eq!(actual.source_status, expected.source_status, "{name}");
+            assert_eq!(actual.source_error, expected.source_error, "{name}");
+            assert_eq!(actual.ready_to_earn, expected.ready_to_earn, "{name}");
+            assert_eq!(actual.in_progress, expected.in_progress, "{name}");
+            assert_eq!(actual.submitted, expected.submitted, "{name}");
+            assert_eq!(actual.paid, expected.paid, "{name}");
+            assert_eq!(
+                actual.verification_unavailable, expected.verification_unavailable,
+                "{name}"
+            );
+
+            if name == "mixed" {
+                let ready_items = apply_query(
+                    items,
+                    &OpportunityQuery {
+                        view: Some("ready_to_earn".to_string()),
+                        source_type: Some("canonical_base".to_string()),
+                        ..OpportunityQuery::default()
+                    },
+                    Some(OpportunityView::ReadyToEarn),
+                    observed_at,
+                );
+                assert_eq!(actual.ready_to_earn, ready_items.len());
+            }
+        }
+    }
+
+    #[test]
     fn public_open_competition_is_primary_ready_to_earn_mode() {
         let (events, profile) = open_competition_fixture();
         let item = open_competition_opportunities(
@@ -2046,6 +2263,19 @@ mod tests {
             applied_view: None,
             degraded: false,
             source_statuses: Vec::new(),
+            inventory_state_breakdown: inventory_state_breakdown_v1(
+                &[],
+                InventorySnapshotMetadata {
+                    generated_at: DateTime::parse_from_rfc3339("2027-01-15T08:01:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    source_available: true,
+                    source_error: None,
+                },
+                DateTime::parse_from_rfc3339("2027-01-15T08:01:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
             items: vec![item],
             evidence_boundary: "Projection only".to_string(),
         };
@@ -2083,6 +2313,19 @@ mod tests {
             applied_view: None,
             degraded: false,
             source_statuses: Vec::new(),
+            inventory_state_breakdown: inventory_state_breakdown_v1(
+                std::slice::from_ref(&item),
+                InventorySnapshotMetadata {
+                    generated_at: DateTime::parse_from_rfc3339("2027-01-15T08:01:00Z")
+                        .unwrap()
+                        .with_timezone(&Utc),
+                    source_available: true,
+                    source_error: None,
+                },
+                DateTime::parse_from_rfc3339("2027-01-15T08:01:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
             items: vec![item],
             evidence_boundary: "Projection only".to_string(),
         };

--- a/scripts/check-inventory-state-breakdown.py
+++ b/scripts/check-inventory-state-breakdown.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Deterministic acceptance checks for inventory-state-breakdown-v1."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", Path(__file__).resolve().parents[1]))
+FIXTURES = ROOT / "scripts" / "fixtures" / "inventory-state-breakdown"
+SCHEMA = "agent-bounties/inventory-state-breakdown-v1"
+MAX_AGE_SECONDS = 300
+COUNT_FIELDS = (
+    "ready_to_earn",
+    "in_progress",
+    "submitted",
+    "paid",
+    "verification_unavailable",
+)
+
+
+def parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def project(snapshot: dict[str, Any]) -> dict[str, Any]:
+    generated_at = parse_time(snapshot["generated_at"])
+    observed_at = parse_time(snapshot["observed_at"])
+    age_seconds = (observed_at - generated_at).total_seconds()
+    source_declared_available = snapshot["source_available"] is True
+    fresh = 0 <= age_seconds <= MAX_AGE_SECONDS
+    source_available = source_declared_available and fresh
+    source_status = (
+        "degraded"
+        if not source_declared_available
+        else "stale"
+        if not fresh
+        else "current"
+    )
+    source_error = snapshot.get("source_error")
+    if not source_declared_available and not source_error:
+        source_error = "canonical_source_unavailable"
+    elif source_declared_available and not fresh:
+        source_error = "canonical_snapshot_stale"
+
+    counts = {field: 0 for field in COUNT_FIELDS}
+    if source_available:
+        for item in snapshot["items"]:
+            status = item["status"]
+            verification_ready = item["verification_ready"] is True
+            fully_funded = int(item["funded"]) >= 1_000_000
+            if status == "claimable" and fully_funded and verification_ready:
+                counts["ready_to_earn"] += 1
+            if status == "claimed":
+                counts["in_progress"] += 1
+            elif status == "submitted":
+                counts["submitted"] += 1
+            elif status == "paid":
+                counts["paid"] += 1
+            if not verification_ready and status != "paid":
+                counts["verification_unavailable"] += 1
+
+    return {
+        "schema_version": SCHEMA,
+        "generated_at": snapshot["generated_at"],
+        "observed_at": snapshot["observed_at"],
+        "source": "canonical_base",
+        "source_available": source_available,
+        "source_degraded": not source_available,
+        "source_status": source_status,
+        "source_error": source_error,
+        **counts,
+    }
+
+
+def check_fixture(name: str) -> None:
+    fixture = json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+    actual = project(fixture)
+    expected = fixture["expected"]
+    for field, value in expected.items():
+        if actual.get(field) != value:
+            raise AssertionError(
+                f"{name}: {field} expected {value!r}, got {actual.get(field)!r}"
+            )
+    for field in COUNT_FIELDS:
+        if not isinstance(actual[field], int) or actual[field] < 0:
+            raise AssertionError(f"{name}: {field} must be a non-negative integer")
+
+
+def check_production_wiring() -> None:
+    opportunities = (ROOT / "crates/api/src/opportunities.rs").read_text(encoding="utf-8")
+    main = (ROOT / "crates/api/src/main.rs").read_text(encoding="utf-8")
+    home = (ROOT / "site/home.js").read_text(encoding="utf-8")
+
+    required_opportunity_fragments = (
+        "agent-bounties/inventory-state-breakdown-v1",
+        "pub fn inventory_state_breakdown_v1",
+        "fn is_ready_to_earn_item",
+        "canonical_snapshot_stale",
+    )
+    for fragment in required_opportunity_fragments:
+        if fragment not in opportunities:
+            raise AssertionError(f"production projector is missing {fragment}")
+    if main.count("inventory_state_breakdown_v1(") != 1:
+        raise AssertionError("API must attach exactly one production inventory breakdown")
+    if "const breakdown = inventoryStateBreakdown(readyProjection);" not in home:
+        raise AssertionError("homepage must consume the ready response's server breakdown")
+    if any(f"breakdown.{field} =" in home for field in COUNT_FIELDS):
+        raise AssertionError("homepage must not overwrite server inventory counts")
+    if "inventory snapshot drift" not in home.lower():
+        raise AssertionError("homepage must surface ready-view drift separately")
+
+
+def main() -> int:
+    try:
+        check_production_wiring()
+        for fixture in ("empty", "mixed", "degraded", "stale"):
+            check_fixture(fixture)
+    except (AssertionError, KeyError, TypeError, ValueError, OSError) as error:
+        print(f"inventory-state breakdown check failed: {error}", file=sys.stderr)
+        return 1
+    print("inventory-state breakdown acceptance checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fixtures/inventory-state-breakdown/degraded.json
+++ b/scripts/fixtures/inventory-state-breakdown/degraded.json
@@ -1,0 +1,21 @@
+{
+  "generated_at": "2026-08-11T02:00:00Z",
+  "observed_at": "2026-08-11T02:00:30Z",
+  "source_available": false,
+  "source_error": "canonical_read_model_unavailable",
+  "items": [
+    {"status": "claimable", "funded": "1000000", "verification_ready": true},
+    {"status": "claimed", "funded": "1000000", "verification_ready": true}
+  ],
+  "expected": {
+    "source_available": false,
+    "source_degraded": true,
+    "source_status": "degraded",
+    "source_error": "canonical_read_model_unavailable",
+    "ready_to_earn": 0,
+    "in_progress": 0,
+    "submitted": 0,
+    "paid": 0,
+    "verification_unavailable": 0
+  }
+}

--- a/scripts/fixtures/inventory-state-breakdown/empty.json
+++ b/scripts/fixtures/inventory-state-breakdown/empty.json
@@ -1,0 +1,18 @@
+{
+  "generated_at": "2026-08-11T02:00:00Z",
+  "observed_at": "2026-08-11T02:00:30Z",
+  "source_available": true,
+  "source_error": null,
+  "items": [],
+  "expected": {
+    "source_available": true,
+    "source_degraded": false,
+    "source_status": "current",
+    "source_error": null,
+    "ready_to_earn": 0,
+    "in_progress": 0,
+    "submitted": 0,
+    "paid": 0,
+    "verification_unavailable": 0
+  }
+}

--- a/scripts/fixtures/inventory-state-breakdown/mixed.json
+++ b/scripts/fixtures/inventory-state-breakdown/mixed.json
@@ -1,0 +1,24 @@
+{
+  "generated_at": "2026-08-11T02:00:00Z",
+  "observed_at": "2026-08-11T02:00:30Z",
+  "source_available": true,
+  "source_error": null,
+  "items": [
+    {"status": "claimable", "funded": "1000000", "verification_ready": true},
+    {"status": "claimed", "funded": "1000000", "verification_ready": true},
+    {"status": "submitted", "funded": "1000000", "verification_ready": true},
+    {"status": "paid", "funded": "1000000", "verification_ready": true},
+    {"status": "claimable", "funded": "1000000", "verification_ready": false}
+  ],
+  "expected": {
+    "source_available": true,
+    "source_degraded": false,
+    "source_status": "current",
+    "source_error": null,
+    "ready_to_earn": 1,
+    "in_progress": 1,
+    "submitted": 1,
+    "paid": 1,
+    "verification_unavailable": 1
+  }
+}

--- a/scripts/fixtures/inventory-state-breakdown/stale.json
+++ b/scripts/fixtures/inventory-state-breakdown/stale.json
@@ -1,0 +1,21 @@
+{
+  "generated_at": "2026-08-11T01:50:00Z",
+  "observed_at": "2026-08-11T02:00:00Z",
+  "source_available": true,
+  "source_error": null,
+  "items": [
+    {"status": "claimable", "funded": "1000000", "verification_ready": true},
+    {"status": "paid", "funded": "1000000", "verification_ready": true}
+  ],
+  "expected": {
+    "source_available": false,
+    "source_degraded": true,
+    "source_status": "stale",
+    "source_error": "canonical_snapshot_stale",
+    "ready_to_earn": 0,
+    "in_progress": 0,
+    "submitted": 0,
+    "paid": 0,
+    "verification_unavailable": 0
+  }
+}

--- a/site/home.js
+++ b/site/home.js
@@ -530,22 +530,48 @@
     return marketState.protocolPromise;
   }
 
+  function inventoryStateBreakdown(projection) {
+    const breakdown = projection && projection.inventory_state_breakdown;
+    const countFields = [
+      "ready_to_earn",
+      "in_progress",
+      "submitted",
+      "paid",
+      "verification_unavailable",
+    ];
+    if (!breakdown
+      || breakdown.schema_version !== "agent-bounties/inventory-state-breakdown-v1"
+      || breakdown.source !== "canonical_base"
+      || countFields.some((field) => !Number.isSafeInteger(breakdown[field]) || breakdown[field] < 0)) {
+      throw new Error("Canonical inventory breakdown is unavailable.");
+    }
+    if (!breakdown.source_available || breakdown.source_degraded) {
+      throw new Error(`Canonical inventory source is ${breakdown.source_status || "unavailable"}.`);
+    }
+    if (!Number.isFinite(Date.parse(breakdown.generated_at))) {
+      throw new Error("Canonical inventory timestamp is invalid.");
+    }
+    return breakdown;
+  }
+
   function renderMarketSnapshot(protocol, projection, readyProjection, claim, metrics) {
     const container = document.getElementById("home-live-inventory");
     const heroSummary = document.querySelector("[data-home-inventory-summary]");
     const detail = document.querySelector("[data-home-inventory-detail]");
     const proof = document.querySelector("[data-market-proof]");
-    const items = projection.items || [];
     const readyItems = readyProjection.items || [];
+    const breakdown = inventoryStateBreakdown(readyProjection);
+    const readyCanonicalSource = (readyProjection.source_statuses || [])
+      .find((source) => source.source_type === "canonical_base");
     if (readyProjection.applied_view !== "ready_to_earn"
-      || readyProjection.degraded
+      || !readyCanonicalSource
+      || !readyCanonicalSource.available
       || readyItems.some((item) => !isReadyToEarn(item))) {
       throw new Error("Live earning inventory failed its claimability gate.");
     }
-    const referenceAt = new Date(metrics.generated_at || claim.generated_at || projection.generated_at);
+    const inventoryDrift = breakdown.ready_to_earn !== readyItems.length;
+    const referenceAt = new Date(breakdown.generated_at);
     const oneWeekAgo = referenceAt.getTime() - (7 * 24 * 60 * 60 * 1_000);
-    const inProgressItems = items.filter((item) => item.source_type === "canonical_base"
-      && (item.work_state === "in_progress" || item.work_state === "submitted"));
     const addedThisWeek = readyItems.filter((item) => {
       const created = Date.parse(item.created_at);
       return Number.isFinite(created) && created >= oneWeekAgo;
@@ -562,21 +588,20 @@
         : total;
     }, 0);
     const activeContributors = Number(claim?.canonical_outcomes?.unique_paid_solver_wallets) || 0;
-
-    setMetric("ready", readyItems.length);
+    setMetric("ready", breakdown.ready_to_earn);
     setMetricText(
       "[data-adoption-ready-weekly]",
-      `${formatMetric(addedThisWeek, 0)} added this week · ${formatMetric(inProgressItems.length, 0)} in progress`,
+      `${formatMetric(addedThisWeek, 0)} added this week · ${formatMetric(breakdown.in_progress + breakdown.submitted, 0)} in progress`,
     );
     setMetric("available", transactionVolumeUsdc, 2);
     setMetric("settled", settlements);
     setMetricText("[data-adoption-settled-weekly]", `+${formatMetric(solvedThisWeek, 0)} this week`);
     setMetric("paid", activeContributors);
-    setMetricText("[data-board-active]", formatMetric(readyItems.length, 0));
+    setMetricText("[data-board-active]", formatMetric(breakdown.ready_to_earn, 0));
     renderOpportunityBoard(container, readyItems);
 
     if (heroSummary) {
-      heroSummary.textContent = `${readyItems.length} bounties ready to claim · ${formatMetric(transactionVolumeUsdc, 2)} USDC canonical payout · ${settlements} settlement events`;
+      heroSummary.textContent = `${breakdown.ready_to_earn} bounties ready to claim · ${formatMetric(transactionVolumeUsdc, 2)} USDC canonical payout · ${settlements} settlement events`;
     }
     const sourceStatuses = projection.source_statuses || [];
     const availableSources = sourceStatuses.filter((source) => source.available).length;
@@ -585,9 +610,14 @@
       .map((source) => source.source_type);
     const protocolStatus = protocol.status === "active" ? "Base mainnet active" : "Canonical protocol not active";
     if (detail) {
-      detail.textContent = unavailable.length
-        ? `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · delayed: ${unavailable.join(", ")}`
-        : `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · server-pushed live stream`;
+      const counts = `${breakdown.ready_to_earn} ready · ${breakdown.in_progress} in progress · ${breakdown.submitted} submitted · ${breakdown.paid} paid · ${breakdown.verification_unavailable} verification unavailable`;
+      const inventoryWarning = inventoryDrift
+        ? ` · inventory snapshot drift: board ${readyItems.length}, snapshot ${breakdown.ready_to_earn}`
+        : "";
+      const sourceWarning = unavailable.length
+        ? ` · other delayed sources: ${unavailable.join(", ")}`
+        : "";
+      detail.textContent = `${protocolStatus} · ${counts} · ${availableSources}/${sourceStatuses.length} sources online${inventoryWarning}${sourceWarning}`;
     }
 
     if (proof && settlements > 0) {
@@ -597,6 +627,7 @@
       proof.hidden = true;
     }
     marketState.evidenceGeneratedAt = referenceAt;
+    return { inventoryDrift };
   }
 
   async function refreshMarket() {
@@ -633,11 +664,17 @@
       marketState.readyProjection = readyProjection;
       marketState.claim = claim;
       marketState.metrics = metrics;
-      renderMarketSnapshot(protocol, projection, readyProjection, claim, metrics);
+      const renderState = renderMarketSnapshot(
+        protocol,
+        projection,
+        readyProjection,
+        claim,
+        metrics,
+      );
       marketState.lastReceivedAt = Date.now();
       marketState.rendered = true;
       if (firstLiveMarketView) track("market_view");
-      setMarketStatus(projection.degraded ? "delayed" : "live");
+      setMarketStatus(renderState.inventoryDrift ? "delayed" : "live");
     } catch (error) {
       setMarketStatus("delayed");
       marketState.fingerprint = "";
@@ -669,7 +706,7 @@
           refreshMarket();
           return;
         }
-        renderMarketSnapshot(
+        const renderState = renderMarketSnapshot(
           protocol,
           marketState.projection,
           readyProjection,
@@ -678,7 +715,8 @@
         );
         marketState.lastReceivedAt = Date.now();
         marketState.rendered = true;
-        setMarketStatus("live");
+        setMarketStatus(renderState.inventoryDrift ? "delayed" : "live");
+        if (renderState.inventoryDrift) refreshMarket();
         updateMarketClock();
       } catch (_error) {
         marketState.lastReceivedAt = null;


### PR DESCRIPTION
## Summary

- add a versioned, server-owned inventory-state breakdown to the opportunities projection
- reuse the strict ready-to-earn predicate and fail closed when the canonical indexer heartbeat is missing, degraded, future-dated, or stale
- consume the unchanged server breakdown on the homepage and report snapshot drift separately
- add four real-projector fixtures covering empty, mixed, degraded, and stale inventory states

## Why

Clients previously had to derive lifecycle counts independently, while aggregate health could mix unrelated source failures into the canonical ready-to-earn view. This gives clients one canonical snapshot with explicit provenance and health metadata without changing filtering behavior.

## Impact

The response adds `agent-bounties/inventory-state-breakdown-v1` under `inventory_state_breakdown`. Existing response fields remain compatible. The homepage no longer invents or overwrites lifecycle counts.

## Verification

- `cargo fmt --all -- --check`
- `node --check site/home.js`
- `WORKSPACE_ROOT=. python3 benchmarks/direct-inventory-v1/inventory-breakdown/check.py`
- `python scripts/check-site.py` in an isolated environment using `scripts/requirements-site.txt`
- `cargo run -p cli -- docs-contract-check`
- `cargo test -p api` (138 passed, 4 database-only tests ignored)

The repository `scripts/preflight.sh core` wrapper cannot start under macOS Bash 3.2 because its empty-array expansion trips `set -u`; the constituent relevant gates above were run directly.

## Bounty evidence

- discovery_source: GitHub issue and the Agent Bounties canonical ready-to-earn feed during an operator-directed bounty scan.
- participation_reason: Canonically funded claim, narrow scope, immutable executable benchmark, and explicit payment evidence.
- improvement_feedback: Show verifier archive-size preflight and current signer liveness before a solver starts the claim clock.

Payment is considered complete only after a canonical `BountySettled` event.

Closes #870