### PR TITLE
Add scoped prover build cleanup

### DIFF
--- a/.github/workflows/clean-open-competition-v2-prover-builds.yml
+++ b/.github/workflows/clean-open-competition-v2-prover-builds.yml
@@ -1,0 +1,53 @@
+name: Clean Open Competition V2 prover build output
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: open-competition-v2-prover-maintenance
+  cancel-in-progress: false
+
+jobs:
+  clean-generated-output:
+    environment: v2-beta2-mainnet
+    runs-on: [self-hosted, Linux, X64, ram-256gb, open-competition-v2-prover]
+    timeout-minutes: 15
+    steps:
+      - name: Validate scope and remove only generated build output
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_workspace=/home/pooln/actions-runner/_work/agent-bounties/agent-bounties
+          workspace="$(realpath -m "$GITHUB_WORKSPACE")"
+          test "$workspace" = "$expected_workspace"
+          test "$workspace" != / && test "$workspace" != /home && test "$workspace" != /home/pooln
+
+          before_bytes="$(df --output=avail -B1 "$workspace" | tail -n 1 | tr -d ' ')"
+          printf 'disk_before_bytes=%s\n' "$before_bytes"
+          df -h "$workspace"
+
+          for relative in \
+            .sp1-safe/target \
+            target \
+            contracts/base-escrow/out \
+            contracts/base-escrow/cache
+          do
+            target="$(realpath -m "$workspace/$relative")"
+            case "$target" in
+              "$workspace"/*) ;;
+              *) echo "refusing out-of-workspace cleanup target: $target" >&2; exit 2 ;;
+            esac
+            if [[ -e "$target" ]]; then
+              du -sh -- "$target" || true
+              rm -rf --one-file-system -- "$target"
+              test ! -e "$target"
+            fi
+          done
+
+          after_bytes="$(df --output=avail -B1 "$workspace" | tail -n 1 | tr -d ' ')"
+          printf 'disk_after_bytes=%s\n' "$after_bytes"
+          df -h "$workspace"
+          test "$after_bytes" -ge 16106127360

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -315,6 +315,7 @@ def main() -> int:
         "scripts.test_deploy_open_competition_v2_beta3",
         "scripts.test_deploy_bounded_open_competition_v2_wallet_factory",
         "scripts.test_seed_open_competition_v2_replenisher_gas",
+        "scripts.test_clean_open_competition_v2_prover_builds",
         "scripts.test_record_open_competition_v2_beta3_gate",
         "scripts.test_build_open_competition_v2_verifier_assets",
         "scripts.test_verify_open_competition_v2_slither",

--- a/scripts/test_clean_open_competition_v2_prover_builds.py
+++ b/scripts/test_clean_open_competition_v2_prover_builds.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Safety contract for the scoped self-hosted prover cleanup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "clean-open-competition-v2-prover-builds.yml"
+EXPECTED_WORKSPACE = "/home/pooln/actions-runner/_work/agent-bounties/agent-bounties"
+
+
+class ProverCleanupWorkflowTests(unittest.TestCase):
+    def test_is_manual_protected_and_pinned_to_the_prover_runner(self) -> None:
+        value = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        triggers = value.get("on", value.get(True))
+        self.assertEqual(triggers, {"workflow_dispatch": None})
+        job = value["jobs"]["clean-generated-output"]
+        self.assertEqual(job["environment"], "v2-beta2-mainnet")
+        self.assertEqual(
+            job["runs-on"],
+            ["self-hosted", "Linux", "X64", "ram-256gb", "open-competition-v2-prover"],
+        )
+
+    def test_cleanup_is_exactly_scoped_to_generated_outputs(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(f"expected_workspace={EXPECTED_WORKSPACE}", text)
+        self.assertIn('test "$workspace" = "$expected_workspace"', text)
+        self.assertIn('"$workspace"/*', text)
+        for relative in (
+            ".sp1-safe/target",
+            "target",
+            "contracts/base-escrow/out",
+            "contracts/base-escrow/cache",
+        ):
+            self.assertIn(relative, text)
+        for forbidden in ("$HOME", "find ", "/mnt/agent-bounties-artifacts", "docker system prune"):
+            self.assertNotIn(forbidden, text)
+
+    def test_requires_recovered_capacity_and_uses_no_secret(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn('test "$after_bytes" -ge 16106127360', text)
+        self.assertIn("df -h", text)
+        self.assertNotIn("secrets.", text)
+        self.assertNotIn("actions/checkout", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Maintainer notice\n\nThe production Open Competition V2 release reached all metric comparison gates but its self-hosted 256-GB proof runner exhausted disk while compiling generated SP1 output. This maintenance-only workflow removes only four reproducible build directories under the exact runner workspace, refuses out-of-workspace paths, never touches /mnt/agent-bounties-artifacts, and requires at least 15 GiB free after cleanup. It changes no contract, metric, candidate, wallet, public metric, or funding behavior and does not overlap PR #970.\n\n## Evidence\n\n- The same setup failure repeated twice with No space left on device.\n- Three workflow safety tests pass.\n- No checkout, secret, wallet, chain transaction, global cache, Docker prune, wildcard discovery, or trusted-setup mutation is permitted.