### PR TITLE
Keep x402 rehearsal shadow-RPC compatible

### DIFF
--- a/scripts/run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/run_open_competition_v2_sepolia_rehearsal.py
@@ -818,12 +818,16 @@ def configure_network(args: argparse.Namespace) -> None:
         CHAIN_ID = 8453
         RUN_LABEL = "mainnet"
         args.rpc_url = args.rpc_url or os.environ.get("BASE_MAINNET_RPC_URL", "https://mainnet.base.org")
-        args.shadow_rpc_url = args.shadow_rpc_url or os.environ.get("BASE_MAINNET_SHADOW_RPC_URL")
+        args.shadow_rpc_url = getattr(args, "shadow_rpc_url", None) or os.environ.get(
+            "BASE_MAINNET_SHADOW_RPC_URL"
+        )
     else:
         CHAIN_ID = 84532
         RUN_LABEL = "sepolia"
         args.rpc_url = args.rpc_url or os.environ.get("BASE_SEPOLIA_RPC_URL", "https://sepolia.base.org")
-        args.shadow_rpc_url = args.shadow_rpc_url or os.environ.get("BASE_SEPOLIA_SHADOW_RPC_URL")
+        args.shadow_rpc_url = getattr(args, "shadow_rpc_url", None) or os.environ.get(
+            "BASE_SEPOLIA_SHADOW_RPC_URL"
+        )
 
 
 def main() -> int:

--- a/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_sepolia_rehearsal.py
@@ -293,6 +293,16 @@ class SepoliaRehearsalTests(unittest.TestCase):
             with self.assertRaises(MODULE.SepoliaRehearsalError):
                 MODULE.normalized_key(value)
 
+    def test_configure_network_accepts_legacy_namespace_without_shadow_rpc_field(self):
+        args = SimpleNamespace(network="base-sepolia", rpc_url="https://primary.invalid")
+        with patch.dict(
+            MODULE.os.environ,
+            {"BASE_SEPOLIA_SHADOW_RPC_URL": "https://shadow.invalid"},
+        ):
+            MODULE.configure_network(args)
+        self.assertEqual(args.rpc_url, "https://primary.invalid")
+        self.assertEqual(args.shadow_rpc_url, "https://shadow.invalid")
+
     def test_x402_canary_spec_binds_artifact_to_the_journal(self):
         fixture = {
             "scope": {


### PR DESCRIPTION
## Outcome\n\nAllows legacy callers such as the x402 rehearsal to reuse configure_network() when their argparse namespace does not define the newly optional shadow_rpc_url field. The core release rehearsal still requires and uses two independent RPCs for malformed-proof consensus.\n\n## Incident evidence\n\n- Run 32588509604 core Sepolia rehearsal completed with passed: true at safe block 45830908.\n- The later x402 wrapper failed before x402 execution with AttributeError: Namespace has no attribute shadow_rpc_url.\n- All mainnet jobs were skipped; no owner funds moved.\n- Maintainer update: https://github.com/NSPG13/agent-bounties/issues/1117#issuecomment-5382426156\n\n## Verification\n\n- 16 	est_run_open_competition_v2_sepolia_rehearsal.py tests passed\n- 11 	est_run_open_competition_v2_x402_rehearsal.py tests passed\n- Python compilation passed\n- git diff --check passed\n\nThis does not weaken verifier rejection, canonical settlement, or payment evidence gates.