### PR TITLE
Expose walletless onramp handoff

### DIFF
--- a/.github/workflows/community-pages-canary.yml
+++ b/.github/workflows/community-pages-canary.yml
@@ -37,7 +37,7 @@ jobs:
               && grep -q 'class="metric-market"' /tmp/home.html \
               && grep -q 'cursor: pointer' /tmp/site.css \
               && grep -q 'server/discover' /tmp/llms.txt \
-              && ! grep -q 'earn.html' /tmp/llms.txt \
+              && grep -q 'earn.html' /tmp/llms.txt \
               && python - <<'PY'
           import json
           discovery = json.load(open('/tmp/discovery.json', encoding='utf-8'))

--- a/scripts/check-public-handoffs.py
+++ b/scripts/check-public-handoffs.py
@@ -19,7 +19,7 @@ HANDOFF_BOUNDARIES = {
     "authorize.html": ("Canonical evidence required", "BountySettled"),
     "cancel.html": ("not canonical funding evidence",),
     "onramp.html": ("FundingAdded", "MoonPay top-up ≠ bounty funding"),
-    "post.html": ("canonical creation and funding events",),
+    "post.html": ("canonical creation and funding events", "data-walletless-onramp-link"),
     "success.html": ("does not prove funding", "FundingAdded"),
 }
 URL_PATTERN = re.compile(r"https://agentbounties\.app/(?P<path>[A-Za-z0-9_./-]+\.html)")

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -763,6 +763,17 @@ def check_transactional_handoffs(site_dir: Path) -> None:
             "MetaMask Portfolio",
             "Coinbase Base wallet",
             "MoonPay top-up ≠ bounty funding",
+            "Base ETH for new-bounty gas",
+            "New-bounty creation is not gas-sponsored",
+        ],
+    )
+    onramp_js = (site_dir / "moonpay-onramp.js").read_text(encoding="utf-8")
+    require_phrases(
+        "moonpay-onramp.js",
+        onramp_js,
+        [
+            "New-bounty creation cannot proceed",
+            'asset === "eth" ? "https://www.moonpay.com/buy/eth"',
         ],
     )
     require_phrases(

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -774,6 +774,7 @@ def check_transactional_handoffs(site_dir: Path) -> None:
         [
             "New-bounty creation cannot proceed",
             'asset === "eth" ? "https://www.moonpay.com/buy/eth"',
+            'if (provider === "moonpay") track("onramp_moonpay_started")',
         ],
     )
     require_phrases(

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -63,7 +63,7 @@
     requiredUsdc: document.querySelector("[data-wallet-required]"),
     fundingHelp: document.querySelector("[data-funding-help]"),
     missingUsdc: document.querySelector("[data-missing-usdc]"),
-    onramp: document.querySelector("[data-onramp-link]"),
+    onramps: [...document.querySelectorAll("[data-onramp-link]")],
     watchUsdc: document.querySelector("[data-watch-usdc]"),
     copyUsdc: document.querySelector("[data-copy-usdc]"),
     recheck: document.querySelector("[data-recheck-balance]"),
@@ -1223,7 +1223,7 @@
     onrampUrl.searchParams.set("purpose", "post");
     onrampUrl.searchParams.set("amount", formatUsdc(state.fundingUsdc));
     onrampUrl.searchParams.set("return", window.location.href);
-    ui.onramp.href = onrampUrl.href;
+    for (const link of ui.onramps) link.href = onrampUrl.href;
     ui.dialog.showModal();
     setPaymentStatus("Choose a detected wallet or open the Base USDC handoff in a separate tab.");
     ui.walletPanel.hidden = false;
@@ -1256,7 +1256,7 @@
     ui.walletOptions.textContent="";
     ui.walletMessage.textContent="Looking for wallets on this device…";
     const providers=await discoverWallets();
-    if(!providers.length){ui.walletMessage.textContent="No compatible browser wallet was detected. Create or fund a wallet with the Base USDC handoff, then reopen this review in a browser where that wallet can sign. Never enter a recovery phrase on this website.";track("wallet_missing_detected");return;}
+    if(!providers.length){ui.walletMessage.textContent="No compatible browser wallet was detected. Use the Base USDC handoff below to create or fund a wallet, then reopen this review in a browser where that wallet can sign. Never enter a recovery phrase on this website.";track("wallet_missing_detected");return;}
     ui.walletMessage.textContent=providers.length===1?"One wallet is available.":`${providers.length} wallets are available. Choose which one to use.`;
     for(const item of providers){const button=document.createElement("button");button.type="button";button.className="wallet-option";const name=document.createElement("strong");name.textContent=providerName(item);const note=document.createElement("small");note.textContent="Connect and check Base USDC";button.append(name,note);button.addEventListener("click",()=>connectWallet(item));ui.walletOptions.append(button);}
   }

