### PR TITLE
Restore V2 distribution and unified inventory indexing

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -5357,20 +5357,38 @@ fn platform_amount(base_units: impl Into<String>) -> Result<PlatformAmountRespon
 fn platform_inventory_response(
     autonomous: Option<AutonomousBountyInventorySummary>,
     competition: Option<OpenCompetitionInventorySummary>,
+    competition_v2: Option<OpenCompetitionInventorySummary>,
 ) -> Result<PlatformInventoryResponse, StatusCode> {
-    match (autonomous, competition) {
-        (Some(autonomous), Some(competition)) => Ok(PlatformInventoryResponse {
+    match (autonomous, competition, competition_v2) {
+        (Some(autonomous), Some(competition), Some(competition_v2)) => {
+            let competition_count = competition
+                .ready_to_earn_count
+                .checked_add(competition_v2.ready_to_earn_count)
+                .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+            let competition_funding = add_platform_base_units(
+                &competition.funded_usdc_base_units,
+                &competition_v2.funded_usdc_base_units,
+            )?;
+            let competition_solver_rewards = add_platform_base_units(
+                &competition.solver_reward_usdc_base_units,
+                &competition_v2.solver_reward_usdc_base_units,
+            )?;
+            let competition_verifier_rewards = add_platform_base_units(
+                &competition.verifier_reward_usdc_base_units,
+                &competition_v2.verifier_reward_usdc_base_units,
+            )?;
+            Ok(PlatformInventoryResponse {
             status: "ready".to_string(),
             active_funded_opportunities: Some(
                 autonomous
                     .claimable_bounty_count
-                    .checked_add(competition.ready_to_earn_count)
+                    .checked_add(competition_count)
                     .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?,
             ),
             available_funding_usdc: Some(exact_usdc(
                 add_platform_base_units(
                     &autonomous.funded_usdc_base_units,
-                    &competition.funded_usdc_base_units,
+                    &competition_funding,
                 )?
                 .parse::<u128>()
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
@@ -5378,7 +5396,7 @@ fn platform_inventory_response(
             available_solver_rewards_usdc: Some(exact_usdc(
                 add_platform_base_units(
                     &autonomous.solver_reward_usdc_base_units,
-                    &competition.solver_reward_usdc_base_units,
+                    &competition_solver_rewards,
                 )?
                 .parse::<u128>()
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
@@ -5386,20 +5404,23 @@ fn platform_inventory_response(
             available_verifier_rewards_usdc: Some(exact_usdc(
                 add_platform_base_units(
                     &autonomous.verifier_reward_usdc_base_units,
-                    &competition.verifier_reward_usdc_base_units,
+                    &competition_verifier_rewards,
                 )?
                 .parse::<u128>()
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
             )),
-            generated_at: Some(if autonomous.generated_at <= competition.generated_at {
-                autonomous.generated_at
-            } else {
-                competition.generated_at
-            }),
+            generated_at: [
+                autonomous.generated_at,
+                competition.generated_at,
+                competition_v2.generated_at,
+            ]
+            .into_iter()
+            .min(),
             definition: "Current funded opportunities are reported as one marketplace total. The point-in-time projection is not added to historical payout or conversion cohorts.".to_string(),
-        }),
-        (autonomous, competition) => Ok(PlatformInventoryResponse {
-            status: if autonomous.is_some() || competition.is_some() {
+        })
+        }
+        (autonomous, competition, competition_v2) => Ok(PlatformInventoryResponse {
+            status: if autonomous.is_some() || competition.is_some() || competition_v2.is_some() {
                 "partial"
             } else {
                 "unavailable"
@@ -5434,11 +5455,14 @@ fn platform_metrics_response(
     policy: PublicMetricsPolicy,
     autonomous_inventory: Option<AutonomousBountyInventorySummary>,
     competition_inventory: Option<OpenCompetitionInventorySummary>,
+    competition_v2_inventory: Option<OpenCompetitionInventorySummary>,
     source_freshness: PlatformCanonicalSourceFreshness,
 ) -> Result<PlatformMetricsResponse, StatusCode> {
     let settlement_rate = (stats.claim_cohort.mature > 0)
         .then(|| stats.claim_cohort.settled as f64 / stats.claim_cohort.mature as f64);
-    let inventory_complete = autonomous_inventory.is_some() && competition_inventory.is_some();
+    let inventory_complete = autonomous_inventory.is_some()
+        && competition_inventory.is_some()
+        && competition_v2_inventory.is_some();
     let coverage_status = if inventory_complete
         && source_freshness.complete()
         && stats.coverage.awaiting_block_time_events == 0
@@ -5447,7 +5471,11 @@ fn platform_metrics_response(
     } else {
         "partial"
     };
-    let inventory = platform_inventory_response(autonomous_inventory, competition_inventory)?;
+    let inventory = platform_inventory_response(
+        autonomous_inventory,
+        competition_inventory,
+        competition_v2_inventory,
+    )?;
     let lifetime_canonical_payouts =
         platform_amount(stats.payouts.lifetime_total_base_units.clone())?;
     let total_gmv_28d = growth
@@ -5750,6 +5778,13 @@ async fn platform_metrics(
     } else {
         None
     };
+    let competition_v2_inventory = if source_freshness.open_competition_v2 {
+        build_open_competition_v2_inventory_summary(&state, "base-mainnet")
+            .await
+            .ok()
+    } else {
+        None
+    };
     let response = platform_metrics_response(
         stats,
         growth,
@@ -5757,6 +5792,7 @@ async fn platform_metrics(
         policy,
         autonomous_inventory,
         competition_inventory,
+        competition_v2_inventory,
         source_freshness,
     )?;
     Ok((
@@ -14365,6 +14401,52 @@ async fn build_open_competition_inventory_summary(
     })
 }
 
+async fn build_open_competition_v2_inventory_summary(
+    state: &SharedState,
+    network: &str,
+) -> Result<OpenCompetitionInventorySummary, StatusCode> {
+    let generated_at = Utc::now();
+    let items = load_public_open_competition_v2_opportunities(
+        state,
+        network,
+        state.public_base_url.trim_end_matches('/'),
+        generated_at,
+    )
+    .await?;
+    let ready = items
+        .iter()
+        .filter(|item| {
+            item.work_state == "claimable"
+                && item.payment_state == "escrowed"
+                && item.payment_committed
+                && item.verification_ready
+                && item
+                    .cash_economics
+                    .as_ref()
+                    .is_some_and(|economics| economics.gross_cash_margin_positive)
+        })
+        .collect::<Vec<_>>();
+    let sum = |field: fn(&OpportunityItem) -> &str| {
+        ready.iter().try_fold(0_u128, |total, item| {
+            field(item)
+                .parse::<u128>()
+                .ok()
+                .and_then(|amount| total.checked_add(amount))
+                .ok_or(StatusCode::INTERNAL_SERVER_ERROR)
+        })
+    };
+    Ok(OpenCompetitionInventorySummary {
+        generated_at: generated_at.to_rfc3339(),
+        ready_to_earn_count: ready.len(),
+        funded_usdc_base_units: sum(|item| &item.funded_amount.amount)?.to_string(),
+        solver_reward_usdc_base_units: sum(|item| &item.reward.amount)?.to_string(),
+        // Open Competition V2 reserves a keeper reward rather than a verifier
+        // reward. Keep this existing role-specific public field truthful while
+        // the full escrow remains included in available_funding_usdc.
+        verifier_reward_usdc_base_units: "0".to_string(),
+    })
+}
+
 fn format_usdc_base_units(amount: u128) -> String {
     format!(
         "{}.{:02}",
@@ -19902,6 +19984,7 @@ mod tests {
             policy,
             None,
             None,
+            None,
             PlatformCanonicalSourceFreshness {
                 autonomous: true,
                 open_competition: true,
@@ -19956,7 +20039,7 @@ mod tests {
     }
 
     #[test]
-    fn platform_inventory_combines_protocols_only_when_both_are_available() {
+    fn platform_inventory_combines_all_fresh_sources_without_type_split() {
         let autonomous = AutonomousBountyInventorySummary {
             schema_version: "test".to_string(),
             network: "base-mainnet".to_string(),
@@ -19981,22 +20064,37 @@ mod tests {
             solver_reward_usdc_base_units: "1000000".to_string(),
             verifier_reward_usdc_base_units: "200000".to_string(),
         };
-        let combined =
-            platform_inventory_response(Some(autonomous.clone()), Some(competition)).unwrap();
+        let competition_v2 = OpenCompetitionInventorySummary {
+            generated_at: "2026-08-12T20:02:00+00:00".to_string(),
+            ready_to_earn_count: 10,
+            funded_usdc_base_units: "30400000".to_string(),
+            solver_reward_usdc_base_units: "30000000".to_string(),
+            verifier_reward_usdc_base_units: "0".to_string(),
+        };
+        let combined = platform_inventory_response(
+            Some(autonomous.clone()),
+            Some(competition),
+            Some(competition_v2),
+        )
+        .unwrap();
 
         assert_eq!(combined.status, "ready");
-        assert_eq!(combined.active_funded_opportunities, Some(3));
-        assert_eq!(combined.available_funding_usdc.as_deref(), Some("4.200000"));
+        assert_eq!(combined.active_funded_opportunities, Some(13));
+        assert_eq!(
+            combined.available_funding_usdc.as_deref(),
+            Some("34.600000")
+        );
         assert_eq!(
             combined.available_solver_rewards_usdc.as_deref(),
-            Some("3.400000")
+            Some("33.400000")
         );
         let combined_json = serde_json::to_string(&combined).unwrap();
         assert!(!combined_json.contains("autonomous_claimable_bounties"));
         assert!(!combined_json.contains("open_competitions_ready_to_earn"));
+        assert!(!combined_json.contains("open_competition_v2"));
         assert!(!combined_json.contains("standing_meta_bounties"));
 
-        let partial = platform_inventory_response(Some(autonomous), None).unwrap();
+        let partial = platform_inventory_response(Some(autonomous), None, None).unwrap();
         assert_eq!(partial.status, "partial");
         assert_eq!(partial.active_funded_opportunities, None);
         assert!(partial.available_funding_usdc.is_none());
@@ -20067,6 +20165,7 @@ mod tests {
                 )
                 .unwrap(),
                 public_metrics_policy().unwrap(),
+                None,
                 None,
                 None,
                 PlatformCanonicalSourceFreshness {

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -36,6 +36,9 @@ struct OpenCompetitionV2PublicMetadata {
     title: String,
     summary: String,
     source_url: String,
+    epoch_starts_at: Option<String>,
+    epoch_ends_at: Option<String>,
+    minimum_score_base_units: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -937,26 +940,57 @@ fn v2_public_metadata(
     let registry: OpenCompetitionV2PublicMetadataRegistry =
         serde_json::from_str(OPEN_COMPETITION_V2_METADATA_JSON)
             .map_err(|error| format!("invalid Open Competition V2 metadata: {error}"))?;
-    if registry.schema_version != "agent-bounties/open-competition-v2-public-metadata-v1"
-        || registry.network != release.network
+    if registry.schema_version != "agent-bounties/open-competition-v2-public-metadata-v1" {
+        return Err("Open Competition V2 public metadata schema mismatch".to_string());
+    }
+    // Display metadata is optional enrichment, not canonical inventory evidence.
+    // A release rotation must not hide otherwise valid safe-block records while
+    // its reviewed metadata registry is being updated.
+    if registry.network != release.network
         || !registry
             .factory_contract
             .eq_ignore_ascii_case(&release.factory_contract)
     {
-        return Err("Open Competition V2 public metadata identity mismatch".to_string());
+        return Ok(BTreeMap::new());
     }
     let mut indexed = BTreeMap::new();
     for item in registry.competitions {
         if item.seed_id.trim().is_empty()
             || item.title.trim().is_empty()
             || item.summary.trim().is_empty()
-            || !item
+            || !(item
                 .source_url
                 .starts_with("https://github.com/NSPG13/agent-bounties/issues/")
+                || item.source_url
+                    == "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json")
             || item.bounty_id.len() != 66
             || item.competition.len() != 42
         {
             return Err("Open Competition V2 public metadata entry is malformed".to_string());
+        }
+        match (&item.epoch_starts_at, &item.epoch_ends_at) {
+            (Some(starts_at), Some(ends_at)) => {
+                let starts_at = DateTime::parse_from_rfc3339(starts_at)
+                    .map_err(|_| "Open Competition V2 metadata start is malformed")?;
+                let ends_at = DateTime::parse_from_rfc3339(ends_at)
+                    .map_err(|_| "Open Competition V2 metadata end is malformed")?;
+                if starts_at >= ends_at
+                    || item
+                        .minimum_score_base_units
+                        .as_deref()
+                        .is_none_or(|value| {
+                            value.parse::<u128>().ok().is_none_or(|value| value == 0)
+                        })
+                {
+                    return Err(
+                        "Open Competition V2 metadata scoring window is malformed".to_string()
+                    );
+                }
+            }
+            (None, None) if item.minimum_score_base_units.is_none() => {}
+            _ => {
+                return Err("Open Competition V2 metadata scoring window is incomplete".to_string())
+            }
         }
         let key = item.competition.to_ascii_lowercase();
         if indexed.insert(key, item).is_some() {
@@ -1104,6 +1138,15 @@ pub fn open_competition_v2_opportunities(
             "verification_policy_hash": projection.verification_policy_hash,
             "settlement_policy_hash": projection.settlement_policy_hash,
             "seed_id": known.map(|item| item.seed_id.clone()),
+            "scoring_window": known.and_then(|item| {
+                item.epoch_starts_at.as_ref().zip(item.epoch_ends_at.as_ref()).map(
+                    |(starts_at, ends_at)| json!({
+                        "starts_at": starts_at,
+                        "ends_at": ends_at,
+                        "minimum_score_base_units": item.minimum_score_base_units.as_deref(),
+                    }),
+                )
+            }),
             "payment_evidence": "CompetitionSettledV2"
         });
         let (categories, skills, keyword_matches) = web_public::discovery_taxonomy_with_matches(
@@ -1970,7 +2013,7 @@ mod tests {
             repository_subject_hash: hash('b'),
             sp1_source_commit: hash('c'),
             sp1_circuit_version: "agent-bounties-sp1-safe-v1".to_string(),
-            factory_contract: "0xa45c6636d75fc94eec8cf6f6a34308c687e42ce4".to_string(),
+            factory_contract: "0x29d0e39e0c03797c690633535722e6b34a69a78a".to_string(),
             factory_runtime_code_hash: hash('d'),
             implementation_contract: address('2'),
             implementation_runtime_code_hash: hash('e'),
@@ -1993,9 +2036,9 @@ mod tests {
             metric_programs: vec![program.clone()],
         };
         let projection = OpenCompetitionV2Projection {
-            bounty_id: "0xe5a73bf7669a2c3fa66ae38a47383bfa8f05448ba54e07a9af1a4013deb30f19"
+            bounty_id: "0x6901f3ecf52842689a4209aac6fa7d8af205a6d2a546d567b77705e06c0a8c9a"
                 .to_string(),
-            competition: "0x0618b169c3c878a0386b5da7b54713f60baa1ec2".to_string(),
+            competition: "0x8c494466711c1de316c7e7599f8b0641a30a0c98".to_string(),
             creator: address('8'),
             state: OpenCompetitionV2ProjectedState::Active,
             solver_reward: 3_000_000,
@@ -2068,13 +2111,21 @@ mod tests {
         .remove(0);
         assert_eq!(
             active.title,
-            "Map the shortest discovery path for eight AI-agent channels"
+            "Highest externally funded canonical GMV — daily August 24"
         );
         assert_eq!(active.work_state, "claimable");
         assert_eq!(active.payment_state, "escrowed");
         assert_eq!(active.competition_mode, "first_proven");
         assert_eq!(active.max_entries, None);
         assert_eq!(active.next_action.action, "quote_open_competition_v2_proof");
+        assert_eq!(
+            active.evidence_requirements["scoring_window"]["starts_at"],
+            "2026-08-24T00:00:00Z"
+        );
+        assert_eq!(
+            active.evidence_requirements["scoring_window"]["minimum_score_base_units"],
+            "1"
+        );
         assert_eq!(
             active.cash_economics.unwrap().gross_cash_margin.amount,
             "2890000"
@@ -2115,6 +2166,118 @@ mod tests {
         .remove(0);
         assert_eq!(paid.payment_state, "paid");
         assert_eq!(paid.proof_urls.len(), 1);
+    }
+
+    #[test]
+    fn beta3_stale_optional_metadata_does_not_hide_canonical_inventory() {
+        let (mut release, mut record) = beta3_release_and_record();
+        release.factory_contract = address_for_test('a');
+        record.factory_contract = release.factory_contract.clone();
+        record.projection.bounty_id = format!("0x{}", "b".repeat(64));
+        record.projection.competition = address_for_test('c');
+        let events = vec![beta3_event(
+            &record,
+            OpenCompetitionV2EventKind::CanonicalCompetitionCreated,
+            90,
+        )];
+        let now = DateTime::<Utc>::from_timestamp(1_800_000_100, 0).unwrap();
+
+        let item = open_competition_v2_opportunities(
+            &[record],
+            &events,
+            &release,
+            "base-mainnet",
+            "https://api.example",
+            100_000,
+            10_000,
+            now,
+        )
+        .unwrap()
+        .remove(0);
+
+        assert_eq!(item.title, "Open Competition 0xbbbbbbbbbb");
+        assert_eq!(item.work_state, "claimable");
+        assert_eq!(item.payment_state, "escrowed");
+        assert_eq!(item.next_action.action, "quote_open_competition_v2_proof");
+    }
+
+    #[test]
+    fn beta3_live_registry_projects_ten_scanner_ready_opportunities_and_feeds() {
+        let (release, template) = beta3_release_and_record();
+        let metadata = v2_public_metadata(&release).unwrap();
+        assert_eq!(metadata.len(), 10);
+        let mut records = Vec::new();
+        let mut events = Vec::new();
+        for (index, item) in metadata.values().enumerate() {
+            let mut record = template.clone();
+            record.projection.bounty_id = item.bounty_id.clone();
+            record.projection.competition = item.competition.clone();
+            record.projection.last_block = 90 + index as u64;
+            record.safe_block_number = 200;
+            events.push(beta3_event(
+                &record,
+                OpenCompetitionV2EventKind::CanonicalCompetitionCreated,
+                90 + index as u64,
+            ));
+            records.push(record);
+        }
+        let now = DateTime::<Utc>::from_timestamp(1_800_000_100, 0).unwrap();
+        let projected = open_competition_v2_opportunities(
+            &records,
+            &events,
+            &release,
+            "base-mainnet",
+            "https://api.example",
+            100_000,
+            10_000,
+            now,
+        )
+        .unwrap();
+        let ready = apply_query(
+            projected,
+            &OpportunityQuery {
+                source_type: Some("canonical_base".to_string()),
+                ..OpportunityQuery::default()
+            },
+            Some(OpportunityView::ReadyToEarn),
+            now,
+        );
+
+        assert_eq!(ready.len(), 10);
+        assert!(ready.iter().all(|item| {
+            item.next_action.action == "quote_open_competition_v2_proof"
+                && item.verification_ready
+                && item.payment_committed
+                && item.evidence_requirements["scoring_window"].is_object()
+                && item
+                    .public_url
+                    .contains("open-competition-v2-forward-gmv-candidate-pool-v2")
+        }));
+        let projection = OpportunityProjectionResponse {
+            schema_version: OPPORTUNITY_PROJECTION_SCHEMA.to_string(),
+            generated_at: now.to_rfc3339(),
+            network: "base-mainnet".to_string(),
+            applied_view: Some("ready_to_earn".to_string()),
+            degraded: false,
+            source_statuses: vec![OpportunitySourceStatus {
+                source_type: "canonical_base".to_string(),
+                available: true,
+                authoritative_urls: vec!["https://api.example/v1/opportunities".to_string()],
+                item_count: ready.len(),
+                error: None,
+            }],
+            items: ready,
+            evidence_boundary: "test".to_string(),
+        };
+        let feeds = render_opportunity_feeds(&projection, "https://api.example");
+        let json: Value = serde_json::from_str(&feeds.json).unwrap();
+        assert_eq!(json["items"].as_array().unwrap().len(), 10);
+        assert!(feeds
+            .rss
+            .contains("Highest externally funded canonical GMV"));
+        assert!(feeds
+            .atom
+            .contains("Highest externally funded canonical GMV"));
     }
 
     fn address_for_test(digit: char) -> String {

--- a/ops/open-competition-v2-public-metadata-v1.json
+++ b/ops/open-competition-v2-public-metadata-v1.json
@@ -1,48 +1,118 @@
 {
   "schema_version": "agent-bounties/open-competition-v2-public-metadata-v1",
   "network": "base-mainnet",
-  "factory_contract": "0xa45c6636d75fc94eec8cf6f6a34308c687e42ce4",
+  "factory_contract": "0x29d0e39e0c03797c690633535722e6b34a69a78a",
   "competitions": [
     {
-      "seed_id": "agent-discovery-surface-map-v1",
-      "bounty_id": "0xe5a73bf7669a2c3fa66ae38a47383bfa8f05448ba54e07a9af1a4013deb30f19",
-      "competition": "0x0618b169c3c878a0386b5da7b54713f60baa1ec2",
-      "title": "Map the shortest discovery path for eight AI-agent channels",
-      "summary": "Produce a machine-readable map showing how agents encounter Agent Bounties and the shortest canonical entry point from each channel.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/issues/1059"
+      "seed_id": "external-gmv-forward-daily-20260824-v2",
+      "bounty_id": "0x6901f3ecf52842689a4209aac6fa7d8af205a6d2a546d567b77705e06c0a8c9a",
+      "competition": "0x8c494466711c1de316c7e7599f8b0641a30a0c98",
+      "title": "Highest externally funded canonical GMV — daily August 24",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-24T00:00:00Z",
+      "epoch_ends_at": "2026-08-25T00:00:00Z",
+      "minimum_score_base_units": "1"
     },
     {
-      "seed_id": "agent-earning-runbook-v1",
-      "bounty_id": "0x6fc6bb1edaef22851ccd26d5820de923d43b3924d8f912374a8586db7449a607",
-      "competition": "0x740bbea2c8075e699c50c20ce71be0a88d6263ec",
-      "title": "Write the shortest deterministic agent earning runbook",
-      "summary": "Produce an ordered, machine-readable runbook that takes a new agent from discovery to canonical payment evidence without hidden human steps.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/issues/1060"
+      "seed_id": "external-gmv-forward-daily-20260825-v2",
+      "bounty_id": "0xf2d4a90fa4bbf9bec25a44b014c1b640cf11449bb3ec35f7f70597db0958e8eb",
+      "competition": "0x6a791b05333d9ca7d28a052003ced4818a372c7f",
+      "title": "Highest externally funded canonical GMV — daily August 25",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-25T00:00:00Z",
+      "epoch_ends_at": "2026-08-26T00:00:00Z",
+      "minimum_score_base_units": "1"
     },
     {
-      "seed_id": "agent-error-recovery-catalog-v1",
-      "bounty_id": "0x1a072fa044f46cbe95659745ca4bcb9450b0e8f1962765870279351dde9e8333",
-      "competition": "0xb9bea3cb1c91c3725961b28f5578a3b43e3eb603",
-      "title": "Build a machine-readable Beta3 error recovery catalog",
-      "summary": "Map common Beta3 transition failures to one exact next action so autonomous agents can recover without guessing.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/issues/1061"
+      "seed_id": "external-gmv-forward-daily-20260826-v2",
+      "bounty_id": "0x2bf21872cbf17425daf5e3231c242185ce89fc601320af5d785b87fc50329b8f",
+      "competition": "0x441e8bded29917999fc0e8330c83553262fa2f08",
+      "title": "Highest externally funded canonical GMV — daily August 26",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-26T00:00:00Z",
+      "epoch_ends_at": "2026-08-27T00:00:00Z",
+      "minimum_score_base_units": "1"
     },
     {
-      "seed_id": "agent-interface-examples-v1",
-      "bounty_id": "0x1257f1b3a66a35cca1cd47b9af982edca9bc3bbe581c15d1b004bb2f49a47ff8",
-      "competition": "0x2d484cdc61218fbcc079488b47471223af170a21",
-      "title": "Create one complete earning example for every agent interface",
-      "summary": "Produce concise equivalent examples for API, MCP, CLI, Python, TypeScript and x402 so agents can use the interface they already have.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/issues/1062"
+      "seed_id": "external-gmv-forward-daily-20260827-v2",
+      "bounty_id": "0xce85cd119ce7f9fedabbc3aa866bb1951719e0a3dd2115c805ef59e16374d47c",
+      "competition": "0x979782be0bfefb78ac0459d4695d619932ecdda4",
+      "title": "Highest externally funded canonical GMV — daily August 27",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-27T00:00:00Z",
+      "epoch_ends_at": "2026-08-28T00:00:00Z",
+      "minimum_score_base_units": "1"
     },
     {
-      "seed_id": "agent-findability-corpus-v1",
-      "bounty_id": "0xf198adda3799e3ba9eccd5c0a705ee137534c4adb1a9b7e0dc2206fd92899268",
-      "competition": "0xbeed3ee13db5ff84dd0f98c7418facc730ea15f4",
-      "title": "Build a 25-case agent findability and task-search corpus",
-      "summary": "Produce search prompts, routes and success criteria that test whether autonomous agents can find profitable Agent Bounties work.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/issues/1063"
+      "seed_id": "external-gmv-forward-week-20260824-v2",
+      "bounty_id": "0x4ffb4c5f75f2816b1d58c97ae440184bb5e75cbc158dc639b66a7e50e5d81417",
+      "competition": "0x2f1d2b24105596b153e473032256569fe544a44f",
+      "title": "Highest externally funded canonical GMV — week of August 24",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-24T00:00:00Z",
+      "epoch_ends_at": "2026-08-31T00:00:00Z",
+      "minimum_score_base_units": "1"
+    },
+    {
+      "seed_id": "external-gmv-forward-week-20260831-v2",
+      "bounty_id": "0x51e1f4e05e3ef3dd61f0867a378005780b8882ed4b991fe0f927e6be44bf29f0",
+      "competition": "0x1692fecdb678537eb4cc0093e9e4e99dbded9806",
+      "title": "Highest externally funded canonical GMV — week of August 31",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-31T00:00:00Z",
+      "epoch_ends_at": "2026-09-07T00:00:00Z",
+      "minimum_score_base_units": "1"
+    },
+    {
+      "seed_id": "external-gmv-forward-fortnight-20260824-v2",
+      "bounty_id": "0x650ab64c02cba5dd8d3d4f3efcc1bf4c2c8125d2fea0e13b69e8e326f1b8b81f",
+      "competition": "0x6f635dfd07085aa48ec8b11767eeb48936969f5c",
+      "title": "Highest externally funded canonical GMV — August 24 to September 7",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-24T00:00:00Z",
+      "epoch_ends_at": "2026-09-07T00:00:00Z",
+      "minimum_score_base_units": "1"
+    },
+    {
+      "seed_id": "external-gmv-forward-fortnight-20260907-v2",
+      "bounty_id": "0x3b74c2a80fd55e9ae72bb8f21b8e2b240a32b1d78676f6fe489fde1099694071",
+      "competition": "0x5817b7742b085d333c7e7831daa62a490c493b56",
+      "title": "Highest externally funded canonical GMV — September 7 to September 21",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-09-07T00:00:00Z",
+      "epoch_ends_at": "2026-09-21T00:00:00Z",
+      "minimum_score_base_units": "1"
+    },
+    {
+      "seed_id": "external-gmv-forward-month-20260824-v2",
+      "bounty_id": "0x54684252bfcece3e9258af16f337391498b1fefd9cbb7690abe149ad5bee60c6",
+      "competition": "0x8c990ddf5360c00ee0b2090000e3a3a6f90a6a9d",
+      "title": "Highest externally funded canonical GMV — August 24 to September 21",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-24T00:00:00Z",
+      "epoch_ends_at": "2026-09-21T00:00:00Z",
+      "minimum_score_base_units": "1"
+    },
+    {
+      "seed_id": "external-gmv-forward-sprint-20260824-v2",
+      "bounty_id": "0x652887c4b67fe6fe8b414074112107347f7e8480d433022252da032f3bcec4cb",
+      "competition": "0x36e45ec89b61f551724558ed799ad4e07c288175",
+      "title": "Highest externally funded canonical GMV — August 24 sprint",
+      "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "epoch_starts_at": "2026-08-24T00:00:00Z",
+      "epoch_ends_at": "2026-08-27T00:00:00Z",
+      "minimum_score_base_units": "1"
     }
   ],
-  "evidence_boundary": "This registry adds public display metadata only. Safe-block contract projections remain authoritative for funding and state; only CompetitionSettledV2 proves solver payment."
+  "evidence_boundary": "This registry adds public display metadata and scoring-window orientation only. Safe-block contract projections and the committed metric program remain authoritative for state and scoring; only CompetitionSettledV2 proves solver payment."
 }


### PR DESCRIPTION
## Outcome\n\nRestores distribution and unified indexing for the ten live Open Competition V2 GMV meta-bounties.\n\n- projects all ten canonically active V2 competitions into unified opportunities, ready-to-earn views, JSON/RSS/Atom feeds, MCP-proxied discovery, and the existing homepage consumer\n- updates reviewed public display/scoring metadata to the current Beta3 factory and live competition addresses\n- makes optional metadata identity drift fail open to generic display metadata while canonical release/indexer evidence remains authoritative\n- adds V2 inventory to the existing unified public aggregate without exposing type-separated counts\n- preserves canonical settlement as the only GMV/payment evidence\n\nPublic maintainer notice: https://github.com/NSPG13/agent-bounties/issues/1117#issuecomment-5388941528\n\nOverlap: PR #996 should rebase after this change and preserve its inventory freshness semantics without introducing public type-separated reporting.\n\n## Validation\n\n- cargo test --quiet -p api — 147 passed, 4 ignored\n- cargo test --quiet -p mcp-server — 68 passed\n- cargo clippy -p api --all-targets -- -D warnings\n- cargo fmt --all -- --check\n- python scripts/check-site.py\n- python scripts/self_heal.py bench --policy ops/self-healing-policy.json --fixtures ops/fixtures/recovery-cases.json — 15/15\n- scripts/preflight.ps1 -Mode core\n