### PR TITLE
Recover Beta3 attempt 9 funding escrow

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -41,6 +41,7 @@ jobs:
             --additional-actor-scope b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
             --funding-competition 0x702b2be0254b7a363d4bfb4e9b72d9424bbe4a8e \
+            --funding-competition 0x23cec46243ad1b849086f3af78744bb2654e6800 \
             --required-actor 0xf723d4ac02331707f39bc9416b11ec25a73743f1 \
             --required-actor 0x300775bb9ae722e94280637c4547260f1708afc3 \
             --required-actor 0xfe9ba5613c36365fdeed32cbe92b2a644fa0f2a3 \


### PR DESCRIPTION
## Summary
- add the exact attempt-9 funding-phase competition to the protected recovery allowlist
- let the existing creator-only cancel and contributor refund path restore its 0.10 test USDC

## Canonical evidence
- factory: 