### PR TITLE
Use a private writable SP1 circuit cache

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -175,11 +175,14 @@ jobs:
           expected_gnark_cli="$(awk 'NR == 1 { print $1 }' target/mainnet-deployment/release-assets/gnark-cli.sha256)"
           actual_gnark_cli="$(docker run --rm --entrypoint sha256sum "$SP1_GNARK_RUNTIME_IMAGE" /gnark-cli | awk 'NR == 1 { print $1 }')"
           test "$actual_gnark_cli" = "$expected_gnark_cli"
+          sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/circuits
           sudo python3 .release-control/scripts/install_open_competition_v2_prover_assets.py \
             --trusted-root "$OPEN_COMPETITION_V2_TRUSTED_SETUP_ROOT" \
-            --install-root /opt/agent-bounties/circuits \
+            --install-root /var/lib/agent-bounties-prover/circuits \
             --circuit-version "$SP1_SAFE_CIRCUIT_VERSION" \
             --output /tmp/open-competition-v2-prover-assets.json
+          sudo chown -R agent-bounties-prover:agent-bounties-prover /var/lib/agent-bounties-prover/circuits
+          sudo chmod -R u=rwX,go= /var/lib/agent-bounties-prover/circuits
           sudo install -d -m 0755 /opt/agent-bounties/bin /opt/agent-bounties/scripts /etc/agent-bounties
           sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/jobs
           sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/tmp
@@ -198,8 +201,8 @@ jobs:
           PORT=9070
           SP1_PROVER=cpu
           SP1_GNARK_IMAGE=$SP1_GNARK_RUNTIME_IMAGE
-          SP1_GROTH16_CIRCUIT_PATH=/opt/agent-bounties/circuits/groth16
-          SP1_PLONK_CIRCUIT_PATH=/opt/agent-bounties/circuits/plonk
+          SP1_GROTH16_CIRCUIT_PATH=/var/lib/agent-bounties-prover/circuits/groth16
+          SP1_PLONK_CIRCUIT_PATH=/var/lib/agent-bounties-prover/circuits/plonk
           EOF
           sudo install -m 0600 target/prover.env /etc/agent-bounties/prover.env
           sudo systemctl daemon-reload

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -963,11 +963,14 @@ jobs:
           set -euo pipefail
           test "${#OPEN_COMPETITION_V2_PROVER_API_KEY}" -ge 32
           test -f "$OPEN_COMPETITION_V2_TRUSTED_SETUP_ROOT/trusted-setup.json"
+          sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/circuits
           sudo python3 scripts/install_open_competition_v2_prover_assets.py \
             --trusted-root "$OPEN_COMPETITION_V2_TRUSTED_SETUP_ROOT" \
-            --install-root /opt/agent-bounties/circuits \
+            --install-root /var/lib/agent-bounties-prover/circuits \
             --circuit-version "$SP1_SAFE_CIRCUIT_VERSION" \
             --output /tmp/open-competition-v2-prover-assets.json
+          sudo chown -R agent-bounties-prover:agent-bounties-prover /var/lib/agent-bounties-prover/circuits
+          sudo chmod -R u=rwX,go= /var/lib/agent-bounties-prover/circuits
           sudo install -d -m 0755 /opt/agent-bounties/bin /opt/agent-bounties/scripts /etc/agent-bounties
           sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/jobs
           sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 /var/lib/agent-bounties-prover/tmp
@@ -986,8 +989,8 @@ jobs:
           PORT=9070
           SP1_PROVER=cpu
           SP1_GNARK_IMAGE=$SP1_GNARK_RUNTIME_IMAGE
-          SP1_GROTH16_CIRCUIT_PATH=/opt/agent-bounties/circuits/groth16
-          SP1_PLONK_CIRCUIT_PATH=/opt/agent-bounties/circuits/plonk
+          SP1_GROTH16_CIRCUIT_PATH=/var/lib/agent-bounties-prover/circuits/groth16
+          SP1_PLONK_CIRCUIT_PATH=/var/lib/agent-bounties-prover/circuits/plonk
           EOF
           sudo install -m 0600 target/prover.env /etc/agent-bounties/prover.env
           sudo systemctl daemon-reload

--- a/.github/workflows/repair-open-competition-v2-beta3-prover.yml
+++ b/.github/workflows/repair-open-competition-v2-beta3-prover.yml
@@ -39,11 +39,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p target
+          sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 \
+            /var/lib/agent-bounties-prover/circuits
           sudo python3 scripts/install_open_competition_v2_prover_assets.py \
             --trusted-root "$OPEN_COMPETITION_V2_TRUSTED_SETUP_ROOT" \
-            --install-root /opt/agent-bounties/circuits \
+            --install-root /var/lib/agent-bounties-prover/circuits \
             --circuit-version "$SP1_SAFE_CIRCUIT_VERSION" \
             --output /tmp/open-competition-v2-prover-assets.json
