### PR TITLE
Fix Beta3 x402 recovery and release-bound selectors

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -61,6 +61,7 @@ jobs:
           test -f target/live-sepolia/failed-x402-charge-refund-2.json
           test -f target/live-sepolia/failed-x402-charge-refund-3.json
           test -f target/live-sepolia/failed-x402-charge-refund-4.json
+          test -f target/live-sepolia/failed-x402-charge-refund-5.json
           jq -e '.passed == true and (.settlement_event_id | length > 0)' target/live-sepolia/sepolia-x402-rehearsal.json >/dev/null
           replacement="$(jq -r .competition target/live-sepolia/x402-canary-replacement.json)"
           test "$replacement" = "$(jq -r .competition target/live-sepolia/sepolia-x402-rehearsal.json)"
@@ -75,6 +76,8 @@ jobs:
             target/live-sepolia/failed-x402-charge-refund-3.json >/dev/null
           jq -e '.passed == true and .amount == "110000" and .payment_transaction == "0xedf4427c273df26905f3a5fe377d17bab4e2f9c8485f38f498652379ff4b622a" and (.refund_transaction | length > 0)' \
             target/live-sepolia/failed-x402-charge-refund-4.json >/dev/null
+          jq -e '.passed == true and .amount == "110000" and .payment_transaction == "0x8b0b85cdd06147ae1e37fdbd4e8ea78876bb312bd234dcd49aadfa25e0b89c27" and (.refund_transaction | length > 0)' \
+            target/live-sepolia/failed-x402-charge-refund-5.json >/dev/null
           jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \
             '.passed == true and .source_commit == $commit' target/live-sepolia/sepolia-rehearsal.json >/dev/null
           jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \

--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -142,8 +142,7 @@ jobs:
       - name: Clear generated files from prior capacity-gated runs
         run: |
           if [ -d "$GITHUB_WORKSPACE/target" ]; then
-            chmod -R u+w "$GITHUB_WORKSPACE/target" || true
-            rm -rf "$GITHUB_WORKSPACE/target"
+            sudo rm -rf "$GITHUB_WORKSPACE/target"
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
@@ -450,7 +449,7 @@ jobs:
             sleep 2
           done
           curl --fail --silent http://127.0.0.1:8788/health >/dev/null
-          python scripts/run_open_competition_v2_x402_rehearsal.py \
+          python target/continuation-control/scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api http://127.0.0.1:8788 \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canaries.json \
             --worker-binary target/continuation-build/release/worker --expect-refund \
@@ -459,7 +458,7 @@ jobs:
             --output target/mainnet-x402-refund.json
           cleanup
           trap - EXIT
-          python scripts/run_open_competition_v2_x402_rehearsal.py \
+          python target/continuation-control/scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api https://api.agentbounties.app \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canaries.json \
             --hosted-workers --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \

--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -59,6 +59,7 @@ jobs:
           test -f target/live-sepolia/x402-canary-replacement.json
           test -f target/live-sepolia/failed-x402-charge-refund.json
           test -f target/live-sepolia/failed-x402-charge-refund-2.json
+          test -f target/live-sepolia/failed-x402-charge-refund-3.json
           jq -e '.passed == true and (.settlement_event_id | length > 0)' target/live-sepolia/sepolia-x402-rehearsal.json >/dev/null
           replacement="$(jq -r .competition target/live-sepolia/x402-canary-replacement.json)"
           test "$replacement" = "$(jq -r .competition target/live-sepolia/sepolia-x402-rehearsal.json)"
@@ -69,6 +70,8 @@ jobs:
             target/live-sepolia/failed-x402-charge-refund.json >/dev/null
           jq -e '.passed == true and .amount == "110000" and .payment_transaction == "0xba73504377041ca89b5262421e7c994a40e7c955c5f71f9dc95f16d2c966d312" and (.refund_transaction | length > 0)' \
             target/live-sepolia/failed-x402-charge-refund-2.json >/dev/null
+          jq -e '.passed == true and .amount == "110000" and .payment_transaction == "0x53fdaf15f234cf1ab4267bde5ce602221b8ad4e81ca011f457ab365a899e1e56" and (.refund_transaction | length > 0)' \
+            target/live-sepolia/failed-x402-charge-refund-3.json >/dev/null
           jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \
             '.passed == true and .source_commit == $commit' target/live-sepolia/sepolia-rehearsal.json >/dev/null
           jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \

--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -332,6 +332,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           ref: ${{ env.RELEASE_SOURCE_COMMIT }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ github.sha }}
+          path: target/continuation-control
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
@@ -370,7 +374,8 @@ jobs:
           KEEPER="${BASE_KEEPER_ADDRESS,,}"
           DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
           chmod 0755 "$OPEN_COMPETITION_V2_PROVER_BINARY"
-          cargo build --locked --release -p api -p worker
+          cargo build --manifest-path target/continuation-control/Cargo.toml \
+            --target-dir target/continuation-build --locked --release -p api -p worker
           bundle=target/mainnet-deployment/mainnet-exact.json
           python scripts/verify_open_competition_v2_beta3_broker_reserve.py \
             --runtime target/production-control-plane/mainnet-broker.runtime.json \
@@ -424,7 +429,7 @@ jobs:
           python scripts/open_competition_v2_failure_prover.py >target/mainnet-failure-prover.log 2>&1 &
           failure_prover_pid=$!
           export PORT=8788
