### PR TITLE
Fix opaque Beta3 proof-payment relay failures

### DIFF
--- a/crates/api/src/open_competition_v2_api.rs
+++ b/crates/api/src/open_competition_v2_api.rs
@@ -971,6 +971,10 @@ pub(crate) async fn pay_proof_job(
         let transaction = match result {
             Ok(transaction) => transaction,
             Err(ProofPaymentBroadcastError::Chain(error)) => {
+                eprintln!(
+                    "open_competition_v2 proof payment relay did not broadcast: job_id={} error={error}",
+                    job.id
+                );
                 if let Some(reason) = retryable_proof_payment_broadcast_error(&error) {
                     return proof_job_payment_retry_response(&job, reason);
                 }
@@ -1357,7 +1361,20 @@ fn retryable_proof_payment_broadcast_error(error: &ChainBaseError) -> Option<&'s
         {
             Some("authorization_not_yet_visible")
         }
+        ChainBaseError::RelayerSimulation(message)
+            if [
+                "authorization is expired",
+                "invalid signature",
+                "authorization is used",
+            ]
+            .iter()
+            .any(|terminal| message.contains(terminal)) =>
+        {
+            None
+        }
+        ChainBaseError::RelayerSimulation(_) => Some("relayer_simulation_retry"),
         ChainBaseError::RelayerProvider(_) => Some("relayer_provider_retry"),
+        ChainBaseError::RelayerGasLimitExceeded { .. } => Some("gas_limit_retry"),
         ChainBaseError::RelayerFeeCapExceeded { .. } => Some("fee_cap_retry"),
         ChainBaseError::RelayerInsufficientBalance { .. } => Some("gas_reserve_retry"),
         _ => None,
@@ -2646,6 +2663,19 @@ mod tests {
                 required: 2,
             }),
             Some("gas_reserve_retry")
+        );
+        assert_eq!(
+            retryable_proof_payment_broadcast_error(&ChainBaseError::RelayerSimulation(
+                "execution reverted without decoded reason".to_string(),
+            )),
+            Some("relayer_simulation_retry")
+        );
+        assert_eq!(
+            retryable_proof_payment_broadcast_error(&ChainBaseError::RelayerGasLimitExceeded {
+                estimated: 2,
+                maximum: 1,
+            }),
+            Some("gas_limit_retry")
         );
     }
 

--- a/scripts/diagnose_open_competition_v2_beta3_render.py
+++ b/scripts/diagnose_open_competition_v2_beta3_render.py
@@ -14,7 +14,12 @@ from typing import Any
 import render_deploy_recovery as render
 
 
-WORKERS = (
+SERVICES = (
+    render.ServiceSpec(
+        "agent-bounties-api",
+        "web_service",
+        "https://agent-bounties-api.onrender.com/health",
+    ),
     render.ServiceSpec(
         "agent-bounties-open-competition-v2-beta3-indexer",
         "background_worker",
@@ -45,8 +50,8 @@ def collect(
 ) -> dict[str, Any]:
     end = now.astimezone(timezone.utc)
     start = end - timedelta(hours=1)
-    workers = []
-    for spec in WORKERS:
+    services = []
+    for spec in SERVICES:
         service = client.resolve_service(spec)
         service_id = service.get("id")
         owner_id = service.get("ownerId")
@@ -65,7 +70,7 @@ def collect(
         }
         query = urllib.parse.urlencode(parameters, doseq=True)
         summary = render.summarize_build_logs(client._read_with_retry(f"/logs?{query}"))
-        workers.append(
+        services.append(
             {
                 "name": spec.name,
                 "service_id": service_id,
@@ -75,7 +80,7 @@ def collect(
     return {
         "schema_version": "agent-bounties/open-competition-v2-beta3-render-diagnostic-v1",
         "observed_at": end.isoformat().replace("+00:00", "Z"),
-        "workers": workers,
+        "services": services,
         "read_only": True,
         "secrets_redacted": True,
         "evidence_boundary": (

--- a/scripts/test_diagnose_open_competition_v2_beta3_render.py
+++ b/scripts/test_diagnose_open_competition_v2_beta3_render.py
@@ -49,9 +49,9 @@ class Beta3RenderDiagnosticTests(unittest.TestCase):
 
         self.assertTrue(result["read_only"])
         self.assertTrue(result["secrets_redacted"])
-        self.assertEqual(len(result["workers"]), 4)
-        self.assertEqual(len(client.paths), 4)
-        for path, worker in zip(client.paths, result["workers"]):
+        self.assertEqual(len(result["services"]), 5)
+        self.assertEqual(len(client.paths), 5)
+        for path, worker in zip(client.paths, result["services"]):
             query = urllib.parse.parse_qs(urllib.parse.urlsplit(path).query)
             self.assertEqual(query["ownerId"], ["tea-workspace"])
             self.assertEqual(query["resource"], [worker["service_id"]])


### PR DESCRIPTION
## Summary
- keep non-terminal pre-broadcast relayer simulation and gas-cap failures in retryable payment state
- preserve terminal rejection for expired, invalid, or reused EIP-3009 authorizations
- log sanitized relayer failures and include the API service in redacted Render diagnostics

## Verification
- cargo test -p api (139 passed, 4 database-dependent ignored)
- python scripts/test_diagnose_open_competition_v2_beta3_render.py -v
- python scripts/test_resume_open_competition_v2_beta3_mainnet.py -v
- cargo fmt --check
- scripts/preflight.ps1 -Mode core

## Payment evidence boundary
No transaction is broadcast by this change. Canonical Base events remain the only settlement evidence.