### PR TITLE
Recover mainnet x402 canary with RPC failover

### DIFF
--- a/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/continue-open-competition-v2-beta3-mainnet.yml
@@ -543,6 +543,7 @@ jobs:
           python target/continuation-control/scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api http://127.0.0.1:8788 \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canaries.json \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --worker-binary target/continuation-build/release/worker --expect-refund \
             --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
@@ -552,6 +553,7 @@ jobs:
           python target/continuation-control/scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api https://api.agentbounties.app \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canaries.json \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --hosted-workers --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
             --output target/mainnet-x402-success.json

--- a/.github/workflows/open-competition-v2-beta3-release.yml
+++ b/.github/workflows/open-competition-v2-beta3-release.yml
@@ -777,6 +777,7 @@ jobs:
           curl --fail --silent "http://127.0.0.1:${api_port}/health" >/dev/null
           python scripts/run_open_competition_v2_x402_rehearsal.py \
             --api "http://127.0.0.1:${api_port}" --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+            --shadow-rpc-url "$BASE_SEPOLIA_SHADOW_RPC_URL" \
             --rehearsal target/sepolia-rehearsal.json --worker-binary target/release/worker \
             --private-key-env BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
@@ -1231,6 +1232,7 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}/scripts
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
           BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
           OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
           BASE_KEEPER_ADDRESS: ${{ vars.BASE_KEEPER_ADDRESS }}
@@ -1324,6 +1326,7 @@ jobs:
           python scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api http://127.0.0.1:8788 \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canaries.json \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --worker-binary target/release/worker --expect-refund \
             --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
@@ -1333,6 +1336,7 @@ jobs:
           python scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api https://api.agentbounties.app \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canaries.json \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --hosted-workers --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$BETA3_ACTOR_DERIVATION_SALT" \
             --output target/mainnet-x402-success.json

--- a/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
+++ b/.github/workflows/resume-open-competition-v2-beta3-mainnet.yml
@@ -12,16 +12,16 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  RELEASE_SOURCE_COMMIT: 4d09d82825c38f2bf93a8ee4375a95b302410c29
-  SOURCE_RUN_ID: "32346174505"
-  SOURCE_ACTOR_DERIVATION_SALT: "32346174505:1:mainnet"
+  RELEASE_SOURCE_COMMIT: 5a351f3e373691be58a9575b4374812b494b6086
+  SOURCE_RUN_ID: "32629535171"
+  SOURCE_ACTOR_DERIVATION_SALT: "32623224167:1:mainnet"
   OPEN_COMPETITION_V2_RUNTIME_READINESS_URL: https://agent-bounties-api.onrender.com/v1/base/open-competition-v2-beta3/release
-  CANARY_TEMPLATE_JOB_ID: bccd0e3e-73d0-41ac-8bbd-0a806ea45194
-  CANARY_SUCCESS_JOB_ID: 57492f09-a3d2-497c-8650-a6bb1fe99f5d
-  PLONK_COMPETITION: "0x3e052b933628b960d61654a68fca23d869d8989f"
-  PLONK_SETTLEMENT_TRANSACTION: "0x830e856ddbade328a0715e47e3aaa36f6363c6be71c18bd20f0baaab75aed4f3"
-  FORCED_REFUND_PAYMENT_TRANSACTION: "0xdb833590333b36c69ee7e7d873a94f87d519278321df13f155253473e4a0a7c2"
-  FORCED_REFUND_TRANSACTION: "0x0fa117876516f1641181e3bb843f29fd74be63262b7685663e6afb6632205d38"
+  CANARY_TEMPLATE_JOB_ID: eed7303a-892a-41e1-81e5-c6c9c37237bd
+  CANARY_SUCCESS_JOB_ID: eed7303a-892a-41e1-81e5-c6c9c37237bd
+  PLONK_COMPETITION: "0x5cf577877c099eb3cdef844793dac152e7f598b5"
+  PLONK_SETTLEMENT_TRANSACTION: "0xc77a2689894c849c215885f63d6e09c1d5432d665d730f2021312994501ce259"
+  FORCED_REFUND_PAYMENT_TRANSACTION: "0x1f35e1eb06f921d7735c29ce3ab01164d46019e60756724d5016a6aad92dec11"
+  FORCED_REFUND_TRANSACTION: "0x2fee2a3cd0e546bf70e54d562f22fbbb810a61f2268b7aa9927b8fda14be1cac"
   BASE_USDC: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
 
 jobs:
