### PR TITLE
Fix preserved canary continuation driver

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -475,7 +475,7 @@ jobs:
             cp -aL "$source/mainnet-proofs" target/
             recovery_args+=(--require-pristine-derived-actors)
           else
-            python scripts/run_open_competition_v2_sepolia_rehearsal.py --network base-mainnet \
+            python target/continuation-control/scripts/run_open_competition_v2_sepolia_rehearsal.py --network base-mainnet \
               --bundle "$bundle" --rpc-url "$BASE_MAINNET_RPC_URL" \
               --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
               --verifier-assets target/mainnet-deployment/release-assets/verifier-assets.json \
@@ -490,7 +490,7 @@ jobs:
                 --output "target/mainnet-proofs/$proof.json" --log-dir "target/mainnet-proof-logs/$proof"
             done
           fi
-          python scripts/run_open_competition_v2_sepolia_rehearsal.py --network base-mainnet \
+          python target/continuation-control/scripts/run_open_competition_v2_sepolia_rehearsal.py --network base-mainnet \
             --bundle target/mainnet-canary-bundle.json --rpc-url "$BASE_MAINNET_RPC_URL" \
             --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --verifier-assets target/mainnet-deployment/release-assets/verifier-assets.json \

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -237,6 +237,12 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         self.assertIn("ref: ${{ github.sha }}", self.text)
         self.assertIn("path: target/continuation-control", self.text)
         self.assertIn("--manifest-path target/continuation-control/Cargo.toml", self.text)
+        self.assertEqual(
+            self.text.count(
+                "target/continuation-control/scripts/run_open_competition_v2_sepolia_rehearsal.py"
+            ),
+            2,
+        )
         self.assertIn("target/continuation-build/release/api", self.text)
         self.assertIn("--worker-binary target/continuation-build/release/worker", self.text)
         self.assertEqual(


### PR DESCRIPTION
## Summary
- run the canary rehearsal from the continuation-control checkout
- keep frozen release contracts, manifests, and proof artifacts unchanged
- assert the recovery driver path in the workflow regression test

## Evidence
- PYTHONPATH=scripts python -m unittest scripts.test_continue_open_competition_v2_beta3_mainnet scripts.test_run_open_competition_v2_sepolia_rehearsal (32 passed)
- python -m ruff check scripts/test_continue_open_competition_v2_beta3_mainnet.py scripts/run_open_competition_v2_sepolia_rehearsal

This fixes the pre-transaction CLI mismatch in run 32627139032. Canonical canary checks remain mandatory.