### PR TITLE
Make Beta3 broker rebalance RPC submission resilient

### DIFF
--- a/scripts/fund_open_competition_v2_beta3_broker.py
+++ b/scripts/fund_open_competition_v2_beta3_broker.py
@@ -64,11 +64,37 @@ def signing_address(address: str) -> str:
 
 
 class SignedRpc:
-    def __init__(self, url: str, signer: Any, chain_id: int) -> None:
+    def __init__(
+        self,
+        url: str,
+        signer: Any,
+        chain_id: int,
+        broadcast_urls: list[str] | None = None,
+    ) -> None:
         self.url = url
         self.signer = signer
         self.chain_id = chain_id
-        require(int(rpc(url, "eth_chainId", []), 16) == chain_id, "RPC chain ID mismatch")
+        self.broadcast_urls = tuple(dict.fromkeys([url, *(broadcast_urls or [])]))
+        for endpoint in self.broadcast_urls:
+            require(
+                int(rpc(endpoint, "eth_chainId", []), 16) == chain_id,
+                "RPC chain ID mismatch",
+            )
+
+    def receipt(self, transaction_hash: str) -> dict[str, Any] | None:
+        for endpoint in self.broadcast_urls:
+            try:
+                receipt = rpc(endpoint, "eth_getTransactionReceipt", [transaction_hash])
+            except RuntimeError:
+                continue
+            if receipt:
+                require(
+                    receipt.get("transactionHash", "").lower()
+                    == transaction_hash.lower(),
+                    "RPC returned a receipt for an unexpected transaction",
+                )
+                return receipt
+        return None
 
     def send(self, *, to: str, data: str = "0x", value: int = 0) -> dict[str, Any]:
         to = signing_address(to)
@@ -105,19 +131,33 @@ class SignedRpc:
                 "type": 2,
             }
         )
-        tx_hash = rpc(
-            self.url,
-            "eth_sendRawTransaction",
-            ["0x" + bytes(signed.raw_transaction).hex()],
-        )
+        raw_transaction = "0x" + bytes(signed.raw_transaction).hex()
+        expected_hash = "0x" + bytes(signed.hash).hex()
+        submitted = False
+        for endpoint in self.broadcast_urls:
+            try:
+                tx_hash = rpc(endpoint, "eth_sendRawTransaction", [raw_transaction])
+            except RuntimeError:
+                continue
+            require(
+                tx_hash.lower() == expected_hash.lower(),
+                "RPC returned an unexpected transaction hash",
+            )
+            submitted = True
+            break
+        if not submitted and self.receipt(expected_hash) is None:
+            raise BrokerFundingError("raw transaction submission failed on every approved RPC")
         deadline = time.time() + 300
         while time.time() < deadline:
-            receipt = rpc(self.url, "eth_getTransactionReceipt", [tx_hash])
+            receipt = self.receipt(expected_hash)
             if receipt:
-                require(int(receipt["status"], 16) == 1, f"reserve transfer reverted: {tx_hash}")
+                require(
+                    int(receipt["status"], 16) == 1,
+                    f"reserve transfer reverted: {expected_hash}",
+                )
                 return receipt
             time.sleep(2)
-        raise BrokerFundingError(f"reserve transfer timed out: {tx_hash}")
+        raise BrokerFundingError(f"reserve transfer timed out: {expected_hash}")
 
     def wait_safe(self, block_number: int) -> dict[str, Any]:
         deadline = time.time() + 1_800

