### PR TITLE
Fix Brave chain-query compatibility for exact GMV authorization

### DIFF
--- a/scripts/serve_open_competition_v2_gmv_confirmation.py
+++ b/scripts/serve_open_competition_v2_gmv_confirmation.py
@@ -49,6 +49,24 @@ HTML = r"""<!doctype html>
 </article></main>
 <script>
 (async () => {
+  async function assertBaseMainnetWhenQueryable(provider) {
+    try {
+      const chain = await provider.request({method: 'eth_chainId'});
+      if (String(chain).toLowerCase() !== '0x2105') {
+        throw new Error('Switch the wallet to Base mainnet, then retry.');
+      }
+      return true;
+    } catch (error) {
+      const code = Number(error && error.code);
+      const message = String(error && error.message ? error.message : error).toLowerCase();
+      const methodUnavailable = code === -32601 || code === 4200 ||
+        message.includes('method not found') || message.includes('method is not supported') ||
+        message.includes('unsupported method');
+      if (!methodUnavailable) throw error;
+      return false;
+    }
+  }
+
   const bundle = await fetch('/bundle', {cache: 'no-store'}).then(r => r.json());
   const summary = bundle.confirmation_summary;
   const facts = [
@@ -68,13 +86,16 @@ HTML = r"""<!doctype html>
     button.disabled = true;
     try {
       if (!window.ethereum) throw new Error('No injected wallet is available in this browser.');
-      const chain = await ethereum.request({method: 'eth_chainId'});
-      if (String(chain).toLowerCase() !== '0x2105') throw new Error('Switch the wallet to Base mainnet, then retry.');
-      const accounts = await ethereum.request({method: 'eth_requestAccounts'});
+      const provider = window.ethereum;
+      const chainWasChecked = await assertBaseMainnetWhenQueryable(provider);
+      if (!chainWasChecked) {
+        status.textContent = 'This wallet cannot report its selected chain. The signature request itself remains locked to Base mainnet.';
+      }
+      const accounts = await provider.request({method: 'eth_requestAccounts'});
       const account = String(accounts[0] || '').toLowerCase();
       if (account !== bundle.owner.toLowerCase()) throw new Error(`Select ${bundle.owner} in the wallet, then retry.`);
       status.textContent = 'Review the exact 77.668098-USDC authorization in your wallet.';
-      const signature = await ethereum.request({
+      const signature = await provider.request({
         method: 'eth_signTypedData_v4',
         params: [account, JSON.stringify(bundle.owner_authorization.typed_data)],
       });

--- a/scripts/test_serve_open_competition_v2_gmv_confirmation.py
+++ b/scripts/test_serve_open_competition_v2_gmv_confirmation.py
@@ -8,10 +8,17 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.serve_open_competition_v2_gmv_confirmation import store_verified_signature
+from scripts.serve_open_competition_v2_gmv_confirmation import HTML, store_verified_signature
 
 
 class GmvConfirmationTests(unittest.TestCase):
+    def test_wallet_chain_query_fallback_remains_narrow_and_base_bound(self) -> None:
+        self.assertIn("code === -32601 || code === 4200", HTML)
+        self.assertIn("message.includes('method is not supported')", HTML)
+        self.assertIn("if (!methodUnavailable) throw error", HTML)
+        self.assertIn("String(chain).toLowerCase() !== '0x2105'", HTML)
+        self.assertIn("method: 'eth_signTypedData_v4'", HTML)
+
     def test_signature_is_written_once_and_not_returned(self) -> None:
         signature = "0x" + "11" * 65
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Outcome

Allows the exact local EIP-3009 authorization page to proceed when an injected Brave Wallet provider reports that `eth_chainId` itself is unsupported.

## Safety

- An explicitly wrong chain still fails closed.
- Only EIP-1193 method-unavailable responses bypass the optional preflight.
- The signed EIP-712 domain remains fixed to Base chain 8453 and native USDC.
- The local server still recovers the exact configured owner before storing the signature once.
- No funding or activation claim is made by this change.

## Validation

- `python -m unittest scripts.test_serve_open_competition_v2_gmv_confirmation`
- `git diff --check`

No overlap with open replenishment PR #970 or KeeperHub PR #932.