### PR TITLE
Preserve acquisition context for Open Competition V2 creation plans

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
+          --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f
+          --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
+          --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f
+          --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
+          --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
+          --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f
+          --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
+          --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
+          --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "c58602e3929f0a9b8d1cc437b58086cd6c5ac2d1194c4e89aeea97184609e
 PIPELINE_TEST_SHA256 = "1665f99a25f3ffdd1be1fb167e4ba9a09c729966c46ec41990629d5dd6f271e5"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"
+WORKER_BUILD_SHA256 = "959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"
 SIGNING_RUNTIME_SHA256 = "292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "8e66b47dedf8b151f5c9563bce456a97d60c6788b298b51c20f919ad4c7f61d8",
+    ".github/workflows/regression-verifier-runner.yml": "042a586afb8a8ced498d103f9f3f8d898547590d96fbe928f0dd4be34ec17f27",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "e608b9f24ccc0c47124ab61d1f7adf1d2adf772a6a3ab080cfe8b93f5ad08fb2",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "d75969bcb747053988c53e0d7abbdaae138f9f869cac2db8b6c2d880a0157d6f",
+    ".github/workflows/regression-verifier-signer.yml": "fb604c0035da8f6c6c9e96cbb741d0e0e6da4209d1af14b50a991657f57477b3",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "218cec37215c99f9bcbf475a9a8dd440ae97d44ec0a4ad961bffa60363c8f41e",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "c58602e3929f0a9b8d1cc437b58086cd6c5ac2d1194c4e89aeea97184609e
 PIPELINE_TEST_SHA256 = "1665f99a25f3ffdd1be1fb167e4ba9a09c729966c46ec41990629d5dd6f271e5"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"
+WORKER_BUILD_SHA256 = "267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607"
 SIGNING_RUNTIME_SHA256 = "292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "042a586afb8a8ced498d103f9f3f8d898547590d96fbe928f0dd4be34ec17f27",
+    ".github/workflows/regression-verifier-runner.yml": "1503493c6657a63e979f0c8d643a26b800a455d8148ee61e5e45a63eb382c5fc",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "fb604c0035da8f6c6c9e96cbb741d0e0e6da4209d1af14b50a991657f57477b3",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "218cec37215c99f9bcbf475a9a8dd440ae97d44ec0a4ad961bffa60363c8f41e",
+    ".github/workflows/regression-verifier-signer.yml": "f97e17e1b327f5db0f46b83e4b8d8e674a91cc096be8267c6f0dafae23b18936",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "5b1a19f0a977a51587a6e6ec049d8da73e42c7f6ba1c97094bf95299928bdf31",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "c58602e3929f0a9b8d1cc437b58086cd6c5ac2d1194c4e89aeea97184609e
 PIPELINE_TEST_SHA256 = "1665f99a25f3ffdd1be1fb167e4ba9a09c729966c46ec41990629d5dd6f271e5"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f"
+WORKER_BUILD_SHA256 = "46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"
 SIGNING_RUNTIME_SHA256 = "292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "4b5de2e6af4688d13bd3e6937a310d4a5ab63a5b5587c2d96d304769385e1ba5",
+    ".github/workflows/regression-verifier-runner.yml": "8e66b47dedf8b151f5c9563bce456a97d60c6788b298b51c20f919ad4c7f61d8",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "a85ea83dcdce8c1275580fe8b2bb29c0f620735bb3c6f4b4829807743f9adc14",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "58c495065c43fa24ba033eaccec8a77c391c760b1e4adf7eebc786016ce0cd9b",
+    ".github/workflows/regression-verifier-signer.yml": "e608b9f24ccc0c47124ab61d1f7adf1d2adf772a6a3ab080cfe8b93f5ad08fb2",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "d75969bcb747053988c53e0d7abbdaae138f9f869cac2db8b6c2d880a0157d6f",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 959096b9fc31c53c10cef949c9e7dd938b7993b7fcb35bf4e0ac6084d8950022"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 267d471f820ba36df63991d7c731222c36a95eb19ab80a1b9a12905340e2f607"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 1bff86e18dbc1a915ad910823815d15c6a90729cd652d044a62a49e1c6f7847f"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 46fa00bdd7247b56024a284140a777c5a01c14e95fbdc4a616400387ec599dc0"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 292a6a94be6f919122558f764505119dff90f61178f1799cc362981dcf34db12"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -85,6 +85,8 @@ pub const DISTRIBUTION_ATTRIBUTION_MIGRATION: &str =
     include_str!("../../../migrations/0032_distribution_attribution.sql");
 pub const DISTRIBUTION_SOURCE_EXPANSION_MIGRATION: &str =
     include_str!("../../../migrations/0033_distribution_source_expansion.sql");
