### PR TITLE
Resume Beta3 with a fresh paid proof job

### DIFF
--- a/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
@@ -16,9 +16,7 @@ env:
   SOURCE_RUN_ID: "32346174505"
   SOURCE_ACTOR_DERIVATION_SALT: "32346174505:1:mainnet"
   OPEN_COMPETITION_V2_RUNTIME_READINESS_URL: https://agent-bounties-api.onrender.com/v1/base/open-competition-v2-beta3/release
-  EXISTING_X402_JOB_ID: 155ef022-8ef3-4453-825c-316d309d9ecf
-  RESUME_X402_JOB_ID: bccd0e3e-73d0-41ac-8bbd-0a806ea45194
-  RESUME_X402_SOLVER_NONCE: "1787226676733703323"
+  CANARY_TEMPLATE_JOB_ID: bccd0e3e-73d0-41ac-8bbd-0a806ea45194
   PLONK_COMPETITION: "0x3e052b933628b960d61654a68fca23d869d8989f"
   PLONK_SETTLEMENT_TRANSACTION: "0x830e856ddbade328a0715e47e3aaa36f6363c6be71c18bd20f0baaab75aed4f3"
   FORCED_REFUND_PAYMENT_TRANSACTION: "0xdb833590333b36c69ee7e7d873a94f87d519278321df13f155253473e4a0a7c2"
@@ -130,7 +128,7 @@ jobs:
           salt = os.environ["SOURCE_ACTOR_DERIVATION_SALT"]
           root = rehearsal.normalized_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"])
           deployer, solver_a, solver_b = rehearsal.actors_for(root, {"source_commit": source}, salt)
-          url = f"https://api.agentbounties.app/v1/base/open-competition-v2-beta3/proof-jobs/{os.environ['EXISTING_X402_JOB_ID']}"
+          url = f"https://api.agentbounties.app/v1/base/open-competition-v2-beta3/proof-jobs/{os.environ['CANARY_TEMPLATE_JOB_ID']}"
           with urlopen(Request(url, headers={"accept": "application/json"}), timeout=45) as response:
               old = json.loads(response.read())["job"]
           inventory_url = "https://api.agentbounties.app/v1/base/open-competition-v2-beta3/inventory?network=base-mainnet"
@@ -144,7 +142,7 @@ jobs:
           )
           program = old["program_input"]
           proof_deadline = int(projection["proof_deadline"])
-          recovery_nonce = os.environ["RESUME_X402_SOLVER_NONCE"]
+          recovery_nonce = str(time.time_ns())
           document = {
               "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-resume-v1",
               "passed": True,
@@ -186,6 +184,10 @@ jobs:
           PY
           proof_deadline="$(jq -r .x402_canary.proof_deadline target/mainnet-canary-resume.json)"
           if (( proof_deadline < $(date +%s) + 2100 )); then
+            now="$(date +%s)"
+            if (( proof_deadline >= now )); then
+              sleep "$((proof_deadline - now + 2))"
+            fi
             python .release-control/scripts/refresh_open_competition_v2_x402_canary.py \
               --network base-mainnet --rpc-url "$BASE_MAINNET_RPC_URL" \
               --runtime target/production-control-plane/mainnet-broker.runtime.json \
@@ -193,16 +195,15 @@ jobs:
               --fixture programs/public-vector-metric-v1/fixtures/rehearsal-best-score-a.json \
               --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
               --actor-derivation-salt "$SOURCE_ACTOR_DERIVATION_SALT" \
-              --solver-nonce "$RESUME_X402_SOLVER_NONCE" \
+              --solver-nonce "$(jq -r .x402_canary.solver_nonce target/mainnet-canary-resume.json)" \
               --skip-solver-service-top-up \
-              --replacement-id 1 --output target/mainnet-x402-canary-replacement.json
+              --replacement-id 2 --output target/mainnet-x402-canary-replacement.json
           fi
           python .release-control/scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api https://api.agentbounties.app \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canary-resume.json \
             --hosted-workers --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$SOURCE_ACTOR_DERIVATION_SALT" \
-            --proof-job-id "$RESUME_X402_JOB_ID" \
             --timeout-seconds 5400 --output target/mainnet-x402-success.json
           python .release-control/scripts/verify_open_competition_v2_beta3_mainnet_recovery.py \
             --api https://api.agentbounties.app --rpc-url "$BASE_MAINNET_RPC_URL" \

--- a/scripts/test_resume_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_resume_open_competition_v2_beta3_mainnet.py
@@ -19,15 +19,19 @@ class MainnetResumeWorkflowTests(unittest.TestCase):
         ):
             self.assertRegex(text, rf'(?m)^  {re.escape(key)}: "0x[0-9a-f]+"$')
 
-    def test_resume_is_protected_and_reuses_canonical_funded_competition(self):
+    def test_resume_is_protected_and_replaces_the_terminal_canary(self):
         text = WORKFLOW.read_text(encoding="utf-8")
         self.assertEqual(text.count("environment: v2-beta2-mainnet"), 2)
         self.assertIn('SOURCE_RUN_ID: "32346174505"', text)
         self.assertIn("open-competition-v2-beta3-mainnet-deployment-continuation", text)
         self.assertIn("open-competition-v2-beta3-production-control-plane-continuation", text)
-        self.assertIn("EXISTING_X402_JOB_ID", text)
+        self.assertIn("CANARY_TEMPLATE_JOB_ID", text)
+        self.assertNotIn("RESUME_X402_JOB_ID", text)
+        self.assertNotIn("--proof-job-id", text)
         self.assertIn("recovery_nonce = str(time.time_ns())", text)
         self.assertIn('"solver_nonce": recovery_nonce', text)
+        self.assertIn('sleep "$((proof_deadline - now + 2))"', text)
+        self.assertIn("--replacement-id 2", text)
         self.assertNotRegex(text, r'"solver_nonce": "\d+"')
         self.assertNotIn("createCompetition(", text)
         self.assertNotIn("approve(address", text)


### PR DESCRIPTION
## Summary
- rebuild the Groth16 resume spec from the latest refunded canary job
- wait for the immutable deadline and recover its escrow before replacement
- create a fresh replacement nonce and a new x402 proof job instead of replaying terminal payment evidence

## Verification
- python -m unittest scripts.test_resume_open_competition_v2_beta3_mainnet scripts.test_resume_open_competition_v2_beta3_x402 scripts.test_refresh_open_competition_v2_x402_canary scripts.test_run_open_competition_v2_x402_rehearsal (21 passed)
- git diff --check

## Payment boundary
This PR does not itself move funds. The protected workflow remains responsible for exact Base-mainnet execution and canonical evidence.