### PR TITLE
Recover exact Beta3 mainnet deployment

### DIFF
--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -841,15 +841,17 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}/scripts
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
           BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
           OPEN_COMPETITION_V2_BROKER_ADDRESS: ${{ vars.OPEN_COMPETITION_V2_BROKER_ADDRESS }}
         run: |
           set -euo pipefail
           test -n "$BASE_MAINNET_RPC_URL" && test -n "$BASE_MAINNET_DEPLOYER_PRIVATE_KEY"
-          test -n "$OPEN_COMPETITION_V2_BROKER_ADDRESS"
+          test -n "$BASE_MAINNET_SHADOW_RPC_URL" && test -n "$OPEN_COMPETITION_V2_BROKER_ADDRESS"
           python -m pip install -r scripts/requirements-wallet.txt
           python scripts/fund_open_competition_v2_beta3_broker.py \
-            --rpc-url "$BASE_MAINNET_RPC_URL" --broker "$OPEN_COMPETITION_V2_BROKER_ADDRESS" \
+            --rpc-url "$BASE_MAINNET_RPC_URL" --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
+            --broker "$OPEN_COMPETITION_V2_BROKER_ADDRESS" \
             --output target/mainnet-broker-seed.json
           forge build --root contracts/base-escrow --force --ast
           DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
@@ -868,6 +870,7 @@ jobs:
             --output target/mainnet-exact.json
           python scripts/deploy_open_competition_v2_beta3.py \
             --bundle target/mainnet-exact.json --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --output target/mainnet-deployment-evidence.json
           FACTORY="$(python -c 'import json; print(json.load(open("target/mainnet-exact.runtime.json"))["factory_contract"])')"
           RELEASE_HASH="$(python -c 'import json; print(json.load(open("target/mainnet-exact.runtime.json"))["release_hash"])')"
@@ -877,6 +880,7 @@ jobs:
           python scripts/deploy_bounded_open_competition_v2_wallet_factory.py \
             --manifest target/bounded-open-competition-v2-wallet-base-mainnet.json \
             --release target/mainnet-exact.runtime.json --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --output target/bounded-open-competition-v2-wallet-deployment-evidence.json
           python scripts/record_open_competition_v2_beta3_gate.py \
             --manifest target/release-gates.json --gate mainnet_verifiers_factory_deployed \

