### PR TITLE
Resume canonically paid Beta3 proof jobs

### DIFF
--- a/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
@@ -17,6 +17,8 @@ env:
   SOURCE_ACTOR_DERIVATION_SALT: "32346174505:1:mainnet"
   OPEN_COMPETITION_V2_RUNTIME_READINESS_URL: https://agent-bounties-api.onrender.com/v1/base/open-competition-v2-beta3/release
   EXISTING_X402_JOB_ID: 155ef022-8ef3-4453-825c-316d309d9ecf
+  RESUME_X402_JOB_ID: bccd0e3e-73d0-41ac-8bbd-0a806ea45194
+  RESUME_X402_SOLVER_NONCE: "1787226676733703323"
   PLONK_COMPETITION: "0x3e052b933628b960d61654a68fca23d869d8989f"
   PLONK_SETTLEMENT_TRANSACTION: "0x830e856ddbade328a0715e47e3aaa36f6363c6be71c18bd20f0baaab75aed4f3"
   FORCED_REFUND_PAYMENT_TRANSACTION: "0xdb833590333b36c69ee7e7d873a94f87d519278321df13f155253473e4a0a7c2"
@@ -142,7 +144,7 @@ jobs:
           )
           program = old["program_input"]
           proof_deadline = int(projection["proof_deadline"])
