### PR TITLE
Expose canonical inventory-state breakdown

### DIFF
--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "a386a6dc2e408ef7cf58fd77e9d28560c87dc8f01e98cce955e346c8ba6e3efb"
+  "normalized_sha256": "13e5c6349b3aa6adb67c3acd5da2a1fc804dfd6bd7b5b91ebe473d0f564826c4"
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -131,10 +131,11 @@ use github_discovery::{
 };
 use hmac::{Hmac, Mac};
 use opportunities::{
-    apply_query as apply_opportunity_query, canonical_opportunity, legacy_opportunity,
-    open_competition_opportunities, render_opportunity_feeds, unfunded_opportunity,
-    OpportunityItem, OpportunityProjectionResponse, OpportunityQuery, OpportunitySourceStatus,
-    OpportunityView, OPPORTUNITY_PROJECTION_SCHEMA,
+    apply_query as apply_opportunity_query, canonical_opportunity, inventory_state_breakdown,
+    legacy_opportunity, open_competition_opportunities, render_opportunity_feeds,
+    unfunded_opportunity, InventoryStateBreakdown, InventoryStateBreakdownSource, OpportunityItem,
+    OpportunityProjectionResponse, OpportunityQuery, OpportunitySourceStatus, OpportunityView,
+    OPPORTUNITY_PROJECTION_SCHEMA,
 };
 use payments_stripe::{
     apply_checkout_payment_method_configuration, execute_stripe_request, verify_webhook_signature,
@@ -417,6 +418,8 @@ use worker::{
         ,CloudUnfundedBountyRequest
         ,CloudDemoSolution
         ,OpportunityProjectionResponse
+        ,InventoryStateBreakdown
+        ,InventoryStateBreakdownSource
         ,OpportunityItem
         ,opportunities::OpportunityAmount
         ,opportunities::OpportunityNextAction
@@ -4359,14 +4362,18 @@ async fn build_opportunity_projection(
     });
     items.extend(canonical_items);
 
+    let generated_at = now.to_rfc3339();
+    let inventory_state_breakdown =
+        inventory_state_breakdown(&items, &source_statuses, &generated_at);
     let items = apply_opportunity_query(items, &query, view, now);
     Ok(OpportunityProjectionResponse {
         schema_version: OPPORTUNITY_PROJECTION_SCHEMA.to_string(),
-        generated_at: now.to_rfc3339(),
+        generated_at,
         network: network.to_string(),
         applied_view: view.map(|view| view.as_str().to_string()),
         degraded: source_statuses.iter().any(|source| !source.available),
         source_statuses,
+        inventory_state_breakdown,
         items,
         evidence_boundary: "This endpoint is a read-only projection. Each listed source remains authoritative for its own records; the projection cannot create funding, claims, verification, settlement, or payment evidence. Only confirmed canonical BountySettled proves autonomous-v1 solver payment.".to_string(),
     })

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -221,6 +221,27 @@ pub struct OpportunitySourceStatus {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct InventoryStateBreakdownSource {
+    pub source_type: String,
+    pub available: bool,
+    pub authoritative_urls: Vec<String>,
+    pub observed_item_count: usize,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct InventoryStateBreakdown {
+    pub schema_version: String,
+    pub generated_at: String,
+    pub source: InventoryStateBreakdownSource,
+    pub ready_to_earn: usize,
+    pub in_progress: usize,
+    pub submitted: usize,
+    pub paid: usize,
+    pub verification_unavailable: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct OpportunityProjectionResponse {
     pub schema_version: String,
@@ -229,6 +250,7 @@ pub struct OpportunityProjectionResponse {
     pub applied_view: Option<String>,
     pub degraded: bool,
     pub source_statuses: Vec<OpportunitySourceStatus>,
+    pub inventory_state_breakdown: InventoryStateBreakdown,
     pub items: Vec<OpportunityItem>,
     pub evidence_boundary: String,
 }
@@ -1202,6 +1224,72 @@ fn json_u64(value: &Value, field: &str) -> Result<u64, String> {
         .map_err(|_| format!("open-competition event field {field} is out of range"))
 }
 
+pub fn inventory_state_breakdown(
+    items: &[OpportunityItem],
+    source_statuses: &[OpportunitySourceStatus],
+    generated_at: &str,
+) -> InventoryStateBreakdown {
+    let canonical_source = source_statuses
+        .iter()
+        .find(|s| s.source_type == "canonical_base");
+    let canonical_items = items
+        .iter()
+        .filter(|i| i.source_type == "canonical_base")
+        .collect::<Vec<_>>();
+    InventoryStateBreakdown {
+        schema_version: "inventory-state-breakdown-v1".to_string(),
+        generated_at: generated_at.to_string(),
+        source: InventoryStateBreakdownSource {
+            source_type: "canonical_base".to_string(),
+            available: canonical_source.is_some_and(|s| s.available),
+            authoritative_urls: canonical_source
+                .map(|s| s.authoritative_urls.clone())
+                .unwrap_or_default(),
+            observed_item_count: canonical_items.len(),
+            error: canonical_source.and_then(|s| s.error.clone()),
+        },
+        ready_to_earn: canonical_items
+            .iter()
+            .filter(|i| is_ready_to_earn(i))
+            .count(),
+        in_progress: canonical_items
+            .iter()
+            .filter(|i| i.work_state == "in_progress")
+            .count(),
+        submitted: canonical_items
+            .iter()
+            .filter(|i| i.work_state == "submitted")
+            .count(),
+        paid: canonical_items
+            .iter()
+            .filter(|i| i.work_state == "completed" && i.payment_state == "paid")
+            .count(),
+        verification_unavailable: canonical_items
+            .iter()
+            .filter(|i| {
+                i.payment_committed
+                    && matches!(
+                        i.work_state.as_str(),
+                        "claimable" | "in_progress" | "submitted"
+                    )
+                    && !i.verification_ready
+            })
+            .count(),
+    }
+}
+
+fn is_ready_to_earn(item: &OpportunityItem) -> bool {
+    item.work_state == "claimable"
+        && item.payment_state == "escrowed"
+        && item.payment_committed
+        && item.verification_ready
+        && (item.source_type != "canonical_base"
+            || item
+                .cash_economics
+                .as_ref()
+                .is_some_and(|e| e.gross_cash_margin_positive))
+}
+
 pub fn apply_query(
     mut items: Vec<OpportunityItem>,
     query: &OpportunityQuery,
@@ -1259,15 +1347,7 @@ fn apply_view(item: &mut OpportunityItem, view: OpportunityView, now: DateTime<U
             matches
         }
         OpportunityView::ReadyToEarn => {
-            let matches = item.work_state == "claimable"
-                && item.payment_state == "escrowed"
-                && item.payment_committed
-                && item.verification_ready
-                && (item.source_type != "canonical_base"
-                    || item
-                        .cash_economics
-                        .as_ref()
-                        .is_some_and(|economics| economics.gross_cash_margin_positive));
+            let matches = is_ready_to_earn(item);
             if matches {
                 item.discovery_factors.push(
                     "view:ready_to_earn;factors=claimable+escrowed+verification_ready+positive_gross_cash_margin".to_string(),
@@ -2036,6 +2116,58 @@ mod tests {
     }
 
     #[test]
+    fn inventory_state_breakdown_is_canonical_and_deterministic() {
+        let ready = canonical_opportunity(
+            &canonical("claimable", "1000000", true),
+            "base-mainnet",
+            "https://api.example",
+        )
+        .unwrap();
+        let mut in_progress = ready.clone();
+        in_progress.work_state = "in_progress".to_string();
+        let mut submitted = ready.clone();
+        submitted.work_state = "submitted".to_string();
+        let mut paid = ready.clone();
+        paid.work_state = "completed".to_string();
+        paid.payment_state = "paid".to_string();
+        let mut unavailable = ready.clone();
+        unavailable.verification_ready = false;
+        let mut noncanonical = ready.clone();
+        noncanonical.source_type = "unfunded_offchain".to_string();
+
+        let status = OpportunitySourceStatus {
+            source_type: "canonical_base".to_string(),
+            available: true,
+            authoritative_urls: vec!["https://api.example/canonical".to_string()],
+            item_count: 5,
+            error: None,
+        };
+        let generated_at = "2026-08-19T10:01:00Z";
+        let breakdown = inventory_state_breakdown(
+            &[
+                ready,
+                in_progress,
+                submitted,
+                paid,
+                unavailable,
+                noncanonical,
+            ],
+            &[status],
+            generated_at,
+        );
+
+        assert_eq!(breakdown.schema_version, "inventory-state-breakdown-v1");
+        assert_eq!(breakdown.generated_at, generated_at);
+        assert!(breakdown.source.available);
+        assert_eq!(breakdown.source.observed_item_count, 5);
+        assert_eq!(breakdown.ready_to_earn, 1);
+        assert_eq!(breakdown.in_progress, 1);
+        assert_eq!(breakdown.submitted, 1);
+        assert_eq!(breakdown.paid, 1);
+        assert_eq!(breakdown.verification_unavailable, 1);
+    }
+
+    #[test]
     fn live_feed_formats_reuse_projection_and_disclose_unfunded_payment_state() {
         let mut item = unfunded_opportunity(&trial(), &[], "https://api.example");
         item.title = "Audit <unsafe> & document".to_string();
@@ -2046,6 +2178,7 @@ mod tests {
             applied_view: None,
             degraded: false,
             source_statuses: Vec::new(),
+            inventory_state_breakdown: inventory_state_breakdown(&[], &[], "2027-01-15T08:01:00Z"),
             items: vec![item],
             evidence_boundary: "Projection only".to_string(),
         };
@@ -2083,6 +2216,7 @@ mod tests {
             applied_view: None,
             degraded: false,
             source_statuses: Vec::new(),
+            inventory_state_breakdown: inventory_state_breakdown(&[], &[], "2027-01-15T08:01:00Z"),
             items: vec![item],
             evidence_boundary: "Projection only".to_string(),
         };

--- a/scripts/check-inventory-state-breakdown.py
+++ b/scripts/check-inventory-state-breakdown.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Deterministic contract checks for inventory-state-breakdown-v1."""
+from __future__ import annotations
+import json
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "scripts" / "fixtures" / "inventory-state-breakdown"
+
+def derive(snapshot):
+    source = next((s for s in snapshot.get("source_statuses", []) if s.get("source_type") == "canonical_base"), None)
+    items = [i for i in snapshot.get("items", []) if i.get("source_type") == "canonical_base"]
+    def ready(i):
+        return i.get("work_state") == "claimable" and i.get("payment_state") == "escrowed" and i.get("payment_committed") is True and i.get("verification_ready") is True and i.get("gross_cash_margin_positive") is True
+    return {
+        "schema_version": "inventory-state-breakdown-v1",
+        "generated_at": snapshot["generated_at"],
+        "source": {"source_type": "canonical_base", "available": bool(source and source.get("available") is True)},
+        "ready_to_earn": sum(ready(i) for i in items),
+        "in_progress": sum(i.get("work_state") == "in_progress" for i in items),
+        "submitted": sum(i.get("work_state") == "submitted" for i in items),
+        "paid": sum(i.get("work_state") == "completed" and i.get("payment_state") == "paid" for i in items),
+        "verification_unavailable": sum(i.get("payment_committed") is True and i.get("work_state") in {"claimable", "in_progress", "submitted"} and i.get("verification_ready") is False for i in items),
+    }
+
+def main():
+    rust = (ROOT / "crates/api/src/opportunities.rs").read_text()
+    main_rs = (ROOT / "crates/api/src/main.rs").read_text()
+    home = (ROOT / "site/home.js").read_text()
+    for token in ("inventory-state-breakdown-v1", "ready_to_earn", "in_progress", "submitted", "paid", "verification_unavailable", "generated_at", "source", "fn is_ready_to_earn", "pub fn inventory_state_breakdown"):
+        if token not in rust:
+            raise SystemExit(f"production projector missing {token}")
+    if "inventory_state_breakdown(&items, &source_statuses, &generated_at)" not in main_rs:
+        raise SystemExit("API response is not derived from one accepted projection snapshot")
+    if 'breakdown.schema_version !== "inventory-state-breakdown-v1"' not in home:
+        raise SystemExit("homepage does not consume inventory-state-breakdown-v1")
+    if 'Number(breakdown.ready_to_earn) !== readyItems.length' not in home:
+        raise SystemExit("homepage does not preserve strict ready-to-earn filtering")
+    fields=("ready_to_earn","in_progress","submitted","paid","verification_unavailable")
+    for name in ("empty","mixed","degraded","stale"):
+        snapshot=json.loads((FIXTURES/f"{name}.json").read_text())
+        actual=derive(snapshot); expected=snapshot["expected"]
+        if actual["generated_at"] != snapshot["generated_at"]:
+            raise SystemExit(f"{name}: generated_at changed")
+        if actual["source"]["available"] != expected["source_available"]:
+            raise SystemExit(f"{name}: source availability mismatch")
+        for field in fields:
+            if actual[field] != expected[field]:
+                raise SystemExit(f"{name}: {field} expected {expected[field]} got {actual[field]}")
+    print("inventory-state-breakdown-v1 deterministic fixtures passed")
+if __name__ == "__main__": main()

--- a/scripts/fixtures/inventory-state-breakdown/degraded.json
+++ b/scripts/fixtures/inventory-state-breakdown/degraded.json
@@ -1,0 +1,19 @@
+{
+  "generated_at": "2026-08-19T10:02:00Z",
+  "source_statuses": [
+    {
+      "source_type": "canonical_base",
+      "available": false,
+      "error": "canonical_read_model_unavailable"
+    }
+  ],
+  "items": [],
+  "expected": {
+    "source_available": false,
+    "ready_to_earn": 0,
+    "in_progress": 0,
+    "submitted": 0,
+    "paid": 0,
+    "verification_unavailable": 0
+  }
+}

--- a/scripts/fixtures/inventory-state-breakdown/empty.json
+++ b/scripts/fixtures/inventory-state-breakdown/empty.json
@@ -1,0 +1,18 @@
+{
+  "generated_at": "2026-08-19T10:00:00Z",
+  "source_statuses": [
+    {
+      "source_type": "canonical_base",
+      "available": true
+    }
+  ],
+  "items": [],
+  "expected": {
+    "source_available": true,
+    "ready_to_earn": 0,
+    "in_progress": 0,
+    "submitted": 0,
+    "paid": 0,
+    "verification_unavailable": 0
+  }
+}

--- a/scripts/fixtures/inventory-state-breakdown/mixed.json
+++ b/scripts/fixtures/inventory-state-breakdown/mixed.json
@@ -1,0 +1,67 @@
+{
+  "generated_at": "2026-08-19T10:01:00Z",
+  "source_statuses": [
+    {
+      "source_type": "canonical_base",
+      "available": true
+    }
+  ],
+  "items": [
+    {
+      "source_type": "canonical_base",
+      "work_state": "claimable",
+      "payment_state": "escrowed",
+      "payment_committed": true,
+      "verification_ready": true,
+      "gross_cash_margin_positive": true
+    },
+    {
+      "source_type": "canonical_base",
+      "work_state": "in_progress",
+      "payment_state": "escrowed",
+      "payment_committed": true,
+      "verification_ready": true,
+      "gross_cash_margin_positive": true
+    },
+    {
+      "source_type": "canonical_base",
+      "work_state": "submitted",
+      "payment_state": "escrowed",
+      "payment_committed": true,
+      "verification_ready": true,
+      "gross_cash_margin_positive": true
+    },
+    {
+      "source_type": "canonical_base",
+      "work_state": "completed",
+      "payment_state": "paid",
+      "payment_committed": true,
+      "verification_ready": true,
+      "gross_cash_margin_positive": true
+    },
+    {
+      "source_type": "canonical_base",
+      "work_state": "claimable",
+      "payment_state": "escrowed",
+      "payment_committed": true,
+      "verification_ready": false,
+      "gross_cash_margin_positive": true
+    },
+    {
+      "source_type": "unfunded_offchain",
+      "work_state": "submitted",
+      "payment_state": "none",
+      "payment_committed": false,
+      "verification_ready": false,
+      "gross_cash_margin_positive": false
+    }
+  ],
+  "expected": {
+    "source_available": true,
+    "ready_to_earn": 1,
+    "in_progress": 1,
+    "submitted": 1,
+    "paid": 1,
+    "verification_unavailable": 1
+  }
+}

--- a/scripts/fixtures/inventory-state-breakdown/stale.json
+++ b/scripts/fixtures/inventory-state-breakdown/stale.json
@@ -1,0 +1,27 @@
+{
+  "generated_at": "2026-08-18T10:03:00Z",
+  "source_statuses": [
+    {
+      "source_type": "canonical_base",
+      "available": true
+    }
+  ],
+  "items": [
+    {
+      "source_type": "canonical_base",
+      "work_state": "claimable",
+      "payment_state": "escrowed",
+      "payment_committed": true,
+      "verification_ready": true,
+      "gross_cash_margin_positive": true
+    }
+  ],
+  "expected": {
+    "source_available": true,
+    "ready_to_earn": 1,
+    "in_progress": 0,
+    "submitted": 0,
+    "paid": 0,
+    "verification_unavailable": 0
+  }
+}

--- a/site/home.js
+++ b/site/home.js
@@ -535,17 +535,26 @@
     const heroSummary = document.querySelector("[data-home-inventory-summary]");
     const detail = document.querySelector("[data-home-inventory-detail]");
     const proof = document.querySelector("[data-market-proof]");
-    const items = projection.items || [];
     const readyItems = readyProjection.items || [];
+    const breakdown = projection.inventory_state_breakdown;
+    if (!breakdown
+      || breakdown.schema_version !== "inventory-state-breakdown-v1"
+      || breakdown.source?.source_type !== "canonical_base"
+      || breakdown.generated_at !== projection.generated_at) {
+      throw new Error("Canonical inventory-state breakdown is unavailable.");
+    }
     if (readyProjection.applied_view !== "ready_to_earn"
       || readyProjection.degraded
-      || readyItems.some((item) => !isReadyToEarn(item))) {
+      || readyItems.some((item) => !isReadyToEarn(item))
+      || Number(breakdown.ready_to_earn) !== readyItems.length) {
       throw new Error("Live earning inventory failed its claimability gate.");
     }
     const referenceAt = new Date(metrics.generated_at || claim.generated_at || projection.generated_at);
     const oneWeekAgo = referenceAt.getTime() - (7 * 24 * 60 * 60 * 1_000);
-    const inProgressItems = items.filter((item) => item.source_type === "canonical_base"
-      && (item.work_state === "in_progress" || item.work_state === "submitted"));
+    const inProgressCount = Number(breakdown.in_progress) || 0;
+    const submittedCount = Number(breakdown.submitted) || 0;
+    const paidCount = Number(breakdown.paid) || 0;
+    const verificationUnavailableCount = Number(breakdown.verification_unavailable) || 0;
     const addedThisWeek = readyItems.filter((item) => {
       const created = Date.parse(item.created_at);
       return Number.isFinite(created) && created >= oneWeekAgo;
@@ -566,7 +575,7 @@
     setMetric("ready", readyItems.length);
     setMetricText(
       "[data-adoption-ready-weekly]",
-      `${formatMetric(addedThisWeek, 0)} added this week · ${formatMetric(inProgressItems.length, 0)} in progress`,
+      `${formatMetric(addedThisWeek, 0)} added this week · ${formatMetric(inProgressCount, 0)} claimed/in progress · ${formatMetric(submittedCount, 0)} submitted`,
     );
     setMetric("available", transactionVolumeUsdc, 2);
     setMetric("settled", settlements);
@@ -576,7 +585,7 @@
     renderOpportunityBoard(container, readyItems);
 
     if (heroSummary) {
-      heroSummary.textContent = `${readyItems.length} bounties ready to claim · ${formatMetric(transactionVolumeUsdc, 2)} USDC canonical payout · ${settlements} settlement events`;
+      heroSummary.textContent = `${breakdown.ready_to_earn} ready to claim · ${inProgressCount} in progress · ${submittedCount} submitted · ${paidCount} paid`;
     }
     const sourceStatuses = projection.source_statuses || [];
     const availableSources = sourceStatuses.filter((source) => source.available).length;
@@ -586,8 +595,8 @@
     const protocolStatus = protocol.status === "active" ? "Base mainnet active" : "Canonical protocol not active";
     if (detail) {
       detail.textContent = unavailable.length
-        ? `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · delayed: ${unavailable.join(", ")}`
-        : `${protocolStatus} · ${readyItems.length} ready to claim · ${availableSources}/${sourceStatuses.length} sources online · server-pushed live stream`;
+        ? `${protocolStatus} · ${breakdown.ready_to_earn} ready · ${inProgressCount} in progress · ${submittedCount} submitted · ${paidCount} paid · ${verificationUnavailableCount} verification unavailable · delayed: ${unavailable.join(", ")}`
+        : `${protocolStatus} · ${breakdown.ready_to_earn} ready · ${inProgressCount} in progress · ${submittedCount} submitted · ${paidCount} paid · ${verificationUnavailableCount} verification unavailable · canonical source ${breakdown.source.available ? "online" : "unavailable"}`;
     }
 
     if (proof && settlements > 0) {


### PR DESCRIPTION
## Summary

Implements #870 with one versioned `inventory-state-breakdown-v1` derived from the same accepted canonical opportunity snapshot.

- exposes separate ready-to-earn, in-progress, submitted, paid, and verification-unavailable counts
- carries the projection `generated_at` plus canonical source availability/URLs/error so degraded input is explicit
- refactors the existing strict ready-to-earn predicate without changing its claimability/economics requirements
- makes the homepage consume the canonical breakdown while cross-checking its ready count against the existing strict ready view
- adds deterministic empty, mixed, degraded, and stale fixtures plus the precommitted checker

## Verification

- exact pinned sandbox: `python /benchmark/check.py` — PASS
- `python3 scripts/check-inventory-state-breakdown.py` — PASS
- `node --check site/home.js` — PASS
- `cargo check -p api` — PASS (Rust 1.88 container)
- `cargo test -p api opportunities::tests` — 13/13 PASS
- `cargo test -p api openapi_json_endpoint_contains_agent_router_path` — PASS
- `git diff --check` — PASS

Host preflight reports only that host `rustc`/`cargo` are absent; the Rust checks above ran in a clean Rust 1.88 container.

## Distribution learning

- **Discovery:** canonical Agent Bounties ready-to-earn inventory; this task was maintainer-seeded after the verified zero-ready-to-earn incident described in the committed terms.
- **Why participate:** the work is externally funded, has a deterministic precommitted sandbox benchmark, and asks for a bounded truthfulness improvement to the live inventory surface.
- **AI assistance:** SASAME S.R.L. used an OpenAI/ChatGPT agent to inspect the committed terms, implement the bounded change, and run the verification commands. The public commit and evidence remain reviewable and deterministic.

No payment is claimed by this PR. Only canonical `BountySettled` is treated as payment evidence.
