### PR TITLE
Preflight Beta3 RPC readiness

### DIFF
--- a/scripts/configure_open_competition_v2_beta3_render.py
+++ b/scripts/configure_open_competition_v2_beta3_render.py
@@ -10,7 +10,9 @@ import json
 import os
 from pathlib import Path
 import re
+import urllib.error
 import urllib.parse
+import urllib.request
 from typing import Any
 
 from eth_account import Account
@@ -88,6 +90,97 @@ def utc_now() -> str:
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise Beta3RenderError(message)
+
+
+def rpc_call(url: str, method: str, params: list[Any], request_id: int) -> Any:
+    payload = json.dumps(
+        {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params},
+        separators=(",", ":"),
+    ).encode()
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "content-type": "application/json",
+            "user-agent": "agent-bounties-beta3-rpc-preflight/1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            value = json.loads(response.read())
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        raise Beta3RenderError(
+            f"{method} RPC preflight failed: {type(error).__name__}"
+        ) from None
+    require(isinstance(value, dict), f"{method} RPC response must be an object")
+    error = value.get("error")
+    require(error is None, f"{method} RPC preflight returned an error")
+    require("result" in value, f"{method} RPC preflight omitted result")
+    return value["result"]
+
+
+def preflight_rpc_pair(
+    runtime: dict[str, Any], primary_rpc_url: str, shadow_rpc_url: str
+) -> dict[str, Any]:
+    deployment_block = runtime["deployment_block"]
+    query_end = deployment_block + 1_999
+    factory = runtime["factory_contract"].lower()
+    safe_blocks: list[dict[str, Any]] = []
+    for offset, url in enumerate((primary_rpc_url, shadow_rpc_url)):
+        chain_id = rpc_call(url, "eth_chainId", [], 910_000 + offset * 10)
+        require(chain_id == "0x2105", "RPC preflight returned a non-Base-mainnet chain id")
+        logs = rpc_call(
+            url,
+            "eth_getLogs",
+            [
+                {
+                    "address": factory,
+                    "fromBlock": hex(deployment_block),
+                    "toBlock": hex(query_end),
+                }
+            ],
+            910_001 + offset * 10,
+        )
+        require(isinstance(logs, list), "RPC preflight logs result must be a list")
+        safe = rpc_call(
+            url, "eth_getBlockByNumber", ["safe", False], 910_002 + offset * 10
+        )
+        require(isinstance(safe, dict), "RPC preflight safe block must be an object")
+        try:
+            number = int(str(safe["number"]), 16)
+        except (KeyError, TypeError, ValueError):
+            raise Beta3RenderError("RPC preflight safe block number is invalid") from None
+        require(number >= deployment_block, "RPC safe head predates the Beta3 deployment")
+        safe_blocks.append({"number": number, "hash": str(safe.get("hash", "")).lower()})
+
+    common = min(item["number"] for item in safe_blocks)
+    common_hashes = []
+    for offset, url in enumerate((primary_rpc_url, shadow_rpc_url)):
+        block = rpc_call(
+            url,
+            "eth_getBlockByNumber",
+            [hex(common), False],
+            910_003 + offset * 10,
+        )
+        require(isinstance(block, dict), "RPC preflight common block must be an object")
+        common_hashes.append(str(block.get("hash", "")).lower())
+    require(
+        len(set(common_hashes)) == 1 and HASH.fullmatch(common_hashes[0]) is not None,
+        "primary and shadow RPCs disagree on the common safe block",
+    )
+    max_lag = max(item["number"] - common for item in safe_blocks)
+    require(max_lag <= 64, "primary and shadow RPC safe heads differ by more than 64 blocks")
+    return {
+        "passed": True,
+        "chain_id": 8453,
+        "factory_contract": factory,
+        "archive_query_from_block": deployment_block,
+        "archive_query_to_block": query_end,
+        "common_safe_block": common,
+        "common_safe_block_hash": common_hashes[0],
+        "max_safe_head_lag_blocks": max_lag,
+        "endpoints_redacted": True,
+    }
 
 
 def validated_runtime(path: Path) -> dict[str, Any]:
@@ -457,6 +550,9 @@ def main() -> int:
         deployer_address=args.deployer_address,
         refund_reserve_min_base_units=args.refund_reserve_min_base_units,
     )
+    rpc_preflight = preflight_rpc_pair(
+        runtime, args.primary_rpc_url, args.shadow_rpc_url
+    )
     client = render.RenderClient(os.environ.get("RENDER_API_KEY", ""))
     evidence = deploy(
         client,
@@ -467,6 +563,7 @@ def main() -> int:
         timeout_seconds=args.timeout_seconds,
         poll_seconds=args.poll_seconds,
     )
+    evidence["rpc_preflight"] = rpc_preflight
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
     print(json.dumps({"passed": True, "output": str(args.output)}))

--- a/scripts/test_configure_open_competition_v2_beta3_render.py
+++ b/scripts/test_configure_open_competition_v2_beta3_render.py
@@ -28,6 +28,48 @@ def runtime() -> dict:
 
 
 class Beta3RenderTests(unittest.TestCase):
+    def test_rpc_preflight_requires_archive_logs_and_common_safe_block(self):
+        calls = []
+
+        def rpc(url, method, params, request_id):
+            calls.append((url, method, params, request_id))
+            if method == "eth_chainId":
+                return "0x2105"
+            if method == "eth_getLogs":
+                return []
+            if params[0] == "safe":
+                number = 200 if "primary" in url else 198
+                return {"number": hex(number), "hash": "0x" + "aa" * 32}
+            return {"number": params[0], "hash": "0x" + "bb" * 32}
+
+        value = runtime()
+        value["deployment_block"] = 123
+        with mock.patch.object(MODULE, "rpc_call", side_effect=rpc):
+            result = MODULE.preflight_rpc_pair(
+                value, "https://primary.example", "https://shadow.example"
+            )
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["archive_query_from_block"], 123)
+        self.assertEqual(result["archive_query_to_block"], 2122)
+        self.assertEqual(result["common_safe_block"], 198)
+        log_calls = [call for call in calls if call[1] == "eth_getLogs"]
+        self.assertEqual(len(log_calls), 2)
+        self.assertEqual(log_calls[0][2][0]["fromBlock"], hex(123))
+        self.assertEqual(log_calls[0][2][0]["toBlock"], hex(2122))
+
+    def test_rpc_preflight_rejects_provider_log_errors(self):
+        value = runtime()
+        with mock.patch.object(
+            MODULE,
+            "rpc_call",
+            side_effect=["0x2105", MODULE.Beta3RenderError("eth_getLogs RPC preflight returned an error")],
+        ):
+            with self.assertRaisesRegex(MODULE.Beta3RenderError, "eth_getLogs"):
+                MODULE.preflight_rpc_pair(
+                    value, "https://primary.example", "https://shadow.example"
+                )
+
     def test_missing_group_link_is_attached_and_verified(self):
         spec = MODULE.V2_SERVICES[0]
         service = {"id": "srv-api", "name": spec.name}

--- a/scripts/test_wait_open_competition_v2_beta3_runtime.py
+++ b/scripts/test_wait_open_competition_v2_beta3_runtime.py
@@ -1,6 +1,9 @@
 import importlib.util
+import io
 from pathlib import Path
 import unittest
+from unittest import mock
+from urllib.error import HTTPError
 
 
 PATH = Path(__file__).with_name("wait_open_competition_v2_beta3_runtime.py")
@@ -30,6 +33,27 @@ class RuntimeWaitTests(unittest.TestCase):
         expected, response = self.fixture()
         response["indexer_agreement"] = None
         self.assertFalse(MODULE.exact_runtime(response, expected, True, False))
