### PR TITLE
Harden Open Competition V2 proof rehearsal

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -699,6 +699,7 @@ jobs:
           done
           python scripts/run_open_competition_v2_sepolia_rehearsal.py --bundle target/sepolia.json \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" --prepared-proof-dir target/sepolia-proof-inputs \
+            --shadow-rpc-url "$BASE_SEPOLIA_SHADOW_RPC_URL" \
             --verifier-assets target/release-assets/verifier-assets.json \
             --private-key-env BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \

--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -39,8 +39,10 @@ jobs:
             --run-id 32147289466 \
             --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 --attempt 7 --attempt 8 --attempt 9 --attempt 12 --attempt 14 \
             --additional-actor-scope b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1 \
+            --additional-actor-scope 0bb9692d0804f72f7735fa5577ecb5c0340ee7b0:32563353721:5 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
             --expired-competition 0x569fc0c653c81dfaca73467a7496c098a620f501 \
+            --expired-competition 0x611aec6ef897f6cfe20afe70daabc4153b16435e \
             --funding-competition 0x702b2be0254b7a363d4bfb4e9b72d9424bbe4a8e \
             --funding-competition 0x23cec46243ad1b849086f3af78744bb2654e6800 \
             --required-actor 0xf723d4ac02331707f39bc9416b11ec25a73743f1 \
@@ -55,6 +57,9 @@ jobs:
             --required-actor 0xc93766c8037783663d0c88e54e1c09db206c41ed \
             --required-actor 0x54a188c7ef1e295b3e0f3fb2d33010b18679687b \
             --required-actor 0x6ab2e7d3f38236411c6d848dcd5cc8710efc359e \
+            --required-actor 0xb2e54a743a1718f4a537aac8ca6ae68ceb20ac5a \
+            --required-actor 0xa898d50b92e103abe626596b6b47d2ebfd506149 \
+            --minimum-usdc 900000 \
             --output target/beta3-sepolia-rehearsal-recovery.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/scripts/run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/run_open_competition_v2_sepolia_rehearsal.py
@@ -17,7 +17,7 @@ from eth_utils import to_checksum_address
 import build_open_competition_v2_beta3_release as release
 import open_competition_v2_proof_rehearsal as rehearsal
 from _shared.evm import keccak256, keccak_bytes
-from _shared.rpc import rpc
+from _shared.rpc import RpcError, rpc
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -105,6 +105,109 @@ def proof_summary(value: dict[str, Any]) -> dict[str, Any]:
         "journal_hash": keccak256(journal),
         "journal_bytes": len(journal),
         "elapsed_seconds": value["elapsed_seconds"],
