### PR TITLE
Fix WebMCP routing and exact reward handoff

### DIFF
--- a/scripts/check-bounty-economics.cjs
+++ b/scripts/check-bounty-economics.cjs
@@ -1,0 +1,33 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const {
+  parsePreparedRewardSplit,
+  rewardSplitForTotal,
+} = require("../site/bounty-composer-v2.js");
+
+const staged = parsePreparedRewardSplit("9", "1");
+const reviewed = rewardSplitForTotal(10, staged);
+const submitted = rewardSplitForTotal(10, staged);
+
+assert.deepEqual(reviewed, {
+  total: 10_000_000n,
+  solver: 9_000_000n,
+  verifier: 1_000_000n,
+});
+assert.deepEqual(submitted, reviewed);
+assert.equal(submitted.verifier, 1_000_000n, "the verifier-sized solver bond must retain the approved amount");
+
+const manual = rewardSplitForTotal(10);
+assert.deepEqual(manual, {
+  total: 10_000_000n,
+  solver: 9_800_000n,
+  verifier: 200_000n,
+});
+
+assert.throws(
+  () => parsePreparedRewardSplit("9.0000001", "1"),
+  /up to six places/,
+);
+
+process.stdout.write("bounty economics behavior check passed\n");

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import subprocess
 import xml.etree.ElementTree as ET
 from html.parser import HTMLParser
 from pathlib import Path
@@ -484,6 +486,18 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
     )
     if "const rewards=splitReward(state.fundingUsdc)" in composer:
         fail("funding must preserve an explicitly prepared solver/verifier reward split")
