### PR TITLE
Audit prover disk consumers precisely

### DIFF
--- a/.github/workflows/clean-open-competition-v2-prover-builds.yml
+++ b/.github/workflows/clean-open-competition-v2-prover-builds.yml
@@ -64,4 +64,24 @@ jobs:
           done
           du -x -h --max-depth=2 -- / 2>/dev/null | sort -h | tail -n 120 || true
           ls -lahS -- / /home/pooln 2>/dev/null || true
+          swapon --show --bytes || true
+          free -h || true
+          if command -v lsof >/dev/null 2>&1; then
+            sudo -n lsof +L1 2>/dev/null || lsof +L1 2>/dev/null || true
+          fi
+          du -x -h --max-depth=1 -- /home/pooln 2>/dev/null | sort -h | tail -n 80 || true
+          for audit_root in \
+            /home/pooln/agent-bounties-artifact-metric \
+            /home/pooln/agent-bounties-beta2 \
+            /home/pooln/agent-bounties-beta2-build-a-466e8d5 \
+            /home/pooln/agent-bounties-beta3 \
+            /home/pooln/agent-bounties-beta3-coordinator \
+            /home/pooln/go-build-cache \
+            /home/pooln/go-mod-cache \
+            /home/pooln/sp1-safe-v2-final
+          do
+            if [[ -e "$audit_root" ]]; then
+              du -x -h --max-depth=2 -- "$audit_root" 2>/dev/null | sort -h | tail -n 60 || true
+            fi
+          done
           test "$after_bytes" -ge 16106127360

--- a/scripts/test_clean_open_competition_v2_prover_builds.py
+++ b/scripts/test_clean_open_competition_v2_prover_builds.py
@@ -49,6 +49,21 @@ class ProverCleanupWorkflowTests(unittest.TestCase):
         self.assertIn("du -x -h --max-depth=2", text)
         self.assertIn("du -x -h --max-depth=2 -- /", text)
         self.assertIn("ls -lahS -- / /home/pooln", text)
+        self.assertIn("swapon --show --bytes", text)
+        self.assertIn("free -h", text)
+        self.assertIn("lsof +L1", text)
+        self.assertIn("du -x -h --max-depth=1 -- /home/pooln", text)
+        for audit_root in (
+            "/home/pooln/agent-bounties-artifact-metric",
+            "/home/pooln/agent-bounties-beta2",
+            "/home/pooln/agent-bounties-beta2-build-a-466e8d5",
+            "/home/pooln/agent-bounties-beta3",
+            "/home/pooln/agent-bounties-beta3-coordinator",
+            "/home/pooln/go-build-cache",
+            "/home/pooln/go-mod-cache",
+            "/home/pooln/sp1-safe-v2-final",
+        ):
+            self.assertIn(audit_root, text)
         self.assertNotIn("secrets.", text)
         self.assertNotIn("actions/checkout", text)
 


### PR DESCRIPTION
## Maintainer notice

The protected Open Competition V2 production release is blocked before proving by an exhausted self-hosted prover disk. This change extends the already protected, no-secret maintenance workflow with read-only evidence for active swap, memory headroom, deleted-open files, and exact legacy proof/build directories. It does not delete additional paths, access trusted setup under `/mnt`, touch wallet material, deploy contracts, or move funds.

Open PR impact: this maintenance-only workflow does not overlap contributor PRs #970, #969, or the public inventory/statistics PRs. It preserves their branches unchanged.

## Validation

- `python scripts/test_clean_open_competition_v2_prover_builds.py`
- `git diff --check`

## Done when

The protected audit identifies a narrowly scoped, regenerable source of at least 15 GiB so the pinned production proof build can resume safely.