### PR TITLE
Fix signed-quorum solver action relay

### DIFF
--- a/docs/autonomous-protocol.md
+++ b/docs/autonomous-protocol.md
@@ -394,15 +394,17 @@ verifier agents.
 
 ### Bounded Public Gas Relay
 
-Low-value deterministic bounties may use the source-controlled GitHub
-`/agent-bounty relay` transport for `claimWithAuthorization`,
-`submitWithSignature`, and a passing `verifyAndSettle` call. The keeper is not
-a settlement authority: each wallet signature is bound to the immutable bounty
-and current action, and the verifier module remains the only acceptance
-authority. The workflow executes trusted `main`, serializes the keeper nonce,
-simulates exact calldata, caps bounty value and gas, and validates confirmed
-post-state. It refuses quorum bounties, unknown modules, failed proofs, legacy
-canaries, arbitrary calldata, ETH value, and creation or funding requests.
+Low-value deterministic and signed-quorum bounties may use the
+source-controlled GitHub `/agent-bounty relay` transport for
+`claimWithAuthorization` and `submitWithSignature`. Only allowlisted
+deterministic bounties may also relay a passing `verifyAndSettle` call. The
+keeper is not a settlement authority: each solver signature is bound to the
+immutable bounty and current action, and the committed verifier remains the
+only acceptance authority. The workflow executes trusted `main`, serializes
+the keeper nonce, simulates exact calldata, caps bounty value and gas, and
+validates confirmed post-state. It refuses signed-quorum settlement, AI-judge
+bounties, unknown modules, failed proofs, legacy canaries, arbitrary calldata,
+ETH value, and creation or funding requests.
 
 `prepare_autonomous_bounty_submission` is the preferred handoff for an active
 claim. It reads canonical indexed state, binds the current solver and round,

--- a/scripts/relay_autonomous_action.py
+++ b/scripts/relay_autonomous_action.py
@@ -2,8 +2,9 @@
 """Relay one bounded autonomous-v1 solver action from a GitHub issue comment.
 
 The keeper is intentionally not a general transaction signer. It accepts only
-three exact calls against low-value canonical Base-mainnet bounties using the
-deployed deterministic verifier module.
+three exact calls against low-value canonical Base-mainnet bounties. Claim and
+submission relays support deterministic and signed-quorum verification;
+settlement remains limited to allowlisted deterministic verifier modules.
 """
 
 from __future__ import annotations
@@ -55,6 +56,9 @@ STATUS_CLAIMABLE = 1
 STATUS_CLAIMED = 2
 STATUS_SUBMITTED = 3
 STATUS_SETTLED = 4
+VERIFICATION_MODE_DETERMINISTIC = 0
+VERIFICATION_MODE_SIGNED_QUORUM = 1
+MAX_SIGNED_QUORUM_THRESHOLD = 8
 HEX_32_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
 HEX_SIGNATURE_RE = re.compile(r"^0x[0-9a-fA-F]{130}$")
 PRIVATE_KEY_RE = re.compile(r"^(?:0x)?[0-9a-fA-F]{64}$")
