### PR TITLE
chore: refresh metrics dashboard asset

### DIFF
--- a/site/metrics.html
+++ b/site/metrics.html
@@ -261,6 +261,6 @@
     <footer class="guild-shell-footer"><span>Public aggregate evidence and canonical transaction proofs. No participant handles or wallet identities are displayed.</span><a href="privacy.html">Privacy</a><a href="https://api.agentbounties.app/api-docs/openapi.json">API</a></footer>
     <script src="analytics-config.js"></script>
     <script src="analytics.js"></script>
-    <script src="metrics.js?v=6"></script>
+    <script src="metrics.js?v=7"></script>
   </body>
 </html>


### PR DESCRIPTION
Bumps the metrics dashboard asset query from v6 to v7 so the exact policy-exclusion precision deployed in #1137 is not hidden by the GitHub Pages 10-minute asset cache. Verified with python scripts/check-site.py and git diff --check.