### PR TITLE
Fix V2 MCP creation attribution for Base network descriptors

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
+          --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
+          --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
+          --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "d24f17f98066ff9df02389252891b85cfe6cea49816a85db83a13082bafed
 PIPELINE_TEST_SHA256 = "505977c92d852b98d92088b8fc26a31eb754f21d75dc3eb8b1275ec98e76f2be"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"
+WORKER_BUILD_SHA256 = "194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"
 SIGNING_RUNTIME_SHA256 = "ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "59b75d2cd73b39ae41b2516d04cb48df5b47d047449fb771062ad473f0010aa3",
+    ".github/workflows/regression-verifier-runner.yml": "7c641a8cda2afb1c7e10be4fdd5431452d217528781d942b46592efa11b1e4d2",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "45546e1ae80bb831fa2d145c8e4228c03f0a359b2df87ae90a4154856c1a85ca",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "b03f1d8afb6b60ca6e88c714aa340f7004c36cfba07f65104097d4a23a6829a8",
+    ".github/workflows/regression-verifier-signer.yml": "146bd0a8bc9035e63c6fbfd2a679c0bb7c152a1edc506cab6bc7b3d2092d1183",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "58ce813cc3e7d453df3ae4a90f9a8251a77d0fd01cfc488a0e60e8fbeee67b6c",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 8a4810a5ddacd300158d30c8368c2747edcb5431347be5098d986b72077bd9ea"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -454,11 +454,21 @@ fn competition_preparation_binding(
     {
         return Err("creation attribution requires the supported Beta3 plan".to_string());
     }
-    let expected_network = chain_base::base_network_descriptor(&plan.network.name)
+    let network_name = match plan.network.name.as_str() {
+        "Base" => "base-mainnet",
+        "Base Sepolia" => "base-sepolia",
+        name => name,
+    };
+    let expected_network = chain_base::base_network_descriptor(network_name)
         .map_err(|_| "creation plan has an unsupported network".to_string())?;
     if plan.network.chain_id != expected_network.chain_id {
         return Err("creation plan network and chain ID disagree".to_string());
     }
+    let network = match expected_network.chain_id {
+        8_453 => "base-mainnet",
+        84_532 => "base-sepolia",
+        _ => return Err("creation plan has an unsupported chain ID".to_string()),
+    };
     let creates: Vec<_> = plan
         .wallet_calls
         .iter()