@@ -554,9 +558,10 @@ def read_state(client: CastClient, contract: str, block: str | None = None) -> B
 def validate_common(
     state: BountyState,
     *,
+    action: str = "claim",
     require_funded: bool = True,
-    verification_mode: int = 0,
-    threshold: int = 1,
+    verification_mode: int | None = None,
+    threshold: int | None = None,
     expected_verifier_module: str | None = None,
 ) -> None:
     expected = {
@@ -566,23 +571,54 @@ def validate_common(
         "factory_implementation": IMPLEMENTATION,
         "factory": FACTORY,
         "settlement_token": USDC,
-        "verification_mode": verification_mode,
-        "threshold": threshold,
     }
+    if verification_mode is not None:
+        expected["verification_mode"] = verification_mode
+    if threshold is not None:
+        expected["threshold"] = threshold
     for field, wanted in expected.items():
         observed = getattr(state, field)
         if observed != wanted:
             raise RelayError(
                 f"fail-closed canonical-state mismatch for {field}: expected {wanted}, got {observed}"
             )
-    allowed_verifier_modules = (
-        ALLOWED_VERIFIER_MODULES
-        if expected_verifier_module is None
-        else (expected_verifier_module,)
-    )
-    if state.verifier_module not in allowed_verifier_modules:
+    if verification_mode is not None:
+        allowed_verifier_modules = (
+            ALLOWED_VERIFIER_MODULES
+            if expected_verifier_module is None
+            else (expected_verifier_module,)
+        )
+        if state.verifier_module not in allowed_verifier_modules:
+            raise RelayError(
+                "verifier module is not allowlisted for the bounded relay: "
+                f"{state.verifier_module}"
+            )
+    elif state.verification_mode == VERIFICATION_MODE_DETERMINISTIC:
+        if state.threshold != 1:
+            raise RelayError("deterministic verification requires threshold 1")
+        allowed_verifier_modules = (
+            ALLOWED_VERIFIER_MODULES
+            if expected_verifier_module is None
+            else (expected_verifier_module,)
+        )
+        if state.verifier_module not in allowed_verifier_modules:
+            raise RelayError(
+                "verifier module is not allowlisted for the bounded relay: "
+                f"{state.verifier_module}"
+            )
+    elif state.verification_mode == VERIFICATION_MODE_SIGNED_QUORUM:
+        if action == "settle":
+            raise RelayError(
+                "signed-quorum settlement is not supported by the deterministic relay"
+            )
+        if state.verifier_module != ZERO_ADDRESS:
+            raise RelayError("signed-quorum verification must not configure a verifier module")
+        if not 1 <= state.threshold <= MAX_SIGNED_QUORUM_THRESHOLD:
+            raise RelayError("signed-quorum threshold must be between 1 and 8")
+    else:
         raise RelayError(
-            f"verifier module is not allowlisted for the bounded relay: {state.verifier_module}"
+            "verification mode is not supported by the bounded relay: "
+            f"{state.verification_mode}"
         )
     if state.target_amount <= 0 or state.target_amount > MAX_TARGET_MINOR:
         raise RelayError("bounty exceeds the public relay 5 USDC target cap")
@@ -693,7 +729,13 @@ def validate_receipt(receipt: Mapping[str, object], contract: str) -> tuple[str,
 
 
 def validate_after(action: str, envelope: Mapping[str, object], before: BountyState, after: BountyState) -> None:
-    validate_common(after, require_funded=action != "settle")
+    validate_common(after, action=action, require_funded=action != "settle")
+    if (
+        after.verification_mode != before.verification_mode
+        or after.verifier_module != before.verifier_module
+        or after.threshold != before.threshold
+    ):
+        raise RelayError("post-transaction verification policy mismatch")
     if after.round != before.round + (1 if action == "claim" else 0):
         raise RelayError("post-transaction round mismatch")
     if action == "claim":
@@ -762,7 +804,11 @@ def read_actionable_state(
     while True:
         attempts += 1
         state = read_state(client, contract, block="latest")
-        validate_common(state, require_funded=state.status != STATUS_SETTLED)
+        validate_common(
+            state,
+            action=action,
+            require_funded=state.status != STATUS_SETTLED,
+        )
         if already_applied(action, event.envelope, state):
             return state, None, attempts
         try:

--- a/scripts/test_relay_autonomous_action.py
+++ b/scripts/test_relay_autonomous_action.py
@@ -302,6 +302,34 @@ class RelayTests(unittest.TestCase):
                 bounty_state(verifier_module="0x9999999999999999999999999999999999999999")
             )
 
+    def test_signed_quorum_allows_solver_actions_but_not_settlement(self) -> None:
+        state = bounty_state(
+            verification_mode=relay.VERIFICATION_MODE_SIGNED_QUORUM,
+            verifier_module=relay.ZERO_ADDRESS,
+            threshold=2,
+        )
+        relay.validate_common(state, action="claim")
+        relay.validate_common(state, action="submit")
+        with self.assertRaisesRegex(relay.RelayError, "settlement is not supported"):
+            relay.validate_common(state, action="settle")
+        with self.assertRaisesRegex(relay.RelayError, "must not configure"):
+            relay.validate_common(
+                bounty_state(
+                    verification_mode=relay.VERIFICATION_MODE_SIGNED_QUORUM,
+                    verifier_module=relay.VERIFIER_MODULE,
+                ),
+                action="submit",
+            )
+        with self.assertRaisesRegex(relay.RelayError, "between 1 and 8"):
+            relay.validate_common(
+                bounty_state(
+                    verification_mode=relay.VERIFICATION_MODE_SIGNED_QUORUM,
+                    verifier_module=relay.ZERO_ADDRESS,
+                    threshold=0,
+                ),
+                action="submit",
+            )
+
     def test_claim_builds_only_bounded_authorization_call(self) -> None:
         client = FakeClient()
         signature, args = relay.action_call(client, event(claim_envelope()), bounty_state())
@@ -516,6 +544,35 @@ class RelayTests(unittest.TestCase):
         )
         report, _ = self.run_relay(before, after, submit_envelope())
         self.assertEqual(report["outcome"], "relayed")
+
+    def test_executes_signed_quorum_submission_without_settlement_authority(self) -> None:
+        policy = {
+            "verification_mode": relay.VERIFICATION_MODE_SIGNED_QUORUM,
+            "verifier_module": relay.ZERO_ADDRESS,
+            "threshold": 1,
+        }
+        before = bounty_state(
+            status=relay.STATUS_CLAIMED,
+            round=1,
+            solver=SOLVER,
+            claim_expires_at=NOW + 1_000,
+            active_claim_bond=100_000,
+            **policy,
+        )
+        after = bounty_state(
+            status=relay.STATUS_SUBMITTED,
+            round=1,
+            solver=SOLVER,
+            claim_expires_at=NOW + 1_000,
+            verification_expires_at=NOW + 2_000,
+            active_claim_bond=100_000,
+            submission_hash=HASH_A,
+            evidence_hash=HASH_B,
+            **policy,
+        )
+        report, client = self.run_relay(before, after, submit_envelope())
+        self.assertEqual(report["outcome"], "relayed")
+        self.assertTrue(client.send_args[3].startswith("submitWithSignature"))
 
     def test_executes_passing_settlement_and_accepts_zero_funded_post_state(self) -> None:
         before = bounty_state(


### PR DESCRIPTION
## Summary

- allow sponsored `claim` and `submit` relays for canonical signed-quorum bounties
- keep `settle` restricted to allowlisted deterministic verifier modules
- preserve exact-mode validation used by bounded-wallet creation recovery
- verify the immutable verification policy is unchanged after every relayed transaction
- add regression coverage for signed-quorum solver actions and settlement refusal

This fixes the relay defect observed on #773 round 5 (`verification_mode: expected 0, got 1`). It does not submit for the claimant, attest, accept bounty work, or authorize payment.

## Safety boundary

Canonical factory/runtime/token checks, target and bond caps, solver/round/deadline/signature binding, gas caps, receipt validation, and post-state reconciliation remain unchanged. Signed-quorum bounties must have a zero verifier module and threshold 1–8. The generic relay still cannot settle signed-quorum work.

## Verification

- `python scripts/test_relay_autonomous_action.py -v` — 22 passed
- `python -m py_compile scripts/relay_autonomous_action.py scripts/test_relay_autonomous_action.py scripts/relay_bounded_wallet_action.py scripts/test_relay_bounded_wallet_action.py` — passed
- `python scripts/check-site.py` — passed
- `scripts/preflight.ps1 -Mode core` — passed
- `git diff --check` — passed
- `scripts/check.ps1` — not started because full preflight reports local Foundry/`forge` unavailable; required GitHub checks install Foundry

## Evidence boundary

This PR repairs relay routing only. A signature or transaction hash is not acceptance or payment evidence; only confirmed canonical `BountySettled` proves payment.