### PR TITLE
Fix and resume Beta3 hosted x402 payment

### DIFF
--- a/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
@@ -1,0 +1,297 @@
+name: Resume Open Competition V2 Beta3 mainnet
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: open-competition-v2-beta3-mainnet-resume
+  cancel-in-progress: false
+
+env:
+  RELEASE_SOURCE_COMMIT: 4d09d82825c38f2bf93a8ee4375a95b302410c29
+  SOURCE_RUN_ID: "32346174505"
+  SOURCE_ACTOR_DERIVATION_SALT: "32346174505:1:mainnet"
+  OPEN_COMPETITION_V2_RUNTIME_READINESS_URL: https://agent-bounties-api.onrender.com/v1/base/open-competition-v2-beta3/release
+  EXISTING_X402_JOB_ID: 155ef022-8ef3-4453-825c-316d309d9ecf
+  PLONK_COMPETITION: 0x3e052b933628b960d61654a68fca23d869d8989f
+  PLONK_SETTLEMENT_TRANSACTION: 0x830e856ddbade328a0715e47e3aaa36f6363c6be71c18bd20f0baaab75aed4f3
+  FORCED_REFUND_PAYMENT_TRANSACTION: 0xdb833590333b36c69ee7e7d873a94f87d519278321df13f155253473e4a0a7c2
+  FORCED_REFUND_TRANSACTION: 0x0fa117876516f1641181e3bb843f29fd74be63262b7685663e6afb6632205d38
+  BASE_USDC: 0x833589fcd6edb6e08f4c7c32d4f71b54bda02913
+
+jobs:
+  deploy-retryable-payment-api:
+    environment: v2-beta2-mainnet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          run-id: ${{ env.SOURCE_RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: open-competition-v2-beta3-production-control-plane-continuation
+          path: target/production-control-plane
+      - name: Deploy retry-safe API and verify broker-only runtime
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          OPEN_COMPETITION_V2_PROVER_API_KEY: ${{ secrets.OPEN_COMPETITION_V2_PROVER_API_KEY }}
+          OPEN_COMPETITION_V2_PROVER_URL: ${{ vars.OPEN_COMPETITION_V2_PROVER_URL }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+          BASE_KEEPER_ADDRESS: ${{ vars.BASE_KEEPER_ADDRESS }}
+          BASE_DEPLOYER_ADDRESS: ${{ vars.BASE_DEPLOYER_ADDRESS }}
+          BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
+        run: |
+          set -euo pipefail
+          python -m pip install -r scripts/requirements-wallet.txt
+          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
+          python scripts/configure_open_competition_v2_beta3_render.py \
+            --runtime target/production-control-plane/mainnet-broker.runtime.json \
+            --revision "$GITHUB_SHA" --primary-rpc-url "$BASE_MAINNET_RPC_URL" \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
+            --prover-url "$OPEN_COMPETITION_V2_PROVER_URL" --broker-address "$BROKER" \
+            --keeper-address "${BASE_KEEPER_ADDRESS,,}" \
+            --deployer-address "${BASE_DEPLOYER_ADDRESS,,}" \
+            --output target/render-retryable-payment-api.json
+          python scripts/wait_open_competition_v2_beta3_runtime.py \
+            --url "$OPEN_COMPETITION_V2_RUNTIME_READINESS_URL" \
+            --runtime target/production-control-plane/mainnet-broker.runtime.json \
+            --expect-broker true --expect-public false \
+            --output target/retryable-payment-api-ready.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: open-competition-v2-beta3-retryable-payment-api
+          path: |
+            target/render-retryable-payment-api.json
+            target/retryable-payment-api-ready.json
+          if-no-files-found: error
+          retention-days: 365
+
+  resume-canary-and-activate:
+    needs: deploy-retryable-payment-api
+    environment: v2-beta2-mainnet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ env.RELEASE_SOURCE_COMMIT }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ github.sha }}
+          path: .release-control
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          run-id: ${{ env.SOURCE_RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: open-competition-v2-beta3-mainnet-deployment-continuation
+          path: target/mainnet-deployment
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          run-id: ${{ env.SOURCE_RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: open-competition-v2-beta3-production-control-plane-continuation
+          path: target/production-control-plane
+      - name: Resume funded x402 canary and reconstruct canonical evidence
+        env:
+          PYTHONPATH: ${{ github.workspace }}/.release-control/scripts
+          BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+          BASE_KEEPER_ADDRESS: ${{ vars.BASE_KEEPER_ADDRESS }}
+          BASE_DEPLOYER_ADDRESS: ${{ vars.BASE_DEPLOYER_ADDRESS }}
+        run: |
+          set -euo pipefail
+          python -m pip install -r scripts/requirements-wallet.txt
+          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
+          export BROKER
+          python - <<'PY'
+          import json, os, time
+          from pathlib import Path
+          from types import SimpleNamespace
+          from urllib.request import Request, urlopen
+          import run_open_competition_v2_sepolia_rehearsal as rehearsal
+
+          rehearsal.configure_network(SimpleNamespace(network="base-mainnet", rpc_url=os.environ["BASE_MAINNET_RPC_URL"]))
+          source = os.environ["RELEASE_SOURCE_COMMIT"]
+          salt = os.environ["SOURCE_ACTOR_DERIVATION_SALT"]
+          root = rehearsal.normalized_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"])
+          deployer, solver_a, solver_b = rehearsal.actors_for(root, {"source_commit": source}, salt)
+          url = f"https://api.agentbounties.app/v1/base/open-competition-v2-beta3/proof-jobs/{os.environ['EXISTING_X402_JOB_ID']}"
+          with urlopen(Request(url, headers={"accept": "application/json"}), timeout=45) as response:
+              old = json.loads(response.read())["job"]
+          inventory_url = "https://api.agentbounties.app/v1/base/open-competition-v2-beta3/inventory?network=base-mainnet"
+          with urlopen(Request(inventory_url, headers={"accept": "application/json"}), timeout=45) as response:
+              inventory = json.loads(response.read())["competitions"]
+          projection = next(
+              item["record"]["projection"]
+              for item in inventory
+              if item["record"]["projection"]["competition"].lower()
+              == old["competition_contract"].lower()
+          )
+          program = old["program_input"]
+          proof_deadline = int(projection["proof_deadline"])
+          if proof_deadline < int(time.time()) + 2_100:
+              raise RuntimeError("preserved canary no longer has enough proof SLA; use a replacement canary")
+          document = {
+              "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-resume-v1",
+              "passed": True,
+              "synthetic": True,
+              "network": "base-mainnet",
+              "source_commit": source,
+              "actor_derivation_id": rehearsal.actor_derivation_id(source, salt),
+              "actors": {
+                  "deployer": deployer.address.lower(),
+                  "solver_a": solver_a.address.lower(),
+                  "solver_b": solver_b.address.lower(),
+              },
+              "transactions": {
+                  "fund_solver_a_gas": "0x4fa91e5fcacba410f183ed98e5d0df35c829cf164ff8a7882783f09078b56468",
+                  "fund_solver_a_usdc": "0x8854c916bc98121c725815437491792016e5741fc0b556bc05b1c26f6677546c",
+              },
+              "byo_proof_submission": {
+                  "transaction_hash": "0xad8b686fd967d8f6a833149a27dcdfb99116f0786997099f51f53be310154628"
+              },
+              "x402_canary": {
+                  "competition": old["competition_contract"],
+                  "bounty_id": projection["bounty_id"],
+                  "solver": solver_a.address.lower(),
+                  "solver_nonce": "4",
+                  "artifact_hash": old["artifact_hash"],
+                  "proof_system": "groth16",
+                  "metric": {
+                      "mode": program["mode"],
+                      "threshold": str(program["threshold"]),
+                      "vectors": program["vectors"],
+                  },
+                  "proof_deadline": proof_deadline,
+                  "active": True,
+                  "resumed_from_job": old["id"],
+              },
+          }
+          Path("target/mainnet-canary-resume.json").write_text(json.dumps(document, indent=2) + "\n")
+          print(json.dumps({"passed": True, "competition": old["competition_contract"], "solver": solver_a.address.lower(), "proof_deadline": proof_deadline}))
+          PY
+          python .release-control/scripts/run_open_competition_v2_x402_rehearsal.py \
+            --network base-mainnet --api https://api.agentbounties.app \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canary-resume.json \
+            --hosted-workers --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
+            --actor-derivation-salt "$SOURCE_ACTOR_DERIVATION_SALT" \
+            --timeout-seconds 5400 --output target/mainnet-x402-success.json
+          python .release-control/scripts/verify_open_competition_v2_beta3_mainnet_recovery.py \
+            --api https://api.agentbounties.app --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --token "$BASE_USDC" --broker "$BROKER" \
+            --payer "$(jq -r .actors.solver_a target/mainnet-canary-resume.json)" \
+            --plonk-competition "$PLONK_COMPETITION" \
+            --plonk-settlement-transaction "$PLONK_SETTLEMENT_TRANSACTION" \
+            --refund-payment-transaction "$FORCED_REFUND_PAYMENT_TRANSACTION" \
+            --refund-transaction "$FORCED_REFUND_TRANSACTION" \
+            --x402-success target/mainnet-x402-success.json --output-dir target/recovered-canaries
+          python .release-control/scripts/verify_open_competition_v2_beta3_interfaces.py \
+            --runtime target/production-control-plane/mainnet-broker.runtime.json \
+            --output target/mainnet-canonical-interfaces.json
+          python .release-control/scripts/verify_open_competition_v2_fresh_agent_flow.py \
+            --rehearsal target/mainnet-canary-resume.json \
+            --x402-success target/mainnet-x402-success.json \
+            --output target/mainnet-fresh-agent-flow.json
+          python .release-control/scripts/verify_open_competition_v2_beta3_broker_reserve.py \
+            --runtime target/production-control-plane/mainnet-broker.runtime.json \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --broker "$BROKER" \
+            --keeper "${BASE_KEEPER_ADDRESS,,}" --deployer "${BASE_DEPLOYER_ADDRESS,,}" \
+            --output target/activation-broker-reserve.json
+      - name: Record exact gates and activate public Beta3
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          OPEN_COMPETITION_V2_PROVER_API_KEY: ${{ secrets.OPEN_COMPETITION_V2_PROVER_API_KEY }}
+          OPEN_COMPETITION_V2_PROVER_URL: ${{ vars.OPEN_COMPETITION_V2_PROVER_URL }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+          BASE_KEEPER_ADDRESS: ${{ vars.BASE_KEEPER_ADDRESS }}
+          BASE_DEPLOYER_ADDRESS: ${{ vars.BASE_DEPLOYER_ADDRESS }}
+          BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
+        run: |
+          set -euo pipefail
+          BROKER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"]).address.lower())')"
+          cp target/production-control-plane/release-gates.json target/release-gates.json
+          evidence_uri="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          python scripts/record_open_competition_v2_beta3_gate.py --manifest target/release-gates.json \
+            --gate broker_refund_reserve_ready --evidence target/activation-broker-reserve.json \
+            --uri "$evidence_uri" --source-commit "$RELEASE_SOURCE_COMMIT"
+          python scripts/record_open_competition_v2_beta3_gate.py --manifest target/release-gates.json \
+            --gate mainnet_groth16_canary_complete --evidence target/mainnet-x402-success.json \
+            --uri "$evidence_uri" --source-commit "$RELEASE_SOURCE_COMMIT"
+          python scripts/record_open_competition_v2_beta3_gate.py --manifest target/release-gates.json \
+            --gate mainnet_plonk_canary_complete --evidence target/recovered-canaries/mainnet-plonk-canary.json \
+            --uri "$evidence_uri" --source-commit "$RELEASE_SOURCE_COMMIT"
+          for gate in mainnet_canary_accounting_reconciled x402_success_and_refund_complete; do
+            python scripts/record_open_competition_v2_beta3_gate.py --manifest target/release-gates.json \
+              --gate "$gate" --evidence target/recovered-canaries/mainnet-accounting.json \
+              --uri "$evidence_uri" --source-commit "$RELEASE_SOURCE_COMMIT"
+          done
+          python scripts/record_open_competition_v2_beta3_gate.py --manifest target/release-gates.json \
+            --gate fresh_agent_wallet_flow_complete --evidence target/mainnet-fresh-agent-flow.json \
+            --uri "$evidence_uri" --source-commit "$RELEASE_SOURCE_COMMIT"
+          python scripts/record_open_competition_v2_beta3_gate.py --manifest target/release-gates.json \
+            --gate production_interfaces_agree --evidence target/mainnet-canonical-interfaces.json \
+            --uri "$evidence_uri" --source-commit "$RELEASE_SOURCE_COMMIT"
+          export RISK_HASH="$(jq -r .beta_risk_hash target/production-control-plane/mainnet-broker.runtime.json)"
+          python - <<'PY'
+          import json, os
+          json.dump({
+              "schema_version": "agent-bounties/open-competition-v2-beta3-owner-activation-approval-v1",
+              "environment": "v2-beta2-mainnet",
+              "run_id": os.environ["GITHUB_RUN_ID"],
+              "source_commit": os.environ["RELEASE_SOURCE_COMMIT"],
+              "risk_hash": os.environ["RISK_HASH"],
+              "approval_scope": "enable public Beta3 creation only for the exact release subject",
+          }, open("target/owner-public-beta-activation.json", "w"), indent=2)
+          PY
+          python scripts/record_open_competition_v2_beta3_gate.py --manifest target/release-gates.json \
+            --gate owner_public_beta_activation_approved \
+            --evidence target/owner-public-beta-activation.json --uri "$evidence_uri" \
+            --source-commit "$RELEASE_SOURCE_COMMIT" --owner-risk-hash "$RISK_HASH"
+          python .release-control/scripts/promote_open_competition_v2_beta3_release.py \
+            --bundle target/mainnet-deployment/mainnet-exact.json \
+            --deployment target/mainnet-deployment/mainnet-deployment-evidence.json \
+            --gates target/release-gates.json --output target/mainnet-public-beta.json \
+            --runtime-output target/mainnet-public-beta.runtime.json
+          jq -e '.public_creation_enabled == true and .proof_broker_enabled == true' \
+            target/mainnet-public-beta.runtime.json >/dev/null
+          python .release-control/scripts/configure_open_competition_v2_beta3_render.py \
+            --runtime target/mainnet-public-beta.runtime.json --revision "$GITHUB_SHA" \
+            --primary-rpc-url "$BASE_MAINNET_RPC_URL" --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
+            --prover-url "$OPEN_COMPETITION_V2_PROVER_URL" --broker-address "$BROKER" \
+            --keeper-address "${BASE_KEEPER_ADDRESS,,}" --deployer-address "${BASE_DEPLOYER_ADDRESS,,}" \
+            --output target/render-public-beta.json
+          python .release-control/scripts/wait_open_competition_v2_beta3_runtime.py \
+            --url "$OPEN_COMPETITION_V2_RUNTIME_READINESS_URL" \
+            --runtime target/mainnet-public-beta.runtime.json --expect-broker true \
+            --expect-public true --output target/public-beta-activation.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: open-competition-v2-beta3-mainnet-resumed-and-activated
+          path: |
+            target/mainnet-canary-resume.json
+            target/mainnet-x402-success.json
+            target/recovered-canaries/*.json
+            target/mainnet-fresh-agent-flow.json
+            target/mainnet-canonical-interfaces.json
+            target/activation-broker-reserve.json
+            target/mainnet-public-beta.json
+            target/mainnet-public-beta.runtime.json
+            target/public-beta-activation.json
+            target/render-public-beta.json
+            target/release-gates.json
+          if-no-files-found: error
+          retention-days: 365

--- a/crates/api/src/open_competition_v2_api.rs
+++ b/crates/api/src/open_competition_v2_api.rs
@@ -10,7 +10,7 @@ use chain_base::{
     fetch_block_number, fetch_exact_block_identity, fetch_transaction_receipt,
     plan_open_competition_v2_action, plan_open_competition_v2_broker_payment,
     plan_open_competition_v2_creation, plan_open_competition_v2_funding,
-    plan_open_competition_v2_proof, validate_open_competition_v2_release,
+    plan_open_competition_v2_proof, validate_open_competition_v2_release, ChainBaseError,
     OpenCompetitionV2BrokerPaymentAuthorization, OpenCompetitionV2CreateParams,
     OpenCompetitionV2CreationRequest, OpenCompetitionV2ProgramClassification,
     OpenCompetitionV2ProofSystem, OpenCompetitionV2Release, OpenCompetitionV2ScoreDirection,
@@ -967,8 +967,17 @@ pub(crate) async fn pay_proof_job(
             .release_x402_relayer_lease(&job.network, lease)
             .await
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
-        let transaction = result?;
         release_result?;
+        let transaction = match result {
+            Ok(transaction) => transaction,
+            Err(ProofPaymentBroadcastError::Chain(error)) => {
+                if let Some(reason) = retryable_proof_payment_broadcast_error(&error) {
+                    return proof_job_payment_retry_response(&job, reason);
+                }
+                return Err(StatusCode::UNPROCESSABLE_ENTITY);
+            }
+            Err(ProofPaymentBroadcastError::Status(status)) => return Err(status),
+        };
         job = store
             .transition_open_competition_v2_proof_job(
                 job.id,
@@ -1279,17 +1288,21 @@ async fn broadcast_proof_job_payment(
     job: &OpenCompetitionV2ProofJob,
     release: &OpenCompetitionV2Release,
     authorization: &payments_x402::ValidatedExactAuthorization,
-) -> Result<chain_base::BaseRelayedTransaction, StatusCode> {
+) -> Result<chain_base::BaseRelayedTransaction, ProofPaymentBroadcastError> {
     let relayer = state
         .x402_relayer
         .relayer
         .as_ref()
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+        .ok_or(ProofPaymentBroadcastError::Status(
+            StatusCode::SERVICE_UNAVAILABLE,
+        ))?;
     if !authorization
         .recipient
         .eq_ignore_ascii_case(&relayer.address())
     {
-        return Err(StatusCode::UNPROCESSABLE_ENTITY);
+        return Err(ProofPaymentBroadcastError::Status(
+            StatusCode::UNPROCESSABLE_ENTITY,
+        ));
     }
     let intent = plan_open_competition_v2_broker_payment(
         &job.network,
@@ -1306,24 +1319,49 @@ async fn broadcast_proof_job_payment(
             s: authorization.s.clone(),
         },
     )
-    .map_err(|_| StatusCode::UNPROCESSABLE_ENTITY)?;
+    .map_err(|_| ProofPaymentBroadcastError::Status(StatusCode::UNPROCESSABLE_ENTITY))?;
     let (_, rpc_url) = state
         .base_rpc_urls
         .resolve(&job.network)
-        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+        .map_err(|_| ProofPaymentBroadcastError::Status(StatusCode::SERVICE_UNAVAILABLE))?;
     timeout(
         Duration::from_secs(state.x402_relayer.rpc_timeout_seconds),
         relayer.simulate_and_broadcast(
             &rpc_url,
-            network_chain_id(&job.network)?,
+            network_chain_id(&job.network).map_err(ProofPaymentBroadcastError::Status)?,
             &intent,
             state.x402_relayer.max_gas,
             state.x402_relayer.max_fee_per_gas_wei,
         ),
     )
     .await
-    .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
-    .map_err(|_| StatusCode::UNPROCESSABLE_ENTITY)
+    .map_err(|_| ProofPaymentBroadcastError::Status(StatusCode::SERVICE_UNAVAILABLE))?
+    .map_err(ProofPaymentBroadcastError::Chain)
+}
+
+#[derive(Debug)]
+enum ProofPaymentBroadcastError {
+    Chain(ChainBaseError),
+    Status(StatusCode),
+}
+
+fn retryable_proof_payment_broadcast_error(error: &ChainBaseError) -> Option<&'static str> {
+    match error {
+        ChainBaseError::RelayerSimulation(message)
+            if message.contains("transfer amount exceeds balance") =>
+        {
+            Some("payer_balance_not_yet_visible")
+        }
+        ChainBaseError::RelayerSimulation(message)
+            if message.contains("authorization is not yet valid") =>
+        {
+            Some("authorization_not_yet_visible")
+        }
+        ChainBaseError::RelayerProvider(_) => Some("relayer_provider_retry"),
+        ChainBaseError::RelayerFeeCapExceeded { .. } => Some("fee_cap_retry"),
+        ChainBaseError::RelayerInsufficientBalance { .. } => Some("gas_reserve_retry"),
+        _ => None,
+    }
 }
 
 async fn reconcile_proof_job_payment(
@@ -1534,6 +1572,35 @@ fn proof_job_payment_response(job: &OpenCompetitionV2ProofJob) -> Result<Respons
             HeaderValue::from_str(&encoded).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
         );
     }
+    Ok(response)
+}
+
+fn proof_job_payment_retry_response(
+    job: &OpenCompetitionV2ProofJob,
+    reason: &'static str,
+) -> Result<Response, StatusCode> {
+    let mut response = (
+        StatusCode::ACCEPTED,
+        Json(json!({
+            "schema_version": "agent-bounties/open-competition-v2-proof-payment-v1",
+            "proof_job_id": job.id,
+            "state": job.state,
+            "payment_evidence": job.payment_evidence,
+            "retryable": true,
+            "retry_after_seconds": 2,
+            "pending_reason": reason,
+            "next_action": "Retry this exact payment endpoint without signing another authorization.",
+            "evidence_boundary": "A retryable relay response is not payment evidence. Only attached canonical Base USDC evidence proves payment."
+        })),
+    )
+        .into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, private"),
+    );
+    response
+        .headers_mut()
+        .insert(header::RETRY_AFTER, HeaderValue::from_static("2"));
     Ok(response)
 }
 
@@ -2557,5 +2624,51 @@ mod tests {
         assert!(!indexer_agreement_is_current(
             &release, &agreement, 121, 120, 64
         ));
+    }
+
+    #[test]
+    fn proof_payment_retries_transient_balance_and_provider_observation() {
+        assert_eq!(
+            retryable_proof_payment_broadcast_error(&ChainBaseError::RelayerSimulation(
+                "execution reverted: ERC20: transfer amount exceeds balance".to_string(),
+            )),
+            Some("payer_balance_not_yet_visible")
+        );
+        assert_eq!(
+            retryable_proof_payment_broadcast_error(&ChainBaseError::RelayerProvider(
+                "temporary upstream failure".to_string(),
+            )),
+            Some("relayer_provider_retry")
+        );
+        assert_eq!(
+            retryable_proof_payment_broadcast_error(&ChainBaseError::RelayerInsufficientBalance {
+                balance: 1,
+                required: 2,
+            }),
+            Some("gas_reserve_retry")
+        );
+    }
+
+    #[test]
+    fn proof_payment_rejects_terminal_authorization_failures() {
+        for message in [
+            "FiatTokenV2: authorization is expired",
+            "FiatTokenV2: invalid signature",
+            "FiatTokenV2: authorization is used",
+        ] {
+            assert_eq!(
+                retryable_proof_payment_broadcast_error(&ChainBaseError::RelayerSimulation(
+                    message.to_string(),
+                )),
+                None
+            );
+        }
+        assert_eq!(
+            retryable_proof_payment_broadcast_error(&ChainBaseError::RelayerChainMismatch {
+                expected: 8453,
+                observed: 1,
+            }),
+            None
+        );
     }
 }

--- a/scripts/test_resume_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_resume_open_competition_v2_beta3_mainnet.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/resume-open-competition-v2-beta3-mainnet.yml"
+
+
+class MainnetResumeWorkflowTests(unittest.TestCase):
+    def test_resume_is_protected_and_reuses_canonical_funded_competition(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertEqual(text.count("environment: v2-beta2-mainnet"), 2)
+        self.assertIn('SOURCE_RUN_ID: "32346174505"', text)
+        self.assertIn("open-competition-v2-beta3-mainnet-deployment-continuation", text)
+        self.assertIn("open-competition-v2-beta3-production-control-plane-continuation", text)
+        self.assertIn("EXISTING_X402_JOB_ID", text)
+        self.assertIn('"solver_nonce": "4"', text)
+        self.assertNotIn("createCompetition(", text)
+        self.assertNotIn("approve(address", text)
+
+    def test_resume_deploys_retry_fix_before_spending_and_activates_exact_release(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        deploy = text.index("deploy-retryable-payment-api:")
+        resume = text.index("resume-canary-and-activate:")
+        pay = text.index("run_open_competition_v2_x402_rehearsal.py")
+        self.assertLess(deploy, resume)
+        self.assertLess(resume, pay)
+        self.assertIn("needs: deploy-retryable-payment-api", text)
+        self.assertIn("verify_open_competition_v2_beta3_mainnet_recovery.py", text)
+        self.assertIn("mainnet_canary_accounting_reconciled", text)
+        self.assertIn("owner_public_beta_activation_approved", text)
+        self.assertIn("--expect-public true", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verify_open_competition_v2_beta3_mainnet_recovery.py
+++ b/scripts/test_verify_open_competition_v2_beta3_mainnet_recovery.py
@@ -1,0 +1,55 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+PATH = Path(__file__).with_name("verify_open_competition_v2_beta3_mainnet_recovery.py")
+SPEC = importlib.util.spec_from_file_location("beta3_mainnet_recovery", PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class RecoveryEvidenceTests(unittest.TestCase):
+    def test_exact_transfer_matches(self):
+        sender = "0x" + "11" * 20
+        recipient = "0x" + "22" * 20
+        token = "0x" + "33" * 20
+        receipt = {
+            "logs": [
+                {
+                    "address": token,
+                    "topics": [
+                        MODULE.TRANSFER_TOPIC,
+                        MODULE.topic_address(sender),
+                        MODULE.topic_address(recipient),
+                    ],
+                    "data": hex(110_000),
+                }
+            ]
+        }
+        MODULE.require_transfer(receipt, token, sender, recipient, 110_000)
+
+    def test_wrong_transfer_is_rejected(self):
+        sender = "0x" + "11" * 20
+        recipient = "0x" + "22" * 20
+        token = "0x" + "33" * 20
+        receipt = {
+            "logs": [
+                {
+                    "address": token,
+                    "topics": [
+                        MODULE.TRANSFER_TOPIC,
+                        MODULE.topic_address(sender),
+                        MODULE.topic_address(recipient),
+                    ],
+                    "data": hex(109_999),
+                }
+            ]
+        }
+        with self.assertRaises(MODULE.RecoveryEvidenceError):
+            MODULE.require_transfer(receipt, token, sender, recipient, 110_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_open_competition_v2_beta3_mainnet_recovery.py
+++ b/scripts/verify_open_competition_v2_beta3_mainnet_recovery.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Reconstruct Beta3 canary evidence from canonical Base and hosted projections."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import time
+from typing import Any
+from urllib.request import Request, urlopen
+
+
+TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+
+class RecoveryEvidenceError(RuntimeError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RecoveryEvidenceError(message)
+
+
+def request_json(url: str) -> dict[str, Any]:
+    with urlopen(Request(url, headers={"accept": "application/json"}), timeout=45) as response:
+        return json.loads(response.read())
+
+
+def rpc(url: str, method: str, params: list[Any]) -> Any:
+    body = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
+        separators=(",", ":"),
+    ).encode()
+    with urlopen(
+        Request(url, data=body, headers={"content-type": "application/json"}), timeout=45
+    ) as response:
+        value = json.loads(response.read())
+    if value.get("error"):
+        raise RecoveryEvidenceError(f"RPC {method} failed: {value['error']}")
+    return value["result"]
+
+
+def topic_address(value: str) -> str:
+    raw = value.lower().removeprefix("0x")
+    require(len(raw) == 40, "invalid EVM address")
+    return "0x" + "0" * 24 + raw
+
+
+def receipt(url: str, transaction: str) -> dict[str, Any]:
+    value = rpc(url, "eth_getTransactionReceipt", [transaction])
+    require(isinstance(value, dict), f"transaction {transaction} is unconfirmed")
+    require(int(value["status"], 16) == 1, f"transaction {transaction} reverted")
+    return value
+
+
+def require_transfer(
+    value: dict[str, Any], token: str, sender: str, recipient: str, amount: int
+) -> None:
+    expected = (topic_address(sender), topic_address(recipient))
+    matches = [
+        log
+        for log in value.get("logs", [])
+        if log.get("address", "").lower() == token.lower()
+        and len(log.get("topics", [])) == 3
+        and log["topics"][0].lower() == TRANSFER_TOPIC
+        and (log["topics"][1].lower(), log["topics"][2].lower()) == expected
+        and int(log.get("data", "0x0"), 16) == amount
+    ]
+    require(len(matches) == 1, f"expected one exact {amount} USDC transfer")
+
+
+def wait_for_settlement(api: str, competition: str, deadline: float) -> tuple[dict[str, Any], dict[str, Any]]:
+    while time.time() < deadline:
+        inventory = request_json(
+            f"{api.rstrip('/')}/v1/base/open-competition-v2-beta3/inventory?network=base-mainnet"
+        )
+        events = request_json(
+            f"{api.rstrip('/')}/v1/base/open-competition-v2-beta3/events?network=base-mainnet"
+        )
+        record = next(
+            (
+                item
+                for item in inventory.get("competitions", [])
+                if item.get("record", {}).get("projection", {}).get("competition", "").lower()
+                == competition.lower()
+            ),
+            None,
+        )
+        settlement = next(
+            (
+                event
+                for event in events.get("events", [])
+                if event.get("kind") == "competition_settled"
+                and event.get("contract_address", "").lower() == competition.lower()
+            ),
+            None,
+        )
+        if (
+            isinstance(record, dict)
+            and record["record"]["projection"].get("state") == "settled"
+            and isinstance(settlement, dict)
+        ):
+            return record, settlement
+        time.sleep(3)
+    raise RecoveryEvidenceError(f"competition {competition} did not reconcile as settled")
+
+
+def write(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api", required=True)
+    parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--token", required=True)
+    parser.add_argument("--broker", required=True)
+    parser.add_argument("--payer", required=True)
+    parser.add_argument("--plonk-competition", required=True)
+    parser.add_argument("--plonk-settlement-transaction", required=True)
+    parser.add_argument("--refund-payment-transaction", required=True)
+    parser.add_argument("--refund-transaction", required=True)
+    parser.add_argument("--x402-success", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=300)
+    args = parser.parse_args()
+
+    success = json.loads(args.x402_success.read_text(encoding="utf-8"))
+    require(success.get("passed") is True, "x402 success evidence did not pass")
+    require(success.get("network") == "base-mainnet", "x402 evidence is not Base mainnet")
+    x402_competition = str(success.get("competition", ""))
+    x402_record, x402_settlement = wait_for_settlement(
+        args.api, x402_competition, time.time() + args.timeout_seconds
+    )
+    plonk_record, plonk_settlement = wait_for_settlement(
+        args.api, args.plonk_competition, time.time() + args.timeout_seconds
+    )
+
+    require(
+        x402_settlement["id"] == success.get("settlement_event_id"),
+        "x402 settlement event differs from hosted proof-job evidence",
+    )
+    require(
+        x402_settlement["tx_hash"].lower() == str(success.get("relay_transaction", "")).lower(),
+        "x402 settlement transaction differs from hosted evidence",
+    )
+    require(
+        plonk_settlement["tx_hash"].lower() == args.plonk_settlement_transaction.lower(),
+        "PLONK settlement transaction differs from the canonical event",
+    )
+
+    safe_block = min(
+        int(x402_record["record"]["safe_block_number"]),
+        int(plonk_record["record"]["safe_block_number"]),
+    )
+    transactions = {
+        "x402_payment": success["payment_transaction"],
+        "x402_settlement": success["relay_transaction"],
+        "forced_failure_payment": args.refund_payment_transaction,
+        "forced_failure_refund": args.refund_transaction,
+        "plonk_settlement": args.plonk_settlement_transaction,
+    }
+    receipts = {name: receipt(args.rpc_url, tx) for name, tx in transactions.items()}
+    for name, value in receipts.items():
+        require(int(value["blockNumber"], 16) <= safe_block, f"{name} is not safe")
+    require_transfer(receipts["x402_payment"], args.token, args.payer, args.broker, 110_000)
+    require_transfer(
+        receipts["forced_failure_payment"], args.token, args.payer, args.broker, 110_000
+    )
+    require_transfer(
+        receipts["forced_failure_refund"], args.token, args.broker, args.payer, 110_000
+    )
+    balance = int(
+        rpc(
+            args.rpc_url,
+            "eth_call",
+            [
+                {
+                    "to": args.token,
+                    "data": "0x70a08231" + "0" * 24 + x402_competition.removeprefix("0x"),
+                },
+                "safe",
+            ],
+        ),
+        16,
+    )
+    require(balance == 0, "settled x402 competition retained USDC")
+
+    plonk = {
+        "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-plonk-recovery-v1",
+        "passed": True,
+        "network": "base-mainnet",
+        "competition": args.plonk_competition.lower(),
+        "settled": True,
+        "winner": plonk_record["record"]["projection"]["winner"],
+        "settlement_event_id": plonk_settlement["id"],
+        "settlement_transaction": plonk_settlement["tx_hash"],
+        "safe_block": safe_block,
+    }
+    refund = {
+        "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-x402-refund-recovery-v1",
+        "passed": True,
+        "network": "base-mainnet",
+        "payer": args.payer.lower(),
+        "broker": args.broker.lower(),
+        "amount": 110_000,
+        "payment_transaction": args.refund_payment_transaction.lower(),
+        "refund_transaction": args.refund_transaction.lower(),
+        "safe_block": safe_block,
+    }
+    accounting = {
+        "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-accounting-v1",
+        "passed": True,
+        "reconstructed_from_canonical_events": True,
+        "competition_escrow_funded_base_units": 525_000,
+        "groth16_solver_reward_base_units": 250_000,
+        "plonk_solver_reward_base_units": 250_000,
+        "keeper_rewards_base_units": 25_000,
+        "x402_success": success,
+        "x402_refund": refund,
+        "plonk": plonk,
+        "safe_block": safe_block,
+    }
+    write(args.output_dir / "mainnet-plonk-canary.json", plonk)
+    write(args.output_dir / "mainnet-x402-refund.json", refund)
+    write(args.output_dir / "mainnet-accounting.json", accounting)
+    print(json.dumps({"passed": True, "safe_block": safe_block, "output": str(args.output_dir)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed
- keep transient hosted x402 relayer/provider failures in `payment_pending` and return retryable HTTP 202 with an exact retry instruction
- reject terminal authorization failures as before
- add canonical Base evidence reconstruction for the already-run PLONK and forced-refund canaries
- add a protected mainnet resume workflow that deploys this fix, completes the already-funded Groth16 canary with a fresh nonce, and activates the exact frozen Beta3 release

## Evidence
- `cargo test -p api --locked`: 139 passed, 4 database-only ignored
- recovery/workflow tests: 14 passed
- core preflight passed
- historical-block `eth_call` accepted the exact failed EIP-3009 authorization; payer held 0.11 USDC and broker held gas; no hosted relay transaction was broadcast

## Scope
No contract, verifier, vkey, release subject, V1 behavior, or payment amount changes.