### PR TITLE
Guard legacy bounty issue content during discoverability backfill

### DIFF
--- a/scripts/reconcile_github_bounty_labels.py
+++ b/scripts/reconcile_github_bounty_labels.py
@@ -1333,6 +1333,24 @@ def replace_managed_block(body: str, managed: str) -> str:
     return f"{body[:start]}{managed}{body[end:]}"
 
 
+def has_current_discovery_block(body: str) -> bool:
+    """Return whether an existing managed block already uses the current layout."""
+    starts = body.count(MANAGED_START)
+    ends = body.count(MANAGED_END)
+    if starts != ends or starts > 1:
+        raise LabelReconciliationError("cannot inspect malformed managed issue body")
+    if starts == 0:
+        return False
+    start = body.index(MANAGED_START)
+    end = body.index(MANAGED_END, start) + len(MANAGED_END)
+    managed = body[start:end]
+    return (
+        "- **Current work state:**" in managed
+        and "- **Current payment state:**" in managed
+        and "- **Current competition state:**" in managed
+    )
+
+
 def trial_claimable_enabled(policy: Mapping[str, Any], generated_at: datetime) -> bool:
     trial = policy["open_competition_compatibility_trial"]
     ends_at = parse_instant(trial["ends_at"], "trial.ends_at")
@@ -1446,6 +1464,15 @@ def build_settlement_receipt(item: Mapping[str, Any]) -> SettlementReceipt:
     return SettlementReceipt(fingerprint=fingerprint, body=body)
 
 
+def created_after_activation(item: Mapping[str, Any], policy: Mapping[str, Any]) -> bool:
+    activation = policy["activation"]
+    return require_unsigned(item["created_block"], "created_block") >= require_unsigned(
+        activation["safe_block"], "activation.safe_block"
+    ) and parse_instant(item["created_at"], "created_at") >= parse_instant(
+        activation["timestamp"], "activation.timestamp"
+    )
+
+
 def create_allowed(item: Mapping[str, Any], policy: Mapping[str, Any]) -> tuple[bool, str]:
     identity = str(item["discovery_id"])
     if identity in policy["required_backfill_discovery_ids"]:
@@ -1453,13 +1480,7 @@ def create_allowed(item: Mapping[str, Any], policy: Mapping[str, Any]) -> tuple[
     state = str(item["lifecycle_state"])
     if state in NONTERMINAL_STATES or item.get("recovery_action_available") is True:
         return True, "current_nonterminal_backfill"
-    activation = policy["activation"]
-    created_after = require_unsigned(item["created_block"], "created_block") >= require_unsigned(
-        activation["safe_block"], "activation.safe_block"
-    ) and parse_instant(item["created_at"], "created_at") >= parse_instant(
-        activation["timestamp"], "activation.timestamp"
-    )
-    if created_after:
+    if created_after_activation(item, policy):
         return True, "post_activation_record"
     return False, "historical_terminal_without_existing_issue"
 
@@ -1554,9 +1575,29 @@ def build_plans(
             eligible = False
             mapping_action = "preserve_closed_historical"
 
-        managed = render_managed_block(item)
         original_body = str(issue.get("body") or "") if issue else ""
-        desired_body = replace_managed_block(original_body, managed) if eligible else original_body
+        post_activation_source = bool(
+            issue
+            and issue_marker(issue) is None
+            and created_after_activation(item, policy)
+        )
+        content_reformat_allowed = bool(
+            issue is None
+            or lifecycle_state == "ready_to_earn"
+            or has_current_discovery_block(original_body)
+            or post_activation_source
+        )
+        title_reformat_allowed = bool(
+            issue is None
+            or lifecycle_state == "ready_to_earn"
+            or post_activation_source
+        )
+        managed = render_managed_block(item)
+        desired_body = (
+            replace_managed_block(original_body, managed)
+            if eligible and content_reformat_allowed
+            else original_body
+        )
         desired = desired_labels(item, policy, generated_at) if eligible else set()
         current_all = label_names(issue) if issue else set()
         current_managed = current_all & MANAGED_LABELS
@@ -1599,7 +1640,12 @@ def build_plans(
         landing = item.get("_landing")
         desired_title = (
             str(issue.get("title") or item["title"])
-            if issue and (preserve_closed_historical or item.get("_landing_action_required"))
+            if issue
+            and (
+                preserve_closed_historical
+                or item.get("_landing_action_required")
+                or not title_reformat_allowed
+            )
             else str(landing["outcome_title"])
             if isinstance(landing, dict)
             else f"[Bounty] {str(item['title']).strip()}"

--- a/scripts/test_reconcile_github_bounty_labels.py
+++ b/scripts/test_reconcile_github_bounty_labels.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from reconcile_github_bounty_labels import (
     BETA3_PROTOCOL,
     LABEL_DEFINITIONS,
+    MANAGED_END,
     MANAGED_START,
     HttpResult,
     LabelReconciliationError,
@@ -460,6 +461,63 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
         self.assertTrue(plan.desired_body.startswith("Keep this human section."))
         self.assertIn(MANAGED_START, plan.desired_body)
         self.assertNotIn("help wanted", plan.remove_labels)
+
+    def test_legacy_non_ready_issue_reconciles_labels_without_reformatting_content(self) -> None:
+        record = item(
+            96,
+            state="unavailable",
+            source_url=f"https://github.com/{REPOSITORY}/issues/96",
+            verifier_ready=False,
+        )
+        legacy_body = (
+            "Human-authored context.\n\n"
+            f"{MANAGED_START}\n"
+            f'<!-- agent-bounties/github-discovery-v1 {{"discovery_id":"{record["discovery_id"]}"}} -->\n'
+            "## Canonical bounty discovery\n\n"
+            "- **Mode:** Exclusive claim\n"
+            "- **Lifecycle:** `ready_to_earn`\n"
+            f"{MANAGED_END}\n"
+        )
+        source = issue(
+            96,
+            body=legacy_body,
+            labels=["bounty", "payments", "ai-agent-welcome", "ready-to-earn"],
+        )
+        plan = build_plans(projection(record), [source], policy(), REPOSITORY)[0]
+        self.assertEqual(plan.original_title, plan.title)
+        self.assertEqual(plan.original_body, plan.desired_body)
+        self.assertIn("ai-agent-welcome", plan.remove_labels)
+        self.assertIn("ready-to-earn", plan.remove_labels)
+        self.assertIn("verification-unavailable", plan.add_labels)
+        self.assertTrue(plan_has_write(plan))
+
+    def test_current_discovery_block_keeps_reconciling_after_work_starts(self) -> None:
+        ready = item(97, source_url=f"https://github.com/{REPOSITORY}/issues/97")
+        source = issue(97, body="Human-authored context.", labels=["bounty"])
+        ready_plan = build_plans(
+            projection(ready),
+            [source],
+            policy(),
+            REPOSITORY,
+            landing_entries=landing(ready, issue_number=97),
+        )[0]
+        active = item(
+            97,
+            state="in_progress",
+            source_url=f"https://github.com/{REPOSITORY}/issues/97",
+        )
+        upgraded = issue(
+            97,
+            body=ready_plan.desired_body,
+            labels=ready_plan.desired_managed_labels,
+        )
+        upgraded["title"] = ready_plan.title
+        active_plan = build_plans(projection(active), [upgraded], policy(), REPOSITORY)[0]
+        self.assertEqual(active_plan.title, ready_plan.title)
+        self.assertNotEqual(active_plan.original_body, active_plan.desired_body)
+        self.assertIn("- **Current work state:** `in_progress`", active_plan.desired_body)
+        self.assertNotIn("ready-to-earn", active_plan.desired_managed_labels)
+        self.assertIn("claimed-live", active_plan.desired_managed_labels)
 
     def test_external_source_creates_central_mirror_and_source_collision_is_unambiguous(self) -> None:
         external = item(3, source_url="https://github.com/external/project/issues/7")


### PR DESCRIPTION
## Summary
- preserve legacy titles and managed blocks for already-mapped non-ready bounty issues
- continue reconciling lifecycle labels without leaving solver invitations on in-progress, verification-pending, or unavailable work
- allow current-schema issues and post-activation source issues to keep receiving managed-block updates

## Why
The production dry-run after #1203 showed 20 safe label removals, but also proposed content rewrites for legacy non-ready issues. The sprint's release boundary permits reformatting current `ready_to_earn` and future issues, not older non-ready issue content. This guard makes that boundary explicit before any live issue execution.

## Evidence
- `python scripts/test_reconcile_github_bounty_labels.py -v` (25 passed)
- `scripts/preflight.ps1 -Mode core`
- `git diff --check`
- production dry-run: 63 canonical records, 20 mapped issues, 100% coverage, zero duplicate mappings; 20 label-only changes, zero title/body/state changes

Follow-up to #1203 and maintainer notice #1193. The change is backward-compatible for current-schema managed blocks and future intake. Branches touching the reconciler should rebase after merge.