--- a/.github/workflows/recover-open-competition-v2-beta3-mainnet-deployment.yml
+++ b/.github/workflows/recover-open-competition-v2-beta3-mainnet-deployment.yml
@@ -1,0 +1,188 @@
+name: Recover Open Competition V2 Beta3 mainnet deployment
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: open-competition-v2-beta3-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  RELEASE_RUN_ID: "32606926043"
+  RELEASE_SOURCE_COMMIT: 5a351f3e373691be58a9575b4374812b494b6086
+  EXPECTED_DEPLOYER: "0xfd7be4c69541ab297aece2a674fc1418b898cc0a"
+  EXPECTED_START_NONCE: "34"
+  EXPECTED_OBSERVED_NONCE: "35"
+  EXPECTED_GROTH16_VERIFIER: "0x6788e13954e7e27f8d2c62ab8ce86b96b8d9169f"
+  EXPECTED_PLONK_VERIFIER: "0xa2549e89b7d56a99ddabcbece342a211e5ef340a"
+  EXPECTED_FACTORY: "0x29d0e39e0c03797c690633535722e6b34a69a78a"
+
+jobs:
+  recover-mainnet-deployment:
+    if: github.ref == 'refs/heads/main'
+    environment: v2-beta2-mainnet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Check out the exact frozen release
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ env.RELEASE_SOURCE_COMMIT }}
+      - name: Check out current fail-closed recovery controls
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5a
+        with:
+          ref: ${{ github.sha }}
+          path: .release-control
+      - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+      - name: Download the exact reviewed verifier assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: open-competition-v2-beta3-release-assets-${{ env.RELEASE_SOURCE_COMMIT }}
+          path: target/release-assets
+          github-token: ${{ github.token }}
+          run-id: ${{ env.RELEASE_RUN_ID }}
+      - name: Download the exact successful Sepolia evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: open-competition-v2-beta3-live-sepolia-${{ env.RELEASE_SOURCE_COMMIT }}
+          path: target/live-sepolia
+          github-token: ${{ github.token }}
+          run-id: ${{ env.RELEASE_RUN_ID }}
+      - name: Recover only the missing exact deployments
+        env:
+          BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
+          BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$BASE_MAINNET_RPC_URL"
+          test -n "$BASE_MAINNET_SHADOW_RPC_URL"
+          test "$BASE_MAINNET_RPC_URL" != "$BASE_MAINNET_SHADOW_RPC_URL"
+          test -n "$BASE_MAINNET_DEPLOYER_PRIVATE_KEY"
+          test "$(git rev-parse HEAD)" = "$RELEASE_SOURCE_COMMIT"
+          test "$(git -C .release-control rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-parse HEAD:contracts/base-escrow)" = \
+            "$(git -C .release-control rev-parse HEAD:contracts/base-escrow)"
+          test -f target/release-assets/verifier-assets.json
+          test -f target/live-sepolia/release-gates.json
+          test -f target/live-sepolia/sepolia-rehearsal.json
+          test -f target/live-sepolia/sepolia-x402-rehearsal.json
+          jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \
+            '.passed == true and .source_commit == $commit' \
+            target/live-sepolia/sepolia-rehearsal.json >/dev/null
+          jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \
+            '.passed == true and .source_commit == $commit and (.settlement_event_id | length > 0)' \
+            target/live-sepolia/sepolia-x402-rehearsal.json >/dev/null
+          jq -e '.asset_state == "self_verified" and
+                 .setup_provenance.mainnet_eligible == true and
+                 (.proof_evidence.groth16_self_verified | length > 0) and
+                 (.proof_evidence.plonk_self_verified_1 | length > 0) and
+                 (.proof_evidence.plonk_self_verified_2 | length > 0)' \
+            target/release-assets/verifier-assets.json >/dev/null
+          python -m pip install -r .release-control/scripts/requirements-wallet.txt
+          forge build --root contracts/base-escrow --force --ast
+          DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
+          test "$DEPLOYER" = "$EXPECTED_DEPLOYER"
+          cp target/live-sepolia/release-gates.json target/release-gates.json
+          export RISK_HASH="$(PYTHONPATH="$GITHUB_WORKSPACE/scripts" python -c 'import json; from eth_utils import keccak; value=json.load(open("target/release-gates.json")); print("0x" + keccak(text=value["beta_risk_preimage"]).hex())')"
+          python - <<'PY'
+          import json
+          import os
+
+          json.dump(
+              {
+                  "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-deployment-recovery-approval-v1",
+                  "environment": "v2-beta2-mainnet",
+                  "run_id": os.environ["GITHUB_RUN_ID"],
+                  "source_commit": os.environ["RELEASE_SOURCE_COMMIT"],
+                  "risk_hash": os.environ["RISK_HASH"],
+                  "release_run_id": os.environ["RELEASE_RUN_ID"],
+                  "approval_scope": "recover only the original nonce-34 exact release deployment",
+                  "evidence_boundary": "This environment approval authorizes exact deployment recovery. It does not authorize owner USDC or bounty settlement.",
+              },
+              open("target/owner-mainnet-deployment-recovery-approval.json", "w"),
+              indent=2,
+          )
+          PY
+          PYTHONPATH="$GITHUB_WORKSPACE/scripts" python scripts/record_open_competition_v2_beta3_gate.py \
+            --manifest target/release-gates.json --gate owner_mainnet_deployment_approved \
+            --evidence target/owner-mainnet-deployment-recovery-approval.json \
+            --uri "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --source-commit "$RELEASE_SOURCE_COMMIT" --owner-risk-hash "$RISK_HASH"
+          PYTHONPATH="$GITHUB_WORKSPACE/.release-control/scripts" \
+            python .release-control/scripts/build_open_competition_v2_beta3_release.py \
+            --network base-mainnet --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --deployer "$DEPLOYER" --source-commit "$RELEASE_SOURCE_COMMIT" \
+            --verifier-assets target/release-assets/verifier-assets.json \
+            --gates target/release-gates.json --output target/mainnet-exact.json \
+            --release-root "$GITHUB_WORKSPACE"
+          jq -e \
+            --argjson start "$EXPECTED_START_NONCE" \
+            --argjson observed "$EXPECTED_OBSERVED_NONCE" \
+            --arg groth "$EXPECTED_GROTH16_VERIFIER" \
+            --arg plonk "$EXPECTED_PLONK_VERIFIER" \
+            --arg factory "$EXPECTED_FACTORY" \
+            '.preflight_safe_block.deployer_nonce == $start and
+             .preflight_safe_block.observed_deployer_nonce == $observed and
+             .preflight_safe_block.resuming_exact_verifiers == true and
+             .groth16_verifier.address == $groth and
+             .plonk_verifier.address == $plonk and
+             .factory.address == $factory and
+             [.deployment_transactions[].from_nonce] == [$start, ($start + 1), ($start + 2)]' \
+            target/mainnet-exact.json >/dev/null
+          PYTHONPATH="$GITHUB_WORKSPACE/.release-control/scripts" \
+            python .release-control/scripts/deploy_open_competition_v2_beta3.py \
+            --bundle target/mainnet-exact.json --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
+            --output target/mainnet-deployment-evidence.json
+          jq -e \
+            --arg groth "$EXPECTED_GROTH16_VERIFIER" \
+            --arg plonk "$EXPECTED_PLONK_VERIFIER" \
+            --arg factory "$EXPECTED_FACTORY" \
+            '.complete == true and
+             .transactions[0].contract_address == $groth and
+             .transactions[0].recovered_exact_deployment == true and
+             .transactions[1].contract_address == $plonk and
+             .transactions[2].contract_address == $factory and
+             (.safe_block.number > 0)' \
+            target/mainnet-deployment-evidence.json >/dev/null
+          FACTORY="$(jq -r .factory_contract target/mainnet-exact.runtime.json)"
+          RELEASE_HASH="$(jq -r .release_hash target/mainnet-exact.runtime.json)"
+          PYTHONPATH="$GITHUB_WORKSPACE/.release-control/scripts" \
+            python .release-control/scripts/build_bounded_open_competition_v2_wallet_bundle.py \
+            --competition-factory "$FACTORY" --release-hash "$RELEASE_HASH" \
+            --output target/bounded-open-competition-v2-wallet-base-mainnet.json
+          PYTHONPATH="$GITHUB_WORKSPACE/.release-control/scripts" \
+            python .release-control/scripts/deploy_bounded_open_competition_v2_wallet_factory.py \
+            --manifest target/bounded-open-competition-v2-wallet-base-mainnet.json \
+            --release target/mainnet-exact.runtime.json --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
+            --output target/bounded-open-competition-v2-wallet-deployment-evidence.json
+          jq -e '.complete == true and (.safe_block.number > 0)' \
+            target/bounded-open-competition-v2-wallet-deployment-evidence.json >/dev/null
+          PYTHONPATH="$GITHUB_WORKSPACE/scripts" python scripts/record_open_competition_v2_beta3_gate.py \
+            --manifest target/release-gates.json --gate mainnet_verifiers_factory_deployed \
+            --evidence target/mainnet-deployment-evidence.json \
+            --uri "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --source-commit "$RELEASE_SOURCE_COMMIT"
+      - name: Preserve canonical recovery evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: open-competition-v2-beta3-mainnet-deployment-recovery-${{ github.sha }}-${{ github.run_attempt }}
+          path: |
+            target/mainnet-exact.json
+            target/mainnet-exact.runtime.json
+            target/mainnet-deployment-evidence.json
+            target/bounded-open-competition-v2-wallet-base-mainnet.json
+            target/bounded-open-competition-v2-wallet-deployment-evidence.json
+            target/owner-mainnet-deployment-recovery-approval.json
+            target/release-gates.json
+          if-no-files-found: error
+          retention-days: 365

