### PR TITLE
Resume Beta3 mainnet deployment after RPC visibility lag

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -34,6 +34,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           ref: ${{ env.RELEASE_SOURCE_COMMIT }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ github.sha }}
+          path: .release-control
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
@@ -105,12 +109,13 @@ jobs:
             --evidence target/owner-mainnet-deployment-approval.json \
             --uri "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --source-commit "$RELEASE_SOURCE_COMMIT" --owner-risk-hash "$RISK_HASH"
-          python scripts/build_open_competition_v2_beta3_release.py --network base-mainnet \
+          python .release-control/scripts/build_open_competition_v2_beta3_release.py --network base-mainnet \
             --rpc-url "$BASE_MAINNET_RPC_URL" --deployer "$DEPLOYER" \
             --source-commit "$RELEASE_SOURCE_COMMIT" \
             --verifier-assets target/release-assets/verifier-assets.json \
-            --gates target/release-gates.json --output target/mainnet-exact.json
-          python scripts/deploy_open_competition_v2_beta3.py \
+            --gates target/release-gates.json --output target/mainnet-exact.json \
+            --release-root "$GITHUB_WORKSPACE"
+          python .release-control/scripts/deploy_open_competition_v2_beta3.py \
             --bundle target/mainnet-exact.json --rpc-url "$BASE_MAINNET_RPC_URL" \
             --output target/mainnet-deployment-evidence.json
           python scripts/record_open_competition_v2_beta3_gate.py \

--- a/scripts/build_open_competition_v2_beta3_release.py
+++ b/scripts/build_open_competition_v2_beta3_release.py
@@ -202,6 +202,13 @@ def source_tree_hash() -> str:
     return "0x" + digest.hexdigest()
 
 
+def configure_release_root(path: Path) -> None:
+    global ROOT, CONTRACT_ROOT, OUT
+    ROOT = path.resolve()
+    CONTRACT_ROOT = ROOT / "contracts" / "base-escrow"
+    OUT = CONTRACT_ROOT / "out"
+
+
 def verify_exact_checkout(source_commit: str) -> None:
     if not re.fullmatch(r"[0-9a-f]{40}", source_commit):
         raise ValueError("source commit must be a full lowercase Git commit")
@@ -490,6 +497,59 @@ def online_preflight(network: dict[str, Any], rpc_url: str, deployer: str) -> di
     }
 
 
