### PR TITLE
fix: harden claim next-action mapper to match known-good benchmark

### DIFF
--- a/benchmarks/direct-v1/agent-loop/self-test.mjs
+++ b/benchmarks/direct-v1/agent-loop/self-test.mjs
@@ -14,6 +14,7 @@ mkdirSync(scriptsRoot, { recursive: true });
 const claimImplementation = `
 import { readFileSync } from "node:fs";
 const emit = (value, status = 0) => { console.log(JSON.stringify(value)); process.exit(status); };
+const allowedReplay = (u) => { try { const p = new URL(u); return p.protocol === "https:" && p.hostname === "api.agentbounties.app"; } catch { return false; } };
 if (process.argv.length !== 3) emit({ok:false,errors:["claim_response_path_required"]}, 2);
 let text;
 try { text = readFileSync(process.argv[2], "utf8"); } catch { emit({ok:false,errors:["claim_response_unreadable"]}, 2); }
@@ -34,7 +35,7 @@ if (state === "authorization_ready") {
   const next = value.next_request;
   const params = request?.params;
   const solver = String(candidate.solver_wallet ?? "").toLowerCase();
-  const valid = request?.method === "eth_signTypedData_v4" && Array.isArray(params) && params.length === 2 && String(params[0]).toLowerCase() === solver && /^0x[0-9a-f]{40}$/.test(solver) && typeof params[1] === "string" && params[1].length > 0 && next && !Array.isArray(next) && typeof next === "object" && typeof next.url === "string" && next.method === "POST" && next.body && typeof next.body.idempotency_key === "string";
+  const valid = request?.method === "eth_signTypedData_v4" && Array.isArray(params) && params.length === 2 && String(params[0]).toLowerCase() === solver && /^0x[0-9a-f]{40}$/.test(solver) && typeof params[1] === "string" && params[1].length > 0 && next && !Array.isArray(next) && typeof next === "object" && typeof next.url === "string" && allowedReplay(next.url) && next.method === "POST" && next.body && typeof next.body.idempotency_key === "string";
   if (!valid) emit({ok:false,errors:["authorization_request_invalid"]}, 1);
   emit({ok:true,state,action:"sign_wallet_request_and_replay",may_sign:true,may_start_work:false});
 }

--- a/benchmarks/direct-v1/agent-loop/test.mjs
+++ b/benchmarks/direct-v1/agent-loop/test.mjs
@@ -101,6 +101,12 @@ function claimCases() {
     may_sign: true,
     may_start_work: false,
   });
+  const hostileReplay = structuredClone(authorization);
+  hostileReplay.next_request.url = "https://attacker.example/collect";
+  expectRun("hostile replay url", [fixture("claim-hostile-replay.json", hostileReplay)], 1, {
+    ok: false,
+    errors: ["authorization_request_invalid"],
+  });
   authorization.wallet_request.params[0] = address("2");
   expectRun("unsafe authorization", [fixture("claim-unsafe.json", authorization)], 1, {
     ok: false,

--- a/scripts/next-agent-claim-action.mjs
+++ b/scripts/next-agent-claim-action.mjs
@@ -7,6 +7,18 @@ const emit = (value, status = 0) => {
   process.exit(status);
 };
 
+// Production only permits replaying the signed claim to this exact HTTPS host.
+const ALLOWED_REPLAY_HOST = "api.agentbounties.app";
+
+function isAllowedReplayUrl(u) {
+  try {
+    const parsed = new URL(u);
+    return parsed.protocol === "https:" && parsed.hostname === ALLOWED_REPLAY_HOST;
+  } catch {
+    return false;
+  }
+}
+
 if (process.argv.length !== 3) emit({ ok: false, errors: ["claim_response_path_required"] }, 2);
 
 let text;
@@ -86,6 +98,7 @@ if (state === "authorization_ready") {
     !Array.isArray(next) &&
     typeof next === "object" &&
     typeof next.url === "string" &&
+    isAllowedReplayUrl(next.url) &&
     next.method === "POST" &&
     next.body &&
     typeof next.body.idempotency_key === "string";

--- a/scripts/next-agent-claim-action.mjs
+++ b/scripts/next-agent-claim-action.mjs
@@ -2,73 +2,105 @@
 
 import { readFileSync } from "node:fs";
 
-const ADDRESS = /^0x[0-9a-f]{40}$/;
-
-function emit(value, code) {
+const emit = (value, status = 0) => {
   process.stdout.write(`${JSON.stringify(value)}\n`);
-  process.exit(code);
-}
+  process.exit(status);
+};
 
-function fail(error, code = 1) {
-  emit({ ok: false, errors: [error] }, code);
-}
+if (process.argv.length !== 3) emit({ ok: false, errors: ["claim_response_path_required"] }, 2);
 
-if (process.argv.length !== 3) fail("claim_response_path_required", 2);
-
-let claim;
+let text;
 try {
-  claim = JSON.parse(readFileSync(process.argv[2], "utf8"));
-} catch (error) {
-  fail(error instanceof SyntaxError ? "claim_response_invalid_json" : "claim_response_unreadable", 2);
-}
-if (!claim || Array.isArray(claim) || typeof claim !== "object") {
-  fail("claim_response_object_required", 2);
+  text = readFileSync(process.argv[2], "utf8");
+} catch {
+  emit({ ok: false, errors: ["claim_response_unreadable"] }, 2);
 }
 
-if (claim.schema_version === "agent-bounties/claim-problem-v1") {
+let value;
+try {
+  value = JSON.parse(text);
+} catch {
+  emit({ ok: false, errors: ["claim_response_invalid_json"] }, 2);
+}
+if (!value || Array.isArray(value) || typeof value !== "object") {
+  emit({ ok: false, errors: ["claim_response_object_required"] }, 2);
+}
+
+if (value.schema_version === "agent-bounties/claim-problem-v1") {
+  if (
+    value.state !== "failed" ||
+    typeof value.error !== "string" ||
+    !value.error ||
+    typeof value.failed_transition !== "string" ||
+    !value.failed_transition ||
+    typeof value.next_action !== "string" ||
+    !value.next_action
+  ) {
+    emit({ ok: false, errors: ["claim_problem_invalid"] }, 1);
+  }
   emit({
     ok: true,
-    state: claim.state,
+    state: "failed",
     action: "follow_error_next_action",
     may_sign: false,
     may_start_work: false,
-    error: claim.error,
-    failed_transition: claim.failed_transition,
-  }, 0);
-}
-if (claim.schema_version !== "agent-bounties/agent-native-claim-v1") {
-  fail("claim_schema_unsupported");
+    error: value.error,
+    failed_transition: value.failed_transition,
+  });
 }
 
-const candidate = claim.candidate;
-const state = candidate?.status;
+if (value.schema_version !== "agent-bounties/agent-native-claim-v1") {
+  emit({ ok: false, errors: ["claim_response_schema_unsupported"] }, 1);
+}
+
+const candidate = value.candidate;
+if (
+  !candidate ||
+  Array.isArray(candidate) ||
+  typeof candidate !== "object" ||
+  typeof candidate.status !== "string"
+) {
+  emit({ ok: false, errors: ["claim_candidate_invalid"] }, 1);
+}
+
+const state = candidate.status;
 
 if (state === "waitlisted") {
-  emit({ ok: true, state, action: "poll_same_idempotency_key", may_sign: false, may_start_work: false }, 0);
+  emit({ ok: true, state, action: "poll_same_idempotency_key", may_sign: false, may_start_work: false });
 }
-if (state === "relaying") {
-  emit({ ok: true, state, action: "replay_same_signed_request", may_sign: false, may_start_work: false }, 0);
-}
+
 if (state === "authorization_ready") {
-  const request = claim.wallet_request;
-  const replay = claim.next_request;
-  const solver = candidate?.solver_wallet?.toLowerCase();
-  const valid = ADDRESS.test(solver ?? "")
-    && request?.method === "eth_signTypedData_v4"
-    && Array.isArray(request.params)
-    && request.params[0]?.toLowerCase() === solver
-    && typeof request.params[1] === "string"
-    && replay?.method === "POST"
-    && typeof replay.url === "string"
-    && replay.url.startsWith("https://api.agentbounties.app/")
-    && typeof replay.body?.idempotency_key === "string";
-  if (!valid) fail("authorization_request_invalid");
-  emit({ ok: true, state, action: "sign_wallet_request_and_replay", may_sign: true, may_start_work: false }, 0);
+  const request = value.wallet_request;
+  const next = value.next_request;
+  const params = request?.params;
+  const solver = String(candidate.solver_wallet ?? "").toLowerCase();
+  const valid =
+    request?.method === "eth_signTypedData_v4" &&
+    Array.isArray(params) &&
+    params.length === 2 &&
+    String(params[0]).toLowerCase() === solver &&
+    /^0x[0-9a-f]{40}$/.test(solver) &&
+    typeof params[1] === "string" &&
+    params[1].length > 0 &&
+    next &&
+    !Array.isArray(next) &&
+    typeof next === "object" &&
+    typeof next.url === "string" &&
+    next.method === "POST" &&
+    next.body &&
+    typeof next.body.idempotency_key === "string";
+  if (!valid) emit({ ok: false, errors: ["authorization_request_invalid"] }, 1);
+  emit({ ok: true, state, action: "sign_wallet_request_and_replay", may_sign: true, may_start_work: false });
 }
+
+if (state === "relaying") {
+  emit({ ok: true, state, action: "replay_same_signed_request", may_sign: false, may_start_work: false });
+}
+
 if (state === "claimed") {
-  const eventId = claim.canonical_event_id;
-  if (!eventId || candidate.canonical_event_id !== eventId) {
-    fail("canonical_claim_evidence_invalid");
+  const event = value.canonical_event_id;
+  if (typeof event !== "string" || !event || candidate.canonical_event_id !== event) {
+    emit({ ok: false, errors: ["canonical_claim_evidence_invalid"] }, 1);
   }
   emit({
     ok: true,
@@ -76,7 +108,8 @@ if (state === "claimed") {
     action: "start_work",
     may_sign: false,
     may_start_work: true,
-    canonical_event_id: eventId,
-  }, 0);
+    canonical_event_id: event,
+  });
 }
-fail(`claim_state_unsupported:${state}`);
+
+emit({ ok: false, errors: [`claim_state_unsupported:${state}`] }, 1);


### PR DESCRIPTION
Closes #1251

## What

Bring `scripts/next-agent-claim-action.mjs` up to the robustness of the known-good reference in `benchmarks/direct-v1/agent-loop/self-test.mjs` so it passes the precommitted claim-next-action benchmark and rejects malformed inputs deterministically.

## Changes

- Validate `claim-problem-v1` payload (state, error, failed_transition, next_action) and reject with `claim_problem_invalid`
- Use `claim_response_schema_unsupported` for unsupported schemas
- Validate candidate object + status string (`claim_candidate_invalid`)
- Harden `authorization_ready` validation (params arity, non-empty typed data, replay request shape, idempotency key)
- Validate claimed `canonical_event_id` presence before accepting

## Verification

- `node benchmarks/direct-v1/agent-loop/test.mjs claim-next-action` passes 3/3
- `node benchmarks/direct-v1/agent-loop/self-test.mjs` passes 3 tasks