### PR TITLE
Reduce Beta3 RPC log batches

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -447,7 +447,7 @@ services:
       - key: OPEN_COMPETITION_V2_INDEXER_CONFIRMATIONS
         value: "2"
       - key: OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY
-        value: "2000"
+        value: "1000"
       - key: BASE_INDEXER_RETRY_INITIAL_SECONDS
         value: "5"
       - key: BASE_INDEXER_RETRY_MAX_SECONDS
@@ -483,7 +483,7 @@ services:
       - key: OPEN_COMPETITION_V2_INDEXER_NETWORK
         value: base-mainnet
       - key: OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY
-        value: "2000"
+        value: "1000"
       - key: OPEN_COMPETITION_V2_SHADOW_POLL_SECONDS
         value: "30"
       - fromGroup: agent-bounties-base

--- a/scripts/configure_open_competition_v2_beta3_render.py
+++ b/scripts/configure_open_competition_v2_beta3_render.py
@@ -23,6 +23,7 @@ import render_deploy_recovery as render
 V2_GROUP = "agent-bounties-v2-beta3"
 RELAYER_GROUP = "agent-bounties-x402-relayer"
 BASE_GROUP = "agent-bounties-base"
+RPC_LOG_BATCH_SIZE = 1_000
 V2_SERVICES = (
     render.ServiceSpec("agent-bounties-api", "web_service", "https://api.agentbounties.app/health"),
     render.ServiceSpec("agent-bounties-mcp", "web_service", "https://mcp.agentbounties.app/health"),
@@ -45,7 +46,7 @@ WORKER_ENVIRONMENT = {
         "OPEN_COMPETITION_V2_INDEXER_NETWORK": "base-mainnet",
         "OPEN_COMPETITION_V2_INDEXER_POLL_SECONDS": "15",
         "OPEN_COMPETITION_V2_INDEXER_CONFIRMATIONS": "2",
-        "OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY": "2000",
+        "OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY": str(RPC_LOG_BATCH_SIZE),
         "BASE_INDEXER_RETRY_INITIAL_SECONDS": "5",
         "BASE_INDEXER_RETRY_MAX_SECONDS": "120",
         "BASE_INDEXER_EXIT_AFTER_FAILURES": "8",
@@ -56,7 +57,7 @@ WORKER_ENVIRONMENT = {
         "RUST_LOG": "info",
         "BASE_INDEXER_PROTOCOL": "open-competition-v2-shadow",
         "OPEN_COMPETITION_V2_INDEXER_NETWORK": "base-mainnet",
-        "OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY": "2000",
+        "OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY": str(RPC_LOG_BATCH_SIZE),
         "OPEN_COMPETITION_V2_SHADOW_POLL_SECONDS": "30",
     },
     "agent-bounties-open-competition-v2-beta3-keeper": {
@@ -92,7 +93,9 @@ def require(condition: bool, message: str) -> None:
         raise Beta3RenderError(message)
 
 
-def rpc_call(url: str, method: str, params: list[Any], request_id: int) -> Any:
+def rpc_call(
+    url: str, method: str, params: list[Any], request_id: int, *, role: str
+) -> Any:
     payload = json.dumps(
         {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params},
         separators=(",", ":"),
@@ -110,12 +113,16 @@ def rpc_call(url: str, method: str, params: list[Any], request_id: int) -> Any:
             value = json.loads(response.read())
     except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
         raise Beta3RenderError(
-            f"{method} RPC preflight failed: {type(error).__name__}"
+            f"{role} {method} RPC preflight failed: {type(error).__name__}"
         ) from None
-    require(isinstance(value, dict), f"{method} RPC response must be an object")
+    require(isinstance(value, dict), f"{role} {method} RPC response must be an object")
     error = value.get("error")
-    require(error is None, f"{method} RPC preflight returned an error")
-    require("result" in value, f"{method} RPC preflight omitted result")
+    if error is not None:
+        code = error.get("code") if isinstance(error, dict) else "unknown"
+        raise Beta3RenderError(
+            f"{role} {method} RPC preflight returned error code={code}"
+        )
+    require("result" in value, f"{role} {method} RPC preflight omitted result")
     return value["result"]
 
 
@@ -123,11 +130,15 @@ def preflight_rpc_pair(
     runtime: dict[str, Any], primary_rpc_url: str, shadow_rpc_url: str
 ) -> dict[str, Any]:
     deployment_block = runtime["deployment_block"]
-    query_end = deployment_block + 1_999
+    query_end = deployment_block + RPC_LOG_BATCH_SIZE - 1
     factory = runtime["factory_contract"].lower()
     safe_blocks: list[dict[str, Any]] = []
-    for offset, url in enumerate((primary_rpc_url, shadow_rpc_url)):
-        chain_id = rpc_call(url, "eth_chainId", [], 910_000 + offset * 10)
+    for offset, (role, url) in enumerate(
+        (("primary", primary_rpc_url), ("shadow", shadow_rpc_url))
+    ):
+        chain_id = rpc_call(
+            url, "eth_chainId", [], 910_000 + offset * 10, role=role
+        )
         require(chain_id == "0x2105", "RPC preflight returned a non-Base-mainnet chain id")
         logs = rpc_call(
             url,
@@ -140,10 +151,15 @@ def preflight_rpc_pair(
                 }
             ],
             910_001 + offset * 10,
+            role=role,
         )
         require(isinstance(logs, list), "RPC preflight logs result must be a list")
         safe = rpc_call(
-            url, "eth_getBlockByNumber", ["safe", False], 910_002 + offset * 10
+            url,
+            "eth_getBlockByNumber",
+            ["safe", False],
+            910_002 + offset * 10,
+            role=role,
         )
         require(isinstance(safe, dict), "RPC preflight safe block must be an object")
         try:
@@ -155,12 +171,15 @@ def preflight_rpc_pair(
 
     common = min(item["number"] for item in safe_blocks)
     common_hashes = []
-    for offset, url in enumerate((primary_rpc_url, shadow_rpc_url)):
+    for offset, (role, url) in enumerate(
+        (("primary", primary_rpc_url), ("shadow", shadow_rpc_url))
+    ):
         block = rpc_call(
             url,
             "eth_getBlockByNumber",
             [hex(common), False],
             910_003 + offset * 10,
+            role=role,
         )
         require(isinstance(block, dict), "RPC preflight common block must be an object")
         common_hashes.append(str(block.get("hash", "")).lower())

--- a/scripts/test_configure_open_competition_v2_beta3_render.py
+++ b/scripts/test_configure_open_competition_v2_beta3_render.py
@@ -31,8 +31,8 @@ class Beta3RenderTests(unittest.TestCase):
     def test_rpc_preflight_requires_archive_logs_and_common_safe_block(self):
         calls = []
 
-        def rpc(url, method, params, request_id):
-            calls.append((url, method, params, request_id))
+        def rpc(url, method, params, request_id, *, role):
+            calls.append((url, method, params, request_id, role))
             if method == "eth_chainId":
                 return "0x2105"
             if method == "eth_getLogs":
@@ -51,19 +51,25 @@ class Beta3RenderTests(unittest.TestCase):
 
         self.assertTrue(result["passed"])
         self.assertEqual(result["archive_query_from_block"], 123)
-        self.assertEqual(result["archive_query_to_block"], 2122)
+        self.assertEqual(result["archive_query_to_block"], 1122)
         self.assertEqual(result["common_safe_block"], 198)
         log_calls = [call for call in calls if call[1] == "eth_getLogs"]
         self.assertEqual(len(log_calls), 2)
         self.assertEqual(log_calls[0][2][0]["fromBlock"], hex(123))
-        self.assertEqual(log_calls[0][2][0]["toBlock"], hex(2122))
+        self.assertEqual(log_calls[0][2][0]["toBlock"], hex(1122))
+        self.assertEqual({call[4] for call in calls}, {"primary", "shadow"})
 
     def test_rpc_preflight_rejects_provider_log_errors(self):
         value = runtime()
         with mock.patch.object(
             MODULE,
             "rpc_call",
-            side_effect=["0x2105", MODULE.Beta3RenderError("eth_getLogs RPC preflight returned an error")],
+            side_effect=[
+                "0x2105",
+                MODULE.Beta3RenderError(
+                    "primary eth_getLogs RPC preflight returned error code=-32005"
+                ),
+            ],
         ):
             with self.assertRaisesRegex(MODULE.Beta3RenderError, "eth_getLogs"):
                 MODULE.preflight_rpc_pair(
@@ -288,6 +294,12 @@ class Beta3RenderTests(unittest.TestCase):
         self.assertEqual(environment["OPEN_COMPETITION_V2_REFUND_RESERVE_MIN_BASE_UNITS"], "110000")
         self.assertEqual(environment["OPEN_COMPETITION_V2_INDEXER_AGREEMENT_MAX_AGE_SECONDS"], "120")
         self.assertEqual(environment["OPEN_COMPETITION_V2_RELAYER_MAX_GAS"], "8000000")
+        self.assertEqual(
+            MODULE.WORKER_ENVIRONMENT[
+                "agent-bounties-open-competition-v2-beta3-indexer"
+            ]["OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY"],
+            "1000",
+        )
 
     def test_environment_rejects_shared_rpc_and_insecure_prover(self):
         common = dict(


### PR DESCRIPTION
## Why
The protected Beta3 deployment failed before Render mutation because the production RPC backend rejected the inclusive 2,000-block historical log request. Base documents log ranges below 2,000 blocks.

## Change
- reduce primary and shadow indexer log batches to 1,000 blocks
- make the deployment preflight exercise the same exact window
- report provider role and JSON-RPC error code without exposing endpoints
- cover the rendered worker environment and preflight request in tests

## Evidence
- 11 Beta3 Render controller tests pass
- 4 runtime readiness tests pass
- 8 continuation workflow tests pass
- 90 Render recovery tests pass
- Render Blueprint check and Python compilation pass
- core preflight passes
- live Tenderly/dRPC check agrees on one canonical Base safe block using the exact 1,000-block deployment-era query