### PR TITLE
Retry GMV delegate gas seed through shadow RPC

### DIFF
--- a/.github/workflows/seed-open-competition-v2-replenisher-gas.yml
+++ b/.github/workflows/seed-open-competition-v2-replenisher-gas.yml
@@ -23,14 +23,18 @@ jobs:
       - name: Seed and reconcile the exact gas-only delegate
         env:
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
           BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          test -n "$BASE_MAINNET_RPC_URL" && test -n "$BASE_MAINNET_DEPLOYER_PRIVATE_KEY"
+          test -n "$BASE_MAINNET_RPC_URL" && test -n "$BASE_MAINNET_SHADOW_RPC_URL"
+          test "$BASE_MAINNET_RPC_URL" != "$BASE_MAINNET_SHADOW_RPC_URL"
+          test -n "$BASE_MAINNET_DEPLOYER_PRIVATE_KEY"
           python -m pip install -r scripts/requirements-wallet.txt
           python scripts/fund_open_competition_v2_beta3_broker.py \
             --network base-mainnet \
             --rpc-url "$BASE_MAINNET_RPC_URL" \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --broker 0xb358898d34c5e907877a1cd7540b234f6851f61b \
             --target-usdc-base-units 0 \
             --target-eth-wei 100000000000000 \

--- a/scripts/test_seed_open_competition_v2_replenisher_gas.py
+++ b/scripts/test_seed_open_competition_v2_replenisher_gas.py
@@ -26,6 +26,9 @@ class ReplenisherGasWorkflowTests(unittest.TestCase):
     def test_seeds_only_exact_delegate_eth_and_zero_usdc(self) -> None:
         text = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn(f"--broker {DELEGATE}", text)
+        self.assertIn('BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}', text)
+        self.assertIn('--shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL"', text)
+        self.assertIn('test "$BASE_MAINNET_RPC_URL" != "$BASE_MAINNET_SHADOW_RPC_URL"', text)
         self.assertIn("--target-usdc-base-units 0", text)
         self.assertIn("--target-eth-wei 100000000000000", text)
         self.assertIn(".funded_usdc_base_units == 0", text)


### PR DESCRIPTION
The first gas-only seed failed before transfer because only the primary read endpoint was supplied. This binds the existing exact-raw-transaction failover to the configured independent shadow RPC and tests that the endpoints are distinct. Both RPCs show the delegate remains zero ETH/zero nonce. USDC target remains zero.