### PR TITLE
Separate state and execution RPC roles in private GMV guard

### DIFF
--- a/scripts/local_open_competition_v2_gmv_guard.py
+++ b/scripts/local_open_competition_v2_gmv_guard.py
@@ -843,6 +843,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--activation-bundle", type=Path, required=True)
     parser.add_argument("--rpc-url", required=True)
     parser.add_argument("--shadow-rpc-url", required=True)
+    parser.add_argument("--execution-rpc-url")
+    parser.add_argument("--shadow-execution-rpc-url")
     parser.add_argument("--receipt-rpc-url")
     parser.add_argument("--shadow-receipt-rpc-url")
     parser.add_argument("--json-out", type=Path)
@@ -862,14 +864,16 @@ def main(argv: list[str] | None = None) -> int:
         reserve_deployment = load_object(args.reserve_deployment)
         pool = load_object(args.candidate_pool)
         bundle = load_object(args.activation_bundle)
+        execution_rpc_url = args.execution_rpc_url or args.rpc_url
+        shadow_execution_rpc_url = args.shadow_execution_rpc_url or args.shadow_rpc_url
         receipt_rpc_url = args.receipt_rpc_url or args.rpc_url
         shadow_receipt_rpc_url = args.shadow_receipt_rpc_url or args.shadow_rpc_url
         validate_reviewed_inputs(release, reserve_deployment, pool, bundle, delegate)
         with exclusive_guard(state_dir):
             resumed = resume_pending(
                 state_dir,
-                args.rpc_url,
-                args.shadow_rpc_url,
+                execution_rpc_url,
+                shadow_execution_rpc_url,
                 receipt_rpc_url,
                 shadow_receipt_rpc_url,
             )
@@ -893,8 +897,8 @@ def main(argv: list[str] | None = None) -> int:
                 direct = {"to": relay["to"], "data": relay["data"]}
                 execution = execute_direct(
                     state_dir,
-                    args.rpc_url,
-                    args.shadow_rpc_url,
+                    execution_rpc_url,
+                    shadow_execution_rpc_url,
                     receipt_rpc_url,
                     shadow_receipt_rpc_url,
                     direct,
@@ -946,8 +950,8 @@ def main(argv: list[str] | None = None) -> int:
                         )
                         execution = execute_direct(
                             state_dir,
-                            args.rpc_url,
-                            args.shadow_rpc_url,
+                            execution_rpc_url,
+                            shadow_execution_rpc_url,
                             receipt_rpc_url,
                             shadow_receipt_rpc_url,
                             creation["delegate_transaction"],

--- a/scripts/test_local_open_competition_v2_gmv_guard.py
+++ b/scripts/test_local_open_competition_v2_gmv_guard.py
@@ -45,7 +45,7 @@ def guard_state(active: int, used: int, *, period_spent: int = 0, lifetime_spent
 
 
 class LocalGmvGuardTests(unittest.TestCase):
-    def test_pending_recovery_uses_separate_receipt_rpc_pair(self) -> None:
+    def test_pending_recovery_uses_execution_pair_and_separate_receipt_pair(self) -> None:
         delegate = "0x" + "22" * 20
         transaction_hash = "0x" + "11" * 32
         ledger = {
@@ -74,15 +74,15 @@ class LocalGmvGuardTests(unittest.TestCase):
             ):
                 resumed = guard_module.resume_pending(
                     state_dir,
-                    "https://state-primary.invalid",
-                    "https://state-shadow.invalid",
+                    "https://execution-primary.invalid",
+                    "https://execution-shadow.invalid",
                     "https://receipt-primary.invalid",
                     "https://receipt-shadow.invalid",
                 )
         self.assertEqual(resumed, [evidence])
         self.assertEqual(
             [call.args[0] for call in rpc.call_args_list],
-            ["https://state-primary.invalid", "https://state-shadow.invalid"],
+            ["https://execution-primary.invalid", "https://execution-shadow.invalid"],
         )
         wait_receipt.assert_called_once_with(
             "https://receipt-primary.invalid",


### PR DESCRIPTION
Adds optional independent execution RPC arguments. Heavy state inspection remains on the state pair, while transaction simulation, gas/nonce checks, exact raw broadcast, and pending rebroadcast use the execution pair; canonical reconciliation remains on the receipt pair. Defaults preserve existing behavior. This lets each independent pair handle only supported query classes without removing any check. Eight focused tests, Ruff, help-surface verification, and git diff check pass.