### PR TITLE
Harden Sepolia x402 prover readiness and recovery

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -718,7 +718,10 @@ jobs:
           export OPEN_COMPETITION_V2_RELAY_FEE_BASE_UNITS=10000
           export OPEN_COMPETITION_V2_GROTH16_PROOF_SLA_SECONDS=1800
           export OPEN_COMPETITION_V2_PLONK_PROOF_SLA_SECONDS=1800
-          export OPEN_COMPETITION_V2_PROVER_URL=http://127.0.0.1:9070/v1/prove
+          port_offset=$(((GITHUB_RUN_ID + GITHUB_RUN_ATTEMPT * 997) % 10000))
+          prover_port=$((20000 + port_offset))
+          api_port=$((30000 + port_offset))
+          export OPEN_COMPETITION_V2_PROVER_URL="http://127.0.0.1:${prover_port}/v1/prove"
           export OPEN_COMPETITION_V2_PROVER_TIMEOUT_SECONDS=600
           export OPEN_COMPETITION_V2_BROKER_LEASE_SECONDS=630
           export OPEN_COMPETITION_V2_PROVER_MAX_SECONDS=1800
@@ -727,19 +730,42 @@ jobs:
           export X402_RELAYER_MIN_USDC_BASE_UNITS=100000
           export X402_RELAYER_MAX_USDC_BASE_UNITS=500000
           export ENABLE_X402_HOSTED_RELAY=true
-          export PUBLIC_BASE_URL=http://127.0.0.1:8787
-          export PORT=9070
+          export PUBLIC_BASE_URL="http://127.0.0.1:${api_port}"
+          export PORT="$prover_port"
           python scripts/open_competition_v2_prover_service.py >target/sepolia-prover.log 2>&1 &
           prover_pid=$!
-          export PORT=8787
+          export PORT="$api_port"
           target/release/api >target/sepolia-api.log 2>&1 &
           api_pid=$!
           cleanup() {
             kill "$api_pid" "$prover_pid" 2>/dev/null || true
           }
           trap cleanup EXIT
+          prover_auth_status=""
           for attempt in $(seq 1 60); do
-            if curl --fail --silent http://127.0.0.1:8787/health >/dev/null; then
+            if ! kill -0 "$prover_pid" 2>/dev/null; then
+              cat target/sepolia-prover.log
+              exit 1
+            fi
+            prover_auth_status="$(curl --silent --output target/sepolia-prover-auth.json \
+              --write-out '%{http_code}' --request POST \
+              --header "Authorization: Bearer ${OPEN_COMPETITION_V2_PROVER_API_KEY}" \
+              --header 'content-type: application/json' \
+              --header 'idempotency-key: beta3-sepolia-auth-readiness' \
+              --data '{}' "$OPEN_COMPETITION_V2_PROVER_URL" || true)"
+            if [[ "$prover_auth_status" == "400" ]]; then
+              break
+            fi
+            if [[ "$prover_auth_status" == "401" ]]; then
+              cat target/sepolia-prover.log
+              cat target/sepolia-prover-auth.json
+              exit 1
+            fi
+            sleep 2
+          done
+          test "$prover_auth_status" = "400"
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent "http://127.0.0.1:${api_port}/health" >/dev/null; then
               break
             fi
             if ! kill -0 "$api_pid" 2>/dev/null; then
@@ -748,9 +774,9 @@ jobs:
             fi
             sleep 2
           done
-          curl --fail --silent http://127.0.0.1:8787/health >/dev/null
+          curl --fail --silent "http://127.0.0.1:${api_port}/health" >/dev/null
           python scripts/run_open_competition_v2_x402_rehearsal.py \
-            --api http://127.0.0.1:8787 --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+            --api "http://127.0.0.1:${api_port}" --rpc-url "$BASE_SEPOLIA_RPC_URL" \
             --rehearsal target/sepolia-rehearsal.json --worker-binary target/release/worker \
             --private-key-env BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
@@ -774,6 +800,7 @@ jobs:
             --evidence target/sepolia-x402-rehearsal.json --uri "$evidence_uri" \
             --source-commit "$GITHUB_SHA"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: always()
         with:
           name: open-competition-v2-beta3-live-sepolia-${{ github.sha }}
           path: |
@@ -786,6 +813,7 @@ jobs:
             target/release-gates.json
             target/sepolia-api.log
             target/sepolia-prover.log
+            target/sepolia-prover-auth.json
           if-no-files-found: error
           retention-days: 90
 

--- a/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
+++ b/.github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml
@@ -26,12 +26,25 @@ jobs:
           BASE_SEPOLIA_RPC_URL: ${{ vars.BASE_SEPOLIA_RPC_URL }}
           BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY }}
           BASE_DEPLOYER_ADDRESS: ${{ vars.BASE_DEPLOYER_ADDRESS }}
