### PR TITLE
Fix Beta3 mainnet replacement evidence gate

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -65,7 +65,6 @@ jobs:
           jq -e '.passed == true and (.settlement_event_id | length > 0)' target/live-sepolia/sepolia-x402-rehearsal.json >/dev/null
           replacement="$(jq -r .competition target/live-sepolia/x402-canary-replacement.json)"
           test "$replacement" = "$(jq -r .competition target/live-sepolia/sepolia-x402-rehearsal.json)"
-          test "$replacement" = "$(jq -r .x402_canary.competition target/live-sepolia/sepolia-rehearsal.json)"
           jq -e '.passed == true and .replacement_id == 1 and .minimum_broker_sla_seconds == 1800 and .superseded_recovery.recovered == true' \
             target/live-sepolia/x402-canary-replacement.json >/dev/null
           jq -e '.passed == true and .amount == "110000" and (.refund_transaction | length > 0)' \

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -90,6 +90,14 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
             self.text,
         )
         self.assertIn(".settlement_event_id | length > 0", self.text)
+        self.assertIn(
+            'test "$replacement" = "$(jq -r .competition target/live-sepolia/sepolia-x402-rehearsal.json)"',
+            self.text,
+        )
+        self.assertNotIn(
+            'test "$replacement" = "$(jq -r .x402_canary.competition',
+            self.text,
+        )
         self.assertIn(".source_commit == $commit", self.text)
         self.assertNotIn('--source-commit "$GITHUB_SHA"', self.text)
 


### PR DESCRIPTION
What passed: canonical Sepolia replacement and settlement evidence agree; all five failed x402 charges have canonical refunds; mainnet run 32264674689 stopped before deployment or transfer. Fix: remove the contradictory assertion that the superseded canary address must equal its replacement, while retaining strict replacement-to-settlement equality and superseded-recovery checks. Verification: focused workflow unit test, YAML parse, and git diff check pass.