### PR TITLE
Reconcile completed Beta3 deployment after RPC timeout

### DIFF
--- a/scripts/build_open_competition_v2_beta3_release.py
+++ b/scripts/build_open_competition_v2_beta3_release.py
@@ -467,24 +467,33 @@ def activation_state(network_name: str, gates: dict[str, Any]) -> dict[str, bool
 
 
 def online_preflight(network: dict[str, Any], rpc_url: str, deployer: str) -> dict[str, Any]:
-    if rpc(rpc_url, "eth_chainId", []) != network["chain_id_hex"]:
+    def read(method: str, params: list[Any]) -> Any:
+        return rpc(
+            rpc_url,
+            method,
+            params,
+            attempts=5,
+            retry_delay=1,
+        )
+
+    if read("eth_chainId", []) != network["chain_id_hex"]:
         raise RuntimeError("RPC chain ID mismatch")
-    block = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False])
+    block = read("eth_getBlockByNumber", ["safe", False])
     if not block or not block.get("hash"):
         raise RuntimeError("RPC did not return a canonical safe block")
     tag = block["number"]
     dependencies = {"settlement_token": network["usdc"]}
     runtime_hashes: dict[str, str] = {}
     for name, address in dependencies.items():
-        code = rpc(rpc_url, "eth_getCode", [address, tag])
+        code = read("eth_getCode", [address, tag])
         if code == "0x":
             raise RuntimeError(f"{name} bytecode is unavailable at the safe block")
         runtime_hashes[name] = keccak256(bytes.fromhex(code[2:]))