+          OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
+          OPEN_COMPETITION_V2_BROKER_ADDRESS: ${{ vars.OPEN_COMPETITION_V2_BROKER_ADDRESS }}
         run: |
           set -euo pipefail
           test -n "$BASE_SEPOLIA_RPC_URL" && test -n "$BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY"
           test "${BASE_DEPLOYER_ADDRESS,,}" = "0xfd7be4c69541ab297aece2a674fc1418b898cc0a"
+          test -n "$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"
+          test "${OPEN_COMPETITION_V2_BROKER_ADDRESS,,}" = "0x176f486a724720c4fdfc920d7c17dd1004c2bfb4"
           python -m pip install -r scripts/requirements-wallet.txt
           python scripts/test_recover_open_competition_v2_rehearsal_funds.py
+          python scripts/recover_open_competition_v2_x402_charge.py \
+            --network base-sepolia \
+            --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+            --payment-transaction 0xe8c661ecb109910de75cd0391c4dc3d07a3a769d5174328a54fe3221cc5aca90 \
+            --asset 0x036cbd53842c5426634e7929541ec2318f3dcf7e \
+            --payer 0xa4b3e826aaa584a45f47906b7b202f695b6640bd \
+            --broker "$OPEN_COMPETITION_V2_BROKER_ADDRESS" \
+            --amount 110000 \
+            --output target/beta3-sepolia-x402-charge-recovery-32596784971.json
           python scripts/recover_open_competition_v2_rehearsal_funds.py \
             --rpc-url "$BASE_SEPOLIA_RPC_URL" \
             --deployer "$BASE_DEPLOYER_ADDRESS" \
@@ -41,10 +54,12 @@ jobs:
             --additional-actor-scope b1ce5c176a3cf6d4e3d4240b0a2fdf1359a3a8c5:32122203861:1 \
             --additional-actor-scope 0bb9692d0804f72f7735fa5577ecb5c0340ee7b0:32563353721:5 \
             --additional-actor-scope 3bab67ff077a02cd45fd3577a7312d9aad4a3a4e:32588509604:1 \
+            --additional-actor-scope 5dbdb1938bcdae0ce43349597973f43d0978909b:32596784971:1 \
             --competition 0x5e87358743dd4dcefc1a71ce9663ccf229ba7559 \
             --expired-competition 0x569fc0c653c81dfaca73467a7496c098a620f501 \
             --expired-competition 0x611aec6ef897f6cfe20afe70daabc4153b16435e \
             --expired-competition 0x41fe1ba2f2fe4615ff205268dcdb7a49c7105bae \
+            --expired-competition 0x2e749dd59cb50e14b61d9bf0d40dd1a012b62efa \
             --funding-competition 0x702b2be0254b7a363d4bfb4e9b72d9424bbe4a8e \
             --funding-competition 0x23cec46243ad1b849086f3af78744bb2654e6800 \
             --required-actor 0xf723d4ac02331707f39bc9416b11ec25a73743f1 \
@@ -66,6 +81,8 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: open-competition-v2-beta3-sepolia-rehearsal-recovery-${{ github.sha }}-${{ github.run_attempt }}
-          path: target/beta3-sepolia-rehearsal-recovery.json
+          path: |
+            target/beta3-sepolia-rehearsal-recovery.json
+            target/beta3-sepolia-x402-charge-recovery-32596784971.json
           if-no-files-found: error
           retention-days: 365

--- a/scripts/test_build_open_competition_v2_beta3_release.py
+++ b/scripts/test_build_open_competition_v2_beta3_release.py
@@ -168,6 +168,29 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
         self.assertIn('X402_RELAYER_PRIVATE_KEY="$OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY"', sepolia)
         self.assertNotIn('X402_RELAYER_PRIVATE_KEY="$BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY"', sepolia)
 
