### PR TITLE
Fix Beta3 refund replay liveness

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -8953,7 +8953,10 @@ fn validate_open_competition_v2_proof_transition(
             "confirmed proof job requires canonical settlement event".to_string(),
         ));
     }
-    if next == OpenCompetitionV2ProofJobState::RefundDue && update.refund_due_at.is_none() {
+    if next == OpenCompetitionV2ProofJobState::RefundDue
+        && expected != OpenCompetitionV2ProofJobState::RefundDue
+        && update.refund_due_at.is_none()
+    {
         return Err(DbError::OpenCompetitionV2Conflict(
             "refund_due proof job requires a refund deadline".to_string(),
         ));
@@ -9366,6 +9369,22 @@ mod tests {
         };
         validate_open_competition_v2_proof_transition(State::Paid, State::RefundDue, &refund_due)
             .unwrap();
+        assert!(validate_open_competition_v2_proof_transition(
+            State::Paid,
+            State::RefundDue,
+            &OpenCompetitionV2ProofJobUpdate::default(),
+        )
+        .is_err());
+        let refund_broadcast = OpenCompetitionV2ProofJobUpdate {
+            refund_tx_hash: Some(format!("0x{}", "33".repeat(32))),
+            ..Default::default()
+        };
+        validate_open_competition_v2_proof_transition(
+            State::RefundDue,
+            State::RefundDue,
+            &refund_broadcast,
+        )
+        .unwrap();
         let refunded = OpenCompetitionV2ProofJobUpdate {
             refund_evidence: Some(
                 serde_json::json!({"transaction_hash": format!("0x{}", "44".repeat(32))}),


### PR DESCRIPTION
## Summary
- require efund_due_at only when first entering efund_due
- permit a persisted efund_due -> refund_due broadcast update to add its canonical candidate transaction hash without restating immutable state
- add regression coverage for fresh-entry and self-update behavior

## Production evidence
Render broker retries currently fail with conflicting Open Competition V2 canonical replay: refund_due proof job requires a refund deadline after refund broadcast planning. Existing jobs already have persisted deadlines; this DB guard incorrectly applies the entry invariant to a self-transition.

## Verification
- cargo fmt --all -- --check
- cargo test -p db -p worker (61 passed, 12 environment-dependent ignored)
- scripts/preflight.ps1 -Mode core

No contract bytecode, V2 policy, public API, or external contributor surface changes.