### PR TITLE
Fix external review contract source staging

### DIFF
--- a/scripts/stage_review_contract_root.py
+++ b/scripts/stage_review_contract_root.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 REQUIRED_SOURCES = (
     Path("crates/api/src/main.rs"),
+    Path("crates/api/src/discoverability.rs"),
+    Path("crates/api/src/open_competition_v2_api.rs"),
     Path("crates/mcp-server/src/main.rs"),
     Path("crates/mcp-server/fixtures/tool-registry.json"),
 )

--- a/scripts/stage_review_contract_root.py
+++ b/scripts/stage_review_contract_root.py
@@ -19,6 +19,13 @@ REQUIRED_SOURCES = (
     Path("crates/mcp-server/src/main.rs"),
     Path("crates/mcp-server/fixtures/tool-registry.json"),
 )
+OPTIONAL_BASE_SOURCES = frozenset(
+    {
+        Path("crates/api/src/discoverability.rs"),
+        Path("crates/api/src/distribution.rs"),
+        Path("crates/api/src/open_competition_v2_api.rs"),
+    }
+)
 MAX_SOURCE_BYTES = 5 * 1024 * 1024
 
 
@@ -66,6 +73,10 @@ def stage_contract_root(
         source = worktree_root / relative
         try:
             source_stat = source.lstat()
+        except FileNotFoundError as error:
+            if relative in OPTIONAL_BASE_SOURCES:
+                continue
+            raise StageError(f"required PR contract source is missing: {relative}") from error
         except OSError as error:
             raise StageError(f"required PR contract source is missing: {relative}") from error
         if stat.S_ISLNK(source_stat.st_mode):

--- a/scripts/test_stage_review_contract_root.py
+++ b/scripts/test_stage_review_contract_root.py
@@ -8,6 +8,18 @@ from stage_review_contract_root import REQUIRED_SOURCES, StageError, stage_contr
 
 
 class StageReviewContractRootTests(unittest.TestCase):
+    def test_stages_every_source_consumed_by_docs_contract_routes(self) -> None:
+        self.assertEqual(
+            REQUIRED_SOURCES,
+            (
+                Path("crates/api/src/main.rs"),
+                Path("crates/api/src/discoverability.rs"),
+                Path("crates/api/src/open_competition_v2_api.rs"),
+                Path("crates/mcp-server/src/main.rs"),
+                Path("crates/mcp-server/fixtures/tool-registry.json"),
+            ),
+        )
+
     def make_worktree(self, root: Path) -> Path:
         worktree = root / "worktree"
         for index, relative in enumerate(REQUIRED_SOURCES):

--- a/scripts/test_stage_review_contract_root.py
+++ b/scripts/test_stage_review_contract_root.py
@@ -4,7 +4,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from stage_review_contract_root import REQUIRED_SOURCES, StageError, stage_contract_root
+from stage_review_contract_root import (
+    OPTIONAL_BASE_SOURCES,
+    REQUIRED_SOURCES,
+    StageError,
+    stage_contract_root,
+)
 
 
 class StageReviewContractRootTests(unittest.TestCase):
@@ -44,6 +49,24 @@ class StageReviewContractRootTests(unittest.TestCase):
                     (output / relative).read_bytes(),
                     (worktree / relative).read_bytes(),
                 )
+
+    def test_skips_modular_api_sources_absent_from_an_older_trusted_base(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            worktree = self.make_worktree(root)
+            for relative in OPTIONAL_BASE_SOURCES:
+                (worktree / relative).unlink()
+
+            report = stage_contract_root(worktree, root / "staged")
+
+            self.assertEqual(
+                [item["path"] for item in report],
+                [
+                    relative.as_posix()
+                    for relative in REQUIRED_SOURCES
+                    if relative not in OPTIONAL_BASE_SOURCES
+                ],
+            )
 
     def test_rejects_missing_required_source(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary
- stage the two API route modules already consumed by `docs-contract-check`
- lock the complete staged source set with a regression test
- restore trusted external-PR intake for #1266, #1267, and #1268

Closes #1269.

## Evidence
- `python scripts/test_stage_review_contract_root.py -v`
- `python scripts/test_review_external_pr.py -v`
- `scripts/preflight.ps1 -Mode core`
- `scripts/review-external-pr.ps1 -Pr 1266` (`docs_contract_check=ok`)
- `scripts/review-external-pr.ps1 -Pr 1267` (`docs_contract_check=ok`)
- `scripts/review-external-pr.ps1 -Pr 1268` (`docs_contract_check=ok`)

## Safety
This changes only the trusted maintainer intake staging allowlist and its tests. It does not execute external contributor code, alter payment state, or change contributor PR contents. Non-doc/risky PRs remain in the manual-security-review lane.