### PR TITLE
Reconcile canonical Beta3 deployment receipts

### DIFF
--- a/.github/workflows/recover-open-competition-v2-beta3-mainnet-deployment.yml
+++ b/.github/workflows/recover-open-competition-v2-beta3-mainnet-deployment.yml
@@ -16,7 +16,6 @@ env:
   RELEASE_SOURCE_COMMIT: 5a351f3e373691be58a9575b4374812b494b6086
   EXPECTED_DEPLOYER: "0xfd7be4c69541ab297aece2a674fc1418b898cc0a"
   EXPECTED_START_NONCE: "34"
-  EXPECTED_OBSERVED_NONCE: "35"
   EXPECTED_GROTH16_VERIFIER: "0x6788e13954e7e27f8d2c62ab8ce86b96b8d9169f"
   EXPECTED_PLONK_VERIFIER: "0xa2549e89b7d56a99ddabcbece342a211e5ef340a"
   EXPECTED_FACTORY: "0x29d0e39e0c03797c690633535722e6b34a69a78a"
@@ -125,12 +124,12 @@ jobs:
             --release-root "$GITHUB_WORKSPACE"
           jq -e \
             --argjson start "$EXPECTED_START_NONCE" \
-            --argjson observed "$EXPECTED_OBSERVED_NONCE" \
             --arg groth "$EXPECTED_GROTH16_VERIFIER" \
             --arg plonk "$EXPECTED_PLONK_VERIFIER" \
             --arg factory "$EXPECTED_FACTORY" \
             '.preflight_safe_block.deployer_nonce == $start and
-             .preflight_safe_block.observed_deployer_nonce == $observed and
+             .preflight_safe_block.observed_deployer_nonce >= 35 and
+             .preflight_safe_block.observed_deployer_nonce <= 37 and
              .preflight_safe_block.resuming_exact_verifiers == true and
              .groth16_verifier.address == $groth and
              .plonk_verifier.address == $plonk and

--- a/scripts/deploy_open_competition_v2_beta3.py
+++ b/scripts/deploy_open_competition_v2_beta3.py
@@ -302,6 +302,30 @@ def recovered_component_record(
     raise RuntimeError(f"timed out recovering exact deployment: {component}")
 
 
+def reconcile_canonical_receipts(
+    evidence: dict[str, Any], client: SignedRpc
+) -> int:
+    for item in evidence["transactions"]:
+        transaction_hash = item["transaction_hash"]
+        if transaction_hash is None:
+            continue
+        receipt = client.receipt(transaction_hash)
+        require(receipt is not None, f"canonical deployment receipt is absent: {transaction_hash}")
+        require(
+            int(receipt["status"], 16) == 1,
+            f"canonical deployment reverted: {transaction_hash}",
+        )
+        observed_address = str(receipt.get("contractAddress", "")).lower()
+        require(
+            observed_address == item["contract_address"],
+            "canonical deployment receipt has another contract address",
+        )
+        item["block_number"] = int(receipt["blockNumber"], 16)
+        item["block_hash"] = receipt["blockHash"].lower()
+        item["gas_used"] = int(receipt["gasUsed"], 16)
+    return max(item["block_number"] for item in evidence["transactions"])
+
+
 def deploy(bundle: dict[str, Any], client: SignedRpc, output: Path) -> dict[str, Any]:
     evidence = load_evidence(bundle, output)
     completed = {item["component"]: item for item in evidence["transactions"]}
@@ -347,8 +371,11 @@ def deploy(bundle: dict[str, Any], client: SignedRpc, output: Path) -> dict[str,
             }
         evidence["transactions"].append(record)
         write_evidence(output, evidence)
-    deployment_block = max(item["block_number"] for item in evidence["transactions"])
+    deployment_block = reconcile_canonical_receipts(evidence, client)
+    client.wait_safe(deployment_block)
+    deployment_block = reconcile_canonical_receipts(evidence, client)
     safe = client.wait_safe(deployment_block)
+    write_evidence(output, evidence)
     for item in evidence["transactions"]:
         if item["transaction_hash"] is None:
             continue

--- a/scripts/test_deploy_open_competition_v2_beta3.py
+++ b/scripts/test_deploy_open_competition_v2_beta3.py
@@ -81,6 +81,64 @@ class DeploymentValidationTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "another release"):
                 deploy.load_evidence(value, output)
 