+def resume_exact_verifier_pair(
+    *,
+    deployer: str,
+    observed_nonce: int,
+    code_hash: Any,
+    groth16_runtime_hash: str,
+    plonk_runtime_hash: str,
+) -> int:
+    """Reuse an exact verifier pair when a prior factory deployment was interrupted."""
+    if observed_nonce < 2:
+        return observed_nonce
+    start_nonce = observed_nonce - 2
+    groth16 = create_address(deployer, start_nonce)
+    plonk = create_address(deployer, start_nonce + 1)
+    factory = create_address(deployer, start_nonce + 2)
+    if (
+        code_hash(groth16) == groth16_runtime_hash
+        and code_hash(plonk) == plonk_runtime_hash
+        and code_hash(factory) is None
+    ):
+        return start_nonce
+    return observed_nonce
+
+
+def apply_partial_deployment_resume(
+    *,
+    preflight: dict[str, Any],
+    rpc_url: str,
+    deployer: str,
+    verifier_assets: dict[str, Any],
+) -> dict[str, Any]:
+    observed_nonce = int(preflight["deployer_nonce"])
+    safe_block = hex(int(preflight["number"]))
+
+    def code_hash(address: str) -> str | None:
+        code = rpc(rpc_url, "eth_getCode", [address, safe_block])
+        return None if code == "0x" else keccak256(bytes.fromhex(code[2:]))
+
+    systems = verifier_assets["proof_systems"]
+    start_nonce = resume_exact_verifier_pair(
+        deployer=deployer,
+        observed_nonce=observed_nonce,
+        code_hash=code_hash,
+        groth16_runtime_hash=systems["groth16"]["runtime_code_hash"],
+        plonk_runtime_hash=systems["plonk"]["runtime_code_hash"],
+    )
+    value = dict(preflight)
+    value["observed_deployer_nonce"] = observed_nonce
+    value["deployer_nonce"] = start_nonce
+    value["resuming_exact_verifiers"] = start_nonce != observed_nonce
+    return value
+
+
 def build_bundle(
     *,
     network_name: str,
@@ -752,6 +812,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--allow-pending-proof-evidence", action="store_true")
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--runtime-manifest-output", type=Path)
+    parser.add_argument(
+        "--release-root",
+        type=Path,
+        help="Exact frozen release checkout to hash and read compiled artifacts from",
+    )
     return parser.parse_args()
 
 
@@ -812,11 +877,23 @@ def runtime_manifest(bundle: dict[str, Any], deployment_block: int = 0) -> dict[
 
 def main() -> int:
     args = parse_args()
+    if args.release_root is not None:
+        configure_release_root(args.release_root)
     network = NETWORKS[args.network]
     deployer = args.deployer.lower()
     verify_exact_checkout(args.source_commit)
     subject_hash = repository_subject_hash(args.source_commit)
-    preflight = online_preflight(network, args.rpc_url or network["rpc"], deployer)
+    rpc_url = args.rpc_url or network["rpc"]
+    verifier_assets = load_verifier_assets(
+        args.verifier_assets,
+        require_proof_evidence=not args.allow_pending_proof_evidence,
+    )
+    preflight = apply_partial_deployment_resume(
+        preflight=online_preflight(network, rpc_url, deployer),
+        rpc_url=rpc_url,
+        deployer=deployer,
+        verifier_assets=verifier_assets,
+    )
     bundle = build_bundle(
         network_name=args.network,
         deployer=deployer,
@@ -824,10 +901,7 @@ def main() -> int:
         repository_subject=subject_hash,
         preflight=preflight,
         gates=load_gates(args.gates, subject_hash),
-        verifier_assets=load_verifier_assets(
-            args.verifier_assets,
-            require_proof_evidence=not args.allow_pending_proof_evidence,
-        ),
+        verifier_assets=verifier_assets,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(bundle, indent=2) + "\n", encoding="utf-8")

--- a/scripts/deploy_open_competition_v2_beta3.py
+++ b/scripts/deploy_open_competition_v2_beta3.py
@@ -142,6 +142,14 @@ class SignedRpc:
             time.sleep(5)
         raise RuntimeError("deployment did not reach a Base safe block")
 
+    def require_safe_code_hashes(
+        self, expected_hashes: dict[str, str], block_number: int
+    ) -> None:
+        safe = self.wait_safe(block_number)
+        for address, expected_hash in expected_hashes.items():
+            actual = self.code_hash(address, safe["number"])
+            require(actual == expected_hash, f"safe runtime hash mismatch: {address}")
+
 
 def expected_runtime_hashes(bundle: dict[str, Any]) -> dict[str, str]:
     return {
@@ -231,6 +239,24 @@ def deploy(bundle: dict[str, Any], client: SignedRpc, output: Path) -> dict[str,
                 f"existing evidence address differs: {component}",
             )
             continue
+        if component == "factory":
+            dependency_blocks = [
+                int(item["block_number"])
+                for item in evidence["transactions"]
+                if item["component"] in {"groth16_verifier", "plonk_verifier"}
+            ]
+            require(len(dependency_blocks) == 2, "factory verifier evidence is incomplete")
+            client.require_safe_code_hashes(
+                {
+                    bundle["groth16_verifier"]["address"]: bundle["groth16_verifier"][
+                        "runtime_code_hash"
+                    ],
+                    bundle["plonk_verifier"]["address"]: bundle["plonk_verifier"][
+                        "runtime_code_hash"
+                    ],
+                },
+                max(dependency_blocks),
+            )
         if client.code_hash(transaction["predicted_address"]) is not None or client.pending_nonce() > transaction["from_nonce"]:
             record = recovered_component_record(bundle, transaction, client)
         else:

--- a/scripts/test_build_open_competition_v2_beta3_release.py
+++ b/scripts/test_build_open_competition_v2_beta3_release.py
@@ -21,6 +21,75 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
             "0xfd7be4c69541ab297aece2a674fc1418b898cc0a",
         )
 
+    def test_resumes_exact_verifiers_after_interrupted_factory_deployment(self):
+        deployer = MODULE.DEFAULT_DEPLOYER
+        expected = {
+            MODULE.create_address(deployer, 2): "groth16",
+            MODULE.create_address(deployer, 3): "plonk",
+        }
+
+        start = MODULE.resume_exact_verifier_pair(
+            deployer=deployer,
+            observed_nonce=4,
+            code_hash=lambda address: expected.get(address),
+            groth16_runtime_hash="groth16",
+            plonk_runtime_hash="plonk",
+        )
+
+        self.assertEqual(start, 2)
+
+    def test_does_not_resume_inexact_or_occupied_partial_deployment(self):
+        deployer = MODULE.DEFAULT_DEPLOYER
+        groth16 = MODULE.create_address(deployer, 2)
+        plonk = MODULE.create_address(deployer, 3)
+        factory = MODULE.create_address(deployer, 4)
+        cases = (
+            {groth16: "wrong", plonk: "plonk"},
+            {groth16: "groth16", plonk: "wrong"},
+            {groth16: "groth16", plonk: "plonk", factory: "occupied"},
+        )
+        for observed in cases:
+            with self.subTest(observed=observed):
+                self.assertEqual(
+                    MODULE.resume_exact_verifier_pair(
+                        deployer=deployer,
+                        observed_nonce=4,
+                        code_hash=lambda address, values=observed: values.get(address),
+                        groth16_runtime_hash="groth16",
+                        plonk_runtime_hash="plonk",
+                    ),
+                    4,
+                )
+
+    def test_release_root_retargets_only_release_files(self):
+        original = (MODULE.ROOT, MODULE.CONTRACT_ROOT, MODULE.OUT)
+        try:
+            release_root = Path("target/frozen-release")
+            MODULE.configure_release_root(release_root)
+            self.assertEqual(MODULE.ROOT, release_root.resolve())
+            self.assertEqual(MODULE.CONTRACT_ROOT, MODULE.ROOT / "contracts/base-escrow")
+            self.assertEqual(MODULE.OUT, MODULE.CONTRACT_ROOT / "out")
+        finally:
+            MODULE.ROOT, MODULE.CONTRACT_ROOT, MODULE.OUT = original
+
+    def test_mainnet_continuation_uses_current_control_on_frozen_release(self):
+        workflow = (
+            MODULE.ROOT / ".github/workflows/continue-open-competition-v2-beta3-mainnet.yml"
+        ).read_text(encoding="utf-8")
+        deploy = workflow.split("  deploy-mainnet:", 1)[1].split(
+            "  deploy-production-prover:", 1
+        )[0]
+        self.assertIn("path: .release-control", deploy)
+        self.assertIn(
+            "python .release-control/scripts/build_open_competition_v2_beta3_release.py",
+            deploy,
+        )
+        self.assertIn('--release-root "$GITHUB_WORKSPACE"', deploy)
+        self.assertIn(
+            "python .release-control/scripts/deploy_open_competition_v2_beta3.py",
+            deploy,
+        )
+
     def test_proof_build_pins_every_bundle_to_the_configured_deployer(self):
         workflow = (
             MODULE.ROOT / ".github/workflows/open-competition-v2-beta3-release.yml"

--- a/scripts/test_deploy_open_competition_v2_beta3.py
+++ b/scripts/test_deploy_open_competition_v2_beta3.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 import deploy_open_competition_v2_beta3 as deploy
 
@@ -78,6 +79,22 @@ class DeploymentValidationTests(unittest.TestCase):
             value["repository_subject"]["hash"] = "0x" + "ff" * 32
             with self.assertRaisesRegex(RuntimeError, "another release"):
                 deploy.load_evidence(value, output)
+
+    def test_safe_runtime_check_uses_one_canonical_safe_block(self) -> None:
+        client = object.__new__(deploy.SignedRpc)
+        client.wait_safe = mock.Mock(return_value={"number": "0x2a"})
+        client.code_hash = mock.Mock(return_value="0xexact")
+
+        addresses = ("0x" + "12" * 20, "0x" + "34" * 20)
+        client.require_safe_code_hashes(
+            {address: "0xexact" for address in addresses}, 41
+        )
+
+        client.wait_safe.assert_called_once_with(41)
+        self.assertEqual(
+            client.code_hash.call_args_list,
+            [mock.call(address, "0x2a") for address in addresses],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- detect and reuse the exact canonical Groth16/PLONK verifier pair after an interrupted factory deployment
- require both verifier runtime hashes at one Base safe block before constructing the dependent factory
- run current release-control scripts against the frozen Beta3 contract checkout

## Incident evidence
Run 32267932625 deployed the exact verifiers at 