### PR TITLE
Fix continuation-control Foundry artifact path

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -422,7 +422,7 @@ jobs:
           KEEPER="${BASE_KEEPER_ADDRESS,,}"
           DEPLOYER="$(python -c 'import os; from eth_account import Account; print(Account.from_key(os.environ["BASE_MAINNET_DEPLOYER_PRIVATE_KEY"]).address.lower())')"
           chmod 0755 "$OPEN_COMPETITION_V2_PROVER_BINARY"
-          forge build --root contracts/base-escrow --force --ast
+          forge build --root target/continuation-control/contracts/base-escrow --force --ast
           cargo build --manifest-path target/continuation-control/Cargo.toml \
             --target-dir target/continuation-build --locked --release -p api -p worker
           bundle=target/mainnet-deployment/mainnet-exact.json

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -236,6 +236,11 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
     def test_canaries_use_current_control_binaries_with_frozen_release_assets(self):
         self.assertIn("ref: ${{ github.sha }}", self.text)
         self.assertIn("path: target/continuation-control", self.text)
+        self.assertIn(
+            "forge build --root target/continuation-control/contracts/base-escrow --force --ast",
+            self.text,
+        )
+        self.assertNotIn("forge build --root contracts/base-escrow --force --ast", self.text)
         self.assertIn("--manifest-path target/continuation-control/Cargo.toml", self.text)
         self.assertEqual(
             self.text.count(


### PR DESCRIPTION
## Outcome

Build Foundry artifacts in the continuation-control checkout so the preserved-proof mainnet canary driver can resolve its expected contract artifacts.

## Safety

- no contract, address, proof, funding, or settlement policy changes
- release source remains frozen
- canonical canary and public activation gates remain mandatory
- regression test rejects the old outer-checkout build path

## Verification

- python -m unittest scripts.test_continue_open_competition_v2_beta3_mainnet
- git diff --check

Closes the fail-closed operational defect observed in run 32628050887. Tracks #1117.