### PR TITLE
Separate frozen release and recovery control checkouts

### DIFF
--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -41,6 +41,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           ref: ${{ env.RELEASE_SOURCE_COMMIT }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ github.sha }}
+          path: target/continuation-control
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
@@ -75,7 +79,7 @@ jobs:
           BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
           test "$DEPLOYER" = "$EXPECTED_SEPOLIA_DEPLOYER"
           test "$BROKER" = "$(printf '%s' "$OPEN_COMPETITION_V2_BROKER_ADDRESS" | tr '[:upper:]' '[:lower:]')"
-          python scripts/recover_open_competition_v2_x402_charge.py \
+          python target/continuation-control/scripts/recover_open_competition_v2_x402_charge.py \
             --network base-sepolia --rpc-url "$BASE_SEPOLIA_RPC_URL" \
             --payment-transaction 0xc724bcc7a1ca76c809a556b2b127d18bdaf626b13e90ad442f88bcfb3acb6684 \
             --asset 0x036CbD53842c5426634e7929541eC2318f3dCF7e \

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -32,7 +32,19 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         self.assertIn("mkdir -p target", text)
         self.assertIn("run_open_competition_v2_x402_rehearsal.py", text)
         self.assertIn("OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY=10000", text)
-        self.assertIn("recover_open_competition_v2_x402_charge.py", text)
+        checkouts = [
+            step
+            for step in job["steps"]
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        ]
+        self.assertEqual(len(checkouts), 2)
+        self.assertEqual(checkouts[0]["with"]["ref"], "${{ env.RELEASE_SOURCE_COMMIT }}")
+        self.assertEqual(checkouts[1]["with"]["ref"], "${{ github.sha }}")
+        self.assertEqual(checkouts[1]["with"]["path"], "target/continuation-control")
+        self.assertIn(
+            "target/continuation-control/scripts/recover_open_competition_v2_x402_charge.py",
+            text,
+        )
         self.assertIn("OPEN_COMPETITION_V2_PROVER_TIMEOUT_SECONDS=1200", text)
         self.assertIn("OPEN_COMPETITION_V2_BROKER_LEASE_SECONDS=1230", text)
         self.assertIn("target/failed-x402-charge-refund.json", text)


### PR DESCRIPTION
## Summary\n\nFix the pre-chain stop in run 32248621144 by separating the two trust domains:\n\n- primary checkout remains the frozen release source 4d09...102410c29\n- a second checkout pins the current workflow SHA under 	arget/continuation-control\n- only the exact failed-charge recovery utility runs from the control checkout\n- contracts, release binaries, prover, API, worker, proof inputs, actor salt and release gates remain frozen\n- focused tests assert both checkout refs and the isolated path\n\n## Verification\n\n- python scripts/test_resume_open_competition_v2_beta3_x402.py\n- python scripts/test_recover_open_competition_v2_x402_charge.py\n- git diff --check\n\nThe prior run stopped before any transaction.