### PR TITLE
Restore x402 retry and refund liveness

### DIFF
--- a/crates/worker/src/open_competition_v2_broker.rs
+++ b/crates/worker/src/open_competition_v2_broker.rs
@@ -1,11 +1,11 @@
 use anyhow::{anyhow, Context};
 use chain_base::{
-    fetch_base_contract_logs, fetch_safe_block_identity, fetch_transaction_receipt,
-    open_competition_v2_broker_refund_digest, plan_open_competition_v2_broker_payment,
-    plan_open_competition_v2_proof, rpc_logs_to_evm_logs, BaseContractLogQuery, BaseRpcUrlConfig,
-    BaseTransactionRelayer, ChainBaseError, EvmLog, OpenCompetitionV2BrokerPaymentAuthorization,
-    OpenCompetitionV2Event, OpenCompetitionV2EventKind, OpenCompetitionV2ProofSystem,
-    OPEN_COMPETITION_V2_PROTOCOL_VERSION,
+    fetch_base_contract_logs, fetch_contract_bool_at, fetch_safe_block_identity,
+    fetch_transaction_receipt, open_competition_v2_broker_refund_digest,
+    plan_open_competition_v2_broker_payment, plan_open_competition_v2_proof, rpc_logs_to_evm_logs,
+    BaseContractLogQuery, BaseRpcUrlConfig, BaseTransactionRelayer, ChainBaseError, EvmLog,
+    OpenCompetitionV2BrokerPaymentAuthorization, OpenCompetitionV2Event,
+    OpenCompetitionV2EventKind, OpenCompetitionV2ProofSystem, OPEN_COMPETITION_V2_PROTOCOL_VERSION,
 };
 use chrono::{Duration as ChronoDuration, Utc};
 use db::{
@@ -26,6 +26,7 @@ const BASE_MAINNET_RELEASE_ENV: &str =
     "BASE_MAINNET_OPEN_COMPETITION_V2_BETA3_RELEASE_MANIFEST_JSON";
 const BASE_SEPOLIA_RELEASE_ENV: &str =
     "BASE_SEPOLIA_OPEN_COMPETITION_V2_BETA3_RELEASE_MANIFEST_JSON";
+const REFUND_LOG_CHUNK_SIZE: u64 = 1_000;
 
 #[derive(Debug, Clone, Deserialize)]
 struct BrokerReleaseIdentity {
@@ -935,29 +936,52 @@ async fn find_canonical_refund(
         .await;
     }
 
+    let authorization_call = authorization_state_call_data(broker, refund_nonce)?;
+    if !fetch_contract_bool_at(
+        rpc_url,
+        settlement_token,
+        &authorization_call,
+        safe.number,
+        84,
+    )
+    .await?
+    {
+        return Ok(None);
+    }
+
     let from_block = job
         .payment_block_number
         .unwrap_or(safe.number)
         .min(safe.number);
-    let query = BaseContractLogQuery::new(
-        settlement_token,
-        from_block,
-        Some(safe.number),
-        vec![event_topic("AuthorizationUsed(address,bytes32)")],
-    )?;
-    let logs = rpc_logs_to_evm_logs(fetch_base_contract_logs(rpc_url, &query, 82).await?.result)?;
     let authorization_topic = event_topic("AuthorizationUsed(address,bytes32)");
     let broker_topic = address_topic(broker)?;
     let nonce_topic = normalize_word(refund_nonce)?;
-    let tx_hash = logs.iter().find_map(|log| {
-        (log.topics.len() == 3
-            && log.topics[0].eq_ignore_ascii_case(&authorization_topic)
-            && log.topics[1].eq_ignore_ascii_case(&broker_topic)
-            && log.topics[2].eq_ignore_ascii_case(&nonce_topic))
-        .then(|| log.tx_hash.clone())
-    });
-    let Some(tx_hash) = tx_hash else {
-        return Ok(None);
+    let mut chunk_start = from_block;
+    let tx_hash = loop {
+        let chunk_end = chunk_start
+            .saturating_add(REFUND_LOG_CHUNK_SIZE - 1)
+            .min(safe.number);
+        let query = BaseContractLogQuery::new(
+            settlement_token,
+            chunk_start,
+            Some(chunk_end),
+            vec![
+                authorization_topic.clone(),
+                broker_topic.clone(),
+                nonce_topic.clone(),
+            ],
+        )?;
+        let logs =
+            rpc_logs_to_evm_logs(fetch_base_contract_logs(rpc_url, &query, 82).await?.result)?;
+        if let Some(tx_hash) = logs.first().map(|log| log.tx_hash.clone()) {
+            break tx_hash;
+        }
+        if chunk_end == safe.number {
+            return Err(anyhow!(
+                "refund authorization is used but its exact bounded event is unavailable"
+            ));
+        }
+        chunk_start = chunk_end + 1;
     };
     canonical_refund_from_transaction(
         rpc_url,
@@ -970,6 +994,18 @@ async fn find_canonical_refund(
         &safe,
     )
     .await
+}
+
+fn authorization_state_call_data(authorizer: &str, nonce: &str) -> anyhow::Result<String> {
+    let selector = Keccak256::digest(b"authorizationState(address,bytes32)");
+    let authorizer = address_topic(authorizer)?;
+    let nonce = normalize_word(nonce)?;
+    Ok(format!(
+        "0x{}{}{}",
+        hex::encode(&selector[..4]),
+        &authorizer[2..],
+        &nonce[2..]
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1466,6 +1502,19 @@ mod tests {
         let mut another = job.clone();
         another.network = "base-mainnet".to_string();
         assert_ne!(nonce, refund_nonce(&another));
+    }
+
+    #[test]
+    fn refund_authorization_state_call_binds_broker_and_nonce() {
+        let broker = format!("0x{}", "11".repeat(20));
+        let nonce = format!("0x{}", "22".repeat(32));
+        let call = authorization_state_call_data(&broker, &nonce).unwrap();
+        assert_eq!(call.len(), 2 + 8 + 64 + 64);
+        assert_eq!(
+            &call[10..74],
+            &format!("{}{}", "00".repeat(12), "11".repeat(20))
+        );
+        assert_eq!(&call[74..], &"22".repeat(32));
     }
 
     #[test]

--- a/scripts/refresh_open_competition_v2_x402_canary.py
+++ b/scripts/refresh_open_competition_v2_x402_canary.py
@@ -282,10 +282,17 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     competition, bounty_id = rehearsal.predict(
         client.url, factory, signer.address, params_tuple, creation_nonce
     )
+    solver_nonce = time.time_ns()
     fixture = rehearsal.fixture_builder.bind(
         template,
         rehearsal.scope(
-            bundle, params_tuple, competition, bounty_id, solver.address, 3, "groth16"
+            bundle,
+            params_tuple,
+            competition,
+            bounty_id,
+            solver.address,
+            solver_nonce,
+            "groth16",
         ),
     )
 
@@ -346,7 +353,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         }
     )
     new_canary = sepolia.x402_canary_spec(
-        fixture, competition, bounty_id, solver.address, 3
+        fixture, competition, bounty_id, solver.address, solver_nonce
     )
     new_canary.update(
         {
@@ -366,6 +373,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "competition": competition,
         "bounty_id": bounty_id,
         "solver": solver.address.lower(),
+        "solver_nonce": str(solver_nonce),
         "solver_x402_service_balance_before": str(solver_balance_before),
         "solver_x402_service_top_up": str(solver_top_up),
         "solver_x402_service_balance_after": str(

--- a/scripts/test_refresh_open_competition_v2_x402_canary.py
+++ b/scripts/test_refresh_open_competition_v2_x402_canary.py
@@ -88,6 +88,11 @@ class RefreshX402CanaryTests(unittest.TestCase):
         self.assertEqual(document["groth16_first_proven"]["competition"], new["competition"])
         self.assertTrue(document["groth16_first_proven"]["settlement_deferred_to_x402"])
 
+    def test_generated_solver_nonce_fits_the_protocol_uint128(self):
+        nonce = MODULE.time.time_ns()
+        self.assertGreater(nonce, 0)
+        self.assertLess(nonce, 2**128)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- query exact EIP-3009 authorization state before refund recovery
- broadcast immediately when unused
- recover crash-after-broadcast cases with exact-topic 1,000-block chunks
- bind each release-canary retry to a fresh uint128 solver nonce while preserving the competition and verification policy

## Root causes
1. The overdue 0.11 USDC refund was blocked by an unbounded USDC log scan rejected by the RPC.
2. A failed unpaid canary quote correctly retained its solver nonce, but release control reused nonce 3 and hit the database replay constraint.

## Verification
- `cargo test -p worker open_competition_v2_broker::tests -- --nocapture` (9 passed)
- `cargo clippy -p worker --lib -- -D warnings` passed
- `python -m unittest scripts.test_refresh_open_competition_v2_x402_canary scripts.test_run_open_competition_v2_x402_rehearsal` (13 passed)
- all-target clippy is independently blocked by a pre-existing Rust 1.97 lint in `open_competition_v2_shadow.rs:340`; this PR does not touch it.