-          recovery_nonce = str(time.time_ns())
+          recovery_nonce = os.environ["RESUME_X402_SOLVER_NONCE"]
           document = {
               "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-resume-v1",
               "passed": True,
@@ -191,6 +193,8 @@ jobs:
               --fixture programs/public-vector-metric-v1/fixtures/rehearsal-best-score-a.json \
               --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
               --actor-derivation-salt "$SOURCE_ACTOR_DERIVATION_SALT" \
+              --solver-nonce "$RESUME_X402_SOLVER_NONCE" \
+              --skip-solver-service-top-up \
               --replacement-id 1 --output target/mainnet-x402-canary-replacement.json
           fi
           python .release-control/scripts/run_open_competition_v2_x402_rehearsal.py \
@@ -198,6 +202,7 @@ jobs:
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canary-resume.json \
             --hosted-workers --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$SOURCE_ACTOR_DERIVATION_SALT" \
+            --proof-job-id "$RESUME_X402_JOB_ID" \
             --timeout-seconds 5400 --output target/mainnet-x402-success.json
           python .release-control/scripts/verify_open_competition_v2_beta3_mainnet_recovery.py \
             --api https://api.agentbounties.app --rpc-url "$BASE_MAINNET_RPC_URL" \

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -6719,6 +6719,7 @@ impl PostgresStore {
               WHERE state IN ('paid', 'proving', 'relaying', 'refund_due')
                 AND (lease_expires_at IS NULL OR lease_expires_at <= now())
               ORDER BY
+                updated_at,
                 CASE state
                   WHEN 'refund_due' THEN 0
                   WHEN 'relaying' THEN 1

--- a/scripts/refresh_open_competition_v2_x402_canary.py
+++ b/scripts/refresh_open_competition_v2_x402_canary.py
@@ -70,6 +70,16 @@ def required_top_up(current: int, target: int) -> int:
     return max(0, target - current)
 
 
+def selected_solver_nonce(explicit: int | None) -> int:
+    nonce = time.time_ns() if explicit is None else explicit
+    require(0 < nonce < 2**128, "solver nonce must fit uint128")
+    return nonce
+
+
+def planned_solver_top_up(current: int, skip: bool) -> int:
+    return 0 if skip else required_top_up(current, TARGET_X402_SERVICE_BALANCE)
+
+
 def replace_rehearsal_canary(
     document: dict[str, Any], new_canary: dict[str, Any], evidence: dict[str, Any]
 ) -> dict[str, Any]:
@@ -282,7 +292,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     competition, bounty_id = rehearsal.predict(
         client.url, factory, signer.address, params_tuple, creation_nonce
     )
-    solver_nonce = time.time_ns()
+    solver_nonce = selected_solver_nonce(args.solver_nonce)
     fixture = rehearsal.fixture_builder.bind(
         template,
         rehearsal.scope(
@@ -319,8 +329,8 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             ),
         )
     solver_balance_before = rehearsal.token_balance(client.url, token, solver.address)
-    solver_top_up = required_top_up(
-        solver_balance_before, TARGET_X402_SERVICE_BALANCE
+    solver_top_up = planned_solver_top_up(
+        solver_balance_before, args.skip_solver_service_top_up
     )
     if solver_top_up:
         require(
@@ -336,11 +346,12 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
                 [solver.address, solver_top_up],
             ),
         )
-    require(
-        rehearsal.token_balance(client.url, token, solver.address)
-        >= TARGET_X402_SERVICE_BALANCE,
-        "generated solver proof-service reserve was not funded",
-    )
+    if not args.skip_solver_service_top_up:
+        require(
+            rehearsal.token_balance(client.url, token, solver.address)
+            >= TARGET_X402_SERVICE_BALANCE,
+            "generated solver proof-service reserve was not funded",
+        )
     proof_deadline = verify_new_canary(
         client.url, token, competition, bounty_id, signer, params_tuple
     )
@@ -408,6 +419,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--private-key-env", default="BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY")
     parser.add_argument("--actor-derivation-salt", required=True)
     parser.add_argument("--replacement-id", type=int, default=1)
+    parser.add_argument("--solver-nonce", type=int)
+    parser.add_argument("--skip-solver-service-top-up", action="store_true")
     parser.add_argument("--safe-timeout", type=int, default=1_800)
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args()

--- a/scripts/run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/run_open_competition_v2_x402_rehearsal.py
@@ -196,6 +196,74 @@ def build_quote_payload(spec: dict[str, Any], network: str) -> dict[str, Any]:
     }
 
 
+def validate_resumable_job(
+    job: dict[str, Any], spec: dict[str, Any], network: str
+) -> None:
+    expected = {
+        "network": network,
+        "competition_contract": str(spec["competition"]).lower(),
+        "solver": str(spec["solver"]).lower(),
+        "solver_nonce": str(spec["solver_nonce"]),
+        "artifact_hash": str(spec["artifact_hash"]).lower(),
+        "proof_system": str(spec["proof_system"]),
+    }
+    for field, value in expected.items():
+        actual = job.get(field)
+        if field in {"competition_contract", "solver", "artifact_hash"}:
+            actual = str(actual).lower()
+        elif field == "solver_nonce":
+            actual = str(actual)
+        require(actual == value, f"resumed proof job {field} differs from the canary")
+    require(job.get("requested_relay") is True, "resumed proof job did not request relay")
+    require(
+        job.get("state") in {"paid", "proving", "proved", "relaying", "submitted", "confirmed"},
+        f"proof job is not resumable from {job.get('state')}",
+    )
+    require(
+        isinstance(job.get("payment_evidence"), dict),
+        "resumed proof job lacks canonical payment evidence",
+    )
+    program = job.get("program_input")
+    metric = spec.get("metric")
+    require(isinstance(program, dict) and isinstance(metric, dict), "metric binding is missing")
+    require(program.get("mode") == metric.get("mode"), "resumed proof job metric mode differs")
+    require(
+        str(program.get("threshold")) == str(metric.get("threshold")),
+        "resumed proof job threshold differs",
+    )
+    require(program.get("vectors") == metric.get("vectors"), "resumed proof job vectors differ")
+    require(
+        isinstance(job.get("expected_public_values"), str)
+        and str(job["expected_public_values"]).startswith("0x"),
+        "resumed proof job lacks its bound public values",
+    )
+    if spec.get("expected_public_values") is not None:
+        require(
+            str(job["expected_public_values"]).lower()
+            == str(spec["expected_public_values"]).lower(),
+            "resumed proof job public values differ from the canary",
+        )
+
+
+def reconcile_payment(
+    payment_url: str,
+    deadline: float,
+    *,
+    payment_signature: str | None = None,
+) -> dict[str, Any]:
+    headers = {"PAYMENT-SIGNATURE": payment_signature} if payment_signature else None
+    status, payment, _ = request_json(
+        "POST", payment_url, headers=headers, expected=(200, 202, 503)
+    )
+    while status in {202, 503} and time.time() < deadline:
+        time.sleep(2)
+        status, payment, _ = request_json(
+            "POST", payment_url, expected=(200, 202, 503)
+        )
+    require(status == 200, "x402 payment did not reconcile canonically")
+    return payment
+
+
 def wait_for_state(
     api: str,
     worker: Path | None,
@@ -241,6 +309,7 @@ def main() -> int:
     parser.add_argument("--worker-binary", type=Path)
     parser.add_argument("--hosted-workers", action="store_true")
     parser.add_argument("--expect-refund", action="store_true")
+    parser.add_argument("--proof-job-id")
     parser.add_argument("--private-key-env", default="BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY")
     parser.add_argument("--actor-derivation-salt", default="local")
     parser.add_argument("--output", type=Path, required=True)
@@ -278,36 +347,39 @@ def main() -> int:
     worker = args.worker_binary.resolve() if args.worker_binary else None
     require(worker is None or worker.is_file(), "worker binary is unavailable")
     require(not (args.hosted_workers and args.expect_refund), "refund canary requires an isolated worker")
+    require(not (args.proof_job_id and args.expect_refund), "refund canary cannot resume a paid job")
     api = args.api.rstrip("/")
     deadline = time.time() + args.timeout_seconds
 
     if worker is not None:
         run_worker(worker, "open-competition-v2-beta3")
         run_worker(worker, "open-competition-v2-shadow")
-    quote_payload = build_quote_payload(spec, args.network)
-    _, quote, _ = request_json(
-        "POST", f"{api}/v1/base/open-competition-v2-beta3/proof-quotes", quote_payload
-    )
-    job_id = quote["proof_job_id"]
-    challenge = quote["payment_required"]
-    payment_url = f"{api}/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/payment"
-    status, _, headers = request_json("POST", payment_url, expected=(402,))
-    require(status == 402 and "payment-required" in headers, "unsigned request did not return 402")
-    require(decode_x402_header(headers["payment-required"]) == challenge, "402 challenge drifted")
-    payment_signature = sign_payment(
-        solver, challenge, chain_id=chain_id, network=eip155
-    )
     payment_started = time.time()
-    status, payment, _ = request_json(
-        "POST",
-        payment_url,
-        headers={"PAYMENT-SIGNATURE": payment_signature},
-        expected=(200, 202),
-    )
-    while status == 202 and time.time() < deadline:
-        time.sleep(2)
-        status, payment, _ = request_json("POST", payment_url, expected=(200, 202))
-    require(status == 200, "x402 payment did not reconcile canonically")
+    quote_id = None
+    if args.proof_job_id:
+        job_id = args.proof_job_id
+        resumed = get_job(api, job_id)
+        validate_resumable_job(resumed, spec, args.network)
+        payment_url = f"{api}/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/payment"
+        payment = reconcile_payment(payment_url, deadline)
+    else:
+        quote_payload = build_quote_payload(spec, args.network)
+        _, quote, _ = request_json(
+            "POST", f"{api}/v1/base/open-competition-v2-beta3/proof-quotes", quote_payload
+        )
+        job_id = quote["proof_job_id"]
+        quote_id = quote["quote"]["quote_id"]
+        challenge = quote["payment_required"]
+        payment_url = f"{api}/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/payment"
+        status, _, headers = request_json("POST", payment_url, expected=(402,))
+        require(status == 402 and "payment-required" in headers, "unsigned request did not return 402")
+        require(decode_x402_header(headers["payment-required"]) == challenge, "402 challenge drifted")
+        payment_signature = sign_payment(
+            solver, challenge, chain_id=chain_id, network=eip155
+        )
+        payment = reconcile_payment(
+            payment_url, deadline, payment_signature=payment_signature
+        )
     payment_evidence = payment.get("payment_evidence")
     require(isinstance(payment_evidence, dict), "canonical x402 payment evidence is missing")
 
@@ -326,7 +398,7 @@ def main() -> int:
             "actor_derivation_id": derivation_id,
             "generated_agent_wallet": True,
             "manual_state_corrections": 0,
-            "quote_id": quote["quote"]["quote_id"],
+            "quote_id": quote_id,
             "proof_job_id": job_id,
             "standard_exact": True,
             "payment_transaction": payment_evidence["transaction_hash"],
@@ -341,27 +413,30 @@ def main() -> int:
         print(json.dumps({"passed": True, "proof_job_id": job_id, "output": str(args.output)}))
         return 0
 
-    job = wait_for_state(api, worker, job_id, {"proved"}, deadline)
-    require(job.get("proof") and job.get("public_values"), "broker did not persist a bound proof")
-    authorization_deadline = min(int(spec["proof_deadline"]), int(time.time()) + 600)
-    relay_url = f"{api}/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/relay-authorization"
-    _, unsigned, _ = request_json(
-        "POST",
-        relay_url,
-        {"authorization_deadline": authorization_deadline, "solver_signature": None},
+    job = wait_for_state(
+        api, worker, job_id, {"proved", "relaying", "submitted", "confirmed"}, deadline
     )
-    signature = sign_relay_authorization(
-        solver, unsigned["plan"]["relay_authorization"]
-    )
-    _, authorized, _ = request_json(
-        "POST",
-        relay_url,
-        {
-            "authorization_deadline": authorization_deadline,
-            "solver_signature": signature,
-        },
-    )
-    require(authorized["state"] == "relaying", "solver relay authorization was not accepted")
+    if job["state"] == "proved":
+        require(job.get("proof") and job.get("public_values"), "broker did not persist a bound proof")
+        authorization_deadline = min(int(spec["proof_deadline"]), int(time.time()) + 600)
+        relay_url = f"{api}/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/relay-authorization"
+        _, unsigned, _ = request_json(
+            "POST",
+            relay_url,
+            {"authorization_deadline": authorization_deadline, "solver_signature": None},
+        )
+        signature = sign_relay_authorization(
+            solver, unsigned["plan"]["relay_authorization"]
+        )
+        _, authorized, _ = request_json(
+            "POST",
+            relay_url,
+            {
+                "authorization_deadline": authorization_deadline,
+                "solver_signature": signature,
+            },
+        )
+        require(authorized["state"] == "relaying", "solver relay authorization was not accepted")
 
     while time.time() < deadline:
         if worker is not None:
@@ -410,7 +485,7 @@ def main() -> int:
         "actor_derivation_id": derivation_id,
         "generated_agent_wallet": True,
         "manual_state_corrections": 0,
-        "quote_id": quote["quote"]["quote_id"],
+        "quote_id": quote_id,
         "proof_job_id": job_id,
         "standard_exact": True,
         "eip3009": True,

--- a/scripts/test_refresh_open_competition_v2_x402_canary.py
+++ b/scripts/test_refresh_open_competition_v2_x402_canary.py
@@ -64,6 +64,15 @@ class RefreshX402CanaryTests(unittest.TestCase):
         self.assertEqual(MODULE.required_top_up(target + 1, target), 0)
         with self.assertRaises(MODULE.CanaryRefreshError):
             MODULE.required_top_up(-1, target)
+        self.assertEqual(MODULE.planned_solver_top_up(0, True), 0)
+        self.assertEqual(MODULE.planned_solver_top_up(0, False), target)
+
+    def test_explicit_solver_nonce_reconstructs_paid_job_without_drift(self):
+        self.assertEqual(MODULE.selected_solver_nonce(1787226676733703323), 1787226676733703323)
+        with self.assertRaises(MODULE.CanaryRefreshError):
+            MODULE.selected_solver_nonce(0)
+        with self.assertRaises(MODULE.CanaryRefreshError):
+            MODULE.selected_solver_nonce(2**128)
 
     def test_rehearsal_preserves_superseded_evidence_and_rebinds_first_proven(self):
         old = {

--- a/scripts/test_run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_x402_rehearsal.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
 from eth_account import Account
 from eth_account.messages import encode_typed_data
@@ -15,6 +16,52 @@ SPEC.loader.exec_module(MODULE)
 
 
 class X402RehearsalTests(unittest.TestCase):
+    def test_resumable_job_requires_exact_paid_scope(self):
+        spec = {
+            "competition": "0x" + "11" * 20,
+            "solver": "0x" + "22" * 20,
+            "solver_nonce": "7",
+            "artifact_hash": "0x" + "33" * 32,
+            "proof_system": "groth16",
+            "metric": {
+                "mode": "maximize_exact_matches",
+                "threshold": "1",
+                "vectors": [{"expected": 1, "observed": 1, "weight": 1}],
+            },
+        }
+        job = {
+            "network": "base-mainnet",
+            "competition_contract": spec["competition"],
+            "solver": spec["solver"],
+            "solver_nonce": spec["solver_nonce"],
+            "artifact_hash": spec["artifact_hash"],
+            "proof_system": spec["proof_system"],
+            "requested_relay": True,
+            "state": "paid",
+            "payment_evidence": {"transaction_hash": "0x" + "44" * 32},
+            "expected_public_values": "0x01",
+            "program_input": spec["metric"],
+        }
+        MODULE.validate_resumable_job(job, spec, "base-mainnet")
+        job["solver_nonce"] = "8"
+        with self.assertRaisesRegex(MODULE.X402RehearsalError, "solver_nonce"):
+            MODULE.validate_resumable_job(job, spec, "base-mainnet")
+
+    def test_payment_reconciliation_recovers_ambiguous_503_without_signature(self):
+        evidence = {"payment_evidence": {"transaction_hash": "0x" + "11" * 32}}
+        responses = [
+            (503, {}, {}),
+            (202, {"state": "paid"}, {}),
+            (200, evidence, {}),
+        ]
+        with patch.object(MODULE, "request_json", side_effect=responses) as request:
+            with patch.object(MODULE.time, "sleep"):
+                result = MODULE.reconcile_payment("https://example.test/payment", float("inf"))
+        self.assertEqual(result, evidence)
+        self.assertEqual(request.call_count, 3)
+        self.assertIsNone(request.call_args_list[1].kwargs.get("headers"))
+        self.assertIsNone(request.call_args_list[2].kwargs.get("headers"))
+
     def test_payment_header_is_standard_exact_eip3009(self):
         actor = Account.from_key("0x" + "11" * 32)
         challenge = {


### PR DESCRIPTION
## Summary
- resume an exact canonically paid x402 proof job without signing or charging again
- reconstruct the paid job's solver nonce while skipping a redundant service-wallet top-up
- recover ambiguous HTTP 503 responses through unsigned payment reconciliation

## Safety
- validates network, competition, solver, nonce, artifact, proof system, relay mode, metric, public-value binding, and canonical payment evidence
- no protocol bytecode or frozen release artifact changes

## Verification
- `PYTHONPATH=scripts python -m unittest scripts.test_run_open_competition_v2_x402_rehearsal scripts.test_refresh_open_competition_v2_x402_canary` (16 passed)
- `python -m py_compile ...`
- `git diff --check`

Public maintainer notice: #888.