### PR TITLE
Fix prover temp mounts under systemd isolation

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -182,6 +182,7 @@ jobs:
             --output /tmp/open-competition-v2-prover-assets.json
           sudo install -d -m 0755 /opt/agent-bounties/bin /opt/agent-bounties/scripts /etc/agent-bounties
           sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/jobs
+          sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/tmp
           sudo install -m 0755 target/mainnet-deployment/release-assets/public-vector-metric-v1-script /opt/agent-bounties/bin/
           sudo install -m 0755 target/mainnet-deployment/release-assets/structured-artifact-metric-v1-script /opt/agent-bounties/bin/
           sudo install -m 0755 scripts/open_competition_v2_prover_service.py /opt/agent-bounties/scripts/

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -970,6 +970,7 @@ jobs:
             --output /tmp/open-competition-v2-prover-assets.json
           sudo install -d -m 0755 /opt/agent-bounties/bin /opt/agent-bounties/scripts /etc/agent-bounties
           sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/jobs
+          sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/tmp
           sudo install -m 0755 target/release-assets/public-vector-metric-v1-script /opt/agent-bounties/bin/
           sudo install -m 0755 target/release-assets/structured-artifact-metric-v1-script /opt/agent-bounties/bin/
           sudo install -m 0755 scripts/open_competition_v2_prover_service.py /opt/agent-bounties/scripts/

--- a/.github/workflows/repair-open-competition-v2-beta3-prover.yml
+++ b/.github/workflows/repair-open-competition-v2-beta3-prover.yml
@@ -44,6 +44,10 @@ jobs:
             --install-root /opt/agent-bounties/circuits \
             --circuit-version "$SP1_SAFE_CIRCUIT_VERSION" \
             --output /tmp/open-competition-v2-prover-assets.json
+          sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 \
+            /var/lib/agent-bounties-prover/tmp
+          sudo install -m 0755 scripts/open_competition_v2_prover_service.py \
+            /opt/agent-bounties/scripts/open_competition_v2_prover_service.py
           sudo install -m 0644 ops/open-competition-v2-prover.service \
             /etc/systemd/system/agent-bounties-open-competition-v2-prover.service
           sudo SP1_GNARK_RUNTIME_IMAGE="$SP1_GNARK_RUNTIME_IMAGE" python3 - <<'PY'
@@ -91,6 +95,18 @@ jobs:
           jq -e '.passed == true and .public_values_match == true and .money_moved == false' \
             target/production-prover-rehearsal.json >/dev/null
 
+      - name: Collect sanitized prover diagnostics
+        if: failure()
+        run: |
+          sudo journalctl \
+            -u agent-bounties-open-competition-v2-prover.service \
+            --since "20 minutes ago" \
+            --no-pager \
+            -o cat \
+            | grep -E '"event":"prover_(subprocess|internal)_failed"' \
+            | tail -200 \
+            > target/prover-service-failure.log || true
+
       - name: Upload repair evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -100,5 +116,6 @@ jobs:
             target/prover-assets.json
             target/prover-health.json
             target/production-prover-rehearsal.json
+            target/prover-service-failure.log
           if-no-files-found: error
           retention-days: 365

--- a/ops/open-competition-v2-prover.service
+++ b/ops/open-competition-v2-prover.service
@@ -9,6 +9,7 @@ User=agent-bounties-prover
 Group=agent-bounties-prover
 SupplementaryGroups=docker
 EnvironmentFile=/etc/agent-bounties/prover.env
+Environment=TMPDIR=/var/lib/agent-bounties-prover/tmp
 ExecStartPre=/usr/bin/docker image inspect ghcr.io/succinctlabs/sp1-gnark:agent-bounties-sp1-safe-v5
 ExecStart=/usr/bin/python3 /opt/agent-bounties/scripts/open_competition_v2_prover_service.py
 Restart=on-failure

--- a/scripts/open_competition_v2_prover_service.py
+++ b/scripts/open_competition_v2_prover_service.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import re
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -28,6 +29,15 @@ HEX_640 = re.compile(r"^0x[0-9a-fA-F]{1280}$")
 
 class QueueFullError(RuntimeError):
     pass
