### PR TITLE
Record Glama connector review submission

### DIFF
--- a/distribution/native-directory-submission/README.md
+++ b/distribution/native-directory-submission/README.md
@@ -2,8 +2,9 @@
 
 This directory is the reusable, source-controlled dossier for Agent Bounties
 skill, MCP, plugin, and agent-directory submissions. It prepares truthful
-materials; it does not submit a listing, spend money, approve a platform
-policy exception, or prove that a listing is live.
+materials and records external truth-state transitions; it does not itself
+submit a listing, spend money, approve a platform policy exception, or prove
+that a submitted listing is accepted or live.
 
 Public maintainer notice: [#1274](https://github.com/NSPG13/agent-bounties/issues/1274).
 
@@ -54,7 +55,7 @@ for the exact bounty-and-crypto workflow is recorded.
 - [ ] Verify the route returns the canonical MCP catalog without redirecting to an untagged rail.
 - [ ] Paste no API key, wallet secret, seed phrase, signing key, or publishing token into the package.
 - [ ] Link [`SECURITY.md`](SECURITY.md), [`TESTING.md`](TESTING.md), and [`DEMO.md`](DEMO.md).
-- [ ] Confirm the target remains `not_submitted` in [`SUBMISSION_LEDGER.md`](SUBMISSION_LEDGER.md) until the external action actually occurs.
+- [ ] Confirm the target remains `not_submitted` in [`SUBMISSION_LEDGER.md`](SUBMISSION_LEDGER.md) until the external action actually occurs, then record `submitted`, `accepted`, `live`, `claimed`, and `healthy` separately.
 - [ ] Describe wallet review as external to the agent host.
 - [ ] Describe a draft, intent, signature, transaction hash, PR, and issue status as non-settlement evidence.
 - [ ] Describe payment only after a confirmed canonical `BountySettled` event.

--- a/distribution/native-directory-submission/SUBMISSION_LEDGER.md
+++ b/distribution/native-directory-submission/SUBMISSION_LEDGER.md
@@ -1,9 +1,10 @@
 # Truth-State Submission Ledger
 
-This ledger distinguishes repository readiness from external state. Every
-target below is **not submitted**. Do not change that state until the exact
-attributed production endpoint is deployed, its connection and lifecycle
-canary passes, and a maintainer completes the external action.
+This ledger distinguishes repository readiness from external state. Native
+targets remain **not submitted**. Glama accepted the remote connector form on
+2026-09-05 UTC and is **submitted / pending review**; that is not evidence of
+acceptance, a live listing, ownership, health, funding, settlement, or paid
+activation.
 
 Install-host blocker: `install.agentbounties.app/{rail}` is not deployed; use
 the rail-specific apex fallback and follow [`INSTALL_SUBDOMAIN.md`](INSTALL_SUBDOMAIN.md).
@@ -18,11 +19,13 @@ the rail-specific apex fallback and follow [`INSTALL_SUBDOMAIN.md`](INSTALL_SUBD
 | GitHub Marketplace | Repository MCP config prepared; hosted App remains a separate workstream | **Not submitted** | [GitHub Marketplace listing requirements](https://docs.github.com/en/apps/github-marketplace/creating-apps-for-github-marketplace/requirements-for-listing-an-app) | Public functional GitHub App; valid contact, description, pricing plan, privacy and support links; working additional links; Marketplace webhook handling; logo, feature card, screenshots, and developer agreement. |
 | GitHub Agent Apps | Agent App architecture remains a separate workstream | **Not submitted / access-gated** | [GitHub Agent Apps partner path](https://github.blog/changelog/2026-06-02-extend-github-with-agent-apps/) | Obtain partner access, host a GitHub App agent, handle GitHub-issued JWT authorization at the MCP boundary, and pass issue-assignment, PR-mention, and Agents UI tests. |
 | Linear | Attributed custom-MCP route prepared; hosted OAuth agent remains a separate workstream | **Not submitted** | [Linear agent guide](https://linear.app/developers/agents) and [directory requirements](https://linear.app/docs/integration-directory) | Hosted OAuth application using `actor=app`; installable app user; native mention, assignment, comment, and result-return behavior; listing copy/assets; directory review submission. |
-| Glama connector | Remote connector form is prepared in the maintainer's Glama session with the exact attributed endpoint; HTTP claim endpoint is disabled until a real token is issued | **Not submitted** | [Glama connector directory](https://glama.ai/mcp/connectors) | Complete the excluded 2-USDC lifecycle canary; submit the prepared remote-server form; configure the Glama-issued `GLAMA_CLAIM_TOKEN`; verify `/.well-known/glama.json`; claim ownership; confirm Glama health from initialize and tools/list; only then activate paid inventory. |
+| Glama connector | Remote connector form was accepted with the exact attributed endpoint; HTTP claim endpoint is disabled until a real token is issued | **Submitted · pending review** | [Glama connector directory](https://glama.ai/mcp/connectors) | Wait for Glama to create the listing and issue the claim token; complete the excluded 2-USDC lifecycle canary; configure `GLAMA_CLAIM_TOKEN`; verify `/.well-known/glama.json`; claim ownership; confirm Glama health from initialize and tools/list; only then activate paid inventory. |
 
-## Promotion Gate
+## Review, Publication, And Promotion Gates
 
-A listing is eligible for external submission only when all are true:
+A directory review submission may occur after gates 1, 2, 3, and 5 pass. A
+listing must not be represented as accepted, live, claimed, healthy, or ready
+for paid promotion until all five are true:
 
 1. Its `https://mcp.agentbounties.app/r/{rail}/mcp` route is deployed.
 2. MCP negotiation and the advertised tool catalog pass through that route.
@@ -39,8 +42,11 @@ the required excluded-operator 2-USDC funded-and-settled mainnet canary. Do not
 activate a listing or paid placement from dry-run evidence alone.
 
 An accepted PR, submitted form, review email, or directory draft is still not
-a live listing. Record `submitted`, `accepted`, and `live` as separate later
-events with the external URL and observed revision.
+a live listing. Record `submitted`, `accepted`, `live`, `claimed`, and `healthy`
+as separate events with the external URL and observed revision. The Glama
+submission receipt is recorded in
+`ops/distribution/glama-connector-submission-v1.json`; its listing URL remains
+unknown while review is pending.
 
 For Glama, the claim token is generated only after submission. Never invent or
 commit it. Configure it as `GLAMA_CLAIM_TOKEN` on the MCP service; the public

--- a/distribution/native-directory-submission/manifest.json
+++ b/distribution/native-directory-submission/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "agent-bounties/native-directory-submission-v1",
-  "release_status": "prepared_not_submitted",
+  "release_status": "glama_submitted_pending_review",
   "maintainer_notice": "https://github.com/NSPG13/agent-bounties/issues/1274",
   "install_host": {
     "requested_origin": "https://install.agentbounties.app",
@@ -146,11 +146,14 @@
       "preferred_alias_after_dns_activation": "https://install.agentbounties.app/glama",
       "connector_submission_url": "https://glama.ai/mcp/connectors",
       "connector_submission_kind": "remote_streamable_http",
-      "connector_form_state": "prepared_not_submitted",
+      "connector_form_state": "submitted_pending_review",
+      "submission_observed_at_utc": "2026-09-05T02:08:46Z",
+      "submission_confirmation": "Your server has been submitted for review",
+      "listing_url": null,
       "claim_method": "http_challenge",
       "claim_url": "https://mcp.agentbounties.app/.well-known/glama.json",
       "claim_token_source": "GLAMA_CLAIM_TOKEN",
-      "claim_state": "awaiting_real_token_after_submission",
+      "claim_state": "awaiting_review_and_real_token",
       "health_test": "initialize_then_tools_list_without_credentials",
       "status": "activate_only_after_attribution_canary",
       "paid_campaign_state": "activate_only_after_excluded_funded_and_settled_canary"
@@ -177,6 +180,7 @@
     "review_checklist": "README.md",
     "truth_state_submission_ledger": "SUBMISSION_LEDGER.md",
     "install_subdomain_contract": "INSTALL_SUBDOMAIN.md",
-    "machine_install_guide": "https://github.com/NSPG13/agent-bounties/blob/main/llms-install.md"
+    "machine_install_guide": "https://github.com/NSPG13/agent-bounties/blob/main/llms-install.md",
+    "glama_submission_record": "ops/distribution/glama-connector-submission-v1.json"
   }
 }

--- a/ops/distribution/glama-connector-submission-v1.json
+++ b/ops/distribution/glama-connector-submission-v1.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "agent-bounties/glama-connector-submission-v1",
+  "vendor_id": "glama",
+  "rail_id": "glama",
+  "submission_observed_at_utc": "2026-09-05T02:08:46Z",
+  "submitted_endpoint": "https://mcp.agentbounties.app/r/glama/mcp",
+  "submission_surface": "https://glama.ai/mcp/connectors",
+  "submission_kind": "remote_streamable_http",
+  "confirmation_text": "Your server has been submitted for review",
+  "external_state": "submitted_pending_review",
+  "listing_url": null,
+  "claim_state": "awaiting_review_and_real_token",
+  "claim_url": "https://mcp.agentbounties.app/.well-known/glama.json",
+  "health_state": "awaiting_listing",
+  "canary_state": "draft_prepared_wallet_not_connected",
+  "paid_campaign_state": "not_activated",
+  "evidence_boundary": "The authenticated form confirmation proves only that Glama accepted a review submission. It does not prove acceptance, publication, ownership, connector health, funding, settlement, or paid activation.",
+  "sensitive_values_recorded": false
+}

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -975,8 +975,8 @@ def check_install_distribution(repo_root: Path, site_dir: Path) -> None:
     package_manifest = json_file(package_dir / "manifest.json")
     if package_manifest.get("schema_version") != "agent-bounties/native-directory-submission-v1":
         fail("native-directory package has the wrong schema version")
-    if package_manifest.get("release_status") != "prepared_not_submitted":
-        fail("native-directory package must not claim an external submission")
+    if package_manifest.get("release_status") != "glama_submitted_pending_review":
+        fail("native-directory package must record the current Glama review state")
     identity = package_manifest.get("identity", {})
     if (
         identity.get("privacy") != "https://agentbounties.app/privacy.html"
@@ -1006,6 +1006,38 @@ def check_install_distribution(repo_root: Path, site_dir: Path) -> None:
     expected_paid = {"glama", "mcp-so", "mcpservers"}
     if set(paid_by_id) != expected_paid:
         fail("paid directory rail inventory drifted")
+    glama_target = paid_by_id["glama"]
+    if (
+        glama_target.get("connector_form_state") != "submitted_pending_review"
+        or glama_target.get("claim_state") != "awaiting_review_and_real_token"
+        or glama_target.get("submission_observed_at_utc")
+        != "2026-09-05T02:08:46Z"
+        or glama_target.get("listing_url") is not None
+        or glama_target.get("submission_confirmation")
+        != "Your server has been submitted for review"
+    ):
+        fail("Glama connector must remain truthfully submitted and pending review")
+    glama_record_path = package_manifest.get("submission_evidence", {}).get(
+        "glama_submission_record"
+    )
+    if glama_record_path != "ops/distribution/glama-connector-submission-v1.json":
+        fail("Glama submission record path drifted")
+    glama_record = json_file(repo_root / glama_record_path)
+    if (
+        glama_record.get("schema_version")
+        != "agent-bounties/glama-connector-submission-v1"
+        or glama_record.get("external_state") != "submitted_pending_review"
+        or glama_record.get("submitted_endpoint")
+        != "https://mcp.agentbounties.app/r/glama/mcp"
+        or glama_record.get("submission_observed_at_utc")
+        != glama_target.get("submission_observed_at_utc")
+        or glama_record.get("listing_url") is not None
+        or glama_record.get("claim_state") != "awaiting_review_and_real_token"
+        or glama_record.get("health_state") != "awaiting_listing"
+        or glama_record.get("paid_campaign_state") != "not_activated"
+        or glama_record.get("sensitive_values_recorded") is not False
+    ):
+        fail("Glama submission evidence overstates or misstates external truth")
     paid_platforms = install_manifest.get("paid_vendors")
     if not isinstance(paid_platforms, list):
         fail("install manifest paid vendors must be an array")


### PR DESCRIPTION
## Summary

- record Glama’s authenticated confirmation that the attributed remote connector was submitted for review
- keep `submitted`, `accepted`, `live`, `claimed`, and `healthy` as distinct external states
- add a token-free operator evidence record and keep paid activation blocked on the excluded 2-USDC settled canary
- update the site contract so stale `not_submitted` state fails closed

Public maintainer notice: #1274 (status follow-up comment included)

## Open PR impact

The open queue was checked before edits. The only likely textual overlap is the native-directory section of `scripts/check-site.py` in #1279; retain both independent checks if Git reports a conflict. No API, MCP, database, contract, payment, attribution, or wallet behavior changes.

## Validation

- `env PATH=/home/user/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH python scripts/check-site.py`
- `cargo run -p cli -- docs-contract-check`
- `python scripts/check-public-handoffs.py`
- `python scripts/check-agent-discovery-contract.py`
- `python scripts/test_check_agent_discovery_contract.py`
- `git diff --check`

Core preflight was attempted and stopped because the host path lacks `npm`; the focused checks above used the bundled Node executable and passed.

## Evidence boundary

Glama’s message “Your server has been submitted for review” proves only a review submission. It does not prove acceptance, publication, ownership, connector health, funding, settlement, or paid activation. The claim endpoint stays fail-closed until Glama issues a real token; no secret is committed.