### PR TITLE
Quarantine canary proofs before validation

### DIFF
--- a/.github/workflows/preserve-open-competition-v2-beta3-mainnet-canary-proofs.yml
+++ b/.github/workflows/preserve-open-competition-v2-beta3-mainnet-canary-proofs.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, ram-256gb, open-competition-v2-prover]
     timeout-minutes: 10
     steps:
-      - name: Validate and stage the exact failed-run proof workspace
+      - name: Stage the failed-run proof workspace before validation
         run: |
           set -euo pipefail
           source="$GITHUB_WORKSPACE/target"
@@ -37,6 +37,16 @@ jobs:
           test -d "$source/mainnet-proof-inputs"
           test -f "$source/mainnet-proofs/plonk_best_a.json"
           test -f "$source/mainnet-proofs/plonk_best_b.json"
+          install -d -m 0700 "$stage"
+          cp -aL "$source/mainnet-canary-bundle.json" "$stage/"
+          cp -aL "$source/mainnet-canary-preparation.json" "$stage/"
+          cp -aL "$source/mainnet-proof-inputs" "$stage/"
+          cp -aL "$source/mainnet-proofs" "$stage/"
+      - name: Validate and hash the isolated proof copy
+        run: |
+          set -euxo pipefail
+          source="$RUNNER_TEMP/open-competition-v2-beta3-mainnet-canary-proofs"
+          stage="$source"
           test -z "$(find "$source/mainnet-proof-inputs" "$source/mainnet-proofs" -type l -print -quit)"
           jq -e --arg context "$PROOF_CONTEXT_HASH" \
             '.passed == true and .proof_context_hash == $context' \
@@ -52,11 +62,6 @@ jobs:
             '.proof_name == "plonk_best_b" and .mode == "plonk" and
              .proof_hash == $proof and .journal_hash == $journal' \
             "$source/mainnet-proofs/plonk_best_b.json" >/dev/null
-          install -d -m 0700 "$stage"
-          cp -a "$source/mainnet-canary-bundle.json" "$stage/"
-          cp -a "$source/mainnet-canary-preparation.json" "$stage/"
-          cp -a "$source/mainnet-proof-inputs" "$stage/"
-          cp -a "$source/mainnet-proofs" "$stage/"
           STAGE="$stage" python3 - <<'PY'
           import json
           import os
@@ -88,6 +93,7 @@ jobs:
               > files.sha256
           )
       - name: Upload exact preserved proof evidence
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: open-competition-v2-beta3-mainnet-canary-proofs-32623224167-1

--- a/scripts/test_preserve_open_competition_v2_beta3_mainnet_canary_proofs.py
+++ b/scripts/test_preserve_open_competition_v2_beta3_mainnet_canary_proofs.py
@@ -37,9 +37,12 @@ class ProofPreservationWorkflowTests(unittest.TestCase):
         self.assertIn(".proof_hash == $proof and .journal_hash == $journal", self.text)
 
     def test_symlinks_are_rejected_and_every_file_is_hashed(self):
+        self.assertIn("Stage the failed-run proof workspace before validation", self.text)
+        self.assertIn('cp -aL "$source/mainnet-proofs" "$stage/"', self.text)
         self.assertIn("-type l -print -quit", self.text)
         self.assertIn("find . -type f ! -name files.sha256 -print0", self.text)
         self.assertIn("xargs -0 sha256sum", self.text)
+        self.assertIn("if: always()", self.text)
         self.assertIn("if-no-files-found: error", self.text)
 
 


### PR DESCRIPTION
Finding: preservation run 32625581097 confirmed the failed canary workspace paths exist but a silent validation assertion exited before the upload step.

Impact: no transaction capability or funds were involved, but the generated proofs are not yet durably captured.

Action: stage and dereference the exact bundle/preparation/inputs/proofs into an isolated runner-temp directory before validation; validate/hash only the isolated copy with traceable commands; upload the private artifact with `always()` so a validation failure cannot destroy diagnostic recoverability. Presence of `preservation-evidence.json` still distinguishes a fully validated artifact.

Validation: focused preservation tests and diff check pass.

Done when: the private artifact is uploaded and inspected; only fully validated evidence may be used for canary recovery.