### PR TITLE
Recover Beta3 Sepolia attempt 9 actors

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -37,7 +37,7 @@ jobs:
             --deployer "$BASE_DEPLOYER_ADDRESS" \
             --source-commit 4d09d82825c38f2bf93a8ee4375a95b302410c29 \
             --run-id 32147289466 \
-            --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 --attempt 7 \
+            --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 --attempt 7 --attempt 8 --attempt 9 \
             --additional-actor-scope b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
             --funding-competition 0x702b2be0254b7a363d4bfb4e9b72d9424bbe4a8e \
@@ -47,6 +47,8 @@ jobs:
             --required-actor 0xdecc449c2af3ec13e348fc920451afa770eee2b5 \
             --required-actor 0xc4d6fa88149d31f6e5f8e46cd71f4c814ffe8526 \
             --required-actor 0xa62a0da47f22e85d688d101ecfc0220f338f5527 \
+            --required-actor 0x3a9119736afe7f1d77d591540a3ca18c197f7df5 \
+            --required-actor 0xfeddf1b81c5cdef4f749c71e67a19343e3ab3c55 \
             --output target/beta3-sepolia-rehearsal-recovery.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:


### PR DESCRIPTION
## Summary
- include protected release attempts 8 and 9 in the exact recovery scope
- require the two attempt-9 derived actor addresses before any sweep
- preserve the existing fixed release run, source commit, competition, and minimum reserve checks

## Evidence
- attempt 9 completed Groth16 and both PLONK proofs
- first approval failed at transport before broadcast; both actor nonces remain zero
- python scripts/test_recover_open_competition_v2_rehearsal_funds.py passes (5 tests)
- Base Sepolia environment now uses the official endpoint for the rerun

Mainnet remains untouched. This PR only expands the testnet recovery allowlist.