@@ -108,6 +108,7 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}/.release-control/scripts
           BASE_MAINNET_RPC_URL: ${{ vars.BASE_MAINNET_RPC_URL }}
+          BASE_MAINNET_SHADOW_RPC_URL: ${{ vars.BASE_MAINNET_SHADOW_RPC_URL }}
           BASE_MAINNET_DEPLOYER_PRIVATE_KEY: ${{ secrets.BASE_MAINNET_DEPLOYER_PRIVATE_KEY }}
           OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY: ${{ secrets.OPEN_COMPETITION_V2_BROKER_PRIVATE_KEY }}
           BASE_KEEPER_ADDRESS: ${{ vars.BASE_KEEPER_ADDRESS }}
@@ -208,6 +209,7 @@ jobs:
           python .release-control/scripts/run_open_competition_v2_x402_rehearsal.py \
             --network base-mainnet --api https://api.agentbounties.app \
             --rpc-url "$BASE_MAINNET_RPC_URL" --rehearsal target/mainnet-canary-resume.json \
+            --shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL" \
             --hosted-workers --private-key-env BASE_MAINNET_DEPLOYER_PRIVATE_KEY \
             --actor-derivation-salt "$SOURCE_ACTOR_DERIVATION_SALT" \
             "${resume_args[@]}" --timeout-seconds 5400 --output target/mainnet-x402-success.json

--- a/scripts/run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/run_open_competition_v2_x402_rehearsal.py
@@ -340,6 +340,7 @@ def main() -> int:
     parser.add_argument("--api", required=True)
     parser.add_argument("--network", choices=("base-sepolia", "base-mainnet"), default="base-sepolia")
     parser.add_argument("--rpc-url", required=True)
+    parser.add_argument("--shadow-rpc-url")
     parser.add_argument("--rehearsal", type=Path, required=True)
     parser.add_argument("--worker-binary", type=Path)
     parser.add_argument("--hosted-workers", action="store_true")
@@ -490,7 +491,7 @@ def main() -> int:
     require(job["state"] == "confirmed", "x402 proof relay did not settle")
     require(job.get("settlement_event_id"), "canonical settlement event is missing")
 
