### PR TITLE
Fix public handoff canary expectations

### DIFF
--- a/.github/workflows/community-pages-canary.yml
+++ b/.github/workflows/community-pages-canary.yml
@@ -56,8 +56,12 @@ jobs:
           assert 'data-market-volume' in metrics
           PY
             then
+              if ! python scripts/check-public-handoffs.py --base-url https://agentbounties.app; then
+                sleep 5
+                continue
+              fi
               removed_ok=true
-              for route in earn.html post.html objective.html funding.html; do
+              for route in objective.html funding.html; do
                 status="$(curl --silent --output /dev/null --write-out '%{http_code}' "https://agentbounties.app/${route}?verify=${nonce}")"
                 if [[ "$status" != "404" ]]; then
                   removed_ok=false


### PR DESCRIPTION
## Summary
- verify all advertised authorization, onramp, post, success, and cancel handoffs in the public-site canary
- stop treating restored post.html and retained earn.html as removed routes
- retain 404 assertions for retired objective.html and funding.html

## Verification
- python scripts/test_check_public_handoffs.py
- python scripts/check-public-handoffs.py --base-url https://agentbounties.app
- git diff --check

Follow-up to #1198. This changes deployment verification only; it does not change payment or protocol behavior.