### PR TITLE
Move market volume into the homepage metric panel

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -322,8 +322,21 @@ def check_homepage(site_dir: Path) -> None:
     if hero_start < 0 or hero_end < 0 or not hero_start < hero_action < hero_end:
         fail("the homepage CTA must remain in the hero flow to prevent headline overlap")
     stylesheet_version = re.search(r'<link rel="stylesheet" href="solarpunk\.css\?v=(\d+)">', page)
-    if not stylesheet_version or int(stylesheet_version.group(1)) < 13:
+    if not stylesheet_version or int(stylesheet_version.group(1)) < 14:
         fail("the homepage must load the flow-layout stylesheet through a cache-busted URL")
+    header_start = page.find('<header class="scene-header">')
+    header_end = page.find("</header>", header_start)
+    market_volume = page.find("data-market-volume")
+    metrics_start = page.find('<section class="market-proof"')
+    metrics_end = page.find("</section>", metrics_start)
+    if min(header_start, header_end, market_volume, metrics_start, metrics_end) < 0:
+        fail("the homepage must retain its header and marketplace metric structure")
+    if header_start < market_volume < header_end:
+        fail("market volume must not be displayed in the navigation header")
+    if not metrics_start < market_volume < metrics_end:
+        fail("market volume must be displayed in the marketplace metrics panel")
+    if 'class="metric-market"' not in page:
+        fail("market volume must occupy the full-width third metric row")
     require_phrases(
         "index.html bounty assistant launcher",
         page,

--- a/site/index.html
+++ b/site/index.html
@@ -35,7 +35,7 @@
         ]
       }
     </script>
-    <link rel="stylesheet" href="solarpunk.css?v=13">
+    <link rel="stylesheet" href="solarpunk.css?v=14">
   </head>
   <body>
     <a class="skip-link" href="#hero-title">Skip to the main message</a>
@@ -79,11 +79,6 @@
           <span><strong>Agent Bounties</strong><small>.APP</small></span>
         </a>
 
-        <a class="market-volume" href="metrics.html#payout-audit" aria-label="Open canonical marketplace payout metrics">
-          <span>Market volume</span>
-          <strong><output data-market-volume>—</output> <small>USDC</small></strong>
-        </a>
-
         <nav class="scene-nav" aria-label="Preview navigation">
           <button type="button" disabled>About us</button>
           <button type="button" disabled>Find bounties</button>
@@ -123,6 +118,14 @@
             <span>Completed bounties</span>
             <output data-completed-bounties aria-label="Canonically settled rounds">—</output>
             <small data-completed-weekly>Canonical history loading</small>
+          </article>
+          <article class="metric-market">
+            <span>Market volume</span>
+            <a class="metric-market-value" href="metrics.html#payout-audit" aria-label="Open the canonical lifetime payout audit">
+              <output data-market-volume aria-label="Canonical lifetime payout volume">—</output>
+              <b>USDC</b>
+            </a>
+            <small>Canonical lifetime payouts · open audit</small>
           </article>
         </div>
 

