### PR TITLE
fix: isolate degraded bounty discovery sources

### DIFF
--- a/scripts/reconcile_github_bounty_labels.py
+++ b/scripts/reconcile_github_bounty_labels.py
@@ -865,12 +865,22 @@ def _augment_projection_with_beta3(
         if isinstance(opportunity_sources, list)
         else []
     )
-    if (
-        opportunities.get("degraded") is not False
-        or len(canonical_sources) != 1
-        or canonical_sources[0].get("available") is not True
-    ):
+    if len(canonical_sources) != 1:
+        raise LabelReconciliationError("Beta3 opportunity source status is malformed")
+    canonical_error = str(canonical_sources[0].get("error") or "")
+    canonical_error_codes = set(canonical_error.split("+")) if canonical_error else set()
+    known_canonical_errors = {
+        "canonical_read_model_unavailable",
+        "open_competition_read_model_unavailable",
+        "open_competition_v2_read_model_unavailable",
+    }
+    if not canonical_error_codes.issubset(known_canonical_errors):
+        raise LabelReconciliationError("Beta3 opportunity source status is malformed")
+    if "open_competition_v2_read_model_unavailable" in canonical_error_codes:
         raise LabelReconciliationError("Beta3 opportunity projection is degraded")
+    expected_available = not canonical_error_codes
+    if canonical_sources[0].get("available") is not expected_available:
+        raise LabelReconciliationError("Beta3 opportunity source status is inconsistent")
     inventory_factory = str(inventory.get("factory_contract") or "").lower()
     event_factory = str(event_feed.get("factory_contract") or "").lower()
     if (

--- a/scripts/reconcile_github_bounty_labels.py
+++ b/scripts/reconcile_github_bounty_labels.py
@@ -524,18 +524,34 @@ def validate_projection(payload: Any, network: str, policy: Mapping[str, Any]) -
         or not TX_HASH.fullmatch(str(safe.get("hash") or "").lower())
     ):
         raise LabelReconciliationError("discovery projection is degraded or stale")
+    partial_protocols_raw = payload.get("partial_protocols", [])
+    if (
+        not isinstance(partial_protocols_raw, list)
+        or not all(isinstance(protocol, str) for protocol in partial_protocols_raw)
+        or len(set(partial_protocols_raw)) != len(partial_protocols_raw)
+        or not set(partial_protocols_raw).issubset({BETA3_PROTOCOL})
+    ):
+        raise LabelReconciliationError("partial projection protocols are malformed")
+    partial_protocols = set(partial_protocols_raw)
     sources = payload.get("source_statuses")
     if not isinstance(sources, list) or {
         source.get("protocol_version") for source in sources if isinstance(source, dict)
     } != SUPPORTED_PROTOCOLS:
         raise LabelReconciliationError("discovery projection protocol adapters are incomplete")
-    if any(
-        not isinstance(source, dict)
-        or source.get("available") is not True
-        or source.get("fresh") is not True
-        for source in sources
-    ):
-        raise LabelReconciliationError("a canonical projection source is degraded")
+    for source in sources:
+        if not isinstance(source, dict):
+            raise LabelReconciliationError("a canonical projection source is malformed")
+        protocol = str(source.get("protocol_version") or "")
+        if protocol in partial_protocols:
+            if (
+                source.get("available") is not False
+                or source.get("fresh") is not False
+                or require_unsigned(source.get("item_count"), f"{protocol}.item_count") != 0
+                or not str(source.get("error") or "").strip()
+            ):
+                raise LabelReconciliationError("a partial projection source is malformed")
+        elif source.get("available") is not True or source.get("fresh") is not True:
+            raise LabelReconciliationError("a canonical projection source is degraded")
     items = payload.get("items")
     if not isinstance(items, list) or not all(isinstance(item, dict) for item in items):
         raise LabelReconciliationError("discovery projection items are malformed")
@@ -550,6 +566,7 @@ def validate_projection(payload: Any, network: str, policy: Mapping[str, Any]) -
             not DISCOVERY_ID.fullmatch(identity)
             or identity in seen
             or protocol not in SUPPORTED_PROTOCOLS
