### PR TITLE
Recover interrupted Sepolia x402 canary

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -40,9 +40,11 @@ jobs:
             --attempt 1 --attempt 2 --attempt 3 --attempt 4 --attempt 5 --attempt 6 --attempt 7 --attempt 8 --attempt 9 --attempt 12 --attempt 14 \
             --additional-actor-scope b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1 \
             --additional-actor-scope 0bb9692d0804f72f7735fa5577ecb5c0340ee7b0:32563353721:5 \
+            --additional-actor-scope 3bab67ff077a02cd45fd3577a7312d9aad4a3a4e:32588509604:1 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
             --expired-competition 0x569fc0c653c81dfaca73467a7496c098a620f501 \
             --expired-competition 0x611aec6ef897f6cfe20afe70daabc4153b16435e \
+            --expired-competition 0x41fe1ba2f2fe4615ff205268dcdb7a49c7105bae \
             --funding-competition 0x702b2be0254b7a363d4bfb4e9b72d9424bbe4a8e \
             --funding-competition 0x23cec46243ad1b849086f3af78744bb2654e6800 \
             --required-actor 0xf723d4ac02331707f39bc9416b11ec25a73743f1 \


### PR DESCRIPTION
## Outcome\n\nAdds the exact actor derivation scope and x402 canary contract left by release run 32588509604 after the core Sepolia rehearsal passed but the x402 wrapper crashed before execution.\n\nCanonical read-only evidence:\n\n- canary: 