### PR TITLE
fix: preserve exact policy exclusion precision

### DIFF
--- a/scripts/test-metrics-dashboard.js
+++ b/scripts/test-metrics-dashboard.js
@@ -300,6 +300,10 @@ test("canonical payout audit reconciles exact public event arithmetic", () => {
   });
 });
 
+test("policy-excluded payout values preserve exact USDC precision", () => {
+  assert.equal(metrics.formatUsdc(0.525, { maximumFractionDigits: 6 }), "0.525 USDC");
+});
+
 test("public policy excludes two canaries and exact current aggregate reconciles", () => {
   const policy = JSON.parse(fs.readFileSync(
     path.join(__dirname, "..", "site", "generated", "public-metrics-policy.json"),

--- a/site/metrics.js
+++ b/site/metrics.js
@@ -41,7 +41,7 @@
 
   function formatUsdc(value, options = {}) {
     const amount = Math.max(0, finiteNumber(value));
-    const maximumFractionDigits = options.compact ? 1 : 2;
+    const maximumFractionDigits = options.maximumFractionDigits ?? (options.compact ? 1 : 2);
     return `${new Intl.NumberFormat("en-US", {
       notation: options.compact && amount >= 1000 ? "compact" : "standard",
       minimumFractionDigits: 0,
@@ -545,7 +545,7 @@
         : formatInteger(audit.excluded_summary.payout_events));
       setText("[data-audit-excluded-volume]", audit.status === "unavailable"
         ? "—"
-        : formatUsdc(audit.excluded_summary.total_base_units / USDC_SCALE));
+        : formatUsdc(audit.excluded_summary.total_base_units / USDC_SCALE, { maximumFractionDigits: 6 }));
       setText("[data-audit-copy]", audit.status === "ready"
         ? "The independent event sum exactly matches the headline payout and settlement count for this period."
         : audit.status === "partial"
@@ -1013,6 +1013,7 @@
     chartSvg,
     combinedStatus,
     dashboardStatus,
+    formatUsdc,
     mergeDaily,
     mergeMetrics,
     normalizedPublicMetricsPolicy,


### PR DESCRIPTION
## Summary

- render the policy-excluded value with enough precision to show the exact `0.525 USDC` canary total
- retain the existing compact two-decimal formatting for ordinary headline amounts
- add a deterministic formatting regression

## Verification

- `node --test scripts/test-metrics-dashboard.js`
- `python scripts/check-site.py`
- `git diff --check`

Final visual-QA follow-up to #1124 and #1135.
