### PR TITLE
ops: recover Beta3 rehearsal attempt 14

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -37,9 +37,10 @@ jobs:
             --deployer "$BASE_DEPLOYER_ADDRESS" \
             --source-commit 4d09d82825c38f2bf93a8ee4375a95b302410c29 \
             --run-id 32147289466 \
-            --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 --attempt 7 --attempt 8 --attempt 9 --attempt 12 \
+            --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 --attempt 7 --attempt 8 --attempt 9 --attempt 12 --attempt 14 \
             --additional-actor-scope b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
+            --competition 0x569fc0c653c81dfaca73467a7496c098a620f501 \
             --funding-competition 0x702b2be0254b7a363d4bfb4e9b72d9424bbe4a8e \
             --funding-competition 0x23cec46243ad1b849086f3af78744bb2654e6800 \
             --required-actor 0xf723d4ac02331707f39bc9416b11ec25a73743f1 \
@@ -52,6 +53,8 @@ jobs:
             --required-actor 0xfeddf1b81c5cdef4f749c71e67a19343e3ab3c55 \
             --required-actor 0x7fe6e588f8ef039d7e5ecb3ecc537145637b4437 \
             --required-actor 0xc93766c8037783663d0c88e54e1c09db206c41ed \
+            --required-actor 0x54a188c7ef1e295b3e0f3fb2d33010b18679687b \
+            --required-actor 0x6ab2e7d3f38236411c6d848dcd5cc8710efc359e \
             --output target/beta3-sepolia-rehearsal-recovery.json
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:


### PR DESCRIPTION
## Scope
- allow exact protected release attempt 14 actor derivation
- expire/refund the exact active no-leader best-score competition after its proof deadline
- require both independently derived attempt-14 actor addresses

## Canonical state before recovery
- first-proven canary settled and paid generated solver A
- best-score escrow: 0.2625 test USDC, no leader, expired 90-second proof window
- production Base mainnet budget untouched

## Verification
- python scripts/test_recover_open_competition_v2_rehearsal_funds.py
- git diff --check

Public notice: https://github.com/NSPG13/agent-bounties/issues/888#issuecomment-5339897268