### PR TITLE
Fit Beta3 discovery seed to funded balance

### DIFF
--- a/ops/open-competition-v2-discovery-seed-v1.json
+++ b/ops/open-competition-v2-discovery-seed-v1.json
@@ -5,7 +5,7 @@
   "profile_id": "structured-artifact-metric-v1",
   "economics": {
     "solver_reward_base_units": 3000000,
-    "keeper_reward_base_units": 50000,
+    "keeper_reward_base_units": 40000,
     "hosted_proof_fee_base_units": 100000,
     "hosted_relay_fee_base_units": 10000,
     "minimum_net_prize_base_units": 2000001

--- a/scripts/seed_open_competition_v2_discovery.py
+++ b/scripts/seed_open_competition_v2_discovery.py
@@ -66,7 +66,7 @@ def validate_manifest(value: dict[str, Any]) -> dict[str, int]:
     minimum_net = int(economics.get("minimum_net_prize_base_units", 0))
     net = solver - proof - relay
     require(solver == 3_000_000, "seed solver reward must be exactly 3 USDC")
-    require(keeper == 50_000 and keeper <= solver // 20, "seed keeper reward is invalid")
+    require(keeper == 40_000 and keeper <= solver // 20, "seed keeper reward is invalid")
     require(proof == 100_000 and relay == 10_000, "seed hosted cost assumptions drifted")
     require(net >= minimum_net and net > 2_000_000, "seed net prize must exceed 2 USDC")
     require(value.get("winner_mode") == "first_proven", "seed winner mode must be first_proven")

--- a/scripts/test_seed_open_competition_v2_discovery.py
+++ b/scripts/test_seed_open_competition_v2_discovery.py
@@ -19,8 +19,8 @@ class DiscoverySeedTests(unittest.TestCase):
 
     def test_exact_seed_has_five_profitable_fully_funded_competitions(self):
         economics = MODULE.validate_manifest(self.manifest())
-        self.assertEqual(economics["funding_per_competition"], 3_050_000)
-        self.assertEqual(economics["total_funding"], 15_250_000)
+        self.assertEqual(economics["funding_per_competition"], 3_040_000)
+        self.assertEqual(economics["total_funding"], 15_200_000)
         self.assertEqual(economics["net_prize"], 2_890_000)
 
     def test_seed_rejects_inventory_or_economic_drift(self):


### PR DESCRIPTION
## Summary
- retain five exact 3.00 USDC solver prizes
- reduce the keeper reward from 0.05 to 0.04 USDC per competition
- fit total escrow to 15.20 USDC while preserving 2.89 USDC hosted net prize

## Verification
- python scripts/test_seed_open_competition_v2_discovery.py (4 passed)
- git diff --check

## Payment boundary
The protected seed workflow still creates and publishes only canonically active, fully funded competitions after Beta3 activation.