-    client = sepolia.SignedRpc(args.rpc_url)
+    client = sepolia.SignedRpc(args.rpc_url, args.shadow_rpc_url)
     token = payment_evidence["asset"]
     require(
         sepolia.rehearsal.token_balance(client.url, token, spec["competition"]) == 0,

--- a/scripts/test_continue_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_continue_open_competition_v2_beta3_mainnet.py
@@ -186,7 +186,7 @@ class MainnetContinuationWorkflowTests(unittest.TestCase):
         self.assertIn("PRESERVED_PLONK_BEST_A_PROOF_HASH", self.text)
         self.assertIn("PRESERVED_PLONK_BEST_B_PROOF_HASH", self.text)
         self.assertIn("--require-pristine-derived-actors", self.text)
-        self.assertGreaterEqual(self.text.count('--shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL"'), 2)
+        self.assertGreaterEqual(self.text.count('--shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL"'), 4)
 
     def test_prover_installs_all_three_reviewed_profiles(self):
         prover = self.text.split("  deploy-production-prover:", 1)[1].split(

--- a/scripts/test_resume_open_competition_v2_beta3_mainnet.py
+++ b/scripts/test_resume_open_competition_v2_beta3_mainnet.py
@@ -22,7 +22,9 @@ class MainnetResumeWorkflowTests(unittest.TestCase):
     def test_resume_is_protected_and_replaces_the_terminal_canary(self):
         text = WORKFLOW.read_text(encoding="utf-8")
         self.assertEqual(text.count("environment: v2-beta2-mainnet"), 2)
-        self.assertIn('SOURCE_RUN_ID: "32346174505"', text)
+        self.assertIn('RELEASE_SOURCE_COMMIT: 5a351f3e373691be58a9575b4374812b494b6086', text)
+        self.assertIn('SOURCE_RUN_ID: "32629535171"', text)
+        self.assertIn('SOURCE_ACTOR_DERIVATION_SALT: "32623224167:1:mainnet"', text)
         self.assertIn("open-competition-v2-beta3-mainnet-deployment-continuation", text)
         self.assertIn("open-competition-v2-beta3-production-control-plane-continuation", text)
         self.assertIn("CANARY_TEMPLATE_JOB_ID", text)
@@ -38,6 +40,20 @@ class MainnetResumeWorkflowTests(unittest.TestCase):
         self.assertNotRegex(text, r'"solver_nonce": "\d+"')
         self.assertNotIn("createCompetition(", text)
         self.assertNotIn("approve(address", text)
+        self.assertIn('CANARY_SUCCESS_JOB_ID: eed7303a-892a-41e1-81e5-c6c9c37237bd', text)
+        self.assertIn(
+            'PLONK_SETTLEMENT_TRANSACTION: "0xc77a2689894c849c215885f63d6e09c1d5432d665d730f2021312994501ce259"',
+            text,
+        )
+        self.assertIn(
+            'FORCED_REFUND_PAYMENT_TRANSACTION: "0x1f35e1eb06f921d7735c29ce3ab01164d46019e60756724d5016a6aad92dec11"',
+            text,
+        )
+        self.assertIn(
+            'FORCED_REFUND_TRANSACTION: "0x2fee2a3cd0e546bf70e54d562f22fbbb810a61f2268b7aa9927b8fda14be1cac"',
+            text,
+        )
+        self.assertIn('--shadow-rpc-url "$BASE_MAINNET_SHADOW_RPC_URL"', text)
 
     def test_resume_deploys_retry_fix_before_spending_and_activates_exact_release(self):
         text = WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/test_run_open_competition_v2_x402_rehearsal.py
+++ b/scripts/test_run_open_competition_v2_x402_rehearsal.py
@@ -16,6 +16,13 @@ SPEC.loader.exec_module(MODULE)
 
 
 class X402RehearsalTests(unittest.TestCase):
+    def test_reclaim_client_keeps_the_configured_shadow_rpc(self):
+        source = PATH.read_text(encoding="utf-8")
+        self.assertIn('parser.add_argument("--shadow-rpc-url")', source)
+        self.assertIn(
+            "sepolia.SignedRpc(args.rpc_url, args.shadow_rpc_url)", source
+        )
+
     def test_fresh_quote_waits_for_active_canonical_projection(self):
         competition = "0x" + "11" * 20
         active = {


### PR DESCRIPTION
## Outcome

- passes the configured shadow RPC into the x402 rehearsal reclaim client
- rebroadcasts only the identical signed raw transaction through the existing retry-safe `SignedRpc`
- binds the protected mainnet resume workflow to release `5a351f3e`, source artifacts from run `32629535171`, hosted job `eed7303a-892a-41e1-81e5-c6c9c37237bd`, and the independently reconciled Plonk/refund transactions
- keeps public activation fail closed behind canonical recovery evidence

## Canonical diagnosis

The mainnet canaries and isolated x402 refund passed in run 32629535171. The hosted proof job canonically settled, then optional solver-USDC reclaim hit primary RPC `-32005 rate limit exceeded`. Two independent Base RPCs agree solver `0x4d381d4dcf82f06275533aaff880b17d03c80d2d` remains nonce 1 with 250,000 USDC base units, so the reclaim did not land or remain pending.

## Validation

- `python -m unittest scripts.test_run_open_competition_v2_x402_rehearsal scripts.test_run_open_competition_v2_sepolia_rehearsal scripts.test_continue_open_competition_v2_beta3_mainnet scripts.test_resume_open_competition_v2_beta3_mainnet` — 47 passed
- modified workflow YAML parses
- `git diff --check`

No proof, canonicality, funding, settlement, or public-activation gate is bypassed. Admin override, if needed, is limited to repository merge/environment approval per owner authorization.

Maintainer notice: #1117