### PR TITLE
Bind Beta3 transaction RPC to verified provider

### DIFF
--- a/scripts/configure_open_competition_v2_beta3_render.py
+++ b/scripts/configure_open_competition_v2_beta3_render.py
@@ -278,6 +278,20 @@ def named_group(client: render.RenderClient, owner_id: str, name: str) -> dict[s
     return client.get_env_group(group["id"])
 
 
+def ensure_base_mainnet_transaction_rpc(
+    client: render.RenderClient, base_group: dict[str, Any], primary_rpc_url: str
+) -> dict[str, Any]:
+    require(primary_rpc_url.startswith("https://"), "Base mainnet transaction RPC must use HTTPS")
+    record = client.ensure_env_group_env_var(
+        base_group, "BASE_MAINNET_RPC_URL", primary_rpc_url
+    )
+    return {
+        "group": BASE_GROUP,
+        "key": "BASE_MAINNET_RPC_URL",
+        "changed": bool(record["changed"]),
+    }
+
+
 def ensure_v2_group(
     client: render.RenderClient,
     owner_id: str,
@@ -490,7 +504,13 @@ def deploy(
             )
         client.disable_native_auto_deploy(service)
 
-    changes = []
+    changes = [
+        ensure_base_mainnet_transaction_rpc(
+            client,
+            base_group,
+            environment["OPEN_COMPETITION_V2_INDEXER_RPC_URL"],
+        )
+    ]
     for key, value in environment.items():
         record = client.ensure_env_group_env_var(v2_group, key, value)
         changes.append({"group": V2_GROUP, "key": key, "changed": bool(record["changed"])})

--- a/scripts/test_configure_open_competition_v2_beta3_render.py
+++ b/scripts/test_configure_open_competition_v2_beta3_render.py
@@ -28,6 +28,27 @@ def runtime() -> dict:
 
 
 class Beta3RenderTests(unittest.TestCase):
+    def test_transaction_rpc_is_bound_to_the_preflighted_primary(self):
+        client = mock.Mock()
+        client.ensure_env_group_env_var.return_value = {"changed": True}
+        group = {"id": "evg-base"}
+
+        result = MODULE.ensure_base_mainnet_transaction_rpc(
+            client, group, "https://primary.example"
+        )
+
+        client.ensure_env_group_env_var.assert_called_once_with(
+            group, "BASE_MAINNET_RPC_URL", "https://primary.example"
+        )
+        self.assertEqual(
+            result,
+            {
+                "group": MODULE.BASE_GROUP,
+                "key": "BASE_MAINNET_RPC_URL",
+                "changed": True,
+            },
+        )
+
     def test_rpc_preflight_requires_archive_logs_and_common_safe_block(self):
         calls = []
 


### PR DESCRIPTION
The Render reconciler now updates the shared BASE_MAINNET_RPC_URL used by broker and keeper transaction code to the exact primary endpoint already preflighted for Beta3. This removes the hidden fallback to the rate-limited public endpoint that blocked refunds and relays.

Verification: configure suite 11/11 passed; Python compilation and diff checks passed.

This preserves the contributor RPC-failover PRs; it changes deployment configuration only.