### PR TITLE
Rebalance exact Sepolia V2 canary reserve

### DIFF
--- a/.github/workflows/rebalance-open-competition-v2-beta3-sepolia-usdc.yml
+++ b/.github/workflows/rebalance-open-competition-v2-beta3-sepolia-usdc.yml
@@ -1,0 +1,40 @@
+name: Rebalance Open Competition V2 Beta3 Sepolia USDC
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: open-competition-v2-beta3-sepolia-rebalance
+  cancel-in-progress: false
+
+jobs:
+  rebalance:
+    environment: v2-beta2-sepolia
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+      - name: Return only the reviewed Sepolia canary deficit
+        env:
+          BASE_SEPOLIA_RPC_URL: ${{ vars.BASE_SEPOLIA_RPC_URL }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$BASE_SEPOLIA_RPC_URL"
+          test -n "$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"
+          python -m pip install -r scripts/requirements-wallet.txt
+          python scripts/rebalance_open_competition_v2_beta3_sepolia_usdc.py \
+            --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+            --output target/open-competition-v2-beta3-sepolia-rebalance.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: open-competition-v2-beta3-sepolia-rebalance-${{ github.sha }}
+          path: target/open-competition-v2-beta3-sepolia-rebalance.json
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/rebalance_open_competition_v2_beta3_sepolia_usdc.py
+++ b/scripts/rebalance_open_competition_v2_beta3_sepolia_usdc.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Return the exact Base Sepolia canary deficit from the broker to the deployer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from eth_account import Account
+
+from _shared.evm import address_word, uint_word
+from _shared.rpc import rpc
+from fund_open_competition_v2_beta3_broker import SignedRpc, usdc_balance
+
+
+CHAIN_ID = 84_532
+USDC = "0x036cbd53842c5426634e7929541ec2318f3dcf7e"
+BROKER = "0x176f486a724720c4fdfc920d7c17dd1004c2bfb4"
+DEPLOYER = "0xfd7be4c69541ab297aece2a674fc1418b898cc0a"
+DEPLOYER_TARGET_USDC = 900_000
+MAX_TRANSFER_USDC = 22_500
+MINIMUM_BROKER_USDC_AFTER = 100_000
+MINIMUM_BROKER_ETH_AFTER = 100_000_000_000_000
+TRANSFER_SELECTOR = "a9059cbb"
+
+
+class SepoliaRebalanceError(RuntimeError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SepoliaRebalanceError(message)
+
+
+def planned_transfer(*, deployer_usdc: int, broker_usdc: int) -> int:
+    require(deployer_usdc >= 0 and broker_usdc >= 0, "balances cannot be negative")
+    deficit = max(DEPLOYER_TARGET_USDC - deployer_usdc, 0)
+    require(deficit <= MAX_TRANSFER_USDC, "Sepolia deployer deficit exceeds the reviewed cap")
+    require(
+        broker_usdc >= deficit + MINIMUM_BROKER_USDC_AFTER,
+        "broker cannot cover the deficit and retain its reviewed test reserve",
+    )
+    return deficit
+
+
+def rebalance(*, rpc_url: str, private_key: str) -> dict[str, Any]:
+    require(rpc_url.startswith("https://"), "Base Sepolia RPC must use HTTPS")
+    signer = Account.from_key(private_key)
+    require(signer.address.lower() == BROKER, "protected signer is not the reviewed broker")
+    client = SignedRpc(rpc_url, signer, CHAIN_ID)
+    safe_before = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False])
+    require(safe_before and safe_before.get("hash"), "RPC did not return a safe block")
+
+    deployer_before = usdc_balance(rpc_url, USDC, DEPLOYER, safe_before["number"])
+    broker_before = usdc_balance(rpc_url, USDC, BROKER, safe_before["number"])
+    broker_eth_before = int(rpc(rpc_url, "eth_getBalance", [BROKER, safe_before["number"]]), 16)
+    transfer = planned_transfer(deployer_usdc=deployer_before, broker_usdc=broker_before)
+    require(
+        broker_eth_before >= MINIMUM_BROKER_ETH_AFTER,
+        "broker lacks the reviewed post-transfer relay reserve",
+    )
+
+    receipt = None
+    safe_after = safe_before
+    if transfer:
+        calldata = "0x" + TRANSFER_SELECTOR + address_word(DEPLOYER).hex() + uint_word(transfer).hex()
+        receipt = client.send(to=USDC, data=calldata)
+        safe_after = client.wait_safe(int(receipt["blockNumber"], 16))
+
+    deployer_after = usdc_balance(rpc_url, USDC, DEPLOYER, safe_after["number"])
+    broker_after = usdc_balance(rpc_url, USDC, BROKER, safe_after["number"])
+    broker_eth_after = int(rpc(rpc_url, "eth_getBalance", [BROKER, safe_after["number"]]), 16)
+    require(deployer_after >= DEPLOYER_TARGET_USDC, "deployer test reserve did not reconcile")
+    require(broker_after >= MINIMUM_BROKER_USDC_AFTER, "broker test reserve fell below its floor")
+    require(broker_eth_after >= MINIMUM_BROKER_ETH_AFTER, "broker relay reserve fell below its floor")
+
+    return {
+        "schema_version": "agent-bounties/open-competition-v2-beta3-sepolia-rebalance-v1",
+        "passed": True,
+        "network": "base-sepolia",
+        "chain_id": CHAIN_ID,
+        "usdc": USDC,
+        "broker": BROKER,
+        "deployer": DEPLOYER,
+        "deployer_usdc_before": deployer_before,
+        "deployer_usdc_after": deployer_after,
+        "broker_usdc_before": broker_before,
+        "broker_usdc_after": broker_after,
+        "broker_eth_before": broker_eth_before,
+        "broker_eth_after": broker_eth_after,
+        "transferred_usdc_base_units": transfer,
+        "transaction": receipt["transactionHash"].lower() if receipt else None,
+        "safe_block_number": int(safe_after["number"], 16),
+        "safe_block_hash": safe_after["hash"].lower(),
+        "evidence_boundary": (
+            "This is a canonical transfer of valueless Base Sepolia test USDC between the dedicated "
+            "Beta3 broker and deployer. It is not mainnet funding, GMV, a bounty settlement, or payment evidence."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--private-key-env", default="OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    private_key = os.environ.get(args.private_key_env, "")
+    require(bool(private_key), f"{args.private_key_env} is required")
+    result = rebalance(rpc_url=args.rpc_url, private_key=private_key)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"passed": True, "output": str(args.output), "transaction": result["transaction"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_rebalance_open_competition_v2_beta3_sepolia_usdc.py
+++ b/scripts/test_rebalance_open_competition_v2_beta3_sepolia_usdc.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Tests for the exact bounded Base Sepolia reserve rebalance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+import yaml
+
+import rebalance_open_competition_v2_beta3_sepolia_usdc as subject
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "rebalance-open-competition-v2-beta3-sepolia-usdc.yml"
+
+
+class SepoliaRebalanceTests(unittest.TestCase):
+    def test_exact_observed_deficit_is_allowed(self) -> None:
+        self.assertEqual(
+            subject.planned_transfer(deployer_usdc=877_500, broker_usdc=122_500),
+            22_500,
+        )
+
+    def test_is_idempotent_after_reconciliation(self) -> None:
+        self.assertEqual(
+            subject.planned_transfer(deployer_usdc=900_000, broker_usdc=100_000),
+            0,
+        )
+
+    def test_fails_closed_on_larger_deficit_or_broker_floor(self) -> None:
+        with self.assertRaises(subject.SepoliaRebalanceError):
+            subject.planned_transfer(deployer_usdc=877_499, broker_usdc=122_501)
+        with self.assertRaises(subject.SepoliaRebalanceError):
+            subject.planned_transfer(deployer_usdc=877_500, broker_usdc=122_499)
+
+    def test_workflow_is_manual_protected_and_has_no_inputs(self) -> None:
+        value = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        triggers = value.get("on", value.get(True))
+        self.assertEqual(triggers, {"workflow_dispatch": None})
+        job = value["jobs"]["rebalance"]
+        self.assertEqual(job["environment"], "v2-beta2-sepolia")
+        self.assertEqual(job["runs-on"], "ubuntu-24.04")
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY", text)
+        self.assertNotIn("BASE_MAINNET", text)
+        self.assertNotIn("wallet", text.lower().replace("requirements-wallet", "requirements"))
+
+    def test_contract_is_exactly_pinned(self) -> None:
+        self.assertEqual(subject.CHAIN_ID, 84_532)
+        self.assertEqual(subject.DEPLOYER_TARGET_USDC, 900_000)
+        self.assertEqual(subject.MAX_TRANSFER_USDC, 22_500)
+        self.assertEqual(subject.MINIMUM_BROKER_USDC_AFTER, 100_000)
+        self.assertEqual(subject.BROKER, "0x176f486a724720c4fdfc920d7c17dd1004c2bfb4")
+        self.assertEqual(subject.DEPLOYER, "0xfd7be4c69541ab297aece2a674fc1418b898cc0a")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Maintainer notice

The pinned V2 production release passed all release assets and three real proof replays, then the live Sepolia job failed closed before deployment because the dedicated deployer held 877,500 test-USDC base units against its reviewed 900,000 canary reserve. The dedicated broker canonically holds 122,500 test-USDC base units and has a zero USDC target for Sepolia.

This protected, no-input workflow returns exactly the 22,500-base-unit deficit (0.0225 valueless Base Sepolia test USDC) from the broker to the deployer, retaining exactly 100,000 base units at the broker. It is idempotent after reconciliation and fails closed on any larger deficit, signer mismatch, balance mismatch, chain mismatch, RPC mismatch, broker floor breach, ETH relay floor breach, or non-canonical result.

No Base mainnet asset, owner wallet, GMV, bounty settlement, trusted setup, or public marketplace surface is touched. Open PR impact: maintenance-only and non-overlapping with contributor PRs.

## Validation

- `PYTHONPATH=scripts python -m unittest scripts.test_rebalance_open_competition_v2_beta3_sepolia_usdc -v`
- `git diff --check`

## Done when

The exact test-USDC transfer is safe-block reconciled, the deployer is at least 900,000 base units, the broker retains at least 100,000, and the pinned live Sepolia rehearsal passes on retry.