### PR TITLE
Rebuild Beta3 contracts before canaries

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -351,6 +351,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           path: target/continuation-control
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
@@ -389,6 +390,7 @@ jobs:
           KEEPER="${BASE_KEEPER_ADDRESS,,}"
           DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
           chmod 0755 "$OPEN_COMPETITION_V2_PROVER_BINARY"
+          forge build --root contracts/base-escrow --force --ast
           cargo build --manifest-path target/continuation-control/Cargo.toml \
             --target-dir target/continuation-build --locked --release -p api -p worker
           bundle=target/mainnet-deployment/mainnet-exact.json

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -1130,6 +1130,7 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
@@ -1169,6 +1170,7 @@ jobs:
           KEEPER="${BASE_KEEPER_ADDRESS,,}"
           DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
           chmod 0755 "$OPEN_COMPETITION_V2_PROVER_BINARY"
+          forge build --root contracts/base-escrow --force --ast
           cargo build --locked --release -p api -p worker
           bundle=target/mainnet-deployment/mainnet-exact.json
           python scripts/verify_open_competition_v2_beta3_broker_reserve.py \

--- a/scripts/test_build_open_competition_v2_beta3_release.py
+++ b/scripts/test_build_open_competition_v2_beta3_release.py
@@ -137,6 +137,24 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
         )
         self.assertNotIn("x402_success_and_refund_canaries_complete", workflow)
 
+    def test_mainnet_canaries_rebuild_cleaned_contract_artifacts(self):
+        for workflow_path in (
+            ".github/workflows/open-competition-v2-beta3-release.yml",
+            ".github/workflows/continue-open-competition-v2-beta3-mainnet.yml",
+        ):
+            workflow = (MODULE.ROOT / workflow_path).read_text(encoding="utf-8")
+            canary = workflow.split("  mainnet-canaries:", 1)[1].split(
+                "  activate-public-beta:", 1
+            )[0]
+            self.assertIn(
+                "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a",
+                canary,
+            )
+            self.assertIn(
+                "forge build --root contracts/base-escrow --force --ast",
+                canary,
+            )
+
     def test_sepolia_rehearsal_uses_an_isolated_broker(self):
         workflow = (MODULE.ROOT / ".github/workflows/open-competition-v2-beta3-release.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- install the pinned Foundry toolchain in both Beta3 mainnet-canary jobs
- rebuild the exact frozen contract artifacts after checkout cleanup
- assert both release paths preserve this precondition

## Incident evidence
Run #32344308784 passed the complete control plane, then stopped before proof preparation or USDC movement because contracts/base-escrow/out/OpenCompetitionBountyFactoryV2Beta3.sol/OpenCompetitionBountyFactoryV2Beta3.json had been cleaned and was never rebuilt.

## Verification
- 34 targeted release/continuation tests pass
- local orge build --root contracts/base-escrow --force --ast succeeds and creates the required artifact
- core preflight and diff check pass

The deployer balance remains exactly 15.915011 USDC; no canary funds moved.