--- a/scripts/rebalance_open_competition_v2_beta3_broker.py
+++ b/scripts/rebalance_open_competition_v2_beta3_broker.py
@@ -154,7 +154,12 @@ def rebalance(
     transaction_hash = None
     transaction_block = safe_before["number"]
     if amount:
-        client = SignedRpc(primary_url, signer, CHAIN_ID)
+        client = SignedRpc(
+            primary_url,
+            signer,
+            CHAIN_ID,
+            broadcast_urls=[shadow_url],
+        )
         receipt = client.send(
             to=USDC,
             data="0x"

--- a/scripts/test_fund_open_competition_v2_beta3_broker.py
+++ b/scripts/test_fund_open_competition_v2_beta3_broker.py
@@ -1,6 +1,8 @@
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 import unittest
+from unittest.mock import patch
 
 
 PATH = Path(__file__).with_name("fund_open_competition_v2_beta3_broker.py")
@@ -55,6 +57,197 @@ class BrokerFundingTests(unittest.TestCase):
     def test_signing_address_rejects_malformed_destination(self):
         with self.assertRaisesRegex(MODULE.BrokerFundingError, "destination is invalid"):
             MODULE.signing_address("0x1234")
+
+    def test_signed_rpc_falls_back_with_the_identical_raw_transaction(self):
+        expected_hash = "0x" + "ab" * 32
+        calls = []
+
+        class Signer:
+            address = "0x0000000000000000000000000000000000000001"
+
+            @staticmethod
+            def sign_transaction(_transaction):
+                return SimpleNamespace(
+                    raw_transaction=bytes.fromhex("1234"),
+                    hash=bytes.fromhex("ab" * 32),
+                )
+
+        def fake_rpc(url, method, params):
+            calls.append((url, method, params))
+            if method == "eth_chainId":
+                return hex(8453)
+            if method == "eth_getTransactionCount":
+                return "0x18"
+            if method == "eth_getBlockByNumber":
+                return {"baseFeePerGas": "0x1"}
+            if method == "eth_maxPriorityFeePerGas":
+                return "0xf4240"
+            if method == "eth_estimateGas":
+                return "0x5208"
+            if method == "eth_sendRawTransaction" and url == "https://primary.invalid":
+                raise RuntimeError("rate limit exceeded")
+            if method == "eth_sendRawTransaction":
+                return expected_hash
+            if method == "eth_getTransactionReceipt" and url == "https://shadow.invalid":
+                return {
+                    "transactionHash": expected_hash,
+                    "blockNumber": "0x2",
+                    "status": "0x1",
+                }
+            if method == "eth_getTransactionReceipt":
+                return None
+            self.fail(f"unexpected RPC call: {url} {method} {params}")
+
+        with patch.object(MODULE, "rpc", side_effect=fake_rpc):
+            client = MODULE.SignedRpc(
+                "https://primary.invalid",
+                Signer(),
+                8453,
+                broadcast_urls=["https://shadow.invalid"],
+            )
+            receipt = client.send(
+                to="0x0000000000000000000000000000000000000002"
+            )
+
+        self.assertEqual(receipt["transactionHash"], expected_hash)
+        submissions = [call for call in calls if call[1] == "eth_sendRawTransaction"]
+        self.assertEqual(
+            submissions,
+            [
+                (
+                    "https://primary.invalid",
+                    "eth_sendRawTransaction",
+                    ["0x1234"],
+                ),
+                (
+                    "https://shadow.invalid",
+                    "eth_sendRawTransaction",
+                    ["0x1234"],
+                ),
+            ],
+        )
+
+    def test_signed_rpc_rejects_a_mismatched_transaction_hash(self):
+        class Signer:
+            address = "0x0000000000000000000000000000000000000001"
+
+            @staticmethod
+            def sign_transaction(_transaction):
+                return SimpleNamespace(
+                    raw_transaction=bytes.fromhex("1234"),
+                    hash=bytes.fromhex("ab" * 32),
+                )
+
+        def fake_rpc(_url, method, _params):
+            if method == "eth_chainId":
+                return hex(8453)
+            if method == "eth_getTransactionCount":
+                return "0x18"
+            if method == "eth_getBlockByNumber":
+                return {"baseFeePerGas": "0x1"}
+            if method == "eth_maxPriorityFeePerGas":
+                return "0xf4240"
+            if method == "eth_estimateGas":
+                return "0x5208"
+            if method == "eth_sendRawTransaction":
+                return "0x" + "cd" * 32
+            self.fail(f"unexpected RPC call: {method}")
+
+        with patch.object(MODULE, "rpc", side_effect=fake_rpc):
+            client = MODULE.SignedRpc("https://primary.invalid", Signer(), 8453)
+            with self.assertRaisesRegex(
+                MODULE.BrokerFundingError,
+                "unexpected transaction hash",
+            ):
+                client.send(to="0x0000000000000000000000000000000000000002")
+
+    def test_signed_rpc_accepts_an_already_known_receipt(self):
+        expected_hash = "0x" + "ab" * 32
+
+        class Signer:
+            address = "0x0000000000000000000000000000000000000001"
+
+            @staticmethod
+            def sign_transaction(_transaction):
+                return SimpleNamespace(
+                    raw_transaction=bytes.fromhex("1234"),
+                    hash=bytes.fromhex("ab" * 32),
+                )
+
+        def fake_rpc(_url, method, _params):
+            if method == "eth_chainId":
+                return hex(8453)
+            if method == "eth_getTransactionCount":
+                return "0x18"
+            if method == "eth_getBlockByNumber":
+                return {"baseFeePerGas": "0x1"}
+            if method == "eth_maxPriorityFeePerGas":
+                return "0xf4240"
+            if method == "eth_estimateGas":
+                return "0x5208"
+            if method == "eth_sendRawTransaction":
+                raise RuntimeError("already known")
+            if method == "eth_getTransactionReceipt":
+                return {
+                    "transactionHash": expected_hash,
+                    "blockNumber": "0x2",
+                    "status": "0x1",
+                }
+            self.fail(f"unexpected RPC call: {method}")
+
+        with patch.object(MODULE, "rpc", side_effect=fake_rpc):
+            client = MODULE.SignedRpc(
+                "https://primary.invalid",
+                Signer(),
+                8453,
+                broadcast_urls=["https://shadow.invalid"],
+            )
+            receipt = client.send(
+                to="0x0000000000000000000000000000000000000002"
+            )
+
+        self.assertEqual(receipt["transactionHash"], expected_hash)
+
+    def test_signed_rpc_fails_when_every_endpoint_rejects_without_a_receipt(self):
+        class Signer:
+            address = "0x0000000000000000000000000000000000000001"
+
+            @staticmethod
+            def sign_transaction(_transaction):
+                return SimpleNamespace(
+                    raw_transaction=bytes.fromhex("1234"),
+                    hash=bytes.fromhex("ab" * 32),
+                )
+
+        def fake_rpc(_url, method, _params):
+            if method == "eth_chainId":
+                return hex(8453)
+            if method == "eth_getTransactionCount":
+                return "0x18"
+            if method == "eth_getBlockByNumber":
+                return {"baseFeePerGas": "0x1"}
+            if method == "eth_maxPriorityFeePerGas":
+                return "0xf4240"
+            if method == "eth_estimateGas":
+                return "0x5208"
+            if method == "eth_sendRawTransaction":
+                raise RuntimeError("rate limit exceeded")
+            if method == "eth_getTransactionReceipt":
+                return None
+            self.fail(f"unexpected RPC call: {method}")
+
+        with patch.object(MODULE, "rpc", side_effect=fake_rpc):
+            client = MODULE.SignedRpc(
+                "https://primary.invalid",
+                Signer(),
+                8453,
+                broadcast_urls=["https://shadow.invalid"],
+            )
+            with self.assertRaisesRegex(
+                MODULE.BrokerFundingError,
+                "every approved RPC",
+            ):
+                client.send(to="0x0000000000000000000000000000000000000002")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Outcome\n- submit the identical signed broker transaction to the approved shadow RPC if the primary rejects submission\n- derive and verify the expected transaction hash locally\n- reconcile receipts across both endpoints and retain fail-closed behavior\n- cover rate-limit fallback, mismatched hashes, already-known receipts, and total rejection\n\n## Evidence\n- python scripts/test_fund_open_competition_v2_beta3_broker.py (8 passed)\n- python scripts/test_rebalance_open_competition_v2_beta3_broker.py (5 passed)\n- python -m py_compile ...\n- scripts/preflight.ps1 -Mode core\n- git diff --check\n\nNo owner-wallet transaction or marketplace funding is performed by this change. The release remains gated on canonical dual-RPC rebalance evidence.