+
+
+def process_diagnostic(value: str) -> str:
+    result = value
+    for key, secret in os.environ.items():
+        if secret and any(marker in key.upper() for marker in ("KEY", "TOKEN", "SECRET", "PASSWORD")):
+            result = result.replace(secret, "[redacted]")
+    result = re.sub(r"(?i)(https?://)[^/@\s:]+:[^/@\s]+@", r"\1[redacted]@", result)
+    return result[-4_000:]
 
 
 def canonical_hash(value: Any) -> str:
@@ -194,7 +204,37 @@ class ProverJobs:
                 failure_code="proof_timeout",
                 failure_message="CPU proving exceeded the request-bound SLA.",
             )
-        except Exception:
+        except subprocess.CalledProcessError as error:
+            print(
+                json.dumps(
+                    {
+                        "event": "prover_subprocess_failed",
+                        "return_code": error.returncode,
+                        "stderr_tail": process_diagnostic(error.stderr or ""),
+                    },
+                    separators=(",", ":"),
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
+            record.update(
+                status="failed",
+                failure_code="proof_failed",
+                failure_message="The pinned CPU prover failed without producing a valid bound proof.",
+            )
+        except Exception as error:
+            print(
+                json.dumps(
+                    {
+                        "event": "prover_internal_failed",
+                        "error_type": type(error).__name__,
+                        "message": process_diagnostic(str(error)),
+                    },
+                    separators=(",", ":"),
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
             record.update(
                 status="failed",
                 failure_code="proof_failed",

--- a/scripts/test_open_competition_v2_prover_service.py
+++ b/scripts/test_open_competition_v2_prover_service.py
@@ -1,7 +1,9 @@
+import os
 import time
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import open_competition_v2_prover_service as service
 
@@ -19,6 +21,15 @@ def request() -> dict:
 
 
 class ProverServiceTests(unittest.TestCase):
+    def test_process_diagnostic_redacts_secrets_and_url_credentials(self) -> None:
+        with patch.dict(os.environ, {"EXAMPLE_SECRET": "do-not-print"}, clear=False):
+            value = service.process_diagnostic(
+                "do-not-print https://user:password@example.test/path"
+            )
+        self.assertNotIn("do-not-print", value)
+        self.assertNotIn("password", value)
+        self.assertIn("[redacted]", value)
+
     def test_request_binds_header_system_and_exact_journal(self) -> None:
         value = request()
         self.assertEqual(service.validate_request(value, "job:one", int(time.time())), value)

--- a/scripts/test_repair_open_competition_v2_beta3_prover.py
+++ b/scripts/test_repair_open_competition_v2_beta3_prover.py
@@ -23,6 +23,7 @@ class ProductionProverRepairWorkflowTests(unittest.TestCase):
     def test_service_pins_local_image_and_required_group(self) -> None:
         text = (ROOT / "ops/open-competition-v2-prover.service").read_text(encoding="utf-8")
         self.assertIn("SupplementaryGroups=docker", text)
+        self.assertIn("Environment=TMPDIR=/var/lib/agent-bounties-prover/tmp", text)
         self.assertIn(
             "ExecStartPre=/usr/bin/docker image inspect ghcr.io/succinctlabs/sp1-gnark:agent-bounties-sp1-safe-v5",
             text,


### PR DESCRIPTION
## Summary
- preserve PrivateTmp while giving the prover a host-visible service-only TMPDIR
- install the current service script during production repair
- emit redacted bounded prover diagnostics and upload failure evidence
- apply the same shared temp directory to release and continuation deploys

## Verification
- python scripts/test_open_competition_v2_prover_service.py -v
- python scripts/test_repair_open_competition_v2_beta3_prover.py -v
- python scripts/test_continue_open_competition_v2_beta3_mainnet.py -v
- python scripts/test_build_open_competition_v2_beta3_release.py -v
- workflow YAML parse
- py_compile
- cargo fmt --all -- --check
- git diff --check
- scripts/preflight.ps1 -Mode core