### PR TITLE
Preserve Beta3 gate subject during promotion

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -287,7 +287,7 @@ jobs:
             --evidence target/production-broker-reserve.json \
             --uri "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --source-commit "$RELEASE_SOURCE_COMMIT"
-          python scripts/promote_open_competition_v2_beta3_release.py \
+          python .release-control/scripts/promote_open_competition_v2_beta3_release.py \
             --bundle target/mainnet-deployment/mainnet-exact.json \
             --deployment target/mainnet-deployment/mainnet-deployment-evidence.json \
             --gates target/release-gates.json --output target/mainnet-broker.json \
@@ -623,7 +623,7 @@ jobs:
             --manifest target/release-gates.json --gate owner_public_beta_activation_approved \
             --evidence target/owner-public-beta-activation.json --uri "$evidence_uri" \
             --source-commit "$RELEASE_SOURCE_COMMIT" --owner-risk-hash "$RISK_HASH"
-          python scripts/promote_open_competition_v2_beta3_release.py \
+          python .release-control/scripts/promote_open_competition_v2_beta3_release.py \
             --bundle target/mainnet-deployment/mainnet-exact.json \
             --deployment target/mainnet-deployment/mainnet-deployment-evidence.json \
             --gates target/release-gates.json --output target/mainnet-public-beta.json \

--- a/scripts/build_open_competition_v2_beta3_release.py
+++ b/scripts/build_open_competition_v2_beta3_release.py
@@ -406,6 +406,7 @@ def load_gates(path: Path, expected_subject_hash: str | None = None) -> dict[str
     value = json.loads(path.read_text(encoding="utf-8"))
     gates = value.get("gates")
     evidence = value.get("evidence")
+    observed_subject_hashes: set[str] = set()
     if value.get("schema_version") != "agent-bounties/open-competition-v2-beta3-release-gates-v5":
         raise ValueError("release gate schema mismatch")
     if not isinstance(gates, dict) or set(gates) != set(REQUIRED_GATE_NAMES):
@@ -432,11 +433,19 @@ def load_gates(path: Path, expected_subject_hash: str | None = None) -> dict[str
             raise ValueError(f"release gate evidence has invalid subject hash: {name}")
         if expected_subject_hash is not None and subject_hash != expected_subject_hash:
             raise ValueError(f"release gate evidence targets another repository subject: {name}")
+        observed_subject_hashes.add(subject_hash)
         if not re.fullmatch(r"0x[0-9a-f]{64}", evidence_hash):
             raise ValueError(f"release gate evidence has invalid hash: {name}")
         if not isinstance(uri, str) or not uri.startswith("https://"):
             raise ValueError(f"release gate evidence requires an HTTPS URI: {name}")
     expected_risk = keccak256(value["beta_risk_preimage"].encode())
+    if len(observed_subject_hashes) > 1:
+        raise ValueError("completed release gates target multiple repository subjects")
+    value["subject_hash"] = (
+        expected_subject_hash
+        if expected_subject_hash is not None
+        else next(iter(observed_subject_hashes), None)
+    )
     value["beta_risk_hash"] = expected_risk
     value["prelaunch_complete"] = all(gates[name] for name in PRELAUNCH_GATE_NAMES)
     value["public_beta_launch_complete"] = all(

--- a/scripts/test_build_open_competition_v2_beta3_release.py
+++ b/scripts/test_build_open_competition_v2_beta3_release.py
@@ -317,6 +317,7 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
             value["evidence"][name] = evidence
         path.write_text(__import__("json").dumps(value), encoding="utf-8")
         gates = MODULE.load_gates(path, self.subject_hash)
+        self.assertEqual(gates["subject_hash"], self.subject_hash)
         self.assertTrue(gates["prelaunch_complete"])
         self.assertFalse(gates["public_beta_launch_complete"])
         self.assertFalse(gates["graduation_complete"])

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -106,6 +106,16 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
             self.text.count('--url "$OPEN_COMPETITION_V2_RUNTIME_READINESS_URL"'),
             3,
         )
+        self.assertEqual(
+            self.text.count(
+                "python .release-control/scripts/promote_open_competition_v2_beta3_release.py"
+            ),
+            2,
+        )
+        self.assertNotIn(
+            "python scripts/promote_open_competition_v2_beta3_release.py",
+            self.text,
+        )
 
     def test_canonical_interfaces_are_proved_on_the_self_hosted_canary_runner(self):
         canaries = self.text.split("  mainnet-canaries:", 1)[1].split(


### PR DESCRIPTION
## Summary
- expose the single validated repository subject from load_gates()
- reject mixed completed-gate subjects even when no expected hash is supplied
- run Beta3 promotion from the current release-control checkout
- add regression coverage for the exact production failure

## Incident evidence
Run #32342829511 passed Render deployment, runtime readiness, primary/shadow agreement, and broker reserve verification. Promotion then stopped with gate subject differs from bundle because the loader validated evidence subjects but omitted the derived top-level field consumed by promotion. No broker enablement, canary, or fund movement occurred.

## Verification
- 35 targeted release/promotion/continuation tests pass
- replaying promote_open_competition_v2_beta3_release.py against run #32342829511's exact mainnet bundle, deployment, and gate artifact now succeeds fail-closed with broker/public disabled
- core preflight and diff check pass

No contract, verifier, proof identity, or settlement logic changes.