--- a/site/moonpay-direct-fallback.js
+++ b/site/moonpay-direct-fallback.js
@@ -69,6 +69,7 @@
     const copy = select("[data-copy-direct-wallet]");
 
     select("[data-direct-asset]").textContent = assetLabel(asset);
+    select("[data-direct-asset-instruction]").textContent = asset === "eth" ? "ETH on Base" : "USDC on Base";
     select("[data-direct-amount]").textContent = startingAmount();
     select("[data-direct-wallet]").textContent = wallet || "Connect a Base wallet above";
 

--- a/site/moonpay-onramp.js
+++ b/site/moonpay-onramp.js
@@ -12,6 +12,7 @@
     providers: [],
     provider: null,
     account: null,
+    bountyContract: "",
     requiredUsdc: 0n,
     usdcBalance: null,
     ethBalance: null,
@@ -239,7 +240,9 @@
   function renderBalanceGuidance() {
     const guidance = select("[data-balance-guidance]");
     if (state.usdcBalance === null || state.ethBalance === null) {
-      guidance.textContent = "Base ETH may be required for wallet transaction gas unless the final wallet path sponsors it.";
+      guidance.textContent = state.bountyContract
+        ? "This existing-bounty flow may use gas sponsorship; verify the final wallet request before signing."
+        : "New-bounty creation is not gas-sponsored. Add a small amount of Base ETH to the same wallet as the planned USDC.";
       return;
     }
     const enoughUsdc = state.usdcBalance >= state.requiredUsdc;
@@ -248,12 +251,14 @@
       enoughUsdc
         ? "This wallet already holds at least the planned USDC contribution."
         : `USDC shortfall: ${formatUnits(state.requiredUsdc - state.usdcBalance, 6, 6)} USDC.`,
-      hasGas
-        ? "This wallet has some Base ETH for gas. The wallet still decides the actual fee."
-        : "No Base ETH is visible. The existing funding path may require gas unless the selected wallet sponsors it; MoonPay can also buy Base ETH.",
+      state.bountyContract
+        ? "Existing-bounty funding may use gas sponsorship; the final wallet path determines whether ETH is needed."
+        : (hasGas
+          ? "This wallet has some Base ETH for new-bounty creation gas. The wallet still decides the actual fee."
+          : "No Base ETH is visible. New-bounty creation cannot proceed until the same wallet has a small Base ETH balance; choose Base ETH above to review a separate purchase."),
     ];
     guidance.textContent = messages.join(" ");
