### PR TITLE
Show V2 break-even win probability

### DIFF
--- a/scripts/test-marketplace-ui.js
+++ b/scripts/test-marketplace-ui.js
@@ -85,6 +85,11 @@ test("economics includes child capital and the complete losing exposure", () => 
   assert.ok(Math.abs(result.loss - (-3.11)) < 1e-9);
   assert.ok(Math.abs(result.expected - (-2.36)) < 1e-9);
   assert.equal(result.totalCost, 3.11);
+  assert.ok(Math.abs(result.breakEvenProbability - (3.11 / 3)) < 1e-9);
+
+  const treatment = competition.economics(6, 0.11, 3, 0, 0.25);
+  assert.ok(Math.abs(treatment.breakEvenProbability - (3.11 / 6)) < 1e-9);
+  assert.ok(Math.abs(treatment.expected - (-1.61)) < 1e-9);
 });
 
 test("the unified card shows complete variable-cost and losing-exposure formulas", () => {

--- a/site/competition.html
+++ b/site/competition.html
@@ -116,6 +116,7 @@
             <div><dt>Capital paid into child work</dt><dd data-econ-child>—</dd></div>
             <div><dt>If you win</dt><dd data-econ-win>—</dd></div>
             <div class="loss"><dt>If you lose</dt><dd data-econ-loss>—</dd></div>
+            <div><dt>Break-even win chance</dt><dd data-econ-breakeven>—</dd></div>
             <div class="expected"><dt>Expected cash result</dt><dd data-econ-expected>—</dd></div>
           </dl>
           <p class="economics-formula" data-economics-formula></p>
@@ -130,6 +131,6 @@
     <script src="analytics-config.js?v=2"></script>
     <script src="analytics.js?v=3"></script>
     <script src="marketplace.js?v=2"></script>
-    <script src="competition.js?v=2"></script>
+    <script src="competition.js?v=3"></script>
   </body>
 </html>

--- a/site/competition.js
+++ b/site/competition.js
@@ -34,6 +34,7 @@
       loss: -totalCost,
       expected: (winProbability * prize) - totalCost,
       totalCost,
+      breakEvenProbability: prize > 0 ? totalCost / prize : null,
     };
   }
 
@@ -224,7 +225,11 @@ Safety:
       setText(doc, "[data-econ-win]", signedUsdc(result.win));
       setText(doc, "[data-econ-loss]", signedUsdc(result.loss));
       setText(doc, "[data-econ-expected]", signedUsdc(result.expected));
-      setText(doc, "[data-economics-formula]", `Expected = ${Math.round(probabilityValue * 100)}% × ${prize.toFixed(2)} prize − ${hosted.toFixed(2)} hosted costs − ${child.toFixed(2)} child funding − ${other.toFixed(2)} other costs.`);
+      const breakEven = result.breakEvenProbability === null
+        ? "No finite break-even chance"
+        : `${(result.breakEvenProbability * 100).toFixed(1)}%${result.breakEvenProbability > 1 ? " — costs exceed the prize" : ""}`;
+      setText(doc, "[data-econ-breakeven]", breakEven);
+      setText(doc, "[data-economics-formula]", `Expected = ${Math.round(probabilityValue * 100)}% × ${prize.toFixed(2)} prize − ${hosted.toFixed(2)} hosted costs − ${child.toFixed(2)} child funding − ${other.toFixed(2)} other costs. Break-even chance = total selected costs ÷ prize.`);
     };
     [childFunding, otherCosts, probability].forEach((control) => control?.addEventListener("input", updateEconomics));
     updateEconomics();


### PR DESCRIPTION
## Outcome
- shows the exact break-even win probability from the agent-selected child funding, hosted costs, and other costs
- explicitly labels cases where selected costs exceed the prize
- keeps expected-value, win, and losing-exposure formulas together on the contract-specific participation page

## Evidence
- the external-agent replay found the 3-USDC default requires a 103.7% win probability and is therefore unprofitable even on a win
- the matched 6-USDC treatment requires a 51.8% win probability at the same 3.11-USDC selected cost

## Validation
- node --test scripts/test-marketplace-ui.js
- python scripts/check-site.py
- git diff --check

## Boundary
This changes decision support only. It does not sign, fund, activate, enter, settle, or establish GMV/payment evidence.