### PR TITLE
Fix empty bytecode parsing in Beta3 canary refresh

### DIFF
--- a/scripts/refresh_open_competition_v2_x402_canary.py
+++ b/scripts/refresh_open_competition_v2_x402_canary.py
@@ -58,6 +58,12 @@ def replacement_funding_deadline(old_proof_deadline: int, replacement_id: int) -
     return old_proof_deadline + replacement_id * REPLACEMENT_FUNDING_STEP
 
 
+def has_runtime_code(value: str) -> bool:
+    require(isinstance(value, str) and value.startswith("0x"), "invalid bytecode response")
+    payload = value[2:]
+    return bool(payload) and int(payload, 16) != 0
+
+
 def replace_rehearsal_canary(
     document: dict[str, Any], new_canary: dict[str, Any], evidence: dict[str, Any]
 ) -> dict[str, Any]:
@@ -276,7 +282,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     )
 
     code = rpc(client.url, "eth_getCode", [competition, "latest"])
-    if int(code, 16) == 0:
+    if not has_runtime_code(code):
         require(
             rehearsal.token_balance(client.url, token, signer.address) >= TARGET_FUNDING,
             "deployer lacks test USDC for the replacement canary",

--- a/scripts/test_refresh_open_competition_v2_x402_canary.py
+++ b/scripts/test_refresh_open_competition_v2_x402_canary.py
@@ -49,6 +49,11 @@ class RefreshX402CanaryTests(unittest.TestCase):
             1_787_747_848,
         )
 
+    def test_empty_bytecode_responses_are_not_deployments(self):
+        self.assertFalse(MODULE.has_runtime_code("0x"))
+        self.assertFalse(MODULE.has_runtime_code("0x0"))
+        self.assertTrue(MODULE.has_runtime_code("0x6000"))
+
     def test_rehearsal_preserves_superseded_evidence_and_rebinds_first_proven(self):
         old = {
             "competition": "0x" + "11" * 20,


### PR DESCRIPTION
## Summary
- treat canonical RPC empty bytecode responses \