### PR TITLE
Pace Beta3 shadow reconciliation

### DIFF
--- a/crates/worker/src/open_competition_v2_shadow.rs
+++ b/crates/worker/src/open_competition_v2_shadow.rs
@@ -1,4 +1,7 @@
-use super::{nonempty, OpenCompetitionV2IndexerConfig, AUTONOMOUS_LOG_ADDRESS_BATCH_SIZE};
+use super::{
+    nonempty, parse_u64_env, OpenCompetitionV2IndexerConfig,
+    AUTONOMOUS_LOG_ADDRESS_BATCH_SIZE,
+};
 use anyhow::{anyhow, Context};
 use chain_base::{
     decode_open_competition_v2_logs, fetch_base_contract_logs, fetch_base_multi_contract_logs,
@@ -11,11 +14,14 @@ use db::{OpenCompetitionV2IndexerAgreement, PostgresStore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenCompetitionV2ShadowConfig {
     pub indexer: OpenCompetitionV2IndexerConfig,
     pub shadow_rpc_url: String,
+    pub request_delay_ms: u64,
 }
 
 impl OpenCompetitionV2ShadowConfig {
@@ -36,9 +42,18 @@ impl OpenCompetitionV2ShadowConfig {
                 "the V2 shadow RPC must be independent from the primary indexer RPC"
             ));
         }
+        let request_delay_ms = lookup("OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS")
+            .filter(|value| nonempty(value))
+            .map(|value| {
+                parse_u64_env("OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS", &value)
+            })
+            .transpose()?
+            .unwrap_or(250)
+            .min(5_000);
         Ok(Self {
             indexer,
             shadow_rpc_url,
+            request_delay_ms,
         })
     }
 }
@@ -189,6 +204,7 @@ async fn fetch_shadow_events(
                 .result,
         )?;
         events.extend(decode_open_competition_v2_logs(logs)?);