+            or protocol in partial_protocols
             or lifecycle not in LIFECYCLE_STATES
             or mode not in {"exclusive_claim", "first_valid_submission", "best_score"}
             or not ADDRESS.fullmatch(contract)
@@ -773,25 +790,56 @@ def augment_projection_with_beta3(
     repository: str,
     projection: Mapping[str, Any],
 ) -> dict[str, Any]:
+    try:
+        return _augment_projection_with_beta3(
+            request, api_base_url, network, repository, projection
+        )
+    except LabelReconciliationError as error:
+        return beta3_unavailable_projection(projection, str(error))
+
+
+def beta3_unavailable_projection(
+    projection: Mapping[str, Any], error: str
+) -> dict[str, Any]:
+    result = dict(projection)
+    existing_items = result.get("items")
+    existing_sources = result.get("source_statuses")
+    if not isinstance(existing_items, list) or not isinstance(existing_sources, list):
+        raise LabelReconciliationError("core discovery projection is malformed")
+    result["items"] = [
+        item
+        for item in existing_items
+        if isinstance(item, dict) and item.get("protocol_version") != BETA3_PROTOCOL
+    ]
+    result["source_statuses"] = [
+        source
+        for source in existing_sources
+        if isinstance(source, dict) and source.get("protocol_version") != BETA3_PROTOCOL
+    ]
+    result["source_statuses"].append(
+        {
+            "source_type": "open_competition_v2",
+            "protocol_version": BETA3_PROTOCOL,
+            "factory_contract": None,
+            "available": False,
+            "fresh": False,
+            "item_count": 0,
+            "persisted_cursor_block": 0,
+            "error": f"beta3_projection_unavailable: {error}",
+        }
+    )
+    result["partial_protocols"] = [BETA3_PROTOCOL]
+    return result
+
+
+def _augment_projection_with_beta3(
+    request: HttpRequest,
+    api_base_url: str,
+    network: str,
+    repository: str,
+    projection: Mapping[str, Any],
+) -> dict[str, Any]:
     query = urllib.parse.urlencode({"network": network})
