### PR TITLE
Allow exact gas-only delegate seed

### DIFF
--- a/scripts/fund_open_competition_v2_beta3_broker.py
+++ b/scripts/fund_open_competition_v2_beta3_broker.py
@@ -58,6 +58,26 @@ def usdc_balance(url: str, token: str, address: str, block: str) -> int:
     return int(rpc(url, "eth_call", [{"to": token, "data": data}, block]), 16)
 
 
+def require_deployer_capacity(
+    *,
+    deployer_usdc: int,
+    deployer_eth: int,
+    usdc_deficit: int,
+    eth_deficit: int,
+    minimum_deployer_usdc_after: int,
+    minimum_deployer_eth_after: int,
+) -> None:
+    if usdc_deficit:
+        require(
+            deployer_usdc >= usdc_deficit + minimum_deployer_usdc_after,
+            "deployer USDC cannot seed broker and retain the canary budget",
+        )
+    require(
+        deployer_eth >= eth_deficit + minimum_deployer_eth_after,
+        "deployer ETH cannot seed broker and retain deployment gas",
+    )
+
+
 def signing_address(address: str) -> str:
     require(ADDRESS.fullmatch(address) is not None, "transaction destination is invalid")
     return to_checksum_address(address)
@@ -224,13 +244,13 @@ def fund(
     )
     deployer_usdc = usdc_balance(rpc_url, network["usdc"], signer.address, "latest")
     deployer_eth = int(rpc(rpc_url, "eth_getBalance", [signer.address, "latest"]), 16)
-    require(
-        deployer_usdc >= usdc_deficit + network["minimum_deployer_usdc_after"],
-        "deployer USDC cannot seed broker and retain the canary budget",
-    )
-    require(
-        deployer_eth >= eth_deficit + network["minimum_deployer_eth_after"],
-        "deployer ETH cannot seed broker and retain deployment gas",
+    require_deployer_capacity(
+        deployer_usdc=deployer_usdc,
+        deployer_eth=deployer_eth,
+        usdc_deficit=usdc_deficit,
+        eth_deficit=eth_deficit,
+        minimum_deployer_usdc_after=network["minimum_deployer_usdc_after"],
+        minimum_deployer_eth_after=network["minimum_deployer_eth_after"],
     )
 
     receipts: list[dict[str, Any]] = []

--- a/scripts/test_fund_open_competition_v2_beta3_broker.py
+++ b/scripts/test_fund_open_competition_v2_beta3_broker.py
@@ -36,6 +36,27 @@ class BrokerFundingTests(unittest.TestCase):
         with self.assertRaisesRegex(MODULE.BrokerFundingError, "are invalid"):
             MODULE.deficits(current_usdc=0, current_eth=0, target_usdc=0, target_eth=0)
 
+    def test_zero_usdc_seed_does_not_require_an_unrelated_usdc_reserve(self):
+        MODULE.require_deployer_capacity(
+            deployer_usdc=0,
+            deployer_eth=300,
+            usdc_deficit=0,
+            eth_deficit=100,
+            minimum_deployer_usdc_after=635_000,
+            minimum_deployer_eth_after=200,
+        )
+
+    def test_positive_usdc_seed_still_preserves_the_canary_reserve(self):
+        with self.assertRaisesRegex(MODULE.BrokerFundingError, "canary budget"):
+            MODULE.require_deployer_capacity(
+                deployer_usdc=635_000,
+                deployer_eth=300,
+                usdc_deficit=1,
+                eth_deficit=100,
+                minimum_deployer_usdc_after=635_000,
+                minimum_deployer_eth_after=200,
+            )
+
     def test_signing_address_accepts_canonical_lowercase_broker(self):
         destination = MODULE.signing_address("0x176f486a724720c4fdfc920d7c17dd1004c2bfb4")
         self.assertEqual(destination, "0x176f486A724720C4FDfc920d7c17Dd1004C2bfb4")


### PR DESCRIPTION
## Finding

Protected gas-only run 32631819333 requested 0 USDC and failed before broadcast because the generic broker helper required a deployer USDC canary reserve despite a zero USDC deficit.

## Change

- require the deployer USDC reserve only when the operation will actually transfer USDC
- preserve the deployer ETH reserve check and all nonce, gas, same-raw-transaction failover, receipt, and safe-block checks
- add zero-USDC and positive-USDC regressions

## Validation

- focused broker/gas-seed tests pass
- `git diff --check`

No funds moved in the failed run. This PR does not authorize or transfer owner USDC.

Maintainer notice: #1117