--- a/scripts/build_open_competition_v2_beta3_release.py
+++ b/scripts/build_open_competition_v2_beta3_release.py
@@ -540,7 +540,17 @@ def resume_exact_verifier_pair(
     groth16_runtime_hash: str,
     plonk_runtime_hash: str,
 ) -> int:
-    """Reuse an exact verifier pair when a prior factory deployment was interrupted."""
+    """Reuse an exact verifier prefix when a prior deployment was interrupted."""
+    if observed_nonce < 1:
+        return observed_nonce
+    single_start = observed_nonce - 1
+    single_groth16 = create_address(deployer, single_start)
+    single_plonk = create_address(deployer, single_start + 1)
+    if (
+        code_hash(single_groth16) == groth16_runtime_hash
+        and code_hash(single_plonk) is None
+    ):
+        return single_start
     if observed_nonce < 2:
         return observed_nonce
     minimum_nonce = max(0, observed_nonce - 16)

--- a/scripts/deploy_bounded_open_competition_v2_wallet_factory.py
+++ b/scripts/deploy_bounded_open_competition_v2_wallet_factory.py
@@ -169,11 +169,7 @@ def send_create2(client: SignedRpc, manifest: dict[str, Any]) -> dict[str, Any]:
             "type": 2,
         }
     )
-    transaction_hash = rpc(
-        client.url,
-        "eth_sendRawTransaction",
-        ["0x" + bytes(signed.raw_transaction).hex()],
-    )
+    transaction_hash = client.broadcast(signed)
     return client.wait_receipt(transaction_hash)
 
 
@@ -266,6 +262,7 @@ def main() -> int:
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--release", type=Path, required=True)
     parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--shadow-rpc-url")
     parser.add_argument("--private-key-env", default="BASE_MAINNET_DEPLOYER_PRIVATE_KEY")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
@@ -277,7 +274,12 @@ def main() -> int:
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
     release = json.loads(args.release.read_text(encoding="utf-8"))
     signer = Account.from_key(private_key)
