### PR TITLE
Fix Beta3 refund recovery and diagnose prover

### DIFF
--- a/.github/workflows/diagnose-open-competition-v2-beta3-prover.yml
+++ b/.github/workflows/diagnose-open-competition-v2-beta3-prover.yml
@@ -1,0 +1,44 @@
+name: Diagnose Open Competition V2 Beta3 prover
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider_job_id:
+        description: "Persisted provider job to replay"
+        required: true
+        default: beta3-a6d75c2a19ded9fb0788d6418db711374780fe83452c70e7db37b989194cb0b5
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    environment: v2-beta2-mainnet
+    runs-on: [self-hosted, linux, x64, ram-256gb, open-competition-v2-prover]
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+
+      - name: Verify diagnostic code
+        run: |
+          python3 scripts/test_diagnose_open_competition_v2_beta3_prover.py -v
+          python3 -m py_compile scripts/diagnose_open_competition_v2_beta3_prover.py
+
+      - name: Replay persisted request with redacted diagnostics
+        env:
+          PROVIDER_JOB_ID: ${{ inputs.provider_job_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p target
+          sudo bash -c "set -a; source /etc/agent-bounties/prover.env; set +a; python3 '$GITHUB_WORKSPACE/scripts/diagnose_open_competition_v2_beta3_prover.py' --provider-job-id '$PROVIDER_JOB_ID' --output /tmp/beta3-prover-diagnostic.json"
+          sudo install -o "$(id -u)" -g "$(id -g)" -m 0600 /tmp/beta3-prover-diagnostic.json target/beta3-prover-diagnostic.json
+          jq '{passed, exit_code, timed_out, elapsed_seconds, stderr_tail}' target/beta3-prover-diagnostic.json
+
+      - name: Upload redacted diagnostic
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: beta3-prover-diagnostic-${{ github.run_id }}
+          path: target/beta3-prover-diagnostic.json
+          if-no-files-found: error
+          retention-days: 14

--- a/crates/worker/src/open_competition_v2_broker.rs
+++ b/crates/worker/src/open_competition_v2_broker.rs
@@ -943,10 +943,7 @@ async fn find_canonical_refund(
         settlement_token,
         from_block,
         Some(safe.number),
-        vec![
-            event_topic("Transfer(address,address,uint256)"),
-            event_topic("AuthorizationUsed(address,bytes32)"),
-        ],
+        vec![event_topic("AuthorizationUsed(address,bytes32)")],
     )?;
     let logs = rpc_logs_to_evm_logs(fetch_base_contract_logs(rpc_url, &query, 82).await?.result)?;
     let authorization_topic = event_topic("AuthorizationUsed(address,bytes32)");
@@ -1361,6 +1358,24 @@ mod tests {
             [0x78, 0x0d, 0x06, 0x43],
             &[0x43, 0x88, 0xa2, 0x1c, 1]
         ));
+    }
+
+    #[test]
+    fn refund_discovery_scans_only_authorization_events() {
+        let query = BaseContractLogQuery::new(
+            format!("0x{}", "11".repeat(20)),
+            100,
+            Some(200),
+            vec![event_topic("AuthorizationUsed(address,bytes32)")],
+        )
+        .unwrap();
+        let request = query.rpc_request(82);
+        assert_eq!(request.params[0].topics.len(), 1);
+        assert_eq!(request.params[0].topics[0].len(), 1);
+        assert_eq!(
+            request.params[0].topics[0][0],
+            event_topic("AuthorizationUsed(address,bytes32)")
+        );
     }
 
     #[test]

