### PR TITLE
Preserve V2 context through child-bounty posting

### DIFF
--- a/scripts/test-marketplace-ui.js
+++ b/scripts/test-marketplace-ui.js
@@ -105,4 +105,8 @@ test("the participation manifest and prefilled child brief are contract-specific
   assert.match(child, new RegExp(item.source_id));
   assert.match(child, /Fully fund before another wallet claims or enters/);
   assert.match(child, /confirmed canonical settlement/);
+  assert.equal(
+    competition.childPostUrl(item),
+    "./?parentCompetition=0x1111111111111111111111111111111111111111&network=base-mainnet#post-a-bounty",
+  );
 });

--- a/scripts/test-solarpunk-home.js
+++ b/scripts/test-solarpunk-home.js
@@ -67,6 +67,43 @@ test("bounty assistant handoffs carry one bounded initialization message", () =>
   assert.equal(home.bountyAssistantLinks("unknown"), null);
 });
 
+test("competition posting handoffs preserve only live canonical context", () => {
+  const contract = "0x1111111111111111111111111111111111111111";
+  const request = home.parseCompetitionPostingRequest(`?parentCompetition=${contract}&network=base-mainnet`);
+  assert.deepEqual(request, { requested: true, valid: true, contract, network: "base-mainnet" });
+  assert.equal(home.parseCompetitionPostingRequest("").requested, false);
+  assert.equal(home.parseCompetitionPostingRequest(`?parentCompetition=${contract}&network=base-sepolia`).valid, false);
+
+  const item = {
+    opportunity_id: `open-competition-v2:base-mainnet:${contract}`,
+    source_id: contract,
+    network: "base-mainnet",
+    source_status: "active",
+    work_state: "claimable",
+    payment_state: "escrowed",
+    payment_committed: true,
+    verification_ready: true,
+    competition_mode: "best_score",
+    evidence_requirements: {
+      program_profile: "forward-canonical-gmv-attribution-metric-v2",
+      scoring_window: {
+        starts_at: "2026-08-24T00:00:00Z",
+        ends_at: "2026-08-31T00:00:00Z",
+      },
+    },
+  };
+  assert.equal(home.competitionPostingItem({ schema_version: "agent-bounties/opportunity-projection-v1", items: [item] }, request), item);
+  assert.throws(() => home.competitionPostingItem({ schema_version: "agent-bounties/opportunity-projection-v1", items: [{ ...item, verification_ready: false }] }, request));
+
+  const prompt = home.competitionPostingPrompt(item);
+  assert.match(prompt, new RegExp(contract));
+  assert.match(prompt, /2026-08-24T00:00:00Z through 2026-08-31T00:00:00Z/);
+  assert.match(prompt, /ask me to fill only its bracketed placeholders/i);
+  assert.match(prompt, /complete win, loss, and expected economics/i);
+  assert.doesNotMatch(prompt, /Begin by asking/);
+  assert.equal(new URL(home.bountyAssistantLinks("gpt", prompt).webUrl).searchParams.get("prompt"), prompt);
+});
+
 test("wallet linking helpers encode exact EIP-191 input without exposing raw errors", () => {
   assert.equal(
     home.shortWalletAddress("0x1234567890abcdef1234567890abcdef12345678"),

--- a/site/competition.html
+++ b/site/competition.html
@@ -130,6 +130,6 @@
     <script src="analytics-config.js?v=2"></script>
     <script src="analytics.js?v=3"></script>
     <script src="marketplace.js?v=1"></script>
-    <script src="competition.js?v=1"></script>
+    <script src="competition.js?v=2"></script>
   </body>
 </html>

--- a/site/competition.js
+++ b/site/competition.js
@@ -71,6 +71,13 @@ Safety:
 - Preserve the child terms hash, funding events, and settlement event for the scoring snapshot.`;
   }
 
+  function childPostUrl(item) {
+    const contract = String(item?.source_id || "").toLowerCase();
+    const network = String(item?.network || "base-mainnet").toLowerCase();
+    if (!/^0x[0-9a-f]{40}$/.test(contract) || network !== "base-mainnet") return null;
+    return `./?parentCompetition=${encodeURIComponent(contract)}&network=${encodeURIComponent(network)}#post-a-bounty`;
+  }
+
   function participationManifest(item, timing) {
     const base = marketplace.apiBase(typeof window !== "undefined" ? window.location : null);
     return {
@@ -190,6 +197,9 @@ Safety:
     const manifest = JSON.stringify(participationManifest(item, timing), null, 2);
     setText(doc, "[data-child-template]", template);
     setText(doc, "[data-machine-request]", manifest);
+    const childPost = doc.querySelector("[data-child-post-started]");
+    const postUrl = childPostUrl(item);
+    if (childPost && postUrl) childPost.href = postUrl;
     const machineSource = doc.querySelector("[data-machine-source]");
     if (machineSource) machineSource.href = marketplace.opportunityFeedUrl(win.location);
     const snapshotSource = doc.querySelector("[data-snapshot-source]");
@@ -303,5 +313,5 @@ Safety:
     }
   }
 
-  return { childTemplate, economics, participationManifest, signedUsdc, start };
+  return { childPostUrl, childTemplate, economics, participationManifest, signedUsdc, start };
 });

