### PR TITLE
Fix Beta3 Render service materialization

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -228,6 +228,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           ref: ${{ env.RELEASE_SOURCE_COMMIT }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ github.sha }}
+          path: .release-control
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
@@ -257,7 +261,7 @@ jobs:
           BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
           KEEPER="${BASE_KEEPER_ADDRESS,,}"
           DEPLOYER="${BASE_DEPLOYER_ADDRESS,,}"
-          python scripts/configure_open_competition_v2_beta3_render.py \
+          python .release-control/scripts/configure_open_competition_v2_beta3_render.py \
             --runtime target/mainnet-prebroker.runtime.json --revision "$GITHUB_SHA" \
             --primary-rpc-url "$BASE_MAINNET_RPC_URL" --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --prover-url "$OPEN_COMPETITION_V2_PROVER_URL" --broker-address "$BROKER" \
@@ -287,7 +291,7 @@ jobs:
             --gates target/release-gates.json --output target/mainnet-broker.json \
             --runtime-output target/mainnet-broker.runtime.json
           jq -e '.proof_broker_enabled == true and .public_creation_enabled == false' target/mainnet-broker.runtime.json >/dev/null
-          python scripts/configure_open_competition_v2_beta3_render.py \
+          python .release-control/scripts/configure_open_competition_v2_beta3_render.py \
             --runtime target/mainnet-broker.runtime.json --revision "$GITHUB_SHA" \
             --primary-rpc-url "$BASE_MAINNET_RPC_URL" --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --prover-url "$OPEN_COMPETITION_V2_PROVER_URL" --broker-address "$BROKER" \
@@ -542,6 +546,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
         with:
           ref: ${{ env.RELEASE_SOURCE_COMMIT }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ github.sha }}
+          path: .release-control
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
@@ -616,7 +624,7 @@ jobs:
             --gates target/release-gates.json --output target/mainnet-public-beta.json \
             --runtime-output target/mainnet-public-beta.runtime.json
           jq -e '.public_creation_enabled == true and .proof_broker_enabled == true' target/mainnet-public-beta.runtime.json >/dev/null
-          python scripts/configure_open_competition_v2_beta3_render.py \
+          python .release-control/scripts/configure_open_competition_v2_beta3_render.py \
             --runtime target/mainnet-public-beta.runtime.json --revision "$GITHUB_SHA" \
             --primary-rpc-url "$BASE_MAINNET_RPC_URL" --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --prover-url "$OPEN_COMPETITION_V2_PROVER_URL" --broker-address "$BROKER" \

