### PR TITLE
Repair Beta3 Render environment links

### DIFF
--- a/scripts/configure_open_competition_v2_beta3_render.py
+++ b/scripts/configure_open_competition_v2_beta3_render.py
@@ -202,6 +202,30 @@ def ensure_v2_group(
     return group
 
 
+def ensure_group_link(
+    client: render.RenderClient,
+    group_name: str,
+    group: dict[str, Any],
+    spec: render.ServiceSpec,
+    service: dict[str, Any],
+) -> dict[str, Any]:
+    current = client.get_env_group(group["id"])
+    if not render.env_group_has_service(current, spec, service["id"]):
+        try:
+            client._write_with_retry(
+                "POST", f"/env-groups/{group['id']}/services/{service['id']}", None
+            )
+        except render.RenderHttpError as error:
+            if error.status != 409:
+                raise
+        current = client.get_env_group(group["id"])
+    require(
+        render.env_group_has_service(current, spec, service["id"]),
+        f"Render did not attach {group_name} to {spec.name}",
+    )
+    return current
+
+
 def provision_worker(
     client: render.RenderClient,
     spec: render.ServiceSpec,
@@ -273,21 +297,7 @@ def provision_worker(
         "new Render worker changed project environments",
     )
     for name, group in groups.items():
-        group_id = group["id"]
-        current = client.get_env_group(group_id)
-        if not render.env_group_has_service(current, spec, created["id"]):
-            try:
-                client._write_with_retry(
-                    "POST", f"/env-groups/{group_id}/services/{created['id']}", None
-                )
-            except render.RenderHttpError as error:
-                if error.status != 409:
-                    raise
-            current = client.get_env_group(group_id)
-        require(
-            render.env_group_has_service(current, spec, created["id"]),
-            f"Render did not attach {name} to {spec.name}",
-        )
+        ensure_group_link(client, name, group, spec, created)
     verified = client.resolve_service(spec)
     require(verified.get("ownerId") == owner_id, "provisioned Render worker changed workspaces")
     require(
@@ -359,10 +369,12 @@ def deploy(
 
     for spec in V2_SERVICES:
         service = services[spec.name]
-        require(render.env_group_has_service(base_group, spec, service["id"]), f"{BASE_GROUP} is not linked to {spec.name}")
-        require(render.env_group_has_service(v2_group, spec, service["id"]), f"{V2_GROUP} is not linked to {spec.name}")
+        base_group = ensure_group_link(client, BASE_GROUP, base_group, spec, service)
+        v2_group = ensure_group_link(client, V2_GROUP, v2_group, spec, service)
         if spec.name in RELAYER_SERVICE_NAMES:
-            require(render.env_group_has_service(relayer_group, spec, service["id"]), f"{RELAYER_GROUP} is not linked to {spec.name}")
+            relayer_group = ensure_group_link(
+                client, RELAYER_GROUP, relayer_group, spec, service
+            )
         client.disable_native_auto_deploy(service)
 
     changes = []

--- a/scripts/test_configure_open_competition_v2_beta3_render.py
+++ b/scripts/test_configure_open_competition_v2_beta3_render.py
@@ -28,6 +28,47 @@ def runtime() -> dict:
 
 
 class Beta3RenderTests(unittest.TestCase):
+    def test_missing_group_link_is_attached_and_verified(self):
+        spec = MODULE.V2_SERVICES[0]
+        service = {"id": "srv-api", "name": spec.name}
+        group = {"id": "evg-beta3", "serviceLinks": []}
+        linked = {
+            **group,
+            "serviceLinks": [
+                {"service": {"id": service["id"], "name": spec.name, "type": "web"}}
+            ],
+        }
+        client = mock.Mock()
+        client.get_env_group.side_effect = [group, linked]
+
+        result = MODULE.ensure_group_link(
+            client, MODULE.V2_GROUP, group, spec, service
+        )
+
+        self.assertEqual(result, linked)
+        client._write_with_retry.assert_called_once_with(
+            "POST", "/env-groups/evg-beta3/services/srv-api", None
+        )
+
+    def test_existing_group_link_is_not_rewritten(self):
+        spec = MODULE.V2_SERVICES[0]
+        service = {"id": "srv-api", "name": spec.name}
+        group = {
+            "id": "evg-beta3",
+            "serviceLinks": [
+                {"service": {"id": service["id"], "name": spec.name, "type": "web"}}
+            ],
+        }
+        client = mock.Mock()
+        client.get_env_group.return_value = group
+
+        result = MODULE.ensure_group_link(
+            client, MODULE.V2_GROUP, group, spec, service
+        )
+
+        self.assertEqual(result, group)
+        client._write_with_retry.assert_not_called()
+
     def test_missing_v2_environment_group_is_created_in_exact_project(self):
         client = mock.Mock()
         client._read_with_retry.return_value = []


### PR DESCRIPTION
## Summary
- attach missing Beta3/base/relayer environment-group links to existing services
- verify each link through Render read-back state
- keep reruns idempotent and reuse the same helper during worker provisioning

## Verification
- python scripts/test_configure_open_competition_v2_beta3_render.py -v
- python scripts/test_render_deploy_recovery.py -v
- python scripts/test_continue_open_competition_v2_beta3_mainnet.py -v
- python scripts/check-render-blueprint.py
- git diff --check