+    def test_refreshes_a_reincluded_transaction_to_its_canonical_receipt(self) -> None:
+        transaction_hash = "0x" + "12" * 32
+        contract = "0x" + "34" * 20
+        evidence = {
+            "transactions": [
+                {
+                    "transaction_hash": transaction_hash,
+                    "block_number": 10,
+                    "block_hash": "0x" + "56" * 32,
+                    "contract_address": contract,
+                    "gas_used": 1,
+                },
+                {
+                    "transaction_hash": None,
+                    "block_number": 11,
+                    "block_hash": "0x" + "78" * 32,
+                    "contract_address": "0x" + "90" * 20,
+                    "gas_used": None,
+                },
+            ]
+        }
+        client = SimpleNamespace(
+            receipt=mock.Mock(
+                return_value={
+                    "transactionHash": transaction_hash,
+                    "status": "0x1",
+                    "blockNumber": "0xc",
+                    "blockHash": "0x" + "ab" * 32,
+                    "contractAddress": contract,
+                    "gasUsed": "0x2a",
+                }
+            )
+        )
+
+        deployment_block = deploy.reconcile_canonical_receipts(evidence, client)
+
+        self.assertEqual(deployment_block, 12)
+        self.assertEqual(evidence["transactions"][0]["block_number"], 12)
+        self.assertEqual(evidence["transactions"][0]["block_hash"], "0x" + "ab" * 32)
+        self.assertEqual(evidence["transactions"][0]["gas_used"], 42)
+
+    def test_rejects_a_missing_canonical_receipt(self) -> None:
+        evidence = {
+            "transactions": [
+                {
+                    "transaction_hash": "0x" + "12" * 32,
+                    "block_number": 10,
+                    "block_hash": "0x" + "56" * 32,
+                    "contract_address": "0x" + "34" * 20,
+                    "gas_used": 1,
+                }
+            ]
+        }
+        client = SimpleNamespace(receipt=mock.Mock(return_value=None))
+
+        with self.assertRaisesRegex(RuntimeError, "canonical deployment receipt is absent"):
+            deploy.reconcile_canonical_receipts(evidence, client)
+
     def test_safe_runtime_check_uses_one_canonical_safe_block(self) -> None:
         client = object.__new__(deploy.SignedRpc)
         client.wait_safe = mock.Mock(return_value={"number": "0x2a"})

--- a/scripts/test_recover_open_competition_v2_beta3_mainnet_deployment.py
+++ b/scripts/test_recover_open_competition_v2_beta3_mainnet_deployment.py
@@ -30,7 +30,7 @@ class MainnetDeploymentRecoveryWorkflowTests(unittest.TestCase):
         self.assertEqual(environment["RELEASE_SOURCE_COMMIT"], SOURCE_COMMIT)
         self.assertEqual(str(environment["RELEASE_RUN_ID"]), RELEASE_RUN_ID)
         self.assertEqual(environment["EXPECTED_START_NONCE"], "34")
-        self.assertEqual(environment["EXPECTED_OBSERVED_NONCE"], "35")
+        self.assertNotIn("EXPECTED_OBSERVED_NONCE", environment)
         self.assertEqual(
             environment["EXPECTED_GROTH16_VERIFIER"],
             "0x6788e13954e7e27f8d2c62ab8ce86b96b8d9169f",
@@ -68,6 +68,8 @@ class MainnetDeploymentRecoveryWorkflowTests(unittest.TestCase):
 
     def test_recovery_reuses_exact_prefix_and_dual_rpc_submission(self) -> None:
         self.assertIn(".preflight_safe_block.resuming_exact_verifiers == true", self.text)
+        self.assertIn(".preflight_safe_block.observed_deployer_nonce >= 35", self.text)
+        self.assertIn(".preflight_safe_block.observed_deployer_nonce <= 37", self.text)
         self.assertIn(".transactions[0].recovered_exact_deployment == true", self.text)
         self.assertEqual(self.text.count('--shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL"'), 2)
         self.assertIn("deploy_open_competition_v2_beta3.py", self.text)


### PR DESCRIPTION
## Finding

Protected recovery run 32620099407 deployed the exact missing nonce-35 Plonk verifier and nonce-36 factory, then failed closed because a transaction receipt was re-included under a different canonical block hash before final evidence reconciliation.

## Impact

The exact core runtime is present on both Base RPCs and the deployer nonce is exactly 37. The bounded reserve factory was not submitted, owner USDC was not touched, and no bounty was activated.

## Action

- refresh signed deployment receipts after the safe wait and bind evidence to the canonical re-inclusion block
- wait again if the canonical receipt moved to a later block
- keep the final block-hash/reorg assertion
- allow the pinned recovery workflow to resume from exact observed nonces 35 through 37 while keeping the original start nonce and all addresses fixed

## Validation

- 18 focused receipt/workflow tests
- 295 Open Competition V2 tests
- both RPCs agree on nonce 37 and the deployed core addresses

## Done when

Merge after checks, dispatch the protected recovery again, deploy/recover the bounded factory, and compare all runtime hashes at a common safe block on both RPCs. PR #970 remains unaffected; no open contributor PR has file overlap.

Next owner: maintainer.