### PR TITLE
Checksum bounded factory deployment target

### DIFF
--- a/scripts/deploy_bounded_open_competition_v2_wallet_factory.py
+++ b/scripts/deploy_bounded_open_competition_v2_wallet_factory.py
@@ -12,6 +12,7 @@ import re
 from typing import Any
 
 from eth_account import Account
+from eth_utils import to_checksum_address
 
 from _shared.evm import keccak256
 from _shared.rpc import rpc
@@ -135,7 +136,9 @@ def write_evidence(output: Path, evidence: dict[str, Any]) -> None:
 
 
 def send_create2(client: SignedRpc, manifest: dict[str, Any]) -> dict[str, Any]:
-    deterministic = manifest["deterministic_deployer"]["address"]
+    deterministic = to_checksum_address(
+        manifest["deterministic_deployer"]["address"]
+    )
     data = manifest["reserve_factory"]["deployment_transaction"]
     nonce = client.pending_nonce()
     latest = rpc(client.url, "eth_getBlockByNumber", ["latest", False])

--- a/scripts/test_deploy_bounded_open_competition_v2_wallet_factory.py
+++ b/scripts/test_deploy_bounded_open_competition_v2_wallet_factory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 import unittest
 from unittest import mock
 
@@ -80,6 +81,39 @@ class ReserveFactoryDeploymentTests(unittest.TestCase):
             changed["reserve_factory"]["deployment_transaction"] += "00"
             with self.assertRaisesRegex(RuntimeError, "manifest_hash"):
                 deploy.load_evidence(output, changed, release, signer)
+
+    @mock.patch.object(deploy, "rpc")
+    def test_create2_signing_checksums_the_lowercase_deployer(
+        self, rpc_call: mock.Mock
+    ) -> None:
+        manifest, _release = fixture()
+        manifest["deterministic_deployer"][
+            "address"
+        ] = "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+        signer = deploy.Account.from_key("0x" + "01".zfill(64))
+        client = SimpleNamespace(
+            url="https://primary.example",
+            signer=signer,
+            pending_nonce=mock.Mock(return_value=0),
+            broadcast=mock.Mock(return_value="0x" + "12" * 32),
+            wait_receipt=mock.Mock(return_value={"status": "0x1"}),
+        )
+
+        def fake_rpc(_url: str, method: str, _params: list[object]):
+            if method == "eth_getBlockByNumber":
+                return {"baseFeePerGas": "0x1"}
+            if method == "eth_maxPriorityFeePerGas":
+                return "0xf4240"
+            if method == "eth_estimateGas":
+                return "0x5208"
+            self.fail(f"unexpected RPC call: {method}")
+
+        rpc_call.side_effect = fake_rpc
+        receipt = deploy.send_create2(client, manifest)
+
+        self.assertEqual(receipt, {"status": "0x1"})
+        client.broadcast.assert_called_once()
+        client.wait_receipt.assert_called_once_with("0x" + "12" * 32)
 
     @mock.patch.object(deploy, "rpc")
     def test_exact_existing_deployment_is_recovered_without_broadcast(self, rpc_call: mock.Mock) -> None:


### PR DESCRIPTION
## Finding

Protected recovery run 32620765947 completed exact core reconciliation at safe block 50337116, then the bounded-factory transaction failed before signing because `eth-account` rejects a lowercase address with alphabetic characters in the typed transaction `to` field.

## Impact

No transaction was signed or broadcast. The deployer nonce remains exactly 37, owner USDC is untouched, and the bounded factory remains absent.

## Action

Checksum the already manifest-validated universal CREATE2 deployer only at the transaction signing boundary. The manifest, calldata, deterministic addresses, and evidence remain unchanged.

## Validation

- actual `eth-account` signing regression for lowercase `0x4e59...`
- 6 bounded-factory deployment tests
- 296 Open Competition V2 tests

## Done when

Merge, rerun the protected exact recovery, and independently verify the bounded factory plus implementation runtime hashes at a common safe block on both RPCs.

Next owner: maintainer. No open contributor PR has file overlap; PR #970 remains unaffected.