+    }
+
+
+def malformed_proof_cases(proof: bytes) -> dict[str, bytes]:
+    require(len(proof) > 5, "proof is too short for malformed-proof probes")
+    selector_mismatch = bytearray(proof)
+    selector_mismatch[0] ^= 1
+    payload_mutation = bytearray(proof)
+    payload_mutation[-1] ^= 1
+    return {
+        "selector_mismatch": bytes(selector_mismatch),
+        "truncated": proof[:-1],
+        "payload_mutation": bytes(payload_mutation),
+        "zeroed_payload": proof[:4] + bytes(len(proof) - 4),
+    }
+
+
+def exact_void_call(
+    url: str,
+    *,
+    sender: str,
+    to: str,
+    data: str,
+    block: str,
+    label: str,
+) -> None:
+    try:
+        result = rpc(url, "eth_call", [{"from": sender, "to": to, "data": data}, block])
+    except RpcError as error:
+        raise SepoliaRehearsalError(f"{label} unexpectedly reverted") from error
+    require(result == "0x", f"{label} returned malformed success data")
+
+
+def rejected_call(
+    url: str,
+    *,
+    sender: str,
+    to: str,
+    data: str,
+    block: str,
+    label: str,
+) -> None:
+    try:
+        result = rpc(url, "eth_call", [{"from": sender, "to": to, "data": data}, block])
+    except RpcError:
+        return
+    raise SepoliaRehearsalError(f"{label} was not rejected (RPC result {result!r})")
+
+
+def proof_rejection_consensus(
+    urls: tuple[str, ...],
+    *,
+    adapter: str,
+    program_vkey: bytes,
+    journal: bytes,
+    proof: bytes,
+    sender: str,
+    block: str,
+) -> dict[str, Any]:
+    unique_urls = tuple(dict.fromkeys(urls))
+    require(len(unique_urls) == 2, "proof rejection requires two independent RPC endpoints")
+    valid_call = rehearsal.function_data(
+        "verify(bytes32,bytes,bytes)",
+        ["bytes32", "bytes", "bytes"],
+        [program_vkey, journal, proof],
+    )
+    invalid_calls = {
+        name: rehearsal.function_data(
+            "verify(bytes32,bytes,bytes)",
+            ["bytes32", "bytes", "bytes"],
+            [program_vkey, journal, invalid_proof],
+        )
+        for name, invalid_proof in malformed_proof_cases(proof).items()
+    }
+    mutated_journal = bytearray(journal)
+    mutated_journal[-1] ^= 1
+    invalid_calls["journal_mutation"] = rehearsal.function_data(
+        "verify(bytes32,bytes,bytes)",
+        ["bytes32", "bytes", "bytes"],
+        [program_vkey, bytes(mutated_journal), proof],
+    )
+    for index, url in enumerate(unique_urls, start=1):
+        exact_void_call(
+            url,
+            sender=sender,
+            to=adapter,
+            data=valid_call,
+            block=block,
+            label=f"RPC {index} valid pinned-verifier probe",
+        )
+        for name, invalid_call in invalid_calls.items():
+            rejected_call(
+                url,
+                sender=sender,
+                to=adapter,
+                data=invalid_call,
+                block=block,
+                label=f"RPC {index} malformed-proof probe {name}",
+            )
+    return {
+        "rpc_endpoint_count": len(unique_urls),
+        "valid_proof_accepted": True,
+        "rejected_cases": sorted(invalid_calls),
     }
 
 
@@ -503,6 +606,11 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
 
     expiry_result = None
     if not args.skip_expiry_refund:
+        require(args.shadow_rpc_url, "expiry and malformed-proof rehearsal requires a shadow RPC")
+        require(
+            int(rpc(args.shadow_rpc_url, "eth_chainId", []), 16) == CHAIN_ID,
+            f"shadow RPC is not {NETWORK}",
+        )
         expiry_template = json.loads(
             (PROGRAM_ROOT / "fixtures/rehearsal-first-proven.json").read_text(encoding="utf-8")
         )
@@ -511,23 +619,40 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         expiry_address, expiry_id = rehearsal.predict(client.url, factory, signer.address, expiry_params, expiry_nonce)
         receipts["approve_expiry"] = client.send(signer, to=token, data=rehearsal.function_data("approve(address,uint256)", ["address", "uint256"], [expiry_address, 105_000]))
         receipts["create_expiry"] = client.send(signer, to=factory, data=rehearsal.function_data(f"createCompetition({rehearsal.PARAM_TYPE},uint256,bytes32,bytes32)", [rehearsal.PARAM_TYPE, "uint256", "bytes32", "bytes32"], [expiry_params, 105_000, expiry_nonce, risk_hash]))
