### PR TITLE
Use conservative Beta3 RPC log windows

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -447,7 +447,7 @@ services:
       - key: OPEN_COMPETITION_V2_INDEXER_CONFIRMATIONS
         value: "2"
       - key: OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY
-        value: "1000"
+        value: "50"
       - key: BASE_INDEXER_RETRY_INITIAL_SECONDS
         value: "5"
       - key: BASE_INDEXER_RETRY_MAX_SECONDS
@@ -483,7 +483,7 @@ services:
       - key: OPEN_COMPETITION_V2_INDEXER_NETWORK
         value: base-mainnet
       - key: OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY
-        value: "1000"
+        value: "50"
       - key: OPEN_COMPETITION_V2_SHADOW_POLL_SECONDS
         value: "30"
       - fromGroup: agent-bounties-base

--- a/scripts/configure_open_competition_v2_beta3_render.py
+++ b/scripts/configure_open_competition_v2_beta3_render.py
@@ -23,7 +23,7 @@ import render_deploy_recovery as render
 V2_GROUP = "agent-bounties-v2-beta3"
 RELAYER_GROUP = "agent-bounties-x402-relayer"
 BASE_GROUP = "agent-bounties-base"
-RPC_LOG_BATCH_SIZE = 1_000
+RPC_LOG_BATCH_SIZE = 50
 V2_SERVICES = (
     render.ServiceSpec("agent-bounties-api", "web_service", "https://api.agentbounties.app/health"),
     render.ServiceSpec("agent-bounties-mcp", "web_service", "https://mcp.agentbounties.app/health"),

--- a/scripts/test_configure_open_competition_v2_beta3_render.py
+++ b/scripts/test_configure_open_competition_v2_beta3_render.py
@@ -51,12 +51,12 @@ class Beta3RenderTests(unittest.TestCase):
 
         self.assertTrue(result["passed"])
         self.assertEqual(result["archive_query_from_block"], 123)
-        self.assertEqual(result["archive_query_to_block"], 1122)
+        self.assertEqual(result["archive_query_to_block"], 172)
         self.assertEqual(result["common_safe_block"], 198)
         log_calls = [call for call in calls if call[1] == "eth_getLogs"]
         self.assertEqual(len(log_calls), 2)
         self.assertEqual(log_calls[0][2][0]["fromBlock"], hex(123))
-        self.assertEqual(log_calls[0][2][0]["toBlock"], hex(1122))
+        self.assertEqual(log_calls[0][2][0]["toBlock"], hex(172))
         self.assertEqual({call[4] for call in calls}, {"primary", "shadow"})
 
     def test_rpc_preflight_rejects_provider_log_errors(self):
@@ -298,7 +298,7 @@ class Beta3RenderTests(unittest.TestCase):
             MODULE.WORKER_ENVIRONMENT[
                 "agent-bounties-open-competition-v2-beta3-indexer"
             ]["OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY"],
-            "1000",
+            "50",
         )
 
     def test_environment_rejects_shared_rpc_and_insecure_prover(self):


### PR DESCRIPTION
## Why
Two anonymous RPC edges accepted the 1,000-block deployment-era query locally but rejected the same filter from GitHub runners with -32602. The control plane correctly failed before mutation.

## Change
- query at most 50 blocks per primary and shadow indexer request
- make the protected preflight exercise exactly the same 50-block window
- keep all canonical hash, independent endpoint, safe-head, and fail-closed checks unchanged

## Evidence
- 11 controller tests pass
- Render Blueprint check passes
- core preflight passes
- exact Thirdweb/Base-reth 50-block deployment-era query passes
- providers agree on the same safe block and hash with zero skew