### PR TITLE
Add bounded rate-limit recovery to private GMV floor guard

### DIFF
--- a/scripts/local_open_competition_v2_gmv_guard.py
+++ b/scripts/local_open_competition_v2_gmv_guard.py
@@ -56,6 +56,9 @@ STATE_KEY_SCHEMA = "agent-bounties/local-delegate-state-v1"
 MAX_GAS_LIMIT = 2_000_000
 MAX_FEE_PER_GAS_WEI = 2_000_000_000
 MAX_TOTAL_GAS_WEI = 3_000_000_000_000_000
+RPC_MIN_INTERVAL_SECONDS = 0.12
+RPC_RETRY_DELAYS = (0.5, 1.0, 2.0, 4.0)
+_LAST_RPC_REQUEST: dict[str, float] = {}
 
 
 class GuardError(ValueError):
@@ -63,21 +66,42 @@ class GuardError(ValueError):
 
 
 def rpc(url: str, method: str, params: list[object], request_id: int) -> object:
-    request = urllib.request.Request(
-        url,
-        data=json.dumps(
-            {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
-        ).encode(),
-        headers={"content-type": "application/json", "user-agent": "agent-bounties-gmv-guard/1"},
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:  # nosec B310
-            payload = json.load(response)
-    except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        raise GuardError(f"RPC {method} failed") from error
-    if not isinstance(payload, dict) or payload.get("error") is not None or "result" not in payload:
-        raise GuardError(f"RPC {method} returned an error")
-    return payload["result"]
+    for attempt in range(len(RPC_RETRY_DELAYS) + 1):
+        now = time.monotonic()
+        wait = _LAST_RPC_REQUEST.get(url, 0.0) + RPC_MIN_INTERVAL_SECONDS - now
+        if wait > 0:
+            time.sleep(wait)
+        _LAST_RPC_REQUEST[url] = time.monotonic()
+        request = urllib.request.Request(
+            url,
+            data=json.dumps(
+                {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+            ).encode(),
+            headers={"content-type": "application/json", "user-agent": "agent-bounties-gmv-guard/1"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:  # nosec B310
+                payload = json.load(response)
+        except urllib.error.HTTPError as error:
+            retryable = error.code == 429 or 500 <= error.code < 600
+            if retryable and attempt < len(RPC_RETRY_DELAYS):
+                time.sleep(RPC_RETRY_DELAYS[attempt])
+                continue
+            raise GuardError(f"RPC {method} failed") from error
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+            if attempt < len(RPC_RETRY_DELAYS):
+                time.sleep(RPC_RETRY_DELAYS[attempt])
+                continue
+            raise GuardError(f"RPC {method} failed") from error
+        error = payload.get("error") if isinstance(payload, dict) else None
+        error_message = str(error.get("message") or "").lower() if isinstance(error, dict) else ""
+        if error is not None and "rate limit" in error_message and attempt < len(RPC_RETRY_DELAYS):
+            time.sleep(RPC_RETRY_DELAYS[attempt])
+            continue
+        if not isinstance(payload, dict) or error is not None or "result" not in payload:
+            raise GuardError(f"RPC {method} returned an error")
+        return payload["result"]
+    raise GuardError(f"RPC {method} failed")
 
 
 def require_private_file(path: Path) -> bytes:

--- a/scripts/test_local_open_competition_v2_gmv_guard.py
+++ b/scripts/test_local_open_competition_v2_gmv_guard.py
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
+import io
+import json
 import unittest
 import sys
+import urllib.error
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parent
 if str(SCRIPTS) not in sys.path:
@@ -18,6 +22,7 @@ from local_open_competition_v2_gmv_guard import (  # noqa: E402
     GuardError,
     choose_creations,
 )
+import local_open_competition_v2_gmv_guard as guard_module  # noqa: E402
 
 
 def guard_state(active: int, used: int, *, period_spent: int = 0, lifetime_spent: int = 0):
@@ -38,6 +43,43 @@ def guard_state(active: int, used: int, *, period_spent: int = 0, lifetime_spent
 
 
 class LocalGmvGuardTests(unittest.TestCase):
+    def test_rpc_retries_http_rate_limit_with_bounded_backoff(self) -> None:
+        rate_limit = urllib.error.HTTPError(
+            "https://primary.invalid", 429, "rate limited", {}, None
+        )
+        success = io.BytesIO(json.dumps({"jsonrpc": "2.0", "id": 1, "result": "0x2105"}).encode())
+        guard_module._LAST_RPC_REQUEST.clear()
+        with (
+            mock.patch.object(guard_module, "RPC_MIN_INTERVAL_SECONDS", 0),
+            mock.patch.object(
+                guard_module.urllib.request,
+                "urlopen",
+                side_effect=[rate_limit, success],
+            ) as urlopen,
+            mock.patch.object(guard_module.time, "sleep") as sleep,
+        ):
+            result = guard_module.rpc("https://primary.invalid", "eth_chainId", [], 1)
+        self.assertEqual(result, "0x2105")
+        self.assertEqual(urlopen.call_count, 2)
+        sleep.assert_called_once_with(guard_module.RPC_RETRY_DELAYS[0])
+
+    def test_rpc_does_not_retry_contract_error(self) -> None:
+        failure = io.BytesIO(
+            json.dumps(
+                {"jsonrpc": "2.0", "id": 1, "error": {"code": 3, "message": "execution reverted"}}
+            ).encode()
+        )
+        guard_module._LAST_RPC_REQUEST.clear()
+        with (
+            mock.patch.object(guard_module, "RPC_MIN_INTERVAL_SECONDS", 0),
+            mock.patch.object(guard_module.urllib.request, "urlopen", return_value=failure) as urlopen,
+            mock.patch.object(guard_module.time, "sleep") as sleep,
+        ):
+            with self.assertRaisesRegex(GuardError, "returned an error"):
+                guard_module.rpc("https://primary.invalid", "eth_call", [], 1)
+        urlopen.assert_called_once()
+        sleep.assert_not_called()
+
     def test_private_inventory_states_restore_exact_target(self) -> None:
         for active in (10, 9, 5, 4, 0):
             with self.subTest(active=active):


### PR DESCRIPTION
Adds per-endpoint pacing and bounded retry for HTTP 429, HTTP 5xx, transport failures, invalid transport JSON, and explicit JSON-RPC rate-limit errors. Contract execution errors remain non-retryable and dual-RPC disagreements still fail closed. This addresses a production read-only inspection stop after the reserve funding transaction was canonically confirmed. Tests cover retry and non-retry behavior. Validation: eight focused tests, Ruff, compileall, and git diff check.