-    eth_balance = int(rpc(rpc_url, "eth_getBalance", [deployer, tag]), 16)
-    nonce = int(rpc(rpc_url, "eth_getTransactionCount", [deployer, tag]), 16)
+    eth_balance = int(read("eth_getBalance", [deployer, tag]), 16)
+    nonce = int(read("eth_getTransactionCount", [deployer, tag]), 16)
     balance_data = "0x70a08231" + address_word(deployer).hex()
     usdc_balance = int(
-        rpc(rpc_url, "eth_call", [{"to": network["usdc"], "data": balance_data}, tag]), 16
+        read("eth_call", [{"to": network["usdc"], "data": balance_data}, tag]), 16
     )
     return {
         "number": int(tag, 16),
@@ -508,16 +517,15 @@ def resume_exact_verifier_pair(
     """Reuse an exact verifier pair when a prior factory deployment was interrupted."""
     if observed_nonce < 2:
         return observed_nonce
-    start_nonce = observed_nonce - 2
-    groth16 = create_address(deployer, start_nonce)
-    plonk = create_address(deployer, start_nonce + 1)
-    factory = create_address(deployer, start_nonce + 2)
-    if (
-        code_hash(groth16) == groth16_runtime_hash
-        and code_hash(plonk) == plonk_runtime_hash
-        and code_hash(factory) is None
-    ):
-        return start_nonce
+    minimum_nonce = max(0, observed_nonce - 16)
+    for start_nonce in range(observed_nonce - 2, minimum_nonce - 1, -1):
+        groth16 = create_address(deployer, start_nonce)
+        plonk = create_address(deployer, start_nonce + 1)
+        if (
+            code_hash(groth16) == groth16_runtime_hash
+            and code_hash(plonk) == plonk_runtime_hash
+        ):
+            return start_nonce
     return observed_nonce
 
 
@@ -532,7 +540,13 @@ def apply_partial_deployment_resume(
     safe_block = hex(int(preflight["number"]))
 
     def code_hash(address: str) -> str | None:
-        code = rpc(rpc_url, "eth_getCode", [address, safe_block])
+        code = rpc(
+            rpc_url,
+            "eth_getCode",
+            [address, safe_block],
+            attempts=5,
+            retry_delay=1,
+        )
         return None if code == "0x" else keccak256(bytes.fromhex(code[2:]))
 
     systems = verifier_assets["proof_systems"]

--- a/scripts/deploy_open_competition_v2_beta3.py
+++ b/scripts/deploy_open_competition_v2_beta3.py
@@ -74,8 +74,16 @@ class SignedRpc:
         require(int(rpc(url, "eth_chainId", []), 16) == 8453, "RPC is not Base mainnet")
 
     def code_hash(self, address: str, block: str = "latest") -> str | None:
-        raw = rpc(self.url, "eth_getCode", [address, block])
-        return None if raw == "0x" else keccak256(bytes.fromhex(raw[2:]))
+        deadline = time.time() + 120
+        last_error: RuntimeError | None = None
+        while time.time() < deadline:
+            try:
+                raw = rpc(self.url, "eth_getCode", [address, block])
+                return None if raw == "0x" else keccak256(bytes.fromhex(raw[2:]))
+            except RuntimeError as error:
+                last_error = error
+                time.sleep(2)
+        raise RuntimeError(f"runtime bytecode lookup failed: {last_error}") from last_error
 
     def pending_nonce(self) -> int:
         return int(
@@ -135,12 +143,19 @@ class SignedRpc:
 
     def wait_safe(self, block_number: int, timeout_seconds: int = 1800) -> dict[str, Any]:
         deadline = time.time() + timeout_seconds
+        last_error: RuntimeError | None = None
         while time.time() < deadline:
-            safe = rpc(self.url, "eth_getBlockByNumber", ["safe", False])
+            try:
+                safe = rpc(self.url, "eth_getBlockByNumber", ["safe", False])
+            except RuntimeError as error:
+                last_error = error
+                time.sleep(5)
+                continue
             if safe and int(safe["number"], 16) >= block_number:
                 return safe
             time.sleep(5)
-        raise RuntimeError("deployment did not reach a Base safe block")
+        detail = f": {last_error}" if last_error is not None else ""
+        raise RuntimeError(f"deployment did not reach a Base safe block{detail}")
 
     def require_safe_code_hashes(
         self, expected_hashes: dict[str, str], block_number: int

--- a/scripts/test_build_open_competition_v2_beta3_release.py
+++ b/scripts/test_build_open_competition_v2_beta3_release.py
@@ -38,15 +38,13 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
 
         self.assertEqual(start, 2)
 
-    def test_does_not_resume_inexact_or_occupied_partial_deployment(self):
+    def test_does_not_resume_inexact_partial_deployment(self):
         deployer = MODULE.DEFAULT_DEPLOYER
         groth16 = MODULE.create_address(deployer, 2)
         plonk = MODULE.create_address(deployer, 3)
-        factory = MODULE.create_address(deployer, 4)
         cases = (
             {groth16: "wrong", plonk: "plonk"},
             {groth16: "groth16", plonk: "wrong"},
-            {groth16: "groth16", plonk: "plonk", factory: "occupied"},
         )
         for observed in cases:
             with self.subTest(observed=observed):
@@ -60,6 +58,25 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
                     ),
                     4,
                 )
+
+    def test_resumes_completed_exact_deployment_for_reconciliation(self):
+        deployer = MODULE.DEFAULT_DEPLOYER
+        observed = {
+            MODULE.create_address(deployer, 2): "groth16",
+            MODULE.create_address(deployer, 3): "plonk",
+            MODULE.create_address(deployer, 4): "factory",
+        }
+
+        self.assertEqual(
+            MODULE.resume_exact_verifier_pair(
+                deployer=deployer,
+                observed_nonce=5,
+                code_hash=lambda address: observed.get(address),
+                groth16_runtime_hash="groth16",
+                plonk_runtime_hash="plonk",
+            ),
+            2,
+        )
 
     def test_release_root_retargets_only_release_files(self):
         original = (MODULE.ROOT, MODULE.CONTRACT_ROOT, MODULE.OUT)

--- a/scripts/test_deploy_open_competition_v2_beta3.py
+++ b/scripts/test_deploy_open_competition_v2_beta3.py
@@ -96,6 +96,25 @@ class DeploymentValidationTests(unittest.TestCase):
             [mock.call(address, "0x2a") for address in addresses],
         )
 
+    @mock.patch.object(deploy.time, "sleep")
+    @mock.patch.object(deploy.time, "time", side_effect=[0, 1, 2])
+    @mock.patch.object(
+        deploy,
+        "rpc",
+        side_effect=[RuntimeError("HTTP 408"), {"number": "0x2a"}],
+    )
+    def test_safe_block_polling_recovers_from_transport_error(
+        self, rpc_call: mock.Mock, _time: mock.Mock, sleep: mock.Mock
+    ) -> None:
+        client = object.__new__(deploy.SignedRpc)
+        client.url = "https://rpc.example"
+
+        result = client.wait_safe(41, timeout_seconds=10)
+
+        self.assertEqual(result["number"], "0x2a")
+        self.assertEqual(rpc_call.call_count, 2)
+        sleep.assert_called_once_with(5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- recognize the exact verifier pair whether the factory is pending or already deployed
- reconcile the existing factory instead of allocating new deployment nonces
- tolerate bounded transient transport failures during bytecode and safe-block reads
- extend release preflight retries

## Canonical state
- Groth16 verifier: 