### PR TITLE
Carry executable Glama verifier through attributed handoffs

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3
+          --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3
+          --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3
+          --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2899,6 +2899,7 @@ dependencies = [
  "tower-http 0.7.0",
  "url",
  "uuid",
+ "verifier-sdk",
  "web-public",
  "worker",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2899,7 +2899,6 @@ dependencies = [
  "tower-http 0.7.0",
  "url",
  "uuid",
- "verifier-sdk",
  "web-public",
  "worker",
 ]

--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ The public homepage opens the assistant chooser, and the first-party review
 handoff is <https://agentbounties.app/post.html>. Machine clients can use
 `prepare_bounty_post` when it appears in their MCP catalog. An approved image
 and its metadata may be supplied together, but are not required by
-provider-neutral clients. Advanced clients should follow the OpenAPI contract
+provider-neutral clients. Funding-ready coding handoffs supply `benchmark` and
+`evidence_schema` together; the benchmark must name an immutable public GitHub
+commit, content-digested benchmark subdirectory, digest-pinned OCI image,
+direct command, and complete bounded sandbox runner manifest. Advanced clients should follow the OpenAPI contract
 and publish inspectable terms with binary, replayable acceptance criteria
 before requesting funds or signatures.
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,8 @@ The public homepage opens the assistant chooser, and the first-party review
 handoff is <https://agentbounties.app/post.html>. Machine clients can use
 `prepare_bounty_post` when it appears in their MCP catalog. An approved image
 and its metadata may be supplied together, but are not required by
-provider-neutral clients. Funding-ready coding handoffs supply `benchmark` and
-`evidence_schema` together; the benchmark must name an immutable public GitHub
-commit, content-digested benchmark subdirectory, digest-pinned OCI image,
-direct command, and complete bounded sandbox runner manifest. Advanced clients should follow the OpenAPI contract
+provider-neutral clients. Funding-ready coding handoffs supply `benchmark` and `evidence_schema` together; pin a public GitHub commit, benchmark digest, digest-pinned OCI image, direct command, and complete bounded runner manifest.
+Advanced clients should follow the OpenAPI contract
 and publish inspectable terms with binary, replayable acceptance criteria
 before requesting funds or signatures.
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "c58602e3929f0a9b8d1cc437b58086cd6c5ac2d1194c4e89aeea97184609e
 PIPELINE_TEST_SHA256 = "1665f99a25f3ffdd1be1fb167e4ba9a09c729966c46ec41990629d5dd6f271e5"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3"
+WORKER_BUILD_SHA256 = "0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060"
 SIGNING_RUNTIME_SHA256 = "292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "d0cd56eed13cd8761995637a4a3244de0cc9f1e00a577f24d8d853d5662f3111",
+    ".github/workflows/regression-verifier-runner.yml": "2c5bf5491c8ec4842b9f254eae0ed9420f7cd6c9b78e968f7e8a878fcc61c217",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "b224d3344b5e6cfbab12c792db908b325bd891fb92a1f83b16a0ccd888c148b0",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "90e643330fa2d1c622376fff2135a89bca9ce1a9e7806f6ab28bb273d5ff945c",
+    ".github/workflows/regression-verifier-signer.yml": "1971ead90ac574822d9d62cbf3bea03a4da1d1675ff50355efbb76df561bf96b",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "cdc5cac68ed32fb8afc4b74cca3c77902ffba6b1e551011dbd629e40841bcb7f",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 7abeaa03f9707bc1580d28fac73ec7ab71de86fc34a2ca7a0764d05c632c86c3"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 0cafc0018871b90328b3acddc43bd1f9bd06ae38102c922c5c984b38ba43f060"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/benchmarks/distribution-v1/glama-onboarding-audit/README.md
+++ b/benchmarks/distribution-v1/glama-onboarding-audit/README.md
@@ -1,0 +1,39 @@
+# Glama onboarding audit benchmark
+
+This benchmark verifies the public evidence bundle for the attributed Glama
+Agent Bounties onboarding canary. It is intentionally task-specific: it must
+not be reused to verify an unrelated bounty.
+
+The solver submission must contain these files at its repository root:
+
+- `glama-onboarding-audit.json` — structured evidence using
+  `agent-bounties/glama-onboarding-audit-evidence-v1`.
+- `glama-onboarding-audit.md` — the linked public audit report.
+
+Run the immutable verifier from a submitted source snapshot with:
+
+```text
+python /benchmark/check.py
+```
+
+The sandbox mounts the immutable benchmark at `/benchmark`, mounts the solver
+snapshot read-only at `/workspace`, disables networking, and sets
+`WORKSPACE_ROOT=/workspace`. The verifier accepts only a Glama first-touch
+session against the canonical attributed MCP and install URLs, redacted MCP
+initialize and tools/list evidence, an explicit wallet-authority boundary, a
+synthetic-canary measurement exclusion, and linked Base-mainnet creation,
+funding, verifier-evidence, and settlement proofs for one bounty contract.
+
+The verifier validates the evidence bundle's shape and internal consistency.
+The signing verifier remains responsible for reconciling the referenced
+transactions and public artifact against current canonical state before it
+signs. A passing sandbox receipt, signature, or transaction hash is not proof
+of payment. Only a confirmed canonical `BountySettled` event is settlement
+evidence.
+
+Run the deterministic known-good and known-bad rehearsal with:
+
+```text
+python benchmarks/distribution-v1/glama-onboarding-audit/self_test.py
+```
+

--- a/benchmarks/distribution-v1/glama-onboarding-audit/check.py
+++ b/benchmarks/distribution-v1/glama-onboarding-audit/check.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Immutable verifier for the attributed Glama onboarding audit canary."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+from urllib.parse import urlparse
+
+
+ROOT = Path(os.environ.get("WORKSPACE_ROOT", "/workspace"))
+EVIDENCE_PATH = ROOT / "glama-onboarding-audit.json"
+REPORT_PATH = ROOT / "glama-onboarding-audit.md"
+SCHEMA = "agent-bounties/glama-onboarding-audit-evidence-v1"
+MCP_ENDPOINT = "https://mcp.agentbounties.app/r/glama/mcp"
+INSTALL_URL = "https://agentbounties.app/install/glama/"
+REVIEW_ORIGIN = "https://agentbounties.app"
+PROTOCOL_VERSION = "2025-06-18"
+TX_RE = re.compile(r"^0x[0-9a-f]{64}$")
+ADDRESS_RE = re.compile(r"^0x[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SIGNED_ATTRIBUTION_RE = re.compile(r"aba1_[0-9a-f]{64}\.[0-9a-f]{64}", re.IGNORECASE)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def exact_keys(value: object, expected: set[str], label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        fail(f"{label} must be an object")
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        fail(f"{label} keys mismatch; missing={missing} extra={extra}")
+    return value
+
+
+def text(value: object, label: str, maximum: int = 4_000) -> str:
+    if not isinstance(value, str) or not value.strip():
+        fail(f"{label} must be a non-empty string")
+    if len(value.encode("utf-8")) > maximum:
+        fail(f"{label} exceeds {maximum} bytes")
+    return value
+
+
+def utc_instant(value: object, label: str) -> datetime:
+    raw = text(value, label, 64)
+    if not raw.endswith("Z"):
+        fail(f"{label} must be an RFC 3339 UTC instant ending in Z")
+    try:
+        parsed = datetime.fromisoformat(raw[:-1] + "+00:00")
+    except ValueError as error:
+        fail(f"{label} is not a valid RFC 3339 instant: {error}")
+    if parsed.tzinfo != timezone.utc:
+        fail(f"{label} must use UTC")
+    return parsed
+
+
+def public_https(value: object, label: str, *, hosts: set[str] | None = None) -> str:
+    raw = text(value, label, 2_000)
+    parsed = urlparse(raw)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+        fail(f"{label} must be a public HTTPS URL without embedded credentials")
+    if parsed.hostname in {"localhost", "127.0.0.1", "::1"}:
+        fail(f"{label} must not use a loopback host")
+    if hosts is not None and parsed.hostname not in hosts:
+        fail(f"{label} must use one of {sorted(hosts)}")
+    return raw
+
+
+def sha256_file(path: Path) -> str:
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def transcript_evidence(value: object, label: str) -> dict[str, object]:
+    record = exact_keys(
+        value,
+        {"captured_at", "request_sha256", "response_sha256", "redacted"},
+        label,
+    )
+    utc_instant(record["captured_at"], f"{label}.captured_at")
+    for field in ("request_sha256", "response_sha256"):
+        if not DIGEST_RE.fullmatch(str(record[field])):
+            fail(f"{label}.{field} must be sha256:<64 lowercase hex>")
+    if record["redacted"] is not True:
+        fail(f"{label}.redacted must be true")
+    return record
+
+
+def event_proof(value: object, name: str) -> dict[str, object]:
+    record = exact_keys(
+        value,
+        {"event", "transaction_hash", "block_number", "log_index", "explorer_url"},
+        f"lifecycle.{name}",
+    )
+    if record["event"] != name:
+        fail(f"lifecycle.{name}.event must be {name}")
+    if not TX_RE.fullmatch(str(record["transaction_hash"])):
+        fail(f"lifecycle.{name}.transaction_hash must be a lowercase transaction hash")
+    if not isinstance(record["block_number"], int) or record["block_number"] <= 0:
+        fail(f"lifecycle.{name}.block_number must be a positive integer")
+    if not isinstance(record["log_index"], int) or record["log_index"] < 0:
+        fail(f"lifecycle.{name}.log_index must be a non-negative integer")
+    expected = f"https://basescan.org/tx/{record['transaction_hash']}"
+    if record["explorer_url"] != expected:
+        fail(f"lifecycle.{name}.explorer_url must be {expected}")
+    return record
+
+
+if not EVIDENCE_PATH.is_file():
+    fail("missing glama-onboarding-audit.json")
+if not REPORT_PATH.is_file():
+    fail("missing glama-onboarding-audit.md")
+if EVIDENCE_PATH.stat().st_size > 64 * 1024:
+    fail("glama-onboarding-audit.json exceeds 64 KiB")
+if REPORT_PATH.stat().st_size > 128 * 1024:
+    fail("glama-onboarding-audit.md exceeds 128 KiB")
+
+try:
+    evidence = json.loads(EVIDENCE_PATH.read_text(encoding="utf-8"))
+except (UnicodeDecodeError, json.JSONDecodeError) as error:
+    fail(f"glama-onboarding-audit.json is invalid UTF-8 JSON: {error}")
+
+evidence = exact_keys(
+    evidence,
+    {
+        "schema_version",
+        "rail",
+        "measurement_exclusion",
+        "mcp",
+        "wallet_boundary",
+        "lifecycle",
+        "report",
+    },
+    "evidence",
+)
+if evidence["schema_version"] != SCHEMA:
+    fail(f"schema_version must be {SCHEMA}")
+if evidence["rail"] != "glama":
+    fail("rail must be glama")
+if evidence["measurement_exclusion"] != "synthetic_canary":
+    fail("measurement_exclusion must be synthetic_canary")
+
+mcp = exact_keys(
+    evidence["mcp"],
+    {
+        "endpoint",
+        "install_url",
+        "protocol_version",
+        "first_touch_rail",
+        "current_rail",
+        "measurement_eligible_at_discovery",
+        "prepare_bounty_post_discoverable",
+        "initialize",
+        "tools_list",
+    },
+    "mcp",
+)
+if mcp["endpoint"] != MCP_ENDPOINT:
+    fail(f"mcp.endpoint must be {MCP_ENDPOINT}")
+if mcp["install_url"] != INSTALL_URL:
+    fail(f"mcp.install_url must be {INSTALL_URL}")
+if mcp["protocol_version"] != PROTOCOL_VERSION:
+    fail(f"mcp.protocol_version must be {PROTOCOL_VERSION}")
+if mcp["first_touch_rail"] != "glama" or mcp["current_rail"] != "glama":
+    fail("MCP first-touch and current rail must both be glama")
+if mcp["measurement_eligible_at_discovery"] is not True:
+    fail("the discovery session must be measurement eligible before canary exclusion")
+if mcp["prepare_bounty_post_discoverable"] is not True:
+    fail("prepare_bounty_post must be discoverable")
+initialize = transcript_evidence(mcp["initialize"], "mcp.initialize")
+tools_list = transcript_evidence(mcp["tools_list"], "mcp.tools_list")
+if utc_instant(initialize["captured_at"], "mcp.initialize.captured_at") > utc_instant(
+    tools_list["captured_at"], "mcp.tools_list.captured_at"
+):
+    fail("initialize evidence must not be later than tools/list evidence")
+
+wallet = exact_keys(
+    evidence["wallet_boundary"],
+    {
+        "first_party_review_url",
+        "human_approval_observed",
+        "agent_received_private_key",
+        "agent_received_seed_phrase",
+        "agent_received_wallet_signature",
+        "agent_received_payout_authority",
+    },
+    "wallet_boundary",
+)
+review_url = public_https(wallet["first_party_review_url"], "wallet_boundary.first_party_review_url")
+if not review_url.startswith(f"{REVIEW_ORIGIN}/post.html?"):
+    fail("wallet review must occur on the first-party Agent Bounties post page")
+if wallet["human_approval_observed"] is not True:
+    fail("human_approval_observed must be true")
+for field in (
+    "agent_received_private_key",
+    "agent_received_seed_phrase",
+    "agent_received_wallet_signature",
+    "agent_received_payout_authority",
+):
+    if wallet[field] is not False:
+        fail(f"wallet_boundary.{field} must be false")
+
+lifecycle = exact_keys(
+    evidence["lifecycle"],
+    {
+        "network",
+        "chain_id",
+        "bounty_contract",
+        "bounty_id",
+        "created",
+        "funded",
+        "verifier_evidence",
+        "settled",
+    },
+    "lifecycle",
+)
+if lifecycle["network"] != "base-mainnet" or lifecycle["chain_id"] != 8453:
+    fail("lifecycle must identify Base mainnet chain 8453")
+if not ADDRESS_RE.fullmatch(str(lifecycle["bounty_contract"])):
+    fail("lifecycle.bounty_contract must be a lowercase EVM address")
+if not isinstance(lifecycle["bounty_id"], int) or lifecycle["bounty_id"] < 0:
+    fail("lifecycle.bounty_id must be a non-negative integer")
+created = event_proof(lifecycle["created"], "CanonicalBountyCreated")
+funded = event_proof(lifecycle["funded"], "FundingAdded")
+settled = event_proof(lifecycle["settled"], "BountySettled")
+if not (created["block_number"] <= funded["block_number"] <= settled["block_number"]):
+    fail("canonical lifecycle events must be ordered by block number")
+verifier = exact_keys(
+    lifecycle["verifier_evidence"],
+    {"public_url", "sha256"},
+    "lifecycle.verifier_evidence",
+)
+public_https(verifier["public_url"], "lifecycle.verifier_evidence.public_url")
+if not DIGEST_RE.fullmatch(str(verifier["sha256"])):
+    fail("lifecycle.verifier_evidence.sha256 must be sha256:<64 lowercase hex>")
+
+report = exact_keys(
+    evidence["report"],
+    {"public_url", "path", "sha256", "started_at", "completed_at"},
+    "report",
+)
+public_https(report["public_url"], "report.public_url")
+if report["path"] != REPORT_PATH.name:
+    fail(f"report.path must be {REPORT_PATH.name}")
+if report["sha256"] != sha256_file(REPORT_PATH):
+    fail("report.sha256 does not match glama-onboarding-audit.md")
+if utc_instant(report["started_at"], "report.started_at") > utc_instant(
+    report["completed_at"], "report.completed_at"
+):
+    fail("report.started_at must not be later than report.completed_at")
+
+report_text = REPORT_PATH.read_text(encoding="utf-8")
+combined = EVIDENCE_PATH.read_text(encoding="utf-8") + "\n" + report_text
+if SIGNED_ATTRIBUTION_RE.search(combined):
+    fail("the public evidence bundle exposes a signed acquisition identifier")
+normalized_report = " ".join(report_text.split())
+for required in (
+    MCP_ENDPOINT,
+    INSTALL_URL,
+    PROTOCOL_VERSION,
+    "First-touch rail: glama",
+    "prepare_bounty_post",
+    "no private key",
+    "no seed phrase",
+    "no wallet signature",
+    "no payout authority",
+    "CanonicalBountyCreated",
+    "FundingAdded",
+    "BountySettled",
+    str(created["transaction_hash"]),
+    str(funded["transaction_hash"]),
+    str(settled["transaction_hash"]),
+    str(verifier["public_url"]),
+):
+    if required not in normalized_report:
+        fail(f"public report is missing required evidence: {required}")
+
+print("Glama onboarding audit benchmark passed")

--- a/benchmarks/distribution-v1/glama-onboarding-audit/fixtures/passing/glama-onboarding-audit.json
+++ b/benchmarks/distribution-v1/glama-onboarding-audit/fixtures/passing/glama-onboarding-audit.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "agent-bounties/glama-onboarding-audit-evidence-v1",
+  "rail": "glama",
+  "measurement_exclusion": "synthetic_canary",
+  "mcp": {
+    "endpoint": "https://mcp.agentbounties.app/r/glama/mcp",
+    "install_url": "https://agentbounties.app/install/glama/",
+    "protocol_version": "2025-06-18",
+    "first_touch_rail": "glama",
+    "current_rail": "glama",
+    "measurement_eligible_at_discovery": true,
+    "prepare_bounty_post_discoverable": true,
+    "initialize": {
+      "captured_at": "2026-09-05T04:01:00Z",
+      "request_sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "response_sha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "redacted": true
+    },
+    "tools_list": {
+      "captured_at": "2026-09-05T04:02:00Z",
+      "request_sha256": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "response_sha256": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "redacted": true
+    }
+  },
+  "wallet_boundary": {
+    "first_party_review_url": "https://agentbounties.app/post.html?fixture=redacted",
+    "human_approval_observed": true,
+    "agent_received_private_key": false,
+    "agent_received_seed_phrase": false,
+    "agent_received_wallet_signature": false,
+    "agent_received_payout_authority": false
+  },
+  "lifecycle": {
+    "network": "base-mainnet",
+    "chain_id": 8453,
+    "bounty_contract": "0x4444444444444444444444444444444444444444",
+    "bounty_id": 1,
+    "created": {
+      "event": "CanonicalBountyCreated",
+      "transaction_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+      "block_number": 100,
+      "log_index": 0,
+      "explorer_url": "https://basescan.org/tx/0x1111111111111111111111111111111111111111111111111111111111111111"
+    },
+    "funded": {
+      "event": "FundingAdded",
+      "transaction_hash": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      "block_number": 101,
+      "log_index": 1,
+      "explorer_url": "https://basescan.org/tx/0x2222222222222222222222222222222222222222222222222222222222222222"
+    },
+    "verifier_evidence": {
+      "public_url": "https://example.com/glama-canary/verifier-evidence.json",
+      "sha256": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    },
+    "settled": {
+      "event": "BountySettled",
+      "transaction_hash": "0x3333333333333333333333333333333333333333333333333333333333333333",
+      "block_number": 102,
+      "log_index": 2,
+      "explorer_url": "https://basescan.org/tx/0x3333333333333333333333333333333333333333333333333333333333333333"
+    }
+  },
+  "report": {
+    "public_url": "https://example.com/glama-canary/glama-onboarding-audit.md",
+    "path": "glama-onboarding-audit.md",
+    "sha256": "sha256:75ee6a50508164b0f8daa18228268131b1d8892ef1430a71be2d1018aaeb2dbc",
+    "started_at": "2026-09-05T04:00:00Z",
+    "completed_at": "2026-09-05T04:20:00Z"
+  }
+}

--- a/benchmarks/distribution-v1/glama-onboarding-audit/fixtures/passing/glama-onboarding-audit.md
+++ b/benchmarks/distribution-v1/glama-onboarding-audit/fixtures/passing/glama-onboarding-audit.md
@@ -1,0 +1,24 @@
+# Glama Agent Bounties onboarding audit
+
+- Started: 2026-09-05T04:00:00Z
+- Completed: 2026-09-05T04:20:00Z
+- First-touch rail: glama
+- MCP protocol version: 2025-06-18
+- Install guide: https://agentbounties.app/install/glama/
+- Attributed MCP: https://mcp.agentbounties.app/r/glama/mcp
+
+The redacted `initialize` and `tools/list` captures confirm that
+`prepare_bounty_post` is discoverable. The acquisition identifier is redacted.
+The agent received no private key, no seed phrase, no wallet signature, and no
+payout authority. Human wallet review occurred only on agentbounties.app.
+
+## Canonical lifecycle
+
+- CanonicalBountyCreated: https://basescan.org/tx/0x1111111111111111111111111111111111111111111111111111111111111111
+- FundingAdded: https://basescan.org/tx/0x2222222222222222222222222222222222222222222222222222222222222222
+- Verifier evidence: https://example.com/glama-canary/verifier-evidence.json
+- BountySettled: https://basescan.org/tx/0x3333333333333333333333333333333333333333333333333333333333333333
+
+This fixture is synthetic self-test data. It is not a real bounty, transaction,
+verification, settlement, payment, or marketing conversion.
+

--- a/benchmarks/distribution-v1/glama-onboarding-audit/self_test.py
+++ b/benchmarks/distribution-v1/glama-onboarding-audit/self_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Known-good and known-bad rehearsal for the Glama onboarding benchmark."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+HERE = Path(__file__).resolve().parent
+FIXTURE = HERE / "fixtures" / "passing"
+CHECK = HERE / "check.py"
+
+
+def run(workspace: Path, should_pass: bool, label: str) -> None:
+    env = dict(os.environ)
+    env["WORKSPACE_ROOT"] = str(workspace)
+    completed = subprocess.run(
+        [sys.executable, str(CHECK)],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=10,
+        check=False,
+    )
+    passed = completed.returncode == 0
+    if passed != should_pass:
+        raise SystemExit(
+            f"{label}: expected {'pass' if should_pass else 'failure'}, "
+            f"got exit {completed.returncode}\n{completed.stdout}"
+        )
+
+
+with tempfile.TemporaryDirectory(prefix="glama-onboarding-benchmark-") as raw:
+    root = Path(raw)
+    passing = root / "passing"
+    shutil.copytree(FIXTURE, passing)
+    run(passing, True, "known-good")
+
+    cases = {
+        "wrong-rail": lambda data: data["mcp"].__setitem__("first_touch_rail", "direct"),
+        "missing-tool": lambda data: data["mcp"].__setitem__(
+            "prepare_bounty_post_discoverable", False
+        ),
+        "wallet-authority": lambda data: data["wallet_boundary"].__setitem__(
+            "agent_received_wallet_signature", True
+        ),
+        "not-settled": lambda data: data["lifecycle"]["settled"].__setitem__(
+            "event", "SubmissionVerified"
+        ),
+        "not-excluded": lambda data: data.__setitem__("measurement_exclusion", "none"),
+    }
+    for name, mutate in cases.items():
+        candidate = root / name
+        shutil.copytree(FIXTURE, candidate)
+        evidence_path = candidate / "glama-onboarding-audit.json"
+        data = json.loads(evidence_path.read_text(encoding="utf-8"))
+        mutate(data)
+        evidence_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        run(candidate, False, name)
+
+print("Glama onboarding audit self-test passed: 1 positive, 5 negative")
+

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -33,5 +33,6 @@ tokio.workspace = true
 tower-http.workspace = true
 url.workspace = true
 uuid.workspace = true
+verifier-sdk = { path = "../verifier-sdk" }
 web-public = { path = "../web-public" }
 worker = { path = "../worker" }

--- a/crates/mcp-server/Cargo.toml
+++ b/crates/mcp-server/Cargo.toml
@@ -33,6 +33,5 @@ tokio.workspace = true
 tower-http.workspace = true
 url.workspace = true
 uuid.workspace = true
-verifier-sdk = { path = "../verifier-sdk" }
 web-public = { path = "../web-public" }
 worker = { path = "../worker" }

--- a/crates/mcp-server/fixtures/public-mcp-contract-v1.json
+++ b/crates/mcp-server/fixtures/public-mcp-contract-v1.json
@@ -16,7 +16,7 @@
         "prepare_moonpay_onramp",
         "render_bounty_feed"
       ],