-        invalid_proof = bytearray(bytes.fromhex(proofs["groth16_first"]["proof_hex"][2:]))
-        invalid_proof[-1] ^= 1
-        invalid_call = rehearsal.function_data(
+        rehearsal_block = receipts["create_expiry"]["blockNumber"]
+        for index, url in enumerate((client.url, args.shadow_rpc_url), start=1):
+            observed_block = rpc(url, "eth_getBlockByNumber", [rehearsal_block, False])
+            require(
+                observed_block
+                and observed_block["hash"].lower()
+                == receipts["create_expiry"]["blockHash"].lower(),
+                f"RPC {index} disagrees on the malformed-proof rehearsal block",
+            )
+        journal = bytes.fromhex(proofs["groth16_first"]["journal_hex"][2:])
+        proof = bytes.fromhex(proofs["groth16_first"]["proof_hex"][2:])
+        rejection_evidence = proof_rejection_consensus(
+            (client.url, args.shadow_rpc_url),
+            adapter=bundle["groth16_adapter"]["address"],
+            program_vkey=bytes.fromhex(bundle["metric_profile"]["program_vkey"][2:]),
+            journal=journal,
+            proof=proof,
+            sender=solver_a.address,
+            block=rehearsal_block,
+        )
+        wrong_scope_call = rehearsal.function_data(
             "submitProof(bytes,bytes)",
             ["bytes", "bytes"],
-            [bytes.fromhex(proofs["groth16_first"]["journal_hex"][2:]), bytes(invalid_proof)],
+            [journal, proof],
         )
-        try:
-            rpc(
-                client.url,
-                "eth_call",
-                [{"from": solver_a.address, "to": expiry_address, "data": invalid_call}, "latest"],
+        for index, url in enumerate((client.url, args.shadow_rpc_url), start=1):
+            rejected_call(
+                url,
+                sender=solver_a.address,
+                to=expiry_address,
+                data=wrong_scope_call,
+                block=rehearsal_block,
+                label=f"RPC {index} wrong-scope competition proof",
             )
-        except RuntimeError:
-            invalid_proof_rejected = True
-        else:
-            raise SepoliaRehearsalError("the pinned verifier accepted a malformed proof")
         wait_until_chain_time(client.url, rehearsal.call_uint(client.url, expiry_address, "proofDeadline()"))
         receipts["expire"] = client.send(signer, to=expiry_address, data=rehearsal.function_data("expireCompetition()", [], []))
         require(has_topic(receipts["expire"], CANCELLED_TOPIC), "expiry cancellation event missing")
@@ -537,7 +662,9 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         expiry_result = {
             "competition": expiry_address,
             "bounty_id": expiry_id,
-            "invalid_proof_rejected": invalid_proof_rejected,
+            "invalid_proof_rejected": True,
+            "proof_rejection_consensus": rejection_evidence,
+            "wrong_scope_proof_rejected": True,
             "permissionless_refund": True,
             "escrow_balance": 0,
         }
@@ -667,6 +794,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--bundle", type=Path, required=True)
     parser.add_argument("--verifier-assets", type=Path, required=True)
     parser.add_argument("--rpc-url")
+    parser.add_argument("--shadow-rpc-url")
     parser.add_argument("--private-key-env", default="BASE_KEEPER_PRIVATE_KEY")
     parser.add_argument("--actor-derivation-salt", default="local")
     parser.add_argument("--actor-eth-wei", type=int, default=100_000_000_000_000)
@@ -690,10 +818,12 @@ def configure_network(args: argparse.Namespace) -> None:
         CHAIN_ID = 8453
         RUN_LABEL = "mainnet"
         args.rpc_url = args.rpc_url or os.environ.get("BASE_MAINNET_RPC_URL", "https://mainnet.base.org")
+        args.shadow_rpc_url = args.shadow_rpc_url or os.environ.get("BASE_MAINNET_SHADOW_RPC_URL")
     else:
         CHAIN_ID = 84532
         RUN_LABEL = "sepolia"
         args.rpc_url = args.rpc_url or os.environ.get("BASE_SEPOLIA_RPC_URL", "https://sepolia.base.org")
+        args.shadow_rpc_url = args.shadow_rpc_url or os.environ.get("BASE_SEPOLIA_SHADOW_RPC_URL")
 
 
 def main() -> int:

--- a/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
@@ -225,6 +225,69 @@ class SepoliaRehearsalTests(unittest.TestCase):
         self.assertNotIn("proof_hex", summary)
         self.assertNotIn("journal_hex", summary)
 
+    def test_malformed_proof_cases_cover_encoding_and_cryptographic_payload(self):
+        proof = bytes(range(32))
+        cases = MODULE.malformed_proof_cases(proof)
+        self.assertEqual(
+            set(cases),
+            {"selector_mismatch", "truncated", "payload_mutation", "zeroed_payload"},
+        )
+        self.assertNotEqual(cases["selector_mismatch"][:4], proof[:4])
+        self.assertEqual(len(cases["truncated"]), len(proof) - 1)
+        self.assertNotEqual(cases["payload_mutation"][-1], proof[-1])
+        self.assertEqual(cases["zeroed_payload"][4:], bytes(len(proof) - 4))
+
+    def test_proof_rejection_consensus_requires_valid_acceptance_and_all_rejections(self):
+        proof = bytes(range(32))
+        calls = []
+
+        def rpc_response(url, method, params):
+            self.assertEqual(method, "eth_call")
+            calls.append((url, params))
+            if len(calls) in (1, 7):
+                return "0x"
+            raise MODULE.RpcError("execution reverted")
+
+        with patch.object(MODULE, "rpc", side_effect=rpc_response):
+            evidence = MODULE.proof_rejection_consensus(
+                ("https://primary.invalid", "https://shadow.invalid"),
+                adapter="0x" + "11" * 20,
+                program_vkey=bytes.fromhex("22" * 32),
+                journal=bytes.fromhex("33" * 64),
+                proof=proof,
+                sender="0x" + "44" * 20,
+                block="0x123",
+            )
+
+        self.assertEqual(evidence["rpc_endpoint_count"], 2)
+        self.assertTrue(evidence["valid_proof_accepted"])
+        self.assertEqual(len(evidence["rejected_cases"]), 5)
+        self.assertEqual(len(calls), 12)
+
+    def test_proof_rejection_consensus_fails_closed_on_duplicate_or_false_success(self):
+        arguments = dict(
+            adapter="0x" + "11" * 20,
+            program_vkey=bytes.fromhex("22" * 32),
+            journal=bytes.fromhex("33" * 64),
+            proof=bytes(range(32)),
+            sender="0x" + "44" * 20,
+            block="0x123",
+        )
+        with self.assertRaisesRegex(MODULE.SepoliaRehearsalError, "two independent"):
+            MODULE.proof_rejection_consensus(
+                ("https://same.invalid", "https://same.invalid"), **arguments
+            )
+        with patch.object(MODULE, "rpc", return_value="0x"):
+            with self.assertRaisesRegex(MODULE.SepoliaRehearsalError, "was not rejected"):
+                MODULE.proof_rejection_consensus(
+                    ("https://primary.invalid", "https://shadow.invalid"), **arguments
+                )
+        with patch.object(MODULE, "rpc", side_effect=RuntimeError("transport failed")):
+            with self.assertRaisesRegex(RuntimeError, "transport failed"):
+                MODULE.proof_rejection_consensus(
+                    ("https://primary.invalid", "https://shadow.invalid"), **arguments
+                )
+
     def test_private_key_validation_fails_closed(self):
         for value in ("", "0x1", "0x" + "00" * 32):
             with self.assertRaises(MODULE.SepoliaRehearsalError):


### PR DESCRIPTION
## Outcome\n\nRepairs the blocked Open Competition V2 Beta3 production release without weakening verifier safety. The live rehearsal now requires two independent Base Sepolia RPCs to accept the exact pinned valid proof and reject selector, truncation, payload, zero-payload, journal, and wrong-scope mutations. Transport failures no longer count as proof rejection.\n\nAdds exact recovery scope for release run 32563353721 attempt 5 so its 900,000 synthetic test-USDC can be recovered before the corrected release starts. No mainnet transaction occurred in the failed run.\n\n## Incident / maintainer notice\n\n- https://github.com/NSPG13/agent-bounties/issues/1117#issuecomment-5381507685\n\n## Open-PR review\n\nInspected all open PRs, including overlapping planner PR #970 and related verifier work #899-#903. This focused repair does not incorporate untrusted PR code and does not supersede contributor work.\n\n## Verification\n\n- scripts/preflight.ps1 -Mode core\n- scripts/preflight.ps1 -Mode full\n- cargo fmt --all -- --check\n- cargo clippy --workspace -- -D warnings\n- CARGO_PROFILE_TEST_DEBUG=0 CARGO_PROFILE_TEST_INCREMENTAL=false cargo test --workspace\n- 15 Sepolia rehearsal tests\n- 8 rehearsal recovery tests\n- 25 Beta3 release tests\n- 8 proof rehearsal tests\n- 5 replenishment workflow tests\n- live exact-proof replay against both configured Base Sepolia RPCs: valid proof accepted; five malformed cases and wrong-scope proof rejected\n- python -m py_compile ...\n- git diff --check\n\nThe first default-debug workspace test attempt hit Windows PDB/disk linker pressure (LNK1180/LNK1318); after the repository-prescribed cargo clean, the complete workspace suite passed with debug symbols and incremental compilation disabled.\n\n## Mainnet boundary\n\nThis PR does not deploy, approve USDC, fund a reserve, create competitions, or settle any bounty. Mainnet remains fail-closed until the corrected protected Sepolia rehearsal passes.