### PR TITLE
Add onboarding analytics forward migration

### DIFF
--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -76,6 +76,8 @@ pub const SITE_AUTH_ACCOUNTS_MIGRATION: &str =
     include_str!("../../../migrations/0026_site_auth_accounts.sql");
 pub const COMPETITION_ACTIVATION_ANALYTICS_MIGRATION: &str =
     include_str!("../../../migrations/0027_competition_activation_analytics.sql");
+pub const ONBOARDING_ANALYTICS_MIGRATION: &str =
+    include_str!("../../../migrations/0028_onboarding_analytics.sql");
 const MIGRATION_ADVISORY_LOCK_ID: i64 = 4_270_265_017;
 const UPSERT_PAYMENT_EVENT_SQL: &str = r#"
             INSERT INTO payment_events (id, rail, external_id, status, payload_hash, received_at)
@@ -1208,6 +1210,7 @@ impl PostgresStore {
                 OPPORTUNITY_FEEDBACK_MIGRATION,
                 SITE_AUTH_ACCOUNTS_MIGRATION,
                 COMPETITION_ACTIVATION_ANALYTICS_MIGRATION,
+                ONBOARDING_ANALYTICS_MIGRATION,
             ] {
                 for statement in migration
                     .split(';')
@@ -10165,6 +10168,31 @@ mod tests {
             assert!(
                 COMPETITION_ACTIVATION_ANALYTICS_MIGRATION.contains(invariant),
                 "missing competition activation analytics invariant {invariant}"
+            );
+        }
+    }
+
+    #[test]
+    fn onboarding_analytics_migration_matches_the_api_allowlist() {
+        for invariant in [
+            "DROP CONSTRAINT IF EXISTS site_analytics_event_name_check",
+            "auth_completed",
+            "wallet_link_started",
+            "wallet_link_confirmed",
+            "wallet_missing_detected",
+            "wallet_connected",
+            "wallet_unfunded_detected",
+            "wallet_funded_observed",
+            "canonical_post_handoff_viewed",
+            "onramp_viewed",
+            "onramp_moonpay_started",
+            "onramp_metamask_started",
+            "onramp_coinbase_started",
+            "onramp_returned",
+        ] {
+            assert!(
+                ONBOARDING_ANALYTICS_MIGRATION.contains(invariant),
+                "missing onboarding analytics invariant {invariant}"
             );
         }
     }

--- a/migrations/0028_onboarding_analytics.sql
+++ b/migrations/0028_onboarding_analytics.sql
@@ -1,0 +1,39 @@
+ALTER TABLE site_analytics_events
+  DROP CONSTRAINT IF EXISTS site_analytics_event_name_check;
+
+ALTER TABLE site_analytics_events
+  ADD CONSTRAINT site_analytics_event_name_check CHECK (event_name IN (
+    'page_view',
+    'market_view',
+    'funded_bounty_click',
+    'unfunded_post_started',
+    'unfunded_post_completed',
+    'funding_started',
+    'claim_started',
+    'claim_confirmed',
+    'competition_entry_started',
+    'competition_entry_confirmed',
+    'competition_reveal_started',
+    'competition_reveal_confirmed',
+    'competition_view',
+    'competition_instructions_copied',
+    'competition_template_copied',
+    'competition_child_post_started',
+    'competition_feedback_started',
+    'competition_feedback_submitted',
+    'canonical_post_started',
+    'canonical_post_confirmed',
+    'auth_completed',
+    'wallet_link_started',
+    'wallet_link_confirmed',
+    'wallet_missing_detected',
+    'wallet_connected',
+    'wallet_unfunded_detected',
+    'wallet_funded_observed',
+    'canonical_post_handoff_viewed',
+    'onramp_viewed',
+    'onramp_moonpay_started',
+    'onramp_metamask_started',
+    'onramp_coinbase_started',
+    'onramp_returned'
+  ));

--- a/migrations/checksums.json
+++ b/migrations/checksums.json
@@ -28,6 +28,7 @@
     "0024_open_competition_v2_beta3.sql": "c9e1110996d70a4fa709dcae01e529b7f2b5304f93d71a7fe6b74bb1141ecf84",
     "0025_opportunity_feedback.sql": "355b584b56fe3e266150533b0d8cb0ac896db17c5d7102e41c15351a63bf84bf",
     "0026_site_auth_accounts.sql": "f3846a415b46b3eb3e48ba82b6922dc023a3d876ce2965f4b2ff0c20591cffdd",
-    "0027_competition_activation_analytics.sql": "e4411c9d4b7f0b99bfa50d127d05598843bedc3fb699821ea661367f05bda9d6"
+    "0027_competition_activation_analytics.sql": "e4411c9d4b7f0b99bfa50d127d05598843bedc3fb699821ea661367f05bda9d6",
+    "0028_onboarding_analytics.sql": "970867ff225a30782a8cf276bb65356566d1ac4ef8dc2d14b0b7e1631166ab3f"
   }
 }


### PR DESCRIPTION
## Summary
- add immutable migration 0028 to extend the deployed site analytics event-name constraint with the onboarding funnel
- run the new migration after competition activation analytics under the existing advisory lock
- pin its checksum and test every new onboarding event name

## Production evidence
A first-party onramp_viewed request currently reaches API validation but returns HTTP 503, while ordinary page views continue to insert. The deployed database constraint predates the new event names.

## Verification
- python scripts/check-migration-history.py
- cargo fmt --all -- --check
- cargo test -p db analytics_migration (3 passed)
- git diff --check

This repairs privacy-minimized measurement only; it does not change canonical lifecycle or payment behavior.