+        pace_shadow_requests(config).await;
         request_id = request_id.saturating_add(1);
         if end == u64::MAX {
             break;
@@ -223,6 +239,7 @@ async fn fetch_shadow_events(
                     .result,
             )?;
             events.extend(decode_open_competition_v2_logs(logs)?);
+            pace_shadow_requests(config).await;
             request_id = request_id.saturating_add(1);
             if end == u64::MAX {
                 break;
@@ -234,6 +251,12 @@ async fn fetch_shadow_events(
     let mut seen = HashSet::new();
     events.retain(|event| seen.insert(event.log_key.clone()));
     Ok(events)
+}
+
+async fn pace_shadow_requests(config: &OpenCompetitionV2ShadowConfig) {
+    if config.request_delay_ms > 0 {
+        sleep(Duration::from_millis(config.request_delay_ms)).await;
+    }
 }
 
 fn query_end(from_block: u64, to_block: u64, max_blocks: u64) -> u64 {
@@ -280,6 +303,27 @@ mod tests {
             _ => None,
         });
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn shadow_request_delay_is_bounded() {
+        let result = OpenCompetitionV2ShadowConfig::from_lookup(|key| match key {
+            "OPEN_COMPETITION_V2_INDEXER_NETWORK" => Some("base-sepolia".to_string()),
+            "OPEN_COMPETITION_V2_FACTORY_CONTRACT" => {
+                Some("0x1111111111111111111111111111111111111111".to_string())
+            }
+            "OPEN_COMPETITION_V2_INDEXER_RPC_URL" => {
+                Some("https://primary.example".to_string())
+            }
+            "OPEN_COMPETITION_V2_SHADOW_RPC_URL" => {
+                Some("https://shadow.example".to_string())
+            }
+            "OPEN_COMPETITION_V2_DEPLOYMENT_BLOCK" => Some("1".to_string()),
+            "OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS" => Some("9999".to_string()),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(result.request_delay_ms, 5_000);
     }
 
     #[test]

--- a/crates/worker/src/open_competition_v2_shadow.rs
+++ b/crates/worker/src/open_competition_v2_shadow.rs
@@ -1,6 +1,5 @@
 use super::{
-    nonempty, parse_u64_env, OpenCompetitionV2IndexerConfig,
-    AUTONOMOUS_LOG_ADDRESS_BATCH_SIZE,
+    nonempty, parse_u64_env, OpenCompetitionV2IndexerConfig, AUTONOMOUS_LOG_ADDRESS_BATCH_SIZE,
 };
 use anyhow::{anyhow, Context};
 use chain_base::{
@@ -44,9 +43,7 @@ impl OpenCompetitionV2ShadowConfig {
         }
         let request_delay_ms = lookup("OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS")
             .filter(|value| nonempty(value))
-            .map(|value| {
-                parse_u64_env("OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS", &value)
-            })
+            .map(|value| parse_u64_env("OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS", &value))
             .transpose()?
             .unwrap_or(250)
             .min(5_000);
@@ -312,12 +309,8 @@ mod tests {
             "OPEN_COMPETITION_V2_FACTORY_CONTRACT" => {
                 Some("0x1111111111111111111111111111111111111111".to_string())
             }
-            "OPEN_COMPETITION_V2_INDEXER_RPC_URL" => {
-                Some("https://primary.example".to_string())
-            }
-            "OPEN_COMPETITION_V2_SHADOW_RPC_URL" => {
-                Some("https://shadow.example".to_string())
-            }
+            "OPEN_COMPETITION_V2_INDEXER_RPC_URL" => Some("https://primary.example".to_string()),
+            "OPEN_COMPETITION_V2_SHADOW_RPC_URL" => Some("https://shadow.example".to_string()),
             "OPEN_COMPETITION_V2_DEPLOYMENT_BLOCK" => Some("1".to_string()),
             "OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS" => Some("9999".to_string()),
             _ => None,

--- a/render.yaml
+++ b/render.yaml
@@ -486,6 +486,8 @@ services:
         value: "50"
       - key: OPEN_COMPETITION_V2_SHADOW_POLL_SECONDS
         value: "30"
+      - key: OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS
+        value: "250"
       - fromGroup: agent-bounties-base
       - fromGroup: agent-bounties-v2-beta3
 

--- a/scripts/configure_open_competition_v2_beta3_render.py
+++ b/scripts/configure_open_competition_v2_beta3_render.py
@@ -59,6 +59,7 @@ WORKER_ENVIRONMENT = {
         "OPEN_COMPETITION_V2_INDEXER_NETWORK": "base-mainnet",
         "OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY": str(RPC_LOG_BATCH_SIZE),
         "OPEN_COMPETITION_V2_SHADOW_POLL_SECONDS": "30",
+        "OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS": "250",
     },
     "agent-bounties-open-competition-v2-beta3-keeper": {
         "APP_PACKAGE": "worker",

--- a/scripts/test_configure_open_competition_v2_beta3_render.py
+++ b/scripts/test_configure_open_competition_v2_beta3_render.py
@@ -300,6 +300,12 @@ class Beta3RenderTests(unittest.TestCase):
             ]["OPEN_COMPETITION_V2_INDEXER_MAX_BLOCKS_PER_QUERY"],
             "50",
         )
+        self.assertEqual(
+            MODULE.WORKER_ENVIRONMENT[
+                "agent-bounties-open-competition-v2-beta3-shadow"
+            ]["OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS"],
+            "250",
+        )
 
     def test_environment_rejects_shared_rpc_and_insecure_prover(self):
         common = dict(


### PR DESCRIPTION
## Why
Protected diagnostic #32337734840 proved the primary indexer is blocked by HTTP 429 before its first cursor. Shadow, keeper, and broker behavior is correct.

## Change
- add a bounded 250 ms delay between shadow historical log requests
- cap configured pacing at 5 seconds
- expose the exact pacing value in Render direct-provision and Blueprint paths
- keep the primary indexer incremental and the shadow fail-closed

The protected RPC variables will rotate separately to Base reth primary and Tenderly shadow after merge. Their exact 50-block deployment-era query already passes with matching canonical block hashes.

## Evidence
- focused Rust shadow tests: 3 passed
- controller tests: 11 passed
- Render Blueprint and core preflight pass
- Python compilation and diff checks pass