### PR TITLE
Fix the published agent entrypoint alias

### DIFF
--- a/scripts/check-agent-discovery-contract.py
+++ b/scripts/check-agent-discovery-contract.py
@@ -80,6 +80,18 @@ def validate_entrypoint_text(
             raise SystemExit(f"{label} uses retired domain {retired_domain}")
 
 
+def validate_static_discovery_urls(discovery: dict[str, object]) -> None:
+    endpoints = discovery.get("endpoints")
+    if not isinstance(endpoints, dict):
+        raise SystemExit("static discovery endpoints must be an object")
+    agent_mode = endpoints.get("agent_mode")
+    agent_markdown = endpoints.get("agent_mode_markdown")
+    if agent_mode != agent_markdown:
+        raise SystemExit(
+            "static discovery agent_mode must resolve to the retained Markdown entrypoint"
+        )
+
+
 def validate_public_agent_entrypoints(root: Path) -> None:
     for relative, (max_lines, max_chars, required) in ENTRYPOINT_CONTRACTS.items():
         path = root / relative
@@ -123,6 +135,7 @@ def validate_public_agent_entrypoints(root: Path) -> None:
             raise SystemExit(f"static discovery advertises removed route {route}")
     if discovery.get("website") != "https://agentbounties.app/":
         raise SystemExit("static discovery website must be https://agentbounties.app/")
+    validate_static_discovery_urls(discovery)
 
     protocol = json.loads((root / "site/protocol.json").read_text(encoding="utf-8"))
     if protocol.get("protocol_version") != "agent-bounties/autonomous-v1":

--- a/scripts/test_check_agent_discovery_contract.py
+++ b/scripts/test_check_agent_discovery_contract.py
@@ -113,6 +113,22 @@ class AgentDiscoveryContractTests(unittest.TestCase):
                 required=(),
             )
 
+    def test_static_agent_entrypoint_must_resolve(self) -> None:
+        discovery = {
+            "endpoints": {
+                "agent_mode": "https://agentbounties.app/agent/",
+                "agent_mode_markdown": "https://agentbounties.app/agent/index.md",
+            }
+        }
+        with self.assertRaisesRegex(SystemExit, "retained Markdown entrypoint"):
+            guard.validate_static_discovery_urls(discovery)
+
+    def test_static_agent_entrypoint_alignment_passes(self) -> None:
+        endpoint = "https://agentbounties.app/agent/index.md"
+        guard.validate_static_discovery_urls(
+            {"endpoints": {"agent_mode": endpoint, "agent_mode_markdown": endpoint}}
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -73,7 +73,7 @@
     "claude_connector_help": "https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp",
     "gemini_connector_help": "https://support.google.com/gemini/answer/17209137",
     "llms_txt": "https://agentbounties.app/llms.txt",
-    "agent_mode": "https://agentbounties.app/agent/",
+    "agent_mode": "https://agentbounties.app/agent/index.md",
     "agent_mode_markdown": "https://agentbounties.app/agent/index.md",
     "openapi": "https://api.agentbounties.app/api-docs/openapi.json",
     "discovery_manifest_schema": "https://agentbounties.app/schemas/discovery-manifest.v2.json",


### PR DESCRIPTION
## Outcome
- points the discovery manifest's agent-mode alias at the retained Markdown entrypoint
- adds a fail-closed regression check for alias divergence
- keeps the reduced two-page HTML surface unchanged

## Validation
- python scripts/test_check_agent_discovery_contract.py (8/8)
- python scripts/check-agent-discovery-contract.py`n- python scripts/check-site.py`n- git diff --check`n
## Live finding
https://agentbounties.app/agent/ returned 404 while https://agentbounties.app/agent/index.md returned 200. This PR makes every advertised agent entry resolve to the latter. No payments, contracts, credentials, or production data are changed.