### PR TITLE
Handle Brave exact unsupported chain-query wording

### DIFF
--- a/scripts/serve_open_competition_v2_gmv_confirmation.py
+++ b/scripts/serve_open_competition_v2_gmv_confirmation.py
@@ -61,7 +61,8 @@ HTML = r"""<!doctype html>
       const message = String(error && error.message ? error.message : error).toLowerCase();
       const methodUnavailable = code === -32601 || code === 4200 ||
         message.includes('method not found') || message.includes('method is not supported') ||
-        message.includes('unsupported method');
+        message.includes('unsupported method') ||
+        (message.includes('request method') && message.includes('is not supported'));
       if (!methodUnavailable) throw error;
       return false;
     }

--- a/scripts/test_serve_open_competition_v2_gmv_confirmation.py
+++ b/scripts/test_serve_open_competition_v2_gmv_confirmation.py
@@ -15,6 +15,10 @@ class GmvConfirmationTests(unittest.TestCase):
     def test_wallet_chain_query_fallback_remains_narrow_and_base_bound(self) -> None:
         self.assertIn("code === -32601 || code === 4200", HTML)
         self.assertIn("message.includes('method is not supported')", HTML)
+        self.assertIn(
+            "message.includes('request method') && message.includes('is not supported')",
+            HTML,
+        )
         self.assertIn("if (!methodUnavailable) throw error", HTML)
         self.assertIn("String(chain).toLowerCase() !== '0x2105'", HTML)
         self.assertIn("method: 'eth_signTypedData_v4'", HTML)


### PR DESCRIPTION
Handles Brave Wallet's observed Request method eth_chainId is not supported message while retaining wrong-chain failure, Base and USDC typed-data binding, and exact owner signature recovery. Adds focused regression coverage. Validated with the confirmation-page unit tests and git diff check. Follow-up to #1162.