### PR TITLE
Fix Beta3 resume restore directory

### DIFF
--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -61,6 +61,7 @@ jobs:
           test -x "$preserved/release/api"
           test -x "$preserved/release/worker"
           test -x "$preserved/release-assets/public-vector-metric-v1-script"
+          mkdir -p target
           cp -a "$preserved/sepolia-rehearsal.json" target/
           cp -a "$preserved/sepolia.runtime.json" target/
           cp -a "$preserved/sepolia-proofs" target/

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -25,6 +25,7 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         self.assertNotIn("push", workflow[True])
         self.assertNotIn("schedule", workflow[True])
         self.assertIn("/mnt/agent-bounties-artifacts/beta3-attempt15", text)
+        self.assertIn("mkdir -p target", text)
         self.assertIn("run_open_competition_v2_x402_rehearsal.py", text)
         self.assertIn("--source-commit \"$RELEASE_SOURCE_COMMIT\"", text)
         self.assertNotIn("deploy_open_competition_v2_beta3.py", text)


### PR DESCRIPTION
## Summary
Create the generated `target/` directory before restoring the preserved Beta3 artifacts, and assert that recovery precondition in the workflow test.

## Evidence
- resume run 32246037779 failed at the first `cp`, before any RPC write
- `python -m unittest scripts.test_resume_open_competition_v2_beta3_x402` passes
- `git diff --check` passes

This does not change signing scope, contracts, proof inputs, release identity, or funding. It only fixes the local restore directory.