### PR TITLE
Fix Beta3 seed transaction signing

### DIFF
--- a/scripts/seed_open_competition_v2_discovery.py
+++ b/scripts/seed_open_competition_v2_discovery.py
@@ -15,7 +15,7 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from eth_account import Account
-from eth_utils import keccak
+from eth_utils import keccak, to_checksum_address
 
 from _shared.evm import address_word
 from _shared.rpc import rpc
@@ -162,10 +162,11 @@ class SignedRpc:
 
     def send_intent(self, intent: dict[str, Any]) -> dict[str, Any]:
         require(intent.get("from", "").lower() == self.signer.address.lower(), "wallet call sender mismatch")
-        to = intent.get("to", "")
+        target = intent.get("to", "")
         data = intent.get("data", "")
         value = int(intent.get("value_wei", 0))
-        require(ADDRESS.fullmatch(to) is not None, "wallet call target is invalid")
+        require(ADDRESS.fullmatch(target) is not None, "wallet call target is invalid")
+        to = to_checksum_address(target)
         require(isinstance(data, str) and data.startswith("0x") and len(data) % 2 == 0, "wallet call data is invalid")
         nonce = int(rpc(self.url, "eth_getTransactionCount", [self.signer.address, "pending"]), 16)
         latest = rpc(self.url, "eth_getBlockByNumber", ["latest", False])

--- a/scripts/test_seed_open_competition_v2_discovery.py
+++ b/scripts/test_seed_open_competition_v2_discovery.py
@@ -4,6 +4,9 @@ import json
 from pathlib import Path
 import unittest
 
+from eth_account import Account
+from eth_utils import to_checksum_address
+
 
 PATH = Path(__file__).with_name("seed_open_competition_v2_discovery.py")
 SPEC = importlib.util.spec_from_file_location("seed_open_competition_v2_discovery", PATH)
@@ -91,6 +94,24 @@ class DiscoverySeedTests(unittest.TestCase):
             profile_document=profile,
         )
         self.assertNotEqual(first["creation_nonce"], third["creation_nonce"])
+
+    def test_base_usdc_target_is_signable_after_checksum_normalization(self):
+        signer = Account.create("agent-bounties-beta3-seed-test")
+        target = to_checksum_address(MODULE.USDC)
+        signed = signer.sign_transaction(
+            {
+                "chainId": MODULE.CHAIN_ID,
+                "to": target,
+                "nonce": 0,
+                "value": 0,
+                "data": "0x",
+                "gas": 21_000,
+                "maxFeePerGas": 2_000_000,
+                "maxPriorityFeePerGas": 1_000_000,
+                "type": 2,
+            }
+        )
+        self.assertGreater(len(signed.raw_transaction), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Normalizes validated EVM targets to EIP-55 checksum form before estimate/sign, fixing the pre-broadcast eth-account failure in seed run 32378754155. Adds a regression that signs the exact Base USDC target. No funds moved in the failed run; deployer remained at nonce 22 with 15.572522 USDC. Verified with five focused tests, py_compile, and diff check.