### PR TITLE
Return guidance when WebMCP resumes without a proof job

### DIFF
--- a/scripts/test-competition-proof.js
+++ b/scripts/test-competition-proof.js
@@ -85,6 +85,20 @@ function proved(server) {
 }
 const input = () => ({ solver: wallet, metric: { profile_id: "structured-artifact-metric-v1", threshold: "1", artifact_utf8: "Hello 🌍", requirements: [{ kind: "utf8_contains", needle: "Hello", minimum_occurrences: 1, weight: 1 }] } });
 const sigs = (env) => env.calls.filter((r) => r.method === "eth_signTypedData_v4");
+test("resuming before a proof quote returns guidance without wallet or service mutations", async () => {
+  const e = setup(), api = await e.start();
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const result = await api.resume();
+    assert.equal(result.state, "not_quoted");
+    assert.equal(result.next_action.action, "prepare_quote");
+    assert.equal(result.proof_job_id, null);
+  }
+  assert.equal(e.calls.length, 0);
+  assert.equal(e.requests.some((request) => request.method === "POST"), false);
+  assert.equal(e.server.quoteCount, undefined);
+  assert.equal(e.doc.querySelector("[data-proof-workspace] [data-legal-consent]").hidden, true);
+});
+
 test("quote preparation derives the domain-bound UTF-8 artifact hash, reuses the job and never signs", async () => {
   const e = setup(), api = await e.start(); await api.prepareQuote(input()); await api.prepareQuote(input());
   assert.equal(e.server.quoteCount, 1); assert.equal(sigs(e).length, 0);

--- a/site/competition-proof.js
+++ b/site/competition-proof.js
@@ -250,7 +250,8 @@
       if (busy) throw new Error("Wait for the current wallet step to finish.");
       busy = true;
       try {
-        await refresh();
+        const refreshed = await refresh();
+        if (!job) return refreshed;
         if (record.paymentEnvelope && job.state === "quoted") await postPayment(record.paymentEnvelope);
         else if (job.state === "payment_pending") await postPayment();
         if (record.relayEnvelope && job.state === "proved") await client.request(relayPath(), record.relayEnvelope);

--- a/site/competition.html
+++ b/site/competition.html
@@ -158,6 +158,6 @@
     <script src="competition.js?v=4"></script>
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
-    <script src="competition-proof.js?v=1"></script>
+    <script src="competition-proof.js?v=2"></script>
   </body>
 </html>


### PR DESCRIPTION
A new WebMCP user could call `agent_bounties_resume_proof_service` before creating a quote and receive a null-state error. Resume now refreshes canonical state and returns the existing next-step guidance when there is no proof job. Existing payment and relay recovery is unchanged, and the competition script URL advances to v2 so browsers fetch the correction.

Validation: reproduced the failing native WebMCP call on production, reproduced the same exception with the new regression, then passed all 80 browser tests and the site checker. The regression repeats resume and checks that no wallet call, quote, POST or consent prompt occurs. Core preflight and git diff --check passed. No live wallet, payment or relay authorization was performed.

Maintainer notice and open PR impact: https://github.com/NSPG13/agent-bounties/issues/1287#issuecomment-5561287335. This narrow follow-up to #1290 has no direct overlap with #1288, #1289 or #1291. Next owner: NSPG13 release operator to verify the native tool on the deployed page. Rollback is a revert and Pages redeploy. Deployment is authorized with admin bypass by the account owner.