### PR TITLE
Fix Pages handoff verification

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -192,7 +192,8 @@ jobs:
           grep -q '<h1>Privacy policy</h1>' /tmp/live-privacy.html
           grep -q '<h1>Terms of use</h1>' /tmp/live-terms.html
           grep -q 'discovery-manifest.v2.json' /tmp/live-discovery.json
-          for route in objective.html funding.html post.html; do
+          python scripts/check-public-handoffs.py --base-url https://agentbounties.app
+          for route in objective.html funding.html; do
             status="$(curl --silent --output /dev/null --write-out '%{http_code}' "https://agentbounties.app/${route}?verify=${nonce}")"
             [[ "${status}" == "404" ]]
           done


### PR DESCRIPTION
## Finding\n\nThe production artifact from #980 deployed successfully, but the post-deploy verifier still required post.html to return 404.\n\n## Impact\n\nPages reported a failed deployment after publishing the restored canonical post handoff.\n\n## Action\n\n- run scripts/check-public-handoffs.py --base-url https://agentbounties.app after deployment\n- retain 404 assertions only for retired objective.html and unding.html\n\n## Done when\n\nThe Pages workflow validates the live transaction handoffs and completes successfully.\n\nVerification: python scripts/check-public-handoffs.py --base-url https://agentbounties.app; python scripts/check-site.py.\n\nNext owner: maintainer merge and observe the replacement Pages run.