### PR TITLE
Fix V2 continuation canary build assertion

### DIFF
--- a/scripts/test_build_open_competition_v2_beta3_release.py
+++ b/scripts/test_build_open_competition_v2_beta3_release.py
@@ -156,10 +156,11 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
         self.assertNotIn("x402_success_and_refund_canaries_complete", workflow)
 
     def test_mainnet_canaries_rebuild_cleaned_contract_artifacts(self):
-        for workflow_path in (
-            ".github/workflows/open-competition-v2-beta3-release.yml",
-            ".github/workflows/continue-open-competition-v2-beta3-mainnet.yml",
-        ):
+        workflows = {
+            ".github/workflows/open-competition-v2-beta3-release.yml": "contracts/base-escrow",
+            ".github/workflows/continue-open-competition-v2-beta3-mainnet.yml": "target/continuation-control/contracts/base-escrow",
+        }
+        for workflow_path, contract_root in workflows.items():
             workflow = (MODULE.ROOT / workflow_path).read_text(encoding="utf-8")
             canary = workflow.split("  mainnet-canaries:", 1)[1].split(
                 "  activate-public-beta:", 1
@@ -169,7 +170,7 @@ class OpenCompetitionV2ReleaseTests(unittest.TestCase):
                 canary,
             )
             self.assertIn(
-                "forge build --root contracts/base-escrow --force --ast",
+                f"forge build --root {contract_root} --force --ast",
                 canary,
             )
 


### PR DESCRIPTION
## Outcome\n\nUnblocks exact-main deployment after #1170 by making the deterministic canary assertion match each workflow's actual checkout root:\n\n- the primary release workflow builds contracts/base-escrow\n- the continuation workflow builds 	arget/continuation-control/contracts/base-escrow\n\nNo contract, runtime, payment, or deployment-policy behavior changes.\n\nNotice: https://github.com/NSPG13/agent-bounties/issues/1117#issuecomment-5389094076\n\n## Validation\n\n- exact formerly failing test passes\n- Python bytecode compilation passes\n- core preflight passes\n- the complete hosted suite will rebuild Foundry artifacts before running the wider release test module\n