-      "normalized_descriptors_sha256": "ab4d2cdfd1277e3f88a32e225ecff7ece2ac658bdacbde11d3d6bbfeb045180f"
+      "normalized_descriptors_sha256": "432451d451b9188fb917a1e68131e24736ab4e325dab1f819f1534f556d3e7d7"
     },
     "core": {
       "tool_count": 13,
@@ -35,7 +35,7 @@
         "prepare_open_competition_v2",
         "render_bounty_feed"
       ],
-      "normalized_descriptors_sha256": "264d7b89e43598309e68f635f75c7c9436d40f2b934cce4b45744ef414a46431"
+      "normalized_descriptors_sha256": "66edfaea62a26c7708dbd764d8628938f28faa0c5188934c4fdf175a4ac57855"
     }
   }
 }

--- a/crates/mcp-server/fixtures/tool-registry.json
+++ b/crates/mcp-server/fixtures/tool-registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "agent-bounties/mcp-tool-registry-v1",
-  "normalized_descriptors_sha256": "4657f08ee7e37f33624c0f65de41539bbc5debbd7624d106409bdd9fabc0f8d6",
+  "normalized_descriptors_sha256": "5f8013b94679be48be58aada96582843cadfa0609c73c9582a174617442081c4",
   "tools": [
     "route_blocked_goal",
     "plan_objective_creation",

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -36,7 +36,6 @@ use sha2::{Digest, Sha256};
 use std::{env, net::IpAddr};
 use url::Url;
 use uuid::Uuid;
-use verifier_sdk::RegressionSandboxPolicy;
 
 const MCP_PROTOCOL_VERSION: &str = "2026-07-28";
 const MCP_LEGACY_PROTOCOL_VERSION: &str = "2025-06-18";
@@ -623,13 +622,166 @@ fn validate_prepared_verifier(
     }
     let runner = benchmark
         .get("runner_manifest")
-        .ok_or_else(|| "benchmark.runner_manifest is required".to_string())?;
-    let policy = serde_json::from_value::<RegressionSandboxPolicy>(runner.clone())
-        .map_err(|error| format!("benchmark.runner_manifest has an invalid shape: {error}"))?;
-    policy
-        .validate()
-        .map_err(|error| format!("benchmark.runner_manifest is not executable: {error}"))?;
+        .and_then(Value::as_object)
+        .ok_or_else(|| "benchmark.runner_manifest must be an object".to_string())?;
+    let expected_runner_keys = [
+        "schema_version",
+        "image",
+        "command",
+        "workdir",
+        "benchmark_digest",
+        "timeout_seconds",
+        "cpu_millis",
+        "memory_bytes",
+        "pids_limit",
+        "max_output_bytes",
+        "tmpfs_bytes",
+        "max_source_bytes",
+        "max_source_files",
+        "max_benchmark_bytes",
+        "max_benchmark_files",
+        "platform",
+        "test_seed",
+    ];
+    if runner.len() != expected_runner_keys.len()
+        || expected_runner_keys
+            .iter()
+            .any(|key| !runner.contains_key(*key))
+    {
+        return Err(
+            "benchmark.runner_manifest must contain the complete regression-sandbox-v1 field set"
+                .to_string(),
+        );
+    }
+    if runner.get("schema_version").and_then(Value::as_str)
+        != Some("agent-bounties/regression-sandbox-v1")
+    {
+        return Err(
+            "benchmark.runner_manifest.schema_version must be agent-bounties/regression-sandbox-v1"
+                .to_string(),
+        );
+    }
+    let image = runner
+        .get("image")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "benchmark.runner_manifest.image is required".to_string())?;
+    let image_parts = image.split('@').collect::<Vec<_>>();
+    if image_parts.len() != 2
+        || image_parts[0].is_empty()
+        || image_parts[0].starts_with('-')
+        || image_parts[0].contains("..")
+        || image_parts[0].bytes().any(|byte| {
+            !(byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'.' | b'/' | b':' | b'_' | b'-'))
+        })
+        || !valid_sha256_digest(image_parts[1])
+    {
+        return Err(
+            "benchmark.runner_manifest.image must be one lowercase OCI reference pinned by sha256 digest"
+                .to_string(),
+        );
+    }
+    let command = runner
+        .get("command")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "benchmark.runner_manifest.command must be an array".to_string())?;
+    if command.is_empty() || command.len() > 64 {
+        return Err(
+            "benchmark.runner_manifest.command must contain 1 to 64 direct argv entries"
+                .to_string(),
+        );
+    }
+    let mut command_bytes = 0usize;
+    for argument in command {
+        let argument = argument.as_str().ok_or_else(|| {
+            "benchmark.runner_manifest.command entries must be strings".to_string()
+        })?;
+        if argument.is_empty() || argument.len() > 4_096 || argument.contains(['\0', '\n', '\r']) {
+            return Err(
+                "benchmark.runner_manifest.command contains an invalid argv entry".to_string(),
+            );
+        }
+        command_bytes = command_bytes.saturating_add(argument.len());
+    }
+    if command_bytes > 16_384 {
+        return Err("benchmark.runner_manifest.command exceeds the argv byte limit".to_string());
+    }
+    let executable = command[0]
+        .as_str()
+        .unwrap_or_default()
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if matches!(
+        executable.as_str(),
+        "sh" | "bash" | "dash" | "zsh" | "cmd" | "cmd.exe" | "powershell" | "pwsh"
+    ) {
+        return Err(
+            "benchmark.runner_manifest.command must use direct argv and cannot invoke a shell"
+                .to_string(),
+        );
+    }
+    if runner.get("workdir").and_then(Value::as_str) != Some("/workspace") {
+        return Err("benchmark.runner_manifest.workdir must be /workspace".to_string());
+    }
+    if !runner
+        .get("benchmark_digest")
+        .and_then(Value::as_str)
+        .is_some_and(valid_sha256_digest)
+    {
+        return Err(
+            "benchmark.runner_manifest.benchmark_digest must use sha256:<64 lowercase hex>"
+                .to_string(),
+        );
+    }
+    let bounds = [
+        ("timeout_seconds", 1, 900),
+        ("cpu_millis", 100, 4_000),
+        ("memory_bytes", 67_108_864, 4_294_967_296),
+        ("pids_limit", 16, 512),
+        ("max_output_bytes", 1_024, 16_777_216),
+        ("tmpfs_bytes", 67_108_864, 4_294_967_296),
+        ("max_source_bytes", 1, 2_147_483_648),
+        ("max_source_files", 1, 100_000),
+        ("max_benchmark_bytes", 1, 536_870_912),
+        ("max_benchmark_files", 1, 50_000),
+        ("test_seed", 0, 9_007_199_254_740_991),
+    ];
+    for (field, minimum, maximum) in bounds {
+        if !runner
+            .get(field)
+            .and_then(Value::as_u64)
+            .is_some_and(|value| (minimum..=maximum).contains(&value))
+        {
+            return Err(format!(
+                "benchmark.runner_manifest.{field} is outside protocol bounds"
+            ));
+        }
+    }
+    if runner["tmpfs_bytes"].as_u64() > runner["memory_bytes"].as_u64() {
+        return Err("benchmark.runner_manifest.tmpfs_bytes cannot exceed memory_bytes".to_string());
+    }
+    if !matches!(
+        runner.get("platform").and_then(Value::as_str),
+        Some("linux/amd64" | "linux/arm64")
+    ) {
+        return Err(
+            "benchmark.runner_manifest.platform must be linux/amd64 or linux/arm64".to_string(),
+        );
+    }
     Ok(())