--- a/scripts/diagnose_open_competition_v2_beta3_prover.py
+++ b/scripts/diagnose_open_competition_v2_beta3_prover.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Replay one persisted Beta3 prover job and emit redacted host diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Any
+
+
+PROVIDER_JOB_ID = re.compile(r"^beta3-[0-9a-f]{64}$")
+PROFILE_ID = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+
+def redact(value: str) -> str:
+    result = value
+    for key, secret in os.environ.items():
+        if secret and any(marker in key.upper() for marker in ("KEY", "TOKEN", "SECRET", "PASSWORD")):
+            result = result.replace(secret, "[redacted]")
+    result = re.sub(r"(?i)(https?://)[^/@\s:]+:[^/@\s]+@", r"\1[redacted]@", result)
+    return result[-8_000:]
+
+
+def load_record(root: Path, provider_job_id: str) -> tuple[Path, dict[str, Any]]:
+    for path in root.glob("*.json"):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        if record.get("provider_job_id") == provider_job_id:
+            return path, record
+    raise RuntimeError("provider job is not present on this prover host")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--provider-job-id", required=True)
+    parser.add_argument("--job-dir", type=Path, default=Path("/var/lib/agent-bounties-prover/jobs"))
+    parser.add_argument("--timeout-seconds", type=int, default=1_800)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if not PROVIDER_JOB_ID.fullmatch(args.provider_job_id):
+        raise SystemExit("provider job id is invalid")
+
+    path, record = load_record(args.job_dir, args.provider_job_id)
+    request = record.get("request")
+    if not isinstance(request, dict) or not isinstance(request.get("program_input"), dict):
+        raise RuntimeError("persisted provider request is invalid")
+    program_input = dict(request["program_input"])
+    profile_id = program_input.pop("_profile_id", "public-vector-metric-v1")
+    if not isinstance(profile_id, str) or not PROFILE_ID.fullmatch(profile_id):
+        raise RuntimeError("persisted provider profile is invalid")
+    binaries = json.loads(os.environ.get("OPEN_COMPETITION_V2_PROVER_BINARIES", "{}"))
+    binary = Path(str(binaries.get(profile_id, "")))
+    if not binary.is_file():
+        raise RuntimeError("the pinned prover binary is unavailable")
+
+    disk = shutil.disk_usage(args.job_dir)
+    diagnostics: dict[str, Any] = {
+        "schema_version": "agent-bounties/open-competition-v2-beta3-prover-diagnostic-v1",
+        "provider_job_id": args.provider_job_id,
+        "persisted_status": record.get("status"),
+        "persisted_failure_code": record.get("failure_code"),
+        "profile_id": profile_id,
+        "proof_system": request.get("proof_system"),
+        "binary_exists": binary.is_file(),
+        "binary_executable": os.access(binary, os.X_OK),
+        "job_record_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "disk_free_bytes": disk.free,
+        "docker_socket_exists": Path("/var/run/docker.sock").exists(),
+        "uid": os.getuid(),
+        "gid": os.getgid(),
+    }
+    started = time.monotonic()
+    try:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "program-input.json"
+            fixture.write_text(json.dumps(program_input, separators=(",", ":")), encoding="utf-8")
+            completed = subprocess.run(
+                [str(binary), str(fixture), str(request["proof_system"])],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=args.timeout_seconds,
+                env={**os.environ, "SP1_PROVER": "cpu"},
+            )
+        diagnostics["exit_code"] = completed.returncode
+        diagnostics["stderr_sha256"] = hashlib.sha256(completed.stderr.encode()).hexdigest()
+        diagnostics["stderr_tail"] = redact(completed.stderr)
+        output = None
+        if completed.stdout.strip():
+            try:
+                output = json.loads(completed.stdout.strip().splitlines()[-1])
+            except json.JSONDecodeError:
+                diagnostics["stdout_tail"] = redact(completed.stdout)
+        journal = output.get("journal_hex") if isinstance(output, dict) else None
+        proof = output.get("proof_hex") if isinstance(output, dict) else None
+        diagnostics["journal_matches"] = (
+            isinstance(journal, str)
+            and journal.lower() == str(request.get("expected_public_values", "")).lower()
+        )
+        diagnostics["proof_present"] = isinstance(proof, str) and proof.startswith("0x")
+        diagnostics["proof_sha256"] = (
+            hashlib.sha256(proof.encode()).hexdigest() if diagnostics["proof_present"] else None
+        )
+        diagnostics["passed"] = (
+            completed.returncode == 0
+            and diagnostics["journal_matches"]
+            and diagnostics["proof_present"]
+        )
+    except subprocess.TimeoutExpired as error:
+        diagnostics.update(
+            passed=False,
+            timed_out=True,
+            stderr_tail=redact((error.stderr or b"").decode() if isinstance(error.stderr, bytes) else (error.stderr or "")),
+        )
+    diagnostics["elapsed_seconds"] = round(time.monotonic() - started, 3)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(diagnostics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({key: diagnostics.get(key) for key in ("passed", "exit_code", "timed_out", "elapsed_seconds")}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_diagnose_open_competition_v2_beta3_prover.py
+++ b/scripts/test_diagnose_open_competition_v2_beta3_prover.py
@@ -1,0 +1,30 @@
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import diagnose_open_competition_v2_beta3_prover as diagnostic
+
+
+class ProverDiagnosticTests(unittest.TestCase):
+    def test_redact_removes_secret_and_url_credentials(self) -> None:
+        with patch.dict(os.environ, {"EXAMPLE_SECRET": "do-not-print"}, clear=False):
+            value = diagnostic.redact("do-not-print https://user:password@example.test/path")
+        self.assertNotIn("do-not-print", value)
+        self.assertNotIn("password", value)
+        self.assertIn("[redacted]", value)
+
+    def test_load_record_matches_exact_provider_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            expected = {"provider_job_id": "beta3-" + "a" * 64}
+            (root / "job.json").write_text(json.dumps(expected), encoding="utf-8")
+            path, record = diagnostic.load_record(root, expected["provider_job_id"])
+        self.assertEqual(path.name, "job.json")
+        self.assertEqual(record, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- narrow canonical refund discovery to the unique EIP-3009 authorization event while retaining exact receipt verification
- add a protected self-hosted replay diagnostic for persisted Beta3 prover jobs
- add focused Rust and Python regression tests

## Validation
- cargo test -p worker open_competition_v2_broker --lib
- python scripts/test_diagnose_open_competition_v2_beta3_prover.py -v
- cargo fmt --all -- --check
- scripts/preflight.ps1 -Mode core
- git diff --check

## Production intent
After merge, redeploy the broker worker, recover proof job 0925f601-527f-47b8-918c-82c81c32ec4d, and run the protected prover diagnostic before retrying the hosted x402 canary.