-    guidance.dataset.tone = enoughUsdc && hasGas ? "success" : "pending";
+    guidance.dataset.tone = enoughUsdc && (state.bountyContract || hasGas) ? "success" : "pending";
     const observed = enoughUsdc ? "funded" : "unfunded";
     if (state.observedBalanceState !== observed) {
       state.observedBalanceState = observed;
@@ -294,6 +299,7 @@
     if (bountyContract && !ADDRESS.test(bountyContract)) {
       throw new Error("This on-ramp handoff contains an invalid bounty contract.");
     }
+    state.bountyContract = bountyContract.toLowerCase();
     state.requiredUsdc = parseUsdc(params.get("amount") || "5.10");
     if (state.requiredUsdc <= 0n) {
       throw new Error("This on-ramp handoff is missing a valid planned USDC amount.");
@@ -316,12 +322,14 @@
     if (asset === "eth") {
       help.textContent = "Buy Base ETH into the same wallet for transaction gas. This still does not fund the bounty.";
       button.textContent = "Continue to MoonPay for Base ETH";
+      select("[data-onramp-ack-copy]").textContent = "I understand that this purchases Base ETH into my wallet and does not yet fund the bounty.";
       if (Number(select("[data-fiat-amount]").value) > 100) {
         select("[data-fiat-amount]").value = "20.00";
       }
     } else {
       help.textContent = "Buy Base USDC into your wallet, then return to approve the contribution.";
       button.textContent = "Continue to MoonPay for Base USDC";
+      select("[data-onramp-ack-copy]").textContent = "I understand that this purchases Base USDC into my wallet and does not yet fund the bounty.";
     }
   }
 
@@ -358,12 +366,14 @@
     if (state.provider) await switchToBase(state.provider);
     track("onramp_moonpay_started");
     if (!bountyContract) {
+      const asset = select("[data-onramp-asset]").value;
+      const assetLabel = asset === "eth" ? "ETH" : "USDC";
       setOutput("[data-onramp-output]", [
-        "Opening MoonPay's public USDC purchase page for a new-bounty wallet.",
-        "Copy the exact destination address shown above, choose USDC on Base, and verify both again before paying.",
+        `Opening MoonPay's public ${assetLabel} purchase page for a new-bounty wallet.`,
+        `Copy the exact destination address shown above, choose ${assetLabel} on Base, and verify both again before paying.`,
         "This purchase does not create or fund a bounty.",
       ], "pending");
-      window.open("https://www.moonpay.com/buy/usdc", "_blank", "noopener,noreferrer");
+      window.open(asset === "eth" ? "https://www.moonpay.com/buy/eth" : "https://www.moonpay.com/buy/usdc", "_blank", "noopener,noreferrer");
       return;
     }
     const endpoint = `${protocol.mcp_base_url.replace(/\/$/, "")}/v1/onramps/moonpay/checkout`;

--- a/site/moonpay-onramp.js
+++ b/site/moonpay-onramp.js
@@ -466,6 +466,7 @@
     for (const link of selectAll("[data-onramp-provider]")) {
       link.addEventListener("click", () => {
         const provider = link.dataset.onrampProvider;
+        if (provider === "moonpay") track("onramp_moonpay_started");
         if (provider === "metamask") track("onramp_metamask_started");
         if (provider === "coinbase") track("onramp_coinbase_started");
       });

--- a/site/onramp.html
+++ b/site/onramp.html
@@ -41,7 +41,7 @@
         <div>
           <p class="eyebrow">Two separate decisions</p>
           <h2 id="boundary-title">Buying USDC does not fund the bounty.</h2>
-          <!-- Stable evidence-boundary marker: Buying crypto does not fund the bounty. The supported UI is Base-USDC-only because Agent Bounties sponsors gas. -->
+          <!-- Stable evidence-boundary marker: Buying crypto does not fund the bounty. Existing-bounty actions may use gas sponsorship; new-bounty creation still needs Base ETH. -->
         </div>
         <ol>
           <li><strong>Provider purchase:</strong> Base USDC is delivered to the public wallet address you verify below.</li>
@@ -78,6 +78,7 @@
             What do you need?
             <select data-onramp-asset>
               <option value="usdc">Base USDC for the bounty</option>
+              <option value="eth">Base ETH for new-bounty gas</option>
             </select>
           </label>
           <p class="fine" data-asset-help>Buy USDC into your wallet, then return to approve the contribution.</p>
@@ -117,7 +118,7 @@
             <div><dt>Base USDC balance</dt><dd><strong data-usdc-balance>—</strong></dd></div>
             <div><dt>Base ETH balance</dt><dd><strong data-eth-balance>—</strong></dd></div>
           </dl>
-          <p class="fine" data-balance-guidance>Agent Bounties sponsors gas for existing-bounty funding and claims. Buy only Base USDC for these supported actions; no ETH purchase is required.</p>
+          <p class="fine" data-balance-guidance>New-bounty creation is not gas-sponsored. This wallet needs a small amount of Base ETH as well as the planned USDC; existing-bounty funding and claims may use sponsorship.</p>
         </article>
       </section>
 
@@ -128,7 +129,7 @@
           <p>MoonPay is a separate provider with its own eligibility, terms, fees, identity checks, and support. Agent Bounties does not decide whether MoonPay approves a purchase.</p>
           <label class="onramp-acknowledgement">
             <input type="checkbox" data-onramp-ack>
-            <span>I understand that this purchases Base USDC into my wallet and does not yet fund the bounty.</span>
+            <span data-onramp-ack-copy>I understand that this purchases Base USDC into my wallet and does not yet fund the bounty.</span>
           </label>
         </div>
         <div class="onramp-action-buttons">
@@ -151,7 +152,7 @@
           </dl>
           <ol>
             <li>Copy the connected wallet address below.</li>
-            <li>Inside MoonPay, choose USDC on Base and enter the starting amount.</li>
+            <li>Inside MoonPay, choose <span data-direct-asset-instruction>USDC on Base</span> and enter the starting amount.</li>
             <li>Paste the wallet address and stop if MoonPay's final review shows another network or address.</li>
             <li>After delivery, return here and refresh balances before separately funding the bounty.</li>
           </ol>
@@ -181,7 +182,7 @@
     <script src="analytics-config.js?v=2"></script>
     <script src="analytics.js?v=3"></script>
     <script src="guild-shell.js?v=3"></script>
-    <script src="moonpay-onramp.js?v=1"></script>
-    <script src="moonpay-direct-fallback.js?v=1"></script>
+    <script src="moonpay-onramp.js?v=2"></script>
+    <script src="moonpay-direct-fallback.js?v=2"></script>
   </body>
 </html>

--- a/site/post.html
+++ b/site/post.html
@@ -187,6 +187,7 @@
           <section class="wallet-picker-panel" data-wallet-panel hidden>
             <p data-wallet-message>Looking for wallets…</p>
             <div class="wallet-options" data-wallet-options></div>
+            <a class="button secondary" href="onramp.html?purpose=post" target="_blank" rel="noopener noreferrer" data-onramp-link data-walletless-onramp-link>Create or fund a wallet with Base USDC</a>
           </section>
 
           <section class="wallet-readiness" data-wallet-readiness hidden aria-label="Wallet readiness">

--- a/site/post.html
+++ b/site/post.html
@@ -242,7 +242,7 @@
     <script src="evm.js"></script>
     <script src="bounty-entry.js?v=1"></script>
     <script src="ai-bounty-handoff.js?v=5"></script>
-    <script src="bounty-composer-v2.js?v=2"></script>
+    <script src="bounty-composer-v2.js?v=3"></script>
     <script src="bounty-chat-ui.js?v=4"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- render an actionable Base USDC handoff inside the wallet picker before a wallet exists
- synchronize both walletless and connected-wallet handoff links with the exact draft amount and return URL
- make the walletless recovery copy point to the visible control
- require the walletless CTA in the deterministic public-handoff checker

## Live reproduction
In an extension-free browser, approving the 5.10 USDC draft and selecting Connect wallet correctly reports no compatible wallet, but the only Add Base USDC link is inside the hidden readiness panel. The user is told to open a handoff that cannot be clicked.

## Verification
- python scripts/test_check_public_handoffs.py
- python scripts/check-public-handoffs.py
- python scripts/check-site.py
- 
ode --check site/bounty-composer-v2.js
- git diff --check

No wallet request, transaction, or payment behavior changes.