### PR TITLE
Audit full prover root capacity

### DIFF
--- a/.github/workflows/clean-open-competition-v2-prover-builds.yml
+++ b/.github/workflows/clean-open-competition-v2-prover-builds.yml
@@ -62,4 +62,6 @@ jobs:
               du -x -h --max-depth=2 -- "$audit_root" 2>/dev/null | sort -h | tail -n 40 || true
             fi
           done
+          du -x -h --max-depth=2 -- / 2>/dev/null | sort -h | tail -n 120 || true
+          ls -lahS -- / /home/pooln 2>/dev/null || true
           test "$after_bytes" -ge 16106127360

--- a/scripts/test_clean_open_competition_v2_prover_builds.py
+++ b/scripts/test_clean_open_competition_v2_prover_builds.py
@@ -47,6 +47,8 @@ class ProverCleanupWorkflowTests(unittest.TestCase):
         self.assertIn("df -h", text)
         self.assertIn("/home/pooln/actions-runner/_work", text)
         self.assertIn("du -x -h --max-depth=2", text)
+        self.assertIn("du -x -h --max-depth=2 -- /", text)
+        self.assertIn("ls -lahS -- / /home/pooln", text)
         self.assertNotIn("secrets.", text)
         self.assertNotIn("actions/checkout", text)
 


### PR DESCRIPTION
The scoped prover cleanup recovered 1.4 GiB but the 246-GiB root volume still has only 1.8 GiB free. This adds only depth-bounded, read-only top-level disk reporting and directory listings so the remaining generated/recoverable storage can be identified exactly before any broader deletion. It adds no deletion target, secret, checkout, trusted-setup access, chain action, or wallet action. Three safety tests pass.