-    evidence = deploy(manifest, release, SignedRpc(args.rpc_url, signer), args.output)
+    evidence = deploy(
+        manifest,
+        release,
+        SignedRpc(args.rpc_url, signer, args.shadow_rpc_url),
+        args.output,
+    )
     print(
         json.dumps(
             {

--- a/scripts/deploy_open_competition_v2_beta3.py
+++ b/scripts/deploy_open_competition_v2_beta3.py
@@ -68,10 +68,73 @@ def validate_bundle(bundle: dict[str, Any], signer_address: str) -> None:
 
 
 class SignedRpc:
-    def __init__(self, url: str, signer: Any) -> None:
+    def __init__(self, url: str, signer: Any, shadow_url: str | None = None) -> None:
         self.url = url
         self.signer = signer
-        require(int(rpc(url, "eth_chainId", []), 16) == 8453, "RPC is not Base mainnet")
+        self.broadcast_urls = tuple(
+            dict.fromkeys([url, *([shadow_url] if shadow_url else [])])
+        )
+        for endpoint in self.broadcast_urls:
+            require(
+                int(rpc(endpoint, "eth_chainId", []), 16) == 8453,
+                "RPC is not Base mainnet",
+            )
+
+    def receipt(self, transaction_hash: str) -> dict[str, Any] | None:
+        for endpoint in self.broadcast_urls:
+            try:
+                receipt = rpc(endpoint, "eth_getTransactionReceipt", [transaction_hash])
+            except RuntimeError:
+                continue
+            if receipt:
+                require(
+                    receipt.get("transactionHash", "").lower()
+                    == transaction_hash.lower(),
+                    "RPC returned a receipt for an unexpected transaction",
+                )
+                return receipt
+        return None
+
+    def transaction(self, transaction_hash: str) -> dict[str, Any] | None:
+        for endpoint in self.broadcast_urls:
+            try:
+                transaction = rpc(endpoint, "eth_getTransactionByHash", [transaction_hash])
+            except RuntimeError:
+                continue
+            if transaction:
+                require(
+                    transaction.get("hash", "").lower() == transaction_hash.lower(),
+                    "RPC returned an unexpected pending transaction",
+                )
+                return transaction
+        return None
+
+    def broadcast(self, signed: Any) -> str:
+        raw_transaction = "0x" + bytes(signed.raw_transaction).hex()
+        expected_hash = "0x" + bytes(signed.hash).hex()
+        submitted = False
+        for endpoint in self.broadcast_urls:
+            try:
+                transaction_hash = rpc(
+                    endpoint,
+                    "eth_sendRawTransaction",
+                    [raw_transaction],
+                )
+            except RuntimeError:
+                continue
+            require(
+                transaction_hash.lower() == expected_hash.lower(),
+                "RPC returned an unexpected transaction hash",
+            )
+            submitted = True
+            break
+        if (
+            not submitted
+            and self.receipt(expected_hash) is None
+            and self.transaction(expected_hash) is None
+        ):
+            raise RuntimeError("raw deployment submission failed on every approved RPC")
+        return expected_hash
 
     def code_hash(self, address: str, block: str = "latest") -> str | None:
         deadline = time.time() + 120
@@ -124,17 +187,13 @@ class SignedRpc:
                 "type": 2,
             }
         )
-        transaction_hash = rpc(
-            self.url,
-            "eth_sendRawTransaction",
-            ["0x" + bytes(signed.raw_transaction).hex()],
-        )
+        transaction_hash = self.broadcast(signed)
         return self.wait_receipt(transaction_hash)
 
     def wait_receipt(self, transaction_hash: str, timeout_seconds: int = 600) -> dict[str, Any]:
         deadline = time.time() + timeout_seconds
         while time.time() < deadline:
-            receipt = rpc(self.url, "eth_getTransactionReceipt", [transaction_hash])
+            receipt = self.receipt(transaction_hash)
             if receipt:
                 require(int(receipt["status"], 16) == 1, f"deployment reverted: {transaction_hash}")
                 return receipt
@@ -316,6 +375,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--bundle", type=Path, required=True)
     parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--shadow-rpc-url")
     parser.add_argument("--private-key-env", default="BASE_MAINNET_DEPLOYER_PRIVATE_KEY")
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args()
@@ -328,7 +388,11 @@ def main() -> int:
     signer = Account.from_key(private_key)
     bundle = json.loads(args.bundle.read_text(encoding="utf-8"))
     validate_bundle(bundle, signer.address)
-    evidence = deploy(bundle, SignedRpc(args.rpc_url, signer), args.output)
+    evidence = deploy(
+        bundle,
+        SignedRpc(args.rpc_url, signer, args.shadow_rpc_url),
+        args.output,
+    )
     print(json.dumps({"output": str(args.output), "factory": bundle["factory"]["address"], "safe_block": evidence["safe_block"]["number"]}))
     return 0
 

--- a/scripts/fund_open_competition_v2_beta3_broker.py
+++ b/scripts/fund_open_competition_v2_beta3_broker.py
@@ -96,6 +96,20 @@ class SignedRpc:
                 return receipt
         return None
 
+    def transaction(self, transaction_hash: str) -> dict[str, Any] | None:
+        for endpoint in self.broadcast_urls:
+            try:
+                transaction = rpc(endpoint, "eth_getTransactionByHash", [transaction_hash])
+            except RuntimeError:
+                continue
+            if transaction:
+                require(
+                    transaction.get("hash", "").lower() == transaction_hash.lower(),
+                    "RPC returned an unexpected pending transaction",
+                )
+                return transaction
+        return None
+
     def send(self, *, to: str, data: str = "0x", value: int = 0) -> dict[str, Any]:
         to = signing_address(to)
         nonce = int(rpc(self.url, "eth_getTransactionCount", [self.signer.address, "pending"]), 16)
@@ -145,7 +159,11 @@ class SignedRpc:
             )
             submitted = True
             break
