### PR TITLE
Sequence Beta3 seed approvals before creation

### DIFF
--- a/scripts/seed_open_competition_v2_discovery.py
+++ b/scripts/seed_open_competition_v2_discovery.py
@@ -408,6 +408,26 @@ After earning, share the canonical proof, tell your human or operator, star the 
 """
 
 
+def wallet_call_phases(
+    prepared: list[dict[str, Any]], factory_contract: str
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    approvals: list[dict[str, Any]] = []
+    creations: list[dict[str, Any]] = []
+    for item in prepared:
+        if item["exists"]:
+            continue
+        calls = item["plan"].get("wallet_calls", [])
+        require(len(calls) == 2, f"{item['task']['seed_id']} must use exact approve and create calls")
+        require(calls[0].get("to", "").lower() == USDC, "approval target is not Base USDC")
+        require(
+            calls[1].get("to", "").lower() == factory_contract.lower(),
+            "creation target is not the canonical factory",
+        )
+        approvals.append(calls[0])
+        creations.append(calls[1])
+    return approvals, creations
+
+
 def seed(
     *, manifest: dict[str, Any], api: str, rpc_url: str, private_key: str, issue_output_dir: Path
 ) -> dict[str, Any]:
@@ -462,16 +482,12 @@ def seed(
     require(balance_of(rpc_url, client.signer.address) >= missing_funding, f"deployer needs {missing_funding} USDC base units for missing seed competitions")
     require(int(rpc(rpc_url, "eth_getBalance", [client.signer.address, "latest"]), 16) >= 100_000_000_000_000, "deployer Base ETH reserve is below 0.0001 ETH")
 
-    receipts: list[dict[str, Any]] = []
-    for item in prepared:
-        if item["exists"]:
-            continue
-        calls = item["plan"].get("wallet_calls", [])
-        require(len(calls) == 2, f"{item['task']['seed_id']} must use exact approve and create calls")
-        require(calls[0].get("to", "").lower() == USDC, "approval target is not Base USDC")
-        require(calls[1].get("to", "").lower() == release["factory_contract"].lower(), "creation target is not the canonical factory")
-        for call in calls:
-            receipts.append(client.send_intent(call))
+    approval_calls, creation_calls = wallet_call_phases(prepared, release["factory_contract"])
+    receipts = [client.send_intent(call) for call in approval_calls]
+    if receipts:
+        highest_approval_block = max(int(receipt["blockNumber"], 16) for receipt in receipts)
+        client.wait_safe(highest_approval_block)
+    receipts.extend(client.send_intent(call) for call in creation_calls)
 
     receipt_block = max([int(receipt["blockNumber"], 16) for receipt in receipts] or [deployment_block])
     safe = client.wait_safe(receipt_block)

--- a/scripts/test_seed_open_competition_v2_discovery.py
+++ b/scripts/test_seed_open_competition_v2_discovery.py
@@ -113,6 +113,33 @@ class DiscoverySeedTests(unittest.TestCase):
         )
         self.assertGreater(len(signed.raw_transaction), 0)
 
+    def test_all_approvals_are_sequenced_before_any_creation(self):
+        factory = "0x" + "aa" * 20
+        approval_a = {"to": MODULE.USDC, "data": "0x01"}
+        approval_b = {"to": MODULE.USDC, "data": "0x02"}
+        create_a = {"to": factory, "data": "0x03"}
+        create_b = {"to": factory, "data": "0x04"}
+        prepared = [
+            {
+                "task": {"seed_id": "a"},
+                "plan": {"wallet_calls": [approval_a, create_a]},
+                "exists": False,
+            },
+            {
+                "task": {"seed_id": "existing"},
+                "plan": {"wallet_calls": [approval_a, create_a]},
+                "exists": True,
+            },
+            {
+                "task": {"seed_id": "b"},
+                "plan": {"wallet_calls": [approval_b, create_b]},
+                "exists": False,
+            },
+        ]
+        approvals, creations = MODULE.wallet_call_phases(prepared, factory)
+        self.assertEqual(approvals, [approval_a, approval_b])
+        self.assertEqual(creations, [create_a, create_b])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Splits the five-task seed into two phases: confirm every approval, wait once for the highest approval block to become Base-safe, then create/fund competitions. This removes the RPC state race seen in run 32379436529. The failed run moved no USDC; it left only a 3.04 USDC allowance. Six focused tests and py_compile pass.