### PR TITLE
Expose V2 best-score competitions in GitHub discovery

### DIFF
--- a/.github/workflows/open-competition-v2-replenishment.yml
+++ b/.github/workflows/open-competition-v2-replenishment.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install pinned snapshot and wallet dependencies
-        run: python -m pip install -r scripts/requirements-attest.txt -r scripts/requirements-wallet.txt
+        run: python -m pip install -r scripts/requirements-attest.txt -r scripts/requirements-wallet.txt -r scripts/requirements-site.txt
       - name: Test private guard, deterministic planning, and materialization
         run: |
           python -m unittest \

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -964,13 +964,7 @@ fn v2_public_metadata(
         if item.seed_id.trim().is_empty()
             || item.title.trim().is_empty()
             || item.summary.trim().is_empty()
-            || !(item
-                .source_url
-                .starts_with("https://github.com/NSPG13/agent-bounties/issues/")
-                || item.source_url
-                    == "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json"
-                || item.source_url
-                    == "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json")
+            || !reviewed_v2_public_source_url(&item.source_url)
             || item.bounty_id.len() != 66
             || item.competition.len() != 42
         {
@@ -1006,6 +1000,28 @@ fn v2_public_metadata(
         }
     }
     Ok(indexed)
+}
+
+fn reviewed_v2_public_source_url(source_url: &str) -> bool {
+    if source_url.starts_with("https://github.com/NSPG13/agent-bounties/issues/") {
+        return true;
+    }
+    let Some(remainder) = source_url.strip_prefix("https://github.com/NSPG13/agent-bounties/blob/")
+    else {
+        return false;
+    };
+    let Some((revision, path)) = remainder.split_once('/') else {
+        return false;
+    };
+    revision.len() == 40
+        && revision
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        && matches!(
+            path,
+            "ops/open-competition-v2-forward-gmv-candidate-pool-v2.json"
+                | "ops/open-competition-v2-forward-gmv-reward-cohort-v1.json"
+        )
 }
 
 fn v2_scoring_phase(
@@ -2412,6 +2428,20 @@ mod tests {
             .next_action
             .instructions
             .contains("Do not generate score"));
+    }
+
+    #[test]
+    fn beta3_public_metadata_source_requires_pinned_reviewed_artifact() {
+        let revision = "b600500a0ba25babe5bf9d262472ef4f701b480a";
+        assert!(reviewed_v2_public_source_url(&format!(
+            "https://github.com/NSPG13/agent-bounties/blob/{revision}/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json"
+        )));
+        assert!(!reviewed_v2_public_source_url(
+            "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json"
+        ));
+        assert!(!reviewed_v2_public_source_url(&format!(
+            "https://github.com/NSPG13/agent-bounties/blob/{revision}/README.md"
+        )));
     }
 
     #[test]

--- a/ops/open-competition-v2-public-metadata-v1.json
+++ b/ops/open-competition-v2-public-metadata-v1.json
@@ -9,7 +9,7 @@
       "competition": "0x8c494466711c1de316c7e7599f8b0641a30a0c98",
       "title": "Highest externally funded canonical GMV \u2014 daily August 24",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-24T00:00:00Z",
       "epoch_ends_at": "2026-08-25T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -20,7 +20,7 @@
       "competition": "0x6a791b05333d9ca7d28a052003ced4818a372c7f",
       "title": "Highest externally funded canonical GMV \u2014 daily August 25",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-25T00:00:00Z",
       "epoch_ends_at": "2026-08-26T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -31,7 +31,7 @@
       "competition": "0x441e8bded29917999fc0e8330c83553262fa2f08",
       "title": "Highest externally funded canonical GMV \u2014 daily August 26",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-26T00:00:00Z",
       "epoch_ends_at": "2026-08-27T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -42,7 +42,7 @@
       "competition": "0x979782be0bfefb78ac0459d4695d619932ecdda4",
       "title": "Highest externally funded canonical GMV \u2014 daily August 27",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-27T00:00:00Z",
       "epoch_ends_at": "2026-08-28T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -53,7 +53,7 @@
       "competition": "0x2f1d2b24105596b153e473032256569fe544a44f",
       "title": "Highest externally funded canonical GMV \u2014 week of August 24",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-24T00:00:00Z",
       "epoch_ends_at": "2026-08-31T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -64,7 +64,7 @@
       "competition": "0x1692fecdb678537eb4cc0093e9e4e99dbded9806",
       "title": "Highest externally funded canonical GMV \u2014 week of August 31",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-31T00:00:00Z",
       "epoch_ends_at": "2026-09-07T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -75,7 +75,7 @@
       "competition": "0x6f635dfd07085aa48ec8b11767eeb48936969f5c",
       "title": "Highest externally funded canonical GMV \u2014 August 24 to September 7",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-24T00:00:00Z",
       "epoch_ends_at": "2026-09-07T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -86,7 +86,7 @@
       "competition": "0x5817b7742b085d333c7e7831daa62a490c493b56",
       "title": "Highest externally funded canonical GMV \u2014 September 7 to September 21",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-09-07T00:00:00Z",
       "epoch_ends_at": "2026-09-21T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -97,7 +97,7 @@
       "competition": "0x8c990ddf5360c00ee0b2090000e3a3a6f90a6a9d",
       "title": "Highest externally funded canonical GMV \u2014 August 24 to September 21",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-24T00:00:00Z",
       "epoch_ends_at": "2026-09-21T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -108,7 +108,7 @@
       "competition": "0x36e45ec89b61f551724558ed799ad4e07c288175",
       "title": "Highest externally funded canonical GMV \u2014 August 24 sprint",
       "summary": "Create and fund useful marketplace demand that settles canonically during the scoring window. Highest eligible externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
       "epoch_starts_at": "2026-08-24T00:00:00Z",
       "epoch_ends_at": "2026-08-27T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -119,7 +119,7 @@
       "competition": "0xbab4de620cee1286307d6551bc5c2816dc27d45a",
       "title": "6 USDC prize \u2014 Highest externally funded canonical GMV \u2014 daily 20260825",
       "summary": "Compete to create and fund marketplace demand that settles canonically during the announced forward window. Highest pro-rata externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
       "epoch_starts_at": "2026-08-25T00:00:00Z",
       "epoch_ends_at": "2026-08-26T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -130,7 +130,7 @@
       "competition": "0x5a096ba0dc8f647cc499d14cd82ff49eef05b828",
       "title": "6 USDC prize \u2014 Highest externally funded canonical GMV \u2014 daily 20260826",
       "summary": "Compete to create and fund marketplace demand that settles canonically during the announced forward window. Highest pro-rata externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
       "epoch_starts_at": "2026-08-26T00:00:00Z",
       "epoch_ends_at": "2026-08-27T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -141,7 +141,7 @@
       "competition": "0xee01479015026afc2b09dea37d2ed805926c3c0d",
       "title": "6 USDC prize \u2014 Highest externally funded canonical GMV \u2014 daily 20260827",
       "summary": "Compete to create and fund marketplace demand that settles canonically during the announced forward window. Highest pro-rata externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
       "epoch_starts_at": "2026-08-27T00:00:00Z",
       "epoch_ends_at": "2026-08-28T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -152,7 +152,7 @@
       "competition": "0xdc1bbcbcb149b07262565c8b9caa1ae5e2058f76",
       "title": "6 USDC prize \u2014 Highest externally funded canonical GMV \u2014 week 20260831",
       "summary": "Compete to create and fund marketplace demand that settles canonically during the announced forward window. Highest pro-rata externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
       "epoch_starts_at": "2026-08-31T00:00:00Z",
       "epoch_ends_at": "2026-09-07T00:00:00Z",
       "minimum_score_base_units": "1"