+    def test_sepolia_rehearsal_authenticates_the_owned_prover_before_payment(self):
+        workflow = (
+            MODULE.ROOT / ".github/workflows/open-competition-v2-beta3-release.yml"
+        ).read_text(encoding="utf-8")
+        sepolia = workflow.split("  live-sepolia-rehearsal:", 1)[1].split(
+            "  deploy-mainnet:", 1
+        )[0]
+        auth_probe = 'Authorization: Bearer ${OPEN_COMPETITION_V2_PROVER_API_KEY}'
+        payment_rehearsal = "python scripts/run_open_competition_v2_x402_rehearsal.py"
+        self.assertIn('kill -0 "$prover_pid"', sepolia)
+        self.assertIn("GITHUB_RUN_ATTEMPT * 997", sepolia)
+        self.assertIn('OPEN_COMPETITION_V2_PROVER_URL="http://127.0.0.1:${prover_port}/v1/prove"', sepolia)
+        self.assertIn('PUBLIC_BASE_URL="http://127.0.0.1:${api_port}"', sepolia)
+        self.assertIn(auth_probe, sepolia)
+        self.assertIn('test "$prover_auth_status" = "400"', sepolia)
+        self.assertLess(sepolia.index(auth_probe), sepolia.index(payment_rehearsal))
+        upload = sepolia.split(
+            "- uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+            1,
+        )[1]
+        self.assertIn("if: always()", upload)
+        self.assertIn("target/sepolia-prover-auth.json", upload)
+
     def test_mainnet_deploys_the_exact_recoverable_reserve_factory(self):
         workflow = (
             MODULE.ROOT / ".github/workflows/open-competition-v2-beta3-release.yml"

--- a/scripts/test_recover_open_competition_v2_rehearsal_funds.py
+++ b/scripts/test_recover_open_competition_v2_rehearsal_funds.py
@@ -1,11 +1,38 @@
 import unittest
+from pathlib import Path
 
 from eth_account import Account
 
 import recover_open_competition_v2_rehearsal_funds as recovery
 
 
+WORKFLOW = (
+    Path(__file__).parents[1]
+    / ".github/workflows/open-competition-v2-beta3-sepolia-rehearsal-recovery.yml"
+)
+
+
 class RehearsalRecoveryTests(unittest.TestCase):
+    def test_current_x402_charge_is_refunded_before_current_actor_sweep(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        refund = "python scripts/recover_open_competition_v2_x402_charge.py"
+        actor_sweep = "python scripts/recover_open_competition_v2_rehearsal_funds.py"
+        self.assertIn(refund, workflow)
+        self.assertIn(
+            "--payment-transaction 0xe8c661ecb109910de75cd0391c4dc3d07a3a769d5174328a54fe3221cc5aca90",
+            workflow,
+        )
+        self.assertIn("--payer 0xa4b3e826aaa584a45f47906b7b202f695b6640bd", workflow)
+        self.assertIn(
+            "--additional-actor-scope 5dbdb1938bcdae0ce43349597973f43d0978909b:32596784971:1",
+            workflow,
+        )
+        self.assertIn(
+            "--expired-competition 0x2e749dd59cb50e14b61d9bf0d40dd1a012b62efa",
+            workflow,
+        )
+        self.assertLess(workflow.index(refund), workflow.index(actor_sweep))
+
     def test_actor_derivation_is_stable_and_unique(self) -> None:
         root = bytes.fromhex("11" * 32)
         actors = recovery.actor_set(


### PR DESCRIPTION
## Finding

Release run 32596784971 passed the full Open Competition V2 Beta3 Sepolia lifecycle, then paid the isolated x402 broker and received HTTP 401 from the loopback prover. The fixed ports allowed a stale listener to satisfy no authenticated readiness check. Failure artifacts were skipped. Mainnet jobs were correctly skipped.

## Impact

No mainnet deployment or owner funds moved. Sepolia has one exact recoverable 110000-unit x402 charge and one leaderless 262500-unit canary escrow. Both are pinned in protected recovery; the competition is not recoverable until 2026-08-23T01:17:40Z.

## Action

- derive run-specific loopback prover/API ports;
- require the spawned prover PID to remain alive;
- require an authenticated malformed preflight to return HTTP 400 before any x402 payment;
- fail immediately on HTTP 401;
- upload failure artifacts unconditionally;
- refund payment 0xe8c661ecb109910de75cd0391c4dc3d07a3a769d5174328a54fe3221cc5aca90 before sweeping the current derived actors;
- add run 32596784971 actor scope and competition 0x2e749dd59cb50e14b61d9bf0d40dd1a012b62efa to protected expiry recovery.

## Validation

- `scripts/preflight.ps1 -Mode core`
- `python scripts/test_build_open_competition_v2_beta3_release.py` (26)
- `python scripts/test_recover_open_competition_v2_rehearsal_funds.py` (9)
- `python scripts/test_recover_open_competition_v2_x402_charge.py` (2)
- `python scripts/test_run_open_competition_v2_x402_rehearsal.py` (11)
- `python scripts/test_rehearse_open_competition_v2_beta3_prover_service.py` (1)
- YAML parse and `git diff --check`

Done when the protected recovery and fresh live Sepolia core+x402 rehearsal both pass with independent two-RPC confirmation. PR #970 and other contributor PRs are untouched.