### PR TITLE
Fix Beta3 resume signer precondition

### DIFF
--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -15,6 +15,7 @@ env:
   SOURCE_RUN_ID: "32147289466"
   SOURCE_RUN_ATTEMPT: "15"
   SOURCE_ACTOR_DERIVATION_SALT: "32147289466:15:sepolia"
+  EXPECTED_SEPOLIA_DEPLOYER: "0xfd7be4c69541ab297aece2a674fc1418b898cc0a"
   SP1_SAFE_CIRCUIT_VERSION: agent-bounties-sp1-safe-v5
 
 jobs:
@@ -72,7 +73,7 @@ jobs:
           python -m pip install -r scripts/requirements-wallet.txt
           DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
           BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
-          test "$DEPLOYER" = "$(jq -r .deployer target/sepolia.runtime.json)"
+          test "$DEPLOYER" = "$EXPECTED_SEPOLIA_DEPLOYER"
           test "$BROKER" = "$(printf '%s' "$OPEN_COMPETITION_V2_BROKER_ADDRESS" | tr '[:upper:]' '[:lower:]')"
           jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \
             '.passed == true and .source_commit == $commit and .x402_canary.active == true' \

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -20,6 +20,10 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
             workflow["env"]["SOURCE_ACTOR_DERIVATION_SALT"],
             "32147289466:15:sepolia",
         )
+        self.assertEqual(
+            workflow["env"]["EXPECTED_SEPOLIA_DEPLOYER"],
+            "0xfd7be4c69541ab297aece2a674fc1418b898cc0a",
+        )
         self.assertEqual(job["environment"], "v2-beta2-sepolia")
         self.assertIn("workflow_dispatch", workflow[True])
         self.assertNotIn("push", workflow[True])
@@ -28,6 +32,7 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         self.assertIn("mkdir -p target", text)
         self.assertIn("run_open_competition_v2_x402_rehearsal.py", text)
         self.assertIn("--source-commit \"$RELEASE_SOURCE_COMMIT\"", text)
+        self.assertNotIn("jq -r .deployer", text)
         self.assertNotIn("deploy_open_competition_v2_beta3.py", text)
         self.assertNotIn("fund_open_competition_v2_beta3_broker.py", text)
         self.assertNotIn("run_open_competition_v2_sepolia_rehearsal.py", text)


### PR DESCRIPTION
## Summary
Pin the published Sepolia deployer address in the bounded recovery workflow instead of reading a deliberately absent signer field from the public runtime manifest.

## Evidence
- run 32246207757 failed after dependency setup, before API startup or RPC writes
- focused workflow test passes
- the test now forbids `jq -r .deployer`

No contract, proof, funding, actor, or signing scope changes.