### PR TITLE
Separate state and receipt RPC pairs in private GMV guard

### DIFF
--- a/scripts/local_open_competition_v2_gmv_guard.py
+++ b/scripts/local_open_competition_v2_gmv_guard.py
@@ -706,7 +706,13 @@ def wait_canonical_receipt(primary: str, shadow: str, tx_hash: str, timeout: int
     raise GuardError(f"transaction canonical reconciliation timed out{boundary}; inspect by hash {tx_hash}")
 
 
-def resume_pending(state_dir: Path, primary: str, shadow: str) -> list[dict[str, Any]]:
+def resume_pending(
+    state_dir: Path,
+    primary: str,
+    shadow: str,
+    receipt_primary: str,
+    receipt_shadow: str,
+) -> list[dict[str, Any]]:
     """Rebroadcast the exact persisted raw transaction before planning new work."""
     ledger = load_ledger(state_dir)
     resumed = []
@@ -730,7 +736,9 @@ def resume_pending(state_dir: Path, primary: str, shadow: str) -> list[dict[str,
                 # Exact raw rebroadcast is idempotent. Canonical receipt evidence below
                 # determines whether an already-known/nonce-used response is acceptable.
                 pass
-        evidence = wait_canonical_receipt(primary, shadow, tx_hash, RECEIPT_TIMEOUT)
+        evidence = wait_canonical_receipt(
+            receipt_primary, receipt_shadow, tx_hash, RECEIPT_TIMEOUT
+        )
         record.update({"status": "canonically_confirmed", **evidence})
         record.pop("raw_transaction", None)
         resumed.append(evidence)
@@ -744,6 +752,8 @@ def execute_direct(
     state_dir: Path,
     primary: str,
     shadow: str,
+    receipt_primary: str,
+    receipt_shadow: str,
     direct: dict[str, Any],
     kind: str,
     candidate_id: str | None,
@@ -812,7 +822,9 @@ def execute_direct(
             raise GuardError(f"both RPC broadcasts failed before a receipt was visible: {errors}")
     record["status"] = "broadcast"
     save_ledger(state_dir, ledger)
-    evidence = wait_canonical_receipt(primary, shadow, tx_hash, RECEIPT_TIMEOUT)
+    evidence = wait_canonical_receipt(
+        receipt_primary, receipt_shadow, tx_hash, RECEIPT_TIMEOUT
+    )
     record.update({"status": "canonically_confirmed", **evidence})
     record.pop("raw_transaction", None)
     save_ledger(state_dir, ledger)
@@ -828,6 +840,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--activation-bundle", type=Path, required=True)
     parser.add_argument("--rpc-url", required=True)
     parser.add_argument("--shadow-rpc-url", required=True)
+    parser.add_argument("--receipt-rpc-url")
+    parser.add_argument("--shadow-receipt-rpc-url")
     parser.add_argument("--json-out", type=Path)
     commands = parser.add_subparsers(dest="command", required=True)
     commands.add_parser("status")
@@ -845,9 +859,17 @@ def main(argv: list[str] | None = None) -> int:
         reserve_deployment = load_object(args.reserve_deployment)
         pool = load_object(args.candidate_pool)
         bundle = load_object(args.activation_bundle)
+        receipt_rpc_url = args.receipt_rpc_url or args.rpc_url
+        shadow_receipt_rpc_url = args.shadow_receipt_rpc_url or args.shadow_rpc_url
         validate_reviewed_inputs(release, reserve_deployment, pool, bundle, delegate)
         with exclusive_guard(state_dir):
-            resumed = resume_pending(state_dir, args.rpc_url, args.shadow_rpc_url)
+            resumed = resume_pending(
+                state_dir,
+                args.rpc_url,
+                args.shadow_rpc_url,
+                receipt_rpc_url,
+                shadow_receipt_rpc_url,
+            )
             state = inspect_state(
                 args.rpc_url,
                 args.shadow_rpc_url,
@@ -870,6 +892,8 @@ def main(argv: list[str] | None = None) -> int:
                     state_dir,
                     args.rpc_url,
                     args.shadow_rpc_url,
+                    receipt_rpc_url,
+                    shadow_receipt_rpc_url,
                     direct,
                     "reserve_funding",
                     None,
@@ -921,6 +945,8 @@ def main(argv: list[str] | None = None) -> int:
                             state_dir,
                             args.rpc_url,
                             args.shadow_rpc_url,
+                            receipt_rpc_url,
+                            shadow_receipt_rpc_url,
                             creation["delegate_transaction"],
                             "create_competition",
                             creation["candidate_id"],

--- a/scripts/test_local_open_competition_v2_gmv_guard.py
+++ b/scripts/test_local_open_competition_v2_gmv_guard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import io
 import json
+import tempfile
 import unittest
 import sys
 import urllib.error
@@ -43,6 +44,52 @@ def guard_state(active: int, used: int, *, period_spent: int = 0, lifetime_spent
 
 
 class LocalGmvGuardTests(unittest.TestCase):
+    def test_pending_recovery_uses_separate_receipt_rpc_pair(self) -> None:
+        delegate = "0x" + "22" * 20
+        transaction_hash = "0x" + "11" * 32
+        ledger = {
+            "schema": guard_module.LEDGER_SCHEMA,
+            "transactions": [
+                {
+                    "kind": "create_competition",
+                    "candidate_id": "candidate-1-v1",
+                    "raw_transaction": "0x01",
+                    "status": "broadcast",
+                    "transaction_hash": transaction_hash,
+                }
+            ],
+        }
+        evidence = {"transaction_hash": transaction_hash, "receipt_block": 123, "safe_block": {}}
+        with tempfile.TemporaryDirectory() as temporary:
+            state_dir = Path(temporary)
+            (state_dir / guard_module.LEDGER_FILE).write_text(json.dumps(ledger), encoding="utf-8")
+            with (
+                mock.patch.object(guard_module, "public_address", return_value=delegate),
+                mock.patch.object(guard_module.Account, "recover_transaction", return_value=delegate),
+                mock.patch.object(guard_module, "rpc", return_value=transaction_hash) as rpc,
+                mock.patch.object(
+                    guard_module, "wait_canonical_receipt", return_value=evidence
+                ) as wait_receipt,
+            ):
+                resumed = guard_module.resume_pending(
+                    state_dir,
+                    "https://state-primary.invalid",
+                    "https://state-shadow.invalid",
+                    "https://receipt-primary.invalid",
+                    "https://receipt-shadow.invalid",
+                )
+        self.assertEqual(resumed, [evidence])
+        self.assertEqual(
+            [call.args[0] for call in rpc.call_args_list],
+            ["https://state-primary.invalid", "https://state-shadow.invalid"],
+        )
+        wait_receipt.assert_called_once_with(
+            "https://receipt-primary.invalid",
+            "https://receipt-shadow.invalid",
+            transaction_hash,
+            guard_module.RECEIPT_TIMEOUT,
+        )
+
     def test_default_rpc_pacing_stays_below_public_quota_bursts(self) -> None:
         self.assertGreaterEqual(guard_module.RPC_MIN_INTERVAL_SECONDS, 1.0)
 


### PR DESCRIPTION
Adds optional independent receipt RPC arguments while preserving the existing state RPC pair defaults. Simulations, broadcasts, code/policy/balance/allowance checks, and candidate inspection continue through the state pair; receipt and receipt-safe-block agreement use the receipt pair. This allows PublicNode+dRPC for supported state scans and official Base+dRPC for canonical receipts without weakening either two-provider invariant. Pending raw-transaction recovery is tested to rebroadcast through the state pair and reconcile through the receipt pair. Seven focused tests, Ruff, compileall, and git diff check pass.