+}
+
+fn valid_sha256_digest(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return false;
+    };
+    hex.len() == 64
+        && hex
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
 }
 
 async fn persist_chatgpt_bounty_image(
@@ -4886,7 +5038,7 @@ mod tests {
             json!("docker.io/library/python:latest");
         assert!(build_bounty_post_handoff(&args, None)
             .unwrap_err()
-            .contains("not executable"));
+            .contains("image must be one lowercase OCI reference pinned by sha256 digest"));
     }
 
     #[test]

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -36,6 +36,7 @@ use sha2::{Digest, Sha256};
 use std::{env, net::IpAddr};
 use url::Url;
 use uuid::Uuid;
+use verifier_sdk::RegressionSandboxPolicy;
 
 const MCP_PROTOCOL_VERSION: &str = "2026-07-28";
 const MCP_LEGACY_PROTOCOL_VERSION: &str = "2025-06-18";
@@ -62,6 +63,7 @@ const BOUNTY_CARD_PREVIEW_HTML: &str = include_str!("../assets/chatgpt-bounty-ca
 const FEED_CARD_ART: &[u8] =
     include_bytes!("../../../site/assets/solarpunk/characters-helping.webp");
 const MAX_BOUNTY_IMAGE_BYTES: usize = 5 * 1024 * 1024;
+const REGRESSION_ENGINE: &str = "sandboxed_regression_v1";
 const CHATGPT_ADVERTISED_TOOL_NAMES: &[&str] = &[
     "get_bounty_feed",
     "render_bounty_feed",
@@ -431,6 +433,7 @@ pub(super) fn build_bounty_post_handoff(
         .as_deref()
         .map(|value| bounded_text(value, "discovery_source", 500))
         .transpose()?;
+    validate_prepared_verifier(args.benchmark.as_ref(), args.evidence_schema.as_ref())?;
     match (
         image,
         args.image_prompt.as_deref(),
@@ -481,6 +484,21 @@ pub(super) fn build_bounty_post_handoff(
                 .as_deref()
                 .unwrap_or("AI assistant via MCP"),
         );
+        if let Some(benchmark) = args.benchmark.as_ref() {
+            query.append_pair(
+                "benchmark",
+                &serde_json::to_string(benchmark)
+                    .map_err(|_| "benchmark could not be encoded for browser review".to_string())?,
+            );
+        }
+        if let Some(evidence_schema) = args.evidence_schema.as_ref() {
+            query.append_pair(
+                "evidenceSchema",
+                &serde_json::to_string(evidence_schema).map_err(|_| {
+                    "evidence_schema could not be encoded for browser review".to_string()
+                })?,
+            );
+        }
         if let Some(image) = image {
             query.append_pair("imageUrl", &image.asset_url);
             query.append_pair("imageSha256", &image.sha256);
@@ -509,6 +527,8 @@ pub(super) fn build_bounty_post_handoff(
         "initial_funding_usdc": if args.crowdfund { "0".to_string() } else { format_usdc(target) },
         "crowdfund": args.crowdfund,
         "source_url": source_url,
+        "benchmark": args.benchmark,
+        "evidence_schema": args.evidence_schema,
         "image": image,
         "post_url": post_url.as_str(),
         "bounty_created": false,
@@ -516,6 +536,100 @@ pub(super) fn build_bounty_post_handoff(
         "next_action": "Open the secure handoff, review every field, and choose whether to deposit 0 USDC now or fully fund. Then connect the creator wallet and approve only the exact Base transaction shown by that wallet.",
         "evidence_boundary": "No bounty id or contract exists yet. Only confirmed CanonicalBountyCreated proves creation; FundingAdded and BountyBecameClaimable prove funding and claimability."
     }))
+}
+
+fn validate_prepared_verifier(
+    benchmark: Option<&Value>,
+    evidence_schema: Option<&Value>,
+) -> Result<(), String> {
+    match (benchmark, evidence_schema) {
+        (None, None) => return Ok(()),
+        (None, Some(_)) => {
+            return Err("benchmark is required when evidence_schema is supplied".to_string())
+        }
+        (Some(_), None) => {
+            return Err("evidence_schema is required when benchmark is supplied".to_string())
+        }
+        (Some(_), Some(_)) => {}
+    }
+    let benchmark = benchmark.expect("matched benchmark presence");
+    let evidence_schema = evidence_schema.expect("matched evidence schema presence");
+    for (value, label) in [
+        (benchmark, "benchmark"),
+        (evidence_schema, "evidence_schema"),
+    ] {
+        let encoded = serde_json::to_vec(value)
+            .map_err(|_| format!("{label} could not be encoded safely"))?;
+        if encoded.len() > 20_000 {
+            return Err(format!("{label} exceeds the 20,000-byte handoff limit"));
+        }
+        if !value.is_object() {
+            return Err(format!("{label} must be an object"));
+        }
+    }
+    if benchmark.get("engine").and_then(Value::as_str) != Some(REGRESSION_ENGINE) {
+        return Err(format!("benchmark.engine must be {REGRESSION_ENGINE}"));
+    }
+    let source = benchmark
+        .get("source")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "benchmark.source must be an object".to_string())?;
+    if source.get("kind").and_then(Value::as_str) != Some("github_commit") {
+        return Err("benchmark.source.kind must be github_commit".to_string());
+    }
+    let repository = source
+        .get("repository")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "benchmark.source.repository is required".to_string())?;
+    let repository_parts = repository.split('/').collect::<Vec<_>>();
+    if repository_parts.len() != 2
+        || repository_parts.iter().any(|part| {
+            part.is_empty()
+                || part.len() > 100
+                || !part
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        })
+    {
+        return Err("benchmark.source.repository must be owner/repository".to_string());
+    }
+    let commit = source
+        .get("commit")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "benchmark.source.commit is required".to_string())?;
+    if commit.len() != 40
+        || !commit
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(
+            "benchmark.source.commit must be 40 lowercase hexadecimal characters".to_string(),
+        );
+    }
+    let subdirectory = source
+        .get("subdirectory")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "benchmark.source.subdirectory is required".to_string())?;
+    if subdirectory.is_empty()
+        || subdirectory.len() > 500
+        || subdirectory.starts_with('/')
+        || subdirectory.ends_with('/')
+        || subdirectory.contains('\\')
+        || subdirectory
+            .split('/')
+            .any(|part| part.is_empty() || matches!(part, "." | ".."))
+    {
+        return Err("benchmark.source.subdirectory must be a normalized non-root path".to_string());
+    }
+    let runner = benchmark
+        .get("runner_manifest")
+        .ok_or_else(|| "benchmark.runner_manifest is required".to_string())?;
+    let policy = serde_json::from_value::<RegressionSandboxPolicy>(runner.clone())
+        .map_err(|error| format!("benchmark.runner_manifest has an invalid shape: {error}"))?;
+    policy
+        .validate()
+        .map_err(|error| format!("benchmark.runner_manifest is not executable: {error}"))?;
+    Ok(())
 }
 
 async fn persist_chatgpt_bounty_image(
@@ -4590,6 +4704,45 @@ mod tests {
             crowdfund: false,
             task_window_days: None,
             discovery_source: Some("ChatGPT user feedback".to_string()),
+            benchmark: Some(json!({
+                "engine": "sandboxed_regression_v1",
+                "source": {
+                    "kind": "github_commit",
+                    "repository": "NSPG13/agent-bounties",
+                    "commit": "0fae18cf9be464132cde52dfb9d464d836e8f024",
+                    "subdirectory": "benchmarks/distribution-v1/glama-onboarding-audit"
+                },
+                "runner_manifest": {
+                    "schema_version": "agent-bounties/regression-sandbox-v1",
+                    "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",
+                    "command": ["python", "/benchmark/check.py"],
+                    "workdir": "/workspace",
+                    "benchmark_digest": "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656",
+                    "timeout_seconds": 120,
+                    "cpu_millis": 1000,
+                    "memory_bytes": 536870912,
+                    "pids_limit": 128,
+                    "max_output_bytes": 1048576,
+                    "tmpfs_bytes": 268435456,
+                    "max_source_bytes": 67108864,
+                    "max_source_files": 1000,
+                    "max_benchmark_bytes": 1048576,
+                    "max_benchmark_files": 100,
+                    "platform": "linux/amd64",
+                    "test_seed": 1
+                }
+            })),
+            evidence_schema: Some(json!({
+                "type": "object",
+                "required": ["source_snapshot_digest"],
+                "properties": {
+                    "source_snapshot_digest": {
+                        "type": "string",
+                        "pattern": "^sha256:[0-9a-f]{64}$"
+                    }
+                },
+                "additionalProperties": false
+            })),
             image_prompt: Some(
                 "Minimal editorial illustration of a reconciliation test becoming green."
                     .to_string(),
@@ -4695,6 +4848,11 @@ mod tests {
         assert_eq!(handoff["initial_funding_usdc"], "2.1");
         assert_eq!(handoff["bounty_created"], false);
         assert_eq!(handoff["wallet_signature_requested"], false);
+        assert_eq!(handoff["benchmark"], *args.benchmark.as_ref().unwrap());
+        assert_eq!(
+            handoff["evidence_schema"],
+            *args.evidence_schema.as_ref().unwrap()
+        );
         assert_eq!(handoff["image"]["source"], "chatgpt_user_generated");
         assert!(pairs
             .iter()
@@ -4706,6 +4864,29 @@ mod tests {
             pairs.iter().filter(|(key, _)| key == "criterion").count(),
             2
         );
+        assert!(pairs.iter().any(|(key, value)| {
+            key == "benchmark"
+                && value.contains("benchmarks/distribution-v1/glama-onboarding-audit")
+        }));
+        assert!(pairs.iter().any(
+            |(key, value)| key == "evidenceSchema" && value.contains("source_snapshot_digest")
+        ));
+    }
+
+    #[test]
+    fn verifier_handoff_rejects_incomplete_or_non_executable_inputs() {
+        let mut args = valid_args();
+        args.evidence_schema = None;
+        assert!(build_bounty_post_handoff(&args, None)
+            .unwrap_err()
+            .contains("evidence_schema is required"));
+
+        let mut args = valid_args();
+        args.benchmark.as_mut().unwrap()["runner_manifest"]["image"] =
+            json!("docker.io/library/python:latest");
+        assert!(build_bounty_post_handoff(&args, None)
+            .unwrap_err()
+            .contains("not executable"));
     }
 
     #[test]

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -536,6 +536,8 @@ tool_args! {
         #[serde(default)]
         crowdfund: bool,
         discovery_source: Option<String>,
+        benchmark: Option<Value>,
+        evidence_schema: Option<Value>,
         image_prompt: Option<String>,
         image_alt_text: Option<String>,
         bounty_image: Option<ChatgptFileInput>,
@@ -555,6 +557,8 @@ tool_args! {
             "source_url": nullable_string_property("Optional public HTTPS source issue or task URL."),
             "crowdfund": {"type": "boolean", "default": false, "description": "Keep false to fund on creation. Set true only to deposit 0 USDC now."},
             "discovery_source": nullable_string_property("Optional public attribution for how the poster found Agent Bounties."),
+            "benchmark": {"type": ["object", "null"], "description": "Optional exact public sandboxed_regression_v1 benchmark. Supply this and evidence_schema together. The source commit, benchmark digest, OCI image, command, and resource limits are immutable bounty terms."},
+            "evidence_schema": {"type": ["object", "null"], "description": "Optional public submission-evidence schema paired with benchmark. Supply both verifier fields or neither."},
             "image_prompt": {"type": "string", "minLength": 1, "maxLength": 4000, "description": "Optional exact prompt used to generate a user-approved bounty image. Supply this, image_alt_text, and bounty_image together, or omit all three to use the deterministic fallback visual."},
             "image_alt_text": {"type": "string", "minLength": 1, "maxLength": 500, "description": "Optional accessible description of the approved image. Supply this, image_prompt, and bounty_image together."},
             "bounty_image": {

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -125,6 +125,10 @@ The human review entry is <https://agentbounties.app/post.html>. MCP clients may
 call `prepare_bounty_post` when that tool appears in their session. The image
 fields are an optional all-or-none group: clients that cannot supply an
 approved image can still prepare a complete provider-neutral posting handoff.
+For a funding-ready coding bounty, pass `benchmark` and `evidence_schema`
+together. The benchmark source commit, subdirectory digest, OCI image digest,
+direct command, and sandbox resource limits become immutable public terms; an
+incomplete or mutable runner is rejected before the wallet-review handoff.
 
 Advanced flow:
 

--- a/docs/chatgpt-app-submission.md
+++ b/docs/chatgpt-app-submission.md
@@ -109,6 +109,10 @@ OpenAI-hosted file URL, validates a PNG/JPEG/WebP payload of at most 5 MiB,
 stores it by SHA-256, and returns a first-party review URL. The private ChatGPT
 `file_id` is never placed in public terms. Provider-neutral clients may omit
 the image, prompt, and alt text together; partial image metadata is rejected.
+Coding bounties may also pass `benchmark` and `evidence_schema` together. The
+server validates the complete sandbox runner manifest and preserves both
+objects through the first-party review URL; partial, mutable, malformed, or
+non-executable verifier inputs are rejected before any wallet surface opens.
 Agent Bounties never generates or substitutes bounty artwork. The review URL
 renders the completed approved terms and optional image; it does not publish or
 move funds without the separate wallet-reviewed flow.

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:2ab745d24cd42403c9c06988b610ac00ac3e17a45ad509d2dcd07628f0e14907",
+    "benchmark_digest": "sha256:2851df1a68ce54112f017bbd51d7222f393379c3b09f469d0379df6117ffd6b6",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",

--- a/scripts/test-ai-bounty-handoff.js
+++ b/scripts/test-ai-bounty-handoff.js
@@ -70,12 +70,32 @@ const draft = api.parseDraft(`\`\`\`json
   "solver_reward_usdc": "4.00",
   "verifier_reward_usdc": "0.10",
   "task_window_days": 21,
-  "source_url": "https://example.com/context"
+  "source_url": "https://example.com/context",
+  "benchmark": {
+    "engine": "sandboxed_regression_v1",
+    "source": {
+      "kind": "github_commit",
+      "repository": "NSPG13/agent-bounties",
+      "commit": "0fae18cf9be464132cde52dfb9d464d836e8f024",
+      "subdirectory": "benchmarks/distribution-v1/glama-onboarding-audit"
+    },
+    "runner_manifest": {
+      "schema_version": "agent-bounties/regression-sandbox-v1"
+    }
+  },
+  "evidence_schema": {
+    "type": "object",
+    "required": ["source_snapshot_digest"]
+  }
 }
 \`\`\``);
 
 if (draft.task_window_days !== 21 || draft.acceptance_criteria.length !== 2) {
   throw new Error(`valid AI draft was not normalized: ${JSON.stringify(draft)}`);
+}
+if (draft.benchmark?.source?.commit !== "0fae18cf9be464132cde52dfb9d464d836e8f024"
+  || draft.evidence_schema?.required?.[0] !== "source_snapshot_digest") {
+  throw new Error("the exact benchmark and evidence schema were stripped from the AI draft");
 }
 
 const approvedImage = {
@@ -122,7 +142,7 @@ for (const invalid of [
 }
 
 const prompt = api.promptFor("Build a public climate dashboard");
-for (const marker of ["prepare_bounty_post", api.mcpUrl, "return ONLY one JSON object", "Otherwise omit all three image fields", "Do not claim that anything is posted"]) {
+for (const marker of ["prepare_bounty_post", api.mcpUrl, "return ONLY one JSON object", "Otherwise omit all three image fields", "exact public sandboxed_regression_v1 benchmark", "Do not claim that anything is posted"]) {
   if (!prompt.includes(marker)) throw new Error(`AI handoff prompt missing: ${marker}`);
 }
 

--- a/site/ai-bounty-handoff.js
+++ b/site/ai-bounty-handoff.js
@@ -90,6 +90,12 @@
       source_url: sourceUrl,
       crowdfund: Boolean(raw.crowdfund),
       discovery_source: boundedText(raw.discovery_source || "User-owned AI assistant", "Discovery source", 500),
+      benchmark: raw.benchmark && typeof raw.benchmark === "object" && !Array.isArray(raw.benchmark)
+        ? raw.benchmark
+        : null,
+      evidence_schema: raw.evidence_schema && typeof raw.evidence_schema === "object" && !Array.isArray(raw.evidence_schema)
+        ? raw.evidence_schema
+        : null,
       ...(raw.image_required === true
         ? {
             image_required: true,
@@ -125,10 +131,12 @@ If the connector is unavailable, ask concise clarifying questions and then retur
   "task_window_days": 30,
   "source_url": null,
   "crowdfund": false,
-  "discovery_source": "AI provider and account used"
+  "discovery_source": "AI provider and account used",
+  "benchmark": null,
+  "evidence_schema": null
 }
 
-Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, each <= 1000; rewards are positive USDC decimals with at most 6 places; task_window_days is 1-30; source_url is HTTPS or null. Do not claim that anything is posted, created, funded, signed, or paid. I must explicitly approve the bounty terms and separately approve any wallet transaction on Agent Bounties.`;
+Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, each <= 1000; rewards are positive USDC decimals with at most 6 places; task_window_days is 1-30; source_url is HTTPS or null. A funded coding bounty must include an exact public sandboxed_regression_v1 benchmark and matching evidence_schema; never invent a commit, digest, OCI image, command, or resource limit. Do not claim that anything is posted, created, funded, signed, or paid. I must explicitly approve the bounty terms and separately approve any wallet transaction on Agent Bounties.`;
   }
 
   function setImportStatus(message, tone = "") {

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -445,8 +445,8 @@
       acceptance_criteria: prepared.acceptance_criteria,
       questions: [],
       risk_flags: [],
-      benchmark: { type: "creator_review" },
-      evidence_schema: { type: "object", additionalProperties: true },
+      benchmark: prepared.benchmark || { type: "creator_review" },
+      evidence_schema: prepared.evidence_schema || { type: "object", additionalProperties: true },
     });
     state.draft = state.initialDraft;
     state.aiRounds = 0;
@@ -1412,6 +1412,16 @@
 
     if (title && goal && criteria.length && solver && verifier) {
       try {
+        const parseHandoffJson = (name) => {
+          const encoded = params.get(name);
+          if (!encoded) return null;
+          if (encoded.length > 20000) throw new Error(`${name} exceeds the browser handoff limit.`);
+          const value = JSON.parse(encoded);
+          if (!value || typeof value !== "object" || Array.isArray(value)) {
+            throw new Error(`${name} must be one JSON object.`);
+          }
+          return value;
+        };
         await importPreparedDraft({
           title,
           goal,
@@ -1422,6 +1432,8 @@
           source_url: params.get("sourceUrl"),
           crowdfund: params.get("crowdfund") === "true",
           discovery_source: params.get("discoverySource") || "AI assistant via MCP",
+          benchmark: parseHandoffJson("benchmark"),
+          evidence_schema: parseHandoffJson("evidenceSchema"),
           image_required: Boolean(params.get("imageUrl")),
           image: params.get("imageUrl") ? {
               source: "chatgpt_user_generated",

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -87,6 +87,12 @@ Safe-block chain manifest: https://raw.githubusercontent.com/NSPG13/agent-bounti
 Person-led: open https://agentbounties.app/#post-a-bounty or call
 `prepare_bounty_post` when the MCP session advertises it.
 
+Funding-ready coding handoffs pass `benchmark` and `evidence_schema` together.
+The benchmark must bind a public GitHub commit and normalized subdirectory to a
+complete `agent-bounties/regression-sandbox-v1` runner with a digest-pinned OCI
+image, direct argv, benchmark digest, and bounded resources. Mutable or partial
+verifier inputs must remain drafts and must not reach wallet review.
+
 Advanced:
 
 1. Define one inspectable goal and binary, replayable acceptance criteria.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -84,15 +84,9 @@ Safe-block chain manifest: https://raw.githubusercontent.com/NSPG13/agent-bounti
 
 ## Post
 
-Person-led: open https://agentbounties.app/#post-a-bounty or call
-`prepare_bounty_post` when the MCP session advertises it.
+Person-led: open https://agentbounties.app/#post-a-bounty or call `prepare_bounty_post` when the MCP session advertises it.
 
-Funding-ready coding handoffs pass `benchmark` and `evidence_schema` together.
-The benchmark must bind a public GitHub commit and normalized subdirectory to a
-complete `agent-bounties/regression-sandbox-v1` runner with a digest-pinned OCI
-image, direct argv, benchmark digest, and bounded resources. Mutable or partial
-verifier inputs must remain drafts and must not reach wallet review.
-
+Funding-ready coding handoffs pass `benchmark` and `evidence_schema` together, binding a public GitHub commit and normalized subdirectory to a complete `agent-bounties/regression-sandbox-v1` runner with a digest-pinned OCI image, direct argv, benchmark digest, and bounded resources; mutable or partial verifier inputs must remain drafts and must not reach wallet review.
 Advanced:
 
 1. Define one inspectable goal and binary, replayable acceptance criteria.


### PR DESCRIPTION
## Outcome

Adds a task-specific public benchmark for the Glama onboarding lifecycle canary and preserves complete `benchmark` plus `evidence_schema` objects from `prepare_bounty_post` through the attributed first-party review URL.

The MCP boundary validates the public GitHub commit, normalized benchmark subdirectory, digest-pinned OCI image, direct argv, complete regression sandbox manifest, and paired evidence schema before returning wallet review. The browser imports the exact verifier rather than replacing it with `creator_review`.

## Safety boundaries

- No wallet key, signature, transaction, funding, or settlement occurs in this change.
- Partial, mutable, malformed, or non-executable verifier inputs fail before wallet review.
- The benchmark requires a synthetic-canary measurement exclusion and canonical Base creation, funding, verifier-evidence, and `BountySettled` references.
- A passing benchmark or transaction hash alone is not represented as settlement.
- Manifest validation is self-contained in the MCP boundary; the isolated signer runtime dependency graph is unchanged.

## Verification

- `cargo test -p mcp-server -- --nocapture` (78 passed)
- `python benchmarks/distribution-v1/glama-onboarding-audit/self_test.py` (1 positive, 5 negative)
- both regression verifier source guards pass with the updated worker-build pin and unchanged signing-runtime pin
- `node scripts/test-ai-bounty-handoff.js`
- `python scripts/check-site.py`
- `python scripts/check-public-handoffs.py`
- `python scripts/check-chatgpt-app-runtime.py`
- `cargo fmt --all -- --check`
- `git diff --check`