### PR TITLE
Keep the solarpunk navigation sticky

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -322,7 +322,7 @@ def check_homepage(site_dir: Path) -> None:
     if hero_start < 0 or hero_end < 0 or not hero_start < hero_action < hero_end:
         fail("the homepage CTA must remain in the hero flow to prevent headline overlap")
     stylesheet_version = re.search(r'<link rel="stylesheet" href="solarpunk\.css\?v=(\d+)">', page)
-    if not stylesheet_version or int(stylesheet_version.group(1)) < 10:
+    if not stylesheet_version or int(stylesheet_version.group(1)) < 11:
         fail("the homepage must load the flow-layout stylesheet through a cache-busted URL")
     require_phrases(
         "index.html bounty assistant launcher",
@@ -410,6 +410,11 @@ def check_homepage(site_dir: Path) -> None:
     hero_action_css = re.search(r"\.hero-action\s*\{(?P<body>[^}]*)\}", css)
     if not hero_action_css or re.search(r"(?<![-\w])(?:position|top|left|transform)\s*:", hero_action_css.group("body")):
         fail("the homepage CTA must not use independent absolute positioning")
+    if "margin-top: clamp(32px, 4vh, 40px)" not in hero_action_css.group("body"):
+        fail("the desktop bounty CTA must retain breathing room below the headline")
+    scene_header_css = re.search(r"\.scene-header\s*\{(?P<body>[^}]*)\}", css)
+    if not scene_header_css or "position: sticky" not in scene_header_css.group("body") or "top: 0" not in scene_header_css.group("body"):
+        fail("the homepage navigation must remain sticky at the top of the viewport")
     for selector in (r"\.stone-title span:nth-child\(1\)", r"\.stone-title span:nth-child\(3\)", r"\.stone-title em"):
         match = re.search(selector + r"\s*\{(?P<body>[^}]*)\}", css)
         if not match or "font-size: inherit" not in match.group("body"):

--- a/site/index.html
+++ b/site/index.html
@@ -35,7 +35,7 @@
         ]
       }
     </script>
-    <link rel="stylesheet" href="solarpunk.css?v=10">
+    <link rel="stylesheet" href="solarpunk.css?v=11">
   </head>
   <body>
     <a class="skip-link" href="#hero-title">Skip to the main message</a>

--- a/site/solarpunk.css
+++ b/site/solarpunk.css
@@ -73,6 +73,7 @@ a:focus-visible {
   isolation: isolate;
   min-height: max(720px, 100svh);
   overflow: hidden;
+  overflow: clip;
   background: #06100c;
 }
 
@@ -140,8 +141,9 @@ html[data-scene-ready="false"] .scene-plate {
 }
 
 .scene-header {
-  position: relative;
+  position: sticky;
   z-index: 20;
+  top: 0;
   display: grid;
   grid-template-columns: minmax(220px, 1fr) auto minmax(360px, 1fr);
   align-items: center;
@@ -391,7 +393,7 @@ html[data-scene-ready="false"] .scene-plate {
 .market-proof {
   position: absolute;
   z-index: 13;
-  top: 57.5%;
+  top: 59%;
   left: 50%;
   display: grid;
   grid-template-columns: 78px minmax(430px, 610px) 78px;
@@ -490,7 +492,7 @@ html[data-scene-ready="false"] .scene-plate {
   display: grid;
   justify-items: center;
   gap: 8px;
-  margin-top: clamp(20px, 2.4vh, 28px);
+  margin-top: clamp(32px, 4vh, 40px);
 }
 
 .hero-action button {


### PR DESCRIPTION
## Summary`n- pin the homepage navigation at the viewport top while scrolling`n- add more desktop breathing room above Post a Bounty`n- move desktop metrics down in tandem so the CTA remains clear`n- bump the stylesheet to v11 and guard both layout rules in the site checker`n`n## Validation`n- Computer Use visual QA in Brave at localhost`n- sticky header verified after scrolling to the footer`n- python scripts/check-site.py`n- node scripts/test-solarpunk-home.js`n- python scripts/test_profitable_inventory_contract.py`n- git diff --check`n`nFollow-up to #1174, #1175, and #1176.