### PR TITLE
Fix Beta3 settlement sync, metrics, and service attribution

### DIFF
--- a/crates/api/fixtures/openapi-contract.json
+++ b/crates/api/fixtures/openapi-contract.json
@@ -1,4 +1,4 @@
 {
   "schema_version": "agent-bounties/openapi-contract-v1",
-  "normalized_sha256": "9e501f7121e9cb617168879992cc48a56dfbdb05184506188af7407189c060f6"
+  "normalized_sha256": "60e37acd7ac9e6c4b5c6cdc6d5948a27f340db1739348fcb1faf591cdb14cfea"
 }

--- a/crates/api/fixtures/public-metrics-policy.json
+++ b/crates/api/fixtures/public-metrics-policy.json
@@ -12,5 +12,11 @@
     "system"
   ],
   "maintainer_wallets": [],
+  "excluded_bounty_contracts": [
+    "0x3e052b933628b960d61654a68fca23d869d8989f",
+    "0xaa4a9300bb1c90f93b4048fd83298da6c6145734",
+    "0xf8c8897e748e4057d52182c27beb4025f4d49d68",
+    "0x5f884d4a4cc2727ddbc22382efd776274bc3e7aa"
+  ],
   "wallet_ownership_boundary": "Wallet ownership is never inferred. Only addresses deliberately added to this public policy are excluded as maintainer-controlled."
 }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -242,6 +242,7 @@ use worker::{
         open_competition_v2_api::prepare_proof,
         open_competition_v2_api::prepare_action,
         open_competition_v2_api::get_proof_job,
+        open_competition_v2_api::proof_attribution,
         open_competition_v2_api::pay_proof_job,
         open_competition_v2_api::authorize_proof_job_relay,
         get_standing_meta_v4_readiness,
@@ -1550,6 +1551,7 @@ struct PublicMetricsPolicy {
     maintainer_github_logins: Vec<String>,
     maintainer_comment_authors: Vec<String>,
     maintainer_wallets: Vec<String>,
+    excluded_bounty_contracts: Vec<String>,
     wallet_ownership_boundary: String,
 }
 
@@ -1605,6 +1607,7 @@ struct PlatformPayoutMetricsResponse {
     lifetime: PlatformAmountResponse,
     selected_solver_pay: PlatformAmountResponse,
     selected_verifier_pay: PlatformAmountResponse,
+    selected_keeper_pay: PlatformAmountResponse,
     selected_completion_bonus: PlatformAmountResponse,
     selected_settled_rounds: u64,
     previous_settled_rounds: u64,
@@ -1650,6 +1653,7 @@ struct PlatformCoverageResponse {
     status: String,
     autonomous_indexer_fresh: bool,
     open_competition_indexer_fresh: bool,
+    open_competition_v2_indexer_fresh: bool,
     verified_canonical_events: u64,
     awaiting_block_time_events: u64,
     opportunity_comments: u64,
@@ -2016,11 +2020,12 @@ struct OpenCompetitionInventorySummary {
 struct PlatformCanonicalSourceFreshness {
     autonomous: bool,
     open_competition: bool,
+    open_competition_v2: bool,
 }
 
 impl PlatformCanonicalSourceFreshness {
     fn complete(self) -> bool {
-        self.autonomous && self.open_competition
+        self.autonomous && self.open_competition && self.open_competition_v2
     }
 }
 
@@ -5163,6 +5168,12 @@ fn public_metrics_policy() -> Result<PublicMetricsPolicy, StatusCode> {
         .map(|value| value.trim().to_ascii_lowercase())
         .filter(|value| !value.is_empty())
         .collect();
+    policy.excluded_bounty_contracts = policy
+        .excluded_bounty_contracts
+        .into_iter()
+        .map(|value| normalize_evm_address(&value).map(|value| value.to_ascii_lowercase()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(policy)
 }
 
@@ -5286,7 +5297,7 @@ fn platform_metrics_response(
     );
     definitions.insert(
         "marketplace_payout_volume".to_string(),
-        "Confirmed solver reward, verifier reward, and completion bonus from block-time-verified BountySettled events across Autonomous and Open Competition, plus verifier pay from block-time-verified SubmissionRejected and CompetitionSubmissionRejected events. Returned bonds, refunds, funding plans, and prizes are excluded.".to_string(),
+        "Confirmed solver, verifier, keeper, and completion-bonus payouts from canonical BountySettled and CompetitionSettledV2 events, plus verifier pay from canonical rejection events. Returned bonds, refunds, funding plans, prizes, and declared synthetic canaries are excluded.".to_string(),
     );
     definitions.insert(
         "mature_claim_to_settlement".to_string(),
@@ -5345,6 +5356,7 @@ fn platform_metrics_response(
             lifetime: platform_amount(stats.payouts.lifetime_total_base_units)?,
             selected_solver_pay: platform_amount(stats.payouts.selected_solver_base_units)?,
             selected_verifier_pay: platform_amount(stats.payouts.selected_verifier_base_units)?,
+            selected_keeper_pay: platform_amount(stats.payouts.selected_keeper_base_units)?,
             selected_completion_bonus: platform_amount(stats.payouts.selected_bonus_base_units)?,
             selected_settled_rounds: stats.payouts.selected_settled_rounds,
             previous_settled_rounds: stats.payouts.previous_settled_rounds,
@@ -5378,6 +5390,7 @@ fn platform_metrics_response(
             status: coverage_status.to_string(),
             autonomous_indexer_fresh: source_freshness.autonomous,
             open_competition_indexer_fresh: source_freshness.open_competition,
+            open_competition_v2_indexer_fresh: source_freshness.open_competition_v2,
             verified_canonical_events: stats.coverage.verified_canonical_events,
             awaiting_block_time_events: stats.coverage.awaiting_block_time_events,
             opportunity_comments: stats.coverage.opportunity_comments,
@@ -5399,7 +5412,7 @@ fn platform_metrics_response(
             ],
         },
         definitions,
-        evidence_boundary: "This public response contains aggregate counts and amounts only. Canonical metrics use events whose Base block time has been verified. It returns no wallet, GitHub, comment-author, event, transaction, or customer identifiers. GitHub participation is intentionally generated as a separate aggregate snapshot to avoid double counting. Only confirmed canonical BountySettled proves solver payment.".to_string(),
+        evidence_boundary: "This public response contains aggregate counts and amounts only. Canonical metrics use block-time-verified legacy events and safe-block V2 events. It returns no wallet, GitHub, comment-author, event, transaction, or customer identifiers. GitHub participation is intentionally generated as a separate aggregate snapshot to avoid double counting. Only BountySettled or CompetitionSettledV2 proves solver payment.".to_string(),
     })
 }
 
@@ -5435,6 +5448,7 @@ async fn platform_canonical_source_freshness(
         return PlatformCanonicalSourceFreshness {
             autonomous: false,
             open_competition: false,
+            open_competition_v2: false,
         };
     };
     let autonomous = if let Some(factory) = autonomous_factory_for_chain(8_453) {
@@ -5456,9 +5470,19 @@ async fn platform_canonical_source_freshness(
             .is_some_and(|heartbeat| public_metrics_indexer_heartbeat_fresh(&heartbeat, now)),
         Err(_) => false,
     };
+    let open_competition_v2 =
+        match open_competition_v2_api::release_from_environment("base-mainnet") {
+            Ok(release) => {
+                open_competition_v2_api::current_indexer_agreement(state, "base-mainnet", &release)
+                    .await
+                    .is_ok()
+            }
+            Err(_) => false,
+        };
     PlatformCanonicalSourceFreshness {
         autonomous,
         open_competition,
+        open_competition_v2,
     }
 }
 
@@ -5482,7 +5506,10 @@ async fn platform_metrics(
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     let window = platform_metric_window(query.period.as_deref(), Utc::now())?;
     let policy = public_metrics_policy()?;
-    let excluded_contracts = state.recovery_reservations.contracts();
+    let mut excluded_contracts = state.recovery_reservations.contracts();
+    excluded_contracts.extend(policy.excluded_bounty_contracts.iter().cloned());
+    excluded_contracts.sort();
+    excluded_contracts.dedup();
     let stats = store
         .platform_metrics_stats(
             "base-mainnet",
@@ -19529,6 +19556,7 @@ mod tests {
                 lifetime_total_base_units: "1350000".to_string(),
                 selected_solver_base_units: "1000000".to_string(),
                 selected_verifier_base_units: "200000".to_string(),
+                selected_keeper_base_units: "0".to_string(),
                 selected_bonus_base_units: "50000".to_string(),
                 selected_settled_rounds: 1,
                 previous_settled_rounds: 0,
@@ -19566,12 +19594,17 @@ mod tests {
             PlatformCanonicalSourceFreshness {
                 autonomous: true,
                 open_competition: true,
+                open_competition_v2: true,
             },
         )
         .unwrap();
         let json = serde_json::to_string(&response).unwrap();
 
         assert_eq!(response.marketplace_payout_volume.selected.usdc, "1.250000");
+        assert_eq!(
+            response.marketplace_payout_volume.selected_keeper_pay.usdc,
+            "0.000000"
+        );
         assert_eq!(
             response.mature_claim_to_settlement.settlement_rate,
             Some(0.5)
@@ -19663,6 +19696,7 @@ mod tests {
                         lifetime_total_base_units: "0".to_string(),
                         selected_solver_base_units: "0".to_string(),
                         selected_verifier_base_units: "0".to_string(),
+                        selected_keeper_base_units: "0".to_string(),
                         selected_bonus_base_units: "0".to_string(),
                         selected_settled_rounds: 0,
                         previous_settled_rounds: 0,
@@ -19694,6 +19728,7 @@ mod tests {
                 PlatformCanonicalSourceFreshness {
                     autonomous: true,
                     open_competition: true,
+                    open_competition_v2: true,
                 },
             )
             .unwrap()
@@ -19799,6 +19834,7 @@ mod tests {
             "/v1/base/open-competition-v2-beta3/events",
             "/v1/base/open-competition-v2-beta3/proof-quotes",
             "/v1/base/open-competition-v2-beta3/proof-preparation",
+            "/v1/base/open-competition-v2-beta3/proof-attribution",
             "/v1/base/open-competition-v2-beta3/action-preparation",
             "/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}",
             "/v1/base/open-competition-v2-beta3/proof-jobs/{job_id}/payment",

--- a/crates/api/src/open_competition_v2_api.rs
+++ b/crates/api/src/open_competition_v2_api.rs
@@ -8,14 +8,16 @@ use axum::{
 };
 use chain_base::{
     fetch_block_number, fetch_exact_block_identity, fetch_transaction_receipt,
-    plan_open_competition_v2_action, plan_open_competition_v2_broker_payment,
-    plan_open_competition_v2_creation, plan_open_competition_v2_funding,
-    plan_open_competition_v2_proof, validate_open_competition_v2_release, ChainBaseError,
+    normalize_evm_address, plan_open_competition_v2_action,
+    plan_open_competition_v2_broker_payment, plan_open_competition_v2_creation,
+    plan_open_competition_v2_funding, plan_open_competition_v2_proof,
+    validate_open_competition_v2_release, ChainBaseError,
     OpenCompetitionV2BrokerPaymentAuthorization, OpenCompetitionV2CreateParams,
-    OpenCompetitionV2CreationRequest, OpenCompetitionV2ProgramClassification,
-    OpenCompetitionV2ProofSystem, OpenCompetitionV2Release, OpenCompetitionV2ScoreDirection,
-    OpenCompetitionV2WinnerMode, OPEN_COMPETITION_V2_BASE_SEPOLIA_USDC,
-    OPEN_COMPETITION_V2_BASE_USDC, OPEN_COMPETITION_V2_PROTOCOL_VERSION,
+    OpenCompetitionV2CreationRequest, OpenCompetitionV2EventKind,
+    OpenCompetitionV2ProgramClassification, OpenCompetitionV2ProofSystem, OpenCompetitionV2Release,
+    OpenCompetitionV2ScoreDirection, OpenCompetitionV2WinnerMode,
+    OPEN_COMPETITION_V2_BASE_SEPOLIA_USDC, OPEN_COMPETITION_V2_BASE_USDC,
+    OPEN_COMPETITION_V2_PROTOCOL_VERSION,
 };
 use chrono::{DateTime, Utc};
 use competition_metric_core::{
@@ -82,6 +84,10 @@ pub(crate) fn router() -> Router<SharedState> {
         .route(
             "/v1/base/open-competition-v2-beta3/proof-preparation",
             post(prepare_proof),
+        )
+        .route(
+            "/v1/base/open-competition-v2-beta3/proof-attribution",
+            get(proof_attribution),
         )
         .route(
             "/v1/base/open-competition-v2-beta3/action-preparation",
@@ -206,6 +212,13 @@ pub(crate) struct ProofQuoteBody {
     artifact_hash: String,
     relay: bool,
     metric: ProofMetricBody,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProofAttributionQuery {
+    network: Option<String>,
+    competition_contract: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -842,6 +855,104 @@ pub(crate) async fn get_proof_job(
         "job": job,
         "next_action": proof_job_next_action(job.state),
         "evidence_boundary": "Only canonical payment and refund evidence attached to the job proves money movement. A hosted state alone does not."
+    })))
+}
+
+#[utoipa::path(get, path = "/v1/base/open-competition-v2-beta3/proof-attribution", params(("network" = Option<String>, Query, description = "Base network"), ("competition_contract" = String, Query, description = "Exact competition contract")), responses((status = 200, description = "Public hosted-proof, x402, relay, and settlement attribution"), (status = 404, description = "No hosted proof jobs found")))]
+pub(crate) async fn proof_attribution(
+    State(state): State<SharedState>,
+    Query(query): Query<ProofAttributionQuery>,
+) -> ApiResult {
+    let network = network_or_default(query.network);
+    let competition_contract =
+        normalize_evm_address(&query.competition_contract).map_err(|_| {
+            bad_request(
+                "proof_attribution",
+                "competition_contract_invalid",
+                "Use the exact EVM competition contract address.",
+            )
+        })?;
+    let release = release_from_environment(&network)?;
+    current_indexer_agreement(&state, &network, &release).await?;
+    let store = state.store.as_ref().ok_or_else(database_unavailable)?;
+    let jobs = store
+        .list_open_competition_v2_proof_jobs_for_contract(&network, &competition_contract)
+        .await
+        .map_err(|error| {
+            service_error(
+                "proof_attribution",
+                "proof_job_read_failed",
+                error.to_string(),
+            )
+        })?;
+    if jobs.is_empty() {
+        return Err(not_found(
+            "proof_attribution",
+            "hosted_proof_jobs_not_found",
+        ));
+    }
+    let events = store
+        .list_open_competition_v2_events_for_contract(&network, &competition_contract)
+        .await
+        .map_err(|error| {
+            service_error(
+                "proof_attribution",
+                "canonical_event_read_failed",
+                error.to_string(),
+            )
+        })?;
+    let relayer = state.x402_relayer.address();
+    let attributed = jobs
+        .iter()
+        .map(|job| {
+            let settlement = events.iter().find(|event| {
+                event.kind == OpenCompetitionV2EventKind::CompetitionSettled
+                    && event
+                        .data
+                        .get("solver")
+                        .and_then(Value::as_str)
+                        .is_some_and(|solver| solver.eq_ignore_ascii_case(&job.solver))
+            });
+            json!({
+                "proof_job_id": job.id,
+                "solver_wallet": job.solver,
+                "state": job.state,
+                "x402_payment": {
+                    "payer": job.payer,
+                    "transaction_hash": job.payment_tx_hash,
+                    "canonical_evidence_recorded": job.payment_evidence.is_some()
+                },
+                "hosted_proof": {
+                    "used": job.proof_provider_job_id.is_some(),
+                    "provider": "agent-bounties-hosted-sp1",
+                    "provider_job_recorded": job.proof_provider_job_id.is_some()
+                },
+                "hosted_relay": {
+                    "requested": job.requested_relay,
+                    "used": job.relay_tx_hash.is_some(),
+                    "relayer_wallet": relayer,
+                    "transaction_hash": job.relay_tx_hash
+                },
+                "canonical_settlement": settlement.map(|event| json!({
+                    "event": "CompetitionSettledV2",
+                    "transaction_hash": event.tx_hash,
+                    "block_number": event.block_number,
+                    "solver_reward": event.data.get("solver_reward"),
+                    "keeper_wallet": event.data.get("keeper"),
+                    "keeper_reward": event.data.get("keeper_reward")
+                })),
+                "contactability": "wallet_only_unless_the_solver_registers_a_signed_contact_profile"
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(Json(json!({
+        "schema_version": "agent-bounties/open-competition-v2-proof-attribution-v1",
+        "protocol_version": OPEN_COMPETITION_V2_PROTOCOL_VERSION,
+        "network": network,
+        "competition_contract": competition_contract,
+        "jobs": attributed,
+        "identity_boundary": "A solver wallet is canonical attribution, not a verified person. Contact requires a separately signed contact profile.",
+        "evidence_boundary": "The proof-job record attributes hosted services. Only CompetitionSettledV2 proves solver and keeper payment."
     })))
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5854,7 +5854,11 @@ fn is_doc_contract_file(path: &Path) -> bool {
 
 fn load_api_routes(contract_root: &Path) -> Result<BTreeSet<String>> {
     let mut routes = BTreeSet::new();
-    for relative_path in ["crates/api/src/main.rs", "crates/mcp-server/src/main.rs"] {
+    for relative_path in [
+        "crates/api/src/main.rs",
+        "crates/api/src/open_competition_v2_api.rs",
+        "crates/mcp-server/src/main.rs",
+    ] {
         let source_path = contract_root.join(relative_path);
         let source = fs::read_to_string(&source_path)
             .with_context(|| format!("failed to read {}", source_path.display()))?;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -581,6 +581,7 @@ pub struct PlatformPayoutStats {
     pub lifetime_total_base_units: String,
     pub selected_solver_base_units: String,
     pub selected_verifier_base_units: String,
+    pub selected_keeper_base_units: String,
     pub selected_bonus_base_units: String,
     pub selected_settled_rounds: u64,
     pub previous_settled_rounds: u64,
@@ -2048,6 +2049,30 @@ impl PostgresStore {
                   'competition_submission_rejected', 'commitment_expired',
                   'bounty_settled', 'entry_bond_withdrawn', 'refund_withdrawn'
                 )
+            ), competition_v2_actors AS (
+              SELECT event.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(CASE
+                       WHEN event.kind = 'canonical_competition_created'
+                         THEN event.data->>'creator'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn')
+                         THEN event.data->>'contributor'
+                       ELSE event.data->>'solver'
+                     END) AS identity,
+                     CASE
+                       WHEN event.kind = 'canonical_competition_created' THEN 'poster'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn') THEN 'funder'
+                       ELSE 'solver'
+                     END AS role
+              FROM open_competition_v2_events AS event
+              WHERE event.network = $1
+                AND event.occurred_at >= $5
+                AND event.occurred_at < $3
+                AND NOT lower(event.contract_address) = ANY($9)
+                AND event.kind IN (
+                  'canonical_competition_created', 'funding_added',
+                  'entry_qualified', 'competition_settled', 'refund_withdrawn'
+                )
             ), verifier_actors AS (
               SELECT payout.occurred_at,
                      'base_wallet'::text AS namespace,
@@ -2114,6 +2139,11 @@ impl PostgresStore {
               UNION ALL
               SELECT occurred_at, namespace, identity, role
               FROM competition_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$'
+                AND NOT identity = ANY($7)
+              UNION ALL
+              SELECT occurred_at, namespace, identity, role
+              FROM competition_v2_actors
               WHERE identity ~ '^0x[0-9a-f]{40}$'
                 AND NOT identity = ANY($7)
               UNION ALL
@@ -2196,6 +2226,7 @@ impl PostgresStore {
                        THEN COALESCE((data->>'solver_reward')::numeric, 0)
                        ELSE 0 END AS solver_amount,
                      COALESCE((data->>'verifier_reward')::numeric, 0) AS verifier_amount,
+                     0::numeric AS keeper_amount,
                      CASE WHEN kind = 'bounty_settled'
                        THEN COALESCE((data->>'timeout_bond_bonus')::numeric, 0)
                        ELSE 0 END AS bonus_amount
@@ -2214,6 +2245,7 @@ impl PostgresStore {
                        THEN COALESCE((data->>'verifier_reward')::numeric, 0)
                        ELSE COALESCE((data->>'bond_paid_to_verifier')::numeric, 0)
                      END AS verifier_amount,
+                     0::numeric AS keeper_amount,
                      CASE WHEN kind = 'bounty_settled'
                        THEN COALESCE((data->>'timeout_bond_bonus')::numeric, 0)
                        ELSE 0 END AS bonus_amount
@@ -2223,8 +2255,20 @@ impl PostgresStore {
                 AND occurred_at >= $5
                 AND occurred_at < $3
                 AND kind IN ('bounty_settled', 'competition_submission_rejected')
+              UNION ALL
+              SELECT occurred_at, TRUE AS settled,
+                     COALESCE((data->>'solver_reward')::numeric, 0) AS solver_amount,
+                     0::numeric AS verifier_amount,
+                     COALESCE((data->>'keeper_reward')::numeric, 0) AS keeper_amount,
+                     0::numeric AS bonus_amount
+              FROM open_competition_v2_events
+              WHERE network = $1
+                AND occurred_at >= $5
+                AND occurred_at < $3
+                AND NOT lower(contract_address) = ANY($7)
+                AND kind = 'competition_settled'
             ), normalized AS (
-              SELECT *, solver_amount + verifier_amount + bonus_amount AS total_amount
+              SELECT *, solver_amount + verifier_amount + keeper_amount + bonus_amount AS total_amount
               FROM payouts
             )
             SELECT
@@ -2244,6 +2288,9 @@ impl PostgresStore {
               COALESCE(SUM(verifier_amount) FILTER (
                 WHERE occurred_at >= $2 AND occurred_at < $3
               ), 0)::text AS selected_verifier,
+              COALESCE(SUM(keeper_amount) FILTER (
+                WHERE occurred_at >= $2 AND occurred_at < $3
+              ), 0)::text AS selected_keeper,
               COALESCE(SUM(bonus_amount) FILTER (
                 WHERE occurred_at >= $2 AND occurred_at < $3
               ), 0)::text AS selected_bonus,
@@ -2266,6 +2313,7 @@ impl PostgresStore {
         .bind(previous_started_at)
         .bind(launch_at)
         .bind(first_month_ended_at)
+        .bind(excluded_bounty_contracts)
         .fetch_one(&self.pool)
         .await?;
 
@@ -2365,6 +2413,24 @@ impl PostgresStore {
                   'competition_submission_rejected', 'commitment_expired',
                   'bounty_settled', 'entry_bond_withdrawn', 'refund_withdrawn'
                 )
+            ), competition_v2_actors AS (
+              SELECT event.occurred_at,
+                     'base_wallet'::text AS namespace,
+                     lower(CASE
+                       WHEN event.kind = 'canonical_competition_created'
+                         THEN event.data->>'creator'
+                       WHEN event.kind IN ('funding_added', 'refund_withdrawn')
+                         THEN event.data->>'contributor'
+                       ELSE event.data->>'solver'
+                     END) AS identity
+              FROM open_competition_v2_events AS event
+              WHERE event.network = $1
+                AND event.occurred_at >= $2 AND event.occurred_at < $3
+                AND NOT lower(event.contract_address) = ANY($6)
+                AND event.kind IN (
+                  'canonical_competition_created', 'funding_added',
+                  'entry_qualified', 'competition_settled', 'refund_withdrawn'
+                )
             ), verifier_actors AS (
               SELECT payout.occurred_at,
                      'base_wallet'::text AS namespace,
@@ -2425,6 +2491,9 @@ impl PostgresStore {
               SELECT occurred_at, namespace, identity FROM competition_actors
               WHERE identity ~ '^0x[0-9a-f]{40}$' AND NOT identity = ANY($4)
               UNION ALL
+              SELECT occurred_at, namespace, identity FROM competition_v2_actors
+              WHERE identity ~ '^0x[0-9a-f]{40}$' AND NOT identity = ANY($4)
+              UNION ALL
               SELECT occurred_at, namespace, identity FROM verifier_actors
               WHERE identity ~ '^0x[0-9a-f]{40}$'
                 AND identity <> '0x0000000000000000000000000000000000000000'
@@ -2465,6 +2534,15 @@ impl PostgresStore {
                 AND block_time_verified = TRUE
                 AND occurred_at >= $2 AND occurred_at < $3
                 AND kind IN ('bounty_settled', 'competition_submission_rejected')
+              UNION ALL
+              SELECT occurred_at, TRUE AS settled,
+                     COALESCE((data->>'solver_reward')::numeric, 0)
+                     + COALESCE((data->>'keeper_reward')::numeric, 0) AS total_amount
+              FROM open_competition_v2_events
+              WHERE network = $1
+                AND occurred_at >= $2 AND occurred_at < $3
+                AND NOT lower(contract_address) = ANY($6)
+                AND kind = 'competition_settled'
             ), days AS (
               SELECT generate_series(
                 date_trunc('day', $2::timestamptz),
@@ -2510,6 +2588,11 @@ impl PostgresStore {
               FROM open_competition_events
               WHERE network = $1
                 AND occurred_at >= $2
+              UNION ALL
+              SELECT TRUE AS block_time_verified, occurred_at
+              FROM open_competition_v2_events
+              WHERE network = $1
+                AND occurred_at >= $2
             )
             SELECT
               COUNT(*) FILTER (WHERE block_time_verified = TRUE) AS verified_events,
@@ -2552,6 +2635,7 @@ impl PostgresStore {
                 lifetime_total_base_units: payout_row.try_get("lifetime_total")?,
                 selected_solver_base_units: payout_row.try_get("selected_solver")?,
                 selected_verifier_base_units: payout_row.try_get("selected_verifier")?,
+                selected_keeper_base_units: payout_row.try_get("selected_keeper")?,
                 selected_bonus_base_units: payout_row.try_get("selected_bonus")?,
                 selected_settled_rounds: u64_from_i64(payout_row.try_get("selected_settled")?)?,
                 previous_settled_rounds: u64_from_i64(payout_row.try_get("previous_settled")?)?,
@@ -6701,6 +6785,27 @@ impl PostgresStore {
         row.map(open_competition_v2_proof_job_from_row).transpose()
     }
 
+    pub async fn list_open_competition_v2_proof_jobs_for_contract(
+        &self,
+        network: &str,
+        competition_contract: &str,
+    ) -> DbResult<Vec<OpenCompetitionV2ProofJob>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT * FROM open_competition_v2_proof_jobs
+            WHERE network = $1 AND competition_contract = $2
+            ORDER BY created_at, id
+            "#,
+        )
+        .bind(network)
+        .bind(normalize_key_address(competition_contract))
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(open_competition_v2_proof_job_from_row)
+            .collect()
+    }
+
     pub async fn lease_next_open_competition_v2_proof_job(
         &self,
         lease_token: Uuid,
@@ -10365,6 +10470,50 @@ mod tests {
             }
         }
 
+        async fn add_competition_v2_settlement(
+            store: &PostgresStore,
+            network: &str,
+            factory_contract: &str,
+            block_number: u64,
+            contract_address: &str,
+            bounty_id: &str,
+            solver: &str,
+            occurred_at: DateTime<Utc>,
+        ) {
+            let block_hash = format!("0x{:064x}", block_number + 1);
+            store
+                .upsert_open_competition_v2_event(
+                    network,
+                    factory_contract,
+                    &OpenCompetitionV2Event {
+                        id: Uuid::new_v4(),
+                        protocol_version: chain_base::OPEN_COMPETITION_V2_PROTOCOL_VERSION
+                            .to_string(),
+                        log_key: format!("v2:{network}:{block_number}:0"),
+                        tx_hash: format!("0x{block_number:064x}"),
+                        block_number,
+                        log_index: 0,
+                        contract_address: contract_address.to_string(),
+                        bounty_id: bounty_id.to_string(),
+                        kind: OpenCompetitionV2EventKind::CompetitionSettled,
+                        data: serde_json::json!({
+                            "solver": solver,
+                            "solver_reward": 3_000_000,
+                            "keeper": "0x6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f6f",
+                            "keeper_reward": 40_000
+                        }),
+                        occurred_at,
+                    },
+                    &OpenCompetitionV2SafeContext {
+                        block_hash: block_hash.clone(),
+                        safe_block_number: block_number + 10,
+                        safe_block_hash: format!("0x{:064x}", block_number + 10),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
         let database_url = std::env::var("AGENT_BOUNTIES_TEST_DATABASE_URL").unwrap();
         let store = PostgresStore::connect(&database_url).await.unwrap();
         store.migrate().await.unwrap();
@@ -10414,6 +10563,30 @@ mod tests {
             true,
         )
         .await;
+
+        for (offset, solver) in [
+            "0x6868686868686868686868686868686868686868",
+            "0x7979797979797979797979797979797979797979",
+            "0x6868686868686868686868686868686868686868",
+            "0x6868686868686868686868686868686868686868",
+            "0x6868686868686868686868686868686868686868",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            block += 1;
+            add_competition_v2_settlement(
+                &store,
+                &network,
+                competition_factory,
+                block,
+                &format!("0x{:040x}", 0x600_u64 + offset as u64),
+                &format!("beta3-{offset}"),
+                solver,
+                at("2099-01-14T05:00:00Z") + chrono::Duration::minutes(offset as i64),
+            )
+            .await;
+        }
 
         block += 1;
         add_competition_event(
@@ -10838,23 +11011,24 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(stats.identities.selected, 11);
+        assert_eq!(stats.identities.selected, 13);
         assert_eq!(stats.identities.previous, 1);
-        assert_eq!(stats.identities.lifetime, 11);
+        assert_eq!(stats.identities.lifetime, 13);
         assert_eq!(stats.identities.posters, 1);
         assert_eq!(stats.identities.funders, 3);
-        assert_eq!(stats.identities.solvers, 6);
+        assert_eq!(stats.identities.solvers, 8);
         assert_eq!(stats.identities.verifiers, 1);
         assert_eq!(stats.identities.commenters, 1);
-        assert_eq!(stats.identities.marketplace_wallets, 10);
+        assert_eq!(stats.identities.marketplace_wallets, 12);
         assert_eq!(stats.identities.opportunity_comment_authors, 1);
         // Recovery reservations protect future earning and verification work; they
         // must not erase block-time-verified payouts from immutable history.
-        assert_eq!(stats.payouts.selected_total_base_units, "159725000");
-        assert_eq!(stats.payouts.selected_solver_base_units, "143000000");
+        assert_eq!(stats.payouts.selected_total_base_units, "174925000");
+        assert_eq!(stats.payouts.selected_solver_base_units, "158000000");
         assert_eq!(stats.payouts.selected_verifier_base_units, "16600000");
+        assert_eq!(stats.payouts.selected_keeper_base_units, "200000");
         assert_eq!(stats.payouts.selected_bonus_base_units, "125000");
-        assert_eq!(stats.payouts.selected_settled_rounds, 4);
+        assert_eq!(stats.payouts.selected_settled_rounds, 9);
         assert_eq!(stats.claim_cohort.settled, 1);
         assert_eq!(stats.claim_cohort.mature, 3);
         assert_eq!(stats.claim_cohort.immature, 1);
@@ -10865,9 +11039,14 @@ mod tests {
                 .iter()
                 .map(|day| day.payout_base_units.parse::<u128>().unwrap())
                 .sum::<u128>(),
-            159_725_000
+            174_925_000
         );
 
+        sqlx::query("DELETE FROM open_competition_v2_events WHERE network = $1")
+            .bind(&network)
+            .execute(&store.pool)
+            .await
+            .unwrap();
         sqlx::query("DELETE FROM open_competition_events WHERE network = $1")
             .bind(&network)
             .execute(&store.pool)

--- a/docs/open-competition-v2-beta3.md
+++ b/docs/open-competition-v2-beta3.md
@@ -1,8 +1,8 @@
 # Open Competition V2 Beta3
 
-Status: implementation beta, not deployed. Creation and hosted proving remain
-disabled until the release gates below produce matching evidence. V2 is
-opt-in and is not the default bounty protocol.
+Status: Base-mainnet public beta. Creation and hosted proving are enabled only
+while the immutable release and primary/shadow safe-block indexers agree. V2
+is opt-in and is not yet the default bounty protocol.
 
 The exact release procedure and current blockers are in
 [`open-competition-v2-beta3-release.md`](open-competition-v2-beta3-release.md).
@@ -208,6 +208,14 @@ selector, a journal mismatch, deterministic relay rejection, or an expired SLA
 becomes `refund_due`. HTTP 429, HTTP 5xx, and transport failures retry only
 until the SLA. Provider credentials are sent as an optional bearer token and
 are never included in proof-job records or public evidence.
+
+Hosted-service attribution is public at
+`GET /v1/base/open-competition-v2-beta3/proof-attribution`. Pass the exact
+`competition_contract`. The response joins each proof job to its x402 payment,
+the project SP1 prover record, hosted relayer wallet and transaction, and the
+safe-block `CompetitionSettledV2` event. It never claims that a wallet is a
+person. Private contact requires a separately signed, consented contact
+profile; permissionless direct solvers may remain pseudonymous.
 
 ## Program Catalog
 

--- a/scripts/check-postgres.ps1
+++ b/scripts/check-postgres.ps1
@@ -25,7 +25,7 @@ try {
             cargo test -p db tests::site_analytics_round_trip_executes_against_migrated_postgres -- --ignored --exact --nocapture
         }
         Invoke-Checked {
-            cargo test -p db tests::platform_metrics_query_enforces_identity_payment_and_cohort_boundaries -- --ignored --exact --nocapture
+            cargo test -p db tests::platform_metrics_query_separates_history_from_identity_and_cohort_boundaries -- --ignored --exact --nocapture
         }
         Invoke-Checked {
             cargo test -p db tests::opportunity_comment_round_trip_is_durable_and_idempotent -- --ignored --exact --nocapture

--- a/scripts/reconcile_github_bounty_labels.py
+++ b/scripts/reconcile_github_bounty_labels.py
@@ -27,12 +27,14 @@ from typing import Any, Callable, Mapping
 USER_AGENT = "agent-bounties-github-discovery/1"
 PROJECTION_SCHEMA = "agent-bounties/github-bounty-discovery-v1"
 POLICY_SCHEMA = "agent-bounties/github-bounty-discovery-policy-v1"
-SUPPORTED_PROTOCOLS = frozenset(
+CORE_DISCOVERY_PROTOCOLS = frozenset(
     {
         "agent-bounties/autonomous-v1",
         "agent-bounties/open-competition-v1",
     }
 )
+BETA3_PROTOCOL = "agent-bounties/open-competition-v2-beta3"
+SUPPORTED_PROTOCOLS = frozenset({*CORE_DISCOVERY_PROTOCOLS, BETA3_PROTOCOL})
 LIFECYCLE_STATES = frozenset(
     {
         "funding_needed",
@@ -104,7 +106,7 @@ LABEL_DEFINITIONS = {
 BOUNDARIES = (
     "GitHub is a discovery mirror, not a funding, verification, or settlement authority.",
     "A missing record never authorizes label removal or issue closure.",
-    "Only confirmed canonical BountySettled settlement_evidence proves payment.",
+    "Only confirmed canonical BountySettled or CompetitionSettledV2 evidence proves payment.",
 )
 
 
@@ -376,7 +378,7 @@ def validate_projection(payload: Any, network: str, policy: Mapping[str, Any]) -
         if not isinstance(action, dict):
             raise LabelReconciliationError(f"next action is malformed: {identity}")
         require_public_https_url(action.get("url"), f"{identity}.next_action.url")
-        if protocol == "agent-bounties/open-competition-v1" and mode != "first_valid_submission":
+        if protocol in {"agent-bounties/open-competition-v1", BETA3_PROTOCOL} and mode != "first_valid_submission":
             raise LabelReconciliationError(f"Open Competition mode mismatch: {identity}")
         if protocol == "agent-bounties/autonomous-v1" and mode != "exclusive_claim":
             raise LabelReconciliationError(f"autonomous-v1 mode mismatch: {identity}")
@@ -421,7 +423,8 @@ def validate_settlement(item: Mapping[str, Any]) -> Mapping[str, Any]:
     evidence = item.get("settlement_evidence")
     if not isinstance(evidence, dict):
         raise LabelReconciliationError(f"settled record lacks evidence: {identity}")
-    if evidence.get("event_name") != "BountySettled" or evidence.get("confirmed_canonical") is not True:
+    event_name = evidence.get("event_name")
+    if event_name not in {"BountySettled", "CompetitionSettledV2"} or evidence.get("confirmed_canonical") is not True:
         raise LabelReconciliationError(f"settlement is not canonical: {identity}")
     if (
         str(evidence.get("bounty_contract") or "").lower()
@@ -431,6 +434,21 @@ def validate_settlement(item: Mapping[str, Any]) -> Mapping[str, Any]:
     ):
         raise LabelReconciliationError(f"settlement identity is malformed: {identity}")
     solver_reward = require_unsigned(evidence.get("solver_reward"), "settlement.solver_reward")
+    if event_name == "CompetitionSettledV2":
+        keeper_reward = require_unsigned(evidence.get("keeper_reward"), "settlement.keeper_reward")
+        if (
+            str(item.get("protocol_version")) != BETA3_PROTOCOL
+            or not ADDRESS.fullmatch(str(evidence.get("keeper_wallet") or "").lower())
+            or solver_reward != require_unsigned(
+                item.get("reward_usdc_base_units"), "reward_usdc_base_units"
+            )
+            or keeper_reward != require_unsigned(
+                item.get("verifier_reward_usdc_base_units"),
+                "verifier_reward_usdc_base_units",
+            )
+        ):
+            raise LabelReconciliationError(f"CompetitionSettledV2 payout is inconsistent: {identity}")
+        return evidence
     returned_bond = require_unsigned(evidence.get("returned_bond"), "settlement.returned_bond")
     bonus = require_unsigned(evidence.get("completion_bonus"), "settlement.completion_bonus")
     payout = require_unsigned(evidence.get("solver_payout"), "settlement.solver_payout")
@@ -451,6 +469,305 @@ def fetch_projection(request: HttpRequest, api_base_url: str, network: str) -> d
     if result.status != 200 or not isinstance(result.body, dict):
         raise LabelReconciliationError(f"discovery projection returned HTTP {result.status}")
     return result.body
+
+
+def fetch_json_object(request: HttpRequest, url: str, label: str) -> dict[str, Any]:
+    result = request_with_retry(request, "GET", url)
+    if result.status != 200 or not isinstance(result.body, dict):
+        raise LabelReconciliationError(f"{label} returned HTTP {result.status}")
+    return result.body
+
+
+def opportunity_amount(opportunity: Mapping[str, Any], field: str) -> int:
+    amount = opportunity.get(field)
+    if not isinstance(amount, dict):
+        raise LabelReconciliationError(f"Beta3 opportunity lacks {field}")
+    if amount.get("currency") != "USDC" or amount.get("unit") != "base_units":
+        raise LabelReconciliationError(f"Beta3 opportunity has invalid {field} units")
+    return require_unsigned(amount.get("amount"), f"Beta3 opportunity {field}")
+
+
+def beta3_settlement_evidence(
+    opportunity: Mapping[str, Any],
+    competition: Mapping[str, Any],
+    events: list[dict[str, Any]],
+    safe_block: int,
+) -> dict[str, Any] | None:
+    state = str(competition.get("state") or "")
+    settled = [
+        event
+        for event in events
+        if event.get("kind") == "competition_settled"
+        and require_unsigned(event.get("block_number"), "Beta3 event block_number") <= safe_block
+    ]
+    if state != "settled":
+        if settled:
+            raise LabelReconciliationError("non-settled Beta3 competition exposes settlement")
+        return None
+    if len(settled) != 1:
+        raise LabelReconciliationError("settled Beta3 competition lacks one canonical settlement")
+    event = settled[0]
+    data = event.get("data")
+    if not isinstance(data, dict):
+        raise LabelReconciliationError("Beta3 settlement data is malformed")
+    contract = str(competition.get("competition") or "").lower()
+    bounty_id = str(competition.get("bounty_id") or "").lower()
+    solver = str(data.get("solver") or "").lower()
+    keeper = str(data.get("keeper") or "").lower()
+    solver_reward = require_unsigned(data.get("solver_reward"), "Beta3 solver_reward")
+    keeper_reward = require_unsigned(data.get("keeper_reward"), "Beta3 keeper_reward")
+    if (
+        str(event.get("contract_address") or "").lower() != contract
+        or str(event.get("bounty_id") or "").lower() != bounty_id
+        or solver != str(competition.get("winner") or "").lower()
+        or solver_reward != opportunity_amount(opportunity, "reward")
+        or solver_reward != require_unsigned(competition.get("solver_reward"), "solver_reward")
+        or keeper_reward != opportunity_amount(opportunity, "completion_bonus")
+        or keeper_reward != require_unsigned(competition.get("keeper_reward"), "keeper_reward")
+        or not ADDRESS.fullmatch(solver)
+        or not ADDRESS.fullmatch(keeper)
+        or not TX_HASH.fullmatch(str(event.get("tx_hash") or "").lower())
+    ):
+        raise LabelReconciliationError("Beta3 settlement does not match canonical inventory")
+    return {
+        "event_name": "CompetitionSettledV2",
+        "bounty_id": bounty_id,
+        "bounty_contract": contract,
+        "transaction_hash": str(event["tx_hash"]).lower(),
+        "block_number": require_unsigned(event.get("block_number"), "settlement block_number"),
+        "log_index": require_unsigned(event.get("log_index"), "settlement log_index"),
+        "solver_wallet": solver,
+        "solver_reward": str(solver_reward),
+        "keeper_wallet": keeper,
+        "keeper_reward": str(keeper_reward),
+        "confirmed_canonical": True,
+    }
+
+
+def beta3_lifecycle(state: str, verification_ready: bool) -> str:
+    if state == "settled":
+        return "settled"
+    if state == "cancelled":
+        return "cancelled"
+    if state == "expired":
+        return "expired"
+    if state == "funding":
+        return "funding_needed"
+    if state == "active" and verification_ready:
+        return "ready_to_earn"
+    return "unavailable"
+
+
+def beta3_discovery_competition_mode(winner_mode: object) -> str:
+    if winner_mode != "first_proven":
+        raise LabelReconciliationError(
+            "GitHub discovery cannot represent this Beta3 winner mode safely"
+        )
+    return "first_valid_submission"
+
+
+def augment_projection_with_beta3(
+    request: HttpRequest,
+    api_base_url: str,
+    network: str,
+    repository: str,
+    projection: Mapping[str, Any],
+) -> dict[str, Any]:
+    query = urllib.parse.urlencode({"network": network})
+    metrics = fetch_json_object(
+        request,
+        f"{api_base_url}/v1/metrics/platform?period=7d",
+        "platform metrics",
+    )
+    coverage = metrics.get("coverage")
+    beta3_fresh = (
+        coverage.get(
+            "open_competition_v2_indexer_fresh",
+            coverage.get("open_competition_indexer_fresh"),
+        )
+        if isinstance(coverage, dict)
+        else False
+    )
+    if (
+        not isinstance(coverage, dict)
+        or beta3_fresh is not True
+        or require_unsigned(coverage.get("awaiting_block_time_events"), "awaiting_block_time_events")
+        != 0
+    ):
+        raise LabelReconciliationError("Beta3 canonical indexer is degraded")
+    inventory = fetch_json_object(
+        request,
+        f"{api_base_url}/v1/base/open-competition-v2-beta3/inventory?{query}",
+        "Beta3 inventory",
+    )
+    event_feed = fetch_json_object(
+        request,
+        f"{api_base_url}/v1/base/open-competition-v2-beta3/events?{query}",
+        "Beta3 events",
+    )
+    opportunities = fetch_json_object(
+        request,
+        f"{api_base_url}/v1/opportunities?{urllib.parse.urlencode({'network': network, 'source_type': 'canonical_base', 'limit': 300})}",
+        "opportunity inventory",
+    )
+    if (
+        inventory.get("network") != network
+        or inventory.get("protocol_version") != BETA3_PROTOCOL
+        or event_feed.get("network") != network
+        or event_feed.get("protocol_version") != BETA3_PROTOCOL
+    ):
+        raise LabelReconciliationError("Beta3 canonical views disagree on protocol or network")
+    competitions = inventory.get("competitions")
+    events = event_feed.get("events")
+    opportunity_items = opportunities.get("items")
+    if (
+        not isinstance(competitions, list)
+        or not isinstance(events, list)
+        or not isinstance(opportunity_items, list)
+        or not all(isinstance(value, dict) for value in competitions + events + opportunity_items)
+    ):
+        raise LabelReconciliationError("Beta3 canonical views are malformed")
+    records: dict[str, tuple[dict[str, Any], int, str]] = {}
+    factories: set[str] = set()
+    for wrapped in competitions:
+        record = wrapped.get("record")
+        canonical = record.get("projection") if isinstance(record, dict) else None
+        if not isinstance(record, dict) or not isinstance(canonical, dict):
+            raise LabelReconciliationError("Beta3 inventory record is malformed")
+        contract = str(canonical.get("competition") or "").lower()
+        factory = str(record.get("factory_contract") or "").lower()
+        safe_number = require_unsigned(record.get("safe_block_number"), "Beta3 safe block")
+        safe_hash = str(record.get("safe_block_hash") or "").lower()
+        if (
+            not ADDRESS.fullmatch(contract)
+            or contract in records
+            or not ADDRESS.fullmatch(factory)
+            or not TX_HASH.fullmatch(safe_hash)
+            or record.get("network") != network
+        ):
+            raise LabelReconciliationError("Beta3 inventory identity is malformed or duplicated")
+        records[contract] = (canonical, safe_number, safe_hash)
+        factories.add(factory)
+    if len(factories) != 1:
+        raise LabelReconciliationError("Beta3 inventory does not have one factory")
+    selected = []
+    chain_id = require_unsigned(projection.get("chain_id"), "projection.chain_id")
+    for opportunity in opportunity_items:
+        requirements = opportunity.get("evidence_requirements")
+        if not isinstance(requirements, dict) or requirements.get("protocol_version") != BETA3_PROTOCOL:
+            continue
+        if parse_same_repository_issue(opportunity.get("source_url"), repository) is None:
+            continue
+        contract = str(opportunity.get("source_id") or "").lower()
+        record = records.get(contract)
+        if record is None:
+            raise LabelReconciliationError("public Beta3 opportunity is absent from canonical inventory")
+        canonical, safe_number, _ = record
+        bounty_id = str(canonical.get("bounty_id") or "").lower()
+        relevant = [
+            event
+            for event in events
+            if str(event.get("contract_address") or "").lower() == contract
+            and str(event.get("bounty_id") or "").lower() == bounty_id
+            and require_unsigned(event.get("block_number"), "Beta3 event block_number")
+            <= safe_number
+        ]
+        if not relevant:
+            raise LabelReconciliationError("public Beta3 opportunity lacks canonical events")
+        state = str(canonical.get("state") or "")
+        verification_ready = opportunity.get("verification_ready") is True
+        lifecycle = beta3_lifecycle(state, verification_ready)
+        competition_mode = beta3_discovery_competition_mode(
+            opportunity.get("winner_mode") or canonical.get("winner_mode")
+        )
+        target = opportunity_amount(opportunity, "funding_target")
+        settlement = beta3_settlement_evidence(opportunity, canonical, relevant, safe_number)
+        created_block = min(
+            require_unsigned(event.get("block_number"), "Beta3 event block_number")
+            for event in relevant
+        )
+        next_action = opportunity.get("next_action")
+        if not isinstance(next_action, dict):
+            raise LabelReconciliationError("public Beta3 opportunity lacks a next action")
+        selected.append(
+            {
+                "discovery_id": f"eip155:{chain_id}:{BETA3_PROTOCOL}:{contract}",
+                "network": network,
+                "chain_id": chain_id,
+                "protocol_version": BETA3_PROTOCOL,
+                "source_id": contract,
+                "visibility": "public",
+                "bounty_id": bounty_id,
+                "bounty_contract": contract,
+                "created_at": opportunity.get("created_at"),
+                "created_block": created_block,
+                "updated_at": opportunity.get("updated_at"),
+                "title": opportunity.get("title"),
+                "summary": opportunity.get("goal") or "",
+                "categories": opportunity.get("categories") or [],
+                "skills": opportunity.get("skills") or [],
+                "difficulty": None,
+                "public_url": opportunity.get("public_url"),
+                "source_url": opportunity.get("source_url"),
+                "competition_mode": competition_mode,
+                "lifecycle_state": lifecycle,
+                "funded": lifecycle in {"ready_to_earn", "settled"},
+                "verification_ready": verification_ready,
+                "ready_to_earn": lifecycle == "ready_to_earn",
+                "reward_usdc_base_units": str(opportunity_amount(opportunity, "reward")),
+                "verifier_reward_usdc_base_units": str(
+                    opportunity_amount(opportunity, "completion_bonus")
+                ),
+                "bond_usdc_base_units": str(opportunity_amount(opportunity, "bond")),
+                "funded_usdc_base_units": str(
+                    target
+                    if lifecycle == "settled"
+                    else opportunity_amount(opportunity, "funded_amount")
+                ),
+                "funding_target_usdc_base_units": str(target),
+                "deadline": opportunity.get("deadline"),
+                "deadline_kind": opportunity.get("deadline_kind"),
+                "entry_count": require_unsigned(opportunity.get("entry_count"), "entry_count"),
+                "max_entries": None,
+                "verifier": {
+                    "profile_id": opportunity.get("verifier_profile_id"),
+                    "display_name": opportunity.get("verifier_profile_name"),
+                    "method": opportunity.get("verification_method"),
+                    "ready": verification_ready,
+                },
+                "next_action": {
+                    "kind": next_action.get("action"),
+                    "label": "Inspect settlement" if lifecycle == "settled" else "Enter competition",
+                    "method": next_action.get("method"),
+                    "url": next_action.get("url"),
+                    "instructions": next_action.get("instructions"),
+                },
+                "recovery_action_available": False,
+                "identity_warning": "One wallet does not prove one independent person.",
+                "settlement_evidence": settlement,
+                "evidence_boundary": "Only CompetitionSettledV2 proves solver payment.",
+            }
+        )
+    result = dict(projection)
+    existing_items = result.get("items")
+    existing_sources = result.get("source_statuses")
+    if not isinstance(existing_items, list) or not isinstance(existing_sources, list):
+        raise LabelReconciliationError("core discovery projection is malformed")
+    result["items"] = [*existing_items, *selected]
+    result["source_statuses"] = [
+        *existing_sources,
+        {
+            "source_type": "open_competition_v2",
+            "protocol_version": BETA3_PROTOCOL,
+            "factory_contract": next(iter(factories)),
+            "available": True,
+            "fresh": True,
+            "item_count": len(selected),
+            "persisted_cursor_block": max((safe for _, safe, _ in records.values()), default=0),
+            "error": None,
+        },
+    ]
+    return result
 
 
 # The claim-comment workflow still consumes the autonomous-v1 full and earning
@@ -805,6 +1122,11 @@ def render_managed_block(item: Mapping[str, Any]) -> str:
                 "First valid confirmed reveal wins. Each wallet may enter once; an entry does not prove one independent person. Save the local commitment recovery envelope because the API never stores its plaintext salt.",
             ]
         )
+    payment_event = (
+        "CompetitionSettledV2"
+        if item.get("protocol_version") == BETA3_PROTOCOL
+        else "BountySettled"
+    )
     lines.extend(
         [
             "",
@@ -820,7 +1142,7 @@ def render_managed_block(item: Mapping[str, Any]) -> str:
     lines.extend(
         [
             "",
-            "> GitHub mirrors canonical public state and cannot fund, claim, verify, settle, or prove payment. Only a confirmed canonical `BountySettled` receipt below proves solver payment.",
+            f"> GitHub mirrors canonical public state and cannot fund, claim, verify, settle, or prove payment. Only a confirmed canonical `{payment_event}` receipt below proves solver payment.",
             MANAGED_END,
         ]
     )
@@ -901,25 +1223,44 @@ def build_settlement_receipt(item: Mapping[str, Any]) -> SettlementReceipt:
     fingerprint = hashlib.sha256(
         json.dumps(evidence, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
-    body = "\n".join(
+    lines = [
+        SETTLEMENT_RECEIPT_MARKER,
+        "## Canonical payout confirmed",
+        "",
+        f"- Bounty ID: `{evidence['bounty_id']}`",
+        f"- Contract: `{evidence['bounty_contract']}`",
+        f"- Settlement: [`{tx_hash}`]({settlement_transaction_url(str(item['network']), tx_hash)})",
+        f"- Solver wallet: `{evidence['solver_wallet']}`",
+        f"- Solver reward: **{format_usdc(evidence['solver_reward'])} USDC**",
+    ]
+    if evidence["event_name"] == "CompetitionSettledV2":
+        attribution_query = urllib.parse.urlencode(
+            {"network": item["network"], "competition_contract": evidence["bounty_contract"]}
+        )
+        lines.extend(
+            [
+                f"- Keeper wallet: `{evidence['keeper_wallet']}`",
+                f"- Keeper reward: **{format_usdc(evidence['keeper_reward'])} USDC**",
+                f"- Hosted proof and relay attribution: [inspect evidence](https://api.agentbounties.app/v1/base/open-competition-v2-beta3/proof-attribution?{attribution_query})",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                f"- Returned bond: **{format_usdc(evidence['returned_bond'])} USDC**",
+                f"- Completion bonus: **{format_usdc(evidence['completion_bonus'])} USDC**",
+                f"- Total solver transfer: **{format_usdc(evidence['solver_payout'])} USDC**",
+                f"- Verifier reward: **{format_usdc(evidence['verifier_reward'])} USDC**",
+            ]
+        )
+    lines.extend(
         [
-            SETTLEMENT_RECEIPT_MARKER,
-            "## Canonical payout confirmed",
-            "",
-            f"- Bounty ID: `{evidence['bounty_id']}`",
-            f"- Contract: `{evidence['bounty_contract']}`",
-            f"- Settlement: [`{tx_hash}`]({settlement_transaction_url(str(item['network']), tx_hash)})",
-            f"- Solver wallet: `{evidence['solver_wallet']}`",
-            f"- Solver reward: **{format_usdc(evidence['solver_reward'])} USDC**",
-            f"- Returned bond: **{format_usdc(evidence['returned_bond'])} USDC**",
-            f"- Completion bonus: **{format_usdc(evidence['completion_bonus'])} USDC**",
-            f"- Total solver transfer: **{format_usdc(evidence['solver_payout'])} USDC**",
-            f"- Verifier reward: **{format_usdc(evidence['verifier_reward'])} USDC**",
             f"- Receipt fingerprint: `{fingerprint}`",
             "",
-            "Only this confirmed canonical `BountySettled` event proves solver payment. This GitHub comment reports the event; it did not authorize or execute settlement.",
+            f"Only this confirmed canonical `{evidence['event_name']}` event proves solver payment. This GitHub comment reports the event; it did not authorize or execute settlement.",
         ]
     )
+    body = "\n".join(lines)
     return SettlementReceipt(fingerprint=fingerprint, body=body)
 
 
@@ -1346,6 +1687,9 @@ def main(argv: list[str] | None = None, request: HttpRequest = default_http_requ
         projection, issues, comments_by_issue = load_fixture(args.fixture)
     else:
         projection = fetch_projection(request, api_base_url, args.network)
+        projection = augment_projection_with_beta3(
+            request, api_base_url, args.network, repository, projection
+        )
         items = validate_projection(projection, args.network, policy)
         issues = fetch_github_issues(request, repository, token or None)
         issues = fetch_linked_source_issues(request, repository, token or None, items, issues)

--- a/scripts/test_reconcile_github_bounty_labels.py
+++ b/scripts/test_reconcile_github_bounty_labels.py
@@ -6,15 +6,16 @@ import json
 import os
 import tempfile
 import unittest
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
 from reconcile_github_bounty_labels import (
+    BETA3_PROTOCOL,
     LABEL_DEFINITIONS,
     MANAGED_START,
     HttpResult,
     LabelReconciliationError,
+    beta3_discovery_competition_mode,
     build_plans,
     execute_plans,
     fetch_github_issues,
@@ -157,6 +158,7 @@ def projection(*items: dict, degraded: bool = False) -> dict:
     competition_count = sum(
         record["protocol_version"] == "agent-bounties/open-competition-v1" for record in items
     )
+    beta3_count = sum(record["protocol_version"] == BETA3_PROTOCOL for record in items)
     return {
         "schema_version": "agent-bounties/github-bounty-discovery-v1",
         "generated_at": NOW,
@@ -188,6 +190,16 @@ def projection(*items: dict, degraded: bool = False) -> dict:
                 "available": not degraded,
                 "fresh": not degraded,
                 "item_count": competition_count,
+                "persisted_cursor_block": 49_799_500,
+                "error": None,
+            },
+            {
+                "source_type": "open_competition_v2",
+                "protocol_version": BETA3_PROTOCOL,
+                "factory_contract": "0x" + "3" * 40,
+                "available": not degraded,
+                "fresh": not degraded,
+                "item_count": beta3_count,
                 "persisted_cursor_block": 49_799_500,
                 "error": None,
             },
@@ -269,6 +281,14 @@ class FakeGitHub:
 
 
 class GitHubDiscoveryReconciliationTests(unittest.TestCase):
+    def test_beta3_discovery_rejects_unrepresentable_winner_mode(self) -> None:
+        self.assertEqual(
+            beta3_discovery_competition_mode("first_proven"),
+            "first_valid_submission",
+        )
+        with self.assertRaisesRegex(LabelReconciliationError, "winner mode safely"):
+            beta3_discovery_competition_mode("best_score")
+
     def test_workflow_is_least_privilege_concurrent_dry_run_by_default(self) -> None:
         workflow = Path(".github/workflows/bounty-inventory-guard.yml").read_text(encoding="utf-8")
         self.assertIn("issues: read", workflow)
@@ -410,6 +430,54 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
         )
         self.assertLess(comment_index, close_index)
         self.assertEqual(service.issues[12]["state_reason"], "completed")
+
+    def test_beta3_settlement_removes_earning_labels_and_records_keeper(self) -> None:
+        settled = item(
+            1059,
+            state="settled",
+            mode="first_valid_submission",
+            source_url=f"https://github.com/{REPOSITORY}/issues/1059",
+        )
+        contract = settled["bounty_contract"]
+        settled.update(
+            {
+                "discovery_id": f"eip155:{CHAIN_ID}:{BETA3_PROTOCOL}:{contract}",
+                "protocol_version": BETA3_PROTOCOL,
+                "reward_usdc_base_units": "3000000",
+                "verifier_reward_usdc_base_units": "40000",
+                "bond_usdc_base_units": "0",
+                "funded_usdc_base_units": "3040000",
+                "funding_target_usdc_base_units": "3040000",
+                "settlement_evidence": {
+                    "event_name": "CompetitionSettledV2",
+                    "bounty_id": settled["bounty_id"],
+                    "bounty_contract": contract,
+                    "transaction_hash": TX,
+                    "block_number": 49_799_005,
+                    "log_index": 435,
+                    "solver_wallet": "0x" + "9" * 40,
+                    "solver_reward": "3000000",
+                    "keeper_wallet": "0x" + "6" * 40,
+                    "keeper_reward": "40000",
+                    "confirmed_canonical": True,
+                },
+            }
+        )
+        source = issue(
+            1059,
+            labels=["bounty", "funded-live", "ready-to-earn", "claimable-live"],
+        )
+        plan = build_plans(projection(settled), [source], policy(), REPOSITORY)[0]
+        self.assertEqual(plan.desired_state, "closed")
+        self.assertEqual(plan.desired_state_reason, "completed")
+        self.assertIn("settled-paid", plan.add_labels)
+        self.assertEqual(
+            set(plan.remove_labels),
+            {"claimable-live", "funded-live", "ready-to-earn"},
+        )
+        self.assertIn("CompetitionSettledV2", plan.settlement_receipt.body)
+        self.assertIn("Keeper wallet", plan.settlement_receipt.body)
+        self.assertIn("0.04 USDC", plan.settlement_receipt.body)
 
     def test_execution_is_idempotent_and_preserves_unmanaged_labels(self) -> None:
         record = item(13, difficulty="beginner")


### PR DESCRIPTION
## Summary
- reconcile public Open Competition V2 Beta3 settlements into GitHub status labels and canonical receipts
- include safe-block Beta3 solver and keeper payouts in public platform metrics while excluding declared synthetic canaries
- expose wallet-level hosted proof, x402 payment, relay, and settlement attribution
- require all three canonical indexers to be fresh before reporting complete metrics coverage

## Expected production correction
- five settled Beta3 rounds become visible in public metrics
- payout volume increases by 15.20 USDC: 15.00 USDC solver rewards plus 0.20 USDC keeper rewards
- lifetime public totals become 54.77 USDC and 41 settled rounds
- GitHub issues #1059-#1063 close with canonical settlement receipts and lose stale earning labels

## Safety boundaries
- only safe-block `CompetitionSettledV2` proves Beta3 payment
- synthetic Beta3 canaries remain excluded from adoption metrics
- attribution identifies wallets and hosted service records, not a human identity
- GitHub remains a non-authoritative discovery mirror
- Beta3 winner modes the current GitHub model cannot represent fail closed

## Verification
- `cargo check -p db -p api`
- `cargo test -p db --lib` (26 passed, 11 DB-gated ignored)
- `cargo test -p api --bin api` (140 passed, 4 environment-gated ignored)
- exact ignored Postgres metrics integration test passed against Docker Postgres
- `python scripts/test_reconcile_github_bounty_labels.py -v` (16 passed)
- `python scripts/test_bounty_inventory_guard.py -v` (17 passed)
- `ruff check scripts/reconcile_github_bounty_labels.py scripts/test_reconcile_github_bounty_labels.py`
- `python scripts/check-site.py`
- `scripts/preflight.ps1 -Mode core`
- live production dry-run: 68 records, 54 covered, exactly 5 writes (#1059-#1063)
- `git diff --check`

Public maintainer notice: https://github.com/NSPG13/agent-bounties/issues/888#issuecomment-5365438651