-        if not submitted and self.receipt(expected_hash) is None:
+        if (
+            not submitted
+            and self.receipt(expected_hash) is None
+            and self.transaction(expected_hash) is None
+        ):
             raise BrokerFundingError("raw transaction submission failed on every approved RPC")
         deadline = time.time() + 300
         while time.time() < deadline:
@@ -173,6 +191,7 @@ def fund(
     *,
     network_name: str,
     rpc_url: str,
+    shadow_rpc_url: str | None,
     private_key: str,
     broker: str,
     target_usdc: int,
@@ -181,10 +200,18 @@ def fund(
     require(network_name in NETWORKS, "unsupported broker funding network")
     network = NETWORKS[network_name]
     require(rpc_url.startswith("https://"), "broker funding RPC must use HTTPS")
+    if shadow_rpc_url:
+        require(shadow_rpc_url.startswith("https://"), "shadow broker RPC must use HTTPS")
+        require(shadow_rpc_url != rpc_url, "broker funding RPCs must be distinct")
     require(ADDRESS.fullmatch(broker) is not None, "broker address is invalid")
     signer = Account.from_key(private_key)
     require(signer.address.lower() != broker.lower(), "broker and deployer must be distinct")
-    client = SignedRpc(rpc_url, signer, network["chain_id"])
+    client = SignedRpc(
+        rpc_url,
+        signer,
+        network["chain_id"],
+        broadcast_urls=[shadow_rpc_url] if shadow_rpc_url else None,
+    )
     safe_before = rpc(rpc_url, "eth_getBlockByNumber", ["safe", False])
     require(safe_before and safe_before.get("hash"), "RPC did not return a safe block")
     current_usdc = usdc_balance(rpc_url, network["usdc"], broker, safe_before["number"])
@@ -244,6 +271,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--network", choices=tuple(NETWORKS), default="base-mainnet")
     parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--shadow-rpc-url")
     parser.add_argument("--private-key-env", default="BASE_MAINNET_DEPLOYER_PRIVATE_KEY")
     parser.add_argument("--broker", required=True)
     parser.add_argument("--target-usdc-base-units", type=int)
@@ -258,6 +286,7 @@ def main() -> int:
     result = fund(
         network_name=args.network,
         rpc_url=args.rpc_url,
+        shadow_rpc_url=args.shadow_rpc_url,
         private_key=private_key,
         broker=args.broker,
         target_usdc=target_usdc,

--- a/scripts/test_build_open_competition_v2_beta3_release.py
+++ b/scripts/test_build_open_competition_v2_beta3_release.py
@@ -38,6 +38,23 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
 
         self.assertEqual(start, 2)
 
+    def test_resumes_one_exact_verifier_after_lost_submission_response(self):
+        deployer = MODULE.DEFAULT_DEPLOYER
+        start_nonce = 34
+        expected = {
+            MODULE.create_address(deployer, start_nonce): "groth16",
+        }
+
+        start = MODULE.resume_exact_verifier_pair(
+            deployer=deployer,
+            observed_nonce=start_nonce + 1,
+            code_hash=lambda address: expected.get(address),
+            groth16_runtime_hash="groth16",
+            plonk_runtime_hash="plonk",
+        )
+
+        self.assertEqual(start, start_nonce)
+
     def test_does_not_resume_inexact_partial_deployment(self):
         deployer = MODULE.DEFAULT_DEPLOYER
         groth16 = MODULE.create_address(deployer, 2)

--- a/scripts/test_deploy_open_competition_v2_beta3.py
+++ b/scripts/test_deploy_open_competition_v2_beta3.py
@@ -1,6 +1,7 @@
 import copy
 import json
 from pathlib import Path
+from types import SimpleNamespace
 import tempfile
 import unittest
 from unittest import mock
@@ -114,6 +115,144 @@ class DeploymentValidationTests(unittest.TestCase):
         self.assertEqual(result["number"], "0x2a")
         self.assertEqual(rpc_call.call_count, 2)
         sleep.assert_called_once_with(5)
+
+    def test_broadcasts_identical_raw_transaction_to_shadow_after_primary_failure(
+        self,
+    ) -> None:
+        primary = "https://primary.example"
+        shadow = "https://shadow.example"
+        expected_hash = "0x" + "12" * 32
+        raw_transaction = "0xaabb"
+        calls: list[tuple[str, str, list[object]]] = []
+
+        def fake_rpc(url: str, method: str, params: list[object]):
+            calls.append((url, method, params))
+            if method == "eth_chainId":
+                return "0x2105"
+            if method == "eth_sendRawTransaction" and url == primary:
+                raise RuntimeError("HTTP 429")
+            if method == "eth_sendRawTransaction":
+                return expected_hash
+            if method == "eth_getTransactionReceipt" and url == primary:
+                raise RuntimeError("HTTP 429")
+            if method == "eth_getTransactionReceipt":
+                return {
+                    "transactionHash": expected_hash,
+                    "status": "0x1",
+                }
+            raise AssertionError((url, method, params))
+
+        signed = SimpleNamespace(
+            raw_transaction=bytes.fromhex(raw_transaction[2:]),
+            hash=bytes.fromhex(expected_hash[2:]),
+        )
+        with mock.patch.object(deploy, "rpc", side_effect=fake_rpc):
+            client = deploy.SignedRpc(primary, SimpleNamespace(address="0x" + "11" * 20), shadow)
+            self.assertEqual(client.broadcast(signed), expected_hash)
+            self.assertEqual(client.receipt(expected_hash)["status"], "0x1")
+
+        submissions = [
+            (url, params[0])
+            for url, method, params in calls
+            if method == "eth_sendRawTransaction"
+        ]
+        self.assertEqual(
+            submissions,
+            [(primary, raw_transaction), (shadow, raw_transaction)],
+        )
+
+    def test_rejects_rpc_transaction_hash_mismatch(self) -> None:
+        primary = "https://primary.example"
+        expected_hash = "0x" + "12" * 32
+
+        def fake_rpc(_url: str, method: str, _params: list[object]):
+            if method == "eth_chainId":
+                return "0x2105"
+            if method == "eth_sendRawTransaction":
+                return "0x" + "34" * 32
+            raise AssertionError(method)
+
+        signed = SimpleNamespace(
+            raw_transaction=bytes.fromhex("aabb"),
+            hash=bytes.fromhex(expected_hash[2:]),
+        )
+        with mock.patch.object(deploy, "rpc", side_effect=fake_rpc):
+            client = deploy.SignedRpc(primary, SimpleNamespace(address="0x" + "11" * 20))
+            with self.assertRaisesRegex(RuntimeError, "unexpected transaction hash"):
+                client.broadcast(signed)
+
+    def test_accepts_already_mined_transaction_when_broadcast_responses_fail(self) -> None:
+        primary = "https://primary.example"
+        shadow = "https://shadow.example"
+        expected_hash = "0x" + "12" * 32
+
+        def fake_rpc(url: str, method: str, _params: list[object]):
+            if method == "eth_chainId":
+                return "0x2105"
+            if method == "eth_sendRawTransaction":
+                raise RuntimeError("already known")
+            if method == "eth_getTransactionReceipt" and url == primary:
+                return None
+            if method == "eth_getTransactionReceipt":
+                return {"transactionHash": expected_hash, "status": "0x1"}
+            raise AssertionError((url, method))
+
+        signed = SimpleNamespace(
+            raw_transaction=bytes.fromhex("aabb"),
+            hash=bytes.fromhex(expected_hash[2:]),
+        )
+        with mock.patch.object(deploy, "rpc", side_effect=fake_rpc):
+            client = deploy.SignedRpc(primary, SimpleNamespace(address="0x" + "11" * 20), shadow)
+            self.assertEqual(client.broadcast(signed), expected_hash)
+
+    def test_accepts_pending_transaction_when_broadcast_responses_fail(self) -> None:
+        primary = "https://primary.example"
+        shadow = "https://shadow.example"
+        expected_hash = "0x" + "12" * 32
+
+        def fake_rpc(url: str, method: str, _params: list[object]):
+            if method == "eth_chainId":
+                return "0x2105"
+            if method == "eth_sendRawTransaction":
+                raise RuntimeError("already known")
+            if method == "eth_getTransactionReceipt":
+                return None
+            if method == "eth_getTransactionByHash" and url == primary:
+                return None
+            if method == "eth_getTransactionByHash":
+                return {"hash": expected_hash, "blockNumber": None}
+            raise AssertionError((url, method))
+
+        signed = SimpleNamespace(
+            raw_transaction=bytes.fromhex("aabb"),
+            hash=bytes.fromhex(expected_hash[2:]),
+        )
+        with mock.patch.object(deploy, "rpc", side_effect=fake_rpc):
+            client = deploy.SignedRpc(primary, SimpleNamespace(address="0x" + "11" * 20), shadow)
+            self.assertEqual(client.broadcast(signed), expected_hash)
+
+    def test_fails_when_every_rpc_rejects_and_transaction_is_absent(self) -> None:
+        primary = "https://primary.example"
+        shadow = "https://shadow.example"
+        expected_hash = "0x" + "12" * 32
+
+        def fake_rpc(_url: str, method: str, _params: list[object]):
+            if method == "eth_chainId":
+                return "0x2105"
+            if method == "eth_sendRawTransaction":
+                raise RuntimeError("rate limit")
+            if method in {"eth_getTransactionReceipt", "eth_getTransactionByHash"}:
+                return None
+            raise AssertionError(method)
+
+        signed = SimpleNamespace(
+            raw_transaction=bytes.fromhex("aabb"),
+            hash=bytes.fromhex(expected_hash[2:]),
+        )
+        with mock.patch.object(deploy, "rpc", side_effect=fake_rpc):
+            client = deploy.SignedRpc(primary, SimpleNamespace(address="0x" + "11" * 20), shadow)
+            with self.assertRaisesRegex(RuntimeError, "every approved RPC"):
+                client.broadcast(signed)
 
 
 if __name__ == "__main__":

--- a/scripts/test_fund_open_competition_v2_beta3_broker.py
+++ b/scripts/test_fund_open_competition_v2_beta3_broker.py
@@ -208,6 +208,65 @@ class BrokerFundingTests(unittest.TestCase):
 
         self.assertEqual(receipt["transactionHash"], expected_hash)
 
+    def test_signed_rpc_accepts_an_already_known_pending_transaction(self):
+        expected_hash = "0x" + "ab" * 32
+
+        class Signer:
+            address = "0x0000000000000000000000000000000000000001"
+
+            @staticmethod
+            def sign_transaction(_transaction):
+                return SimpleNamespace(
+                    raw_transaction=bytes.fromhex("1234"),
+                    hash=bytes.fromhex("ab" * 32),
+                )
+
+        receipt_calls = 0
+
+        def fake_rpc(url, method, _params):
+            nonlocal receipt_calls
+            if method == "eth_chainId":
+                return hex(8453)
+            if method == "eth_getTransactionCount":
+                return "0x18"
+            if method == "eth_getBlockByNumber":
+                return {"baseFeePerGas": "0x1"}
+            if method == "eth_maxPriorityFeePerGas":
+                return "0xf4240"
+            if method == "eth_estimateGas":
+                return "0x5208"
+            if method == "eth_sendRawTransaction":
+                raise RuntimeError("already known")
+            if method == "eth_getTransactionReceipt":
+                receipt_calls += 1
+                if receipt_calls <= 2:
+                    return None
+                return {
+                    "transactionHash": expected_hash,
+                    "blockNumber": "0x2",
+                    "status": "0x1",
+                }
+            if method == "eth_getTransactionByHash" and url == "https://primary.invalid":
+                return None
+            if method == "eth_getTransactionByHash":
+                return {"hash": expected_hash, "blockNumber": None}
+            self.fail(f"unexpected RPC call: {url} {method}")
+
+        with patch.object(MODULE, "rpc", side_effect=fake_rpc), patch.object(
+            MODULE.time, "sleep"
+        ):
+            client = MODULE.SignedRpc(
+                "https://primary.invalid",
+                Signer(),
+                8453,
+                broadcast_urls=["https://shadow.invalid"],
+            )
+            receipt = client.send(
+                to="0x0000000000000000000000000000000000000002"
+            )
+
+        self.assertEqual(receipt["transactionHash"], expected_hash)
+
     def test_signed_rpc_fails_when_every_endpoint_rejects_without_a_receipt(self):
         class Signer:
             address = "0x0000000000000000000000000000000000000001"
@@ -233,6 +292,8 @@ class BrokerFundingTests(unittest.TestCase):
             if method == "eth_sendRawTransaction":
                 raise RuntimeError("rate limit exceeded")
             if method == "eth_getTransactionReceipt":
+                return None
+            if method == "eth_getTransactionByHash":
                 return None
             self.fail(f"unexpected RPC call: {method}")
 

--- a/scripts/test_recover_open_competition_v2_beta3_mainnet_deployment.py
+++ b/scripts/test_recover_open_competition_v2_beta3_mainnet_deployment.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/recover-open-competition-v2-beta3-mainnet-deployment.yml"
+SOURCE_COMMIT = "5a351f3e373691be58a9575b4374812b494b6086"
+RELEASE_RUN_ID = "32606926043"
+
+
+class MainnetDeploymentRecoveryWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+        cls.workflow = yaml.safe_load(cls.text)
+
+    def test_recovery_is_manual_main_only_and_protected(self) -> None:
+        self.assertIn("workflow_dispatch", self.workflow[True])
+        self.assertNotIn("push", self.workflow[True])
+        self.assertNotIn("schedule", self.workflow[True])
+        job = self.workflow["jobs"]["recover-mainnet-deployment"]
+        self.assertEqual(job["if"], "github.ref == 'refs/heads/main'")
+        self.assertEqual(job["environment"], "v2-beta2-mainnet")
+        self.assertEqual(self.workflow["permissions"], {"actions": "read", "contents": "read"})
+
+    def test_exact_release_artifacts_and_addresses_are_pinned(self) -> None:
+        environment = self.workflow["env"]
+        self.assertEqual(environment["RELEASE_SOURCE_COMMIT"], SOURCE_COMMIT)
+        self.assertEqual(str(environment["RELEASE_RUN_ID"]), RELEASE_RUN_ID)
+        self.assertEqual(environment["EXPECTED_START_NONCE"], "34")
+        self.assertEqual(environment["EXPECTED_OBSERVED_NONCE"], "35")
+        self.assertEqual(
+            environment["EXPECTED_GROTH16_VERIFIER"],
+            "0x6788e13954e7e27f8d2c62ab8ce86b96b8d9169f",
+        )
+        self.assertEqual(
+            environment["EXPECTED_PLONK_VERIFIER"],
+            "0xa2549e89b7d56a99ddabcbece342a211e5ef340a",
+        )
+        self.assertEqual(
+            environment["EXPECTED_FACTORY"],
+            "0x29d0e39e0c03797c690633535722e6b34a69a78a",
+        )
+        self.assertIn("run-id: ${{ env.RELEASE_RUN_ID }}", self.text)
+        self.assertIn(
+            "open-competition-v2-beta3-release-assets-${{ env.RELEASE_SOURCE_COMMIT }}",
+            self.text,
+        )
+        self.assertIn(
+            "open-competition-v2-beta3-live-sepolia-${{ env.RELEASE_SOURCE_COMMIT }}",
+            self.text,
+        )
+
+    def test_frozen_source_and_current_recovery_controls_are_separate(self) -> None:
+        job = self.workflow["jobs"]["recover-mainnet-deployment"]
+        checkouts = [
+            step
+            for step in job["steps"]
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        ]
+        self.assertEqual(checkouts[0]["with"]["ref"], "${{ env.RELEASE_SOURCE_COMMIT }}")
+        self.assertEqual(checkouts[1]["with"]["ref"], "${{ github.sha }}")
+        self.assertEqual(checkouts[1]["with"]["path"], ".release-control")
+        self.assertIn("HEAD:contracts/base-escrow", self.text)
+        self.assertIn("--release-root \"$GITHUB_WORKSPACE\"", self.text)
+
+    def test_recovery_reuses_exact_prefix_and_dual_rpc_submission(self) -> None:
+        self.assertIn(".preflight_safe_block.resuming_exact_verifiers == true", self.text)
+        self.assertIn(".transactions[0].recovered_exact_deployment == true", self.text)
+        self.assertEqual(self.text.count('--shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL"'), 2)
+        self.assertIn("deploy_open_competition_v2_beta3.py", self.text)
+        self.assertIn("deploy_bounded_open_competition_v2_wallet_factory.py", self.text)
+        self.assertNotIn("fund_open_competition_v2_beta3_broker.py", self.text)
+
+    def test_recovery_does_not_authorize_owner_funds(self) -> None:
+        self.assertIn("does not authorize owner USDC or bounty settlement", self.text)
+        self.assertNotIn("OWNER_PRIVATE_KEY", self.text)
+        self.assertNotIn("77.668098", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Recovers the interrupted Open Competition V2 Beta3 mainnet deployment without changing the frozen release, signer-bound nonce sequence, verifier identities, or factory address.

## Safety

- recognizes only the exact nonce-34 Groth16 runtime prefix already canonical on Base
- keeps the original nonce 34/35/36 address sequence
- broadcasts the same signed raw transaction to the approved shadow RPC only after primary rejection
- reconciles mined and pending already-known transactions by locally derived hash
- deploys the bounded recoverable reserve factory before any owner USDC authorization
- adds a protected, main-only recovery workflow pinned to release run 32606926043 and source 5a351f3e373691be58a9575b4374812b494b6086
- does not authorize, transfer, or custody owner-wallet USDC

## Validation

- `scripts/preflight.ps1 -Mode core`
- 57 focused deployment/recovery tests
- 293 Open Competition V2 tests
- independent Base RPC checks agree on safe nonce 35 and exact Groth16 runtime hash; remaining pinned addresses are empty

## Open PR impact

PR #970 has no file overlap and remains the separately reviewed replenishment planner. PR #884 is conceptually related shared-RPC work but has no file overlap; this release-specific recovery remains self-contained and can later adopt a reviewed shared transport without changing this frozen deployment.

## Next owner

Maintainer: merge after required checks, dispatch the protected recovery workflow, verify canonical runtime hashes on both RPCs, then rerun only the failed job of pinned release run 32606926043.