### PR TITLE
Make Beta3 canary recovery nonce replay-safe

### DIFF
--- a/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
@@ -144,6 +144,7 @@ jobs:
           proof_deadline = int(projection["proof_deadline"])
           if proof_deadline < int(time.time()) + 2_100:
               raise RuntimeError("preserved canary no longer has enough proof SLA; use a replacement canary")
+          recovery_nonce = str(time.time_ns())
           document = {
               "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-resume-v1",
               "passed": True,
@@ -167,7 +168,7 @@ jobs:
                   "competition": old["competition_contract"],
                   "bounty_id": projection["bounty_id"],
                   "solver": solver_a.address.lower(),
-                  "solver_nonce": "4",
+                  "solver_nonce": recovery_nonce,
                   "artifact_hash": old["artifact_hash"],
                   "proof_system": "groth16",
                   "metric": {

--- a/scripts/test_resume_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_resume_open_competition_v2_beta3_mainnet.py
@@ -26,7 +26,9 @@ class MainnetResumeWorkflowTests(unittest.TestCase):
         self.assertIn("open-competition-v2-beta3-mainnet-deployment-continuation", text)
         self.assertIn("open-competition-v2-beta3-production-control-plane-continuation", text)
         self.assertIn("EXISTING_X402_JOB_ID", text)
-        self.assertIn('"solver_nonce": "4"', text)
+        self.assertIn("recovery_nonce = str(time.time_ns())", text)
+        self.assertIn('"solver_nonce": recovery_nonce', text)
+        self.assertNotRegex(text, r'"solver_nonce": "\d+"')
         self.assertNotIn("createCompetition(", text)
         self.assertNotIn("approve(address", text)
 


### PR DESCRIPTION
## Summary
- derive a fresh uint256 solver nonce for each canary recovery attempt
- prevent hard-coded recovery nonces with a workflow regression test

## Verification
- python scripts/test_resume_open_competition_v2_beta3_mainnet.py -v
- GitHub workflow YAML parses successfully
- git diff --check

The preceding attempt stopped at quote creation with 409; no transaction or payment was broadcast.