@@ -163,7 +163,7 @@
       "competition": "0x81f0dd1f7da5f53ab6317e27131f9af45392b84c",
       "title": "6 USDC prize \u2014 Highest externally funded canonical GMV \u2014 fortnight 20260907",
       "summary": "Compete to create and fund marketplace demand that settles canonically during the announced forward window. Highest pro-rata externally funded GMV wins.",
-      "source_url": "https://github.com/NSPG13/agent-bounties/blob/main/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
+      "source_url": "https://github.com/NSPG13/agent-bounties/blob/b600500a0ba25babe5bf9d262472ef4f701b480a/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
       "epoch_starts_at": "2026-09-07T00:00:00Z",
       "epoch_ends_at": "2026-09-21T00:00:00Z",
       "minimum_score_base_units": "1"

--- a/scripts/bounty_inventory_guard.py
+++ b/scripts/bounty_inventory_guard.py
@@ -67,7 +67,7 @@ REQUIRED_GMV_PROFILE = {
     "elf_hash": "0x75a339253a0b0dac3162abf55f4a1a97ff6d9ae471992b44e9f54cc17978c7b8",
     "journal_schema_hash": "0x660ddc720ea9fc13e7bbdd88839a2ac7b19a124e5daf046518350fa6febe8a40",
     "metric_program_hash": "0xe1b52ffcfff0675b7dacea84dcabdf3fbcf1cde09b3d2fb55aa389acac5c2ff9",
-    "review_evidence_hash": "0xa721b85db55db5c827dee508d89de09a222d9d70150f3eeb2a69a34b670023dd",
+    "review_evidence_hash": "0x3e2c7a15171134c86436148ff0d0f871eeeca205f1328b3f41a23e75437a5c21",
 }
 
 

--- a/scripts/plan_open_competition_v2_replenishment.py
+++ b/scripts/plan_open_competition_v2_replenishment.py
@@ -83,7 +83,7 @@ REQUIRED_LIVE_GMV_PROFILE = {
     "elf_hash": "0x75a339253a0b0dac3162abf55f4a1a97ff6d9ae471992b44e9f54cc17978c7b8",
     "journal_schema_hash": GMV_JOURNAL_SCHEMA_HASH,
     "metric_program_hash": GMV_METRIC_PROGRAM_HASH,
-    "review_evidence_hash": "0xa721b85db55db5c827dee508d89de09a222d9d70150f3eeb2a69a34b670023dd",
+    "review_evidence_hash": "0x3e2c7a15171134c86436148ff0d0f871eeeca205f1328b3f41a23e75437a5c21",
 }
 
 

--- a/scripts/reconcile_github_bounty_labels.py
+++ b/scripts/reconcile_github_bounty_labels.py
@@ -28,6 +28,12 @@ USER_AGENT = "agent-bounties-github-discovery/1"
 PROJECTION_SCHEMA = "agent-bounties/github-bounty-discovery-v1"
 POLICY_SCHEMA = "agent-bounties/github-bounty-discovery-policy-v1"
 LANDING_COPY_SCHEMA = "agent-bounties/github-bounty-landing-copy-v1"
