### PR TITLE
fix(rpc): preserve JSON-RPC errors on HTTP failures

### DIFF
--- a/scripts/_shared/rpc.py
+++ b/scripts/_shared/rpc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import time
 from typing import Any, Sequence
 from urllib.error import HTTPError, URLError
@@ -18,7 +19,9 @@ BASE_RPC_ENDPOINTS: Sequence[str] = (
 )
 MAX_RETRIES = 3
 INITIAL_BACKOFF_SECONDS = 0.5
-RETRYABLE_HTTP_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+MAX_RPC_ERROR_BODY_BYTES = 65536
+# Bounded retry: transport failures, HTTP 408/429, and every HTTP 5xx (500-599).
+RETRYABLE_HTTP_STATUS = frozenset({408, 429, *range(500, 600)})
 RETRYABLE_TRANSPORT_MARKERS = (
     "http error 408",
     "http error 429",
@@ -41,6 +44,8 @@ RETRYABLE_TRANSPORT_MARKERS = (
     "timed out",
     "timeout",
 )
+_ABSOLUTE_URL_RE = re.compile(r"https?://[^\s'\"<>]+", re.IGNORECASE)
+_HTTP_STATUS_IN_TEXT_RE = re.compile(r"http(?:\s+error)?\s+(\d{3})\b", re.IGNORECASE)
 
 
 class TransportError(RuntimeError):
@@ -76,6 +81,11 @@ def redact_rpc_endpoint(endpoint: str) -> str:
     return _redact_endpoint(endpoint)
 
 
+def _without_absolute_urls(value: object) -> str:
+    """Strip absolute URLs from interpolated error text."""
+    return _ABSOLUTE_URL_RE.sub("<redacted-url>", str(value))
+
+
 def _is_https(endpoint: str) -> bool:
     try:
         parsed = urlsplit(endpoint)
@@ -84,12 +94,49 @@ def _is_https(endpoint: str) -> bool:
         return False
 
 
+def is_retryable_http_status(status: int) -> bool:
+    """Retry HTTP 408, 429, and every HTTP 5xx; never other client errors."""
+    return int(status) in RETRYABLE_HTTP_STATUS
+
+
 def is_retryable_transport_output(value: object) -> bool:
-    """Classify subprocess output without treating JSON-RPC errors as transport."""
+    """Classify output; explicit JSON-RPC errors take precedence over HTTP text."""
     text = str(value).lower()
-    if "json-rpc" in text and "error" in text and "http" not in text:
+    if "json-rpc" in text and "error" in text:
         return False
+    match = _HTTP_STATUS_IN_TEXT_RE.search(text)
+    if match and is_retryable_http_status(int(match.group(1))):
+        return True
     return any(marker in text for marker in RETRYABLE_TRANSPORT_MARKERS)
+
+
+def _read_bounded_http_error_body(error: HTTPError) -> bytes:
+    """Read at most MAX_RPC_ERROR_BODY_BYTES+1 from an HTTPError response."""
+    reader = getattr(error, "read", None)
+    if not callable(reader):
+        return b""
+    try:
+        return reader(MAX_RPC_ERROR_BODY_BYTES + 1)
+    except (OSError, ValueError, AttributeError, TypeError):
+        return b""
+
+
+def _jsonrpc_error_object(raw: bytes) -> object | None:
+    """Return the JSON-RPC error object from a bounded HTTP error body, if any."""
+    if not raw or len(raw) > MAX_RPC_ERROR_BODY_BYTES:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    payload = parsed.get("error")
+    if not isinstance(payload, dict) or not payload:
+        return None
+    if "code" not in payload or "message" not in payload:
+        return None
+    return payload
 
 
 def _rpc_call(
@@ -111,37 +158,56 @@ def _rpc_call(
             "user-agent": "agent-bounties-rpc/1",
         },
     )
+    # Raise transport and JSON-RPC errors after the except block so urllib
+    # HTTPError/URLError objects (filename/url/userinfo/path/query/fragment)
+    # cannot survive as __cause__ or __context__, and failover cannot hide a
+    # confirmed JSON-RPC execution error carried in an HTTP error body.
+    transport_error: TransportError | None = None
+    jsonrpc_error: object | None = None
+    body: Any = None
     try:
         with urlopen(request, timeout=timeout) as response:
             status = response.getcode() if hasattr(response, "getcode") else 200
             status = 200 if status is None else int(status)
-            if status in RETRYABLE_HTTP_STATUS:
-                raise TransportError(
-                    f"HTTP {status} from {_redact_endpoint(endpoint)}",
-                    retryable=True,
-                )
             if status >= 400:
-                raise TransportError(
+                transport_error = TransportError(
                     f"HTTP {status} from {_redact_endpoint(endpoint)}",
-                    retryable=False,
+                    retryable=is_retryable_http_status(status),
                 )
-            body = json.load(response)
+            else:
+                body = json.load(response)
     except HTTPError as error:
         code = int(error.code)
-        raise TransportError(
-            f"HTTP {code} from {_redact_endpoint(endpoint)}",
-            retryable=code in RETRYABLE_HTTP_STATUS,
-        ) from error
+        raw = b""
+        try:
+            raw = _read_bounded_http_error_body(error)
+        finally:
+            error.close()
+        error_object = _jsonrpc_error_object(raw)
+        if error_object is not None:
+            jsonrpc_error = error_object
+        else:
+            transport_error = TransportError(
+                f"HTTP {code} from {_redact_endpoint(endpoint)}",
+                retryable=is_retryable_http_status(code),
+            )
     except (TimeoutError, URLError, OSError) as error:
-        raise TransportError(
-            f"RPC transport failed for {method} at {_redact_endpoint(endpoint)}: {error}",
+        transport_error = TransportError(
+            f"RPC transport failed for {method} at {_redact_endpoint(endpoint)}: "
+            f"{_without_absolute_urls(error)}",
             retryable=True,
-        ) from error
-    except (json.JSONDecodeError, UnicodeDecodeError) as error:
-        raise TransportError(
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        transport_error = TransportError(
             f"RPC response was invalid for {method} at {_redact_endpoint(endpoint)}",
             retryable=True,
-        ) from error
+        )
+    if jsonrpc_error is not None:
+        raise RpcError(
+            f"RPC {method} failed: {json.dumps(jsonrpc_error, sort_keys=True)}"
+        )
+    if transport_error is not None:
+        raise transport_error
 
     if not isinstance(body, dict):
         raise TransportError(

--- a/scripts/_shared/rpc.py
+++ b/scripts/_shared/rpc.py
@@ -154,18 +154,14 @@ def _jsonrpc_id_binds_to_request(
     return False
 
 
-def _jsonrpc_error_object(raw: bytes, request_id: object) -> tuple[int, str] | None:
-    """Return matching JSON-RPC 2.0 code and message, else None.
+def _jsonrpc_error_fields(
+    parsed: object, request_id: object
+) -> tuple[int, str] | None:
+    """Return matching JSON-RPC 2.0 code and message from a parsed object.
 
     Message length is not a recognition criterion. Safe projection bounds
     the message when raising RpcError.
     """
-    if not raw or len(raw) > MAX_RPC_ERROR_BODY_BYTES:
-        return None
-    try:
-        parsed = json.loads(raw)
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
-        return None
     if not isinstance(parsed, dict):
         return None
     if parsed.get("jsonrpc") != "2.0":
@@ -186,6 +182,21 @@ def _jsonrpc_error_object(raw: bytes, request_id: object) -> tuple[int, str] | N
     if not _jsonrpc_id_binds_to_request(parsed["id"], request_id, code):
         return None
     return code, message
+
+
+def _jsonrpc_error_object(raw: bytes, request_id: object) -> tuple[int, str] | None:
+    """Return matching JSON-RPC 2.0 code and message, else None.
+
+    Parses at most MAX_RPC_ERROR_BODY_BYTES and delegates field validation
+    to _jsonrpc_error_fields. Message length is not a recognition criterion.
+    """
+    if not raw or len(raw) > MAX_RPC_ERROR_BODY_BYTES:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+    return _jsonrpc_error_fields(parsed, request_id)
 
 
 def _project_rpc_error_message(message: str) -> str:
@@ -262,7 +273,7 @@ def _rpc_call(
             f"{_without_absolute_urls(error)}",
             retryable=True,
         )
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
         transport_error = TransportError(
             f"RPC response was invalid for {method} at {_redact_endpoint(endpoint)}",
             retryable=True,
@@ -281,9 +292,17 @@ def _rpc_call(
             f"RPC response was not an object for {method} at {_redact_endpoint(endpoint)}",
             retryable=True,
         )
-    if body.get("error"):
+    if "error" in body:
+        recognized = _jsonrpc_error_fields(body, request_id)
+        if recognized is None:
+            raise TransportError(
+                f"RPC response was invalid for {method} at {_redact_endpoint(endpoint)}",
+                retryable=True,
+            )
+        code, message = recognized
         raise RpcError(
-            f"RPC {method} failed: {json.dumps(body['error'], sort_keys=True)}"
+            f"RPC {method} failed: "
+            f"{json.dumps({'code': code, 'message': _project_rpc_error_message(message)}, sort_keys=True)}"
         )
     return body.get("result")
 

--- a/scripts/_shared/rpc.py
+++ b/scripts/_shared/rpc.py
@@ -20,6 +20,8 @@ BASE_RPC_ENDPOINTS: Sequence[str] = (
 MAX_RETRIES = 3
 INITIAL_BACKOFF_SECONDS = 0.5
 MAX_RPC_ERROR_BODY_BYTES = 65536
+MAX_RPC_ERROR_MESSAGE_CHARS = 4096
+RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR = "...[truncated]"
 # Bounded retry: transport failures, HTTP 408/429, and every HTTP 5xx (500-599).
 RETRYABLE_HTTP_STATUS = frozenset({408, 429, *range(500, 600)})
 RETRYABLE_TRANSPORT_MARKERS = (
@@ -121,8 +123,43 @@ def _read_bounded_http_error_body(error: HTTPError) -> bytes:
         return b""
 
 
-def _jsonrpc_error_object(raw: bytes) -> object | None:
-    """Return the JSON-RPC error object from a bounded HTTP error body, if any."""
+# JSON-RPC 2.0 allows id=null only when the request id could not be detected.
+_JSONRPC_NULL_ID_ERROR_CODES = frozenset({-32700, -32600})
+
+
+def _jsonrpc_id_binds_to_request(
+    response_id: object, request_id: object, error_code: object
+) -> bool:
+    """True when this JSON-RPC error is a response to the in-flight request."""
+    if response_id is None:
+        return (
+            isinstance(error_code, int)
+            and not isinstance(error_code, bool)
+            and error_code in _JSONRPC_NULL_ID_ERROR_CODES
+        )
+    if isinstance(response_id, bool) or isinstance(request_id, bool):
+        return False
+    if isinstance(response_id, str) or isinstance(request_id, str):
+        return (
+            isinstance(response_id, str)
+            and isinstance(request_id, str)
+            and response_id == request_id
+        )
+    if isinstance(response_id, int) or isinstance(request_id, int):
+        return (
+            isinstance(response_id, int)
+            and isinstance(request_id, int)
+            and response_id == request_id
+        )
+    return False
+
+
+def _jsonrpc_error_object(raw: bytes, request_id: object) -> tuple[int, str] | None:
+    """Return matching JSON-RPC 2.0 code and message, else None.
+
+    Message length is not a recognition criterion. Safe projection bounds
+    the message when raising RpcError.
+    """
     if not raw or len(raw) > MAX_RPC_ERROR_BODY_BYTES:
         return None
     try:
@@ -131,12 +168,39 @@ def _jsonrpc_error_object(raw: bytes) -> object | None:
         return None
     if not isinstance(parsed, dict):
         return None
+    if parsed.get("jsonrpc") != "2.0":
+        return None
+    if "id" not in parsed:
+        return None
+    if "result" in parsed:
+        return None
     payload = parsed.get("error")
-    if not isinstance(payload, dict) or not payload:
+    if not isinstance(payload, dict):
         return None
-    if "code" not in payload or "message" not in payload:
+    code = payload.get("code")
+    message = payload.get("message")
+    if not isinstance(code, int) or isinstance(code, bool):
         return None
-    return payload
+    if not isinstance(message, str):
+        return None
+    if not _jsonrpc_id_binds_to_request(parsed["id"], request_id, code):
+        return None
+    return code, message
+
+
+def _project_rpc_error_message(message: str) -> str:
+    """Redact absolute URLs, then truncate to at most 4,096 characters.
+
+    Redaction runs first so truncation cannot split a credential-bearing URL
+    and so a longer placeholder cannot push the emitted field past the bound.
+    """
+    redacted = _without_absolute_urls(message)
+    if len(redacted) <= MAX_RPC_ERROR_MESSAGE_CHARS:
+        return redacted
+    indicator = RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR
+    keep = max(MAX_RPC_ERROR_MESSAGE_CHARS - len(indicator), 0)
+    projected = f"{redacted[:keep]}{indicator}"
+    return projected[:MAX_RPC_ERROR_MESSAGE_CHARS]
 
 
 def _rpc_call(
@@ -163,7 +227,7 @@ def _rpc_call(
     # cannot survive as __cause__ or __context__, and failover cannot hide a
     # confirmed JSON-RPC execution error carried in an HTTP error body.
     transport_error: TransportError | None = None
-    jsonrpc_error: object | None = None
+    jsonrpc_error: tuple[int, str] | None = None
     body: Any = None
     try:
         with urlopen(request, timeout=timeout) as response:
@@ -183,9 +247,10 @@ def _rpc_call(
             raw = _read_bounded_http_error_body(error)
         finally:
             error.close()
-        error_object = _jsonrpc_error_object(raw)
-        if error_object is not None:
-            jsonrpc_error = error_object
+        recognized = _jsonrpc_error_object(raw, request_id)
+        if recognized is not None:
+            code, message = recognized
+            jsonrpc_error = (code, _project_rpc_error_message(message))
         else:
             transport_error = TransportError(
                 f"HTTP {code} from {_redact_endpoint(endpoint)}",
@@ -203,8 +268,10 @@ def _rpc_call(
             retryable=True,
         )
     if jsonrpc_error is not None:
+        code, message = jsonrpc_error
         raise RpcError(
-            f"RPC {method} failed: {json.dumps(jsonrpc_error, sort_keys=True)}"
+            f"RPC {method} failed: "
+            f"{json.dumps({'code': code, 'message': message}, sort_keys=True)}"
         )
     if transport_error is not None:
         raise transport_error

--- a/scripts/test_shared_rpc.py
+++ b/scripts/test_shared_rpc.py
@@ -152,12 +152,41 @@ def envelopeless_gateway_http_error(
     return http_error_with_json(url, status, {"error": error}, reason)
 
 
+LIVE_CODE15_MESSAGE = (
+    "You reached Public endpoint rate limit, please upgrade to paid plan"
+)
+LIVE_CODE15_ERROR: dict[str, object] = {
+    "code": 15,
+    "message": LIVE_CODE15_MESSAGE,
+}
+
+
+def jsonrpc_error_response(
+    error: dict[str, object],
+    *,
+    response_id: object = 1,
+) -> Response:
+    return Response(
+        json.dumps(
+            {"jsonrpc": "2.0", "id": response_id, "error": error}
+        ).encode("utf-8")
+    )
+
+
+def envelopeless_http_200(error: dict[str, object]) -> Response:
+    return Response(json.dumps({"error": error}).encode("utf-8"))
+
+
+def http_200_json(body: dict[str, object]) -> Response:
+    return Response(json.dumps(body).encode("utf-8"))
+
+
 class RpcTest(unittest.TestCase):
     def test_single_endpoint_result_and_rpc_error_contracts(self) -> None:
         cases = (
             (b'{"result":"0x2105"}', "0x2105", None),
             (
-                b'{"error":{"code":-1,"message":"bad"}}',
+                b'{"jsonrpc":"2.0","id":7,"error":{"code":-1,"message":"bad"}}',
                 None,
                 'RPC eth_chainId failed: {"code": -1, "message": "bad"}',
             ),
@@ -228,8 +257,8 @@ class RpcTest(unittest.TestCase):
     def test_chain_rpc_error_never_calls_a_second_endpoint(self) -> None:
         with patch(
             "_shared.rpc.urlopen",
-            return_value=Response(
-                b'{"error":{"code":-32000,"message":"execution reverted"}}'
+            return_value=jsonrpc_error_response(
+                {"code": -32000, "message": "execution reverted"}
             ),
         ) as opened, self.assertRaisesRegex(RpcError, "execution reverted"):
             select_working_base_rpc(
@@ -245,8 +274,8 @@ class RpcTest(unittest.TestCase):
             calls += 1
             if request_method(request) == "eth_chainId":
                 return Response(b'{"result":"0x2105"}')
-            return Response(
-                b'{"error":{"code":-32000,"message":"execution reverted"}}'
+            return jsonrpc_error_response(
+                {"code": -32000, "message": "execution reverted"}
             )
 
         with patch(
@@ -1293,8 +1322,8 @@ class RpcTest(unittest.TestCase):
                 raise HTTPError(SECRET_ENDPOINT, 501, "not implemented", {}, None)
             if method == "eth_chainId":
                 return Response(b'{"result":"0x2105"}')
-            return Response(
-                b'{"error":{"code":-32000,"message":"execution reverted"}}'
+            return jsonrpc_error_response(
+                {"code": -32000, "message": "execution reverted"}
             )
 
         with patch("_shared.rpc.urlopen", side_effect=open_response), patch(
@@ -1355,6 +1384,485 @@ class RpcTest(unittest.TestCase):
             if isinstance(filename, str):
                 for fragment in SECRET_FRAGMENTS:
                     self.assertNotIn(fragment, filename)
+
+    def _assert_body_free_retryable_transport(self, exc: BaseException) -> None:
+        surface = exception_chain_text(exc)
+        self.assertIn("RPC response was invalid", surface)
+        for fragment in (
+            LIVE_CODE15_MESSAGE,
+            "paid plan",
+            "rate limit",
+            '"code": 15',
+            '"code":15',
+            "execution reverted",
+            '"data"',
+            '"extra"',
+            *SECRET_FRAGMENTS,
+        ):
+            self.assertNotIn(fragment, surface)
+        self.assertTrue(
+            any(
+                isinstance(node, TransportError) and node.retryable
+                for node in walk_exception_chain(exc)
+            )
+        )
+        for node in walk_exception_chain(exc):
+            self.assertNotIsInstance(node, RpcError)
+            self.assertNotIsInstance(node, HTTPError)
+
+    def test_http_200_envelopeless_code15_retries_then_recovers(self) -> None:
+        first = envelopeless_http_200(LIVE_CODE15_ERROR)
+        with patch("_shared.rpc.urlopen", side_effect=[first]) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RuntimeError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_chainId", [], attempts=1, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(first.closed)
+        self._assert_body_free_retryable_transport(raised.exception)
+
+        first = envelopeless_http_200(LIVE_CODE15_ERROR)
+        responses = [first, Response(b'{"result":"0x14a34"}')]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
+
+    def test_http_200_envelopeless_code15_fails_over_chain_probe(self) -> None:
+        seen: list[tuple[str, str]] = []
+
+        def open_response(request: object, **_kwargs: object) -> Response:
+            url = str(getattr(request, "full_url"))
+            method = request_method(request)
+            seen.append((url, method))
+            if url == SECRET_ENDPOINT:
+                return envelopeless_http_200(LIVE_CODE15_ERROR)
+            return Response(b'{"result":"0x2105"}')
+
+        with patch("_shared.rpc.urlopen", side_effect=open_response) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            selected = select_working_base_rpc(
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=1,
+            )
+        self.assertEqual(selected, "https://second.local")
+        self.assertEqual(
+            seen,
+            [
+                (SECRET_ENDPOINT, "eth_chainId"),
+                ("https://second.local", "eth_chainId"),
+            ],
+        )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_not_called()
+
+        seen.clear()
+        with patch("_shared.rpc.urlopen", side_effect=open_response), patch(
+            "_shared.rpc.time.sleep"
+        ):
+            result = rpc_failover(
+                "eth_chainId",
+                [],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=1,
+            )
+        self.assertEqual(result, hex(BASE_CHAIN_ID))
+        self.assertEqual(
+            seen,
+            [
+                (SECRET_ENDPOINT, "eth_chainId"),
+                ("https://second.local", "eth_chainId"),
+            ],
+        )
+
+    def test_http_200_envelopeless_code15_fails_over_target_method(self) -> None:
+        seen: list[tuple[str, str]] = []
+
+        def open_response(request: object, **_kwargs: object) -> Response:
+            url = str(getattr(request, "full_url"))
+            method = request_method(request)
+            seen.append((url, method))
+            if method == "eth_chainId":
+                return Response(b'{"result":"0x2105"}')
+            if url == SECRET_ENDPOINT:
+                return envelopeless_http_200(LIVE_CODE15_ERROR)
+            return Response(b'{"result":"0xabc"}')
+
+        with patch("_shared.rpc.urlopen", side_effect=open_response), patch(
+            "_shared.rpc.time.sleep"
+        ):
+            result = rpc_failover(
+                "eth_blockNumber",
+                [],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=1,
+            )
+        self.assertEqual(result, "0xabc")
+        self.assertEqual(
+            seen,
+            [
+                (SECRET_ENDPOINT, "eth_chainId"),
+                (SECRET_ENDPOINT, "eth_blockNumber"),
+                ("https://second.local", "eth_chainId"),
+                ("https://second.local", "eth_blockNumber"),
+            ],
+        )
+
+    def test_http_200_malformed_and_falsey_errors_retry_then_recover(self) -> None:
+        valid_error = {"code": -32000, "message": "execution reverted"}
+        cases: tuple[dict[str, object], ...] = (
+            {"error": LIVE_CODE15_ERROR},
+            {"id": 1, "error": valid_error},
+            {"jsonrpc": "1.0", "id": 1, "error": valid_error},
+            {"jsonrpc": "2", "id": 1, "error": valid_error},
+            {"jsonrpc": 2.0, "id": 1, "error": valid_error},
+            {"jsonrpc": "2.0", "error": valid_error},
+            {"jsonrpc": "2.0", "id": 999, "error": valid_error},
+            {"jsonrpc": "2.0", "id": "1", "error": valid_error},
+            {"jsonrpc": "2.0", "id": True, "error": valid_error},
+            {"jsonrpc": "2.0", "id": 1.0, "error": valid_error},
+            {"jsonrpc": "2.0", "id": None, "error": valid_error},
+            {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": 15, "message": LIVE_CODE15_MESSAGE},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": True, "message": "bad"},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32000.0, "message": "bad"},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": "-32000", "message": "bad"},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32000, "message": 7},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32000, "message": None},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": None,
+                "error": valid_error,
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": "0x2105",
+                "error": valid_error,
+            },
+            {"error": None},
+            {"error": {}},
+            {"error": False},
+            {"error": 0},
+            {"error": ""},
+            {"error": []},
+            {"jsonrpc": "2.0", "id": 1, "error": None},
+            {"jsonrpc": "2.0", "id": 1, "error": {}},
+            {"jsonrpc": "2.0", "id": 1, "error": False},
+            {"jsonrpc": "2.0", "id": 1, "error": []},
+        )
+        for envelope in cases:
+            with self.subTest(envelope=envelope):
+                first = http_200_json(envelope)
+                with patch(
+                    "_shared.rpc.urlopen",
+                    side_effect=[first, Response(b'{"result":"0x14a34"}')],
+                ) as opened, patch("_shared.rpc.time.sleep") as slept:
+                    result = rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0)
+                self.assertEqual(result, "0x14a34")
+                self.assertEqual(opened.call_count, 2)
+                slept.assert_called_once_with(0)
+                self.assertTrue(first.closed)
+
+    def test_http_200_matching_jsonrpc_error_never_retries(self) -> None:
+        cases = (
+            ({"code": -32000, "message": "execution reverted"}, 1, "eth_call"),
+            ({"code": -1, "message": "bad"}, 7, "eth_chainId"),
+            (
+                {
+                    "code": 15,
+                    "message": LIVE_CODE15_MESSAGE,
+                    "data": {"credential": "rpc-error-data-secret-marker"},
+                    "extra": "rpc-error-data-secret-marker",
+                },
+                1,
+                "eth_chainId",
+            ),
+        )
+        for error, request_id, method in cases:
+            with self.subTest(request_id=request_id, method=method, code=error["code"]):
+                first = jsonrpc_error_response(error, response_id=request_id)
+                with patch("_shared.rpc.urlopen", return_value=first) as opened, patch(
+                    "_shared.rpc.time.sleep"
+                ) as slept, self.assertRaises(RpcError) as raised:
+                    rpc(
+                        SECRET_ENDPOINT,
+                        method,
+                        [],
+                        request_id,
+                        attempts=3,
+                        retry_delay=0,
+                    )
+                self.assertEqual(opened.call_count, 1)
+                slept.assert_not_called()
+                self.assertTrue(first.closed)
+                payload = json.loads(str(raised.exception).split("failed: ", 1)[1])
+                self.assertEqual(
+                    payload,
+                    {"code": error["code"], "message": error["message"]},
+                )
+                surface = exception_chain_text(raised.exception)
+                self.assertNotIn('"data"', surface)
+                self.assertNotIn('"extra"', surface)
+                self.assertNotIn("rpc-error-data-secret-marker", surface)
+                for fragment in SECRET_FRAGMENTS:
+                    self.assertNotIn(fragment, surface)
+                for node in walk_exception_chain(raised.exception):
+                    self.assertNotIsInstance(node, HTTPError)
+                    self.assertNotIsInstance(node, TransportError)
+
+        string_error = jsonrpc_error_response(
+            {"code": -32000, "message": "string id error"},
+            response_id="request-1",
+        )
+        with patch("_shared.rpc.urlopen", return_value=string_error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaisesRegex(RpcError, "string id error"):
+            rpc(
+                SECRET_ENDPOINT,
+                "eth_call",
+                [],
+                "request-1",  # type: ignore[arg-type]
+                attempts=3,
+                retry_delay=0,
+            )
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+
+        for code, message in ((-32700, "Parse error"), (-32600, "Invalid Request")):
+            with self.subTest(null_id_code=code):
+                first = jsonrpc_error_response(
+                    {"code": code, "message": message},
+                    response_id=None,
+                )
+                with patch(
+                    "_shared.rpc.urlopen", return_value=first
+                ) as opened, patch("_shared.rpc.time.sleep") as slept, self.assertRaises(
+                    RpcError
+                ) as raised:
+                    rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0)
+                self.assertEqual(opened.call_count, 1)
+                slept.assert_not_called()
+                payload = json.loads(str(raised.exception).split("failed: ", 1)[1])
+                self.assertEqual(payload, {"code": code, "message": message})
+                for node in walk_exception_chain(raised.exception):
+                    self.assertNotIsInstance(node, HTTPError)
+                    self.assertNotIsInstance(node, TransportError)
+
+    def test_http_200_matching_jsonrpc_error_never_fails_over(self) -> None:
+        seen: list[tuple[str, str]] = []
+
+        def open_response(request: object, **_kwargs: object) -> Response:
+            url = str(getattr(request, "full_url"))
+            method = request_method(request)
+            seen.append((url, method))
+            if method == "eth_chainId":
+                return Response(b'{"result":"0x2105"}')
+            return jsonrpc_error_response(
+                {
+                    "code": -32000,
+                    "message": "execution reverted",
+                    "data": {"endpoint": SECRET_ENDPOINT},
+                    "extra": "rpc-error-data-secret-marker",
+                }
+            )
+
+        with patch("_shared.rpc.urlopen", side_effect=open_response) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc_failover(
+                "eth_call",
+                [],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(
+            seen,
+            [(SECRET_ENDPOINT, "eth_chainId"), (SECRET_ENDPOINT, "eth_call")],
+        )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_not_called()
+        payload = json.loads(str(raised.exception).split("failed: ", 1)[1])
+        self.assertEqual(
+            payload, {"code": -32000, "message": "execution reverted"}
+        )
+        surface = exception_chain_text(raised.exception)
+        self.assertNotIn('"data"', surface)
+        self.assertNotIn('"extra"', surface)
+        self.assertNotIn("rpc-error-data-secret-marker", surface)
+        for fragment in SECRET_FRAGMENTS:
+            self.assertNotIn(fragment, surface)
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+        seen.clear()
+
+        def open_null_parse(request: object, **_kwargs: object) -> Response:
+            url = str(getattr(request, "full_url"))
+            method = request_method(request)
+            seen.append((url, method))
+            return jsonrpc_error_response(
+                {"code": -32700, "message": "Parse error"},
+                response_id=None,
+            )
+
+        with patch("_shared.rpc.urlopen", side_effect=open_null_parse) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaisesRegex(RpcError, "Parse error") as raised:
+            rpc_failover(
+                "eth_call",
+                [],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(seen, [(SECRET_ENDPOINT, "eth_chainId")])
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertIn('"code": -32700', str(raised.exception))
+
+    def test_http_200_jsonrpc_long_secret_message_is_redacted_and_truncated(
+        self,
+    ) -> None:
+        data_secret = "rpc-error-data-secret-marker"
+        tail_secret = "rpc-error-message-tail-secret"
+        indicator = RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR
+        keep = max(MAX_RPC_ERROR_MESSAGE_CHARS - len(indicator), 0)
+        long_message = ("x" * keep) + tail_secret
+        self.assertGreater(len(long_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        expected_message = (long_message[:keep] + indicator)[
+            :MAX_RPC_ERROR_MESSAGE_CHARS
+        ]
+        self.assertEqual(len(expected_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        error_fields: dict[str, object] = {
+            "code": -32000,
+            "message": long_message,
+            "data": {"credential": data_secret, "endpoint": SECRET_ENDPOINT},
+            "extra": data_secret,
+        }
+        expected_exc = (
+            "RPC eth_call failed: "
+            + json.dumps(
+                {"code": -32000, "message": expected_message},
+                sort_keys=True,
+            )
+        )
+
+        first = jsonrpc_error_response(error_fields)
+        with patch("_shared.rpc.urlopen", return_value=first) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0.25)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(first.closed)
+        self.assertEqual(str(raised.exception), expected_exc)
+        payload = json.loads(str(raised.exception).split("failed: ", 1)[1])
+        self.assertEqual(payload, {"code": -32000, "message": expected_message})
+        surface = exception_chain_text(raised.exception)
+        for fragment in (data_secret, tail_secret, long_message, *SECRET_FRAGMENTS):
+            self.assertNotIn(fragment, surface)
+        self.assertNotIn('"data"', surface)
+        self.assertNotIn('"extra"', surface)
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+        echoed = f"execution reverted at {SECRET_ENDPOINT}"
+        expected_redacted = _without_absolute_urls(echoed)
+        echoed_error = jsonrpc_error_response(
+            {
+                "code": -32000,
+                "message": echoed,
+                "data": {"endpoint": SECRET_ENDPOINT, "credential": data_secret},
+                "extra": data_secret,
+            }
+        )
+        with patch("_shared.rpc.urlopen", return_value=echoed_error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        payload = json.loads(str(raised.exception).split("failed: ", 1)[1])
+        self.assertEqual(
+            payload, {"code": -32000, "message": expected_redacted}
+        )
+        self.assertIn("<redacted-url>", payload["message"])
+        surface = exception_chain_text(raised.exception)
+        for fragment in (*SECRET_FRAGMENTS, data_secret):
+            self.assertNotIn(fragment, surface)
+        self.assertNotIn("https://", str(raised.exception))
+        self.assertNotIn('"data"', surface)
+        self.assertNotIn('"extra"', surface)
+
+    def test_http_200_5000_digit_json_integer_retries_then_recovers(self) -> None:
+        oversized = b'{"result":' + (b"1" * 5000) + b"}"
+        first = Response(oversized)
+        with patch("_shared.rpc.urlopen", side_effect=[first]) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RuntimeError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_chainId", [], attempts=1, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(first.closed)
+        surface = exception_chain_text(raised.exception)
+        self.assertIn("RPC response was invalid", surface)
+        self.assertNotIn("1" * 32, surface)
+        self.assertNotIn("5000 digits", surface)
+        self.assertNotIn("4300 digits", surface)
+        self.assertTrue(
+            any(
+                isinstance(node, TransportError) and node.retryable
+                for node in walk_exception_chain(raised.exception)
+            )
+        )
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, RpcError)
+
+        first = Response(oversized)
+        responses = [first, Response(b'{"result":"0x14a34"}')]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
 
 
 if __name__ == "__main__":

--- a/scripts/test_shared_rpc.py
+++ b/scripts/test_shared_rpc.py
@@ -20,11 +20,15 @@ if str(SCRIPTS) not in sys.path:
 from _shared.rpc import (
     BASE_CHAIN_ID,
     BASE_RPC_ENDPOINTS,
+    MAX_RPC_ERROR_BODY_BYTES,
+    MAX_RPC_ERROR_MESSAGE_CHARS,
     RETRYABLE_HTTP_STATUS,
+    RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR,
     RpcError,
     TransportError,
     _redact_endpoint,
     _validate_chain,
+    _without_absolute_urls,
     is_retryable_http_status,
     is_retryable_transport_output,
     rpc,
@@ -113,14 +117,39 @@ def request_method(request: object) -> str:
     return str(json.loads(getattr(request, "data").decode("utf-8"))["method"])
 
 
+def http_error_with_json(
+    url: str,
+    status: int,
+    body: dict[str, object],
+    reason: str = "upstream",
+) -> HTTPError:
+    payload = json.dumps(body).encode("utf-8")
+    return HTTPError(url, status, reason, {}, io.BytesIO(payload))
+
+
 def jsonrpc_http_error(
     url: str,
     status: int,
     error: dict[str, object],
     reason: str = "upstream",
+    *,
+    response_id: object = 1,
 ) -> HTTPError:
-    payload = json.dumps({"error": error}).encode("utf-8")
-    return HTTPError(url, status, reason, {}, io.BytesIO(payload))
+    return http_error_with_json(
+        url,
+        status,
+        {"jsonrpc": "2.0", "id": response_id, "error": error},
+        reason,
+    )
+
+
+def envelopeless_gateway_http_error(
+    url: str,
+    status: int,
+    error: dict[str, object],
+    reason: str = "upstream",
+) -> HTTPError:
+    return http_error_with_json(url, status, {"error": error}, reason)
 
 
 class RpcTest(unittest.TestCase):
@@ -445,6 +474,744 @@ class RpcTest(unittest.TestCase):
         for node in walk_exception_chain(raised.exception):
             self.assertNotIsInstance(node, HTTPError)
             self.assertNotIsInstance(node, TransportError)
+
+    def test_envelopeless_gateway_errors_retry_then_recover(self) -> None:
+        cases = (
+            (429, "Too Many Requests", "too many requests"),
+            (500, "Internal Server Error", "internal"),
+            (503, "Service Unavailable", "unavailable"),
+        )
+        for status, message, reason in cases:
+            with self.subTest(status=status):
+                first = envelopeless_gateway_http_error(
+                    SECRET_ENDPOINT,
+                    status,
+                    {"code": status, "message": message},
+                    reason,
+                )
+                responses = [first, Response(b'{"result":"0x14a34"}')]
+                with patch(
+                    "_shared.rpc.urlopen", side_effect=responses
+                ) as opened, patch("_shared.rpc.time.sleep") as slept:
+                    self.assertEqual(
+                        rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                        "0x14a34",
+                    )
+                self.assertEqual(opened.call_count, 2)
+                slept.assert_called_once_with(0.25)
+                self.assertTrue(first.closed)
+                self.assertTrue(first.fp.closed)
+
+    def test_envelopeless_gateway_errors_fail_over_target_method(self) -> None:
+        for status, message, reason in (
+            (429, "Too Many Requests", "too many requests"),
+            (500, "Internal Server Error", "internal"),
+            (503, "Service Unavailable", "unavailable"),
+        ):
+            with self.subTest(status=status):
+                seen: list[tuple[str, str]] = []
+
+                def open_response(request: object, **_kwargs: object) -> Response:
+                    url = str(getattr(request, "full_url"))
+                    method = request_method(request)
+                    seen.append((url, method))
+                    if method == "eth_chainId":
+                        return Response(b'{"result":"0x2105"}')
+                    if url == SECRET_ENDPOINT:
+                        raise envelopeless_gateway_http_error(
+                            SECRET_ENDPOINT,
+                            status,
+                            {"code": status, "message": message},
+                            reason,
+                        )
+                    return Response(b'{"result":"0xabc"}')
+
+                with patch(
+                    "_shared.rpc.urlopen", side_effect=open_response
+                ), patch("_shared.rpc.time.sleep"):
+                    result = rpc_failover(
+                        "eth_blockNumber",
+                        [],
+                        endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                        max_retries=1,
+                    )
+                self.assertEqual(result, "0xabc")
+                self.assertEqual(
+                    seen,
+                    [
+                        (SECRET_ENDPOINT, "eth_chainId"),
+                        (SECRET_ENDPOINT, "eth_blockNumber"),
+                        ("https://second.local", "eth_chainId"),
+                        ("https://second.local", "eth_blockNumber"),
+                    ],
+                )
+
+    def test_http_500_jsonrpc_matching_custom_request_id_never_retries(self) -> None:
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": "execution reverted"},
+            response_id=7,
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaisesRegex(RpcError, "execution reverted") as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], 7, attempts=3, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(error.closed)
+        self.assertIn('"code": -32000', str(raised.exception))
+        self.assertIn('"message": "execution reverted"', str(raised.exception))
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+    def test_http_500_jsonrpc_null_id_parse_error_never_retries(self) -> None:
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32700, "message": "Parse error"},
+            response_id=None,
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaisesRegex(RpcError, "Parse error") as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(error.closed)
+        self.assertIn('"code": -32700', str(raised.exception))
+        self.assertIn('"message": "Parse error"', str(raised.exception))
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+    def test_http_500_jsonrpc_null_id_invalid_request_never_fails_over(self) -> None:
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32600, "message": "Invalid Request"},
+            response_id=None,
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ), self.assertRaisesRegex(RpcError, "Invalid Request") as raised:
+            rpc_failover(
+                "eth_call",
+                [{"to": "0x00"}],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(opened.call_count, 1)
+        self.assertTrue(error.closed)
+        self.assertIn('"code": -32600', str(raised.exception))
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+    def test_http_429_jsonrpc_null_id_application_error_retries_then_recovers(
+        self,
+    ) -> None:
+        first = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            429,
+            {"code": 429, "message": "Too Many Requests"},
+            response_id=None,
+        )
+        responses = [first, Response(b'{"result":"0x14a34"}')]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
+
+    def test_http_429_jsonrpc_id_mismatch_retries_then_recovers(self) -> None:
+        first = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            429,
+            {"code": -32000, "message": "execution reverted"},
+            response_id=999,
+        )
+        responses = [first, Response(b'{"result":"0x14a34"}')]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
+
+    def test_http_500_jsonrpc_id_mismatch_retries_then_recovers(self) -> None:
+        first = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": "execution reverted"},
+            response_id="other",
+        )
+        responses = [first, Response(b'{"result":"0x14a34"}')]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
+
+    def test_http_500_jsonrpc_missing_id_retries_then_recovers(self) -> None:
+        first = http_error_with_json(
+            SECRET_ENDPOINT,
+            500,
+            {
+                "jsonrpc": "2.0",
+                "error": {"code": -32000, "message": "execution reverted"},
+            },
+            "internal",
+        )
+        responses = [first, Response(b'{"result":"0x14a34"}')]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
+
+    def test_http_429_jsonrpc_version_mismatch_retries_then_recovers(self) -> None:
+        first = http_error_with_json(
+            SECRET_ENDPOINT,
+            429,
+            {
+                "jsonrpc": "1.0",
+                "id": 1,
+                "error": {"code": -32000, "message": "execution reverted"},
+            },
+            "too many requests",
+        )
+        responses = [first, Response(b'{"result":"0x14a34"}')]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
+
+    def test_malformed_http_jsonrpc_envelopes_use_http_classifier(self) -> None:
+        valid_error = {"code": -32000, "message": "execution reverted"}
+        cases = (
+            {"jsonrpc": "2.0", "id": True, "error": valid_error},
+            {"jsonrpc": "2.0", "id": "1", "error": valid_error},
+            {"jsonrpc": "2.0", "id": 1.0, "error": valid_error},
+            {"jsonrpc": "2.0", "id": 1, "result": None, "error": valid_error},
+            {"jsonrpc": "2.0", "id": 1, "error": []},
+            {"jsonrpc": "2.0", "id": 1, "error": {"code": True, "message": "bad"}},
+            {"jsonrpc": "2.0", "id": 1, "error": {"code": -32000.0, "message": "bad"}},
+            {"jsonrpc": "2.0", "id": 1, "error": {"code": -32000, "message": 7}},
+            {"jsonrpc": "2.0", "id": None, "error": {"code": True, "message": "bad"}},
+        )
+        for envelope in cases:
+            with self.subTest(envelope=envelope):
+                first = http_error_with_json(SECRET_ENDPOINT, 500, envelope)
+                with patch(
+                    "_shared.rpc.urlopen",
+                    side_effect=[first, Response(b'{"result":"0x14a34"}')],
+                ) as opened, patch("_shared.rpc.time.sleep") as slept:
+                    result = rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0)
+                self.assertEqual(result, "0x14a34")
+                self.assertEqual(opened.call_count, 2)
+                slept.assert_called_once_with(0)
+                self.assertTrue(first.closed)
+
+    def test_string_request_id_binds_only_string_response_id(self) -> None:
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": "string id error"},
+            response_id="request-1",
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaisesRegex(RpcError, "string id error"):
+            rpc(SECRET_ENDPOINT, "eth_call", [], "request-1")  # type: ignore[arg-type]
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+
+    def test_http_jsonrpc_long_valid_message_is_confirmed_truncated_rpc_error(
+        self,
+    ) -> None:
+        data_secret = "rpc-error-data-secret-marker"
+        tail_secret = "rpc-error-message-tail-secret"
+        indicator = RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR
+        keep = max(MAX_RPC_ERROR_MESSAGE_CHARS - len(indicator), 0)
+        long_message = ("x" * keep) + tail_secret
+        self.assertGreater(len(long_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        expected_message = (long_message[:keep] + indicator)[:MAX_RPC_ERROR_MESSAGE_CHARS]
+        self.assertEqual(len(expected_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        self.assertTrue(expected_message.endswith(indicator))
+        simple_body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32000, "message": "x" * 4097},
+            }
+        ).encode("utf-8")
+        self.assertEqual(len(simple_body), 4166)
+        self.assertLessEqual(len(simple_body), MAX_RPC_ERROR_BODY_BYTES)
+        error_fields: dict[str, object] = {
+            "code": -32000,
+            "message": long_message,
+            "data": {"credential": data_secret, "endpoint": SECRET_ENDPOINT},
+            "extra": data_secret,
+        }
+        expected_exc = (
+            "RPC eth_call failed: "
+            + json.dumps(
+                {"code": -32000, "message": expected_message},
+                sort_keys=True,
+            )
+        )
+
+        def assert_safe_rpc_error(exc: BaseException) -> None:
+            self.assertEqual(str(exc), expected_exc)
+            payload = json.loads(str(exc).split("failed: ", 1)[1])
+            self.assertEqual(
+                payload, {"code": -32000, "message": expected_message}
+            )
+            self.assertLessEqual(len(payload["message"]), MAX_RPC_ERROR_MESSAGE_CHARS)
+            self.assertLessEqual(len(str(exc)), len(expected_exc))
+            surface = exception_chain_text(exc)
+            for fragment in (
+                data_secret,
+                tail_secret,
+                long_message,
+                *SECRET_FRAGMENTS,
+            ):
+                self.assertNotIn(fragment, surface)
+            self.assertNotIn('"data"', surface)
+            self.assertNotIn('"extra"', surface)
+            for node in walk_exception_chain(exc):
+                self.assertNotIsInstance(node, HTTPError)
+                self.assertNotIsInstance(node, TransportError)
+
+        first = jsonrpc_http_error(SECRET_ENDPOINT, 500, error_fields)
+        with patch("_shared.rpc.urlopen", side_effect=first) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0.25)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(first.closed)
+        self.assertTrue(first.fp.closed)
+        assert_safe_rpc_error(raised.exception)
+
+        seen: list[tuple[str, str]] = []
+
+        def open_response(request: object, **_kwargs: object) -> Response:
+            url = str(getattr(request, "full_url"))
+            method = request_method(request)
+            seen.append((url, method))
+            if method == "eth_chainId":
+                return Response(b'{"result":"0x2105"}')
+            raise jsonrpc_http_error(url, 500, error_fields)
+
+        with patch("_shared.rpc.urlopen", side_effect=open_response) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc_failover(
+                "eth_call",
+                [],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(
+            seen,
+            [(SECRET_ENDPOINT, "eth_chainId"), (SECRET_ENDPOINT, "eth_call")],
+        )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_not_called()
+        assert_safe_rpc_error(raised.exception)
+
+    def test_http_jsonrpc_message_at_char_bound_is_not_truncated(self) -> None:
+        message = "z" * MAX_RPC_ERROR_MESSAGE_CHARS
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": message},
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(error.closed)
+        self.assertIn(message, str(raised.exception))
+        self.assertNotIn(RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR, str(raised.exception))
+
+    def test_http_jsonrpc_body_over_byte_limit_uses_http_classifier(self) -> None:
+        envelope = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32000, "message": "execution reverted"},
+            }
+        ).encode("utf-8")
+        cases = (
+            (MAX_RPC_ERROR_BODY_BYTES, True),
+            (MAX_RPC_ERROR_BODY_BYTES + 1, False),
+        )
+        for size, confirmed in cases:
+            with self.subTest(size=size, confirmed=confirmed):
+                raw = envelope + (b" " * (size - len(envelope)))
+                self.assertEqual(len(raw), size)
+                first = HTTPError(
+                    SECRET_ENDPOINT,
+                    500,
+                    "internal",
+                    {},
+                    io.BytesIO(raw),
+                )
+                if confirmed:
+                    with patch(
+                        "_shared.rpc.urlopen", side_effect=first
+                    ) as opened, patch("_shared.rpc.time.sleep") as slept, self.assertRaises(
+                        RpcError
+                    ) as raised:
+                        rpc(
+                            SECRET_ENDPOINT,
+                            "eth_call",
+                            [],
+                            attempts=3,
+                            retry_delay=0.25,
+                        )
+                    self.assertEqual(opened.call_count, 1)
+                    slept.assert_not_called()
+                    self.assertIn('"code": -32000', str(raised.exception))
+                    self.assertIn('"message": "execution reverted"', str(raised.exception))
+                    self.assertNotIn('"data"', str(raised.exception))
+                    for node in walk_exception_chain(raised.exception):
+                        self.assertNotIsInstance(node, HTTPError)
+                        self.assertNotIsInstance(node, TransportError)
+                else:
+                    with patch(
+                        "_shared.rpc.urlopen",
+                        side_effect=[first, Response(b'{"result":"0x14a34"}')],
+                    ) as opened, patch("_shared.rpc.time.sleep") as slept:
+                        result = rpc(
+                            SECRET_ENDPOINT,
+                            "eth_chainId",
+                            [],
+                            retry_delay=0.25,
+                        )
+                    self.assertEqual(result, "0x14a34")
+                    self.assertEqual(opened.call_count, 2)
+                    slept.assert_called_once_with(0.25)
+                self.assertTrue(first.closed)
+                self.assertTrue(first.fp.closed)
+
+    def test_http_jsonrpc_short_message_echoing_secret_endpoint_is_redacted(
+        self,
+    ) -> None:
+        raw_message = f"execution reverted at {SECRET_ENDPOINT}"
+        expected_message = _without_absolute_urls(raw_message)
+        self.assertIn("<redacted-url>", expected_message)
+        self.assertNotIn(SECRET_ENDPOINT, expected_message)
+        self.assertLessEqual(len(expected_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        error_fields: dict[str, object] = {
+            "code": -32000,
+            "message": raw_message,
+            "data": {"endpoint": SECRET_ENDPOINT, "credential": "leaked-query"},
+        }
+        expected_exc = (
+            "RPC eth_call failed: "
+            + json.dumps({"code": -32000, "message": expected_message}, sort_keys=True)
+        )
+
+        def assert_redacted_rpc_error(exc: BaseException) -> None:
+            self.assertEqual(str(exc), expected_exc)
+            payload = json.loads(str(exc).split("failed: ", 1)[1])
+            self.assertEqual(payload, {"code": -32000, "message": expected_message})
+            self.assertNotIn(RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR, payload["message"])
+            surface = exception_chain_text(exc)
+            for fragment in SECRET_FRAGMENTS:
+                self.assertNotIn(fragment, surface)
+            self.assertNotIn("https://", str(exc))
+            self.assertNotIn("http://", str(exc))
+            self.assertNotIn('"data"', surface)
+            for node in walk_exception_chain(exc):
+                self.assertNotIsInstance(node, HTTPError)
+                self.assertNotIsInstance(node, TransportError)
+
+        first = jsonrpc_http_error(SECRET_ENDPOINT, 500, error_fields)
+        with patch("_shared.rpc.urlopen", side_effect=first) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0.25)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(first.closed)
+        self.assertTrue(first.fp.closed)
+        assert_redacted_rpc_error(raised.exception)
+
+        seen: list[tuple[str, str]] = []
+
+        def open_response(request: object, **_kwargs: object) -> Response:
+            url = str(getattr(request, "full_url"))
+            method = request_method(request)
+            seen.append((url, method))
+            if method == "eth_chainId":
+                return Response(b'{"result":"0x2105"}')
+            raise jsonrpc_http_error(url, 500, error_fields)
+
+        with patch("_shared.rpc.urlopen", side_effect=open_response) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc_failover(
+                "eth_call",
+                [],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(
+            seen,
+            [(SECRET_ENDPOINT, "eth_chainId"), (SECRET_ENDPOINT, "eth_call")],
+        )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_not_called()
+        assert_redacted_rpc_error(raised.exception)
+
+    def test_http_jsonrpc_long_message_echoing_secret_endpoint_is_redacted_and_truncated(
+        self,
+    ) -> None:
+        indicator = RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR
+        keep = max(MAX_RPC_ERROR_MESSAGE_CHARS - len(indicator), 0)
+        placeholder = _without_absolute_urls(SECRET_ENDPOINT)
+        self.assertEqual(placeholder, "<redacted-url>")
+        # Spaces stop the absolute-URL matcher from consuming the filler.
+        filler_len = MAX_RPC_ERROR_MESSAGE_CHARS - (2 * len(placeholder) + 2) + 1
+        filler = "x" * filler_len
+        long_message = f"{SECRET_ENDPOINT} {filler} {SECRET_ENDPOINT}"
+        self.assertGreater(len(long_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        redacted = _without_absolute_urls(long_message)
+        self.assertEqual(redacted, f"{placeholder} {filler} {placeholder}")
+        self.assertGreater(len(redacted), MAX_RPC_ERROR_MESSAGE_CHARS)
+        expected_message = (redacted[:keep] + indicator)[:MAX_RPC_ERROR_MESSAGE_CHARS]
+        self.assertEqual(len(expected_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        self.assertTrue(expected_message.endswith(indicator))
+        self.assertTrue(expected_message.startswith(placeholder))
+        expected_exc = (
+            "RPC eth_call failed: "
+            + json.dumps({"code": -32000, "message": expected_message}, sort_keys=True)
+        )
+
+        def assert_redacted_truncated(exc: BaseException) -> None:
+            self.assertEqual(str(exc), expected_exc)
+            payload = json.loads(str(exc).split("failed: ", 1)[1])
+            self.assertEqual(payload, {"code": -32000, "message": expected_message})
+            self.assertLessEqual(len(payload["message"]), MAX_RPC_ERROR_MESSAGE_CHARS)
+            surface = exception_chain_text(exc)
+            for fragment in SECRET_FRAGMENTS:
+                self.assertNotIn(fragment, surface)
+            self.assertNotIn("https://", str(exc))
+            self.assertNotIn("http://", str(exc))
+            for node in walk_exception_chain(exc):
+                self.assertNotIsInstance(node, HTTPError)
+                self.assertNotIsInstance(node, TransportError)
+
+        first = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": long_message, "data": SECRET_ENDPOINT},
+        )
+        with patch("_shared.rpc.urlopen", side_effect=first) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0.25)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(first.closed)
+        self.assertTrue(first.fp.closed)
+        assert_redacted_truncated(raised.exception)
+
+        expanding = ("http://a " * (MAX_RPC_ERROR_MESSAGE_CHARS // 9 + 10)).rstrip()
+        expanded = _without_absolute_urls(expanding)
+        self.assertGreater(len(expanded), len(expanding))
+        self.assertGreater(len(expanded), MAX_RPC_ERROR_MESSAGE_CHARS)
+        expansion_error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": expanding},
+        )
+        with patch("_shared.rpc.urlopen", side_effect=expansion_error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        payload = json.loads(str(raised.exception).split("failed: ", 1)[1])
+        self.assertEqual(len(payload["message"]), MAX_RPC_ERROR_MESSAGE_CHARS)
+        self.assertTrue(payload["message"].endswith(indicator))
+        self.assertNotIn("http://", payload["message"])
+        for fragment in SECRET_FRAGMENTS:
+            self.assertNotIn(fragment, exception_chain_text(raised.exception))
+
+    def test_http_jsonrpc_unicode_long_message_rendered_output_is_bounded(
+        self,
+    ) -> None:
+        indicator = RPC_ERROR_MESSAGE_TRUNCATION_INDICATOR
+        keep = max(MAX_RPC_ERROR_MESSAGE_CHARS - len(indicator), 0)
+        char = "\u03b1"
+        long_message = char * (MAX_RPC_ERROR_MESSAGE_CHARS + 8)
+        expected_message = (char * keep) + indicator
+        self.assertEqual(len(expected_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        self.assertGreater(len(long_message), MAX_RPC_ERROR_MESSAGE_CHARS)
+        expected_exc = (
+            "RPC eth_call failed: "
+            + json.dumps({"code": -32000, "message": expected_message}, sort_keys=True)
+        )
+        unbounded = json.dumps(
+            {"code": -32000, "message": long_message}, sort_keys=True
+        )
+        bounded_json = json.dumps(
+            {"code": -32000, "message": expected_message}, sort_keys=True
+        )
+        self.assertLess(len(bounded_json), len(unbounded))
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": long_message},
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaises(RpcError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(error.closed)
+        self.assertEqual(str(raised.exception), expected_exc)
+        payload = json.loads(str(raised.exception).split("failed: ", 1)[1])
+        self.assertEqual(payload, {"code": -32000, "message": expected_message})
+        self.assertLessEqual(len(payload["message"]), MAX_RPC_ERROR_MESSAGE_CHARS)
+        self.assertLessEqual(len(str(raised.exception)), len(expected_exc))
+        self.assertLess(
+            len(str(raised.exception)),
+            len("RPC eth_call failed: ") + len(unbounded),
+        )
+        self.assertLessEqual(
+            len(str(raised.exception)),
+            256 + (MAX_RPC_ERROR_MESSAGE_CHARS * 12),
+        )
+        surface = exception_chain_text(raised.exception)
+        for fragment in SECRET_FRAGMENTS:
+            self.assertNotIn(fragment, surface)
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+    def test_http_jsonrpc_oversized_body_with_secret_message_uses_http_classifier(
+        self,
+    ) -> None:
+        envelope = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "code": -32000,
+                    "message": f"execution reverted at {SECRET_ENDPOINT}",
+                },
+            }
+        ).encode("utf-8")
+        size = MAX_RPC_ERROR_BODY_BYTES + 1
+        raw = envelope + (b" " * (size - len(envelope)))
+        self.assertEqual(len(raw), size)
+        self.assertGreater(len(raw), MAX_RPC_ERROR_BODY_BYTES)
+        first = HTTPError(
+            SECRET_ENDPOINT,
+            500,
+            "internal",
+            {},
+            io.BytesIO(raw),
+        )
+        with patch(
+            "_shared.rpc.urlopen",
+            side_effect=[first, Response(b'{"result":"0x14a34"}')],
+        ) as opened, patch("_shared.rpc.time.sleep") as slept:
+            result = rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25)
+        self.assertEqual(result, "0x14a34")
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
+        self.assertTrue(first.fp.closed)
+
+    def test_caught_http_rpc_error_exposes_only_code_and_message(self) -> None:
+        secret_marker = "rpc-error-data-secret-marker"
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {
+                "code": -32000,
+                "message": "execution reverted",
+                "data": {"credential": secret_marker},
+                "extra": secret_marker,
+            },
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error), self.assertRaises(
+            RpcError
+        ) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=1)
+        surface = exception_chain_text(raised.exception)
+        self.assertIn('"code": -32000', surface)
+        self.assertIn('"message": "execution reverted"', surface)
+        self.assertNotIn(secret_marker, surface)
+        self.assertNotIn('"data"', surface)
+        self.assertNotIn('"extra"', surface)
+
+    def test_matching_http_rpc_error_stops_on_target_method(self) -> None:
+        seen: list[tuple[str, str]] = []
+
+        def open_response(request: object, **_kwargs: object) -> Response:
+            url = str(getattr(request, "full_url"))
+            method = request_method(request)
+            seen.append((url, method))
+            if method == "eth_chainId":
+                return Response(b'{"result":"0x2105"}')
+            raise jsonrpc_http_error(
+                url,
+                500,
+                {"code": -32000, "message": "execution reverted"},
+            )
+
+        with patch("_shared.rpc.urlopen", side_effect=open_response), patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaisesRegex(RpcError, "execution reverted"):
+            rpc_failover(
+                "eth_call",
+                [],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(
+            seen,
+            [(SECRET_ENDPOINT, "eth_chainId"), (SECRET_ENDPOINT, "eth_call")],
+        )
+        slept.assert_not_called()
 
     def test_http_error_response_is_closed(self) -> None:
         error = HTTPError(

--- a/scripts/test_shared_rpc.py
+++ b/scripts/test_shared_rpc.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import io
 import json
 import sys
+import traceback
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -19,15 +20,77 @@ if str(SCRIPTS) not in sys.path:
 from _shared.rpc import (
     BASE_CHAIN_ID,
     BASE_RPC_ENDPOINTS,
+    RETRYABLE_HTTP_STATUS,
     RpcError,
     TransportError,
     _redact_endpoint,
     _validate_chain,
+    is_retryable_http_status,
     is_retryable_transport_output,
     rpc,
     rpc_failover,
     select_working_base_rpc,
 )
+
+SECRET_ENDPOINT = (
+    "https://leaked-user:leaked-pass@rpc.example/v2/leaked-path"
+    "?api_key=leaked-query#leaked-frag"
+)
+SECRET_FRAGMENTS = (
+    SECRET_ENDPOINT,
+    "leaked-user",
+    "leaked-pass",
+    "leaked-path",
+    "leaked-query",
+    "leaked-frag",
+    "/v2/leaked-path",
+    "api_key=leaked-query",
+    "leaked-user:leaked-pass",
+)
+
+
+def walk_exception_chain(exc: BaseException | None) -> list[BaseException]:
+    seen: set[int] = set()
+    ordered: list[BaseException] = []
+
+    def visit(node: BaseException | None) -> None:
+        if node is None or id(node) in seen:
+            return
+        seen.add(id(node))
+        ordered.append(node)
+        visit(getattr(node, "__cause__", None))
+        visit(getattr(node, "__context__", None))
+        for inner in getattr(node, "exceptions", ()) or ():
+            if isinstance(inner, BaseException):
+                visit(inner)
+
+    visit(exc)
+    return ordered
+
+
+def _text_value(value: object) -> str | None:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def exception_chain_text(exc: BaseException) -> str:
+    chunks: list[str] = ["".join(traceback.format_exception(exc))]
+    for node in walk_exception_chain(exc):
+        chunks.extend((str(node), repr(node), repr(getattr(node, "args", ()))))
+        for name in ("filename", "url", "msg", "reason", "message"):
+            text = _text_value(getattr(node, name, None))
+            if text is not None:
+                chunks.append(text)
+        getter = getattr(node, "geturl", None)
+        if callable(getter):
+            try:
+                chunks.append(str(getter()))
+            except (AttributeError, TypeError, ValueError, OSError):
+                pass
+    return "\n".join(chunks)
 
 
 class Response(io.BytesIO):
@@ -48,6 +111,16 @@ class Response(io.BytesIO):
 
 def request_method(request: object) -> str:
     return str(json.loads(getattr(request, "data").decode("utf-8"))["method"])
+
+
+def jsonrpc_http_error(
+    url: str,
+    status: int,
+    error: dict[str, object],
+    reason: str = "upstream",
+) -> HTTPError:
+    payload = json.dumps({"error": error}).encode("utf-8")
+    return HTTPError(url, status, reason, {}, io.BytesIO(payload))
 
 
 class RpcTest(unittest.TestCase):
@@ -242,20 +315,279 @@ class RpcTest(unittest.TestCase):
 
     def test_endpoint_redaction_removes_all_secret_locations(self) -> None:
         value = _redact_endpoint(
-            "https://user:pass@rpc.example/v2/secret?api_key=also-secret"
+            "https://user:pass@rpc.example/v2/secret?api_key=also-secret#frag"
         )
         self.assertEqual(value, "https://rpc.example")
         self.assertNotIn("secret", value)
         self.assertNotIn("user", value)
+        self.assertNotIn("frag", value)
 
     def test_cast_transport_classifier_excludes_json_rpc_errors(self) -> None:
         self.assertTrue(is_retryable_transport_output("HTTP error 429: over rate limit"))
         self.assertTrue(is_retryable_transport_output("connection reset by peer"))
+        self.assertTrue(is_retryable_transport_output("HTTP error 501: not implemented"))
+        self.assertTrue(is_retryable_transport_output("HTTP 599"))
+        self.assertFalse(is_retryable_transport_output("HTTP error 401: unauthorized"))
         self.assertFalse(
             is_retryable_transport_output(
                 "JSON-RPC error: execution reverted"
             )
         )
+        self.assertFalse(
+            is_retryable_transport_output(
+                "JSON-RPC error: upstream returned HTTP 501"
+            )
+        )
+        self.assertFalse(
+            is_retryable_transport_output(
+                "JSON-RPC error: upstream returned HTTP 500"
+            )
+        )
+
+    def test_retryable_http_status_covers_every_5xx(self) -> None:
+        self.assertTrue(is_retryable_http_status(408))
+        self.assertTrue(is_retryable_http_status(429))
+        self.assertTrue(is_retryable_http_status(500))
+        self.assertTrue(is_retryable_http_status(501))
+        self.assertTrue(is_retryable_http_status(599))
+        self.assertEqual(RETRYABLE_HTTP_STATUS, frozenset({408, 429, *range(500, 600)}))
+        self.assertFalse(is_retryable_http_status(400))
+        self.assertFalse(is_retryable_http_status(401))
+        self.assertFalse(is_retryable_http_status(499))
+        self.assertFalse(is_retryable_http_status(600))
+
+    def test_http_500_jsonrpc_error_body_never_retries(self) -> None:
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": "execution reverted"},
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaisesRegex(RpcError, "execution reverted") as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(error.closed)
+        self.assertTrue(error.fp.closed)
+        self.assertIn('"code": -32000', str(raised.exception))
+        self.assertIn('"message": "execution reverted"', str(raised.exception))
+        surface = exception_chain_text(raised.exception)
+        for fragment in SECRET_FRAGMENTS:
+            self.assertNotIn(fragment, surface)
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+    def test_http_501_jsonrpc_error_body_never_retries(self) -> None:
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            501,
+            {"code": -32601, "message": "method not found"},
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept, self.assertRaisesRegex(RpcError, "method not found") as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=3, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        slept.assert_not_called()
+        self.assertTrue(error.closed)
+        self.assertTrue(error.fp.closed)
+        self.assertIn('"code": -32601', str(raised.exception))
+        self.assertIn('"message": "method not found"', str(raised.exception))
+        surface = exception_chain_text(raised.exception)
+        for fragment in SECRET_FRAGMENTS:
+            self.assertNotIn(fragment, surface)
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+    def test_http_500_jsonrpc_error_body_never_fails_over(self) -> None:
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            500,
+            {"code": -32000, "message": "execution reverted"},
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ), self.assertRaisesRegex(RpcError, "execution reverted") as raised:
+            rpc_failover(
+                "eth_call",
+                [{"to": "0x00"}],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(opened.call_count, 1)
+        self.assertTrue(error.closed)
+        self.assertIn('"code": -32000', str(raised.exception))
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+    def test_http_501_jsonrpc_error_body_never_fails_over(self) -> None:
+        error = jsonrpc_http_error(
+            SECRET_ENDPOINT,
+            501,
+            {"code": -32601, "message": "method not found"},
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ), self.assertRaisesRegex(RpcError, "method not found") as raised:
+            rpc_failover(
+                "eth_call",
+                [{"to": "0x00"}],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(opened.call_count, 1)
+        self.assertTrue(error.closed)
+        self.assertIn('"code": -32601', str(raised.exception))
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            self.assertNotIsInstance(node, TransportError)
+
+    def test_http_error_response_is_closed(self) -> None:
+        error = HTTPError(
+            SECRET_ENDPOINT,
+            503,
+            "unavailable",
+            {},
+            io.BytesIO(b"<html>unavailable</html>"),
+        )
+        with patch("_shared.rpc.urlopen", side_effect=error) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ), self.assertRaises(RuntimeError):
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=1, retry_delay=0)
+        self.assertEqual(opened.call_count, 1)
+        self.assertTrue(error.closed)
+        self.assertTrue(error.fp.closed)
+
+    def test_http_500_without_jsonrpc_error_body_still_retries(self) -> None:
+        first = HTTPError(
+            SECRET_ENDPOINT,
+            500,
+            "internal",
+            {},
+            io.BytesIO(b"<html>fail</html>"),
+        )
+        responses = [first, Response(b'{"result":"0x14a34"}')]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+        self.assertTrue(first.closed)
+
+    def test_http_501_retries_then_recovers_on_same_endpoint(self) -> None:
+        responses = [
+            HTTPError(SECRET_ENDPOINT, 501, "not implemented", {}, None),
+            Response(b'{"result":"0x14a34"}'),
+        ]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            self.assertEqual(
+                rpc(SECRET_ENDPOINT, "eth_chainId", [], retry_delay=0.25),
+                "0x14a34",
+            )
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once_with(0.25)
+
+    def test_http_599_retries_then_uses_same_endpoint(self) -> None:
+        responses = [
+            Response(b"{}", 599),
+            Response(b'{"result":"0x2105"}'),
+        ]
+        with patch("_shared.rpc.urlopen", side_effect=responses) as opened, patch(
+            "_shared.rpc.time.sleep"
+        ) as slept:
+            selected = select_working_base_rpc(
+                endpoints=(SECRET_ENDPOINT,),
+                max_retries=3,
+            )
+        self.assertEqual(selected, SECRET_ENDPOINT)
+        self.assertEqual(opened.call_count, 2)
+        slept.assert_called_once()
+
+    def test_confirmed_json_rpc_error_never_retries_after_http_501(self) -> None:
+        seen: list[tuple[str, str]] = []
+
+        def open_response(request: object, **_kwargs: object) -> Response:
+            url = str(getattr(request, "full_url"))
+            method = request_method(request)
+            seen.append((url, method))
+            if url == SECRET_ENDPOINT and method == "eth_chainId" and seen == [
+                (SECRET_ENDPOINT, "eth_chainId")
+            ]:
+                raise HTTPError(SECRET_ENDPOINT, 501, "not implemented", {}, None)
+            if method == "eth_chainId":
+                return Response(b'{"result":"0x2105"}')
+            return Response(
+                b'{"error":{"code":-32000,"message":"execution reverted"}}'
+            )
+
+        with patch("_shared.rpc.urlopen", side_effect=open_response), patch(
+            "_shared.rpc.time.sleep"
+        ), self.assertRaisesRegex(RpcError, "execution reverted"):
+            rpc_failover(
+                "eth_call",
+                [{"to": "0x00"}],
+                endpoints=(SECRET_ENDPOINT, "https://second.local"),
+                max_retries=3,
+            )
+        self.assertEqual(
+            seen,
+            [
+                (SECRET_ENDPOINT, "eth_chainId"),
+                (SECRET_ENDPOINT, "eth_chainId"),
+                (SECRET_ENDPOINT, "eth_call"),
+            ],
+        )
+        self.assertNotIn("https://second.local", [url for url, _method in seen])
+
+    def test_exception_chain_cannot_retain_secret_bearing_urls(self) -> None:
+        error = HTTPError(SECRET_ENDPOINT, 501, "not implemented", {}, None)
+        with patch("_shared.rpc.urlopen", side_effect=error), patch(
+            "_shared.rpc.time.sleep"
+        ), self.assertRaises(RuntimeError) as raised:
+            rpc(SECRET_ENDPOINT, "eth_call", [], attempts=1, retry_delay=0)
+        surface = exception_chain_text(raised.exception)
+        for fragment in SECRET_FRAGMENTS:
+            self.assertNotIn(fragment, surface)
+        self.assertIn("HTTP 501", str(raised.exception))
+        self.assertIn("https://rpc.example", str(raised.exception))
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, HTTPError)
+            filename = getattr(node, "filename", None)
+            if isinstance(filename, str):
+                for fragment in SECRET_FRAGMENTS:
+                    self.assertNotIn(fragment, filename)
+
+    def test_urlerror_context_cannot_retain_secret_bearing_urls(self) -> None:
+        nested = URLError("timed out")
+        nested.filename = SECRET_ENDPOINT
+        with patch("_shared.rpc.urlopen", side_effect=nested), patch(
+            "_shared.rpc.time.sleep"
+        ), self.assertRaises(RuntimeError) as raised:
+            rpc_failover(
+                "eth_chainId",
+                [],
+                endpoints=(SECRET_ENDPOINT,),
+                max_retries=1,
+            )
+        surface = exception_chain_text(raised.exception)
+        for fragment in SECRET_FRAGMENTS:
+            self.assertNotIn(fragment, surface)
+        for node in walk_exception_chain(raised.exception):
+            self.assertNotIsInstance(node, URLError)
+            filename = getattr(node, "filename", None)
+            if isinstance(filename, str):
+                for fragment in SECRET_FRAGMENTS:
+                    self.assertNotIn(fragment, filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- inspect JSON-RPC error bodies carried inside HTTP 500 and 501 responses before transport retry logic
- preserve the original RPC error code and message without retrying or failing over
- close caught HTTP error responses deterministically while keeping non-JSON server failures retryable

This is a narrow transport-hardening contribution against current `main`. It is unrelated to the retired bounty and makes no bounty claim.

## Tests

- `python3 -W error::ResourceWarning -m unittest scripts.test_shared_rpc -q` (27/27)
- `python3 -m unittest scripts.test_activate_routed_v3_replacements -q` (19/19)
- `python3 scripts/test_bounty_inventory_guard.py -q` (17/17)
- `WORKSPACE_ROOT=. python3 benchmarks/direct-inventory-v1/rpc-failover/check.py`
- `python3 -m py_compile ...`
- `git diff --check HEAD^ HEAD`

## Related work

PRs #884, #910, and #1024 overlap with or discuss nearby RPC transport behavior. This PR is intentionally limited to current-main HTTP error-body precedence and response cleanup.