-    metrics = fetch_json_object(
-        request,
-        f"{api_base_url}/v1/metrics/platform?period=7d",
-        "platform metrics",
-    )
-    coverage = metrics.get("coverage")
-    beta3_fresh = (
-        coverage.get("marketplace_indexers_fresh")
-        if isinstance(coverage, dict)
-        else False
-    )
-    if (
-        not isinstance(coverage, dict)
-        or beta3_fresh is not True
-        or require_unsigned(coverage.get("awaiting_block_time_events"), "awaiting_block_time_events")
-        != 0
-    ):
-        raise LabelReconciliationError("Beta3 canonical indexer is degraded")
     inventory = fetch_json_object(
         request,
         f"{api_base_url}/v1/base/open-competition-v2-beta3/inventory?{query}",
@@ -807,11 +855,31 @@ def augment_projection_with_beta3(
         f"{api_base_url}/v1/opportunities?{urllib.parse.urlencode({'network': network, 'source_type': 'canonical_base', 'limit': 300})}",
         "opportunity inventory",
     )
+    opportunity_sources = opportunities.get("source_statuses")
+    canonical_sources = (
+        [
+            source
+            for source in opportunity_sources
+            if isinstance(source, dict) and source.get("source_type") == "canonical_base"
+        ]
+        if isinstance(opportunity_sources, list)
+        else []
+    )
+    if (
+        opportunities.get("degraded") is not False
+        or len(canonical_sources) != 1
+        or canonical_sources[0].get("available") is not True
+    ):
+        raise LabelReconciliationError("Beta3 opportunity projection is degraded")
+    inventory_factory = str(inventory.get("factory_contract") or "").lower()
+    event_factory = str(event_feed.get("factory_contract") or "").lower()
     if (
         inventory.get("network") != network
         or inventory.get("protocol_version") != BETA3_PROTOCOL
         or event_feed.get("network") != network
         or event_feed.get("protocol_version") != BETA3_PROTOCOL
+        or not ADDRESS.fullmatch(inventory_factory)
+        or inventory_factory != event_factory
     ):
         raise LabelReconciliationError("Beta3 canonical views disagree on protocol or network")
     competitions = inventory.get("competitions")
@@ -845,7 +913,7 @@ def augment_projection_with_beta3(
             raise LabelReconciliationError("Beta3 inventory identity is malformed or duplicated")
         records[contract] = (canonical, safe_number, safe_hash)
         factories.add(factory)
-    if len(factories) != 1:
+    if factories != {inventory_factory}:
         raise LabelReconciliationError("Beta3 inventory does not have one factory")
     selected = []
     chain_id = require_unsigned(projection.get("chain_id"), "projection.chain_id")
@@ -1003,6 +1071,7 @@ def augment_projection_with_beta3(
             "error": None,
         },
     ]
+    result.pop("partial_protocols", None)
     return result
 
 
@@ -2177,6 +2246,8 @@ def main(argv: list[str] | None = None, request: HttpRequest = default_http_requ
         "projection_schema_version": projection.get("schema_version"),
         "projection_generated_at": projection.get("generated_at"),
         "projection_safe_block": projection.get("safe_block"),
+        "partial_protocols": projection.get("partial_protocols", []),
+        "source_statuses": projection.get("source_statuses", []),
         "projection_record_count": len(plans),
         "mapped_issue_count_before_reconciliation": sum(
             plan.issue_number is not None for plan in eligible

--- a/scripts/test_reconcile_github_bounty_labels.py
+++ b/scripts/test_reconcile_github_bounty_labels.py
@@ -27,6 +27,7 @@ from reconcile_github_bounty_labels import (
     main,
     plan_has_write,
     request_with_retry,
+    validate_projection,
 )
 from github_claim_comment import open_competition_wrong_mode_plan
 
@@ -537,24 +538,26 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
             },
         }
 
+        inventory["factory_contract"] = "0x" + "3" * 40
+        events["factory_contract"] = "0x" + "3" * 40
+
         def request(method, url, body, headers):
-            if "/v1/metrics/platform" in url:
-                return HttpResult(
-                    200,
-                    {
-                        "coverage": {
-                            "marketplace_indexers_fresh": True,
-                            "awaiting_block_time_events": 0,
-                        }
-                    },
-                    {},
-                )
             if "/inventory?" in url:
                 return HttpResult(200, inventory, {})
             if "/events?" in url:
                 return HttpResult(200, events, {})
             if "/v1/opportunities?" in url:
-                return HttpResult(200, {"items": [opportunity]}, {})
+                return HttpResult(
+                    200,
+                    {
+                        "degraded": False,
+                        "source_statuses": [
+                            {"source_type": "canonical_base", "available": True}
+                        ],
+                        "items": [opportunity],
+                    },
+                    {},
+                )
             raise AssertionError(url)
 
         augmented = augment_projection_with_beta3(
@@ -573,6 +576,58 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
         self.assertEqual(beta3[0]["competition_mode"], "best_score")
         self.assertEqual(beta3[0]["participation_phase"], "upcoming")
         self.assertEqual(beta3[0]["next_action"]["label"], "Prepare scoring work")
+
+    def test_beta3_outage_preserves_other_protocol_reconciliation(self) -> None:
+        core = item(42)
+        base = projection(core)
+        base["source_statuses"] = [
+            source
+            for source in base["source_statuses"]
+            if source["protocol_version"] != BETA3_PROTOCOL
+        ]
+
+        def request(method, url, body, headers):
+            if "/inventory?" in url:
+                return HttpResult(503, {"error": "read model unavailable"}, {})
+            raise AssertionError(url)
+
+        augmented = augment_projection_with_beta3(
+            request,
+            "https://api.agentbounties.app",
+            NETWORK,
+            REPOSITORY,
+            base,
+        )
+        validated = validate_projection(augmented, NETWORK, policy())
+
+        self.assertEqual(validated, [core])
+        self.assertEqual(augmented["partial_protocols"], [BETA3_PROTOCOL])
+        beta3_source = next(
+            source
+            for source in augmented["source_statuses"]
+            if source["protocol_version"] == BETA3_PROTOCOL
+        )
+        self.assertFalse(beta3_source["available"])
+        self.assertFalse(beta3_source["fresh"])
+        self.assertIn("returned HTTP 503", beta3_source["error"])
+
+    def test_partial_protocol_cannot_publish_items(self) -> None:
+        beta3 = item(43)
+        beta3["protocol_version"] = BETA3_PROTOCOL
+        beta3["competition_mode"] = "best_score"
+        partial = projection(beta3)
+        partial["partial_protocols"] = [BETA3_PROTOCOL]
+        beta3_source = next(
+            source
+            for source in partial["source_statuses"]
+            if source["protocol_version"] == BETA3_PROTOCOL
+        )
+        beta3_source.update(
+            {"available": False, "fresh": False, "item_count": 0, "error": "unavailable"}
+        )
+
+        with self.assertRaisesRegex(LabelReconciliationError, "malformed discovery record"):
+            validate_projection(partial, NETWORK, policy())
 
     def test_workflow_is_least_privilege_concurrent_dry_run_by_default(self) -> None:
         workflow = Path(".github/workflows/bounty-inventory-guard.yml").read_text(encoding="utf-8")
@@ -1017,6 +1072,8 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
             self.assertEqual(payload["mode"], "dry-run")
             self.assertEqual(payload["coverage_percent"], 100.0)
             self.assertEqual(payload["covered_record_count"], 1)
+            self.assertEqual(payload["partial_protocols"], [])
+            self.assertEqual(len(payload["source_statuses"]), 3)
             self.assertIn("Covered records: `1`", markdown.read_text(encoding="utf-8"))
             with self.assertRaisesRegex(LabelReconciliationError, "fixture mode"):
                 with patch.dict(os.environ, {"GITHUB_TOKEN": "token"}):

--- a/scripts/test_reconcile_github_bounty_labels.py
+++ b/scripts/test_reconcile_github_bounty_labels.py
@@ -550,9 +550,13 @@ class GitHubDiscoveryReconciliationTests(unittest.TestCase):
                 return HttpResult(
                     200,
                     {
-                        "degraded": False,
+                        "degraded": True,
                         "source_statuses": [
-                            {"source_type": "canonical_base", "available": True}
+                            {
+                                "source_type": "canonical_base",
+                                "available": False,
+                                "error": "canonical_read_model_unavailable",
+                            }
                         ],
                         "items": [opportunity],
                     },


### PR DESCRIPTION
## Summary

- isolate Open Competition V2 Beta3 discovery outages from healthy autonomous-v1 and open-competition-v1 lifecycle reconciliation
- preserve every Beta3 issue unchanged while its source is unavailable
- keep strict fail-closed validation for any source that is published
- expose partial protocols and source status in reconciliation reports
- remove the unrelated global platform-metrics freshness dependency

Maintainer notice: #1248

## Why

Thirteen canonically expired claim/submission rounds were reopened on 2026-08-27, but GitHub labels could not converge whenever the intermittent Beta3 read model made the aggregate marketplace freshness signal false. A missing/degraded Beta3 record must never authorize a Beta3 write, but it also should not strand healthy autonomous lifecycle updates.

## Verification

- `python -B scripts/test_reconcile_github_bounty_labels.py -v` — 31 passed
- `python -m py_compile scripts/reconcile_github_bounty_labels.py scripts/test_reconcile_github_bounty_labels.py` — passed
- `scripts/preflight.ps1 -Mode core` — passed
- live dry run — 13 pending safe reconciliation writes identified
- `scripts/check.ps1` — stopped at full preflight because `forge` is not installed locally; no repository test ran or failed

## Safety boundaries

- GitHub remains a non-authoritative discovery mirror.
- Missing Beta3 data preserves existing Beta3 issues and labels unchanged.
- Only confirmed canonical settlement events can produce paid language.
- No contract, wallet, escrow, or payout behavior changes.