@@ -489,7 +499,7 @@ fn competition_preparation_binding(
     Ok(DistributionCompetitionBinding {
         acquisition_id: attribution.acquisition_id,
         protocol_version: plan.protocol_version,
-        network: plan.network.name,
+        network: network.to_string(),
         factory_contract: address(&create.to)?,
         bounty_id,
         competition_contract: address(&plan.predicted_competition)?,
@@ -5234,8 +5244,7 @@ mod tests {
             "plan": {
                 "schema_version": "agent-bounties/open-competition-v2-creation-plan-v1",
                 "protocol_version": "agent-bounties/open-competition-v2-beta3",
-                "network": {"name": "base-mainnet", "chain_id": 8453,
-                    "rpc_url_env": "BASE_MAINNET_RPC_URL", "native_usdc_token_address": format!("0x{}", "1".repeat(40))},
+                "network": chain_base::base_network_descriptor("base-mainnet").unwrap(),
                 "bounty_id": format!("0x{}", "2".repeat(64)),
                 "predicted_competition": format!("0x{}", "3".repeat(40)),
                 "funding_target": "2100000", "remaining_funding_after_creation": "0",
@@ -5263,6 +5272,7 @@ mod tests {
         let binding = competition_preparation_binding(&result, &attribution).unwrap();
         assert!(binding.prepared_at >= received_at);
         assert_eq!(binding.acquisition_id, attribution.acquisition_id);
+        assert_eq!(binding.network, "base-mainnet");
         for status in [json!(400), json!(503), Value::Null, json!("200")] {
             let mut invalid = result.clone();
             invalid["http_status"] = status;
@@ -5298,6 +5308,29 @@ mod tests {
             let mut invalid = result.clone();
             invalid["body"]["plan"]["wallet_calls"] = calls;
             assert!(competition_preparation_binding(&invalid, &attribution).is_err());
+        }
+    }
+
+    #[test]
+    fn distribution_competition_binding_normalizes_both_shared_network_descriptors() {
+        let attribution = McpDistributionAttribution {
+            acquisition_id: Uuid::new_v4(),
+            acquisition_token: "opaque".to_string(),
+            first_touch_rail: "mcp-so-paid".to_string(),
+            current_rail: "mcp-so-paid".to_string(),
+            measurement_eligible: false,
+        };
+        for network in ["base-mainnet", "base-sepolia"] {
+            let descriptor = chain_base::base_network_descriptor(network).unwrap();
+            let mut result = distribution_competition_fixture();
+            result["body"]["plan"]["network"] = json!(descriptor);
+            for name in [descriptor.name.as_str(), network] {
+                result["body"]["plan"]["network"]["name"] = json!(name);
+                let binding = competition_preparation_binding(&result, &attribution).unwrap();
+                assert_eq!(binding.network, network);
+            }
+            result["body"]["plan"]["network"]["chain_id"] = json!(1);
+            assert!(competition_preparation_binding(&result, &attribution).is_err());
         }
     }
 

--- a/docs/distribution-attribution.md
+++ b/docs/distribution-attribution.md
@@ -78,6 +78,9 @@ An attributed MCP `prepare_open_competition_v2` call with `operation=create`
 also preserves its source. Only a successful Beta3 creation plan is eligible for
 an analytics-only preparation record. Its exact network, factory, bounty ID,
 predicted competition address, and creator bind to the existing acquisition.
+Bindings use `base-mainnet` or `base-sepolia`, including when the unsigned
+plan uses the shared descriptor's display name, `Base` or `Base Sepolia`.
+The network name and chain ID must still identify the same supported chain.
 Identical retries preserve the first preparation time; another acquisition or a
 changed identity cannot replace that binding. Other V2 operations and unattributed
 requests retain their existing behavior. No wallet call is executed by this step.

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:9217b3f431b998152ad4facd673ca83fe91e4e17477b0b1e49fde228c802cab1",
+    "benchmark_digest": "sha256:2714bc6336ad4a6d72dbe07309a7bc32c8fd156a3c658cfdb68d504b51c0c8cc",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",


### PR DESCRIPTION
## What Changed

Attributed V2 creation failed because the real unsigned plan names its network `Base`, while the preparation-binding schema requires `base-mainnet`. Normalize the shared Base and Base Sepolia descriptors to canonical IDs, retaining the name/chain-ID consistency check. Regression fixtures now use the actual shared descriptor instead of a hand-written machine name. The reviewed worker-build fingerprints and unfunded watchdog fixture are refreshed because their source set includes all Rust crates. The signing-runtime fingerprint is unchanged.

## Linked Bounty Or Issue

Fixes #1296. Maintainer compatibility repair; no bounty or payout claim.

## Maintainer Change Notice

Notice: #1296, published before edits. Rechecked 87 open PRs; active #1295 changed frontend files and has since merged. This branch is rebased onto that merge. #1281 remains changes-requested with failing checks. Older #910 is conflicting; its owner should preserve canonical network identifiers when rebasing. No new migration or collaboration branch is required for this repair.

## Discovery Feedback

Found during maintainer verification of the attributed MCP creation flow. Trust improves when tests use the same descriptors that production emits. No external discovery or earning claim.

## Acceptance Criteria

- [x] Both real shared descriptors produce canonical binding IDs.
- [x] Unsupported or inconsistent network/chain pairs still fail.
- [x] Wallet calls, contracts, payment and settlement rules are unchanged.

## SDLC And Recovery

R2 compatibility fix. Sources of truth: shared Base network descriptor and the existing binding schema. Failure mode: display labels fail persistence. The existing network/factory/bounty identity remains the retry key; exact retries preserve the original preparation. Forward repair is this mapping; reverting restores the known attribution failure. Release check: an excluded unsigned MCP creation must persist its source and retry successfully on the deployed revision. No recovery automation or financial actions are added.

## Local Checks

`./scripts/preflight.ps1 -Mode core` passed. The updated regression first failed on the old implementation (`Base` versus `base-mainnet`). `cargo test -p mcp-server distribution_competition -- --nocapture` passed all four focused tests; `cargo test -p mcp-server` passed all 83 tests. `git diff --check` passed. Postgres binding constraints and retry coverage passed in required CI. All 16 source-guard/watchdog unit tests pass. The full known-good/known-bad watchdog rehearsal passed. All required CI passed on `8844ec0a37acc2b0b1fc0711bd76fc2a22d2b6f3`: full-check, postgres-sync, sdlc-recovery and ruleset-drift ([run](https://github.com/NSPG13/agent-bounties/actions/runs/34064895783)).

## Review Lane

Ready for review and required CI. Production source-binding verification follows deployment. Preparation success does not prove creation, funding or settlement.
