### PR TITLE
Add redacted Beta3 runtime diagnostics

### DIFF
--- a/.github/workflows/diagnose-open-competition-v2-beta3-render.yml
+++ b/.github/workflows/diagnose-open-competition-v2-beta3-render.yml
@@ -1,0 +1,40 @@
+name: Diagnose Open Competition V2 Beta3 Render
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: v2-beta2-mainnet
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - name: Verify diagnostic contract
+        run: |
+          python scripts/test_diagnose_open_competition_v2_beta3_render.py -v
+          python -m py_compile scripts/diagnose_open_competition_v2_beta3_render.py
+
+      - name: Collect redacted runtime diagnostics
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: |
+          python scripts/diagnose_open_competition_v2_beta3_render.py \
+            --output target/beta3-render-diagnostic.json
+
+      - name: Upload redacted diagnostic
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: beta3-render-diagnostic-${{ github.run_id }}
+          path: target/beta3-render-diagnostic.json
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/diagnose_open_competition_v2_beta3_render.py
+++ b/scripts/diagnose_open_competition_v2_beta3_render.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Collect redacted recent runtime diagnostics for Beta3 Render workers."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import urllib.parse
+from typing import Any
+
+import render_deploy_recovery as render
+
+
+WORKERS = (
+    render.ServiceSpec(
+        "agent-bounties-open-competition-v2-beta3-indexer",
+        "background_worker",
+        None,
+    ),
+    render.ServiceSpec(
+        "agent-bounties-open-competition-v2-beta3-shadow",
+        "background_worker",
+        None,
+    ),
+    render.ServiceSpec(
+        "agent-bounties-open-competition-v2-beta3-keeper",
+        "background_worker",
+        None,
+    ),
+    render.ServiceSpec(
+        "agent-bounties-open-competition-v2-beta3-broker",
+        "background_worker",
+        None,
+    ),
+)
+
+
+def collect(
+    client: render.RenderClient,
+    *,
+    now: datetime,
+) -> dict[str, Any]:
+    end = now.astimezone(timezone.utc)
+    start = end - timedelta(hours=1)
+    workers = []
+    for spec in WORKERS:
+        service = client.resolve_service(spec)
+        service_id = service.get("id")
+        owner_id = service.get("ownerId")
+        if not isinstance(service_id, str) or not service_id.startswith("srv-"):
+            raise render.RecoveryError(f"{spec.name} is missing its Render service id")
+        if not isinstance(owner_id, str) or not owner_id:
+            raise render.RecoveryError(f"{spec.name} is missing its Render workspace id")
+        parameters: dict[str, object] = {
+            "ownerId": owner_id,
+            "resource": [service_id],
+            "type": ["app"],
+            "direction": "backward",
+            "startTime": start.isoformat().replace("+00:00", "Z"),
+            "endTime": end.isoformat().replace("+00:00", "Z"),
+            "limit": "100",
+        }
+        query = urllib.parse.urlencode(parameters, doseq=True)
+        summary = render.summarize_build_logs(client._read_with_retry(f"/logs?{query}"))
+        workers.append(
+            {
+                "name": spec.name,
+                "service_id": service_id,
+                "runtime_logs": summary,
+            }
+        )
+    return {
+        "schema_version": "agent-bounties/open-competition-v2-beta3-render-diagnostic-v1",
+        "observed_at": end.isoformat().replace("+00:00", "Z"),
+        "workers": workers,
+        "read_only": True,
+        "secrets_redacted": True,
+        "evidence_boundary": (
+            "Runtime diagnostics can explain readiness failures. They cannot prove "
+            "funding, qualification, settlement, payout, or refund."
+        ),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    client = render.RenderClient(os.environ.get("RENDER_API_KEY", ""))
+    result = collect(client, now=datetime.now(timezone.utc))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(result, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_diagnose_open_competition_v2_beta3_render.py
+++ b/scripts/test_diagnose_open_competition_v2_beta3_render.py
@@ -1,0 +1,66 @@
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+import unittest
+import urllib.parse
+
+
+PATH = Path(__file__).with_name("diagnose_open_competition_v2_beta3_render.py")
+SPEC = importlib.util.spec_from_file_location(
+    "diagnose_open_competition_v2_beta3_render", PATH
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeClient:
+    def __init__(self):
+        self.paths = []
+
+    def resolve_service(self, spec):
+        return {
+            "id": f"srv-{spec.name.rsplit('-', 1)[-1]}",
+            "name": spec.name,
+            "ownerId": "tea-workspace",
+        }
+
+    def _read_with_retry(self, path):
+        self.paths.append(path)
+        return {
+            "logs": [
+                {
+                    "message": (
+                        "rpc failed at https://user:secret@example.invalid/v1 "
+                        "for 0x" + "ab" * 32
+                    )
+                }
+            ]
+        }
+
+
+class Beta3RenderDiagnosticTests(unittest.TestCase):
+    def test_collect_is_read_only_scoped_and_redacted(self):
+        client = FakeClient()
+        result = MODULE.collect(
+            client,
+            now=datetime(2026, 8, 20, 6, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertTrue(result["read_only"])
+        self.assertTrue(result["secrets_redacted"])
+        self.assertEqual(len(result["workers"]), 4)
+        self.assertEqual(len(client.paths), 4)
+        for path, worker in zip(client.paths, result["workers"]):
+            query = urllib.parse.parse_qs(urllib.parse.urlsplit(path).query)
+            self.assertEqual(query["ownerId"], ["tea-workspace"])
+            self.assertEqual(query["resource"], [worker["service_id"]])
+            self.assertEqual(query["type"], ["app"])
+            excerpts = "\n".join(worker["runtime_logs"]["excerpts"])
+            self.assertNotIn("secret", excerpts)
+            self.assertNotIn("example.invalid", excerpts)
+            self.assertNotIn("ab" * 32, excerpts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
The Beta3 control plane can prove Render deploys are live but currently reports only last=None when worker reconciliation never reaches the API. Operators need worker runtime evidence without exposing credentials.

## Change
- add a protected, read-only workflow for the four Beta3 workers
- query only the last hour of application logs for each exact Render service
- reuse the repository's bounded redaction and classification logic
- upload only the redacted diagnostic artifact

## Safety
The workflow cannot mutate Render, contracts, balances, or settlement. URLs, database strings, credentials, tokens, private material, and long hex values are redacted.

## Evidence
- diagnostic contract test passes
- Python compilation passes
- Render Blueprint check passes
- core preflight passes