--- a/site/solarpunk.css
+++ b/site/solarpunk.css
@@ -145,7 +145,7 @@ html[data-scene-ready="false"] .scene-plate {
   z-index: 20;
   top: 0;
   display: grid;
-  grid-template-columns: minmax(220px, 1fr) auto minmax(360px, 1fr);
+  grid-template-columns: minmax(220px, 1fr) minmax(360px, auto);
   align-items: center;
   gap: 24px;
   height: var(--header-height);
@@ -202,49 +202,6 @@ html[data-scene-ready="false"] .scene-plate {
   font-size: .55rem;
   font-weight: 800;
   letter-spacing: .18em;
-}
-
-.market-volume {
-  display: grid;
-  min-width: 178px;
-  padding: 8px 19px 9px;
-  border: 1px solid rgba(201, 225, 182, 0.28);
-  border-radius: 3px 18px 3px 18px;
-  background:
-    linear-gradient(110deg, rgba(15, 32, 23, .76), rgba(5, 17, 12, .68)),
-    repeating-linear-gradient(92deg, rgba(255, 255, 255, .025) 0 1px, transparent 1px 7px);
-  text-decoration: none;
-  box-shadow: inset 0 0 26px rgba(89, 216, 211, .04), 0 14px 30px rgba(0, 0, 0, .18);
-  transition: border-color 180ms ease, transform 180ms ease, background 180ms ease;
-}
-
-.market-volume:hover {
-  border-color: rgba(213, 241, 120, .68);
-  background-color: rgba(18, 40, 27, .76);
-  transform: translateY(-1px);
-}
-
-.market-volume > span {
-  color: #aeb9ad;
-  font-size: .63rem;
-  font-weight: 800;
-  letter-spacing: .14em;
-  text-transform: uppercase;
-}
-
-.market-volume strong {
-  color: #f2f3e7;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 1.1rem;
-  font-weight: 600;
-  letter-spacing: .03em;
-}
-
-.market-volume small {
-  color: var(--rune);
-  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
-  font-size: .58rem;
-  letter-spacing: .11em;
 }
 
 .scene-nav {
@@ -438,8 +395,9 @@ html[data-scene-ready="false"] .scene-plate {
 .metric-pair {
   display: grid;
   grid-template-columns: 1fr 1px 1fr;
+  grid-template-rows: auto auto;
   align-items: center;
-  min-height: 118px;
+  min-height: 166px;
   padding: 17px 26px 18px;
   border-block: 1px solid rgba(214, 229, 197, .24);
   background:
@@ -487,6 +445,35 @@ html[data-scene-ready="false"] .scene-plate {
 
 .metric-pair output[data-loaded="true"] {
   animation: metric-live 900ms ease both;
+}
+
+.metric-market {
+  grid-column: 1 / -1;
+  padding-top: 11px;
+  border-top: 1px solid rgba(190, 213, 169, .22);
+}
+
+.metric-market-value {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 7px;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 180ms ease, filter 180ms ease;
+}
+
+.metric-market-value b {
+  color: var(--rune);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: .64rem;
+  letter-spacing: .12em;
+}
+
+.metric-market-value:hover {
+  color: #f5fadf;
+  filter: drop-shadow(0 0 10px rgba(213, 241, 120, .2));
 }
 
 .hero-action {
@@ -2031,7 +2018,7 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .scene-header {
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: 1fr auto;
     gap: 14px;
     padding-inline: 20px;
   }
@@ -2067,7 +2054,7 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .scene-header {
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: 1fr auto;
   }
 
   .scene-nav button:not(.login-preview) {
@@ -2149,19 +2136,6 @@ html[data-scene-ready="false"] .scene-plate {
     font-size: .92rem;
   }
 
-  .market-volume {
-    min-width: 112px;
-    padding: 6px 10px 7px;
-  }
-
-  .market-volume > span {
-    font-size: .52rem;
-  }
-
-  .market-volume strong {
-    font-size: .83rem;
-  }
-
   .login-preview {
     min-width: 58px !important;
     min-height: 36px !important;
@@ -2212,7 +2186,7 @@ html[data-scene-ready="false"] .scene-plate {
   }
 
   .metric-pair {
-    min-height: 102px;
+    min-height: 142px;
     padding: 12px 6px 13px;
     backdrop-filter: blur(3px);
   }
@@ -2232,6 +2206,18 @@ html[data-scene-ready="false"] .scene-plate {
 
   .metric-pair > i {
     height: 65px;
+  }
+
+  .metric-market {
+    padding-top: 8px;
+  }
+
+  .metric-market-value {
+    gap: 5px;
+  }
+
+  .metric-market-value b {
+    font-size: .52rem;
   }
 
   .hero-action {


### PR DESCRIPTION
## Outcome
- removes Market Volume from the sticky navigation
- adds it as a full-width third row beneath Live and Completed Bounties
- preserves the canonical lifetime payout source and payout-audit link
- adds a site-contract assertion for this layout

## Validation
- exact viewport screenshots: 1440x900, 1024x768, 390x844, 360x800
- Login, Post a Bounty, and audit-link cursor/interaction checks
- 
ode --test scripts/test-solarpunk-home.js (11/11)
- python scripts/check-site.py`n- python scripts/check-agent-discovery-contract.py`n- cargo run -p cli -- docs-contract-check (120 files, 320 API routes, 129 MCP tools)
- scripts/preflight.ps1 -Mode core`n- git diff --check`n
No payment, contract, credential, or production-data behavior changes.