-          target/release/api >target/mainnet-canary-api.log 2>&1 &
+          target/continuation-build/release/api >target/mainnet-canary-api.log 2>&1 &
           canary_api_pid=$!
           cleanup() {
             kill "$canary_api_pid" "$failure_prover_pid" 2>/dev/null || true
@@ -442,7 +447,7 @@ jobs:
           python scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api http://127.0.0.1:8788 \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canaries.json \
-            --worker-binary target/release/worker --expect-refund \
+            --worker-binary target/continuation-build/release/worker --expect-refund \
             --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
             --output target/mainnet-x402-refund.json

--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -331,8 +331,7 @@ jobs:
       - name: Clear generated files from prior capacity-gated runs
         run: |
           if [ -d "$GITHUB_WORKSPACE/target" ]; then
-            chmod -R u+w "$GITHUB_WORKSPACE/target" || true
-            rm -rf "$GITHUB_WORKSPACE/target"
+            sudo rm -rf "$GITHUB_WORKSPACE/target"
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:

--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -60,6 +60,7 @@ jobs:
           test -f target/live-sepolia/failed-x402-charge-refund.json
           test -f target/live-sepolia/failed-x402-charge-refund-2.json
           test -f target/live-sepolia/failed-x402-charge-refund-3.json
+          test -f target/live-sepolia/failed-x402-charge-refund-4.json
           jq -e '.passed == true and (.settlement_event_id | length > 0)' target/live-sepolia/sepolia-x402-rehearsal.json >/dev/null
           replacement="$(jq -r .competition target/live-sepolia/x402-canary-replacement.json)"
           test "$replacement" = "$(jq -r .competition target/live-sepolia/sepolia-x402-rehearsal.json)"
@@ -72,6 +73,8 @@ jobs:
             target/live-sepolia/failed-x402-charge-refund-2.json >/dev/null
           jq -e '.passed == true and .amount == "110000" and .payment_transaction == "0x53fdaf15f234cf1ab4267bde5ce602221b8ad4e81ca011f457ab365a899e1e56" and (.refund_transaction | length > 0)' \
             target/live-sepolia/failed-x402-charge-refund-3.json >/dev/null
+          jq -e '.passed == true and .amount == "110000" and .payment_transaction == "0xedf4427c273df26905f3a5fe377d17bab4e2f9c8485f38f498652379ff4b622a" and (.refund_transaction | length > 0)' \
+            target/live-sepolia/failed-x402-charge-refund-4.json >/dev/null
           jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \
             '.passed == true and .source_commit == $commit' target/live-sepolia/sepolia-rehearsal.json >/dev/null
           jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \

--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -125,11 +125,18 @@ jobs:
             --payer 0xbb1215ed6f843e0caefe363bbb2b509f4d65b11e \
             --broker "$BROKER" --amount 110000 \
             --output target/failed-x402-charge-refund-4.json
+          python target/continuation-control/scripts/recover_open_competition_v2_x402_charge.py \
+            --network base-sepolia --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+            --payment-transaction 0x8b0b85cdd06147ae1e37fdbd4e8ea78876bb312bd234dcd49aadfa25e0b89c27 \
+            --asset 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+            --payer 0xbb1215ed6f843e0caefe363bbb2b509f4d65b11e \
+            --broker "$BROKER" --amount 110000 \
+            --output target/failed-x402-charge-refund-5.json
           if [[ "$RECOVERY_ONLY" == "true" ]]; then
             exit 0
           fi
           cargo build --manifest-path target/continuation-control/Cargo.toml \
-            --target-dir target/continuation-build --locked --release -p worker
+            --target-dir target/continuation-build --locked --release -p api -p worker
           python target/continuation-control/scripts/refresh_open_competition_v2_x402_canary.py \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" \
             --runtime target/sepolia.runtime.json \
@@ -182,7 +189,7 @@ jobs:
           python scripts/open_competition_v2_prover_service.py >target/sepolia-prover.log 2>&1 &
           prover_pid=$!
           export PORT=8787
-          target/release/api >target/sepolia-api.log 2>&1 &
+          target/continuation-build/release/api >target/sepolia-api.log 2>&1 &
           api_pid=$!
           cleanup() {
             kill "$api_pid" "$prover_pid" 2>/dev/null || true
@@ -197,7 +204,7 @@ jobs:
             sleep 2
           done
           curl --fail --silent http://127.0.0.1:8787/health >/dev/null
-          python scripts/run_open_competition_v2_x402_rehearsal.py \
+          python target/continuation-control/scripts/run_open_competition_v2_x402_rehearsal.py \
             --api http://127.0.0.1:8787 --rpc-url "$BASE_SEPOLIA_RPC_URL" \
             --rehearsal target/sepolia-rehearsal.json \
             --worker-binary target/continuation-build/release/worker \
@@ -234,6 +241,7 @@ jobs:
             target/failed-x402-charge-refund-2.json
             target/failed-x402-charge-refund-3.json
             target/failed-x402-charge-refund-4.json
+            target/failed-x402-charge-refund-5.json
             target/sepolia-proofs/*.json
             target/release-gates.json
             target/release-assets/**
@@ -244,11 +252,12 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: inputs.mode == 'recover-second-only'
         with:
-          name: open-competition-v2-beta3-x402-charge-recovery-4
+          name: open-competition-v2-beta3-x402-charge-recovery-5
           path: |
             target/failed-x402-charge-refund.json
             target/failed-x402-charge-refund-2.json
             target/failed-x402-charge-refund-3.json
             target/failed-x402-charge-refund-4.json
+            target/failed-x402-charge-refund-5.json
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -56,8 +56,7 @@ jobs:
       - name: Reset generated output from prior containerized runs
         run: |
           if [[ -d target ]]; then
-            sudo chown -R "$(id -u):$(id -g)" target
-            rm -rf target
+            sudo rm -rf target
           fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:

--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Recover the second failed charge only, or resume after diagnostics pass"
+        description: "Recover all known failed charges only, or resume after diagnostics pass"
         required: true
         default: recover-second-only
         type: choice
@@ -105,6 +105,13 @@ jobs:
             --payer 0xbb1215ed6f843e0caefe363bbb2b509f4d65b11e \
             --broker "$BROKER" --amount 110000 \
             --output target/failed-x402-charge-refund-2.json
+          python target/continuation-control/scripts/recover_open_competition_v2_x402_charge.py \
+            --network base-sepolia --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+            --payment-transaction 0x53fdaf15f234cf1ab4267bde5ce602221b8ad4e81ca011f457ab365a899e1e56 \
+            --asset 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+            --payer 0xbb1215ed6f843e0caefe363bbb2b509f4d65b11e \
+            --broker "$BROKER" --amount 110000 \
+            --output target/failed-x402-charge-refund-3.json
           if [[ "$RECOVERY_ONLY" == "true" ]]; then
             exit 0
           fi
@@ -209,6 +216,7 @@ jobs:
             target/x402-canary-replacement.json
             target/failed-x402-charge-refund.json
             target/failed-x402-charge-refund-2.json
+            target/failed-x402-charge-refund-3.json
             target/sepolia-proofs/*.json
             target/release-gates.json
             target/release-assets/**
@@ -219,9 +227,10 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: inputs.mode == 'recover-second-only'
         with:
-          name: open-competition-v2-beta3-x402-charge-recovery-2
+          name: open-competition-v2-beta3-x402-charge-recovery-3
           path: |
             target/failed-x402-charge-refund.json
             target/failed-x402-charge-refund-2.json
+            target/failed-x402-charge-refund-3.json
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -112,6 +112,13 @@ jobs:
             --payer 0xbb1215ed6f843e0caefe363bbb2b509f4d65b11e \
             --broker "$BROKER" --amount 110000 \
             --output target/failed-x402-charge-refund-3.json
+          python target/continuation-control/scripts/recover_open_competition_v2_x402_charge.py \
+            --network base-sepolia --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+            --payment-transaction 0xedf4427c273df26905f3a5fe377d17bab4e2f9c8485f38f498652379ff4b622a \
+            --asset 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+            --payer 0xbb1215ed6f843e0caefe363bbb2b509f4d65b11e \
+            --broker "$BROKER" --amount 110000 \
+            --output target/failed-x402-charge-refund-4.json
           if [[ "$RECOVERY_ONLY" == "true" ]]; then
             exit 0
           fi
@@ -220,6 +227,7 @@ jobs:
             target/failed-x402-charge-refund.json
             target/failed-x402-charge-refund-2.json
             target/failed-x402-charge-refund-3.json
+            target/failed-x402-charge-refund-4.json
             target/sepolia-proofs/*.json
             target/release-gates.json
             target/release-assets/**
@@ -230,10 +238,11 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: inputs.mode == 'recover-second-only'
         with:
-          name: open-competition-v2-beta3-x402-charge-recovery-3
+          name: open-competition-v2-beta3-x402-charge-recovery-4
           path: |
             target/failed-x402-charge-refund.json
             target/failed-x402-charge-refund-2.json
             target/failed-x402-charge-refund-3.json
+            target/failed-x402-charge-refund-4.json
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -115,6 +115,8 @@ jobs:
           if [[ "$RECOVERY_ONLY" == "true" ]]; then
             exit 0
           fi
+          cargo build --manifest-path target/continuation-control/Cargo.toml \
+            --target-dir target/continuation-build --locked --release -p worker
           python target/continuation-control/scripts/refresh_open_competition_v2_x402_canary.py \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" \
             --runtime target/sepolia.runtime.json \
@@ -184,7 +186,8 @@ jobs:
           curl --fail --silent http://127.0.0.1:8787/health >/dev/null
           python scripts/run_open_competition_v2_x402_rehearsal.py \
             --api http://127.0.0.1:8787 --rpc-url "$BASE_SEPOLIA_RPC_URL" \
-            --rehearsal target/sepolia-rehearsal.json --worker-binary target/release/worker \
+            --rehearsal target/sepolia-rehearsal.json \
+            --worker-binary target/continuation-build/release/worker \
             --private-key-env BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$SOURCE_ACTOR_DERIVATION_SALT" \
             --output target/sepolia-x402-rehearsal.json

--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -153,12 +153,12 @@ jobs:
               base_sepolia_pooled_funding_complete \
               base_sepolia_expiry_refunds_complete \
               base_sepolia_verifier_failure_refunds_complete; do
-              python target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py \
+              python scripts/record_open_competition_v2_beta3_gate.py \
                 --manifest target/release-gates.json --gate "$gate" \
                 --evidence target/sepolia-rehearsal.json --uri "$evidence_uri" \
                 --source-commit "$RELEASE_SOURCE_COMMIT"
             done
-            python target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py \
+            python scripts/record_open_competition_v2_beta3_gate.py \
               --manifest target/release-gates.json --gate base_sepolia_x402_and_byo_complete \
               --evidence target/sepolia-x402-rehearsal.json --uri "$evidence_uri" \
               --source-commit "$RELEASE_SOURCE_COMMIT"
@@ -249,12 +249,12 @@ jobs:
             base_sepolia_pooled_funding_complete \
             base_sepolia_expiry_refunds_complete \
             base_sepolia_verifier_failure_refunds_complete; do
-            python target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py \
+            python scripts/record_open_competition_v2_beta3_gate.py \
               --manifest target/release-gates.json --gate "$gate" \
               --evidence target/sepolia-rehearsal.json --uri "$evidence_uri" \
               --source-commit "$RELEASE_SOURCE_COMMIT"
           done
-          python target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py \
+          python scripts/record_open_competition_v2_beta3_gate.py \
             --manifest target/release-gates.json --gate base_sepolia_x402_and_byo_complete \
             --evidence target/sepolia-x402-rehearsal.json --uri "$evidence_uri" \
             --source-commit "$RELEASE_SOURCE_COMMIT"

--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - recover-second-only
+          - finalize-success
           - resume-rehearsal
 
 permissions:
@@ -76,6 +77,7 @@ jobs:
           OPEN_COMPETITION_V2_PROVER_API_KEY: beta3-sepolia-rehearsal-only-api-key
           SP1_PROVER: cpu
           RECOVERY_ONLY: ${{ inputs.mode == 'recover-second-only' }}
+          FINALIZE_SUCCESS: ${{ inputs.mode == 'finalize-success' }}
         run: |
           set -euo pipefail
           preserved=/mnt/agent-bounties-artifacts/beta3-attempt15
@@ -133,6 +135,33 @@ jobs:
             --broker "$BROKER" --amount 110000 \
             --output target/failed-x402-charge-refund-5.json
           if [[ "$RECOVERY_ONLY" == "true" ]]; then
+            exit 0
+          fi
+          if [[ "$FINALIZE_SUCCESS" == "true" ]]; then
+            cp "$preserved/sepolia-x402-rehearsal-success.json" target/sepolia-x402-rehearsal.json
+            cp "$preserved/x402-canary-replacement-success.json" target/x402-canary-replacement.json
+            cp target/release-assets/release-gates.json target/release-gates.json
+            chmod u+w target/release-gates.json
+            jq -e '.passed == true and (.settlement_event_id | length > 0)' \
+              target/sepolia-x402-rehearsal.json >/dev/null
+            replacement="$(jq -r .competition target/x402-canary-replacement.json)"
+            test "$replacement" = "$(jq -r .competition target/sepolia-x402-rehearsal.json)"
+            evidence_uri="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            for gate in \
+              base_sepolia_groth16_first_proven_complete \
+              base_sepolia_plonk_best_score_complete \
+              base_sepolia_pooled_funding_complete \
+              base_sepolia_expiry_refunds_complete \
+              base_sepolia_verifier_failure_refunds_complete; do
+              python target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py \
+                --manifest target/release-gates.json --gate "$gate" \
+                --evidence target/sepolia-rehearsal.json --uri "$evidence_uri" \
+                --source-commit "$RELEASE_SOURCE_COMMIT"
+            done
+            python target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py \
+              --manifest target/release-gates.json --gate base_sepolia_x402_and_byo_complete \
+              --evidence target/sepolia-x402-rehearsal.json --uri "$evidence_uri" \
+              --source-commit "$RELEASE_SOURCE_COMMIT"
             exit 0
           fi
           cargo build --manifest-path target/continuation-control/Cargo.toml \
@@ -212,6 +241,7 @@ jobs:
             --actor-derivation-salt "$SOURCE_ACTOR_DERIVATION_SALT" \
             --output target/sepolia-x402-rehearsal.json
           cp target/release-assets/release-gates.json target/release-gates.json
+          chmod u+w target/release-gates.json
           evidence_uri="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           for gate in \
             base_sepolia_groth16_first_proven_complete \
@@ -219,17 +249,17 @@ jobs:
             base_sepolia_pooled_funding_complete \
             base_sepolia_expiry_refunds_complete \
             base_sepolia_verifier_failure_refunds_complete; do
-            python scripts/record_open_competition_v2_beta3_gate.py \
+            python target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py \
               --manifest target/release-gates.json --gate "$gate" \
               --evidence target/sepolia-rehearsal.json --uri "$evidence_uri" \
               --source-commit "$RELEASE_SOURCE_COMMIT"
           done
-          python scripts/record_open_competition_v2_beta3_gate.py \
+          python target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py \
             --manifest target/release-gates.json --gate base_sepolia_x402_and_byo_complete \
             --evidence target/sepolia-x402-rehearsal.json --uri "$evidence_uri" \
             --source-commit "$RELEASE_SOURCE_COMMIT"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        if: inputs.mode == 'resume-rehearsal'
+        if: inputs.mode != 'recover-second-only'
         with:
           name: open-competition-v2-beta3-live-sepolia-resumed
           path: |

--- a/.github/workflows/resume-open-competition-v2-beta3-x402.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-x402.yml
@@ -52,6 +52,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           ref: ${{ env.RELEASE_SOURCE_COMMIT }}
+          clean: false
+      - name: Reset generated output from prior containerized runs
+        run: |
+          if [[ -d target ]]; then
+            sudo chown -R "$(id -u):$(id -g)" target
+            rm -rf target
+          fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           ref: ${{ github.sha }}

--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "a386a6dc2e408ef7cf58fd77e9d28560c87dc8f01e98cce955e346c8ba6e3efb"
+  "normalized_sha256": "9e501f7121e9cb617168879992cc48a56dfbdb05184506188af7407189c060f6"
 }

--- a/crates/api/src/open_competition_v2_api.rs
+++ b/crates/api/src/open_competition_v2_api.rs
@@ -988,7 +988,7 @@ pub(crate) async fn pay_proof_job(
     proof_job_payment_response(&job)
 }
 
-#[utoipa::path(post, path = "/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/relay-authorization", params(("job_id" = Uuid, Path, description = "Proved hosted job ID")), responses((status = 200, description = "Exact EIP-712 digest or accepted scoped signature"), (status = 409, description = "Job is not relayable")))]
+#[utoipa::path(post, path = "/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/relay-authorization", params(("job_id" = Uuid, Path, description = "Proved hosted job ID")), responses((status = 200, description = "Exact EIP-712 typed data or accepted scoped signature"), (status = 409, description = "Job is not relayable")))]
 pub(crate) async fn authorize_proof_job_relay(
     State(state): State<SharedState>,
     Path(job_id): Path<Uuid>,
@@ -1164,7 +1164,7 @@ pub(crate) async fn authorize_proof_job_relay(
         "proof_job_id": job.id,
         "state": job.state,
         "plan": plan,
-        "next_action": "Sign plan.relay_authorization.digest with the solver wallet, then call this endpoint again with solver_signature."
+        "next_action": "Sign the exact plan.relay_authorization EIP-712 typed data with the solver wallet, then call this endpoint again with solver_signature."
     })))
 }
 

--- a/crates/chain-base/src/open_competition_v2_planner.rs
+++ b/crates/chain-base/src/open_competition_v2_planner.rs
@@ -259,6 +259,7 @@ pub struct OpenCompetitionV2ActionPlan {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OpenCompetitionV2ProofAuthorizationMessage {
     pub solver: String,
     pub solver_nonce: String,
@@ -268,6 +269,7 @@ pub struct OpenCompetitionV2ProofAuthorizationMessage {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OpenCompetitionV2ProofAuthorizationTypedData {
     pub types: BTreeMap<String, Vec<Eip712TypeField>>,
     pub domain: Eip712DomainData,
@@ -1082,6 +1084,11 @@ mod tests {
         assert_eq!(plan.direct_call.function, "submitProof(bytes,bytes)");
         assert!(plan.relay_call_after_signature.is_none());
         assert_eq!(plan.relay_authorization.message.solver_nonce, "7");
+        let typed_data = serde_json::to_value(&plan.relay_authorization).unwrap();
+        assert_eq!(typed_data["primaryType"], "SubmitProof");
+        assert_eq!(typed_data["message"]["solverNonce"], "7");
+        assert!(typed_data.get("primary_type").is_none());
+        assert!(typed_data["message"].get("solver_nonce").is_none());
     }
 
     #[test]

--- a/crates/worker/src/open_competition_v2_broker.rs
+++ b/crates/worker/src/open_competition_v2_broker.rs
@@ -5,6 +5,7 @@ use chain_base::{
     plan_open_competition_v2_proof, rpc_logs_to_evm_logs, BaseContractLogQuery, BaseRpcUrlConfig,
     BaseTransactionRelayer, ChainBaseError, EvmLog, OpenCompetitionV2BrokerPaymentAuthorization,
     OpenCompetitionV2Event, OpenCompetitionV2EventKind, OpenCompetitionV2ProofSystem,
+    OPEN_COMPETITION_V2_PROTOCOL_VERSION,
 };
 use chrono::{Duration as ChronoDuration, Utc};
 use db::{
@@ -15,12 +16,30 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha3::{Digest, Keccak256};
-use std::time::Duration;
+use std::{collections::BTreeMap, time::Duration};
 use uuid::Uuid;
 
 pub const OPEN_COMPETITION_V2_PROVER_URL_ENV: &str = "OPEN_COMPETITION_V2_PROVER_URL";
 pub const OPEN_COMPETITION_V2_PROVER_API_KEY_ENV: &str = "OPEN_COMPETITION_V2_PROVER_API_KEY";
 pub const OPEN_COMPETITION_V2_RELAYER_PRIVATE_KEY_ENV: &str = "X402_RELAYER_PRIVATE_KEY";
+const BASE_MAINNET_RELEASE_ENV: &str =
+    "BASE_MAINNET_OPEN_COMPETITION_V2_BETA3_RELEASE_MANIFEST_JSON";
+const BASE_SEPOLIA_RELEASE_ENV: &str =
+    "BASE_SEPOLIA_OPEN_COMPETITION_V2_BETA3_RELEASE_MANIFEST_JSON";
+
+#[derive(Debug, Clone, Deserialize)]
+struct BrokerReleaseIdentity {
+    protocol_version: String,
+    network: String,
+    groth16_verifier_hash: String,
+    plonk_verifier_hash: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProofSelectors {
+    groth16: [u8; 4],
+    plonk: [u8; 4],
+}
 
 #[derive(Clone)]
 pub struct OpenCompetitionV2BrokerConfig {
@@ -29,6 +48,7 @@ pub struct OpenCompetitionV2BrokerConfig {
     pub request_timeout_seconds: u64,
     pub lease_seconds: u32,
     pub refund_window_seconds: i64,
+    proof_selectors: BTreeMap<String, ProofSelectors>,
     client: reqwest::Client,
 }
 
@@ -41,6 +61,10 @@ impl std::fmt::Debug for OpenCompetitionV2BrokerConfig {
             .field("request_timeout_seconds", &self.request_timeout_seconds)
             .field("lease_seconds", &self.lease_seconds)
             .field("refund_window_seconds", &self.refund_window_seconds)
+            .field(
+                "selector_networks",
+                &self.proof_selectors.keys().collect::<Vec<_>>(),
+            )
             .finish()
     }
 }
@@ -95,6 +119,7 @@ impl OpenCompetitionV2BrokerConfig {
                 "OPEN_COMPETITION_V2_REFUND_WINDOW_SECONDS cannot exceed 1800"
             ));
         }
+        let proof_selectors = release_proof_selectors(&lookup)?;
         let client = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .timeout(Duration::from_secs(request_timeout_seconds))
@@ -107,9 +132,64 @@ impl OpenCompetitionV2BrokerConfig {
             request_timeout_seconds,
             lease_seconds,
             refund_window_seconds,
+            proof_selectors,
             client,
         })
     }
+
+    fn proof_selector(&self, network: &str, proof_system: &str) -> anyhow::Result<[u8; 4]> {
+        let selectors = self
+            .proof_selectors
+            .get(network)
+            .with_context(|| format!("no Beta3 release selector is configured for {network}"))?;
+        match proof_system {
+            "groth16" | "sp1-groth16" => Ok(selectors.groth16),
+            "plonk" | "sp1-plonk" => Ok(selectors.plonk),
+            _ => Err(anyhow!("unsupported stored proof system")),
+        }
+    }
+}
+
+fn release_proof_selectors<F>(lookup: &F) -> anyhow::Result<BTreeMap<String, ProofSelectors>>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut selectors = BTreeMap::new();
+    for (expected_network, variable) in [
+        ("base-mainnet", BASE_MAINNET_RELEASE_ENV),
+        ("base-sepolia", BASE_SEPOLIA_RELEASE_ENV),
+    ] {
+        let Some(raw) = lookup(variable) else {
+            continue;
+        };
+        let release: BrokerReleaseIdentity = serde_json::from_str(&raw)
+            .with_context(|| format!("{variable} is not valid release JSON"))?;
+        if release.protocol_version != OPEN_COMPETITION_V2_PROTOCOL_VERSION
+            || release.network != expected_network
+        {
+            return Err(anyhow!("{variable} has the wrong protocol or network"));
+        }
+        selectors.insert(
+            expected_network.to_string(),
+            ProofSelectors {
+                groth16: verifier_selector(&release.groth16_verifier_hash)
+                    .with_context(|| format!("{variable} has an invalid Groth16 verifier hash"))?,
+                plonk: verifier_selector(&release.plonk_verifier_hash)
+                    .with_context(|| format!("{variable} has an invalid PLONK verifier hash"))?,
+            },
+        );
+    }
+    if selectors.is_empty() {
+        return Err(anyhow!(
+            "a Base mainnet or Sepolia Beta3 release manifest is required"
+        ));
+    }
+    Ok(selectors)
+}
+
+fn verifier_selector(value: &str) -> anyhow::Result<[u8; 4]> {
+    let bytes = bounded_hex(value, 32, 32)?;
+    Ok(bytes[..4].try_into().expect("four-byte slice"))
 }
 
 #[derive(Clone)]
@@ -205,7 +285,7 @@ struct ProverPayloadError {
 
 fn validate_proved_response(
     response: &ProverResponse,
-    proof_system: &str,
+    expected_selector: [u8; 4],
     expected_public_values: &str,
 ) -> Result<ValidatedProverPayload, ProverPayloadError> {
     let invalid = || ProverPayloadError {
@@ -218,7 +298,7 @@ fn validate_proved_response(
         4 * 1024 * 1024,
     )
     .map_err(|_| invalid())?;
-    if !proof_has_expected_selector(proof_system, &proof) {
+    if !proof_has_expected_selector(expected_selector, &proof) {
         return Err(ProverPayloadError {
             code: "proof_system_selector_mismatch",
             message: "Proof bytes did not carry the quote-bound canonical SP1 verifier selector.",
@@ -417,9 +497,23 @@ async fn process_prover_job(
             Ok((job.state, "refund_due".to_string()))
         }
         ProverStatus::Proved => {
+            let expected_selector = match config.proof_selector(&job.network, &job.proof_system) {
+                Ok(selector) => selector,
+                Err(_) => {
+                    *job = mark_refund_due(
+                        store,
+                        config,
+                        job,
+                        "proof_release_selector_unavailable",
+                        "The broker has no release-bound selector for this job.",
+                    )
+                    .await?;
+                    return Ok((job.state, "refund_due".to_string()));
+                }
+            };
             let payload = match validate_proved_response(
                 &response,
-                &job.proof_system,
+                expected_selector,
                 &job.expected_public_values,
             ) {
                 Ok(payload) => payload,
@@ -988,12 +1082,7 @@ fn parse_proof_system(value: &str) -> anyhow::Result<OpenCompetitionV2ProofSyste
     }
 }
 
-fn proof_has_expected_selector(proof_system: &str, proof: &[u8]) -> bool {
-    let expected = match proof_system {
-        "groth16" | "sp1-groth16" => [0x43, 0x88, 0xa2, 0x1c],
-        "plonk" | "sp1-plonk" => [0x5a, 0x09, 0x3a, 0x2f],
-        _ => return false,
-    };
+fn proof_has_expected_selector(expected: [u8; 4], proof: &[u8]) -> bool {
     proof.starts_with(&expected)
 }
 
@@ -1134,6 +1223,16 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    fn broker_release(network: &str) -> String {
+        serde_json::json!({
+            "protocol_version": OPEN_COMPETITION_V2_PROTOCOL_VERSION,
+            "network": network,
+            "groth16_verifier_hash": "0x780d0643126338d5f2ac4520b2dcf0823292e0b82f21610e443da02edb5c2951",
+            "plonk_verifier_hash": "0x7e52d06272ffc34edbfb7c21582ea2496b6a0f779fd8883341642a92846b183c"
+        })
+        .to_string()
+    }
+
     fn proof_job() -> OpenCompetitionV2ProofJob {
         let now = Utc::now();
         let mut public_values = vec![0_u8; 640];
@@ -1207,25 +1306,38 @@ mod tests {
 
     #[test]
     fn broker_config_requires_https_and_bounded_refunds() {
-        let values = HashMap::from([(
-            OPEN_COMPETITION_V2_PROVER_URL_ENV,
-            "https://prover.example/jobs",
-        )]);
-        let config = OpenCompetitionV2BrokerConfig::from_lookup(|key| {
-            values.get(key).map(|value| value.to_string())
-        })
-        .unwrap();
+        let values = HashMap::from([
+            (
+                OPEN_COMPETITION_V2_PROVER_URL_ENV,
+                "https://prover.example/jobs".to_string(),
+            ),
+            (BASE_MAINNET_RELEASE_ENV, broker_release("base-mainnet")),
+        ]);
+        let config =
+            OpenCompetitionV2BrokerConfig::from_lookup(|key| values.get(key).cloned()).unwrap();
         assert_eq!(config.refund_window_seconds, 1_800);
         assert!(config.lease_seconds > config.request_timeout_seconds as u32);
+        assert_eq!(
+            config.proof_selector("base-mainnet", "groth16").unwrap(),
+            [0x78, 0x0d, 0x06, 0x43]
+        );
+        assert_eq!(
+            config.proof_selector("base-mainnet", "plonk").unwrap(),
+            [0x7e, 0x52, 0xd0, 0x62]
+        );
+        assert!(config.proof_selector("base-sepolia", "groth16").is_err());
 
-        let insecure = HashMap::from([(
-            OPEN_COMPETITION_V2_PROVER_URL_ENV,
-            "http://prover.example/jobs",
-        )]);
-        assert!(OpenCompetitionV2BrokerConfig::from_lookup(|key| {
-            insecure.get(key).map(|value| value.to_string())
-        })
-        .is_err());
+        let insecure = HashMap::from([
+            (
+                OPEN_COMPETITION_V2_PROVER_URL_ENV,
+                "http://prover.example/jobs".to_string(),
+            ),
+            (BASE_MAINNET_RELEASE_ENV, broker_release("base-mainnet")),
+        ]);
+        assert!(
+            OpenCompetitionV2BrokerConfig::from_lookup(|key| { insecure.get(key).cloned() })
+                .is_err()
+        );
     }
 
     #[test]
@@ -1238,16 +1350,16 @@ mod tests {
             "0xbef7892d64c4651df16fad4b6d6ed8a97654e5e6e3c3bbdde31b80c440c7b133"
         );
         assert!(proof_has_expected_selector(
-            "groth16",
-            &[0x43, 0x88, 0xa2, 0x1c, 1]
+            [0x78, 0x0d, 0x06, 0x43],
+            &[0x78, 0x0d, 0x06, 0x43, 1]
         ));
         assert!(proof_has_expected_selector(
-            "plonk",
-            &[0x5a, 0x09, 0x3a, 0x2f, 1]
+            [0x7e, 0x52, 0xd0, 0x62],
+            &[0x7e, 0x52, 0xd0, 0x62, 1]
         ));
         assert!(!proof_has_expected_selector(
-            "groth16",
-            &[0x5a, 0x09, 0x3a, 0x2f]
+            [0x78, 0x0d, 0x06, 0x43],
+            &[0x43, 0x88, 0xa2, 0x1c, 1]
         ));
     }
 
@@ -1257,33 +1369,34 @@ mod tests {
         let mut response = ProverResponse {
             status: ProverStatus::Proved,
             provider_job_id: "provider-1".to_string(),
-            proof: Some("0x4388a21c01".to_string()),
+            proof: Some("0x780d064301".to_string()),
             public_values: Some(expected.clone()),
             failure_code: None,
             failure_message: None,
         };
-        let payload = validate_proved_response(&response, "groth16", &expected).unwrap();
-        assert_eq!(payload.proof, [0x43, 0x88, 0xa2, 0x1c, 0x01]);
+        let selector = [0x78, 0x0d, 0x06, 0x43];
+        let payload = validate_proved_response(&response, selector, &expected).unwrap();
+        assert_eq!(payload.proof, [0x78, 0x0d, 0x06, 0x43, 0x01]);
         assert_eq!(payload.public_values.len(), 640);
 
         response.proof = None;
         assert_eq!(
-            validate_proved_response(&response, "groth16", &expected)
+            validate_proved_response(&response, selector, &expected)
                 .unwrap_err()
                 .code,
             "proof_provider_response_invalid"
         );
-        response.proof = Some("0x5a093a2f01".to_string());
+        response.proof = Some("0x4388a21c01".to_string());
         assert_eq!(
-            validate_proved_response(&response, "groth16", &expected)
+            validate_proved_response(&response, selector, &expected)
                 .unwrap_err()
                 .code,
             "proof_system_selector_mismatch"
         );
-        response.proof = Some("0x4388a21c01".to_string());
+        response.proof = Some("0x780d064301".to_string());
         response.public_values = Some(format!("0x{}", "cd".repeat(640)));
         assert_eq!(
-            validate_proved_response(&response, "groth16", &expected)
+            validate_proved_response(&response, selector, &expected)
                 .unwrap_err()
                 .code,
             "proof_journal_mismatch"

--- a/scripts/run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/run_open_competition_v2_x402_rehearsal.py
@@ -149,6 +149,21 @@ def sign_payment(
     ).decode()
 
 
+def sign_relay_authorization(actor: Any, authorization: dict[str, Any]) -> str:
+    require(
+        authorization.get("primaryType") == "SubmitProof",
+        "relay authorization has the wrong EIP-712 primary type",
+    )
+    require(
+        isinstance(authorization.get("types"), dict)
+        and isinstance(authorization.get("domain"), dict)
+        and isinstance(authorization.get("message"), dict),
+        "relay authorization is not complete EIP-712 typed data",
+    )
+    signed = actor.sign_message(encode_typed_data(full_message=authorization))
+    return "0x" + bytes(signed.signature).hex()
+
+
 def run_worker(binary: Path, protocol: str) -> str:
     environment = {**os.environ, "BASE_INDEXER_PROTOCOL": protocol, "BASE_INDEXER_ONCE": "true"}
     completed = subprocess.run(
@@ -335,14 +350,15 @@ def main() -> int:
         relay_url,
         {"authorization_deadline": authorization_deadline, "solver_signature": None},
     )
-    digest = unsigned["plan"]["relay_authorization"]["digest"]
-    signature = solver.unsafe_sign_hash(bytes.fromhex(digest.removeprefix("0x"))).signature
+    signature = sign_relay_authorization(
+        solver, unsigned["plan"]["relay_authorization"]
+    )
     _, authorized, _ = request_json(
         "POST",
         relay_url,
         {
             "authorization_deadline": authorization_deadline,
-            "solver_signature": "0x" + bytes(signature).hex(),
+            "solver_signature": signature,
         },
     )
     require(authorized["state"] == "relaying", "solver relay authorization was not accepted")

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -89,6 +89,13 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         self.assertIn("expected_gnark_cli", self.text)
         self.assertNotIn('docker pull "$SP1_GNARK_RUNTIME_IMAGE"', self.text)
 
+    def test_canaries_use_current_control_binaries_with_frozen_release_assets(self):
+        self.assertIn("ref: ${{ github.sha }}", self.text)
+        self.assertIn("path: target/continuation-control", self.text)
+        self.assertIn("--manifest-path target/continuation-control/Cargo.toml", self.text)
+        self.assertIn("target/continuation-build/release/api", self.text)
+        self.assertIn("--worker-binary target/continuation-build/release/worker", self.text)
+
     def test_canaries_and_activation_remain_mandatory(self):
         for evidence in (
             "mainnet-x402-success.json",

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -105,6 +105,13 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         self.assertIn("--manifest-path target/continuation-control/Cargo.toml", self.text)
         self.assertIn("target/continuation-build/release/api", self.text)
         self.assertIn("--worker-binary target/continuation-build/release/worker", self.text)
+        self.assertEqual(
+            self.text.count(
+                "target/continuation-control/scripts/run_open_competition_v2_x402_rehearsal.py"
+            ),
+            2,
+        )
+        self.assertIn('sudo rm -rf "$GITHUB_WORKSPACE/target"', self.text)
 
     def test_canaries_and_activation_remain_mandatory(self):
         for evidence in (

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -67,11 +67,16 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         self.assertIn("open-competition-v2-beta3-live-sepolia-resumed", self.text)
         self.assertIn("failed-x402-charge-refund.json", self.text)
         self.assertIn("failed-x402-charge-refund-2.json", self.text)
+        self.assertIn("failed-x402-charge-refund-3.json", self.text)
         self.assertIn("x402-canary-replacement.json", self.text)
         self.assertIn(".minimum_broker_sla_seconds == 1800", self.text)
         self.assertIn(".superseded_recovery.recovered == true", self.text)
         self.assertIn(
             "0xba73504377041ca89b5262421e7c994a40e7c955c5f71f9dc95f16d2c966d312",
+            self.text,
+        )
+        self.assertIn(
+            "0x53fdaf15f234cf1ab4267bde5ce602221b8ad4e81ca011f457ab365a899e1e56",
             self.text,
         )
         self.assertIn(".settlement_event_id | length > 0", self.text)

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -111,7 +111,10 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertIn('sudo rm -rf "$GITHUB_WORKSPACE/target"', self.text)
+        self.assertEqual(
+            self.text.count('sudo rm -rf "$GITHUB_WORKSPACE/target"'),
+            2,
+        )
 
     def test_canaries_and_activation_remain_mandatory(self):
         for evidence in (

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -69,6 +69,7 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         self.assertIn("failed-x402-charge-refund-2.json", self.text)
         self.assertIn("failed-x402-charge-refund-3.json", self.text)
         self.assertIn("failed-x402-charge-refund-4.json", self.text)
+        self.assertIn("failed-x402-charge-refund-5.json", self.text)
         self.assertIn("x402-canary-replacement.json", self.text)
         self.assertIn(".minimum_broker_sla_seconds == 1800", self.text)
         self.assertIn(".superseded_recovery.recovered == true", self.text)
@@ -82,6 +83,10 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         )
         self.assertIn(
             "0xedf4427c273df26905f3a5fe377d17bab4e2f9c8485f38f498652379ff4b622a",
+            self.text,
+        )
+        self.assertIn(
+            "0x8b0b85cdd06147ae1e37fdbd4e8ea78876bb312bd234dcd49aadfa25e0b89c27",
             self.text,
         )
         self.assertIn(".settlement_event_id | length > 0", self.text)

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -68,6 +68,7 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         self.assertIn("failed-x402-charge-refund.json", self.text)
         self.assertIn("failed-x402-charge-refund-2.json", self.text)
         self.assertIn("failed-x402-charge-refund-3.json", self.text)
+        self.assertIn("failed-x402-charge-refund-4.json", self.text)
         self.assertIn("x402-canary-replacement.json", self.text)
         self.assertIn(".minimum_broker_sla_seconds == 1800", self.text)
         self.assertIn(".superseded_recovery.recovered == true", self.text)
@@ -77,6 +78,10 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         )
         self.assertIn(
             "0x53fdaf15f234cf1ab4267bde5ce602221b8ad4e81ca011f457ab365a899e1e56",
+            self.text,
+        )
+        self.assertIn(
+            "0xedf4427c273df26905f3a5fe377d17bab4e2f9c8485f38f498652379ff4b622a",
             self.text,
         )
         self.assertIn(".settlement_event_id | length > 0", self.text)

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -89,6 +89,11 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         self.assertIn("sepolia-x402-rehearsal-success.json", text)
         self.assertIn("x402-canary-replacement-success.json", text)
         self.assertIn("chmod u+w target/release-gates.json", text)
+        self.assertNotIn(
+            "target/continuation-control/scripts/record_open_competition_v2_beta3_gate.py",
+            text,
+        )
+        self.assertIn("python scripts/record_open_competition_v2_beta3_gate.py", text)
         self.assertIn("if: inputs.mode != 'recover-second-only'", text)
         self.assertIn("open-competition-v2-beta3-x402-charge-recovery-5", text)
         self.assertIn('docker tag "$SP1_GNARK_IMAGE" "$SP1_GNARK_RUNTIME_IMAGE"', text)

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -48,8 +48,7 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         self.assertFalse(checkouts[0]["with"]["clean"])
         self.assertEqual(checkouts[1]["with"]["ref"], "${{ github.sha }}")
         self.assertEqual(checkouts[1]["with"]["path"], "target/continuation-control")
-        self.assertIn("sudo chown -R", text)
-        self.assertIn("rm -rf target", text)
+        self.assertIn("sudo rm -rf target", text)
         self.assertIn(
             "target/continuation-control/scripts/recover_open_competition_v2_x402_charge.py",
             text,

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -77,6 +77,8 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         self.assertIn('docker tag "$SP1_GNARK_IMAGE" "$SP1_GNARK_RUNTIME_IMAGE"', text)
         self.assertIn("expected_gnark_image_id", text)
         self.assertIn("expected_gnark_cli", text)
+        self.assertIn("--manifest-path target/continuation-control/Cargo.toml", text)
+        self.assertIn("--worker-binary target/continuation-build/release/worker", text)
         self.assertIn("--source-commit \"$RELEASE_SOURCE_COMMIT\"", text)
         self.assertNotIn("jq -r .deployer", text)
         self.assertNotIn("deploy_open_competition_v2_beta3.py", text)

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -79,13 +79,24 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
             text,
         )
         self.assertIn("target/failed-x402-charge-refund-4.json", text)
+        self.assertIn(
+            "0x8b0b85cdd06147ae1e37fdbd4e8ea78876bb312bd234dcd49aadfa25e0b89c27",
+            text,
+        )
+        self.assertIn("target/failed-x402-charge-refund-5.json", text)
         self.assertIn('if [[ "$RECOVERY_ONLY" == "true" ]]', text)
-        self.assertIn("open-competition-v2-beta3-x402-charge-recovery-4", text)
+        self.assertIn("open-competition-v2-beta3-x402-charge-recovery-5", text)
         self.assertIn('docker tag "$SP1_GNARK_IMAGE" "$SP1_GNARK_RUNTIME_IMAGE"', text)
         self.assertIn("expected_gnark_image_id", text)
         self.assertIn("expected_gnark_cli", text)
         self.assertIn("--manifest-path target/continuation-control/Cargo.toml", text)
+        self.assertIn("--release -p api -p worker", text)
+        self.assertIn("target/continuation-build/release/api", text)
         self.assertIn("--worker-binary target/continuation-build/release/worker", text)
+        self.assertIn(
+            "target/continuation-control/scripts/run_open_competition_v2_x402_rehearsal.py",
+            text,
+        )
         self.assertIn("--source-commit \"$RELEASE_SOURCE_COMMIT\"", text)
         self.assertNotIn("jq -r .deployer", text)
         self.assertNotIn("deploy_open_competition_v2_beta3.py", text)

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -45,8 +45,11 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         ]
         self.assertEqual(len(checkouts), 2)
         self.assertEqual(checkouts[0]["with"]["ref"], "${{ env.RELEASE_SOURCE_COMMIT }}")
+        self.assertFalse(checkouts[0]["with"]["clean"])
         self.assertEqual(checkouts[1]["with"]["ref"], "${{ github.sha }}")
         self.assertEqual(checkouts[1]["with"]["path"], "target/continuation-control")
+        self.assertIn("sudo chown -R", text)
+        self.assertIn("rm -rf target", text)
         self.assertIn(
             "target/continuation-control/scripts/recover_open_competition_v2_x402_charge.py",
             text,

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -30,7 +30,7 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         self.assertEqual(dispatch["inputs"]["mode"]["default"], "recover-second-only")
         self.assertEqual(
             dispatch["inputs"]["mode"]["options"],
-            ["recover-second-only", "resume-rehearsal"],
+            ["recover-second-only", "finalize-success", "resume-rehearsal"],
         )
         self.assertNotIn("push", workflow[True])
         self.assertNotIn("schedule", workflow[True])
@@ -85,6 +85,11 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
         )
         self.assertIn("target/failed-x402-charge-refund-5.json", text)
         self.assertIn('if [[ "$RECOVERY_ONLY" == "true" ]]', text)
+        self.assertIn('if [[ "$FINALIZE_SUCCESS" == "true" ]]', text)
+        self.assertIn("sepolia-x402-rehearsal-success.json", text)
+        self.assertIn("x402-canary-replacement-success.json", text)
+        self.assertIn("chmod u+w target/release-gates.json", text)
+        self.assertIn("if: inputs.mode != 'recover-second-only'", text)
         self.assertIn("open-competition-v2-beta3-x402-charge-recovery-5", text)
         self.assertIn('docker tag "$SP1_GNARK_IMAGE" "$SP1_GNARK_RUNTIME_IMAGE"', text)
         self.assertIn("expected_gnark_image_id", text)

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -72,8 +72,13 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
             text,
         )
         self.assertIn("target/failed-x402-charge-refund-3.json", text)
+        self.assertIn(
+            "0xedf4427c273df26905f3a5fe377d17bab4e2f9c8485f38f498652379ff4b622a",
+            text,
+        )
+        self.assertIn("target/failed-x402-charge-refund-4.json", text)
         self.assertIn('if [[ "$RECOVERY_ONLY" == "true" ]]', text)
-        self.assertIn("open-competition-v2-beta3-x402-charge-recovery-3", text)
+        self.assertIn("open-competition-v2-beta3-x402-charge-recovery-4", text)
         self.assertIn('docker tag "$SP1_GNARK_IMAGE" "$SP1_GNARK_RUNTIME_IMAGE"', text)
         self.assertIn("expected_gnark_image_id", text)
         self.assertIn("expected_gnark_cli", text)

--- a/scripts/test_resume_open_competition_v2_beta3_x402.py
+++ b/scripts/test_resume_open_competition_v2_beta3_x402.py
@@ -67,8 +67,13 @@ class ResumeBeta3X402WorkflowTests(unittest.TestCase):
             text,
         )
         self.assertIn("target/failed-x402-charge-refund-2.json", text)
+        self.assertIn(
+            "0x53fdaf15f234cf1ab4267bde5ce602221b8ad4e81ca011f457ab365a899e1e56",
+            text,
+        )
+        self.assertIn("target/failed-x402-charge-refund-3.json", text)
         self.assertIn('if [[ "$RECOVERY_ONLY" == "true" ]]', text)
-        self.assertIn("open-competition-v2-beta3-x402-charge-recovery-2", text)
+        self.assertIn("open-competition-v2-beta3-x402-charge-recovery-3", text)
         self.assertIn('docker tag "$SP1_GNARK_IMAGE" "$SP1_GNARK_RUNTIME_IMAGE"', text)
         self.assertIn("expected_gnark_image_id", text)
         self.assertIn("expected_gnark_cli", text)

--- a/scripts/test_run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_x402_rehearsal.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import unittest
 
 from eth_account import Account
+from eth_account.messages import encode_typed_data
 
 
 PATH = Path(__file__).with_name("run_open_competition_v2_x402_rehearsal.py")
@@ -81,6 +82,51 @@ class X402RehearsalTests(unittest.TestCase):
         self.assertEqual(payload["network"], "base-mainnet")
         self.assertEqual(payload["competition_contract"], spec["competition"])
         self.assertTrue(payload["relay"])
+
+    def test_relay_authorization_signs_exact_api_typed_data(self):
+        actor = Account.from_key("0x" + "11" * 32)
+        authorization = {
+            "types": {
+                "EIP712Domain": [
+                    {"name": "name", "type": "string"},
+                    {"name": "version", "type": "string"},
+                    {"name": "chainId", "type": "uint256"},
+                    {"name": "verifyingContract", "type": "address"},
+                ],
+                "SubmitProof": [
+                    {"name": "solver", "type": "address"},
+                    {"name": "solverNonce", "type": "uint256"},
+                    {"name": "publicValuesHash", "type": "bytes32"},
+                    {"name": "proofHash", "type": "bytes32"},
+                    {"name": "authorizationDeadline", "type": "uint256"},
+                ],
+            },
+            "primaryType": "SubmitProof",
+            "domain": {
+                "name": "Agent Bounties Open Competition V2 Beta3",
+                "version": "1",
+                "chainId": 84532,
+                "verifyingContract": "0x" + "22" * 20,
+            },
+            "message": {
+                "solver": actor.address,
+                "solverNonce": "7",
+                "publicValuesHash": "0x" + "33" * 32,
+                "proofHash": "0x" + "44" * 32,
+                "authorizationDeadline": "2000000000",
+            },
+        }
+        signature = MODULE.sign_relay_authorization(actor, authorization)
+        recovered = Account.recover_message(
+            encode_typed_data(full_message=authorization), signature=signature
+        )
+        self.assertEqual(recovered, actor.address)
+        self.assertRegex(signature, r"^0x[0-9a-f]{130}$")
+
+    def test_relay_authorization_rejects_stale_digest_shape(self):
+        actor = Account.from_key("0x" + "11" * 32)
+        with self.assertRaises(MODULE.X402RehearsalError):
+            MODULE.sign_relay_authorization(actor, {"digest": "0x" + "00" * 32})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- recover the exact third failed Sepolia x402 charge and make mainnet continuation require its refund evidence
- derive proof selectors from each signed Beta3 release manifest instead of obsolete generic constants
- build current broker/API control binaries separately while preserving frozen contract and verifier assets

## Evidence
- canonical third refund: `0x79ca1d0a65c146b1ea7a939029a45571d14a059a2ab57a5a7d18e6f10efc9e75`
- `cargo test -p worker --lib`: 32 passed, 1 Docker-only ignored
- `cargo clippy -p worker --lib -- -D warnings`: passed
- focused workflow tests: 7 passed
- YAML parse and core preflight: passed

## Safety boundary
This does not change verifier bytecode, proof assets, factory bytecode, release source identity, or any mainnet state. Unknown release networks and proof systems move paid jobs to the refund path. Only canonical chain events prove settlement.