--- a/site/index.html
+++ b/site/index.html
@@ -359,6 +359,6 @@
     <noscript><p class="noscript-note">JavaScript is required for the living scene and live marketplace metrics.</p></noscript>
     <script src="analytics-config.js?v=2"></script>
     <script src="analytics.js?v=3"></script>
-    <script src="solarpunk-home.js?v=7"></script>
+    <script src="solarpunk-home.js?v=8"></script>
   </body>
 </html>

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -134,6 +134,96 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
     return Object.hasOwn(links, key) ? links[key] : null;
   }
 
+  function parseCompetitionPostingRequest(search) {
+    const params = new URLSearchParams(String(search || ""));
+    if (!params.has("parentCompetition")) return { requested: false, valid: false };
+    const contract = String(params.get("parentCompetition") || "").trim().toLowerCase();
+    const network = String(params.get("network") || "base-mainnet").trim().toLowerCase();
+    return {
+      requested: true,
+      valid: /^0x[0-9a-f]{40}$/.test(contract) && network === "base-mainnet",
+      contract,
+      network,
+    };
+  }
+
+  function competitionPostingItem(projection, request) {
+    if (!request?.requested || !request.valid) throw new Error("invalid competition posting context");
+    if (projection?.schema_version !== "agent-bounties/opportunity-projection-v1" || !Array.isArray(projection.items)) {
+      throw new Error("invalid unified opportunity projection");
+    }
+    const item = projection.items.find((candidate) =>
+      String(candidate?.source_id || "").toLowerCase() === request.contract
+      && String(candidate?.network || "").toLowerCase() === request.network
+      && String(candidate?.opportunity_id || "").startsWith("open-competition-v2:")
+    );
+    const window = item?.evidence_requirements?.scoring_window;
+    const startsAt = Date.parse(String(window?.starts_at || ""));
+    const endsAt = Date.parse(String(window?.ends_at || ""));
+    if (!item
+      || item.source_status !== "active"
+      || item.work_state !== "claimable"
+      || item.payment_state !== "escrowed"
+      || item.payment_committed !== true
+      || item.verification_ready !== true
+      || item.competition_mode !== "best_score"
+      || item.evidence_requirements?.program_profile !== "forward-canonical-gmv-attribution-metric-v2"
+      || !Number.isFinite(startsAt)
+      || !Number.isFinite(endsAt)
+      || endsAt <= startsAt) {
+      throw new Error("competition is not ready for a bound posting handoff");
+    }
+    return item;
+  }
+
+  function competitionChildBrief(item) {
+    const window = item.evidence_requirements.scoring_window;
+    const windowText = `${window.starts_at} through ${window.ends_at}`;
+    return `Qualifying Agent Bounties demand brief
+
+Parent competition: ${item.source_id}
+Entering/funding wallet: 0xYOUR_BASE_WALLET
+Scoring window: ${windowText}
+
+Outcome requested:
+[Describe one useful digital result that another agent can deliver.]
+
+Objective acceptance tests:
+1. [Binary or measurable test]
+2. [Exact artifact/evidence schema]
+3. [Deterministic verifier or precommitted quorum]
+
+Funding:
+- Network: Base mainnet
+- Asset: native USDC
+- Solver reward: [AMOUNT]
+- Fully fund before another wallet claims or enters
+
+Canonical completion requirement:
+- A wallet different from the creator completes the child bounty.
+- The child reaches confirmed canonical settlement inside ${windowText}.
+- Funding attributable to 0xYOUR_BASE_WALLET is used in the parent score.
+
+Safety:
+- Do not use an operator/reserve wallet or excluded reward contract.
+- A plan, signature, broadcast, or transaction hash is not GMV or payment evidence.
+- Preserve the child terms hash, funding events, and settlement event for the scoring snapshot.`;
+  }
+
+  function competitionPostingPrompt(item) {
+    const basePrompt = BOUNTY_POSTING_PROMPT.replace(/\n\nBegin by asking:[\s\S]*$/, "");
+    return `${basePrompt}
+
+This is a contract-bound Open Competition V2 child-bounty posting session.
+- Parent competition: ${item.source_id}
+- Network: ${item.network}
+- Do not replace the parent contract, network, or UTC scoring window.
+- Do not restart with a generic outcome question. Present the reviewed brief below, ask me to fill only its bracketed placeholders, and warn if the proposed child cannot settle inside the window.
+- Before any wallet interaction, calculate the parent competition's complete win, loss, and expected economics using the child funding I select.
+
+${competitionChildBrief(item)}`;
+  }
+
   function shortWalletAddress(value) {
     const address = String(value || "").trim().toLowerCase();
     return /^0x[0-9a-f]{40}$/.test(address) ? `${address.slice(0, 8)}…${address.slice(-6)}` : "";
@@ -1010,10 +1100,16 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
       const copyButton = dialog.querySelector("[data-bounty-copy]");
       const webFallback = dialog.querySelector("[data-bounty-web-fallback]");
       const promptDetails = dialog.querySelector(".bounty-prompt-preview");
+      const launcherTitle = dialog.querySelector("#bounty-launcher-title");
+      const launcherDescription = dialog.querySelector("#bounty-launcher-description");
+      const postingRequest = parseCompetitionPostingRequest(win.location.search);
+      let launcherPrompt = BOUNTY_POSTING_PROMPT;
+      let contextReady = !postingRequest.requested;
+      let contextStatus = postingRequest.requested ? "Verifying the parent competition and reviewed child-bounty brief…" : "";
       let launchTimer = 0;
       let appHandoffObserved = false;
 
-      if (promptPreview) promptPreview.textContent = BOUNTY_POSTING_PROMPT;
+      if (promptPreview) promptPreview.textContent = launcherPrompt;
 
       const setStatus = (message) => {
         if (status) status.textContent = message;
@@ -1036,7 +1132,9 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
           webFallback.removeAttribute("href");
         }
         promptDetails?.removeAttribute("open");
-        setStatus("");
+        assistantButtons.forEach((button) => { button.disabled = !contextReady; });
+        if (copyButton) copyButton.disabled = !contextReady;
+        setStatus(contextStatus);
       };
       const showDialog = () => {
         resetLauncher();
@@ -1050,11 +1148,11 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
       };
       const copyPrompt = async () => {
         try {
-          await win.navigator.clipboard.writeText(BOUNTY_POSTING_PROMPT);
+          await win.navigator.clipboard.writeText(launcherPrompt);
           return true;
         } catch (error) {
           const textarea = doc.createElement("textarea");
-          textarea.value = BOUNTY_POSTING_PROMPT;
+          textarea.value = launcherPrompt;
           textarea.setAttribute("readonly", "");
           textarea.style.position = "fixed";
           textarea.style.opacity = "0";
@@ -1099,7 +1197,7 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
         button.addEventListener("click", async () => {
           clearLaunchProbe();
           const key = String(button.dataset.bountyAssistant || "").toLowerCase();
-          const links = bountyAssistantLinks(key);
+          const links = bountyAssistantLinks(key, launcherPrompt);
           if (!links) return;
           assistantButtons.forEach((item) => item.removeAttribute("aria-current"));
           button.setAttribute("aria-current", "true");
@@ -1146,6 +1244,27 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
       });
       if (win.location.hash === "#post-a-bounty") {
         win.requestAnimationFrame?.(showDialog);
+      }
+      if (postingRequest.requested) {
+        void (async () => {
+          if (!postingRequest.valid) throw new Error("invalid competition posting context");
+          const protocol = await requestJson("protocol.json");
+          const apiBase = String(protocol?.api_base_url || "").replace(/\/$/, "");
+          if (!/^https:\/\//.test(apiBase)) throw new Error("API discovery is unavailable");
+          const projection = await requestJson(`${apiBase}/v1/opportunities?network=${encodeURIComponent(postingRequest.network)}&view=ready_to_earn&source_type=canonical_base&limit=300&live=${Date.now()}`);
+          const item = competitionPostingItem(projection, postingRequest);
+          launcherPrompt = competitionPostingPrompt(item);
+          contextReady = true;
+          contextStatus = `Verified ${shortWalletAddress(item.source_id)}. The selected assistant will receive the exact parent contract, UTC window, and reviewed child brief.`;
+          if (launcherTitle) launcherTitle.textContent = "Post a qualifying bounty";
+          if (launcherDescription) launcherDescription.textContent = `Bound to ${shortWalletAddress(item.source_id)} · ${item.evidence_requirements.scoring_window.starts_at} → ${item.evidence_requirements.scoring_window.ends_at}`;
+          if (promptPreview) promptPreview.textContent = launcherPrompt;
+          resetLauncher();
+        })().catch(() => {
+          contextReady = false;
+          contextStatus = "This competition could not be verified in the live unified projection. Return to its participation page; no generic posting prompt was substituted.";
+          resetLauncher();
+        });
       }
     }
 
@@ -1197,6 +1316,9 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
     authProviderPath,
     authResultMessage,
     bountyAssistantLinks,
+    competitionChildBrief,
+    competitionPostingItem,
+    competitionPostingPrompt,
     clamp,
     flameMotion,
     hashSeed,
@@ -1204,6 +1326,7 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
     isReadyToEarn,
     marketSnapshot,
     parseSceneTime,
+    parseCompetitionPostingRequest,
     sceneBlend,
     sceneTimeOverride,
     seededRandom,


### PR DESCRIPTION
## Outcome

External agents no longer lose the parent competition when they start posting a qualifying child bounty.

- carries only the validated `parentCompetition` and `base-mainnet` selector from the contract-specific participation page
- re-reads the live unified projection and fails closed unless the exact V2 forward-GMV competition is active, escrowed, claimable, and verification-ready
- prefills GPT, Claude, Cursor, or copy handoffs with the exact parent contract, UTC window, reviewed child brief, and a complete-economics warning
- disables every provider instead of substituting the generic posting prompt when context is stale or invalid
- preserves the ordinary generic `Post a bounty` journey

## Live diagnosis

The production page currently makes the primary economic blocker explicit: for a 3 USDC child bounty, the 3 USDC parent prize produces -0.11 USDC on a win, -3.11 USDC on a loss, and -2.36 USDC expected cash result at a 25% win probability, before labor. The current ten V2 competitions still have zero entries. Longer 3/7/14/28-day windows have not activated an entrant yet, so duration alone is not sufficient evidence.

## Validation

- `python scripts/test_check_agent_discovery_contract.py -v` (9 passed on rebased `main`)
- `python scripts/check-agent-discovery-contract.py`
- `node --test scripts/test-solarpunk-home.js scripts/test-metrics-dashboard.js scripts/test-marketplace-ui.js` (31 passed)
- `python scripts/check-site.py`
- `python scripts/check-migration-history.py`
- `git diff --check`
- local in-app browser replay against the live canonical projection:
  - verified contract opened ChatGPT with the exact contract/window/template prefilled and no submission
  - nonexistent contract left all providers disabled and refused generic fallback

## Boundaries

No wallet was connected, no prompt was submitted, and no funding, proof, verification, settlement, or payout state was changed. Public marketplace reporting remains unified. PR #980 changes a different provider-neutral hosted-review path and has no overlapping files.

The branch is rebased on #1191 and reuses its canonical A2A discovery-gate repair without duplicating it.

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/1183#issuecomment-5393303300