+    node = shutil.which("node")
+    if not node:
+        fail("node is required for the WebMCP reward-handoff behavior check")
+    behavior = subprocess.run(
+        [node, str(repo_root / "scripts" / "check-bounty-economics.cjs")],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if behavior.returncode != 0:
+        fail(f"WebMCP reward-handoff behavior check failed:\n{behavior.stdout}{behavior.stderr}")
     workflow = (repo_root / ".github" / "workflows" / "pages.yml").read_text(encoding="utf-8")
     require_phrases("Pages analytics configuration", workflow, ["GA_MEASUREMENT_ID", "^G-[A-Z0-9]+$"])
 

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -461,6 +461,29 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
             fail(f"analytics.js must not collect or store {forbidden}")
     if not re.search(r'googleMeasurementId:\s*"(?:|G-[A-Z0-9]+)"', config):
         fail("analytics-config.js must contain an empty or valid GA4 measurement ID")
+    require_phrases(
+        "WebMCP production hotpath",
+        config,
+        [
+            "document.modelContext",
+            'new URL("/competition.html", window.location.origin)',
+            'new URL("/post.html?from=webmcp", window.location.origin)',
+        ],
+    )
+    composer = (site_dir / "bounty-composer-v2.js").read_text(encoding="utf-8")
+    require_phrases(
+        "WebMCP exact reward handoff",
+        composer,
+        [
+            "function parsePreparedRewardSplit",
+            "function currentRewardSplit",
+            "state.preparedRewards = preparedRewards",
+            "const rewards=currentRewardSplit()",
+            "Verifier reward and solver bond:",
+        ],
+    )
+    if "const rewards=splitReward(state.fundingUsdc)" in composer:
+        fail("funding must preserve an explicitly prepared solver/verifier reward split")
     workflow = (repo_root / ".github" / "workflows" / "pages.yml").read_text(encoding="utf-8")
     require_phrases("Pages analytics configuration", workflow, ["GA_MEASUREMENT_ID", "^G-[A-Z0-9]+$"])
 

--- a/site/analytics-config.js
+++ b/site/analytics-config.js
@@ -156,7 +156,7 @@ window.agentBountiesAnalyticsConfig = Object.freeze({
     const isV2 = String(item?.opportunity_id || "").startsWith("open-competition-v2:")
       || String(item?.next_action?.action || "").includes("open_competition_v2");
     if (isV2 && /^0x[0-9a-fA-F]{40}$/.test(String(item?.source_id || ""))) {
-      const target = new URL("competition.html", window.location.href);
+      const target = new URL("/competition.html", window.location.origin);
       target.searchParams.set("bountyContract", item.source_id);
       target.searchParams.set("network", item.network || NETWORK);
       return target.href;
@@ -318,7 +318,7 @@ window.agentBountiesAnalyticsConfig = Object.freeze({
       const draft = normalizeDraft(input);
       if (/\/post\.html$/.test(window.location.pathname)) return stageOnPostPage(draft);
       if (!persistPendingDraft(draft)) throw new Error("This browser cannot preserve the draft across navigation. Open /post.html and call this tool again.");
-      const target = new URL("post.html?from=webmcp", window.location.href).href;
+      const target = new URL("/post.html?from=webmcp", window.location.origin).href;
       window.setTimeout(() => window.location.assign(target), 0);
       return {
         status: "navigating_to_review",

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -91,6 +91,7 @@
     selectedTaskId: null,
     taskWindowDays: null,
     fundingUsdc: null,
+    preparedRewards: null,
     visualSpec: null,
     visualSource: "fallback",
     visualCache: new Map(),
@@ -210,6 +211,27 @@
     const solver = totalUnits - cappedVerifier;
     if (solver < 10_000n) throw new Error("The solver reward must remain at least 0.01 USDC.");
     return { total: totalUnits, solver, verifier: cappedVerifier };
+  }
+
+  function parsePreparedRewardSplit(solverValue, verifierValue) {
+    const decimalUsdc = /^\d+(?:\.\d{1,6})?$/;
+    if (!decimalUsdc.test(String(solverValue || "").trim()) || !decimalUsdc.test(String(verifierValue || "").trim())) {
+      throw new Error("Solver and verifier rewards must be decimal USDC amounts with up to six places.");
+    }
+    const solver = usdcBaseUnits(solverValue);
+    const verifier = usdcBaseUnits(verifierValue);
+    const total = solver + verifier;
+    if (solver <= 0n || verifier <= 0n) throw new Error("Solver and verifier rewards must both be positive.");
+    if (total < usdcBaseUnits(MIN_TOTAL_USDC) || total > usdcBaseUnits(MAX_TOTAL_USDC)) {
+      throw new Error("The combined reward is invalid.");
+    }
+    return { total, solver, verifier };
+  }
+
+  function currentRewardSplit() {
+    const total = usdcBaseUnits(state.fundingUsdc);
+    if (state.preparedRewards && state.preparedRewards.total === total) return state.preparedRewards;
+    return splitReward(state.fundingUsdc);
   }
 
   function parseFunding(value) {
@@ -366,9 +388,9 @@
     if (!prepared || typeof prepared !== "object") throw new Error("The prepared bounty draft is invalid.");
 
     const days = Number(prepared.task_window_days || MAX_TASK_DAYS);
-    const total = Number(prepared.solver_reward_usdc) + Number(prepared.verifier_reward_usdc);
+    const preparedRewards = parsePreparedRewardSplit(prepared.solver_reward_usdc, prepared.verifier_reward_usdc);
+    const total = Number(preparedRewards.total) / 1_000_000;
     if (!Number.isInteger(days) || days < 1 || days > MAX_TASK_DAYS) throw new Error(`The task window must be from 1 to ${MAX_TASK_DAYS} days.`);
-    if (!Number.isFinite(total) || total < MIN_TOTAL_USDC || total > MAX_TOTAL_USDC) throw new Error("The combined reward is invalid.");
     const bountyImage = normalizeBountyImage(prepared.image);
     if (prepared.image_required === true && !bountyImage) {
       throw new Error("The prepared bounty must include the exact image generated and approved in ChatGPT.");
@@ -403,6 +425,7 @@
     state.selectedTaskId = null;
     state.taskWindowDays = days;
     state.fundingUsdc = total;
+    state.preparedRewards = preparedRewards;
     state.bountyImage = bountyImage;
     state.approved = false;
     ui.input.value = "";
@@ -603,6 +626,7 @@
       state.missionPlan = null;
       state.taskWindowDays = null;
       state.fundingUsdc = parseFunding(value);
+      state.preparedRewards = null;
       requestUserOwnedAi(value);
       ui.input.value = "";
       return;
@@ -659,12 +683,13 @@
         return;
       }
       state.fundingUsdc = amount;
+      state.preparedRewards = null;
       setStatus("");
       renderPreview();
       return;
     }
     if (state.phase === "revise") {
-      const rewards = splitReward(state.fundingUsdc);
+      const rewards = currentRewardSplit();
       requestUserOwnedAi(value, {
         draft: state.draft,
         solver_reward_usdc: formatUsdc(Number(rewards.solver) / 1_000_000),
@@ -729,9 +754,10 @@
   }
 
   function renderCardText() {
+    const rewards = currentRewardSplit();
     ui.title.textContent = state.draft.title;
     ui.goal.textContent = state.draft.goal;
-    ui.reward.textContent = `${formatUsdc(state.fundingUsdc)} USDC`;
+    ui.reward.textContent = `${formatUsdc(state.fundingUsdc)} USDC (${formatUsdc(Number(rewards.solver) / 1_000_000)} solver + ${formatUsdc(Number(rewards.verifier) / 1_000_000)} verifier)`;
     ui.deadline.textContent = state.scope === "mission"
       ? `${state.taskWindowDays} days for this task · ${state.horizon.label} mission`
       : state.horizon.label;
@@ -761,7 +787,7 @@
 
   async function renderPreview() {
     if (!state.draft || state.fundingUsdc == null || !state.horizon || !state.taskWindowDays) return;
-    splitReward(state.fundingUsdc);
+    currentRewardSplit();
     state.phase = "review";
     state.approved = false;
     state.imageReady = false;
@@ -1299,7 +1325,7 @@
 
   async function fetchFeedItem(api,contract){try{const items=await requestJson(`${api}/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false`,{cache:"no-store"});return items.find((item)=>String(item.bounty_contract).toLowerCase()===String(contract).toLowerCase())||null;}catch(_error){return null;}}
 
-  async function fundApprovedBounty(){if(!state.approved||!state.provider||!state.account||!state.balances)return;track("canonical_post_started");ui.fundNow.disabled=true;setPaymentStatus("Preparing the exact canonical Base USDC funding request…","pending");try{await refreshWalletReadiness();if(state.balances.usdc<state.balances.required||state.balances.eth===0n)throw new Error("The wallet is not ready to fund this bounty.");if(!window.AgentBountiesLegal)throw new Error("The legal agreement could not be loaded. Reload before using the wallet.");await window.AgentBountiesLegal.requireAcceptance({action:"post_bounty",walletAddress:state.account,scope:ui.dialog});const protocol=await loadProtocol();const api=String(protocol.api_base_url).replace(/\/$/,"");const rewards=splitReward(state.fundingUsdc);const committed=contractTerms(protocol,rewards);const document=termsDocument(committed);const terms=await requestJson(`${api}/v1/base/autonomous-bounties/terms`,{method:"POST",body:JSON.stringify({creator_wallet:state.account,document})});const create=createPayload(terms,committed);const plan=await requestJson(`${api}/v1/base/autonomous-bounties/creation-plan`,{method:"POST",body:JSON.stringify({network:"base-mainnet",create})});validateCreationPlan(plan,protocol,create);setPaymentStatus(["Review the wallet request carefully.",`Exact total funding: ${formatUsdc(state.fundingUsdc)} Base USDC.`,`Predicted bounty: ${plan.predicted_bounty_contract}`,"A signature or transaction hash is not funding evidence."].join("\n"),"pending");let transactionHash=null;if(!(await isContractAccount())&&plan.eip3009_authorization){const signature=await state.provider.request({method:"eth_signTypedData_v4",params:[state.account,JSON.stringify(plan.eip3009_authorization)]});const authorized=await requestJson(`${api}/v1/base/autonomous-bounties/authorized-creation-plan`,{method:"POST",body:JSON.stringify({network:"base-mainnet",create,signature:signatureParts(signature),relayer:state.account})});if(!authorized.relay_transaction||String(authorized.relay_transaction.to).toLowerCase()!==String(protocol.factory).toLowerCase())throw new Error("The authorized transaction does not target the canonical factory.");transactionHash=await sendTransaction(authorized.relay_transaction);await waitReceipt(transactionHash);}else{const result=await sendWalletCalls(plan.wallet_calls,protocol);if(typeof result==="string"&&result.startsWith("0x"))transactionHash=result;}state.bountyContract=plan.predicted_bounty_contract;state.bountyId=plan.bounty_id;setPaymentStatus("Transaction confirmed. Waiting for canonical FundingAdded and BountyBecameClaimable evidence…","pending");const events=await pollCreation(api,plan.bounty_id);if(!events){setPaymentStatus(["The transaction was confirmed, but canonical funding evidence is still pending.",transactionHash?`Transaction: ${protocol.explorer_url}/tx/${transactionHash}`:"Wallet batch submitted.","Do not describe the bounty as funded until FundingAdded and BountyBecameClaimable are confirmed."].join("\n"),"pending");return;}const item=await fetchFeedItem(api,state.bountyContract);if(item?.verification_ready){ui.badge.textContent="Funded · ready to earn";setPaymentStatus(["Bounty funded and ready for public earning.",`Contract: ${state.bountyContract}`,"Solver payment will be proven only by BountySettled."].join("\n"),"success");}else{ui.badge.textContent="Funded · verifier setup required";setPaymentStatus(["Canonical funding is confirmed.",`Contract: ${state.bountyContract}`,"The creator is the committed verifier. The bounty will not appear in the default ready-to-earn inventory until verifier availability is represented by the protocol.","Solver payment will be proven only by BountySettled."].join("\n"),"success");}ui.fundNow.textContent="Funded ✓";ui.fundNow.disabled=true;track("canonical_post_confirmed",{bounty_contract:state.bountyContract});}catch(error){setPaymentStatus(error.message||String(error),"error");ui.fundNow.disabled=false;}}
+  async function fundApprovedBounty(){if(!state.approved||!state.provider||!state.account||!state.balances)return;track("canonical_post_started");ui.fundNow.disabled=true;setPaymentStatus("Preparing the exact canonical Base USDC funding request…","pending");try{await refreshWalletReadiness();if(state.balances.usdc<state.balances.required||state.balances.eth===0n)throw new Error("The wallet is not ready to fund this bounty.");if(!window.AgentBountiesLegal)throw new Error("The legal agreement could not be loaded. Reload before using the wallet.");await window.AgentBountiesLegal.requireAcceptance({action:"post_bounty",walletAddress:state.account,scope:ui.dialog});const protocol=await loadProtocol();const api=String(protocol.api_base_url).replace(/\/$/,"");const rewards=currentRewardSplit();const committed=contractTerms(protocol,rewards);const document=termsDocument(committed);const terms=await requestJson(`${api}/v1/base/autonomous-bounties/terms`,{method:"POST",body:JSON.stringify({creator_wallet:state.account,document})});const create=createPayload(terms,committed);const plan=await requestJson(`${api}/v1/base/autonomous-bounties/creation-plan`,{method:"POST",body:JSON.stringify({network:"base-mainnet",create})});validateCreationPlan(plan,protocol,create);setPaymentStatus(["Review the wallet request carefully.",`Exact total funding: ${formatUsdc(state.fundingUsdc)} Base USDC.`,`Solver reward: ${formatUsdc(Number(rewards.solver)/1_000_000)} Base USDC.`,`Verifier reward and solver bond: ${formatUsdc(Number(rewards.verifier)/1_000_000)} Base USDC.`,`Predicted bounty: ${plan.predicted_bounty_contract}`,"A signature or transaction hash is not funding evidence."].join("\n"),"pending");let transactionHash=null;if(!(await isContractAccount())&&plan.eip3009_authorization){const signature=await state.provider.request({method:"eth_signTypedData_v4",params:[state.account,JSON.stringify(plan.eip3009_authorization)]});const authorized=await requestJson(`${api}/v1/base/autonomous-bounties/authorized-creation-plan`,{method:"POST",body:JSON.stringify({network:"base-mainnet",create,signature:signatureParts(signature),relayer:state.account})});if(!authorized.relay_transaction||String(authorized.relay_transaction.to).toLowerCase()!==String(protocol.factory).toLowerCase())throw new Error("The authorized transaction does not target the canonical factory.");transactionHash=await sendTransaction(authorized.relay_transaction);await waitReceipt(transactionHash);}else{const result=await sendWalletCalls(plan.wallet_calls,protocol);if(typeof result==="string"&&result.startsWith("0x"))transactionHash=result;}state.bountyContract=plan.predicted_bounty_contract;state.bountyId=plan.bounty_id;setPaymentStatus("Transaction confirmed. Waiting for canonical FundingAdded and BountyBecameClaimable evidence…","pending");const events=await pollCreation(api,plan.bounty_id);if(!events){setPaymentStatus(["The transaction was confirmed, but canonical funding evidence is still pending.",transactionHash?`Transaction: ${protocol.explorer_url}/tx/${transactionHash}`:"Wallet batch submitted.","Do not describe the bounty as funded until FundingAdded and BountyBecameClaimable are confirmed."].join("\n"),"pending");return;}const item=await fetchFeedItem(api,state.bountyContract);if(item?.verification_ready){ui.badge.textContent="Funded · ready to earn";setPaymentStatus(["Bounty funded and ready for public earning.",`Contract: ${state.bountyContract}`,"Solver payment will be proven only by BountySettled."].join("\n"),"success");}else{ui.badge.textContent="Funded · verifier setup required";setPaymentStatus(["Canonical funding is confirmed.",`Contract: ${state.bountyContract}`,"The creator is the committed verifier. The bounty will not appear in the default ready-to-earn inventory until verifier availability is represented by the protocol.","Solver payment will be proven only by BountySettled."].join("\n"),"success");}ui.fundNow.textContent="Funded ✓";ui.fundNow.disabled=true;track("canonical_post_confirmed",{bounty_contract:state.bountyContract});}catch(error){setPaymentStatus(error.message||String(error),"error");ui.fundNow.disabled=false;}}
 
   function configureSpeech(){const Recognition=window.SpeechRecognition||window.webkitSpeechRecognition;if(!Recognition){ui.mic.hidden=true;ui.hint.textContent="Type naturally. Your words are not posted until you approve the final card.";return;}const recognition=new Recognition();recognition.continuous=false;recognition.interimResults=true;recognition.lang=document.documentElement.lang||navigator.language||"en-US";let original="";recognition.addEventListener("start",()=>{original=ui.input.value.trim();ui.mic.dataset.listening="true";setStatus("Listening…","pending");});recognition.addEventListener("result",(event)=>{let transcript="";for(let index=event.resultIndex;index<event.results.length;index+=1)transcript+=event.results[index][0].transcript;ui.input.value=[original,transcript.trim()].filter(Boolean).join(original?" ":"");});recognition.addEventListener("end",()=>{ui.mic.dataset.listening="false";setStatus("Review the dictated text, then continue.");});recognition.addEventListener("error",(event)=>{ui.mic.dataset.listening="false";setStatus(event.error==="not-allowed"?"Microphone permission was not granted. You can still type.":"Dictation stopped. You can continue typing.","error");});ui.mic.addEventListener("click",()=>{if(ui.mic.dataset.listening==="true")recognition.stop();else recognition.start();});state.speech=recognition;}
 
@@ -1352,7 +1378,14 @@
           ui.input.value = [draft.draft_objective, draft.goal, ...(draft.acceptance_criteria || [])].filter(Boolean).join("\n");
           const importedSolver = Number(draft.solver_reward && draft.solver_reward.amount || 0);
           const importedVerifier = Number(draft.verifier_reward && draft.verifier_reward.amount || 0);
-          if (Number.isSafeInteger(importedSolver) && Number.isSafeInteger(importedVerifier)) state.fundingUsdc = (importedSolver + importedVerifier) / 1_000_000;
+          if (Number.isSafeInteger(importedSolver) && importedSolver > 0 && Number.isSafeInteger(importedVerifier) && importedVerifier > 0) {
+            state.preparedRewards = {
+              solver: BigInt(importedSolver),
+              verifier: BigInt(importedVerifier),
+              total: BigInt(importedSolver + importedVerifier),
+            };
+            state.fundingUsdc = Number(state.preparedRewards.total) / 1_000_000;
+          }
           setStatus("Draft imported. It has not been posted or funded. Describe any changes, then continue.", "pending");
         }
       } catch (error) {

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -19,6 +19,11 @@
     "sun", "road", "lamp", "building", "tree", "water", "screen", "document", "network", "tool", "person", "check", "bridge", "book", "chart",
   ]);
 
+  if (typeof module === "object" && module.exports) {
+    module.exports = Object.freeze({ parsePreparedRewardSplit, rewardSplitForTotal });
+    return;
+  }
+
   const ui = {
     form: document.getElementById("bounty-composer-form"),
     input: document.getElementById("bounty-composer-input"),
@@ -229,9 +234,13 @@
   }
 
   function currentRewardSplit() {
-    const total = usdcBaseUnits(state.fundingUsdc);
-    if (state.preparedRewards && state.preparedRewards.total === total) return state.preparedRewards;
-    return splitReward(state.fundingUsdc);
+    return rewardSplitForTotal(state.fundingUsdc, state.preparedRewards);
+  }
+
+  function rewardSplitForTotal(total, preparedRewards = null) {
+    const totalUnits = usdcBaseUnits(total);
+    if (preparedRewards && preparedRewards.total === totalUnits) return preparedRewards;
+    return splitReward(total);
   }
 
   function parseFunding(value) {


### PR DESCRIPTION
## Summary

- root WebMCP internal transitions at the production origin so nested pages cannot navigate under `/blog/`
- preserve an explicitly prepared solver/verifier reward split through review and canonical creation
- show the exact solver reward, verifier reward, and verifier-sized solver bond before wallet signing
- extend the site gate to pin the current `document.modelContext` API, root routes, and exact-split funding path

Closes #1278.

## Review findings addressed

- #1277 discussion_r3928758507: confirmed and fixed
- #1277 discussion_r3928758514: confirmed and fixed
- #1277 discussion_r3928758498: current `document.modelContext` behavior retained because it matches the current WebMCP spec and Chrome documentation; changing only to `navigator.modelContext` would regress the production API

## Validation

- `node --check site/analytics-config.js`
- `node --check site/bounty-composer-v2.js`
- `python scripts/check-site.py`
- `git diff --check`

## Payment boundary

This changes no on-chain protocol. It prevents an approved browser handoff from silently changing solver payout, verifier payout, or the verifier-sized solver bond. A wallet signature or transaction hash remains non-settlement evidence; only confirmed canonical events establish funding or payment.

**Next owner:** non-author reviewer
**Recheck:** `python scripts/check-site.py`
**Done when:** required checks pass on the latest head, all threads are resolved, and a non-author approval is recorded.