### PR TITLE
Wait for Beta3 projection before proof quote

### DIFF
--- a/scripts/run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/run_open_competition_v2_x402_rehearsal.py
@@ -69,6 +69,35 @@ def request_json(
     return status, value, response_headers
 
 
+def wait_for_active_competition(
+    api: str, network: str, competition: str, deadline: float
+) -> None:
+    inventory_url = (
+        f"{api}/v1/base/open-competition-v2-beta3/inventory?network={network}"
+    )
+    while time.time() < deadline:
+        _, inventory, _ = request_json("GET", inventory_url)
+        projection = next(
+            (
+                item.get("record", {}).get("projection", {})
+                for item in inventory.get("competitions", [])
+                if item.get("record", {})
+                .get("projection", {})
+                .get("competition", "")
+                .lower()
+                == competition.lower()
+            ),
+            None,
+        )
+        if projection is None:
+            time.sleep(3)
+            continue
+        state = projection.get("state")
+        require(state == "active", f"competition became {state} before proof quote")
+        return
+    raise X402RehearsalError("competition did not become active in hosted inventory")
+
+
 def decode_x402_header(value: str) -> dict[str, Any]:
     try:
         decoded = base64.b64decode(value, validate=True)
@@ -368,6 +397,7 @@ def main() -> int:
         validate_resumable_job(resumed, spec, args.network)
         payment = resumed_payment(resumed)
     else:
+        wait_for_active_competition(api, args.network, spec["competition"], deadline)
         quote_payload = build_quote_payload(spec, args.network)
         _, quote, _ = request_json(
             "POST", f"{api}/v1/base/open-competition-v2-beta3/proof-quotes", quote_payload

--- a/scripts/test_run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_x402_rehearsal.py
@@ -16,6 +16,56 @@ SPEC.loader.exec_module(MODULE)
 
 
 class X402RehearsalTests(unittest.TestCase):
+    def test_fresh_quote_waits_for_active_canonical_projection(self):
+        competition = "0x" + "11" * 20
+        active = {
+            "competitions": [
+                {
+                    "record": {
+                        "projection": {
+                            "competition": competition,
+                            "state": "active",
+                        }
+                    }
+                }
+            ]
+        }
+        with patch.object(
+            MODULE,
+            "request_json",
+            side_effect=[(200, {"competitions": []}, {}), (200, active, {})],
+        ) as request:
+            with patch.object(MODULE.time, "sleep") as sleep:
+                MODULE.wait_for_active_competition(
+                    "https://api.example.test", "base-mainnet", competition, float("inf")
+                )
+        self.assertEqual(request.call_count, 2)
+        sleep.assert_called_once_with(3)
+
+    def test_fresh_quote_rejects_terminal_projection(self):
+        competition = "0x" + "11" * 20
+        inventory = {
+            "competitions": [
+                {
+                    "record": {
+                        "projection": {
+                            "competition": competition,
+                            "state": "expired",
+                        }
+                    }
+                }
+            ]
+        }
+        with patch.object(
+            MODULE, "request_json", return_value=(200, inventory, {})
+        ):
+            with self.assertRaisesRegex(
+                MODULE.X402RehearsalError, "became expired"
+            ):
+                MODULE.wait_for_active_competition(
+                    "https://api.example.test", "base-mainnet", competition, float("inf")
+                )
+
     def test_resumable_job_requires_exact_paid_scope(self):
         spec = {
             "competition": "0x" + "11" * 20,


### PR DESCRIPTION
## Summary
- wait for a fresh competition to appear as canonically active in hosted inventory before requesting a proof quote
- reject terminal projections instead of retrying blindly
- cover indexer-lag and terminal-state paths

## Verification
- python scripts/test_run_open_competition_v2_x402_rehearsal.py (11 passed)
- python scripts/test_resume_open_competition_v2_beta3_mainnet.py (3 passed)
- python scripts/test_refresh_open_competition_v2_x402_canary.py (8 passed)
- git diff --check

## Incident evidence
Run 32372140934 created and funded replacement 2 but received competition_not_indexed before any x402 charge. This change waits on the exact missing canonical projection.