### PR TITLE
Recover canonical bounded factory receipt

### DIFF
--- a/.github/workflows/recover-open-competition-v2-beta3-mainnet-deployment.yml
+++ b/.github/workflows/recover-open-competition-v2-beta3-mainnet-deployment.yml
@@ -129,7 +129,7 @@ jobs:
             --arg factory "$EXPECTED_FACTORY" \
             '.preflight_safe_block.deployer_nonce == $start and
              .preflight_safe_block.observed_deployer_nonce >= 35 and
-             .preflight_safe_block.observed_deployer_nonce <= 37 and
+             .preflight_safe_block.observed_deployer_nonce <= 38 and
              .preflight_safe_block.resuming_exact_verifiers == true and
              .groth16_verifier.address == $groth and
              .plonk_verifier.address == $plonk and
@@ -163,6 +163,7 @@ jobs:
             --manifest target/bounded-open-competition-v2-wallet-base-mainnet.json \
             --release target/mainnet-exact.runtime.json --rpc-url "$BASE_MAINNET_RPC_URL" \
             --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
+            --maximum-new-deployment-nonce 37 \
             --output target/bounded-open-competition-v2-wallet-deployment-evidence.json
           jq -e '.complete == true and (.safe_block.number > 0)' \
             target/bounded-open-competition-v2-wallet-deployment-evidence.json >/dev/null

--- a/scripts/deploy_bounded_open_competition_v2_wallet_factory.py
+++ b/scripts/deploy_bounded_open_competition_v2_wallet_factory.py
@@ -135,12 +135,21 @@ def write_evidence(output: Path, evidence: dict[str, Any]) -> None:
     output.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
 
 
-def send_create2(client: SignedRpc, manifest: dict[str, Any]) -> dict[str, Any]:
+def send_create2(
+    client: SignedRpc,
+    manifest: dict[str, Any],
+    maximum_new_deployment_nonce: int | None = None,
+) -> dict[str, Any]:
     deterministic = to_checksum_address(
         manifest["deterministic_deployer"]["address"]
     )
     data = manifest["reserve_factory"]["deployment_transaction"]
     nonce = client.pending_nonce()
+    if maximum_new_deployment_nonce is not None:
+        require(
+            nonce <= maximum_new_deployment_nonce,
+            "deployer nonce moved without the exact reserve factory",
+        )
     latest = rpc(client.url, "eth_getBlockByNumber", ["latest", False])
     base_fee = int(latest.get("baseFeePerGas", "0x0"), 16)
     try:
@@ -176,11 +185,31 @@ def send_create2(client: SignedRpc, manifest: dict[str, Any]) -> dict[str, Any]:
     return client.wait_receipt(transaction_hash)
 
 
+def reconcile_canonical_receipt(
+    evidence: dict[str, Any], client: SignedRpc
+) -> int:
+    transaction = evidence["transaction"]
+    transaction_hash = transaction["transaction_hash"]
+    if transaction_hash is None:
+        return int(transaction["block_number"])
+    receipt = client.receipt(transaction_hash)
+    require(receipt is not None, "canonical reserve deployment receipt is absent")
+    require(
+        int(receipt["status"], 16) == 1,
+        f"canonical reserve deployment reverted: {transaction_hash}",
+    )
+    transaction["block_number"] = int(receipt["blockNumber"], 16)
+    transaction["block_hash"] = receipt["blockHash"].lower()
+    transaction["gas_used"] = int(receipt["gasUsed"], 16)
+    return int(transaction["block_number"])
+
+
 def deploy(
     manifest: dict[str, Any],
     release: dict[str, Any],
     client: SignedRpc,
     output: Path,
+    maximum_new_deployment_nonce: int | None = None,
 ) -> dict[str, Any]:
     validate_manifest(manifest, release)
     evidence = load_evidence(output, manifest, release, client.signer.address)