+REVIEWED_BETA3_SOURCE_PATHS = frozenset(
+    {
+        "ops/open-competition-v2-forward-gmv-candidate-pool-v2.json",
+        "ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
+    }
+)
 CORE_DISCOVERY_PROTOCOLS = frozenset(
     {
         "agent-bounties/autonomous-v1",
@@ -431,6 +437,50 @@ def attach_landing_copy(
         if item.get("lifecycle_state") == "ready_to_earn":
             identity = str(item["discovery_id"])
             landing = entries.get(identity)
+            if (
+                landing is None
+                and item.get("protocol_version") == BETA3_PROTOCOL
+                and item.get("competition_mode") == "best_score"
+                and is_same_repository_reviewed_beta3_artifact(
+                    item.get("source_url"), repository
+                )
+            ):
+                scoring_window = item.get("scoring_window")
+                if not isinstance(scoring_window, dict):
+                    raise LabelReconciliationError(
+                        f"reviewed Beta3 landing copy lacks a scoring window: {identity}"
+                    )
+                public_url = require_public_https_url(
+                    item.get("public_url"), f"{identity}.public_url"
+                )
+                title = f"Generate qualifying GMV for {str(item.get('title') or '').strip()}"
+                if len(title) > 160:
+                    raise LabelReconciliationError(
+                        f"reviewed Beta3 landing title is too long: {identity}"
+                    )
+                landing = {
+                    "issue_number": None,
+                    "outcome_title": title,
+                    "intent_summary": (
+                        "Create and fund useful marketplace demand that settles canonically inside the exact scoring window. "
+                        "Produce the highest eligible externally funded GMV score without counting excluded wallets or contracts."
+                    ),
+                    "skills": ["research", "browser"],
+                    "canonical_opportunity_url": public_url,
+                    "acceptance_criteria": [
+                        "Use the same Base wallet for qualifying child-bounty funding and the competition entry.",
+                        "Have a different eligible wallet complete the useful child bounty.",
+                        f"Reach confirmed canonical child settlement between {scoring_window.get('starts_at')} and {scoring_window.get('ends_at')}.",
+                        "Preserve the contract-bound funding and settlement evidence required by the published snapshot and verifier.",
+                    ],
+                    "safe_start": {
+                        "label": "Open the contract-specific participation page",
+                        "url": public_url,
+                        "instructions": "Read the exact UTC window, complete economics, exclusions, and current next action before funding anything.",
+                    },
+                    "reviewed_by": "reviewed Beta3 public metadata",
+                    "reviewed_at": item.get("updated_at"),
+                }
             if landing is None:
                 item["_landing_action_required"] = [
                     "outcome_title",
@@ -446,9 +496,14 @@ def attach_landing_copy(
                         f"reviewed canonical opportunity URL drifted from projection: {identity}"
                     )
                 source_issue = parse_same_repository_issue(item.get("source_url"), repository)
-                if source_issue is not None and source_issue != landing.get("issue_number"):
+                landing_issue = landing.get("issue_number")
+                if source_issue is not None and source_issue != landing_issue:
                     raise LabelReconciliationError(
                         f"reviewed landing copy maps the wrong source issue: {identity}"
+                    )
+                if source_issue is None and landing_issue is not None:
+                    raise LabelReconciliationError(
+                        f"artifact-backed landing copy must not preassign an issue: {identity}"
                     )
                 item["_landing"] = dict(landing)
         attached.append(item)
@@ -496,7 +551,7 @@ def validate_projection(payload: Any, network: str, policy: Mapping[str, Any]) -
             or identity in seen
             or protocol not in SUPPORTED_PROTOCOLS
             or lifecycle not in LIFECYCLE_STATES
-            or mode not in {"exclusive_claim", "first_valid_submission"}
+            or mode not in {"exclusive_claim", "first_valid_submission", "best_score"}
             or not ADDRESS.fullmatch(contract)
             or item.get("network") != network
             or item.get("chain_id") != policy.get("chain_id")
@@ -516,7 +571,9 @@ def validate_projection(payload: Any, network: str, policy: Mapping[str, Any]) -
         if not isinstance(action, dict):
             raise LabelReconciliationError(f"next action is malformed: {identity}")
         require_public_https_url(action.get("url"), f"{identity}.next_action.url")
-        if protocol in {"agent-bounties/open-competition-v1", BETA3_PROTOCOL} and mode != "first_valid_submission":
+        if protocol == "agent-bounties/open-competition-v1" and mode != "first_valid_submission":
+            raise LabelReconciliationError(f"Open Competition mode mismatch: {identity}")
+        if protocol == BETA3_PROTOCOL and mode not in {"first_valid_submission", "best_score"}:
             raise LabelReconciliationError(f"Open Competition mode mismatch: {identity}")
         if protocol == "agent-bounties/autonomous-v1" and mode != "exclusive_claim":
             raise LabelReconciliationError(f"autonomous-v1 mode mismatch: {identity}")
@@ -697,11 +754,16 @@ def beta3_lifecycle(state: str, verification_ready: bool) -> str:
 
 
 def beta3_discovery_competition_mode(winner_mode: object) -> str:
-    if winner_mode != "first_proven":
+    modes = {
+        "first_proven": "first_valid_submission",
+        "best_score": "best_score",
+    }
+    try:
+        return modes[str(winner_mode)]
+    except KeyError as error:
         raise LabelReconciliationError(
             "GitHub discovery cannot represent this Beta3 winner mode safely"
-        )
-    return "first_valid_submission"
+        ) from error
 
 
 def augment_projection_with_beta3(
@@ -791,7 +853,11 @@ def augment_projection_with_beta3(
         requirements = opportunity.get("evidence_requirements")
         if not isinstance(requirements, dict) or requirements.get("protocol_version") != BETA3_PROTOCOL:
             continue
-        if parse_same_repository_issue(opportunity.get("source_url"), repository) is None:
+        source_url = opportunity.get("source_url")
+        if (
+            parse_same_repository_issue(source_url, repository) is None
+            and not is_same_repository_reviewed_beta3_artifact(source_url, repository)
+        ):
             continue
         contract = str(opportunity.get("source_id") or "").lower()
         record = records.get(contract)
@@ -815,6 +881,28 @@ def augment_projection_with_beta3(
         competition_mode = beta3_discovery_competition_mode(
             opportunity.get("winner_mode") or canonical.get("winner_mode")
         )
+        participation_phase = requirements.get("participation_phase")
+        scoring_window = requirements.get("scoring_window")
+        scoring_formula = requirements.get("scoring_formula")
+        qualifying_action = requirements.get("qualifying_action")
+        cash_economics = opportunity.get("cash_economics")
+        if competition_mode == "best_score":
+            if participation_phase not in {"upcoming", "scoring", "proof"}:
+                raise LabelReconciliationError("best-score Beta3 participation phase is malformed")
+            if not isinstance(scoring_window, dict):
+                raise LabelReconciliationError("best-score Beta3 scoring window is missing")
+            starts_at = parse_instant(scoring_window.get("starts_at"), "scoring_window.starts_at")
+            ends_at = parse_instant(scoring_window.get("ends_at"), "scoring_window.ends_at")
+            if starts_at >= ends_at:
+                raise LabelReconciliationError("best-score Beta3 scoring window is malformed")
+            if not isinstance(scoring_formula, str) or not scoring_formula.strip():
+                raise LabelReconciliationError("best-score Beta3 scoring formula is missing")
+            if not isinstance(qualifying_action, dict) or not str(
+                qualifying_action.get("objective") or ""
+            ).strip():
+                raise LabelReconciliationError("best-score Beta3 qualifying action is missing")
+            if not isinstance(cash_economics, dict):
+                raise LabelReconciliationError("best-score Beta3 cash economics are missing")
         target = opportunity_amount(opportunity, "funding_target")
         settlement = beta3_settlement_evidence(opportunity, canonical, relevant, safe_number)
         created_block = min(
@@ -824,6 +912,14 @@ def augment_projection_with_beta3(
         next_action = opportunity.get("next_action")
         if not isinstance(next_action, dict):
             raise LabelReconciliationError("public Beta3 opportunity lacks a next action")
+        next_action_kind = str(next_action.get("action") or "")
+        next_action_label = {
+            "prepare_open_competition_v2_score": "Prepare scoring work",
+            "generate_open_competition_v2_score": "Generate a qualifying score",
+            "inspect_open_competition_v2_snapshot": "Inspect the scoring snapshot",
+            "quote_open_competition_v2_proof": "Enter competition",
+            "inspect_open_competition_v2_settlement": "Inspect settlement",
+        }.get(next_action_kind, "Enter competition")
         selected.append(
             {
                 "discovery_id": f"eip155:{chain_id}:{BETA3_PROTOCOL}:{contract}",
@@ -871,12 +967,17 @@ def augment_projection_with_beta3(
                     "ready": verification_ready,
                 },
                 "next_action": {
-                    "kind": next_action.get("action"),
-                    "label": "Inspect settlement" if lifecycle == "settled" else "Enter competition",
+                    "kind": next_action_kind,
+                    "label": "Inspect settlement" if lifecycle == "settled" else next_action_label,
                     "method": next_action.get("method"),
                     "url": next_action.get("url"),
                     "instructions": next_action.get("instructions"),
                 },
+                "participation_phase": participation_phase,
+                "scoring_window": scoring_window,
+                "scoring_formula": scoring_formula,
+                "qualifying_action": qualifying_action,
+                "cash_economics": cash_economics,
                 "recovery_action_available": False,
                 "identity_warning": "One wallet does not prove one independent person.",
                 "settlement_evidence": settlement,
@@ -1098,6 +1199,30 @@ def parse_same_repository_issue(source_url: Any, repository: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
+def is_same_repository_reviewed_beta3_artifact(source_url: Any, repository: str) -> bool:
+    """Admit only immutable, reviewed Beta3 source artifacts from this repository."""
+    if source_url is None:
+        return False
+    try:
+        parsed = urllib.parse.urlsplit(str(source_url))
+    except ValueError as error:
+        raise LabelReconciliationError("source URL is malformed") from error
+    if parsed.scheme != "https" or parsed.hostname != "github.com":
+        return False
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise LabelReconciliationError("GitHub source URL must be exact and credential-free")
+    prefix = f"/{repository}/blob/"
+    if not parsed.path.startswith(prefix):
+        return False
+    remainder = parsed.path[len(prefix) :]
+    revision, separator, path = remainder.partition("/")
+    return bool(
+        separator
+        and re.fullmatch(r"[0-9a-f]{40}", revision)
+        and path in REVIEWED_BETA3_SOURCE_PATHS
+    )
+
+
 def fetch_linked_source_issues(
     request: HttpRequest,
     repository: str,
@@ -1228,6 +1353,12 @@ def render_managed_block(item: Mapping[str, Any]) -> str:
     if not isinstance(next_action, dict) or not isinstance(next_action.get("label"), str):
         raise LabelReconciliationError(f"next action is malformed: {identity}")
     action_url = add_attribution(str(next_action.get("url")), identity)
+    competition_mode = str(item["competition_mode"])
+    competition_state = competition_mode
+    if competition_mode == "first_valid_submission" and item["lifecycle_state"] == "ready_to_earn":
+        competition_state = "accepting_entries"
+    elif competition_mode == "best_score":
+        competition_state = str(item.get("participation_phase") or "best_score")
     lines = [
         MANAGED_START,
         f"<!-- agent-bounties/github-discovery-v1 {marker} -->",
@@ -1237,7 +1368,7 @@ def render_managed_block(item: Mapping[str, Any]) -> str:
         "",
         f"- **Current work state:** `{item['lifecycle_state']}`",
         f"- **Current payment state:** `{'paid' if item['lifecycle_state'] == 'settled' else 'escrowed' if item.get('funded') is True else 'unfunded'}`",
-        f"- **Current competition state:** `{'accepting_entries' if item['competition_mode'] == 'first_valid_submission' and item['lifecycle_state'] == 'ready_to_earn' else item['competition_mode']}`",
+        f"- **Current competition state:** `{competition_state}`",
         f"- **Solver reward:** {format_usdc(item['reward_usdc_base_units'])} USDC",
         f"- **Entry/claim bond:** {format_usdc(item['bond_usdc_base_units'])} USDC",
         f"- **Funding:** {format_usdc(item['funded_usdc_base_units'])} / {format_usdc(item['funding_target_usdc_base_units'])} USDC",
@@ -1248,8 +1379,10 @@ def render_managed_block(item: Mapping[str, Any]) -> str:
             f"- **Verifier:** {verifier.get('display_name', 'Unspecified')} "
             f"(`{verifier.get('method', 'unknown')}`; ready: `{str(verifier.get('ready') is True).lower()}`)"
         )
-    if item.get("entry_count") is not None or item.get("max_entries") is not None:
-        lines.append(f"- **Capacity:** {item.get('entry_count', 0)} / {item.get('max_entries', '?')} entries")
+    if item.get("max_entries") is not None:
+        lines.append(f"- **Capacity:** {item.get('entry_count', 0)} / {item['max_entries']} entries")
+    elif item.get("entry_count") is not None:
+        lines.append(f"- **Accepted entries:** {item['entry_count']}")
     if item.get("deadline"):
         lines.append(f"- **{str(item.get('deadline_kind') or 'Deadline').replace('_', ' ').title()}:** `{item['deadline']}`")
     if action_required:
@@ -1292,6 +1425,36 @@ def render_managed_block(item: Mapping[str, Any]) -> str:
                 "### Open Competition rules",
                 "",
                 "First valid confirmed reveal wins. Each wallet may enter once; an entry does not prove one independent person. Save the local commitment recovery envelope because the API never stores its plaintext salt.",
+            ]
+        )
+    elif item["competition_mode"] == "best_score":
+        scoring_window = item.get("scoring_window")
+        qualifying_action = item.get("qualifying_action")
+        cash_economics = item.get("cash_economics")
+        if (
+            not isinstance(scoring_window, dict)
+            or not isinstance(qualifying_action, dict)
+            or not isinstance(cash_economics, dict)
+        ):
+            raise LabelReconciliationError(f"best-score discovery evidence is missing: {identity}")
+        exclusions = qualifying_action.get("excluded")
+        if not isinstance(exclusions, list) or not all(
+            isinstance(value, str) and value.strip() for value in exclusions
+        ):
+            raise LabelReconciliationError(f"best-score exclusions are malformed: {identity}")
+        lines.extend(
+            [
+                "",
+                "### Best-score competition rules",
+                "",
+                str(qualifying_action.get("objective") or "").strip(),
+                "",
+                f"- **Scoring window:** `{scoring_window['starts_at']}` to `{scoring_window['ends_at']}`",
+                f"- **Scoring formula:** `{item['scoring_formula']}`",
+                f"- **Excluded:** {'; '.join(exclusions)}",
+                f"- **Hosted proof and relay cost:** {format_usdc(opportunity_amount(cash_economics, 'required_external_spend'))} USDC",
+                "- **Child funding:** user-selected, paid to the child solver after settlement, and still spent if this competition entry loses.",
+                "- **Decision rule:** use the contract-specific page to calculate win, loss, break-even, and expected cash result before funding.",
             ]
         )
     payment_event = (
@@ -1370,18 +1533,18 @@ def desired_labels(item: Mapping[str, Any], policy: Mapping[str, Any], generated
             labels.update({"ai-agent-welcome", "ready-to-earn", "claimable-live"})
             if isinstance(landing, dict):
                 labels.update(f"skill:{skill}" for skill in landing["skills"])
-            if mode == "first_valid_submission":
+            if mode in {"first_valid_submission", "best_score"}:
                 labels.update({"open-competition", "verifier"})
                 if not trial_claimable_enabled(policy, generated_at):
                     labels.discard("claimable-live")
     elif state == "in_progress":
         labels.add("funded-live")
         labels.add("claimed-live" if mode == "exclusive_claim" else "in-progress")
-        if mode == "first_valid_submission":
+        if mode in {"first_valid_submission", "best_score"}:
             labels.add("open-competition")
     elif state == "verification_pending":
         labels.update({"funded-live", "verification-pending"})
-        if mode == "first_valid_submission":
+        if mode in {"first_valid_submission", "best_score"}:
             labels.add("open-competition")
     elif state == "unavailable":
         if item.get("funded") is True:
@@ -1390,7 +1553,7 @@ def desired_labels(item: Mapping[str, Any], policy: Mapping[str, Any], generated
             labels.add("verification-unavailable")
         else:
             labels.add("in-progress")
-        if mode == "first_valid_submission":
+        if mode in {"first_valid_submission", "best_score"}:
             labels.add("open-competition")
     elif state in {"cancelled", "expired"}:
         labels.add(state)

--- a/scripts/sync_open_competition_v2_reward_public_metadata.py
+++ b/scripts/sync_open_competition_v2_reward_public_metadata.py
@@ -18,8 +18,9 @@ REGISTRY_SCHEMA = "agent-bounties/open-competition-v2-public-metadata-v1"
 COHORT_SCHEMA = "agent-bounties/open-competition-v2-forward-gmv-reward-cohort-v1"
 BUNDLE_SCHEMA = "agent-bounties/open-competition-v2-reward-policy-rotation-v1"
 RESULT_SCHEMA = "agent-bounties/open-competition-v2-reward-execution-v1"
+SOURCE_COMMIT = "b600500a0ba25babe5bf9d262472ef4f701b480a"
 SOURCE_URL = (
-    "https://github.com/NSPG13/agent-bounties/blob/main/ops/"
+    f"https://github.com/NSPG13/agent-bounties/blob/{SOURCE_COMMIT}/ops/"
     "open-competition-v2-forward-gmv-reward-cohort-v1.json"
 )
 ADDRESS = re.compile(r"^0x[0-9a-f]{40}$")

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -54,6 +54,22 @@ async function permissionlessDirectManifest() {
   return manifest;
 }
 
+test("canonical GMV review evidence stays pinned to the current release identity", async () => {
+  const identity = (
+    await readFile(
+      new URL(
+        "../programs/forward-canonical-gmv-attribution-metric-v2/release-identity.json",
+        import.meta.url,
+      ),
+      "utf8",
+    )
+  ).replaceAll("\r\n", "\n");
+  assert.equal(
+    CANONICAL_GMV_PROFILE.review_evidence_hash,
+    keccak256Hex(`0x${Buffer.from(identity, "utf8").toString("hex")}`),
+  );
+});
+
 test("Base RPC transport chunks public-endpoint batches and retries rate limits", async () => {
   const calls = Array.from({ length: 12 }, (_, index) => ({
     key: `call_${index}`,

--- a/scripts/test_agent_bounties_openclaw_skill.mjs
+++ b/scripts/test_agent_bounties_openclaw_skill.mjs
@@ -64,10 +64,15 @@ test("canonical GMV review evidence stays pinned to the current release identity
       "utf8",
     )
   ).replaceAll("\r\n", "\n");
-  assert.equal(
-    CANONICAL_GMV_PROFILE.review_evidence_hash,
-    keccak256Hex(`0x${Buffer.from(identity, "utf8").toString("hex")}`),
-  );
+  const expected = keccak256Hex(`0x${Buffer.from(identity, "utf8").toString("hex")}`);
+  assert.equal(CANONICAL_GMV_PROFILE.review_evidence_hash, expected);
+  for (const path of [
+    "../scripts/bounty_inventory_guard.py",
+    "../scripts/plan_open_competition_v2_replenishment.py",
+  ]) {
+    const source = await readFile(new URL(path, import.meta.url), "utf8");
+    assert.match(source, new RegExp(`review_evidence_hash["']?\\s*:\\s*["']${expected}["']`));
+  }
 });
 
 test("Base RPC transport chunks public-endpoint batches and retries rate limits", async () => {

--- a/scripts/test_bounty_inventory_guard.py
+++ b/scripts/test_bounty_inventory_guard.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 import unittest
@@ -19,7 +20,6 @@ if str(SCRIPT.parent) not in sys.path:
     sys.path.insert(0, str(SCRIPT.parent))
 
 import bounty_inventory_guard as GUARD
-import plan_open_competition_v2_replenishment as REPLENISHMENT
 
 
 def run_guard(
@@ -150,9 +150,12 @@ def open_competition_v2_report(*, count: int = 5) -> Path:
 class BountyInventoryGuardTests(unittest.TestCase):
     def test_gmv_review_evidence_matches_release_and_replenisher(self) -> None:
         expected = GUARD.REQUIRED_GMV_PROFILE["review_evidence_hash"]
-        self.assertEqual(GUARD.REQUIRED_GMV_PROFILE["review_evidence_hash"], expected)
+        replenisher = (SCRIPT.parent / "plan_open_competition_v2_replenishment.py").read_text(
+            encoding="utf-8"
+        )
         self.assertEqual(
-            REPLENISHMENT.REQUIRED_LIVE_GMV_PROFILE["review_evidence_hash"], expected
+            re.findall(r'"review_evidence_hash":\s*"(0x[0-9a-f]{64})"', replenisher),
+            [expected],
         )
 
     def test_rpc_probe_uses_failover_pool_and_redacts_credentials(self) -> None:

--- a/scripts/test_bounty_inventory_guard.py
+++ b/scripts/test_bounty_inventory_guard.py
@@ -19,7 +19,6 @@ if str(SCRIPT.parent) not in sys.path:
     sys.path.insert(0, str(SCRIPT.parent))
 
 import bounty_inventory_guard as GUARD
-import build_open_competition_v2_beta3_release as RELEASE
 import plan_open_competition_v2_replenishment as REPLENISHMENT
 
 
@@ -150,7 +149,7 @@ def open_competition_v2_report(*, count: int = 5) -> Path:
 
 class BountyInventoryGuardTests(unittest.TestCase):
     def test_gmv_review_evidence_matches_release_and_replenisher(self) -> None:
-        expected = RELEASE.CANONICAL_GMV_REVIEW_EVIDENCE_HASH
+        expected = GUARD.REQUIRED_GMV_PROFILE["review_evidence_hash"]
         self.assertEqual(GUARD.REQUIRED_GMV_PROFILE["review_evidence_hash"], expected)
         self.assertEqual(
             REPLENISHMENT.REQUIRED_LIVE_GMV_PROFILE["review_evidence_hash"], expected

--- a/scripts/test_bounty_inventory_guard.py
+++ b/scripts/test_bounty_inventory_guard.py
@@ -19,6 +19,8 @@ if str(SCRIPT.parent) not in sys.path:
     sys.path.insert(0, str(SCRIPT.parent))
 
 import bounty_inventory_guard as GUARD
+import build_open_competition_v2_beta3_release as RELEASE
+import plan_open_competition_v2_replenishment as REPLENISHMENT
 
 
 def run_guard(
@@ -147,6 +149,13 @@ def open_competition_v2_report(*, count: int = 5) -> Path:
 
 
 class BountyInventoryGuardTests(unittest.TestCase):
+    def test_gmv_review_evidence_matches_release_and_replenisher(self) -> None:
+        expected = RELEASE.CANONICAL_GMV_REVIEW_EVIDENCE_HASH
+        self.assertEqual(GUARD.REQUIRED_GMV_PROFILE["review_evidence_hash"], expected)
+        self.assertEqual(
+            REPLENISHMENT.REQUIRED_LIVE_GMV_PROFILE["review_evidence_hash"], expected
+        )
+
     def test_rpc_probe_uses_failover_pool_and_redacts_credentials(self) -> None:
         credentialed = "https://user:pass@rpc.example/v2/secret?api_key=hidden"
         with mock.patch.object(

--- a/scripts/test_open_competition_v2_replenishment_workflow.py
+++ b/scripts/test_open_competition_v2_replenishment_workflow.py
@@ -57,6 +57,7 @@ class ReplenishmentWorkflowContractTests(unittest.TestCase):
             "python -m pip install -r scripts/requirements-attest.txt",
             self.text,
         )
+        self.assertIn("-r scripts/requirements-site.txt", self.text)
 
 
 if __name__ == "__main__":

--- a/scripts/test_reconcile_github_bounty_labels.py
+++ b/scripts/test_reconcile_github_bounty_labels.py
@@ -16,11 +16,13 @@ from reconcile_github_bounty_labels import (
     MANAGED_START,
     HttpResult,
     LabelReconciliationError,
+    augment_projection_with_beta3,
     beta3_discovery_competition_mode,
     build_plans,
     execute_plans,
     fetch_github_issues,
     issue_marker,
+    is_same_repository_reviewed_beta3_artifact,
     load_landing_copy,
     main,
     plan_has_write,
@@ -403,13 +405,174 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
             with self.assertRaisesRegex(LabelReconciliationError, "exactly two sentences"):
                 load_landing_copy(path, REPOSITORY)
 
-    def test_beta3_discovery_rejects_unrepresentable_winner_mode(self) -> None:
+    def test_beta3_discovery_represents_supported_winner_modes(self) -> None:
         self.assertEqual(
             beta3_discovery_competition_mode("first_proven"),
             "first_valid_submission",
         )
+        self.assertEqual(beta3_discovery_competition_mode("best_score"), "best_score")
         with self.assertRaisesRegex(LabelReconciliationError, "winner mode safely"):
-            beta3_discovery_competition_mode("best_score")
+            beta3_discovery_competition_mode("subjective_judgment")
+
+    def test_beta3_artifact_source_requires_pinned_allowlisted_same_repo_url(self) -> None:
+        pinned = (
+            f"https://github.com/{REPOSITORY}/blob/"
+            + "a" * 40
+            + "/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json"
+        )
+        self.assertTrue(is_same_repository_reviewed_beta3_artifact(pinned, REPOSITORY))
+        self.assertFalse(
+            is_same_repository_reviewed_beta3_artifact(
+                f"https://github.com/{REPOSITORY}/blob/main/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
+                REPOSITORY,
+            )
+        )
+        self.assertFalse(
+            is_same_repository_reviewed_beta3_artifact(
+                f"https://github.com/{REPOSITORY}/blob/{'a' * 40}/README.md",
+                REPOSITORY,
+            )
+        )
+        self.assertFalse(
+            is_same_repository_reviewed_beta3_artifact(
+                f"https://github.com/another/repo/blob/{'a' * 40}/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json",
+                REPOSITORY,
+            )
+        )
+
+    def test_beta3_augmentation_includes_pinned_best_score_artifact(self) -> None:
+        contract = "0x" + "4" * 40
+        bounty_id = "0x" + "5" * 64
+        source_url = (
+            f"https://github.com/{REPOSITORY}/blob/"
+            + "a" * 40
+            + "/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json"
+        )
+        base = projection()
+        base["source_statuses"] = [
+            source
+            for source in base["source_statuses"]
+            if source["protocol_version"] != BETA3_PROTOCOL
+        ]
+        amount = lambda value: {
+            "amount": str(value),
+            "currency": "USDC",
+            "unit": "base_units",
+        }
+        inventory = {
+            "network": NETWORK,
+            "protocol_version": BETA3_PROTOCOL,
+            "competitions": [
+                {
+                    "record": {
+                        "network": NETWORK,
+                        "factory_contract": "0x" + "3" * 40,
+                        "safe_block_number": 49_799_500,
+                        "safe_block_hash": "0x" + "d" * 64,
+                        "projection": {
+                            "competition": contract,
+                            "bounty_id": bounty_id,
+                            "state": "active",
+                            "winner_mode": "best_score",
+                        },
+                    }
+                }
+            ],
+        }
+        events = {
+            "network": NETWORK,
+            "protocol_version": BETA3_PROTOCOL,
+            "events": [
+                {
+                    "contract_address": contract,
+                    "bounty_id": bounty_id,
+                    "block_number": 49_799_100,
+                    "kind": "competition_activated",
+                }
+            ],
+        }
+        opportunity = {
+            "source_id": contract,
+            "source_url": source_url,
+            "created_at": "2026-08-24T18:00:00Z",
+            "updated_at": "2026-08-24T18:00:00Z",
+            "title": "6 USDC prize — Highest externally funded canonical GMV — daily 20260825",
+            "goal": "Create and fund useful demand. Highest eligible score wins.",
+            "categories": ["research"],
+            "skills": ["browser"],
+            "public_url": f"https://agentbounties.app/competition.html?bountyContract={contract}&network=base-mainnet",
+            "verification_ready": True,
+            "winner_mode": "best_score",
+            "reward": amount(6_000_000),
+            "completion_bonus": amount(40_000),
+            "bond": amount(0),
+            "funded_amount": amount(6_040_000),
+            "funding_target": amount(6_040_000),
+            "entry_count": 0,
+            "deadline": "2026-11-22T00:00:00Z",
+            "deadline_kind": "proof_deadline",
+            "verifier_profile_id": "forward-canonical-gmv-attribution-metric-v2",
+            "verifier_profile_name": "forward-canonical-gmv-attribution-metric-v2",
+            "verification_method": "sp1_plonk",
+            "cash_economics": {"required_external_spend": amount(110_000)},
+            "evidence_requirements": {
+                "protocol_version": BETA3_PROTOCOL,
+                "participation_phase": "upcoming",
+                "scoring_window": {
+                    "starts_at": "2026-08-25T00:00:00Z",
+                    "ends_at": "2026-08-26T00:00:00Z",
+                    "minimum_score_base_units": "1",
+                },
+                "scoring_formula": "sum(settlement_gmv * entrant_funding / total_funding)",
+                "qualifying_action": {
+                    "objective": "Post or fund useful marketplace demand that reaches canonical settlement inside the scoring window.",
+                    "excluded": ["operator or reserve wallets"],
+                },
+            },
+            "next_action": {
+                "action": "prepare_open_competition_v2_score",
+                "method": "GET",
+                "url": f"https://agentbounties.app/competition.html?bountyContract={contract}&network=base-mainnet",
+                "instructions": "Prepare the exact child-bounty brief.",
+            },
+        }
+
+        def request(method, url, body, headers):
+            if "/v1/metrics/platform" in url:
+                return HttpResult(
+                    200,
+                    {
+                        "coverage": {
+                            "marketplace_indexers_fresh": True,
+                            "awaiting_block_time_events": 0,
+                        }
+                    },
+                    {},
+                )
+            if "/inventory?" in url:
+                return HttpResult(200, inventory, {})
+            if "/events?" in url:
+                return HttpResult(200, events, {})
+            if "/v1/opportunities?" in url:
+                return HttpResult(200, {"items": [opportunity]}, {})
+            raise AssertionError(url)
+
+        augmented = augment_projection_with_beta3(
+            request,
+            "https://api.agentbounties.app",
+            NETWORK,
+            REPOSITORY,
+            base,
+        )
+        beta3 = [
+            record
+            for record in augmented["items"]
+            if record["protocol_version"] == BETA3_PROTOCOL
+        ]
+        self.assertEqual(len(beta3), 1)
+        self.assertEqual(beta3[0]["competition_mode"], "best_score")
+        self.assertEqual(beta3[0]["participation_phase"], "upcoming")
+        self.assertEqual(beta3[0]["next_action"]["label"], "Prepare scoring work")
 
     def test_workflow_is_least_privilege_concurrent_dry_run_by_default(self) -> None:
         workflow = Path(".github/workflows/bounty-inventory-guard.yml").read_text(encoding="utf-8")
@@ -438,6 +601,76 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
         self.assertIn("First valid confirmed reveal wins", plan.desired_body)
         self.assertIn("discovery_id=", plan.desired_body)
         self.assertNotIn("competition", plan.desired_managed_labels)
+
+    def test_best_score_beta3_artifact_creates_decision_grade_mirror(self) -> None:
+        record = item(1060)
+        contract = record["bounty_contract"]
+        record.update(
+            {
+                "discovery_id": f"eip155:{CHAIN_ID}:{BETA3_PROTOCOL}:{contract}",
+                "protocol_version": BETA3_PROTOCOL,
+                "source_url": (
+                    f"https://github.com/{REPOSITORY}/blob/"
+                    + "a" * 40
+                    + "/ops/open-competition-v2-forward-gmv-reward-cohort-v1.json"
+                ),
+                "competition_mode": "best_score",
+                "title": "6 USDC prize — Highest externally funded canonical GMV — daily 20260825",
+                "public_url": f"https://agentbounties.app/competition.html?bountyContract={contract}&network=base-mainnet",
+                "reward_usdc_base_units": "6000000",
+                "verifier_reward_usdc_base_units": "40000",
+                "bond_usdc_base_units": "0",
+                "funded_usdc_base_units": "6040000",
+                "funding_target_usdc_base_units": "6040000",
+                "entry_count": 0,
+                "max_entries": None,
+                "participation_phase": "upcoming",
+                "scoring_window": {
+                    "starts_at": "2026-08-25T00:00:00Z",
+                    "ends_at": "2026-08-26T00:00:00Z",
+                    "minimum_score_base_units": "1",
+                },
+                "scoring_formula": "sum(settlement_gmv * entrant_funding / total_funding)",
+                "qualifying_action": {
+                    "objective": "Post or fund useful marketplace demand that reaches canonical settlement inside the scoring window.",
+                    "excluded": ["operator or reserve wallets", "excluded reward contracts"],
+                },
+                "cash_economics": {
+                    "required_external_spend": {
+                        "amount": "110000",
+                        "currency": "USDC",
+                        "unit": "base_units",
+                    }
+                },
+                "next_action": {
+                    "kind": "prepare_open_competition_v2_score",
+                    "label": "Prepare scoring work",
+                    "method": "GET",
+                    "url": f"https://agentbounties.app/competition.html?bountyContract={contract}&network=base-mainnet",
+                    "instructions": "Prepare now; do not fund score before the UTC window starts.",
+                },
+            }
+        )
+        plan = build_plans(
+            projection(record),
+            [],
+            policy(),
+            REPOSITORY,
+            landing_entries={},
+        )[0]
+        self.assertTrue(plan.create_eligible)
+        self.assertEqual(plan.mapping_action, "current_nonterminal_backfill")
+        self.assertTrue(
+            {"ready-to-earn", "claimable-live", "open-competition", "verifier"}.issubset(
+                plan.desired_managed_labels
+            )
+        )
+        self.assertIn("Current competition state:** `upcoming`", plan.desired_body)
+        self.assertIn("2026-08-25T00:00:00Z", plan.desired_body)
+        self.assertIn("Hosted proof and relay cost:** 0.11 USDC", plan.desired_body)
+        self.assertIn("still spent if this competition entry loses", plan.desired_body)
+        self.assertIn("Prepare scoring work", plan.desired_body)
+        self.assertTrue(plan.title.startswith("Generate qualifying GMV"))
 
     def test_github_claim_command_recovers_to_open_competition(self) -> None:
         contract = "0x" + "3" * 40

--- a/skills/agent-bounties/scripts/check-in.mjs
+++ b/skills/agent-bounties/scripts/check-in.mjs
@@ -26,7 +26,7 @@ export const CANONICAL_GMV_PROFILE = Object.freeze({
   elf_hash: "0x75a339253a0b0dac3162abf55f4a1a97ff6d9ae471992b44e9f54cc17978c7b8",
   journal_schema_hash: "0x660ddc720ea9fc13e7bbdd88839a2ac7b19a124e5daf046518350fa6febe8a40",
   metric_program_hash: "0xe1b52ffcfff0675b7dacea84dcabdf3fbcf1cde09b3d2fb55aa389acac5c2ff9",
-  review_evidence_hash: "0xa721b85db55db5c827dee508d89de09a222d9d70150f3eeb2a69a34b670023dd",
+  review_evidence_hash: "0x3e2c7a15171134c86436148ff0d0f871eeeca205f1328b3f41a23e75437a5c21",
 });
 
 const ADDRESS = /^0x[0-9a-fA-F]{40}$/;


### PR DESCRIPTION
## Outcome

Make canonically funded Open Competition V2 `best_score` opportunities discoverable through the existing unified GitHub bounty mirror, while keeping public marketplace totals mechanism-neutral.

## Finding / impact / action

- Finding: the reconciler admitted V2 only when `source_url` was an existing same-repository issue and rejected `best_score`, so all 15 active V2 records were absent from the GitHub discovery projection.
- Impact: external agents searching the repository's bounty labels could not discover the competitions. A separate stale review-evidence hash also made the private floor guard report the 15 canonically active contracts as unhealthy.
- Action: accept only exact, immutable, commit-addressed reviewed V2 artifacts; represent `best_score`; synthesize decision-grade mirror copy with phase, UTC window, scoring rule, exclusions, proof cost, losing exposure, and contract-specific action; pin the current release-evidence hash across all guard consumers.
- Done when: production dry-run selects the V2 records, one idempotent mirror exists per contract, a second dry-run plans no writes, and the portable V2 floor is healthy.

## Safety boundaries

- GitHub remains a non-authoritative discovery mirror. This patch cannot fund, enter, verify, settle, or prove payment.
- No public bounty-type counts or split GMV are added.
- Source provenance is allowlisted to two reviewed ops artifacts at lowercase 40-hex commits; branches, arbitrary paths, credentials, query strings, and fragments fail closed.
- The separate standing-meta invariant is unchanged.

## Maintainer notice and overlap

- Notice: https://github.com/NSPG13/agent-bounties/issues/1183#issuecomment-5399581178
- Review-hash finding: https://github.com/NSPG13/agent-bounties/issues/1183#issuecomment-5399766955
- Rechecked the open PR queue before push. PR #903 remains relevant to broader unassisted usability but does not implement this discovery provenance/indexing repair. PR #970 remains a separate planner and is not reused or modified here.

## Validation

- `scripts/check.ps1` (full repository gate) — passed after adding the existing Foundry install to `PATH`
- Rust workspace: fmt, clippy, all unit/doc tests, API/MCP build and service smoke — passed
- Python/Node/TypeScript/site/docs/SDK checks — passed
- `forge test --fuzz-runs 1000` — 219 passed, 0 failed, 11 skipped
- V2 release/prover regression suite — 118 passed
- Focused reconciler tests — 28 passed