### PR TITLE
Use python3 for Beta3 prover evidence

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -199,7 +199,7 @@ jobs:
           curl --fail --silent http://127.0.0.1:9070/health | tee target/prover-health.json
           public_health="${OPEN_COMPETITION_V2_PROVER_URL%/v1/prove}/health"
           curl --fail --silent "$public_health" | tee target/prover-public-health.json
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           json.dump({
               "schema_version": "agent-bounties/open-competition-v2-beta3-prover-deployment-v1",

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -34,6 +34,13 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         cls.text = WORKFLOW.read_text(encoding="utf-8")
         cls.workflow = yaml.load(cls.text, Loader=UniqueKeyLoader)
 
+    def test_self_hosted_prover_uses_available_python3(self):
+        prover = self.text.split("  deploy-production-prover:", 1)[1].split(
+            "  deploy-production-control-plane:", 1
+        )[0]
+        self.assertIn("python3 - <<'PY'", prover)
+        self.assertNotIn("python - <<'PY'", prover)
+
     def test_release_and_protected_environment_are_pinned(self):
         self.assertEqual(
             self.workflow["env"]["RELEASE_SOURCE_COMMIT"], RELEASE_SOURCE_COMMIT


### PR DESCRIPTION
The reviewed CPU prover installed and both local/public health checks passed in run 32272097361. The job failed only because the self-hosted host has python3 and no python alias. This changes that one evidence-writing command and adds a workflow regression test.