@@ -199,7 +228,7 @@ def deploy(
     implementation_hash = client.code_hash(reserve["implementation"])
     if factory_hash is None:
         require(implementation_hash is None, "reserve implementation address is unexpectedly occupied")
-        receipt = send_create2(client, manifest)
+        receipt = send_create2(client, manifest, maximum_new_deployment_nonce)
         deployment_block = int(receipt["blockNumber"], 16)
         evidence["transaction"] = {
             "transaction_hash": receipt["transactionHash"].lower(),
@@ -231,7 +260,10 @@ def deploy(
             }
             write_evidence(output, evidence)
 
+    client.wait_safe(deployment_block)
+    deployment_block = reconcile_canonical_receipt(evidence, client)
     safe = client.wait_safe(deployment_block)
+    write_evidence(output, evidence)
     safe_tag = safe["number"]
     expected = {
         deterministic["address"]: deterministic["runtime_code_hash"],
@@ -266,6 +298,7 @@ def main() -> int:
     parser.add_argument("--release", type=Path, required=True)
     parser.add_argument("--rpc-url", required=True)
     parser.add_argument("--shadow-rpc-url")
+    parser.add_argument("--maximum-new-deployment-nonce", type=int)
     parser.add_argument("--private-key-env", default="BASE_MAINNET_DEPLOYER_PRIVATE_KEY")
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
@@ -282,6 +315,7 @@ def main() -> int:
         release,
         SignedRpc(args.rpc_url, signer, args.shadow_rpc_url),
         args.output,
+        args.maximum_new_deployment_nonce,
     )
     print(
         json.dumps(

--- a/scripts/test_deploy_bounded_open_competition_v2_wallet_factory.py
+++ b/scripts/test_deploy_bounded_open_competition_v2_wallet_factory.py
@@ -115,6 +115,48 @@ class ReserveFactoryDeploymentTests(unittest.TestCase):
         client.broadcast.assert_called_once()
         client.wait_receipt.assert_called_once_with("0x" + "12" * 32)
 
+    def test_new_deployment_fails_when_the_bounded_nonce_has_moved(self) -> None:
+        manifest, _release = fixture()
+        client = SimpleNamespace(pending_nonce=mock.Mock(return_value=38))
+
+        with self.assertRaisesRegex(
+            RuntimeError, "nonce moved without the exact reserve factory"
+        ):
+            deploy.send_create2(
+                client,
+                manifest,
+                maximum_new_deployment_nonce=37,
+            )
+
+    def test_refreshes_reincluded_reserve_receipt(self) -> None:
+        transaction_hash = "0x" + "12" * 32
+        evidence = {
+            "transaction": {
+                "transaction_hash": transaction_hash,
+                "block_number": 10,
+                "block_hash": "0x" + "34" * 32,
+                "gas_used": 1,
+            }
+        }
+        client = SimpleNamespace(
+            receipt=mock.Mock(
+                return_value={
+                    "transactionHash": transaction_hash,
+                    "status": "0x1",
+                    "blockNumber": "0xc",
+                    "blockHash": "0x" + "56" * 32,
+                    "gasUsed": "0x2a",
+                }
+            )
+        )
+
+        deployment_block = deploy.reconcile_canonical_receipt(evidence, client)
+
+        self.assertEqual(deployment_block, 12)
+        self.assertEqual(evidence["transaction"]["block_number"], 12)
+        self.assertEqual(evidence["transaction"]["block_hash"], "0x" + "56" * 32)
+        self.assertEqual(evidence["transaction"]["gas_used"], 42)
+
     @mock.patch.object(deploy, "rpc")
     def test_exact_existing_deployment_is_recovered_without_broadcast(self, rpc_call: mock.Mock) -> None:
         manifest, release = fixture()
@@ -173,13 +215,15 @@ class ReserveFactoryDeploymentTests(unittest.TestCase):
             "blockNumber": "0x29",
             "blockHash": "0x" + "ff" * 32,
             "gasUsed": "0x100",
+            "status": "0x1",
         }
+        client.receipt.return_value = send.return_value
         rpc_call.return_value = {"hash": "0x" + "ff" * 32}
         with tempfile.TemporaryDirectory() as directory:
             evidence = deploy.deploy(manifest, release, client, Path(directory) / "evidence.json")
         self.assertTrue(evidence["complete"])
         self.assertFalse(evidence["transaction"]["recovered_exact_deployment"])
-        send.assert_called_once_with(client, manifest)
+        send.assert_called_once_with(client, manifest, None)
 
 
 if __name__ == "__main__":

--- a/scripts/test_recover_open_competition_v2_beta3_mainnet_deployment.py
+++ b/scripts/test_recover_open_competition_v2_beta3_mainnet_deployment.py
@@ -69,7 +69,8 @@ class MainnetDeploymentRecoveryWorkflowTests(unittest.TestCase):
     def test_recovery_reuses_exact_prefix_and_dual_rpc_submission(self) -> None:
         self.assertIn(".preflight_safe_block.resuming_exact_verifiers == true", self.text)
         self.assertIn(".preflight_safe_block.observed_deployer_nonce >= 35", self.text)
-        self.assertIn(".preflight_safe_block.observed_deployer_nonce <= 37", self.text)
+        self.assertIn(".preflight_safe_block.observed_deployer_nonce <= 38", self.text)
+        self.assertIn("--maximum-new-deployment-nonce 37", self.text)
         self.assertIn(".transactions[0].recovered_exact_deployment == true", self.text)
         self.assertEqual(self.text.count('--shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL"'), 2)
         self.assertIn("deploy_open_competition_v2_beta3.py", self.text)


### PR DESCRIPTION
## Finding

Protected run 32621110897 deployed the exact bounded reserve factory at nonce 37 and reached safe nonce 38, then failed closed because the stored receipt was re-included under a new canonical block hash.

## Impact

The deterministic reserve factory is already on-chain. Owner USDC is untouched. A continuation must not issue another deployment transaction.

## Action

- refresh the bounded deployment receipt after its safe wait and bind evidence to the canonical re-inclusion block
- permit the recovery workflow to observe nonce 38
- enforce `--maximum-new-deployment-nonce 37`, so nonce 38 is accepted only by recovering an already-existing exact factory; an absent factory fails before signing

## Validation

- canonical bounded receipt refresh regression
- moved-nonce/no-new-signing regression
- 13 focused tests
- 298 Open Competition V2 tests

## Done when

Merge, rerun protected recovery without any new transaction, and verify the reserve factory and implementation hashes at a common safe block on both RPCs.

Next owner: maintainer. PR #970 remains unaffected; no contributor PR has file overlap.