### PR TITLE
Prevent cached CSS from overlapping the solarpunk hero

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -321,6 +321,9 @@ def check_homepage(site_dir: Path) -> None:
     hero_action = page.find('<div class="hero-action">', hero_start)
     if hero_start < 0 or hero_end < 0 or not hero_start < hero_action < hero_end:
         fail("the homepage CTA must remain in the hero flow to prevent headline overlap")
+    stylesheet_version = re.search(r'<link rel="stylesheet" href="solarpunk\.css\?v=(\d+)">', page)
+    if not stylesheet_version or int(stylesheet_version.group(1)) < 10:
+        fail("the homepage must load the flow-layout stylesheet through a cache-busted URL")
     require_phrases(
         "index.html bounty assistant launcher",
         page,

--- a/site/index.html
+++ b/site/index.html
@@ -35,7 +35,7 @@
         ]
       }
     </script>
-    <link rel="stylesheet" href="solarpunk.css?v=9">
+    <link rel="stylesheet" href="solarpunk.css?v=10">
   </head>
   <body>
     <a class="skip-link" href="#hero-title">Skip to the main message</a>


### PR DESCRIPTION
## Summary`n- bump the homepage solarpunk stylesheet URL from v9 to v10`n- prevent mixed old-CSS/new-HTML hero layouts in browser caches`n- add a static-site regression guard for the cache-busted flow stylesheet`n`n## Validation`n- python scripts/check-site.py`n- node scripts/test-solarpunk-home.js`n- python scripts/test_profitable_inventory_contract.py`n- git diff --check`n`nFollow-up to #1174 and #1175. This is a narrow static-site cache coherency fix.