### PR TITLE
Scope attribution coverage to instrumented outcomes

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870
+          --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870
+          --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870
+          --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "c58602e3929f0a9b8d1cc437b58086cd6c5ac2d1194c4e89aeea97184609e
 PIPELINE_TEST_SHA256 = "1665f99a25f3ffdd1be1fb167e4ba9a09c729966c46ec41990629d5dd6f271e5"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870"
+WORKER_BUILD_SHA256 = "70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb"
 SIGNING_RUNTIME_SHA256 = "292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "aa5cf692404a44bc71c3ea3614676d7425544b0139d1257921730f14e872b848",
+    ".github/workflows/regression-verifier-runner.yml": "20e743db9d85519bc6d46f1acae4c240c660c1d475323031b9299f3e0bd9f36d",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "d6900a74e57aa95c604c6f83d54bb207605c1d5966c751ae97b2dc673fecdf60",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "eba91d4aad2964afc35e005417d705169b9f0d2b6e6eedc653a19c966306b811",
+    ".github/workflows/regression-verifier-signer.yml": "4245b819583c9e31be8742bf5b6911592f79f742adb3a8427c7eee85ee3e1390",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "30dde9d12a6b3700ba68169a974401ec1cae3be4a35b5b8c5007a73b6c4f3b0a",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 cf2b54048a4d69385271940a71777da59cbdd2952707d44d9c533621a158a870"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 70ef386e87d1e78cb481508fd12324ad9d866878b8a285c7cb5980df0e0caddb"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -2499,6 +2499,9 @@ impl PostgresStore {
             r#"
             WITH rail_names AS (
               SELECT unnest($2::text[]) AS rail
+            ), measurement_window AS (
+              SELECT MIN(first_observed_at) AS started_at
+              FROM distribution_acquisitions
             ), excluded_wallets AS (
               SELECT DISTINCT wallet_address
               FROM distribution_wallet_exclusions
@@ -2508,12 +2511,15 @@ impl PostgresStore {
                      lower(data->>'bounty_contract') AS bounty_contract,
                      lower(data->>'creator') AS creator_wallet,
                      lower(data->>'terms_hash') AS terms_hash
-              FROM autonomous_bounty_events
-              WHERE kind = 'canonical_bounty_created'
-                AND block_time_verified = TRUE
-                AND data->>'bounty_contract' IS NOT NULL
-                AND data->>'creator' IS NOT NULL
-                AND data->>'terms_hash' IS NOT NULL
+              FROM autonomous_bounty_events AS creation_event
+              CROSS JOIN measurement_window
+              WHERE creation_event.kind = 'canonical_bounty_created'
+                AND creation_event.block_time_verified = TRUE
+                AND creation_event.data->>'bounty_contract' IS NOT NULL
+                AND creation_event.data->>'creator' IS NOT NULL
+                AND creation_event.data->>'terms_hash' IS NOT NULL
+                AND measurement_window.started_at IS NOT NULL
+                AND creation_event.occurred_at >= measurement_window.started_at
             ), economics AS (
               SELECT network, bounty_id,
                      MAX((data->>'target_amount')::numeric) AS target_amount
@@ -2750,7 +2756,10 @@ impl PostgresStore {
             .sum::<u64>();
         let total_row = sqlx::query(
             r#"
-            WITH excluded_wallets AS (
+            WITH measurement_window AS (
+              SELECT MIN(first_observed_at) AS started_at
+              FROM distribution_acquisitions
+            ), excluded_wallets AS (
               SELECT DISTINCT wallet_address
               FROM distribution_wallet_exclusions
               WHERE active = TRUE AND exclusion_class = ANY($1::text[])
@@ -2759,12 +2768,15 @@ impl PostgresStore {
                      lower(data->>'bounty_contract') AS bounty_contract,
                      lower(data->>'creator') AS creator_wallet,
                      lower(data->>'terms_hash') AS terms_hash
-              FROM autonomous_bounty_events
-              WHERE kind = 'canonical_bounty_created'
-                AND block_time_verified = TRUE
-                AND data->>'bounty_contract' IS NOT NULL
-                AND data->>'creator' IS NOT NULL
-                AND data->>'terms_hash' IS NOT NULL
+              FROM autonomous_bounty_events AS creation_event
+              CROSS JOIN measurement_window
+              WHERE creation_event.kind = 'canonical_bounty_created'
+                AND creation_event.block_time_verified = TRUE
+                AND creation_event.data->>'bounty_contract' IS NOT NULL
+                AND creation_event.data->>'creator' IS NOT NULL
+                AND creation_event.data->>'terms_hash' IS NOT NULL
+                AND measurement_window.started_at IS NOT NULL
+                AND creation_event.occurred_at >= measurement_window.started_at
             ), economics AS (
               SELECT network, bounty_id,
                      MAX((data->>'target_amount')::numeric) AS target_amount
@@ -11632,6 +11644,79 @@ mod tests {
             )
             .await
             .unwrap();
+
+        let historical_creator_seed = Uuid::new_v4().simple().to_string();
+        let historical_creator = format!(
+            "0x{historical_creator_seed}{}",
+            &historical_creator_seed[..8]
+        );
+        let historical_contract_seed = Uuid::new_v4().simple().to_string();
+        let historical_contract = format!(
+            "0x{historical_contract_seed}{}",
+            &historical_contract_seed[..8]
+        );
+        let historical_bounty_id = format!("0x{}", Uuid::new_v4().simple().to_string().repeat(2));
+        let historical_terms_hash = format!("0x{}", Uuid::new_v4().simple().to_string().repeat(2));
+        let historical_at = now - chrono::Duration::days(365);
+        for (event_index, (kind, data)) in [
+            (
+                AutonomousBountyEventKind::CanonicalBountyCreated,
+                serde_json::json!({
+                    "bounty_contract": historical_contract.clone(),
+                    "creator": historical_creator.clone(),
+                    "terms_hash": historical_terms_hash,
+                }),
+            ),
+            (
+                AutonomousBountyEventKind::CanonicalBountyEconomicsConfigured,
+                serde_json::json!({"target_amount": "2100000"}),
+            ),
+            (
+                AutonomousBountyEventKind::FundingAdded,
+                serde_json::json!({
+                    "contributor": historical_creator.clone(),
+                    "amount": "2100000"
+                }),
+            ),
+            (
+                AutonomousBountyEventKind::BountyBecameClaimable,
+                serde_json::json!({"funded_amount": "2100000"}),
+            ),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let block_number = 50 + event_index as u64;
+            store
+                .upsert_autonomous_bounty_event(
+                    &network,
+                    &AutonomousBountyEvent {
+                        id: Uuid::new_v4(),
+                        log_key: format!("{network}:{block_number}:historical"),
+                        tx_hash: format!("0x{block_number:064x}"),
+                        block_number,
+                        log_index: 0,
+                        contract_address: if event_index == 0 {
+                            factory.clone()
+                        } else {
+                            historical_contract.clone()
+                        },
+                        bounty_id: historical_bounty_id.clone(),
+                        kind,
+                        data,
+                        occurred_at: historical_at,
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                store
+                    .confirm_autonomous_event_block_time(&network, block_number, historical_at,)
+                    .await
+                    .unwrap(),
+                1
+            );
+        }
 
         for (index, (rail, excluded_subsidy)) in
             [("bankr", false), ("github", false), ("vscode", true)]


### PR DESCRIPTION
## Outcome

Starts the attribution-coverage denominator at the first persisted, instrumented acquisition (including excluded canaries). Historical funded bounties from before attribution existed no longer make the paid-rail gate misleading, while every external funded bounty after instrumentation still counts whether attributed or not.

## Verification

- PostgreSQL 16 ignored integration test, including an otherwise-valid funded bounty one year before the instrumentation watermark
- `cargo clippy --workspace -- -D warnings`
- DB unit tests
- immutable verifier source guard
- known-good/known-bad verifier rehearsal
- migration history check

No wallet, payment, verification, or settlement authority changes.