+
+    def test_fetch_uses_only_the_supported_network_query(self):
+        response = mock.MagicMock()
+        response.read.return_value = b'{"ok":true}'
+        response.__enter__.return_value = response
+        with mock.patch.object(MODULE, "urlopen", return_value=response) as urlopen:
+            result = MODULE.fetch("https://api.example/release?network=stale")
+
+        self.assertEqual(result, {"ok": True})
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "https://api.example/release?network=base-mainnet")
+        self.assertEqual(request.get_header("Cache-control"), "no-store")
+        self.assertNotIn("_probe", request.full_url)
+
+    def test_wait_reports_typed_transport_failure(self):
+        error = HTTPError("https://api.example", 400, "bad request", {}, io.BytesIO())
+        with mock.patch.object(MODULE, "fetch", side_effect=error), mock.patch.object(
+            MODULE.time, "monotonic", side_effect=[0.0, 0.0, 1.0]
+        ), mock.patch.object(MODULE.time, "sleep"):
+            with self.assertRaisesRegex(MODULE.RuntimeWaitError, "http_status=400"):
+                MODULE.wait("https://api.example", {}, False, False, 0.5, 0.01)
 
 
 if __name__ == "__main__":

--- a/scripts/wait_open_competition_v2_beta3_runtime.py
+++ b/scripts/wait_open_competition_v2_beta3_runtime.py
@@ -8,7 +8,7 @@ import json
 from pathlib import Path
 import time
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 from typing import Any
 
@@ -55,10 +55,18 @@ def exact_runtime(response: dict[str, Any], expected: dict[str, Any], broker: bo
 
 
 def fetch(url: str) -> dict[str, Any]:
-    separator = "&" if "?" in url else "?"
+    parsed = urlsplit(url)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query["network"] = "base-mainnet"
+    target = urlunsplit(parsed._replace(query=urlencode(query)))
     request = Request(
-        f"{url}{separator}{urlencode({'network': 'base-mainnet', '_probe': time.time_ns()})}",
-        headers={"accept": "application/json", "cache-control": "no-store"},
+        target,
+        headers={
+            "accept": "application/json",
+            "cache-control": "no-store",
+            "pragma": "no-cache",
+            "user-agent": "agent-bounties-beta3-readiness/1",
+        },
     )
     with urlopen(request, timeout=20) as response:
         return json.loads(response.read())
@@ -67,15 +75,25 @@ def fetch(url: str) -> dict[str, Any]:
 def wait(url: str, expected: dict[str, Any], broker: bool, public: bool, timeout: float, poll: float) -> dict[str, Any]:
     deadline = time.monotonic() + timeout
     last: dict[str, Any] | None = None
+    last_error = "none"
     while time.monotonic() < deadline:
         try:
             last = fetch(url)
             if exact_runtime(last, expected, broker, public):
                 return last
-        except (HTTPError, URLError, TimeoutError, json.JSONDecodeError):
-            pass
+            last_error = "runtime_mismatch"
+        except HTTPError as error:
+            last_error = f"http_status={error.code}"
+        except URLError as error:
+            last_error = f"url_error={type(error.reason).__name__}"
+        except TimeoutError:
+            last_error = "timeout"
+        except json.JSONDecodeError:
+            last_error = "invalid_json"
         time.sleep(poll)
-    raise RuntimeWaitError(f"hosted runtime did not reconcile before timeout; last={last}")
+    raise RuntimeWaitError(
+        f"hosted runtime did not reconcile before timeout; last_error={last_error}; last={last}"
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- preflight both Base RPCs for chain identity, exact 2,000-block historical log capability, common safe-block agreement, and bounded lag before mutating Render
- stop sending the unsupported readiness query field that caused every hosted probe to return HTTP 400
- preserve no-cache semantics and report typed bounded probe failures
- switch the protected mainnet variables to the live-tested Base official primary and independent Tenderly shadow endpoints

## Incident boundary
Run 32309990630 deployed services but failed before broker enablement and before canaries. No canary or bounty funds moved.

## Verification
- core preflight passed
- exact production RPC preflight passed at deployment block 50195099
- 4 readiness tests passed
- 11 Render Beta3 tests passed
- 8 continuation workflow tests passed
- 90 Render recovery tests passed
- Blueprint, py_compile, and diff checks passed