### PR TITLE
Fix solarpunk hero scale and spacing

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -316,6 +316,11 @@ def check_homepage(site_dir: Path) -> None:
     )
     if page.count("<button type=\"button\" disabled>") < 2:
         fail("unfinished About and Find controls must remain native disabled buttons")
+    hero_start = page.find('<section class="hero"')
+    hero_end = page.find("</section>", hero_start)
+    hero_action = page.find('<div class="hero-action">', hero_start)
+    if hero_start < 0 or hero_end < 0 or not hero_start < hero_action < hero_end:
+        fail("the homepage CTA must remain in the hero flow to prevent headline overlap")
     require_phrases(
         "index.html bounty assistant launcher",
         page,
@@ -388,6 +393,9 @@ def check_homepage(site_dir: Path) -> None:
         css,
         [
             ".stone-title",
+            ".stone-title span:nth-child(1) {\n  font-size: inherit;",
+            ".stone-title span:nth-child(3) {",
+            ".stone-title em {",
             ".vine-column",
             ".fire-aura",
             ".auth-dialog::backdrop",
@@ -396,6 +404,13 @@ def check_homepage(site_dir: Path) -> None:
             "@media (max-width: 560px)",
         ],
     )
+    hero_action_css = re.search(r"\.hero-action\s*\{(?P<body>[^}]*)\}", css)
+    if not hero_action_css or re.search(r"(?<![-\w])(?:position|top|left|transform)\s*:", hero_action_css.group("body")):
+        fail("the homepage CTA must not use independent absolute positioning")
+    for selector in (r"\.stone-title span:nth-child\(1\)", r"\.stone-title span:nth-child\(3\)", r"\.stone-title em"):
+        match = re.search(selector + r"\s*\{(?P<body>[^}]*)\}", css)
+        if not match or "font-size: inherit" not in match.group("body"):
+            fail("every hero headline phrase must inherit one shared font size")
     structured = re.search(r'<script\s+type="application/ld\+json">\s*(\{.*?\})\s*</script>', page, re.DOTALL)
     if not structured:
         fail("homepage must expose JSON-LD identity")

--- a/site/index.html
+++ b/site/index.html
@@ -98,12 +98,11 @@
           <span>compete <em>&amp;</em> collaborate</span>
           <span>to solve your problems</span>
         </h1>
+        <div class="hero-action">
+          <button type="button" data-bounty-open aria-haspopup="dialog" aria-controls="bounty-launcher" aria-expanded="false">Post a bounty</button>
+          <p data-market-status aria-live="polite">Connecting to canonical marketplace evidence…</p>
+        </div>
       </section>
-
-      <div class="hero-action">
-        <button type="button" data-bounty-open aria-haspopup="dialog" aria-controls="bounty-launcher" aria-expanded="false">Post a bounty</button>
-        <p data-market-status aria-live="polite">Connecting to canonical marketplace evidence…</p>
-      </div>
 
       <section class="market-proof" aria-label="Live marketplace metrics">
         <svg class="vine-column vine-left" viewBox="0 0 86 230" aria-hidden="true">

