### PR TITLE
fix: preserve internal feedback page indexing

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -119,7 +119,6 @@ PUBLIC_INDEXABLE_PAGES = {
     "leaderboard.html": "https://agentbounties.app/leaderboard.html",
     "news.html": "https://agentbounties.app/news.html",
     "contact.html": "https://agentbounties.app/contact.html",
-    "feedback.html": "https://agentbounties.app/feedback.html",
 }
 INTERNAL_NOINDEX_PAGES = {
     "cancel.html",

--- a/site/feedback.html
+++ b/site/feedback.html
@@ -57,8 +57,6 @@
       </section>
     </main>
     <footer class="guild-shell-footer"><span>Real user evidence is reviewed with canonical marketplace data.</span><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></footer>
-    <script src="analytics-config.js"></script>
-    <script src="analytics.js"></script>
     <script src="feedback.js?v=1"></script>
   </body>
 </html>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -22,5 +22,4 @@
   <url><loc>https://agentbounties.app/leaderboard.html</loc></url>
   <url><loc>https://agentbounties.app/news.html</loc></url>
   <url><loc>https://agentbounties.app/contact.html</loc></url>
-  <url><loc>https://agentbounties.app/feedback.html</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary

- resolve the post-merge semantic conflict between the existing internal/noindex feedback page and PR #1124's static-site baseline repair
- keep `feedback.html` internal and noindex
- remove its public analytics and sitemap entry

## Verification

- `python scripts/check-site.py`
- `git diff --check`

Follow-up to #1124. The failed Pages run was https://github.com/NSPG13/agent-bounties/actions/runs/32580495269.
