### PR TITLE
Teach discovery guard to verify implemented A2A

### DIFF
--- a/scripts/check-agent-discovery-contract.py
+++ b/scripts/check-agent-discovery-contract.py
@@ -45,7 +45,11 @@ ENTRYPOINT_CONTRACTS = {
     "site/llms.txt": (
         140,
         13_000,
-        ("server/discover", "get_bounty_feed", "Only `BountySettled` proves payment."),
+        (
+            "server/discover",
+            "get_bounty_feed",
+            "Only a confirmed canonical `BountySettled` or `CompetitionSettledV2` event",
+        ),
     ),
     "site/agent/index.md": (
         90,
@@ -151,22 +155,6 @@ def validate_agent_discovery_contract(root: Path) -> None:
     quickstart = (root / "docs" / "agent-quickstart.md").read_text(encoding="utf-8")
     status = (root / "docs" / "a2a-status.md").read_text(encoding="utf-8")
 
-    forbidden = {
-        "API well-known A2A route": "/.well-known/agent-card.json",
-        "API A2A handler": "async fn agent_card",
-    }
-    for label, marker in forbidden.items():
-        if marker in api:
-            raise SystemExit(
-                f"{label} is advertised without a conforming A2A server; "
-                "implement and test every required A2A core operation before restoring it"
-            )
-
-    if "pub agent_card" in public or "/.well-known/agent-card.json" in public:
-        raise SystemExit("public discovery manifest advertises an unsupported A2A Agent Card")
-    if "A2A Agent Card" in quickstart or "/.well-known/agent-card.json" in quickstart:
-        raise SystemExit("agent quickstart advertises an unsupported A2A Agent Card")
-
     retired_artifacts = (
         root / "fixtures" / "a2a-agent-card.json",
         root / "docs" / "a2a-direct-api-binding-v1.md",
@@ -178,10 +166,29 @@ def validate_agent_discovery_contract(root: Path) -> None:
                 f"retired unsupported A2A artifact remains: {path.relative_to(root)}"
             )
 
-    if "does not currently implement the Agent2Agent (A2A) protocol" not in status:
-        raise SystemExit("A2A status must state that the protocol is not implemented")
     if "a2aproject/A2A/blob/main/docs/specification.md" not in status:
         raise SystemExit("A2A status must link the current primary specification")
+
+    a2a_source_path = root / "crates" / "api" / "src" / "a2a.rs"
+    api_advertises_a2a = (
+        "/.well-known/agent-card.json" in api
+        or "mod a2a;" in api
+        or a2a_source_path.exists()
+    )
+    other_a2a_advertising = any(
+        (
+            "A2A Agent Card" in quickstart,
+            "/.well-known/agent-card.json" in quickstart,
+            "pub agent_card" in public,
+            "/.well-known/agent-card.json" in public,
+            (root / "crates/api/fixtures/agent-card.json").exists(),
+            (root / "site/.well-known/agent-card.json").exists(),
+        )
+    )
+    if api_advertises_a2a or other_a2a_advertising:
+        validate_a2a_implementation(root, api, status)
+    elif "does not currently implement the Agent2Agent (A2A) protocol" not in status:
+        raise SystemExit("A2A status must state that the protocol is not implemented")
 
     required = {
         "API generic discovery route": "/.well-known/agent-bounties.json",
@@ -192,6 +199,77 @@ def validate_agent_discovery_contract(root: Path) -> None:
             raise SystemExit(f"missing {label}")
     if "/.well-known/agent-bounties.json" not in quickstart:
         raise SystemExit("agent quickstart must retain the generic discovery manifest")
+
+
+def validate_a2a_implementation(root: Path, api: str, status: str) -> None:
+    source_path = root / "crates/api/src/a2a.rs"
+    api_card_path = root / "crates/api/fixtures/agent-card.json"
+    site_card_path = root / "site/.well-known/agent-card.json"
+    docs_path = root / "docs/a2a.md"
+    required_paths = (source_path, api_card_path, site_card_path, docs_path)
+    missing = [str(path.relative_to(root)) for path in required_paths if not path.exists()]
+    if missing:
+        raise SystemExit(
+            "A2A is advertised without a conforming A2A server; missing "
+            + ", ".join(missing)
+        )
+
+    source = source_path.read_text(encoding="utf-8")
+    source_markers = {
+        "well-known Agent Card route": "/.well-known/agent-card.json",
+        "SendMessage route": "/a2a/v1/message:send",
+        "GetTask/ListTasks routes": "/a2a/v1/tasks",
+        "Agent Card handler": "fn agent_card",
+        "SendMessage handler": "fn send_message",
+        "GetTask handler": "fn get_task",
+        "ListTasks handler": "fn list_tasks",
+        "CancelTask handler": "fn cancel_task",
+        "A2A response media type": "application/a2a+json",
+        "A2A Major.Minor version": 'A2A_PROTOCOL_VERSION: &str = "1.0"',
+        "bounded request body": "DefaultBodyLimit::max",
+    }
+    missing_markers = [label for label, marker in source_markers.items() if marker not in source]
+    if missing_markers:
+        raise SystemExit(
+            "A2A is advertised without a conforming A2A server; missing core operations: "
+            + ", ".join(missing_markers)
+        )
+
+    api_markers = (
+        "mod a2a;",
+        ".merge(a2a::router())",
+        "a2a_router_serves_card_and_core_task_operations",
+    )
+    for marker in api_markers:
+        if marker not in api:
+            raise SystemExit(f"A2A API integration is missing required marker {marker!r}")
+
+    if api_card_path.read_bytes() != site_card_path.read_bytes():
+        raise SystemExit("API and website A2A Agent Cards must be byte-for-byte identical")
+    try:
+        card = json.loads(api_card_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"A2A Agent Card is not valid JSON: {error}") from error
+    interfaces = card.get("supportedInterfaces")
+    expected_interface = {
+        "url": "https://api.agentbounties.app/a2a/v1",
+        "protocolBinding": "HTTP+JSON",
+        "protocolVersion": "1.0",
+    }
+    if not isinstance(interfaces, list) or expected_interface not in interfaces:
+        raise SystemExit("A2A Agent Card must advertise the implemented HTTP+JSON 1.0 interface")
+    if not isinstance(card.get("skills"), list) or not card["skills"]:
+        raise SystemExit("A2A Agent Card must declare at least one implemented skill")
+    capabilities = card.get("capabilities")
+    if not isinstance(capabilities, dict):
+        raise SystemExit("A2A Agent Card capabilities must be an object")
+    for unsupported in ("streaming", "pushNotifications", "extendedAgentCard"):
+        if capabilities.get(unsupported) is not False:
+            raise SystemExit(f"A2A Agent Card must truthfully declare {unsupported}=false")
+
+    normalized_status = " ".join(status.split())
+    if "implements a public, read-only Agent2Agent (A2A) 1.0 HTTP+JSON interface" not in normalized_status:
+        raise SystemExit("A2A status must describe the implemented read-only HTTP+JSON interface")
 
 
 def main() -> int:

--- a/scripts/test_check_agent_discovery_contract.py
+++ b/scripts/test_check_agent_discovery_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import tempfile
 import unittest
@@ -17,7 +18,9 @@ SPEC.loader.exec_module(guard)
 
 
 class AgentDiscoveryContractTests(unittest.TestCase):
-    def create_repository(self, root: Path, *, advertise_a2a: bool) -> None:
+    def create_repository(
+        self, root: Path, *, advertise_a2a: bool, conforming_a2a: bool = False
+    ) -> None:
         api = root / "crates" / "api" / "src" / "main.rs"
         api.parent.mkdir(parents=True)
         api.write_text(
@@ -55,11 +58,59 @@ class AgentDiscoveryContractTests(unittest.TestCase):
         )
         status = root / "docs" / "a2a-status.md"
         status.write_text(
-            "Agent Bounties does not currently implement the Agent2Agent (A2A) "
-            "protocol.\n"
-            "https://github.com/a2aproject/A2A/blob/main/docs/specification.md\n",
+            (
+                "Agent Bounties implements a public, read-only Agent2Agent (A2A) "
+                "1.0 HTTP+JSON interface.\n"
+                if conforming_a2a
+                else "Agent Bounties does not currently implement the Agent2Agent "
+                "(A2A) protocol.\n"
+            )
+            + "https://github.com/a2aproject/A2A/blob/main/docs/specification.md\n",
             encoding="utf-8",
         )
+        if conforming_a2a:
+            a2a = root / "crates" / "api" / "src" / "a2a.rs"
+            a2a.write_text(
+                'const A2A_PROTOCOL_VERSION: &str = "1.0";\n'
+                'const MEDIA: &str = "application/a2a+json";\n'
+                'route("/.well-known/agent-card.json", get(agent_card));\n'
+                'route("/a2a/v1/message:send", post(send_message));\n'
+                'route("/a2a/v1/tasks", get(list_tasks));\n'
+                "DefaultBodyLimit::max(65536);\n"
+                "fn agent_card() {}\nfn send_message() {}\nfn get_task() {}\n"
+                "fn list_tasks() {}\nfn cancel_task() {}\n",
+                encoding="utf-8",
+            )
+            with api.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    "mod a2a;\n.merge(a2a::router())\n"
+                    "fn a2a_router_serves_card_and_core_task_operations() {}\n"
+                )
+            card = {
+                "supportedInterfaces": [
+                    {
+                        "url": "https://api.agentbounties.app/a2a/v1",
+                        "protocolBinding": "HTTP+JSON",
+                        "protocolVersion": "1.0",
+                    }
+                ],
+                "capabilities": {
+                    "streaming": False,
+                    "pushNotifications": False,
+                    "extendedAgentCard": False,
+                },
+                "skills": [{"id": "discover"}],
+            }
+            card_bytes = (json.dumps(card, indent=2) + "\n").encode()
+            for relative in (
+                "crates/api/fixtures/agent-card.json",
+                "site/.well-known/agent-card.json",
+            ):
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(card_bytes)
+            docs = root / "docs" / "a2a.md"
+            docs.write_text("# A2A\n", encoding="utf-8")
 
     def test_generic_discovery_without_a2a_passes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -73,6 +124,12 @@ class AgentDiscoveryContractTests(unittest.TestCase):
             self.create_repository(root, advertise_a2a=True)
             with self.assertRaisesRegex(SystemExit, "without a conforming A2A server"):
                 guard.validate_agent_discovery_contract(root)
+
+    def test_conforming_a2a_advertisement_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_repository(root, advertise_a2a=True, conforming_a2a=True)
+            guard.validate_agent_discovery_contract(root)
 
     def test_retired_agent_card_fixture_fails(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -71,19 +71,16 @@ dual-attested snapshot unchanged. Omit `artifact_hash` for this profile: the
 API validates the signatures and immutable policy, then derives the
 solver-bound submission hash before it creates a payable quote.
 
-Portable skill:
-https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
+Portable skill: https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/SKILL.md
 
 Install and check inventory:
 
     npx skills add NSPG13/agent-bounties --skill agent-bounties --yes
     node skills/agent-bounties/scripts/check-in.mjs --solver-wallet 0xYourPublicBaseAddress
 
-Helper:
-https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/scripts/check-in.mjs
+Helper: https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/scripts/check-in.mjs
 
-Safe-block chain manifest:
-https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/fixtures/base-mainnet-canaries.json
+Safe-block chain manifest: https://raw.githubusercontent.com/NSPG13/agent-bounties/main/skills/agent-bounties/fixtures/base-mainnet-canaries.json
 
 ## Post
 
@@ -140,5 +137,4 @@ cancelled. Follow the live OpenAPI cancel and refund operations and confirm
     cargo run -p cli -- docs-contract-check
     python scripts/check-mcp-protocol-eras.py --endpoint https://mcp.agentbounties.app/mcp --expect dual
 
-Full quickstart:
-https://github.com/NSPG13/agent-bounties/blob/main/docs/agent-quickstart.md
+Full quickstart: https://github.com/NSPG13/agent-bounties/blob/main/docs/agent-quickstart.md


### PR DESCRIPTION
## Outcome

Repairs the fail-closed agent-discovery gate after #1190 implemented a real A2A 1.0 server. The guard now rejects incomplete advertisements while accepting only a source-backed, tested implementation.

## Validation

- requires SendMessage, GetTask, ListTasks, CancelTask, Agent Card, media type, Major.Minor version, bounded body, router integration, and the core router test;
- verifies API and website Agent Cards are byte-identical and advertise the implemented HTTP+JSON 1.0 interface;
- requires declared skills and truthful unsupported-capability flags;
- preserves the unsupported-advertisement failure test and adds a conforming-server pass test;
- keeps llms.txt within its 140-line discovery budget and updates the payment marker for V1/V2 wording.

Local checks: discovery guard, nine guard tests, static site, Python compile, and diff check pass. The full local repository wrapper cannot start because Forge is not installed on this Windows host; CI provides Forge. This directly addresses the only failing step from main CI run 32711193703.

Follow-up to #1190 and maintainer notice #1187.