--- a/site/solarpunk.css
+++ b/site/solarpunk.css
@@ -294,7 +294,7 @@ html[data-scene-ready="false"] .scene-plate {
   z-index: 12;
   top: clamp(132px, 16.5vh, 176px);
   left: 50%;
-  width: min(900px, calc(100vw - 48px));
+  width: min(980px, calc(100vw - 48px));
   text-align: center;
   transform: translateX(-50%);
   animation: hero-arrive 1.1s cubic-bezier(.2, .7, .2, 1) both;
@@ -333,12 +333,12 @@ html[data-scene-ready="false"] .scene-plate {
   margin: 0;
   color: var(--stone-top);
   font-family: "Iowan Old Style", Baskerville, "Palatino Linotype", "Book Antiqua", Georgia, serif;
-  font-size: clamp(3.1rem, 5.25vw, 5.1rem);
+  font-size: clamp(2.85rem, 4.15vw, 4.35rem);
   font-feature-settings: "kern" 1, "liga" 1;
   font-kerning: normal;
   font-weight: 600;
-  line-height: .925;
-  letter-spacing: -.041em;
+  line-height: .96;
+  letter-spacing: -.035em;
   text-rendering: optimizeLegibility;
   text-wrap: balance;
   -webkit-font-smoothing: antialiased;
@@ -367,31 +367,31 @@ html[data-scene-ready="false"] .scene-plate {
 }
 
 .stone-title span:nth-child(1) {
-  font-size: .7em;
-  letter-spacing: -.025em;
+  font-size: inherit;
+  letter-spacing: inherit;
 }
 
 .stone-title span:nth-child(2) {
-  margin-top: .06em;
+  margin-top: .04em;
 }
 
 .stone-title span:nth-child(3) {
-  margin-top: .08em;
-  font-size: .72em;
-  letter-spacing: -.035em;
+  margin-top: .04em;
+  font-size: inherit;
+  letter-spacing: inherit;
 }
 
 .stone-title em {
   color: inherit;
-  font-size: .75em;
-  font-weight: 500;
+  font-size: inherit;
+  font-weight: inherit;
   text-shadow: inherit;
 }
 
 .market-proof {
   position: absolute;
   z-index: 13;
-  top: 54%;
+  top: 57.5%;
   left: 50%;
   display: grid;
   grid-template-columns: 78px minmax(430px, 610px) 78px;
@@ -487,14 +487,10 @@ html[data-scene-ready="false"] .scene-plate {
 }
 
 .hero-action {
-  position: absolute;
-  z-index: 14;
-  top: 42.7%;
-  left: 50%;
   display: grid;
   justify-items: center;
   gap: 8px;
-  transform: translateX(-50%);
+  margin-top: clamp(20px, 2.4vh, 28px);
 }
 
 .hero-action button {
@@ -2022,11 +2018,11 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .market-proof {
-    top: 53.5%;
+    top: 57%;
   }
 
   .hero-action {
-    top: 41.8%;
+    margin-top: 20px;
   }
 }
 
@@ -2052,11 +2048,11 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .stone-title {
-    font-size: clamp(2.85rem, 8vw, 4rem);
+    font-size: clamp(2.7rem, 6.5vw, 3.7rem);
   }
 
   .market-proof {
-    top: 53%;
+    top: 57.5%;
     grid-template-columns: 58px minmax(0, 1fr) 58px;
   }
 
@@ -2083,7 +2079,7 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .hero-action {
-    top: 41.7%;
+    margin-top: 18px;
   }
 }
 
@@ -2151,12 +2147,12 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .stone-title {
-    font-size: clamp(2.45rem, 11.4vw, 3.1rem);
-    line-height: .94;
+    font-size: clamp(1.9rem, 8.2vw, 2.15rem);
+    line-height: .98;
   }
 
   .stone-title span:nth-child(1) {
-    font-size: .76em;
+    font-size: inherit;
   }
 
   .stone-title span:nth-child(2) {
@@ -2165,11 +2161,11 @@ html[data-scene-ready="false"] .scene-plate {
 
   .stone-title span:nth-child(3) {
     width: 100%;
-    font-size: .76em;
+    font-size: inherit;
   }
 
   .market-proof {
-    top: 53.5%;
+    top: 56.5%;
     grid-template-columns: 38px minmax(0, 1fr) 38px;
     width: calc(100vw - 10px);
     min-height: 146px;
@@ -2204,7 +2200,7 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .hero-action {
-    top: 42%;
+    margin-top: 16px;
   }
 
   .hero-action button {
@@ -2396,16 +2392,16 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .stone-title {
-    font-size: clamp(2.75rem, 5vw, 4rem);
+    font-size: clamp(2.65rem, 4.5vw, 3.55rem);
   }
 
   .market-proof {
-    top: 52.5%;
+    top: 57%;
     transform: translateX(-50%) scale(.9);
   }
 
   .hero-action {
-    top: 39.5%;
+    margin-top: 16px;
   }
 }
 


### PR DESCRIPTION
## Summary
- use one shared computed font size for all three hero headline lines, including the ampersand
- keep the Post a Bounty CTA in the hero document flow so it cannot overlap the headline
- rebalance the metrics stage at desktop, tablet, mobile, and short landscape heights
- add static regression checks for the shared type scale and non-absolute CTA layout

Closes #1174

## Maintainer protocol
- Notice: #1174
- Open PRs checked: all 82 open PRs before editing
- Affected PRs: none known; #908 changes crawl/link behavior and does not overlap this presentation-only repair
- Compatibility risk: low, R0 HTML/CSS presentation change only
- Migration/repair path: none required; later homepage work should rebase on `main` and preserve the new layout assertions

## Validation
- `scripts/preflight.ps1 -Mode core`
- `python scripts/check-site.py`
- `node scripts/test-solarpunk-home.js`
- `python scripts/test_profitable_inventory_contract.py`
- `python -m py_compile scripts/check-site.py`
- responsive browser QA at 1536x920, 1440x900, 1024x768, 390x844, and 360x800
- `git diff --check`

All three headline spans computed to the same font size at every tested breakpoint. Headline-to-CTA and CTA-to-metrics gaps remained positive with no horizontal overflow.