### PR TITLE
Fund replacement canary solver reserve

### DIFF
--- a/scripts/refresh_open_competition_v2_x402_canary.py
+++ b/scripts/refresh_open_competition_v2_x402_canary.py
@@ -18,6 +18,7 @@ from _shared.rpc import rpc
 
 
 TARGET_FUNDING = 262_500
+TARGET_X402_SERVICE_BALANCE = 110_000
 PROOF_WINDOW = 7_200
 MINIMUM_SLA = 1_800
 DEADLINE_MARGIN = 300
@@ -62,6 +63,11 @@ def has_runtime_code(value: str) -> bool:
     require(isinstance(value, str) and value.startswith("0x"), "invalid bytecode response")
     payload = value[2:]
     return bool(payload) and int(payload, 16) != 0
+
+
+def required_top_up(current: int, target: int) -> int:
+    require(current >= 0 and target >= 0, "token balances cannot be negative")
+    return max(0, target - current)
 
 
 def replace_rehearsal_canary(
@@ -305,6 +311,29 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
                 [params_tuple, TARGET_FUNDING, creation_nonce, rehearsal.b32(bundle["risk"]["hash"])],
             ),
         )
+    solver_balance_before = rehearsal.token_balance(client.url, token, solver.address)
+    solver_top_up = required_top_up(
+        solver_balance_before, TARGET_X402_SERVICE_BALANCE
+    )
+    if solver_top_up:
+        require(
+            rehearsal.token_balance(client.url, token, signer.address) >= solver_top_up,
+            "deployer lacks USDC for the generated solver proof-service reserve",
+        )
+        receipts["fund_solver_x402_service"] = client.send(
+            signer,
+            to=token,
+            data=rehearsal.function_data(
+                "transfer(address,uint256)",
+                ["address", "uint256"],
+                [solver.address, solver_top_up],
+            ),
+        )
+    require(
+        rehearsal.token_balance(client.url, token, solver.address)
+        >= TARGET_X402_SERVICE_BALANCE,
+        "generated solver proof-service reserve was not funded",
+    )
     proof_deadline = verify_new_canary(
         client.url, token, competition, bounty_id, signer, params_tuple
     )
@@ -337,6 +366,11 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "competition": competition,
         "bounty_id": bounty_id,
         "solver": solver.address.lower(),
+        "solver_x402_service_balance_before": str(solver_balance_before),
+        "solver_x402_service_top_up": str(solver_top_up),
+        "solver_x402_service_balance_after": str(
+            rehearsal.token_balance(client.url, token, solver.address)
+        ),
         "proof_deadline": proof_deadline,
         "minimum_broker_sla_seconds": MINIMUM_SLA,
         "superseded_recovery": recovery,

--- a/scripts/test_refresh_open_competition_v2_x402_canary.py
+++ b/scripts/test_refresh_open_competition_v2_x402_canary.py
@@ -56,6 +56,15 @@ class RefreshX402CanaryTests(unittest.TestCase):
         self.assertFalse(MODULE.has_runtime_code("0x0"))
         self.assertTrue(MODULE.has_runtime_code("0x6000"))
 
+    def test_solver_service_top_up_is_exact_and_idempotent(self):
+        target = MODULE.TARGET_X402_SERVICE_BALANCE
+        self.assertEqual(MODULE.required_top_up(0, target), target)
+        self.assertEqual(MODULE.required_top_up(10_000, target), 100_000)
+        self.assertEqual(MODULE.required_top_up(target, target), 0)
+        self.assertEqual(MODULE.required_top_up(target + 1, target), 0)
+        with self.assertRaises(MODULE.CanaryRefreshError):
+            MODULE.required_top_up(-1, target)
+
     def test_rehearsal_preserves_superseded_evidence_and_rebinds_first_proven(self):
         old = {
             "competition": "0x" + "11" * 20,


### PR DESCRIPTION
## Summary
- top up the generated canary solver to the exact 0.11 USDC x402 charge
- reuse any retained balance and transfer only the deficit
- record before/top-up/after evidence in the replacement artifact
- add exact/idempotent regression coverage

## Evidence
- python -m unittest scripts.test_refresh_open_competition_v2_x402_canary scripts.test_run_open_competition_v2_x402_rehearsal (12 passed)
- failed chain receipt 