### PR TITLE
Poll resumed Beta3 jobs without repaying

### DIFF
--- a/scripts/run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/run_open_competition_v2_x402_rehearsal.py
@@ -264,6 +264,12 @@ def reconcile_payment(
     return payment
 
 
+def resumed_payment(job: dict[str, Any]) -> dict[str, Any]:
+    evidence = job.get("payment_evidence")
+    require(isinstance(evidence, dict), "resumed proof job lacks canonical payment evidence")
+    return {"payment_evidence": evidence}
+
+
 def wait_for_state(
     api: str,
     worker: Path | None,
@@ -360,8 +366,7 @@ def main() -> int:
         job_id = args.proof_job_id
         resumed = get_job(api, job_id)
         validate_resumable_job(resumed, spec, args.network)
-        payment_url = f"{api}/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/payment"
-        payment = reconcile_payment(payment_url, deadline)
+        payment = resumed_payment(resumed)
     else:
         quote_payload = build_quote_payload(spec, args.network)
         _, quote, _ = request_json(

--- a/scripts/test_run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_x402_rehearsal.py
@@ -62,6 +62,13 @@ class X402RehearsalTests(unittest.TestCase):
         self.assertIsNone(request.call_args_list[1].kwargs.get("headers"))
         self.assertIsNone(request.call_args_list[2].kwargs.get("headers"))
 
+    def test_resumed_job_payment_evidence_needs_no_payment_endpoint_call(self):
+        job = {"payment_evidence": {"transaction_hash": "0x" + "11" * 32}}
+        payment = MODULE.resumed_payment(job)
+        self.assertIs(payment["payment_evidence"], job["payment_evidence"])
+        with self.assertRaises(MODULE.X402RehearsalError):
+            MODULE.resumed_payment({})
+
     def test_payment_header_is_standard_exact_eip3009(self):
         actor = Account.from_key("0x" + "11" * 32)
         challenge = {


### PR DESCRIPTION
Resumed proof jobs now consume their existing canonical payment evidence and never call the payment endpoint. This closes the paid-to-proving race that correctly returned HTTP 409. New quote/payment flows retain retry-safe 503 reconciliation.

Verification: 17 targeted tests passed; Python compilation and diff checks passed.