### PR TITLE
Keep V2 verification current with independently checked prefixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Run Postgres sync regressions
         run: |
           cargo test -p db distribution_ -- --ignored --nocapture
+          cargo test -p worker open_competition_v2_shadow::tests::postgres_shadow_cache_certifies_full_sets_and_recovers_from_disagreement -- --ignored --exact --nocapture
           cargo test -p db tests::x402_relay_attempt_is_idempotent_and_lease_bounded -- --ignored --exact --nocapture
           cargo test -p api github_issue_api_sync_postgres -- --ignored --nocapture
           cargo test -p api tests::bounty_status_reads_base_events_from_postgres_after_cross_process_indexing -- --ignored --exact --nocapture

--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada
+          --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada
+          --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada
+          --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5403,6 +5403,7 @@ dependencies = [
  "service-runtime",
  "sha2",
  "sha3 0.10.9",
+ "sqlx",
  "tokio",
  "uuid",
  "verifier-sdk",

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "d24f17f98066ff9df02389252891b85cfe6cea49816a85db83a13082bafed
 PIPELINE_TEST_SHA256 = "505977c92d852b98d92088b8fc26a31eb754f21d75dc3eb8b1275ec98e76f2be"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada"
+WORKER_BUILD_SHA256 = "8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"
 SIGNING_RUNTIME_SHA256 = "ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "cbc931dd53e5d9583958e934320eb2a13a7af5212c9a8fe35124413131396078",
+    ".github/workflows/regression-verifier-runner.yml": "59b75d2cd73b39ae41b2516d04cb48df5b47d047449fb771062ad473f0010aa3",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "8be877f344145664f2a4f9d50b27d25cd44e82e877732cbc15c37d4f8c9dc9b2",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "610a1c28cee8577d1da4d9eb69c4ff2a3a330099186fd56b49b8bc6bfb8813ef",
+    ".github/workflows/regression-verifier-signer.yml": "45546e1ae80bb831fa2d145c8e4228c03f0a359b2df87ae90a4154856c1a85ca",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "b03f1d8afb6b60ca6e88c714aa340f7004c36cfba07f65104097d4a23a6829a8",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c88bedacdf4c999d1620e223c12ddae9a0410dc4a390277e6f999fc852fc7ada"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -28,3 +28,4 @@ web-public = { path = "../web-public" }
 uuid.workspace = true
 
 [dev-dependencies]
+sqlx.workspace = true

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -9,15 +9,15 @@ use worker::{
     dispatch_discovery_webhooks_once, indexer_error_is_retryable,
     poll_autonomous_indexer_once_with_heartbeat, poll_open_competition_indexer_once_with_heartbeat,
     poll_open_competition_v2_broker_once, poll_open_competition_v2_indexer_once_with_heartbeat,
-    poll_open_competition_v2_keeper_once, poll_open_competition_v2_shadow_once,
+    poll_open_competition_v2_keeper_once, poll_open_competition_v2_shadow_with_cache,
     redact_operational_error, run_regression_sandbox_request, snapshot_directory,
     stage_regression_input, validate_regression_candidate, AutonomousIndexerConfig,
     DiscoveryWebhookConfig, IndexerRecoveryDecision, IndexerRecoveryPolicy,
     OpenCompetitionIndexerConfig, OpenCompetitionV2BrokerChainConfig,
     OpenCompetitionV2BrokerConfig, OpenCompetitionV2IndexerConfig, OpenCompetitionV2KeeperConfig,
-    OpenCompetitionV2ShadowConfig, RegressionCandidateValidationRequest, RegressionInputKind,
-    RegressionSandboxRunRequest, REGRESSION_SANDBOX_DOCKER_BINARY_ENV,
-    REGRESSION_SANDBOX_STAGING_ROOT_ENV,
+    OpenCompetitionV2ShadowCache, OpenCompetitionV2ShadowConfig,
+    RegressionCandidateValidationRequest, RegressionInputKind, RegressionSandboxRunRequest,
+    REGRESSION_SANDBOX_DOCKER_BINARY_ENV, REGRESSION_SANDBOX_STAGING_ROOT_ENV,
 };
 
 #[tokio::main]
@@ -207,8 +207,9 @@ async fn main() -> anyhow::Result<()> {
 async fn run_open_competition_v2_shadow(store: &PostgresStore, once: bool) -> anyhow::Result<()> {
     let config = OpenCompetitionV2ShadowConfig::from_env()?;
     let poll_seconds = env_u64("OPEN_COMPETITION_V2_SHADOW_POLL_SECONDS", 30)?.clamp(5, 300);
+    let mut cache = OpenCompetitionV2ShadowCache::default();
     loop {
-        match poll_open_competition_v2_shadow_once(store, &config).await {
+        match poll_open_competition_v2_shadow_with_cache(store, &config, &mut cache).await {
             Ok(report) => println!("{}", serde_json::to_string(&report)?),
             Err(error) => eprintln!(
                 "{}",

--- a/crates/worker/src/open_competition_v2_shadow.rs
+++ b/crates/worker/src/open_competition_v2_shadow.rs
@@ -12,7 +12,7 @@ use chrono::Utc;
 use db::{OpenCompetitionV2IndexerAgreement, PostgresStore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -85,10 +85,41 @@ struct CanonicalEventIdentity<'a> {
     data: &'a serde_json::Value,
 }
 
+/// A process-local optimization, populated only after independent verification
+/// and a successful agreement write. It is never restored from primary events.
+#[derive(Default)]
+pub struct OpenCompetitionV2ShadowCache {
+    verified: Option<VerifiedShadowPrefix>,
+}
+
+struct VerifiedShadowPrefix {
+    config: OpenCompetitionV2ShadowConfig,
+    block: u64,
+    block_hash: String,
+    events: Vec<OpenCompetitionV2Event>,
+}
+
 pub async fn poll_open_competition_v2_shadow_once(
     store: &PostgresStore,
     config: &OpenCompetitionV2ShadowConfig,
 ) -> anyhow::Result<OpenCompetitionV2ShadowReport> {
+    poll_open_competition_v2_shadow_with_cache(
+        store,
+        config,
+        &mut OpenCompetitionV2ShadowCache::default(),
+    )
+    .await
+}
+
+pub async fn poll_open_competition_v2_shadow_with_cache(
+    store: &PostgresStore,
+    config: &OpenCompetitionV2ShadowConfig,
+    cache: &mut OpenCompetitionV2ShadowCache,
+) -> anyhow::Result<OpenCompetitionV2ShadowReport> {
+    // Taking the prefix makes every early error (including cancellation) leave
+    // the next poll on the complete-replay path.
+    let previous = cache.verified.take();
+    let observed_at = Utc::now();
     let primary_cursor = store
         .get_base_log_cursor(&config.indexer.network, &config.indexer.factory_contract)
         .await?
@@ -120,18 +151,47 @@ pub async fn poll_open_competition_v2_shadow_once(
         config.indexer.request_id + 100_003,
     )
     .await?;
+    let previous = reusable_prefix(previous, config, common_safe_block).await?;
+    let shadow_events = fetch_shadow_events(config, common_safe_block, previous.as_ref()).await?;
+    // A block reorganization during a scan must not certify logs fetched from
+    // different histories. The target commits to the entire cached prefix too.
+    let primary_after = fetch_exact_block_identity(
+        &config.indexer.rpc_url,
+        common_safe_block,
+        config.indexer.request_id + 100_006,
+    )
+    .await?;
+    let shadow_after = fetch_exact_block_identity(
+        &config.shadow_rpc_url,
+        common_safe_block,
+        config.indexer.request_id + 100_007,
+    )
+    .await?;
     let primary_events = store
         .list_open_competition_v2_events(&config.indexer.network, &config.indexer.factory_contract)
         .await?
         .into_iter()
         .filter(|event| event.block_number <= common_safe_block)
         .collect::<Vec<_>>();
-    let shadow_events = fetch_shadow_events(config, common_safe_block).await?;
     let primary_hash = canonical_event_set_hash(&primary_events)?;
     let shadow_hash = canonical_event_set_hash(&shadow_events)?;
     let block_hashes_match = primary_identity
         .hash
-        .eq_ignore_ascii_case(&shadow_identity.hash);
+        .eq_ignore_ascii_case(&shadow_identity.hash)
+        && primary_identity
+            .hash
+            .eq_ignore_ascii_case(&primary_after.hash)
+        && shadow_identity
+            .hash
+            .eq_ignore_ascii_case(&shadow_after.hash)
+        && [
+            primary_identity.number,
+            shadow_identity.number,
+            primary_after.number,
+            shadow_after.number,
+        ]
+        .iter()
+        .all(|number| *number == common_safe_block);
     let events_match = primary_hash == shadow_hash;
     let agrees = block_hashes_match && events_match;
     let failure_code = if !block_hashes_match {
@@ -158,9 +218,18 @@ pub async fn poll_open_competition_v2_shadow_once(
             canonical_event_set_hash: primary_hash.clone(),
             agrees,
             failure_code: failure_code.clone(),
-            observed_at: Utc::now(),
+            observed_at,
         })
         .await?;
+    let shadow_event_count = shadow_events.len();
+    if agrees {
+        cache.verified = Some(VerifiedShadowPrefix {
+            config: config.clone(),
+            block: common_safe_block,
+            block_hash: primary_identity.hash.clone(),
+            events: shadow_events,
+        });
+    }
     Ok(OpenCompetitionV2ShadowReport {
         protocol_version: OPEN_COMPETITION_V2_PROTOCOL_VERSION.to_string(),
         network: config.indexer.network.clone(),
@@ -171,7 +240,7 @@ pub async fn poll_open_competition_v2_shadow_once(
         primary_block_hash: primary_identity.hash,
         shadow_block_hash: shadow_identity.hash,
         primary_event_count: primary_events.len(),
-        shadow_event_count: shadow_events.len(),
+        shadow_event_count,
         canonical_event_set_hash: primary_hash,
         agrees,
         failure_code,
@@ -179,13 +248,62 @@ pub async fn poll_open_competition_v2_shadow_once(
     })
 }
 
+async fn reusable_prefix(
+    previous: Option<VerifiedShadowPrefix>,
+    config: &OpenCompetitionV2ShadowConfig,
+    common_safe_block: u64,
+) -> anyhow::Result<Option<VerifiedShadowPrefix>> {
+    let Some(previous) = previous.filter(|prefix| {
+        prefix.config == *config
+            && prefix.block >= config.indexer.deployment_block
+            && prefix.block <= common_safe_block
+    }) else {
+        return Ok(None);
+    };
+    let primary = fetch_exact_block_identity(
+        &config.indexer.rpc_url,
+        previous.block,
+        config.indexer.request_id + 100_004,
+    )
+    .await?;
+    let shadow = fetch_exact_block_identity(
+        &config.shadow_rpc_url,
+        previous.block,
+        config.indexer.request_id + 100_005,
+    )
+    .await?;
+    if primary.number != previous.block || shadow.number != previous.block {
+        return Err(anyhow!(
+            "shadow prefix anchor response has another block number"
+        ));
+    }
+    if primary.hash.eq_ignore_ascii_case(&previous.block_hash)
+        && shadow.hash.eq_ignore_ascii_case(&previous.block_hash)
+    {
+        Ok(Some(previous))
+    } else {
+        Ok(None)
+    }
+}
+
 async fn fetch_shadow_events(
     config: &OpenCompetitionV2ShadowConfig,
     to_block: u64,
+    previous: Option<&VerifiedShadowPrefix>,
 ) -> anyhow::Result<Vec<OpenCompetitionV2Event>> {
     let topics = open_competition_v2_event_topics();
-    let mut events = Vec::new();
-    let mut from_block = config.indexer.deployment_block;
+    let mut events = previous
+        .map(|prefix| prefix.events.clone())
+        .unwrap_or_default();
+    let first_block = match previous {
+        Some(prefix) if prefix.block == to_block => return Ok(events),
+        Some(prefix) => prefix
+            .block
+            .checked_add(1)
+            .context("shadow prefix block overflow")?,
+        None => config.indexer.deployment_block,
+    };
+    let mut from_block = first_block;
     let mut request_id = config.indexer.request_id + 110_000;
     while from_block <= to_block {
         let end = query_end(from_block, to_block, config.indexer.max_blocks_per_query);
@@ -200,7 +318,12 @@ async fn fetch_shadow_events(
                 .await?
                 .result,
         )?;
-        events.extend(decode_open_competition_v2_logs(logs)?);
+        events.extend(decode_shadow_range(
+            logs,
+            from_block,
+            end,
+            &[config.indexer.factory_contract.clone()],
+        )?);
         pace_shadow_requests(config).await;
         request_id = request_id.saturating_add(1);
         if end == u64::MAX {
@@ -221,7 +344,7 @@ async fn fetch_shadow_events(
     competitions.sort();
     competitions.dedup();
     for batch in competitions.chunks(AUTONOMOUS_LOG_ADDRESS_BATCH_SIZE) {
-        let mut from_block = config.indexer.deployment_block;
+        let mut from_block = first_block;
         while from_block <= to_block {
             let end = query_end(from_block, to_block, config.indexer.max_blocks_per_query);
             let query = BaseMultiContractLogQuery::new(
@@ -235,7 +358,7 @@ async fn fetch_shadow_events(
                     .await?
                     .result,
             )?;
-            events.extend(decode_open_competition_v2_logs(logs)?);
+            events.extend(decode_shadow_range(logs, from_block, end, batch)?);
             pace_shadow_requests(config).await;
             request_id = request_id.saturating_add(1);
             if end == u64::MAX {
@@ -245,9 +368,40 @@ async fn fetch_shadow_events(
         }
     }
     events.sort_by_key(|event| (event.block_number, event.log_index));
-    let mut seen = HashSet::new();
-    events.retain(|event| seen.insert(event.log_key.clone()));
-    Ok(events)
+    let mut seen = HashMap::new();
+    let mut unique = Vec::new();
+    for event in events {
+        let hash = canonical_event_set_hash(std::slice::from_ref(&event))?;
+        if let Some(previous) = seen.insert(event.log_key.clone(), hash.clone()) {
+            if previous != hash {
+                return Err(anyhow!(
+                    "shadow RPC returned conflicting canonical log identities"
+                ));
+            }
+        } else {
+            unique.push(event);
+        }
+    }
+    Ok(unique)
+}
+
+fn decode_shadow_range(
+    logs: Vec<chain_base::EvmLog>,
+    from_block: u64,
+    to_block: u64,
+    addresses: &[String],
+) -> anyhow::Result<Vec<OpenCompetitionV2Event>> {
+    if logs.iter().any(|log| {
+        !(from_block..=to_block).contains(&log.block_number)
+            || !addresses
+                .iter()
+                .any(|address| address.eq_ignore_ascii_case(&log.address))
+    }) {
+        return Err(anyhow!(
+            "shadow RPC returned a log outside the requested range or emitters"
+        ));
+    }
+    Ok(decode_open_competition_v2_logs(logs)?)
 }
 
 async fn pace_shadow_requests(config: &OpenCompetitionV2ShadowConfig) {
@@ -285,6 +439,433 @@ fn canonical_event_set_hash(events: &[OpenCompetitionV2Event]) -> anyhow::Result
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::{json, Value};
+    use std::sync::{Arc, Mutex};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    struct RpcFixture {
+        url: String,
+        requests: Arc<Mutex<Vec<Value>>>,
+        observed_at: Arc<Mutex<Vec<chrono::DateTime<Utc>>>>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for RpcFixture {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    async fn rpc_fixture(respond: impl Fn(&Value) -> Value + Send + Sync + 'static) -> RpcFixture {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let observed_at = Arc::new(Mutex::new(Vec::new()));
+        let timestamps = observed_at.clone();
+        let recorded = requests.clone();
+        let respond = Arc::new(respond);
+        let task = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let recorded = recorded.clone();
+                let timestamps = timestamps.clone();
+                let respond = respond.clone();
+                tokio::spawn(async move {
+                    let mut bytes = Vec::new();
+                    let mut buffer = [0; 4096];
+                    let request = loop {
+                        let read = stream.read(&mut buffer).await.unwrap();
+                        assert!(read > 0);
+                        bytes.extend_from_slice(&buffer[..read]);
+                        if let Some(end) = bytes.windows(4).position(|part| part == b"\r\n\r\n") {
+                            let headers = String::from_utf8_lossy(&bytes[..end]);
+                            let length: usize = headers
+                                .lines()
+                                .find_map(|line| {
+                                    let (key, value) = line.split_once(':')?;
+                                    key.eq_ignore_ascii_case("content-length")
+                                        .then(|| value.trim().parse().unwrap())
+                                })
+                                .unwrap();
+                            if bytes.len() >= end + 4 + length {
+                                break serde_json::from_slice::<Value>(
+                                    &bytes[end + 4..end + 4 + length],
+                                )
+                                .unwrap();
+                            }
+                        }
+                    };
+                    recorded.lock().unwrap().push(request.clone());
+                    timestamps.lock().unwrap().push(Utc::now());
+                    let body =
+                        json!({"jsonrpc":"2.0","id":request["id"],"result":respond(&request)})
+                            .to_string();
+                    let response = format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body);
+                    stream.write_all(response.as_bytes()).await.unwrap();
+                });
+            }
+        });
+        RpcFixture {
+            url,
+            requests,
+            observed_at,
+            task,
+        }
+    }
+
+    fn config(primary: &str, shadow: &str) -> OpenCompetitionV2ShadowConfig {
+        OpenCompetitionV2ShadowConfig::from_lookup(|key| match key {
+            "OPEN_COMPETITION_V2_INDEXER_NETWORK" => Some("base-sepolia".into()),
+            "OPEN_COMPETITION_V2_FACTORY_CONTRACT" => Some(format!("0x{}", "11".repeat(20))),
+            "OPEN_COMPETITION_V2_INDEXER_RPC_URL" => Some(primary.into()),
+            "OPEN_COMPETITION_V2_SHADOW_RPC_URL" => Some(shadow.into()),
+            "OPEN_COMPETITION_V2_DEPLOYMENT_BLOCK" => Some("1".into()),
+            "OPEN_COMPETITION_V2_SHADOW_REQUEST_DELAY_MS" => Some("0".into()),
+            _ => None,
+        })
+        .unwrap()
+    }
+
+    fn hash() -> String {
+        format!("0x{}", "aa".repeat(32))
+    }
+
+    fn block_response(request: &Value) -> Value {
+        json!({"number":request["params"][0],"hash":hash(),"timestamp":"0x1"})
+    }
+
+    fn prefix(config: &OpenCompetitionV2ShadowConfig) -> VerifiedShadowPrefix {
+        VerifiedShadowPrefix {
+            config: config.clone(),
+            block: 10,
+            block_hash: hash(),
+            events: vec![],
+        }
+    }
+
+    fn creation_log(block: u64, competition_byte: &str) -> Value {
+        let topic = hex::encode(sha3::Keccak256::digest(
+            b"CanonicalCompetitionCreatedV2(bytes32,address,address,bytes32,bytes32)",
+        ));
+        json!({"address":format!("0x{}","11".repeat(20)),
+            "topics":[format!("0x{topic}"),format!("0x{block:064x}"),
+                format!("0x{}{}","00".repeat(12),competition_byte.repeat(20)),format!("0x{}{}","00".repeat(12),"33".repeat(20))],
+            "data":format!("0x{}","00".repeat(64)),"transactionHash":format!("0x{block:064x}"),
+            "blockNumber":format!("0x{block:x}"),"logIndex":"0x0"})
+    }
+
+    fn decoded_creation(block: u64, competition_byte: &str) -> OpenCompetitionV2Event {
+        let log: chain_base::RpcEvmLog =
+            serde_json::from_value(creation_log(block, competition_byte)).unwrap();
+        decode_open_competition_v2_logs(rpc_logs_to_evm_logs([log]).unwrap())
+            .unwrap()
+            .remove(0)
+    }
+
+    #[tokio::test]
+    async fn cold_replay_reads_from_deployment_and_warm_replay_includes_new_competitions() {
+        let rpc = rpc_fixture(|request| {
+            let query = &request["params"][0];
+            if query["address"].is_string() {
+                json!([creation_log(11, "44")])
+            } else {
+                json!([])
+            }
+        })
+        .await;
+        let config = config("http://primary.invalid", &rpc.url);
+        let cold = fetch_shadow_events(&config, 12, None).await.unwrap();
+        assert_eq!(cold.len(), 1);
+        assert!(rpc
+            .requests
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|r| r["params"][0]["fromBlock"] == "0x1"));
+        rpc.requests.lock().unwrap().clear();
+        let mut old = prefix(&config);
+        old.events.push(decoded_creation(2, "22"));
+        let warm = fetch_shadow_events(&config, 12, Some(&old)).await.unwrap();
+        assert_eq!(warm.len(), 2);
+        let queries = rpc.requests.lock().unwrap();
+        assert_eq!(queries.len(), 2);
+        assert!(queries.iter().all(|r| r["params"][0]["fromBlock"] == "0xb"));
+        let addresses = queries[1]["params"][0]["address"].as_array().unwrap();
+        assert!(addresses.contains(&json!(format!("0x{}", "22".repeat(20)))));
+        assert!(addresses.contains(&json!(format!("0x{}", "44".repeat(20)))));
+        assert_eq!(
+            canonical_event_set_hash(&warm).unwrap(),
+            canonical_event_set_hash(&[decoded_creation(2, "22"), decoded_creation(11, "44")])
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn verified_anchor_is_rechecked_on_both_providers_even_without_new_blocks() {
+        let primary = rpc_fixture(block_response).await;
+        let shadow = rpc_fixture(block_response).await;
+        let config = config(&primary.url, &shadow.url);
+        let old = reusable_prefix(Some(prefix(&config)), &config, 10)
+            .await
+            .unwrap()
+            .unwrap();
+        let events = fetch_shadow_events(&config, 10, Some(&old)).await.unwrap();
+        assert!(events.is_empty());
+        assert_eq!(primary.requests.lock().unwrap().len(), 1);
+        assert_eq!(shadow.requests.lock().unwrap().len(), 1);
+        assert_eq!(
+            shadow.requests.lock().unwrap()[0]["method"],
+            "eth_getBlockByNumber"
+        );
+    }
+
+    #[tokio::test]
+    async fn reorg_and_rpc_identity_changes_invalidate_the_verified_prefix() {
+        let primary = rpc_fixture(block_response).await;
+        let shadow = rpc_fixture(|request| {
+            let mut block = block_response(request);
+            block["hash"] = json!(format!("0x{}", "bb".repeat(32)));
+            block
+        })
+        .await;
+        let config = config(&primary.url, &shadow.url);
+        assert!(reusable_prefix(Some(prefix(&config)), &config, 12)
+            .await
+            .unwrap()
+            .is_none());
+        let mut changed = config.clone();
+        changed.shadow_rpc_url = "http://different.invalid".into();
+        assert!(reusable_prefix(Some(prefix(&config)), &changed, 12)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(reusable_prefix(Some(prefix(&config)), &config, 9)
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(primary.requests.lock().unwrap().len(), 1);
+        assert_eq!(shadow.requests.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn malformed_anchor_response_is_an_error_instead_of_reusing_the_cache() {
+        let primary = rpc_fixture(|_| Value::Null).await;
+        let config = config(&primary.url, "http://shadow.invalid");
+        assert!(reusable_prefix(Some(prefix(&config)), &config, 12)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn failed_poll_discards_the_prefix_before_any_database_or_rpc_work() {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://unused:unused@localhost/unused")
+            .unwrap();
+        pool.close().await;
+        let store = PostgresStore::from_pool(pool);
+        let config = config("http://primary.invalid", "http://shadow.invalid");
+        let mut cache = OpenCompetitionV2ShadowCache {
+            verified: Some(prefix(&config)),
+        };
+        assert!(
+            poll_open_competition_v2_shadow_with_cache(&store, &config, &mut cache)
+                .await
+                .is_err()
+        );
+        assert!(cache.verified.is_none());
+    }
+
+    #[tokio::test]
+    async fn out_of_range_logs_cannot_be_appended_to_a_verified_prefix() {
+        let rpc = rpc_fixture(|_| json!([creation_log(2, "22")])).await;
+        let config = config("http://primary.invalid", &rpc.url);
+        let result = fetch_shadow_events(&config, 12, Some(&prefix(&config))).await;
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("outside the requested range"));
+    }
+
+    #[tokio::test]
+    async fn conflicting_duplicate_logs_are_rejected() {
+        let rpc = rpc_fixture(|request| {
+            if request["params"][0]["address"].is_string() {
+                json!([creation_log(2, "22"), creation_log(2, "44")])
+            } else {
+                json!([])
+            }
+        })
+        .await;
+        let config = config("http://primary.invalid", &rpc.url);
+        assert!(fetch_shadow_events(&config, 12, None)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("conflicting canonical log identities"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AGENT_BOUNTIES_TEST_DATABASE_URL"]
+    async fn postgres_shadow_cache_certifies_full_sets_and_recovers_from_disagreement() {
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+        let database_url = std::env::var("AGENT_BOUNTIES_TEST_DATABASE_URL").unwrap();
+        let store = PostgresStore::connect(&database_url).await.unwrap();
+        store.migrate().await.unwrap();
+        let head = Arc::new(AtomicU64::new(10));
+        let reorg = Arc::new(AtomicBool::new(false));
+        let reorg_on_logs = Arc::new(AtomicBool::new(false));
+        let logs = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let primary = {
+            let head = head.clone();
+            let reorg = reorg.clone();
+            rpc_fixture(move |request| {
+                let number = if request["params"][0] == "safe" { json!(format!("0x{:x}", head.load(Ordering::SeqCst))) } else { request["params"][0].clone() };
+                json!({"number":number,"hash":if reorg.load(Ordering::SeqCst) {format!("0x{}","bb".repeat(32))} else {hash()},"timestamp":"0x1"})
+            }).await
+        };
+        let shadow = {
+            let head = head.clone();
+            let logs = logs.clone();
+            let reorg = reorg.clone();
+            let reorg_on_logs = reorg_on_logs.clone();
+            rpc_fixture(move |request| {
+                if request["method"] == "eth_getLogs" {
+                    if reorg_on_logs.load(Ordering::SeqCst) { reorg.store(true, Ordering::SeqCst); }
+                    let query = &request["params"][0];
+                    let from = u64::from_str_radix(query["fromBlock"].as_str().unwrap().trim_start_matches("0x"), 16).unwrap();
+                    let to = u64::from_str_radix(query["toBlock"].as_str().unwrap().trim_start_matches("0x"), 16).unwrap();
+                    return json!(logs.lock().unwrap().iter().filter(|log| {
+                        let block = u64::from_str_radix(log["blockNumber"].as_str().unwrap().trim_start_matches("0x"),16).unwrap();
+                        (from..=to).contains(&block) && (query["address"] == log["address"] || query["address"].as_array().is_some_and(|addresses| addresses.contains(&log["address"])))
+                    }).cloned().collect::<Vec<_>>());
+                }
+                let number = if request["params"][0] == "safe" { json!(format!("0x{:x}", head.load(Ordering::SeqCst))) } else { request["params"][0].clone() };
+                json!({"number":number,"hash":if reorg.load(Ordering::SeqCst) {format!("0x{}","bb".repeat(32))} else {hash()},"timestamp":"0x1"})
+            }).await
+        };
+        let mut config = config(&primary.url, &shadow.url);
+        config.indexer.factory_contract = format!("0x00000000{}", uuid::Uuid::new_v4().simple());
+        async fn add(
+            store: &PostgresStore,
+            config: &OpenCompetitionV2ShadowConfig,
+            block: u64,
+        ) -> Value {
+            let mut raw = creation_log(block, &format!("{block:02x}"));
+            raw["address"] = json!(config.indexer.factory_contract);
+            let log: chain_base::RpcEvmLog = serde_json::from_value(raw.clone()).unwrap();
+            let event = decode_open_competition_v2_logs(rpc_logs_to_evm_logs([log]).unwrap())
+                .unwrap()
+                .remove(0);
+            store
+                .upsert_open_competition_v2_event(
+                    &config.indexer.network,
+                    &config.indexer.factory_contract,
+                    &event,
+                    &db::OpenCompetitionV2SafeContext {
+                        block_hash: hash(),
+                        safe_block_number: 20,
+                        safe_block_hash: hash(),
+                    },
+                )
+                .await
+                .unwrap();
+            raw
+        }
+        let first_log = add(&store, &config, 2).await;
+        logs.lock().unwrap().push(first_log);
+        store
+            .upsert_base_log_cursor(
+                &config.indexer.network,
+                &config.indexer.factory_contract,
+                10,
+                None,
+            )
+            .await
+            .unwrap();
+        let mut cache = OpenCompetitionV2ShadowCache::default();
+        let start = Utc::now();
+        let cold = poll_open_competition_v2_shadow_with_cache(&store, &config, &mut cache)
+            .await
+            .unwrap();
+        assert!(cold.agrees && cache.verified.is_some());
+        let agreement = store
+            .get_open_competition_v2_indexer_agreement(
+                &config.indexer.network,
+                &config.indexer.factory_contract,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(agreement.observed_at >= start && agreement.observed_at <= Utc::now());
+        assert!(agreement.observed_at <= primary.observed_at.lock().unwrap()[0]);
+        let next_log = add(&store, &config, 11).await;
+        logs.lock().unwrap().push(next_log);
+        head.store(12, Ordering::SeqCst);
+        store
+            .upsert_base_log_cursor(
+                &config.indexer.network,
+                &config.indexer.factory_contract,
+                12,
+                None,
+            )
+            .await
+            .unwrap();
+        shadow.requests.lock().unwrap().clear();
+        let warm = poll_open_competition_v2_shadow_with_cache(&store, &config, &mut cache)
+            .await
+            .unwrap();
+        assert!(warm.agrees);
+        assert_eq!(
+            warm.canonical_event_set_hash,
+            canonical_event_set_hash(&cache.verified.as_ref().unwrap().events).unwrap()
+        );
+        assert!(shadow
+            .requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r["method"] == "eth_getLogs")
+            .all(|r| r["params"][0]["fromBlock"] == "0xb"));
+        let absent_from_shadow = add(&store, &config, 12).await;
+        let mismatch = poll_open_competition_v2_shadow_with_cache(&store, &config, &mut cache)
+            .await
+            .unwrap();
+        assert!(!mismatch.agrees && cache.verified.is_none());
+        logs.lock().unwrap().push(absent_from_shadow);
+        shadow.requests.lock().unwrap().clear();
+        assert!(
+            poll_open_competition_v2_shadow_with_cache(&store, &config, &mut cache)
+                .await
+                .unwrap()
+                .agrees
+        );
+        assert!(shadow
+            .requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r["method"] == "eth_getLogs")
+            .all(|r| r["params"][0]["fromBlock"] == "0x1"));
+        head.store(14, Ordering::SeqCst);
+        store
+            .upsert_base_log_cursor(
+                &config.indexer.network,
+                &config.indexer.factory_contract,
+                14,
+                None,
+            )
+            .await
+            .unwrap();
+        reorg_on_logs.store(true, Ordering::SeqCst);
+        let changed_during_scan =
+            poll_open_competition_v2_shadow_with_cache(&store, &config, &mut cache)
+                .await
+                .unwrap();
+        assert!(!changed_during_scan.agrees && cache.verified.is_none());
+        assert_eq!(
+            changed_during_scan.failure_code.as_deref(),
+            Some("safe_block_hash_mismatch")
+        );
+    }
 
     #[test]
     fn shadow_rpc_must_be_independent() {

--- a/docs/open-competition-v2-shadow-verification.md
+++ b/docs/open-competition-v2-shadow-verification.md
@@ -1,0 +1,37 @@
+# Open Competition V2 shadow verification
+
+The shadow worker independently reads the canonical V2 event set through a
+second RPC provider. Agreement requires matching block identities and the
+complete event-set digest from the primary indexer and the shadow provider.
+An agreement is a verification read model; canonical settlement events remain
+the only proof of payment.
+
+The long-running worker retains a process-local prefix only after agreement
+has been persisted successfully. Every reuse requires identical configuration,
+a non-regressing common-safe block, and the cached anchor hash from both RPCs.
+It then scans the suffix for factory events and all previously or newly
+discovered competition contracts. The full combined event set must still match
+the primary database. A repeated safe block requires fresh anchor checks and a
+new comparison with the primary event set, without repeating historical log
+queries.
+
+Both providers must return the same target block before and after scanning.
+Out-of-range logs, unexpected emitters, conflicting duplicate logs, malformed
+responses, or database errors fail verification. Disagreement and failed or
+cancelled polls discard the cache. Reorgs, changed configuration, and cursor
+regression require a full replay. A process restart also starts from the
+deployment block; no cached history is reconstructed from the primary database.
+
+The observation timestamp is captured before the poll starts. A long replay
+cannot refresh old observations merely by completing late. Existing API
+freshness and lag limits remain enforced during cold replay and recovery.
+
+Validation:
+
+```bash
+cargo test -p worker open_competition_v2_shadow --lib
+# Requires an isolated test database; also enforced by the Postgres CI job.
+cargo test -p worker open_competition_v2_shadow::tests::postgres_shadow_cache_certifies_full_sets_and_recovers_from_disagreement -- --ignored --exact
+```
+
+Maintainer scope and contributor impact: [notice #1293](https://github.com/NSPG13/agent-bounties/issues/1293).

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:b0069e98c0490d0926b4f50ffd17c88915aa8cd2d6c23998065a9f309bdbaf4a",
+    "benchmark_digest": "sha256:9217b3f431b998152ad4facd673ca83fe91e4e17477b0b1e49fde228c802cab1",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",


### PR DESCRIPTION
Full-history shadow replays can outlast the V2 freshness window and temporarily block bounty creation. The long-running worker now retains only an independently verified prefix, rechecks its anchor through both providers, scans new factory and competition logs, and compares the complete event set against the primary database before publishing agreement.

Errors, cancellation, disagreement, reorgs, changed configuration, or cursor regression discard the cache or require a full replay. Target block identities are checked before and after scanning; malformed ranges, emitters, and conflicting logs fail closed. The observation timestamp now reflects poll start. Existing API freshness limits and all payment/settlement requirements remain unchanged.

Notice: #1293. Change class: R2, rebuildable verification read model. Inspected all 86 open PRs; none modifies the shadow module. #910 has an older conflicting worker-startup diff: rebase and preserve the stateful loop, then run the worker tests and normal gates. No migration or collaboration branch is required. The one-shot function remains compatible.

Validation:
- `cargo test -p worker`: 42 passed; Docker rehearsal and new Postgres integration test require their dedicated environments.
- 16 source-guard/watchdog unit tests passed; exact worker-build and unchanged signing-runtime digests verified.
- Added Postgres CI coverage for full replay, warm suffix verification, complete-set disagreement, recovery, and a reorg during scanning.
- Known-good/known-bad watchdog rehearsal passed. Required CI, including the Postgres integration test, passed on `f335a8f017d5dc42656ae6f370c0afc0d707854a` (run 34056189471). Code and security reviews completed without findings.

The V2 shadow worker has a separate deployment path. After reviewed merge and successful main CI, deploy that worker and verify sustained fresh agreement across multiple cycles; API/MCP deployment alone does not deliver this repair.
