### PR TITLE
Preserve exact mainnet canary proofs

### DIFF
--- a/.github/workflows/preserve-open-competition-v2-beta3-mainnet-canary-proofs.yml
+++ b/.github/workflows/preserve-open-competition-v2-beta3-mainnet-canary-proofs.yml
@@ -1,0 +1,96 @@
+name: Preserve Open Competition V2 Beta3 mainnet canary proofs
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: open-competition-v2-beta3-mainnet-canary-proof-preservation
+  cancel-in-progress: false
+
+env:
+  SOURCE_RUN_ID: "32623224167"
+  SOURCE_RUN_ATTEMPT: "1"
+  RELEASE_SOURCE_COMMIT: 5a351f3e373691be58a9575b4374812b494b6086
+  PROOF_CONTEXT_HASH: "0x9fab869a09818ded5b5b066489ed8732bdd5ae0fffbbe3172f72c11de44b9640"
+  PLONK_BEST_A_PROOF_HASH: "0xf2b2dc02af5c30b66f45dd14389aac1b7716fe6534da242525da965fb0f916be"
+  PLONK_BEST_A_JOURNAL_HASH: "0xd42664c3b36ed9639b48d9fd15b765b1837b7cd0c865c29da637731403727645"
+  PLONK_BEST_B_PROOF_HASH: "0x2a0d37fba6bc77bcf75cfd4c821dcc0e538bdf87fe32ec826cc47d3aa4ed9b54"
+  PLONK_BEST_B_JOURNAL_HASH: "0x1ab38e9a9a1094a8d7a75ad605c2ea0927dc5dd7f6676795581e15cdcd447f8b"
+
+jobs:
+  preserve:
+    if: github.ref == 'refs/heads/main'
+    environment: v2-beta2-mainnet
+    runs-on: [self-hosted, linux, x64, ram-256gb, open-competition-v2-prover]
+    timeout-minutes: 10
+    steps:
+      - name: Validate and stage the exact failed-run proof workspace
+        run: |
+          set -euo pipefail
+          source="$GITHUB_WORKSPACE/target"
+          stage="$RUNNER_TEMP/open-competition-v2-beta3-mainnet-canary-proofs"
+          test -f "$source/mainnet-canary-bundle.json"
+          test -f "$source/mainnet-canary-preparation.json"
+          test -d "$source/mainnet-proof-inputs"
+          test -f "$source/mainnet-proofs/plonk_best_a.json"
+          test -f "$source/mainnet-proofs/plonk_best_b.json"
+          test -z "$(find "$source/mainnet-proof-inputs" "$source/mainnet-proofs" -type l -print -quit)"
+          jq -e --arg context "$PROOF_CONTEXT_HASH" \
+            '.passed == true and .proof_context_hash == $context' \
+            "$source/mainnet-canary-preparation.json" >/dev/null
+          jq -e --arg commit "$RELEASE_SOURCE_COMMIT" \
+            '.network == "base-mainnet" and .source_commit == $commit' \
+            "$source/mainnet-canary-bundle.json" >/dev/null
+          jq -e --arg proof "$PLONK_BEST_A_PROOF_HASH" --arg journal "$PLONK_BEST_A_JOURNAL_HASH" \
+            '.proof_name == "plonk_best_a" and .mode == "plonk" and
+             .proof_hash == $proof and .journal_hash == $journal' \
+            "$source/mainnet-proofs/plonk_best_a.json" >/dev/null
+          jq -e --arg proof "$PLONK_BEST_B_PROOF_HASH" --arg journal "$PLONK_BEST_B_JOURNAL_HASH" \
+            '.proof_name == "plonk_best_b" and .mode == "plonk" and
+             .proof_hash == $proof and .journal_hash == $journal' \
+            "$source/mainnet-proofs/plonk_best_b.json" >/dev/null
+          install -d -m 0700 "$stage"
+          cp -a "$source/mainnet-canary-bundle.json" "$stage/"
+          cp -a "$source/mainnet-canary-preparation.json" "$stage/"
+          cp -a "$source/mainnet-proof-inputs" "$stage/"
+          cp -a "$source/mainnet-proofs" "$stage/"
+          STAGE="$stage" python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          stage = Path(os.environ["STAGE"])
+          evidence = {
+              "schema_version": "agent-bounties/open-competition-v2-beta3-mainnet-canary-proof-preservation-v1",
+              "source_run_id": os.environ["SOURCE_RUN_ID"],
+              "source_run_attempt": os.environ["SOURCE_RUN_ATTEMPT"],
+              "source_commit": os.environ["RELEASE_SOURCE_COMMIT"],
+              "actor_derivation_salt": f'{os.environ["SOURCE_RUN_ID"]}:{os.environ["SOURCE_RUN_ATTEMPT"]}:mainnet',
+              "proof_context_hash": os.environ["PROOF_CONTEXT_HASH"],
+              "proof_hashes": {
+                  "plonk_best_a": os.environ["PLONK_BEST_A_PROOF_HASH"],
+                  "plonk_best_b": os.environ["PLONK_BEST_B_PROOF_HASH"],
+              },
+              "money_moved_by_preservation": False,
+          }
+          (stage / "preservation-evidence.json").write_text(
+              json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
+          (
+            cd "$stage"
+            find . -type f ! -name files.sha256 -print0 \
+              | sort -z \
+              | xargs -0 sha256sum \
+              > files.sha256
+          )
+      - name: Upload exact preserved proof evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: open-competition-v2-beta3-mainnet-canary-proofs-32623224167-1
+          path: ${{ runner.temp }}/open-competition-v2-beta3-mainnet-canary-proofs
+          if-no-files-found: error
+          retention-days: 365

--- a/scripts/test_preserve_open_competition_v2_beta3_mainnet_canary_proofs.py
+++ b/scripts/test_preserve_open_competition_v2_beta3_mainnet_canary_proofs.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/preserve-open-competition-v2-beta3-mainnet-canary-proofs.yml"
+
+
+class ProofPreservationWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+        cls.workflow = yaml.safe_load(cls.text)
+
+    def test_preservation_cannot_sign_or_move_funds(self):
+        self.assertNotIn("actions/checkout", self.text)
+        self.assertNotIn("PRIVATE_KEY", self.text)
+        self.assertNotIn("eth_sendRawTransaction", self.text)
+        self.assertNotIn("cast send", self.text)
+        self.assertIn('"money_moved_by_preservation": False', self.text)
+
+    def test_exact_failed_run_and_proof_hashes_are_pinned_as_strings(self):
+        env = self.workflow["env"]
+        self.assertEqual(env["SOURCE_RUN_ID"], "32623224167")
+        self.assertEqual(env["SOURCE_RUN_ATTEMPT"], "1")
+        for name in (
+            "PROOF_CONTEXT_HASH",
+            "PLONK_BEST_A_PROOF_HASH",
+            "PLONK_BEST_A_JOURNAL_HASH",
+            "PLONK_BEST_B_PROOF_HASH",
+            "PLONK_BEST_B_JOURNAL_HASH",
+        ):
+            self.assertIsInstance(env[name], str)
+            self.assertTrue(env[name].startswith("0x"))
+        self.assertIn(".proof_hash == $proof and .journal_hash == $journal", self.text)
+
+    def test_symlinks_are_rejected_and_every_file_is_hashed(self):
+        self.assertIn("-type l -print -quit", self.text)
+        self.assertIn("find . -type f ! -name files.sha256 -print0", self.text)
+        self.assertIn("xargs -0 sha256sum", self.text)
+        self.assertIn("if-no-files-found: error", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Finding: mainnet canary run 32623224167 generated both reviewed Plonk proofs, then the first actor-gas broadcast returned an RPC rate-limit error before the script received a transaction hash.

Impact: public activation remains blocked. Blind rerun would waste ~38 minutes of deterministic proof work and use a new actor salt; another self-hosted job could clean the proof workspace.

Action: protected preservation workflow runs on the same labeled runner without checkout, private keys, or transaction capability. It requires the exact source run/attempt, source commit, proof-context hash, both proof hashes, and both journal hashes; rejects symlinks; copies only the bundle/preparation/inputs/proofs; hashes every preserved file; and uploads private repository evidence.

Validation: focused workflow test and `git diff --check` pass.

Done when: the preservation artifact uploads with `money_moved_by_preservation=false`, after which an idempotent same-actor recovery can be reviewed.