+pub const DISTRIBUTION_COMPETITION_BINDINGS_MIGRATION: &str =
+    include_str!("../../../migrations/0034_distribution_competition_bindings.sql");
 const MIGRATION_ADVISORY_LOCK_ID: i64 = 4_270_265_017;
 const UPSERT_PAYMENT_EVENT_SQL: &str = r#"
             INSERT INTO payment_events (id, rail, external_id, status, payload_hash, received_at)
@@ -749,6 +751,19 @@ pub struct DistributionHandoff {
     pub prepared_at: DateTime<Utc>,
     pub wallet_reviewed_at: Option<DateTime<Utc>>,
     pub terms_bound_at: Option<DateTime<Utc>>,
+}
+
+/// An unsigned preparation observation. Canonical events establish all outcomes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DistributionCompetitionBinding {
+    pub acquisition_id: Uuid,
+    pub protocol_version: String,
+    pub network: String,
+    pub factory_contract: String,
+    pub bounty_id: String,
+    pub competition_contract: String,
+    pub creator_wallet: String,
+    pub prepared_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1471,6 +1486,7 @@ impl PostgresStore {
                 // histories additive and non-conflicting.
                 DISTRIBUTION_ATTRIBUTION_MIGRATION,
                 DISTRIBUTION_SOURCE_EXPANSION_MIGRATION,
+                DISTRIBUTION_COMPETITION_BINDINGS_MIGRATION,
             ] {
                 for statement in migration
                     .split(';')
@@ -2320,6 +2336,44 @@ impl PostgresStore {
         .fetch_one(&self.pool)
         .await?;
         distribution_handoff_from_row(row)
+    }
+
+    pub async fn bind_distribution_competition(
+        &self,
+        binding: &DistributionCompetitionBinding,
+    ) -> DbResult<()> {
+        let affected = sqlx::query(
+            r#"
+            INSERT INTO distribution_competition_bindings
+              (network, factory_contract, bounty_id, protocol_version,
+               competition_contract, creator_wallet, acquisition_id, prepared_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            ON CONFLICT (network, factory_contract, bounty_id) DO UPDATE
+              SET acquisition_id = distribution_competition_bindings.acquisition_id
+            WHERE distribution_competition_bindings.acquisition_id = EXCLUDED.acquisition_id
+              AND distribution_competition_bindings.protocol_version = EXCLUDED.protocol_version
+              AND distribution_competition_bindings.competition_contract = EXCLUDED.competition_contract
+              AND distribution_competition_bindings.creator_wallet = EXCLUDED.creator_wallet
+            "#,
+        )
+        .bind(&binding.network)
+        .bind(binding.factory_contract.to_ascii_lowercase())
+        .bind(binding.bounty_id.to_ascii_lowercase())
+        .bind(&binding.protocol_version)
+        .bind(binding.competition_contract.to_ascii_lowercase())
+        .bind(binding.creator_wallet.to_ascii_lowercase())
+        .bind(binding.acquisition_id)
+        .bind(binding.prepared_at)
+        .execute(&self.pool)
+        .await?
+        .rows_affected();
+        if affected != 1 {
+            return Err(DbError::DistributionAttributionConflict(
+                "competition preparation is already bound to another acquisition or plan"
+                    .to_string(),
+            ));
+        }
+        Ok(())
     }
 
     pub async fn mark_distribution_handoff_wallet_reviewed(
@@ -11584,6 +11638,88 @@ mod tests {
             normalize_distribution_exclusion_class("related"),
             Some("related_party")
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
+    async fn distribution_competition_binding_is_immutable_and_retry_safe() {
+        let database_url = std::env::var("AGENT_BOUNTIES_TEST_DATABASE_URL").unwrap();
+        let store = PostgresStore::connect(&database_url).await.unwrap();
+        store.migrate().await.unwrap();
+        let now = DateTime::from_timestamp(Utc::now().timestamp(), 0).unwrap();
+        let acquisition = store
+            .observe_distribution_acquisition(
+                "glama-paid",
+                &format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple()),
+                Some("dry-run-v1"),
+                now,
+            )
+            .await
+            .unwrap();
+        let other = store
+            .observe_distribution_acquisition(
+                "glama",
+                &format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple()),
+                Some("dry-run-v1"),
+                now,
+            )
+            .await
+            .unwrap();
+        let suffix = Uuid::new_v4().simple().to_string();
+        let binding = DistributionCompetitionBinding {
+            acquisition_id: acquisition.id,
+            protocol_version: "agent-bounties/open-competition-v2-beta3".to_string(),
+            network: "base-mainnet".to_string(),
+            factory_contract: format!("0x{}", "a".repeat(40)),
+            bounty_id: format!("0x{suffix}{suffix}"),
+            competition_contract: format!("0x00000000{suffix}"),
+            creator_wallet: format!("0x{}", "b".repeat(40)),
+            prepared_at: now,
+        };
+        store.bind_distribution_competition(&binding).await.unwrap();
+        let mut replay = binding.clone();
+        replay.prepared_at = now + chrono::Duration::seconds(60);
+        store.bind_distribution_competition(&replay).await.unwrap();
+        store.migrate().await.unwrap();
+        store.bind_distribution_competition(&replay).await.unwrap();
+        let recorded_at: DateTime<Utc> = sqlx::query_scalar(
+            "SELECT prepared_at FROM distribution_competition_bindings WHERE network = $1 AND factory_contract = $2 AND bounty_id = $3",
+        ).bind(&binding.network).bind(&binding.factory_contract).bind(&binding.bounty_id)
+            .fetch_one(&store.pool).await.unwrap();
+        assert_eq!(recorded_at, now);
+        for changed in [
+            DistributionCompetitionBinding {
+                acquisition_id: other.id,
+                ..binding.clone()
+            },
+            DistributionCompetitionBinding {
+                creator_wallet: format!("0x{}", "c".repeat(40)),
+                ..binding.clone()
+            },
+            DistributionCompetitionBinding {
+                competition_contract: format!("0x{}", "d".repeat(40)),
+                ..binding.clone()
+            },
+        ] {
+            assert!(matches!(
+                store.bind_distribution_competition(&changed).await,
+                Err(DbError::DistributionAttributionConflict(_))
+            ));
+        }
+        let separate_chain = DistributionCompetitionBinding {
+            network: "base-sepolia".to_string(),
+            ..binding.clone()
+        };
+        store
+            .bind_distribution_competition(&separate_chain)
+            .await
+            .unwrap();
+        let invalid = DistributionCompetitionBinding {
+            network: "unsupported-chain".to_string(),
+            ..binding
+        };
+        assert!(store.bind_distribution_competition(&invalid).await.is_err());
+        assert!(!acquisition.measurement_eligible);
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -2138,7 +2138,7 @@ async fn call_tool(
                 .map_err(|error| format!("invalid get_bounty_feed arguments: {error}"))?;
             return Ok(tool_result(
                 load_bounty_feed(args, &[]).await?,
-                "Returned a fresh public opportunity projection. Funding, claimability, verification, settlement, and payment remain bound to each sourceâ€™s authoritative evidence.",
+                "Returned a fresh public opportunity projection. Funding, claimability, verification, settlement, and payment remain bound to each source’s authoritative evidence.",
                 false,
             ));
         }
@@ -6159,7 +6159,7 @@ mod tests {
 
     #[test]
     fn modern_name_header_supports_the_required_base64_sentinel() {
-        let resource_uri = "ui://agent-bounties/ä¸–ç•Œ.html";
+        let resource_uri = "ui://agent-bounties/世界.html";
         let encoded = format!(
             "=?base64?{}?=",
             base64::engine::general_purpose::STANDARD.encode(resource_uri)
@@ -6386,7 +6386,7 @@ mod tests {
             .as_str()
             .unwrap()
             .to_ascii_lowercase()
-            .contains("pokÃ©mon"));
+            .contains("pokémon"));
         for outdated_term in ["collectible", "quest card", "instagram-inspired"] {
             assert!(
                 !contents["_meta"]["openai/widgetDescription"]
@@ -6445,7 +6445,7 @@ mod tests {
         assert!(!html.contains("__CHATGPT_APP_BASE_URL_JSON__"));
         assert!(html.contains("bridgeRequest(\"tools/call\""));
         assert!(!html.contains("window.location.replace"));
-        assert!(html.contains("Preview data Â· no writes"));
+        assert!(html.contains("Preview data · no writes"));
         assert!(html.contains("Safe fixture data"));
         assert!(!html.contains("open for competition"));
         assert!(!html.contains("ready to compete"));

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -27,7 +27,7 @@ use axum::{
 use base64::Engine as _;
 use db::{
     distribution_acquisition_token_hash, normalize_distribution_rail,
-    sign_distribution_acquisition_token, NewBountyImageAsset,
+    sign_distribution_acquisition_token, DistributionCompetitionBinding, NewBountyImageAsset,
 };
 use domain::BountyImageReference;
 use serde::{Deserialize, Serialize};
@@ -379,6 +379,103 @@ fn distribution_request_fingerprint(arguments: &Value) -> String {
     hex::encode(Sha256::digest(
         serde_json::to_vec(arguments).unwrap_or_else(|_| b"invalid-json-value".to_vec()),
     ))
+}
+
+fn competition_preparation_binding(
+    result: &Value,
+    attribution: &McpDistributionAttribution,
+    prepared_at: chrono::DateTime<chrono::Utc>,
+) -> Result<DistributionCompetitionBinding, String> {
+    let plan: chain_base::OpenCompetitionV2CreationPlan = serde_json::from_value(
+        result
+            .get("plan")
+            .cloned()
+            .ok_or("creation result has no plan")?,
+    )
+    .map_err(|_| "creation result has an invalid plan".to_string())?;
+    if plan.schema_version != "agent-bounties/open-competition-v2-creation-plan-v1"
+        || plan.protocol_version != "agent-bounties/open-competition-v2-beta3"
+    {
+        return Err("creation attribution requires the supported Beta3 plan".to_string());
+    }
+    let expected_network = chain_base::base_network_descriptor(&plan.network.name)
+        .map_err(|_| "creation plan has an unsupported network".to_string())?;
+    if plan.network.chain_id != expected_network.chain_id {
+        return Err("creation plan network and chain ID disagree".to_string());
+    }
+    let creates: Vec<_> = plan
+        .wallet_calls
+        .iter()
+        .filter(|call| call.function.starts_with("createCompetition("))
+        .collect();
+    if creates.len() != 1 {
+        return Err("creation plan must contain exactly one factory creation call".to_string());
+    }
+    let create = creates[0];
+    let address = |value: &str| {
+        chain_base::normalize_evm_address(value)
+            .map(|value| value.to_ascii_lowercase())
+            .map_err(|_| "creation plan has an invalid address".to_string())
+    };
+    let creator = address(
+        create
+            .from
+            .as_deref()
+            .ok_or("creation plan has no creator")?,
+    )?;
+    let bounty_id = plan.bounty_id.to_ascii_lowercase();
+    if bounty_id.len() != 66
+        || !bounty_id.starts_with("0x")
+        || !bounty_id[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("creation plan has an invalid bounty ID".to_string());
+    }
+    Ok(DistributionCompetitionBinding {
+        acquisition_id: attribution.acquisition_id,
+        protocol_version: plan.protocol_version,
+        network: plan.network.name,
+        factory_contract: address(&create.to)?,
+        bounty_id,
+        competition_contract: address(&plan.predicted_competition)?,
+        creator_wallet: creator,
+        prepared_at,
+    })
+}
+
+async fn attach_competition_preparation_attribution(
+    state: &SharedState,
+    mut result: Value,
+    attribution: Option<&McpDistributionAttribution>,
+    prepared_at: chrono::DateTime<chrono::Utc>,
+) -> Result<Value, String> {
+    let Some(attribution) = attribution else {
+        return Ok(result);
+    };
+    let binding = competition_preparation_binding(&result, attribution, prepared_at)?;
+    state
+        .store
+        .as_ref()
+        .ok_or("durable competition attribution is unavailable")?
+        .bind_distribution_competition(&binding)
+        .await
+        .map_err(|_| "competition preparation attribution could not be preserved".to_string())?;
+    result.as_object_mut().ok_or("creation response is not an object")?.insert(
+        "attribution".to_string(),
+        json!({
+            "authority": "analytics_only",
+            "state": "unsigned_preparation_recorded",
+            "first_touch_rail": attribution.first_touch_rail,
+            "current_rail": attribution.current_rail,
+            "measurement_eligible": attribution.measurement_eligible,
+            "protocol_version": binding.protocol_version,
+            "network": binding.network,
+            "factory_contract": binding.factory_contract,
+            "bounty_id": binding.bounty_id,
+            "competition_contract": binding.competition_contract,
+            "evidence_boundary": "A preparation is not creation, funding, activation, or settlement. Only matching confirmed canonical events establish those outcomes."
+        }),
+    );
+    Ok(result)
 }
 
 async fn record_prepare_handoff_failure(
@@ -2209,8 +2306,21 @@ async fn call_tool(
                 serde_json::from_value(arguments).map_err(|error| {
                     format!("invalid prepare_open_competition_v2 arguments: {error}")
                 })?;
+            let is_creation = args.operation == "create";
+            let prepared_at = chrono::Utc::now();
+            let result = legacy_result(
+                prepare_open_competition_v2(State(state.clone()), Json(args))
+                    .await
+                    .0,
+            )?;
+            let result = if is_creation {
+                attach_competition_preparation_attribution(&state, result, attribution, prepared_at)
+                    .await?
+            } else {
+                result
+            };
             return Ok(tool_result(
-                legacy_result(prepare_open_competition_v2(State(state), Json(args)).await.0)?,
+                result,
                 "Prepared one exact Open Competition V2 Beta3 action. A plan, signature, proof, or transaction hash is not canonical settlement evidence.",
                 false,
             ));
@@ -4971,6 +5081,109 @@ mod tests {
         assert_ne!(first, changed);
         assert_eq!(first.len(), 64);
         assert!(!first.contains("private"));
+    }
+
+    fn distribution_competition_fixture() -> Value {
+        json!({
+            "state": "awaiting_wallet_calls",
+            "plan": {
+                "schema_version": "agent-bounties/open-competition-v2-creation-plan-v1",
+                "protocol_version": "agent-bounties/open-competition-v2-beta3",
+                "network": {"name": "base-mainnet", "chain_id": 8453,
+                    "rpc_url_env": "BASE_MAINNET_RPC_URL", "native_usdc_token_address": format!("0x{}", "1".repeat(40))},
+                "bounty_id": format!("0x{}", "2".repeat(64)),
+                "predicted_competition": format!("0x{}", "3".repeat(40)),
+                "funding_target": "2100000", "remaining_funding_after_creation": "0",
+                "profitable_if_win": true, "public_inventory_eligible_after_confirmation": true,
+                "wallet_calls": [{"from": format!("0x{}", "4".repeat(40)),
+                    "to": format!("0x{}", "5".repeat(40)), "value_wei": 0,
+                    "data": "0x", "function": "createCompetition(params,funding,nonce,risk)"}],
+                "next_action": "Review unsigned calls", "evidence_boundary": "Unsigned preparation only"
+            }
+        })
+    }
+
+    #[test]
+    fn distribution_competition_binding_uses_the_validated_creation_call() {
+        let attribution = McpDistributionAttribution {
+            acquisition_id: Uuid::new_v4(),
+            acquisition_token: "opaque".to_string(),
+            first_touch_rail: "glama-paid".to_string(),
+            current_rail: "cursor".to_string(),
+            measurement_eligible: false,
+        };
+        let result = distribution_competition_fixture();
+        let binding =
+            competition_preparation_binding(&result, &attribution, chrono::Utc::now()).unwrap();
+        assert_eq!(binding.acquisition_id, attribution.acquisition_id);
+        assert_eq!(
+            binding.creator_wallet,
+            result["plan"]["wallet_calls"][0]["from"]
+        );
+        assert_eq!(
+            binding.factory_contract,
+            result["plan"]["wallet_calls"][0]["to"]
+        );
+        assert_eq!(
+            binding.competition_contract,
+            result["plan"]["predicted_competition"]
+        );
+        for (key, value) in [
+            ("chain_id", json!(84532)),
+            ("name", json!("unsupported-chain")),
+        ] {
+            let mut invalid = result.clone();
+            invalid["plan"]["network"][key] = value;
+            assert!(
+                competition_preparation_binding(&invalid, &attribution, chrono::Utc::now())
+                    .is_err()
+            );
+        }
+        for calls in [
+            json!([]),
+            json!([
+                result["plan"]["wallet_calls"][0],
+                result["plan"]["wallet_calls"][0]
+            ]),
+        ] {
+            let mut invalid = result.clone();
+            invalid["plan"]["wallet_calls"] = calls;
+            assert!(
+                competition_preparation_binding(&invalid, &attribution, chrono::Utc::now())
+                    .is_err()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn distribution_competition_preparation_requires_durable_attribution() {
+        let state = public_tool_test_state();
+        let result = distribution_competition_fixture();
+        let unchanged = attach_competition_preparation_attribution(
+            &state,
+            result.clone(),
+            None,
+            chrono::Utc::now(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(unchanged, result);
+        let attribution = McpDistributionAttribution {
+            acquisition_id: Uuid::new_v4(),
+            acquisition_token: "opaque".to_string(),
+            first_touch_rail: "mcp-so-paid".to_string(),
+            current_rail: "mcp-so-paid".to_string(),
+            measurement_eligible: false,
+        };
+        assert!(attach_competition_preparation_attribution(
+            &state,
+            result,
+            Some(&attribution),
+            chrono::Utc::now()
+        )
+        .await
+        .unwrap_err()
+        .contains("unavailable"));
     }
 
     #[tokio::test]

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -384,11 +384,17 @@ fn distribution_request_fingerprint(arguments: &Value) -> String {
 fn competition_preparation_binding(
     result: &Value,
     attribution: &McpDistributionAttribution,
-    prepared_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<DistributionCompetitionBinding, String> {
+    if !result
+        .get("http_status")
+        .and_then(Value::as_u64)
+        .is_some_and(|status| (200..300).contains(&status))
+    {
+        return Err("creation API did not return a successful HTTP status".to_string());
+    }
     let plan: chain_base::OpenCompetitionV2CreationPlan = serde_json::from_value(
         result
-            .get("plan")
+            .pointer("/body/plan")
             .cloned()
             .ok_or("creation result has no plan")?,
     )
@@ -438,7 +444,8 @@ fn competition_preparation_binding(
         bounty_id,
         competition_contract: address(&plan.predicted_competition)?,
         creator_wallet: creator,
-        prepared_at,
+        // Timestamp the successfully parsed response, never the earlier request.
+        prepared_at: chrono::Utc::now(),
     })
 }
 
@@ -446,12 +453,11 @@ async fn attach_competition_preparation_attribution(
     state: &SharedState,
     mut result: Value,
     attribution: Option<&McpDistributionAttribution>,
-    prepared_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<Value, String> {
     let Some(attribution) = attribution else {
         return Ok(result);
     };
-    let binding = competition_preparation_binding(&result, attribution, prepared_at)?;
+    let binding = competition_preparation_binding(&result, attribution)?;
     state
         .store
         .as_ref()
@@ -2132,7 +2138,7 @@ async fn call_tool(
                 .map_err(|error| format!("invalid get_bounty_feed arguments: {error}"))?;
             return Ok(tool_result(
                 load_bounty_feed(args, &[]).await?,
-                "Returned a fresh public opportunity projection. Funding, claimability, verification, settlement, and payment remain bound to each source’s authoritative evidence.",
+                "Returned a fresh public opportunity projection. Funding, claimability, verification, settlement, and payment remain bound to each sourceâ€™s authoritative evidence.",
                 false,
             ));
         }
@@ -2307,15 +2313,13 @@ async fn call_tool(
                     format!("invalid prepare_open_competition_v2 arguments: {error}")
                 })?;
             let is_creation = args.operation == "create";
-            let prepared_at = chrono::Utc::now();
             let result = legacy_result(
                 prepare_open_competition_v2(State(state.clone()), Json(args))
                     .await
                     .0,
             )?;
             let result = if is_creation {
-                attach_competition_preparation_attribution(&state, result, attribution, prepared_at)
-                    .await?
+                attach_competition_preparation_attribution(&state, result, attribution).await?
             } else {
                 result
             };
@@ -5084,7 +5088,7 @@ mod tests {
     }
 
     fn distribution_competition_fixture() -> Value {
-        json!({
+        let api_body = json!({
             "state": "awaiting_wallet_calls",
             "plan": {
                 "schema_version": "agent-bounties/open-competition-v2-creation-plan-v1",
@@ -5100,7 +5104,8 @@ mod tests {
                     "data": "0x", "function": "createCompetition(params,funding,nonce,risk)"}],
                 "next_action": "Review unsigned calls", "evidence_boundary": "Unsigned preparation only"
             }
-        })
+        });
+        legacy_result(crate::mcp_json(json!({"http_status": 200, "body": api_body})).0).unwrap()
     }
 
     #[test]
@@ -5113,45 +5118,45 @@ mod tests {
             measurement_eligible: false,
         };
         let result = distribution_competition_fixture();
-        let binding =
-            competition_preparation_binding(&result, &attribution, chrono::Utc::now()).unwrap();
+        let received_at = chrono::Utc::now();
+        let binding = competition_preparation_binding(&result, &attribution).unwrap();
+        assert!(binding.prepared_at >= received_at);
         assert_eq!(binding.acquisition_id, attribution.acquisition_id);
+        for status in [json!(400), json!(503), Value::Null, json!("200")] {
+            let mut invalid = result.clone();
+            invalid["http_status"] = status;
+            assert!(competition_preparation_binding(&invalid, &attribution).is_err());
+        }
         assert_eq!(
             binding.creator_wallet,
-            result["plan"]["wallet_calls"][0]["from"]
+            result["body"]["plan"]["wallet_calls"][0]["from"]
         );
         assert_eq!(
             binding.factory_contract,
-            result["plan"]["wallet_calls"][0]["to"]
+            result["body"]["plan"]["wallet_calls"][0]["to"]
         );
         assert_eq!(
             binding.competition_contract,
-            result["plan"]["predicted_competition"]
+            result["body"]["plan"]["predicted_competition"]
         );
         for (key, value) in [
             ("chain_id", json!(84532)),
             ("name", json!("unsupported-chain")),
         ] {
             let mut invalid = result.clone();
-            invalid["plan"]["network"][key] = value;
-            assert!(
-                competition_preparation_binding(&invalid, &attribution, chrono::Utc::now())
-                    .is_err()
-            );
+            invalid["body"]["plan"]["network"][key] = value;
+            assert!(competition_preparation_binding(&invalid, &attribution).is_err());
         }
         for calls in [
             json!([]),
             json!([
-                result["plan"]["wallet_calls"][0],
-                result["plan"]["wallet_calls"][0]
+                result["body"]["plan"]["wallet_calls"][0],
+                result["body"]["plan"]["wallet_calls"][0]
             ]),
         ] {
             let mut invalid = result.clone();
-            invalid["plan"]["wallet_calls"] = calls;
-            assert!(
-                competition_preparation_binding(&invalid, &attribution, chrono::Utc::now())
-                    .is_err()
-            );
+            invalid["body"]["plan"]["wallet_calls"] = calls;
+            assert!(competition_preparation_binding(&invalid, &attribution).is_err());
         }
     }
 
@@ -5159,14 +5164,9 @@ mod tests {
     async fn distribution_competition_preparation_requires_durable_attribution() {
         let state = public_tool_test_state();
         let result = distribution_competition_fixture();
-        let unchanged = attach_competition_preparation_attribution(
-            &state,
-            result.clone(),
-            None,
-            chrono::Utc::now(),
-        )
-        .await
-        .unwrap();
+        let unchanged = attach_competition_preparation_attribution(&state, result.clone(), None)
+            .await
+            .unwrap();
         assert_eq!(unchanged, result);
         let attribution = McpDistributionAttribution {
             acquisition_id: Uuid::new_v4(),
@@ -5175,15 +5175,68 @@ mod tests {
             current_rail: "mcp-so-paid".to_string(),
             measurement_eligible: false,
         };
-        assert!(attach_competition_preparation_attribution(
-            &state,
-            result,
-            Some(&attribution),
-            chrono::Utc::now()
-        )
-        .await
-        .unwrap_err()
-        .contains("unavailable"));
+        assert!(
+            attach_competition_preparation_attribution(&state, result, Some(&attribution))
+                .await
+                .unwrap_err()
+                .contains("unavailable")
+        );
+    }
+
+    #[tokio::test]
+    async fn distribution_competition_reads_real_proxy_envelopes_after_response() {
+        let api_body = distribution_competition_fixture()["body"].clone();
+        let failed_body = api_body.clone();
+        let router = axum::Router::new()
+            .route(
+                "/create",
+                axum::routing::post(move || {
+                    let mut body = api_body.clone();
+                    async move {
+                        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                        body["response_prepared_at"] = json!(chrono::Utc::now());
+                        Json(body)
+                    }
+                }),
+            )
+            .route(
+                "/unavailable",
+                axum::routing::post(move || {
+                    let body = failed_body.clone();
+                    async move { (StatusCode::SERVICE_UNAVAILABLE, Json(body)) }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let attribution = McpDistributionAttribution {
+            acquisition_id: Uuid::new_v4(),
+            acquisition_token: "opaque".to_string(),
+            first_touch_rail: "glama-paid".to_string(),
+            current_rail: "glama-paid".to_string(),
+            measurement_eligible: false,
+        };
+        for path in ["create", "unavailable"] {
+            let proxied = crate::proxy_public_json_response_with_timeout(
+                reqwest::Client::new().post(format!("http://{socket}/{path}")),
+                "fixture API",
+                5,
+            )
+            .await
+            .0;
+            let result = legacy_result(proxied).unwrap();
+            let binding = competition_preparation_binding(&result, &attribution);
+            if path == "create" {
+                let response_time = chrono::DateTime::parse_from_rfc3339(
+                    result["body"]["response_prepared_at"].as_str().unwrap(),
+                )
+                .unwrap();
+                assert!(binding.unwrap().prepared_at >= response_time);
+            } else {
+                assert!(binding.unwrap_err().contains("HTTP status"));
+            }
+        }
+        server.abort();
     }
 
     #[tokio::test]
@@ -6106,7 +6159,7 @@ mod tests {
 
     #[test]
     fn modern_name_header_supports_the_required_base64_sentinel() {
-        let resource_uri = "ui://agent-bounties/世界.html";
+        let resource_uri = "ui://agent-bounties/ä¸–ç•Œ.html";
         let encoded = format!(
             "=?base64?{}?=",
             base64::engine::general_purpose::STANDARD.encode(resource_uri)
@@ -6333,7 +6386,7 @@ mod tests {
             .as_str()
             .unwrap()
             .to_ascii_lowercase()
-            .contains("pokémon"));
+            .contains("pokÃ©mon"));
         for outdated_term in ["collectible", "quest card", "instagram-inspired"] {
             assert!(
                 !contents["_meta"]["openai/widgetDescription"]
@@ -6392,7 +6445,7 @@ mod tests {
         assert!(!html.contains("__CHATGPT_APP_BASE_URL_JSON__"));
         assert!(html.contains("bridgeRequest(\"tools/call\""));
         assert!(!html.contains("window.location.replace"));
-        assert!(html.contains("Preview data · no writes"));
+        assert!(html.contains("Preview data Â· no writes"));
         assert!(html.contains("Safe fixture data"));
         assert!(!html.contains("open for competition"));
         assert!(!html.contains("ready to compete"));

--- a/docs/distribution-attribution.md
+++ b/docs/distribution-attribution.md
@@ -69,6 +69,22 @@ creator conflict.
 
 ## Reports and evidence boundaries
 
+An attributed MCP `prepare_open_competition_v2` call with `operation=create`
+also preserves its source. Only a successful Beta3 creation plan is eligible for
+an analytics-only preparation record. Its exact network, factory, bounty ID,
+predicted competition address, and creator bind to the existing acquisition.
+Identical retries preserve the first preparation time; another acquisition or a
+changed identity cannot replace that binding. Other V2 operations and unattributed
+requests retain their existing behavior. No wallet call is executed by this step.
+
+The record is an unsigned preparation observation, not proof of wallet ownership,
+creation, funding, activation, verification, or settlement. Any outcome join must
+match the exact canonical identities and require preparation before creation.
+Operator reporting and campaign calculations remain private. The shared report
+below still exposes only its explicitly declared autonomous-v1 scope; recording
+a V2 preparation does not silently expand that report or turn missing outcomes
+into zero.
+
 `GET /v1/operator/distribution/report` requires the existing operator token and
 returns one cumulative, event-driven funnel per approved rail: acquisitions,
 assists, MCP requests and failures, prepared handoffs, bound terms, externally

--- a/migrations/0034_distribution_competition_bindings.sql
+++ b/migrations/0034_distribution_competition_bindings.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS distribution_competition_bindings (
+  network TEXT NOT NULL CHECK (network IN ('base-mainnet', 'base-sepolia')),
+  factory_contract TEXT NOT NULL CHECK (factory_contract ~ '^0x[a-f0-9]{40}$'),
+  bounty_id TEXT NOT NULL CHECK (bounty_id ~ '^0x[a-f0-9]{64}$'),
+  protocol_version TEXT NOT NULL CHECK (
+    protocol_version = 'agent-bounties/open-competition-v2-beta3'
+  ),
+  competition_contract TEXT NOT NULL CHECK (competition_contract ~ '^0x[a-f0-9]{40}$'),
+  creator_wallet TEXT NOT NULL CHECK (creator_wallet ~ '^0x[a-f0-9]{40}$'),
+  acquisition_id UUID NOT NULL REFERENCES distribution_acquisitions(id) ON DELETE CASCADE,
+  prepared_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (network, factory_contract, bounty_id),
+  UNIQUE (network, competition_contract)
+);
+
+CREATE INDEX IF NOT EXISTS distribution_competition_bindings_acquisition_idx
+  ON distribution_competition_bindings (acquisition_id);

--- a/migrations/checksums.json
+++ b/migrations/checksums.json
@@ -32,6 +32,7 @@
     "0028_onboarding_analytics.sql": "970867ff225a30782a8cf276bb65356566d1ac4ef8dc2d14b0b7e1631166ab3f",
     "0029_discoverability_measurement.sql": "e5a63387e1bc4beab72fa73035717488fea4d312ded3b576839452ab21b25a77",
     "0032_distribution_attribution.sql": "5175b58667e90ef00b09560a6bf9df81080448b5fd706ce14491e23bf419e2cb",
-    "0033_distribution_source_expansion.sql": "7e3fc06ed599122e086c09277018508ea1bde1e7647d78c590f7db527df9c202"
+    "0033_distribution_source_expansion.sql": "7e3fc06ed599122e086c09277018508ea1bde1e7647d78c590f7db527df9c202",
+    "0034_distribution_competition_bindings.sql": "2265009b9cc590ec14ac4026bbf3defec4409bda5f4dfa6a87df613718d32786"
   }
 }

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:0bdbcea6f05b784f1d863b40342fb7e682325cd6b0d78b3d2eb498c98388401b",
+    "benchmark_digest": "sha256:d39e48e5ac755134d959e314d884c5245fab51a1cafadd0580e3635df20cbf2c",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:d39e48e5ac755134d959e314d884c5245fab51a1cafadd0580e3635df20cbf2c",
+    "benchmark_digest": "sha256:5e49d3e3acb2adafd9e94cd36f6d1986eb0f56d938fd23c89e9771afd5e5e77c",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:5e49d3e3acb2adafd9e94cd36f6d1986eb0f56d938fd23c89e9771afd5e5e77c",
+    "benchmark_digest": "sha256:2b37d10ffe76961d7780932b8b5382562aef0ec3f0719157a9d743ca13291427",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",


### PR DESCRIPTION
An attributed MCP `prepare_open_competition_v2` creation currently loses its acquisition context when returning unsigned wallet calls. Preserve an analytics-only association between that acquisition and the successful plan's exact network, factory, bounty ID, predicted contract, and creator. Identical retries preserve the first preparation time; another acquisition or changed identity cannot replace it. Storage failure returns an error before handing the plan back.

This does not execute wallet calls or claim a draft is funded. Other V2 operations and unattributed calls retain their existing behavior. The shared aggregate report remains explicitly autonomous-v1; private reporting can join these preparation observations to matching confirmed canonical events without publishing customer records or campaign logic.

Migration 0034 is additive and replay-safe. Required PostgreSQL CI already includes the `distribution_` integration tests, including the new retry, conflict, cross-chain, and migration replay cases. The reviewed worker-build source pins and unfunded watchdog precommit digest reflect this source change; signing-runtime behavior is unchanged.

Validation: all 81 MCP tests, 16 source-guard/precommit tests, site and migration-history checks, and the known-good/known-bad watchdog rehearsal pass locally. All required CI passes on 81e227cdddb5f2a355f08be5f148bcccd708d75b: full-check, postgres-sync (including binding migration replay), and sdlc-recovery. CI: https://github.com/NSPG13/agent-bounties/actions/runs/34005069426

Risk: R3 (database migration). Public files are protocol bindings, compatibility documentation, and deterministic tests. Campaign calculations and private evidence remain outside this repository. Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/1274#issuecomment-5555951928

Depends on #1289 and is targeted to its branch. Recheck corrective #1288 first; preserve its verifier, evidence, and privacy fixes when rebasing. Reviewed new open #1290: its WebMCP/site flow changes do not own this database/MCP binding. Migration 0031 remains reserved for #910. Next owner: maintainer and independent reviewer. Roll back the MCP use of the new binding before removing publication; retain historical source records.