+          sudo chown -R agent-bounties-prover:agent-bounties-prover \
+            /var/lib/agent-bounties-prover/circuits
+          sudo chmod -R u=rwX,go= /var/lib/agent-bounties-prover/circuits
           sudo install -d -o agent-bounties-prover -g agent-bounties-prover -m 0700 \
             /var/lib/agent-bounties-prover/tmp
           sudo install -m 0755 scripts/open_competition_v2_prover_service.py \
@@ -57,8 +62,8 @@ jobs:
           path = Path("/etc/agent-bounties/prover.env")
           updates = {
               "SP1_GNARK_IMAGE": os.environ["SP1_GNARK_RUNTIME_IMAGE"],
-              "SP1_GROTH16_CIRCUIT_PATH": "/opt/agent-bounties/circuits/groth16",
-              "SP1_PLONK_CIRCUIT_PATH": "/opt/agent-bounties/circuits/plonk",
+              "SP1_GROTH16_CIRCUIT_PATH": "/var/lib/agent-bounties-prover/circuits/groth16",
+              "SP1_PLONK_CIRCUIT_PATH": "/var/lib/agent-bounties-prover/circuits/plonk",
           }
           kept = []
           for line in path.read_text(encoding="utf-8").splitlines():

--- a/ops/open-competition-v2-prover.service
+++ b/ops/open-competition-v2-prover.service
@@ -11,6 +11,8 @@ SupplementaryGroups=docker
 EnvironmentFile=/etc/agent-bounties/prover.env
 Environment=TMPDIR=/var/lib/agent-bounties-prover/tmp
 ExecStartPre=/usr/bin/docker image inspect ghcr.io/succinctlabs/sp1-gnark:agent-bounties-sp1-safe-v5
+ExecStartPre=/usr/bin/test -f /var/lib/agent-bounties-prover/circuits/groth16/agent-bounties-sp1-safe-v5/.complete
+ExecStartPre=/usr/bin/test -f /var/lib/agent-bounties-prover/circuits/plonk/agent-bounties-sp1-safe-v5/.complete
 ExecStart=/usr/bin/python3 /opt/agent-bounties/scripts/open_competition_v2_prover_service.py
 Restart=on-failure
 RestartSec=5

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -183,11 +183,11 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
             self.text,
         )
         self.assertIn(
-            "SP1_GROTH16_CIRCUIT_PATH=/opt/agent-bounties/circuits/groth16",
+            "SP1_GROTH16_CIRCUIT_PATH=/var/lib/agent-bounties-prover/circuits/groth16",
             self.text,
         )
         self.assertIn(
-            "SP1_PLONK_CIRCUIT_PATH=/opt/agent-bounties/circuits/plonk",
+            "SP1_PLONK_CIRCUIT_PATH=/var/lib/agent-bounties-prover/circuits/plonk",
             self.text,
         )
         self.assertNotIn(

--- a/scripts/test_repair_open_competition_v2_beta3_prover.py
+++ b/scripts/test_repair_open_competition_v2_beta3_prover.py
@@ -25,9 +25,23 @@ class ProductionProverRepairWorkflowTests(unittest.TestCase):
         self.assertIn("SupplementaryGroups=docker", text)
         self.assertIn("Environment=TMPDIR=/var/lib/agent-bounties-prover/tmp", text)
         self.assertIn(
+            "ExecStartPre=/usr/bin/test -f /var/lib/agent-bounties-prover/circuits/groth16/agent-bounties-sp1-safe-v5/.complete",
+            text,
+        )
+        self.assertIn(
             "ExecStartPre=/usr/bin/docker image inspect ghcr.io/succinctlabs/sp1-gnark:agent-bounties-sp1-safe-v5",
             text,
         )
+
+    def test_repair_uses_private_writable_verified_circuit_cache(self) -> None:
+        text = (
+            ROOT / ".github/workflows/repair-open-competition-v2-beta3-prover.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "--install-root /var/lib/agent-bounties-prover/circuits", text
+        )
+        self.assertIn("sudo chmod -R u=rwX,go=", text)
+        self.assertNotIn("--install-root /opt/agent-bounties/circuits", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- install hash-verified runtime circuit copies in the prover service's private state directory
- retain immutable trusted-setup source and systemd ProtectSystem=strict
- require both exact safe-v5 completion markers before service startup
- use the same cache contract in repair, release, and continuation workflows

## Production evidence
Run 32360628941 reached Groth16 wrapping and failed closed because SP1's atomic circuit setup path was under read-only /opt. No funds moved.

## Verification
- installer, prover-service, repair, continuation, and release unit tests
- all workflow YAML parsed
- py_compile
- cargo fmt --all -- --check
- git diff --check
- core preflight