### PR TITLE
Add protected V2 replenisher gas seed

### DIFF
--- a/.github/workflows/open-competition-v2-replenishment.yml
+++ b/.github/workflows/open-competition-v2-replenishment.yml
@@ -29,6 +29,8 @@ on:
       - "scripts/test_forward_canonical_gmv.py"
       - "scripts/test_build_forward_open_competition_v2_gmv_candidate_pool.py"
       - "scripts/test_open_competition_v2_replenishment_workflow.py"
+      - ".github/workflows/seed-open-competition-v2-replenisher-gas.yml"
+      - "scripts/test_seed_open_competition_v2_replenisher_gas.py"
 
 permissions:
   contents: read
@@ -59,6 +61,7 @@ jobs:
             scripts.test_forward_canonical_gmv \
             scripts.test_build_forward_open_competition_v2_gmv_candidate_pool \
             scripts.test_open_competition_v2_replenishment_workflow \
+            scripts.test_seed_open_competition_v2_replenisher_gas \
             -v
 
   plan-or-execute:

--- a/.github/workflows/seed-open-competition-v2-replenisher-gas.yml
+++ b/.github/workflows/seed-open-competition-v2-replenisher-gas.yml
@@ -1,0 +1,51 @@
+name: Seed Open Competition V2 replenisher gas
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: open-competition-v2-replenisher-gas
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    environment: v2-beta2-mainnet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+      - name: Seed and reconcile the exact gas-only delegate
+        env:
+          BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$BASE_MAINNET_RPC_URL" && test -n "$BASE_MAINNET_DEPLOYER_PRIVATE_KEY"
+          python -m pip install -r scripts/requirements-wallet.txt
+          python scripts/fund_open_competition_v2_beta3_broker.py \
+            --network base-mainnet \
+            --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --broker 0xfb58949365e3a30fd62e86edb0daffccf4ef7477 \
+            --target-usdc-base-units 0 \
+            --target-eth-wei 100000000000000 \
+            --output target/open-competition-v2-replenisher-gas.json
+          jq -e '
+            .passed == true and
+            .broker == "0xfb58949365e3a30fd62e86edb0daffccf4ef7477" and
+            .target_usdc_base_units == 0 and
+            .funded_usdc_base_units == 0 and
+            .target_eth_wei == 100000000000000 and
+            .final_eth_wei >= 100000000000000
+          ' target/open-competition-v2-replenisher-gas.json >/dev/null
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: open-competition-v2-replenisher-gas-${{ github.sha }}
+          path: target/open-competition-v2-replenisher-gas.json
+          if-no-files-found: error
+          retention-days: 365

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -314,6 +314,7 @@ def main() -> int:
         "scripts.test_run_open_competition_v2_sepolia_rehearsal",
         "scripts.test_deploy_open_competition_v2_beta3",
         "scripts.test_deploy_bounded_open_competition_v2_wallet_factory",
+        "scripts.test_seed_open_competition_v2_replenisher_gas",
         "scripts.test_record_open_competition_v2_beta3_gate",
         "scripts.test_build_open_competition_v2_verifier_assets",
         "scripts.test_verify_open_competition_v2_slither",

--- a/scripts/test_seed_open_competition_v2_replenisher_gas.py
+++ b/scripts/test_seed_open_competition_v2_replenisher_gas.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Regression tests for the protected gas-only V2 replenisher seed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "seed-open-competition-v2-replenisher-gas.yml"
+DELEGATE = "0xfb58949365e3a30fd62e86edb0daffccf4ef7477"
+
+
+class ReplenisherGasWorkflowTests(unittest.TestCase):
+    def test_is_manual_protected_and_has_no_mutable_inputs(self) -> None:
+        value = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        triggers = value.get("on", value.get(True))
+        self.assertEqual(triggers, {"workflow_dispatch": None})
+        job = value["jobs"]["seed"]
+        self.assertEqual(job["environment"], "v2-beta2-mainnet")
+        self.assertEqual(value["permissions"], {"contents": "read"})
+
+    def test_seeds_only_exact_delegate_eth_and_zero_usdc(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(f"--broker {DELEGATE}", text)
+        self.assertIn("--target-usdc-base-units 0", text)
+        self.assertIn("--target-eth-wei 100000000000000", text)
+        self.assertIn(".funded_usdc_base_units == 0", text)
+        self.assertNotIn("BASE_KEEPER_PRIVATE_KEY", text)
+        self.assertNotIn("github.event.inputs", text)
+
+    def test_requires_canonical_reconciliation_artifact(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(".passed == true", text)
+        self.assertIn(".final_eth_wei >= 100000000000000", text)
+        self.assertIn("if-no-files-found: error", text)
+        self.assertIn("retention-days: 365", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Maintainer notice\n\nThis follow-up closes the one-confirm activation gap for the forward-GMV Open Competition V2 reserve. It adds a manual, protected mainnet workflow with no inputs that can seed only the fixed replenisher delegate 