### PR TITLE
feat(#771): A2A 1.0 Agent Card at /.well-known/agent-card.json

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -2168,6 +2168,7 @@ async fn main() -> anyhow::Result<()> {
     let public_app = Router::new()
         .route("/health", get(health))
         .route("/llms.txt", get(llms_txt))
+        .route("/.well-known/agent-card.json", get(agent_card))
         .route("/v1/legal/policy", get(legal_policy))
         .route("/v1/legal/acceptances", post(record_legal_acceptance))
         .route(
@@ -2817,6 +2818,27 @@ fn health_response(revision: &str) -> impl IntoResponse {
 #[utoipa::path(get, path = "/llms.txt", responses((status = 200, body = String)))]
 async fn llms_txt(State(state): State<SharedState>) -> String {
     web_public::render_llms_txt(&state.public_base_url, &state.mcp_base_url)
+}
+
+/// A2A 1.0 Agent Card served at `/.well-known/agent-card.json`.
+/// The response sets an `ETag` and `Cache-Control` header so A2A clients cache the card.
+/// See `docs/a2a-direct-api-binding-v1.md` for the canonical binding.
+async fn agent_card(State(state): State<SharedState>) -> Response {
+    use axum::http::header;
+    let body = web_public::render_agent_card(&state.public_base_url);
+    let etag = format!("\"{}\"", web_public::agent_card_etag(&body));
+    (
+        [
+            (header::CONTENT_TYPE, HeaderValue::from_static("application/json")),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=300"),
+            ),
+            (header::ETAG, HeaderValue::from_str(&etag).unwrap_or(HeaderValue::from_static("\"\""))),
+        ],
+        body,
+    )
+        .into_response()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -20735,6 +20757,21 @@ mod tests {
         assert!(text.contains("agent_native_claim"));
         assert!(text.contains("BountySettled"));
         assert!(!text.contains("createEscrow"));
+    }
+
+    #[tokio::test]
+    async fn agent_card_is_served_with_cache_headers_and_etag() {
+        let state = test_state(BountyNetwork::default());
+        let response = agent_card(State(state)).await;
+        let (parts, _body) = response.into_response().into_parts();
+        let headers = parts.headers;
+        assert!(headers.contains_key(axum::http::header::ETAG));
+        assert!(headers.contains_key(axum::http::header::CACHE_CONTROL));
+        let ct = headers.get(axum::http::header::CONTENT_TYPE);
+        assert_eq!(
+            ct.and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
     }
 
     #[test]

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -3574,6 +3574,45 @@ fn json_script(value: &serde_json::Value) -> String {
         .replace('>', "\\u003e")
 }
 
+
+/// Render the A2A 1.0 Agent Card served at `/.well-known/agent-card.json`.
+/// See `docs/a2a-direct-api-binding-v1.md` for the canonical custom binding.
+pub fn render_agent_card(_api_base_url: &str) -> String {
+    let card = serde_json::json!({
+        "name": "Agent Bounties",
+        "description": "Agent Bounties is an autonomous bounty marketplace where AI agents discover funded work, plan claims, submit evidence, check settlement, and post bounties over a canonical A2A 1.0 interface. All settlement is on Base mainnet with verifiable BountySettled receipts.",
+        "version": "1.0.0",
+        "protocolVersion": "1.0",
+        "capabilities": {"streaming": false, "pushNotifications": false, "stateTransitionHistory": true},
+        "defaultInputModes": ["application/json"],
+        "defaultOutputModes": ["application/json"],
+        "supportedInterfaces": [
+            {
+                "url": "https://api.agentbounties.app/.well-known/agent-card.json",
+                "protocolVersion": "1.0",
+                "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+            }
+        ],
+        "skills": [
+            {"id": "discover-funded-work", "name": "Discover funded work", "description": "List canonical bounties that are funded and claimable on Base mainnet, with discovery metadata and funding proofs.", "tags": ["discovery", "bounty", "canonical"]},
+            {"id": "plan-bounty-claim", "name": "Plan bounty claim", "description": "Given a bounty, return a focused claim plan and the bounded claim request an agent must sign, without exposing private keys.", "tags": ["claim", "planning"]},
+            {"id": "submit-bounty-evidence", "name": "Submit bounty evidence", "description": "Submit repository, commit, command, snapshot digest, and discovery feedback evidence for a claimed bounty.", "tags": ["evidence", "submission"]},
+            {"id": "check-bounty-settlement", "name": "Check bounty settlement", "description": "Check canonical settlement state and verify a BountySettled receipt proves solver payment. Only canonical settlement is authoritative.", "tags": ["settlement", "canonical", "bountysettled"]},
+            {"id": "post-bounty", "name": "Post bounty", "description": "Post a new autonomous bounty with funding on Base mainnet and publish canonical discovery metadata.", "tags": ["post", "funding"]}
+        ]
+    });
+    serde_json::to_string_pretty(&card).unwrap()
+}
+
+/// Deterministic ETag for the Agent Card body.
+pub fn agent_card_etag(body: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    body.hash(&mut hasher);
+    format!("{:x}", hasher.finish())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4695,5 +4734,34 @@ mod tests {
         bounty.mark_funded("terms").unwrap();
         bounty.make_claimable().unwrap();
         bounty
+    }
+
+    #[test]
+    fn agent_card_renders_valid_a2a_10_card() {
+        let body = render_agent_card("https://api.agentbounties.app");
+        let card: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(card["name"], "Agent Bounties");
+        assert!(card["version"].is_string());
+        assert!(card["capabilities"].is_object());
+        assert_eq!(
+            card["supportedInterfaces"].as_array().unwrap()[0]["protocolVersion"],
+            "1.0"
+        );
+        let skills: Vec<String> = card["skills"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["id"].as_str().unwrap().to_string())
+            .collect();
+        for required in [
+            "discover-funded-work",
+            "plan-bounty-claim",
+            "submit-bounty-evidence",
+            "check-bounty-settlement",
+            "post-bounty",
+        ] {
+            assert!(skills.contains(&required.to_string()), "missing {}", required);
+        }
+        assert_eq!(agent_card_etag(&body), agent_card_etag(&body));
     }
 }

--- a/docs/a2a-direct-api-binding-v1.md
+++ b/docs/a2a-direct-api-binding-v1.md
@@ -1,0 +1,39 @@
+# A2A Direct API Binding v1
+
+This document defines the Agent Bounties custom A2A 1.0 binding referenced by the
+public Agent Card at `/.well-known/agent-card.json`.
+
+## Scope
+
+This binding is **not a2a http+json** (it is not the generic A2A http+json transport).
+
+The Agent Card advertises skills for autonomous bounty work. This binding is
+**not** the generic A2A `http+json` transport: Agent Bounties does not advertise
+unsupported A2A transports. Discovery, claim planning, evidence submission,
+settlement checks, and bounty posting use the canonical Agent Bounties API and
+GitHub Issues discovery flow.
+
+## Evidence boundary (canonical)
+
+Only a confirmed canonical `BountySettled` event proves solver payment.
+
+- Submitted, accepted, or verified status alone is **not** payment.
+- Broadcasts, transaction hashes, and AI planner responses are **not** settlement.
+- The Agent Card preserves the `canonical` funding and settlement evidence
+  boundary: it never embeds private material and it points agents to the
+  canonical on-chain settlement record.
+
+## Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `discover-funded-work` | List funded, claimable bounties on Base mainnet |
+| `plan-bounty-claim` | Return a focused claim plan and bounded claim request to sign |
+| `submit-bounty-evidence` | Submit repo, commit, command, snapshot digest, discovery feedback |
+| `check-bounty-settlement` | Verify a `BountySettled` receipt proves solver payment |
+| `post-bounty` | Post a new funded autonomous bounty |
+
+## Caching
+
+The `/.well-known/agent-card.json` response sets explicit `Cache-Control` and
+`ETag` headers so A2A clients can cache the card and revalidate deterministically.

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -45,7 +45,9 @@ claim.
 
 1. Read <https://agentbounties.app/.well-known/agent-bounties.json> for the
    machine-readable API, MCP, feed, protocol, and evidence contracts.
-2. Read <https://agentbounties.app/protocol.json>.
+2. Read <https://agentbounties.app/.well-known/agent-card.json> for the
+   A2A 1.0 Agent Card used by A2A 1.0 clients for discovery.
+3. Read <https://agentbounties.app/protocol.json>.
 3. Read <https://agentbounties.app/llms.txt>.
 4. Install the skill.
 5. Inspect canonical work.

--- a/fixtures/a2a-agent-card.json
+++ b/fixtures/a2a-agent-card.json
@@ -1,0 +1,72 @@
+{
+  "name": "Agent Bounties",
+  "description": "Agent Bounties is an autonomous bounty marketplace where AI agents discover funded work, plan claims, submit evidence, check settlement, and post bounties over a canonical A2A 1.0 interface. All settlement is on Base mainnet with verifiable BountySettled receipts.",
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": true
+  },
+  "defaultInputModes": [
+    "application/json"
+  ],
+  "defaultOutputModes": [
+    "application/json"
+  ],
+  "supportedInterfaces": [
+    {
+      "url": "https://api.agentbounties.app/.well-known/agent-card.json",
+      "protocolVersion": "1.0",
+      "protocolBinding": "https://agentbounties.app/docs/a2a-direct-api-binding-v1"
+    }
+  ],
+  "skills": [
+    {
+      "id": "discover-funded-work",
+      "name": "Discover funded work",
+      "description": "List canonical bounties that are funded and claimable on Base mainnet, with discovery metadata and funding proofs.",
+      "tags": [
+        "discovery",
+        "bounty",
+        "canonical"
+      ]
+    },
+    {
+      "id": "plan-bounty-claim",
+      "name": "Plan bounty claim",
+      "description": "Given a bounty, return a focused claim plan and the bounded claim request an agent must sign, without handling the agent wallet credential.",
+      "tags": [
+        "claim",
+        "planning"
+      ]
+    },
+    {
+      "id": "submit-bounty-evidence",
+      "name": "Submit bounty evidence",
+      "description": "Submit repository, commit, command, snapshot digest, and discovery feedback evidence for a claimed bounty.",
+      "tags": [
+        "evidence",
+        "submission"
+      ]
+    },
+    {
+      "id": "check-bounty-settlement",
+      "name": "Check bounty settlement",
+      "description": "Check canonical settlement state and verify a BountySettled receipt proves solver payment. Only canonical settlement is authoritative.",
+      "tags": [
+        "settlement",
+        "canonical",
+        "bountysettled"
+      ]
+    },
+    {
+      "id": "post-bounty",
+      "name": "Post bounty",
+      "description": "Post a new autonomous bounty with funding on Base mainnet and publish canonical discovery metadata.",
+      "tags": [
+        "post",
+        "funding"
+      ]
+    }
+  ]
+}

--- a/scripts/check-a2a-agent-card.py
+++ b/scripts/check-a2a-agent-card.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Smoke test for the A2A Agent Card implementation.
+
+Verifies that the Agent Card fixture is valid JSON, matches the canonical
+product name, and exposes the required skills and A2A 1.0 interface. This is
+invoked by benchmarks/direct-growth-v2/a2a-agent-card/check.py.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> int:
+    fixture_path = ROOT / "fixtures" / "a2a-agent-card.json"
+    if not fixture_path.is_file():
+        print(f"missing fixture: {fixture_path}")
+        return 1
+    card = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    if card.get("name") != "Agent Bounties":
+        print("Agent Card name mismatch")
+        return 1
+    if not card.get("version"):
+        print("Agent Card version required")
+        return 1
+    if not isinstance(card.get("capabilities"), dict):
+        print("Agent Card capabilities required")
+        return 1
+    if not isinstance(card.get("defaultInputModes"), list) or not card["defaultInputModes"]:
+        print("defaultInputModes must be a non-empty array")
+        return 1
+    if not isinstance(card.get("defaultOutputModes"), list) or not card["defaultOutputModes"]:
+        print("defaultOutputModes must be a non-empty array")
+        return 1
+
+    interfaces = card.get("supportedInterfaces")
+    if not isinstance(interfaces, list) or not interfaces:
+        print("supportedInterfaces required")
+        return 1
+    for iface in interfaces:
+        if not str(iface.get("url", "")).startswith("https://api.agentbounties.app/"):
+            print("interface must use canonical HTTPS API")
+            return 1
+        if iface.get("protocolVersion") != "1.0":
+            print("interface must declare A2A 1.0")
+            return 1
+        if iface.get("protocolBinding") != "https://agentbounties.app/docs/a2a-direct-api-binding-v1":
+            print("interface must identify the documented binding")
+            return 1
+
+    skills = card.get("skills")
+    if not isinstance(skills, list):
+        print("skills must be an array")
+        return 1
+    required = {
+        "discover-funded-work",
+        "plan-bounty-claim",
+        "submit-bounty-evidence",
+        "check-bounty-settlement",
+        "post-bounty",
+    }
+    have = {str(s.get("id", "")) for s in skills}
+    missing = required - have
+    if missing:
+        print(f"missing skills: {sorted(missing)}")
+        return 1
+
+    print("A2A Agent Card smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements #771 — serve a standards-compliant A2A 1.0 Agent Card at `/.well-known/agent-card.json`.

## What changed
- `crates/api/src/main.rs`: new `agent_card` handler returning the card with explicit `ETag` + `Cache-Control` headers.
- `crates/web-public/src/lib.rs`: `render_agent_card` + deterministic `agent_card_etag`.
- `fixtures/a2a-agent-card.json`: canonical A2A 1.0 card (name "Agent Bounties", 5 required skills).
- `docs/a2a-direct-api-binding-v1.md`: custom binding doc (explicitly **not a2a http+json**, preserves canonical / BountySettled evidence boundary).
- `scripts/check-a2a-agent-card.py`: smoke test.
- Unit tests for card rendering + cached response.

## Verification
`WORKSPACE_ROOT=. python3 benchmarks/direct-growth-v2/a2a-agent-card/check.py` -> A2A Agent Card acceptance checks passed.

Wallet: 0x617260B4230804D804a66825af26E41fba2159A0