--- a/scripts/configure_open_competition_v2_beta3_render.py
+++ b/scripts/configure_open_competition_v2_beta3_render.py
@@ -118,6 +118,21 @@ def named_group(client: render.RenderClient, owner_id: str, name: str) -> dict[s
     return client.get_env_group(group["id"])
 
 
+def resolve_services(client: render.RenderClient) -> dict[str, dict[str, Any]]:
+    services: dict[str, dict[str, Any]] = {}
+    missing: list[render.ServiceSpec] = []
+    for spec in V2_SERVICES:
+        try:
+            services[spec.name] = client.resolve_service(spec)
+        except render.RenderServiceMissing:
+            missing.append(spec)
+    for spec in missing:
+        services[spec.name] = client.ensure_blueprint_service(spec)
+    if missing:
+        services = {spec.name: client.resolve_service(spec) for spec in V2_SERVICES}
+    return services
+
+
 def deploy(
     client: render.RenderClient,
     runtime: dict[str, Any],
@@ -135,7 +150,7 @@ def deploy(
         == environment["OPEN_COMPETITION_V2_BROKER_PAYMENT_ADDRESS"],
         "relayer private key does not match the isolated broker address",
     )
-    services = {spec.name: client.resolve_service(spec) for spec in V2_SERVICES}
+    services = resolve_services(client)
     owner_ids = {str(service.get("ownerId")) for service in services.values()}
     require(len(owner_ids) == 1, "Beta3 services do not share one Render workspace")
     owner_id = render.validate_owner_id(owner_ids.pop())

--- a/scripts/render_deploy_recovery.py
+++ b/scripts/render_deploy_recovery.py
@@ -24,7 +24,13 @@ REPOSITORY = "github.com/nspg13/agent-bounties"
 PROTOCOL = "agent-bounties/autonomous-v1"
 BLUEPRINT_PATH = "render.yaml"
 BLUEPRINT_RECOVERABLE_SERVICE_NAMES = frozenset(
-    {"agent-bounties-open-competition-v1-indexer"}
+    {
+        "agent-bounties-open-competition-v1-indexer",
+        "agent-bounties-open-competition-v2-beta3-indexer",
+        "agent-bounties-open-competition-v2-beta3-shadow",
+        "agent-bounties-open-competition-v2-beta3-keeper",
+        "agent-bounties-open-competition-v2-beta3-broker",
+    }
 )
 BLUEPRINT_STATUSES = {"created", "paused", "in_sync", "syncing", "error"}
 ENV_GROUP_SERVICE_TYPES = {

--- a/scripts/test_configure_open_competition_v2_beta3_render.py
+++ b/scripts/test_configure_open_competition_v2_beta3_render.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
 
 
 PATH = Path(__file__).with_name("configure_open_competition_v2_beta3_render.py")
@@ -27,6 +28,35 @@ def runtime() -> dict:
 
 
 class Beta3RenderTests(unittest.TestCase):
+    def test_missing_beta3_service_is_materialized_before_revalidation(self):
+        services = {
+            spec.name: {"id": f"srv-{index:020d}", "name": spec.name}
+            for index, spec in enumerate(MODULE.V2_SERVICES, start=1)
+        }
+        missing_name = "agent-bounties-open-competition-v2-beta3-indexer"
+        recovered = False
+        client = mock.Mock()
+
+        def resolve(spec):
+            if spec.name == missing_name and not recovered:
+                raise MODULE.render.RenderServiceMissing(spec.name)
+            return services[spec.name]
+
+        def materialize(spec):
+            nonlocal recovered
+            self.assertEqual(spec.name, missing_name)
+            recovered = True
+            return services[spec.name]
+
+        client.resolve_service.side_effect = resolve
+        client.ensure_blueprint_service.side_effect = materialize
+
+        resolved = MODULE.resolve_services(client)
+
+        self.assertEqual(resolved, services)
+        client.ensure_blueprint_service.assert_called_once()
+        self.assertEqual(client.resolve_service.call_count, len(MODULE.V2_SERVICES) * 2)
+
     def test_runtime_validation_rejects_non_mainnet_or_pending_deployment(self):
         for network, block in (("base-sepolia", 123), ("base-mainnet", 0)):
             value = runtime()

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -69,6 +69,28 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
             ["deploy-mainnet", "deploy-production-control-plane", "mainnet-canaries"],
         )
 
+    def test_render_recovery_uses_current_controller_with_frozen_release(self):
+        for job_name, expected_calls in (
+            ("deploy-production-control-plane", 2),
+            ("activate-public-beta", 1),
+        ):
+            job = self.workflow["jobs"][job_name]
+            checkouts = [
+                step
+                for step in job["steps"]
+                if str(step.get("uses", "")).startswith("actions/checkout@")
+            ]
+            self.assertEqual(checkouts[0]["with"]["ref"], "${{ env.RELEASE_SOURCE_COMMIT }}")
+            self.assertEqual(checkouts[1]["with"]["ref"], "${{ github.sha }}")
+            self.assertEqual(checkouts[1]["with"]["path"], ".release-control")
+            run = "\n".join(str(step.get("run", "")) for step in job["steps"])
+            self.assertEqual(
+                run.count(
+                    "python .release-control/scripts/configure_open_competition_v2_beta3_render.py"
+                ),
+                expected_calls,
+            )
+
     def test_only_successful_frozen_sepolia_evidence_can_continue(self):
         self.assertIn("run-id: ${{ inputs.sepolia_run_id }}", self.text)
         self.assertIn("open-competition-v2-beta3-live-sepolia-resumed", self.text)


### PR DESCRIPTION
## Summary
- authorize Blueprint recovery for the four exact Beta3 workers
- materialize missing workers before fail-closed runtime configuration
- run the current recovery controller while preserving frozen release artifacts
- add regression tests for provisioning and workflow boundaries

## Verification
- python scripts/test_configure_open_competition_v2_beta3_render.py -v
- python scripts/test_continue_open_competition_v2_beta3_mainnet.py -v
- python scripts/test_render_deploy_recovery.py -v
- workflow YAML parse
- git diff --check

No contract bytecode, vkey, settlement policy, or contributor-facing interface changes.