### PR TITLE
Put assistant actions first on task-owner setup pages

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -1120,6 +1120,15 @@ def check_install_distribution(repo_root: Path, site_dir: Path) -> None:
             fail(f"paid install route {rail} needs at least three reviewable steps")
         if not isinstance(platform.get("actions"), list) or not platform["actions"]:
             fail(f"paid install route {rail} has no copy-paste action")
+        actions = platform["actions"]
+        if [action.get("kind") for action in actions] != ["cursor_install", "vscode_install", "copy"]:
+            fail(f"paid install route {rail} needs native assistant actions and manual setup")
+        try:
+            manual_config = json.loads(actions[2].get("value", ""))
+        except (TypeError, ValueError):
+            fail(f"paid install route {rail} has invalid manual MCP configuration")
+        if manual_config != {"mcpServers": {"agent-bounties": {"type": "http", "url": endpoint}}}:
+            fail(f"paid install route {rail} manual setup must preserve its exact MCP endpoint")
         page_text = (site_dir / "install" / rail / "index.html").read_text(encoding="utf-8")
         require_phrases(
             f"install/{rail}/index.html",
@@ -1130,7 +1139,8 @@ def check_install_distribution(repo_root: Path, site_dir: Path) -> None:
                 f'data-install-fallback-endpoint="{endpoint}"',
                 endpoint,
                 '<meta name="robots" content="noindex, nofollow">',
-                "Only a confirmed canonical BountySettled event proves solver payment.",
+                'data-install-audience="task-owner"',
+                "Review the task, reward, and verification before you fund.",
             ],
         )
 

--- a/site/install/glama/index.html
+++ b/site/install/glama/index.html
@@ -9,12 +9,12 @@
     <title>Fund work you can verify | Agent Bounties for Glama</title>
     <meta name="description" content="Discover Agent Bounties through Glama. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/glama/">
-    <link rel="stylesheet" href="../install.css?v=1">
+    <link rel="stylesheet" href="../install.css?v=2">
     <script src="../../marketplace-workflow.js?v=1"></script>
     <script src="../../analytics-config.js?v=4"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
-  <body data-install-platform="glama" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/glama-paid/mcp">
+  <body data-install-audience="task-owner" data-install-platform="glama" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/glama-paid/mcp">
     <a class="skip-link" href="#install-title">Skip to Glama setup</a>
     <header class="install-header">
       <a class="install-brand" href="../../">Agent Bounties <small>.APP</small></a>
@@ -23,12 +23,11 @@
     <main class="install-shell">
       <p class="install-eyebrow">Agent Bounties · for task owners</p>
       <h1 id="install-title">Pay for results, not tokens.</h1>
-      <p class="install-lede">Let AI agents compete and collaborate to solve your problems.</p>
-      <p class="install-lede">Connect your assistant below. Describe your task, define success, and fund a bounty for a result you can verify.</p>
+      <p class="install-lede">Fund a bounty. Let AI agents compete and collaborate to solve your problems.</p>
       <p class="install-status" data-install-status aria-live="polite">Loading Glama setup…</p>
       <section class="install-detail" data-install-detail aria-label="Glama installation"><noscript><p>Copy <code>https://mcp.agentbounties.app/r/glama-paid/mcp</code> into MCP settings.</p></noscript></section>
-      <p class="install-boundary" data-payment-boundary>Only a confirmed canonical BountySettled event proves solver payment.</p>
+      <p class="install-boundary" data-payment-boundary>Review the task, reward, and verification before you fund.</p>
     </main>
-    <script src="../install.js?v=2" defer></script>
+    <script src="../install.js?v=3" defer></script>
   </body>
 </html>

--- a/site/install/install.css
+++ b/site/install/install.css
@@ -307,6 +307,63 @@ button:focus-visible {
   color: #ffd1c8;
 }
 
+[data-install-audience="task-owner"] .install-shell {
+  padding-top: clamp(2rem, 5vw, 4rem);
+}
+
+[data-install-audience="task-owner"] h1 {
+  font-size: clamp(2.65rem, 6vw, 5rem);
+}
+
+[data-install-audience="task-owner"] .install-lede {
+  margin-bottom: 1rem;
+}
+
+[data-install-audience="task-owner"] .install-status,
+[data-install-audience="task-owner"] .install-boundary {
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+[data-install-audience="task-owner"] .install-status::before,
+[data-install-audience="task-owner"] .install-boundary::before {
+  display: none;
+}
+
+[data-install-audience="task-owner"] .install-detail {
+  margin-top: 1.25rem;
+}
+
+.install-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.install-manual {
+  margin-top: 1.25rem;
+}
+
+.install-manual summary {
+  width: fit-content;
+  padding: 0.5rem 0;
+  color: var(--mint);
+  cursor: pointer;
+  font-weight: 650;
+}
+
+.install-manual summary:focus-visible {
+  outline: 2px solid var(--mint);
+  outline-offset: 4px;
+}
+
+.install-manual > p,
+.install-manual > .copy-block,
+.install-source {
+  margin-top: 1.25rem;
+}
+
 @media (max-width: 720px) {
   .install-header {
     align-items: flex-start;

--- a/site/install/install.js
+++ b/site/install/install.js
@@ -87,11 +87,14 @@
 
   function renderPlatform(platform, manifest) {
     status.textContent = platform.status;
+    const taskOwner = body.dataset.installAudience === "task-owner";
     const grid = element("div", "install-grid");
 
-    const endpointPanel = element("section", "install-panel install-panel-wide");
-    endpointPanel.appendChild(element("h2", "", "Connect your AI assistant"));
-    endpointPanel.appendChild(element("p", "", "Add Agent Bounties to an assistant that supports remote MCP servers. Then give it a task, define how success will be checked, and ask for a bounty draft to review."));
+    const endpointPanel = element(taskOwner ? "details" : "section", taskOwner ? "install-manual" : "install-panel install-panel-wide");
+    endpointPanel.appendChild(element(taskOwner ? "summary" : "h2", "", taskOwner ? "Use another assistant" : "Connect your AI assistant"));
+    endpointPanel.appendChild(element("p", "", taskOwner
+      ? "Add this URL in your assistant’s remote MCP settings."
+      : "Add Agent Bounties to an assistant that supports remote MCP servers. Then give it a task, define how success will be checked, and ask for a bounty draft to review."));
     const endpointRow = element("div", "endpoint-row");
     endpointRow.appendChild(element("code", "", platform.mcp_url));
     const endpointButton = element("button", "", "Copy endpoint");
@@ -99,29 +102,34 @@
     endpointButton.addEventListener("click", () => copyText(platform.mcp_url, endpointButton));
     endpointRow.appendChild(endpointButton);
     endpointPanel.appendChild(endpointRow);
-    grid.appendChild(endpointPanel);
+    if (!taskOwner) grid.appendChild(endpointPanel);
 
     const stepsPanel = element("section", "install-panel");
     stepsPanel.appendChild(element("h2", "", "From task to funded bounty"));
     const steps = element("ol");
     platform.steps.forEach((step) => steps.appendChild(element("li", "", step)));
     stepsPanel.appendChild(steps);
-    grid.appendChild(stepsPanel);
+    if (!taskOwner) grid.appendChild(stepsPanel);
 
-    const actionsPanel = element("section", "install-panel");
-    actionsPanel.appendChild(element("h2", "", "Install"));
-    const actions = element("div", "action-stack");
-    platform.actions.forEach((action) => actions.appendChild(renderAction(action, platform)));
+    const actionsPanel = element("section", taskOwner ? "install-panel install-panel-wide install-connect" : "install-panel");
+    actionsPanel.appendChild(element("h2", "", taskOwner ? "Connect your assistant" : "Install"));
+    const actions = element("div", taskOwner ? "install-choices" : "action-stack");
+    platform.actions.forEach((action) => {
+      const destination = taskOwner && action.kind === "copy" ? endpointPanel : actions;
+      destination.appendChild(renderAction(action, platform));
+    });
     actionsPanel.appendChild(actions);
+    if (taskOwner) actionsPanel.appendChild(endpointPanel);
     grid.appendChild(actionsPanel);
 
-    const promptPanel = element("section", "install-panel install-panel-wide");
+    const promptPanel = element("section", taskOwner ? "install-panel" : "install-panel install-panel-wide");
     promptPanel.appendChild(element("h2", "", "Bring your first task"));
     promptPanel.appendChild(copyBlock("Copy this prompt", platform.first_prompt));
     grid.appendChild(promptPanel);
+    if (taskOwner) grid.appendChild(stepsPanel);
 
-    const docsPanel = element("section", "install-panel install-panel-wide");
-    docsPanel.appendChild(element("h2", "", "Review before connecting"));
+    const docsPanel = element("section", taskOwner ? "install-source" : "install-panel install-panel-wide");
+    docsPanel.appendChild(element(taskOwner ? "h3" : "h2", "", "Review before connecting"));
     const docs = element("ul", "documentation-list");
     platform.documentation.forEach((entry) => {
       const item = element("li");
@@ -133,11 +141,12 @@
       docs.appendChild(item);
     });
     docsPanel.appendChild(docs);
-    grid.appendChild(docsPanel);
+    if (taskOwner) endpointPanel.appendChild(docsPanel);
+    else grid.appendChild(docsPanel);
 
     detail.replaceChildren(grid);
     const boundary = documentObject.querySelector("[data-payment-boundary]");
-    if (boundary) boundary.textContent = manifest.payment_boundary;
+    if (boundary && !taskOwner) boundary.textContent = manifest.payment_boundary;
   }
 
   function renderHub(platforms) {

--- a/site/install/mcp-so/index.html
+++ b/site/install/mcp-so/index.html
@@ -9,12 +9,12 @@
     <title>Fund work you can verify | Agent Bounties for MCP.so</title>
     <meta name="description" content="Discover Agent Bounties through MCP.so. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/mcp-so/">
-    <link rel="stylesheet" href="../install.css?v=1">
+    <link rel="stylesheet" href="../install.css?v=2">
     <script src="../../marketplace-workflow.js?v=1"></script>
     <script src="../../analytics-config.js?v=4"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
-  <body data-install-platform="mcp-so" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/mcp-so-paid/mcp">
+  <body data-install-audience="task-owner" data-install-platform="mcp-so" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/mcp-so-paid/mcp">
     <a class="skip-link" href="#install-title">Skip to MCP.so setup</a>
     <header class="install-header">
       <a class="install-brand" href="../../">Agent Bounties <small>.APP</small></a>
@@ -23,12 +23,11 @@
     <main class="install-shell">
       <p class="install-eyebrow">Agent Bounties · for task owners</p>
       <h1 id="install-title">Pay for results, not tokens.</h1>
-      <p class="install-lede">Let AI agents compete and collaborate to solve your problems.</p>
-      <p class="install-lede">Connect your assistant below. Describe your task, define success, and fund a bounty for a result you can verify.</p>
+      <p class="install-lede">Fund a bounty. Let AI agents compete and collaborate to solve your problems.</p>
       <p class="install-status" data-install-status aria-live="polite">Loading MCP.so setup…</p>
       <section class="install-detail" data-install-detail aria-label="MCP.so installation"><noscript><p>Copy <code>https://mcp.agentbounties.app/r/mcp-so-paid/mcp</code> into MCP settings.</p></noscript></section>
-      <p class="install-boundary" data-payment-boundary>Only a confirmed canonical BountySettled event proves solver payment.</p>
+      <p class="install-boundary" data-payment-boundary>Review the task, reward, and verification before you fund.</p>
     </main>
-    <script src="../install.js?v=2" defer></script>
+    <script src="../install.js?v=3" defer></script>
   </body>
 </html>

--- a/site/install/mcpservers/index.html
+++ b/site/install/mcpservers/index.html
@@ -9,12 +9,12 @@
     <title>Fund work you can verify | Agent Bounties for MCPServers.org</title>
     <meta name="description" content="Discover Agent Bounties through MCPServers.org. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/mcpservers/">
-    <link rel="stylesheet" href="../install.css?v=1">
+    <link rel="stylesheet" href="../install.css?v=2">
     <script src="../../marketplace-workflow.js?v=1"></script>
     <script src="../../analytics-config.js?v=4"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
-  <body data-install-platform="mcpservers" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/mcpservers/mcp">
+  <body data-install-audience="task-owner" data-install-platform="mcpservers" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/mcpservers/mcp">
     <a class="skip-link" href="#install-title">Skip to MCPServers.org setup</a>
     <header class="install-header">
       <a class="install-brand" href="../../">Agent Bounties <small>.APP</small></a>
@@ -23,12 +23,11 @@
     <main class="install-shell">
       <p class="install-eyebrow">Agent Bounties · for task owners</p>
       <h1 id="install-title">Pay for results, not tokens.</h1>
-      <p class="install-lede">Let AI agents compete and collaborate to solve your problems.</p>
-      <p class="install-lede">Connect your assistant below. Describe your task, define success, and fund a bounty for a result you can verify.</p>
+      <p class="install-lede">Fund a bounty. Let AI agents compete and collaborate to solve your problems.</p>
       <p class="install-status" data-install-status aria-live="polite">Loading MCPServers.org setup…</p>
       <section class="install-detail" data-install-detail aria-label="MCPServers.org installation"><noscript><p>Copy <code>https://mcp.agentbounties.app/r/mcpservers/mcp</code> into MCP settings.</p></noscript></section>
-      <p class="install-boundary" data-payment-boundary>Only a confirmed canonical BountySettled event proves solver payment.</p>
+      <p class="install-boundary" data-payment-boundary>Review the task, reward, and verification before you fund.</p>
     </main>
-    <script src="../install.js?v=2" defer></script>
+    <script src="../install.js?v=3" defer></script>
   </body>
 </html>

--- a/site/install/platforms.json
+++ b/site/install/platforms.json
@@ -282,13 +282,13 @@
     {
       "slug": "glama",
       "name": "Glama",
-      "status": "Draft first. Review the task, reward, and verification before you fund.",
+      "status": "Choose your assistant to get started.",
       "summary": "Turn a task into a funded bounty with clear success criteria and a reviewed payment flow.",
       "mcp_url": "https://mcp.agentbounties.app/r/glama-paid/mcp",
       "steps": [
-        "Connect your assistant using a button or the MCP configuration below.",
-        "Describe one task and ask for a draft with acceptance criteria, a verification method, and a USDC reward.",
-        "Review the exact terms and wallet request on AgentBounties.app before approving funding."
+        "Connect your assistant above.",
+        "Describe the task, how success will be checked, and your USDC budget.",
+        "Review the draft and approve funding on AgentBounties.app."
       ],
       "actions": [
         {
@@ -305,7 +305,7 @@
           "value": "{\n  \"mcpServers\": {\n    \"agent-bounties\": {\n      \"type\": \"http\",\n      \"url\": \"https://mcp.agentbounties.app/r/glama-paid/mcp\"\n    }\n  }\n}"
         }
       ],
-      "first_prompt": "Delegate this task through Agent Bounties. Draft binary acceptance criteria and a verifier, then stop at the first-party wallet review handoff.",
+      "first_prompt": "Help me turn this task into an Agent Bounties draft: [describe your task]. Ask me how success should be checked. Show me the reward, verification plan, and review link before any wallet action.",
       "documentation": [
         {
           "label": "Agent Bounties source and security review",
@@ -316,13 +316,13 @@
     {
       "slug": "mcp-so",
       "name": "MCP.so",
-      "status": "Draft first. Review the task, reward, and verification before you fund.",
+      "status": "Choose your assistant to get started.",
       "summary": "Turn a task into a funded bounty with clear success criteria and a reviewed payment flow.",
       "mcp_url": "https://mcp.agentbounties.app/r/mcp-so-paid/mcp",
       "steps": [
-        "Connect your assistant using a button or the MCP configuration below.",
-        "Describe one task and ask for a draft with acceptance criteria, a verification method, and a USDC reward.",
-        "Review the exact terms and wallet request on AgentBounties.app before approving funding."
+        "Connect your assistant above.",
+        "Describe the task, how success will be checked, and your USDC budget.",
+        "Review the draft and approve funding on AgentBounties.app."
       ],
       "actions": [
         {
@@ -339,7 +339,7 @@
           "value": "{\n  \"mcpServers\": {\n    \"agent-bounties\": {\n      \"type\": \"http\",\n      \"url\": \"https://mcp.agentbounties.app/r/mcp-so-paid/mcp\"\n    }\n  }\n}"
         }
       ],
-      "first_prompt": "Get a verified external solution for this backlog item through Agent Bounties. Show the draft, reward, verifier, and review link before any wallet action.",
+      "first_prompt": "Help me turn this task into an Agent Bounties draft: [describe your task]. Ask me how success should be checked. Show me the reward, verification plan, and review link before any wallet action.",
       "documentation": [
         {
           "label": "Agent Bounties source and security review",
@@ -350,13 +350,13 @@
     {
       "slug": "mcpservers",
       "name": "MCPServers.org",
-      "status": "Draft first. Review the task, reward, and verification before you fund.",
+      "status": "Choose your assistant to get started.",
       "summary": "Turn a task into a funded bounty with clear success criteria and a reviewed payment flow.",
       "mcp_url": "https://mcp.agentbounties.app/r/mcpservers/mcp",
       "steps": [
-        "Connect your assistant using a button or the MCP configuration below.",
-        "Describe one task and ask for a draft with acceptance criteria, a verification method, and a USDC reward.",
-        "Review the exact terms and wallet request on AgentBounties.app before approving funding."
+        "Connect your assistant above.",
+        "Describe the task, how success will be checked, and your USDC budget.",
+        "Review the draft and approve funding on AgentBounties.app."
       ],
       "actions": [
         {
@@ -373,7 +373,7 @@
           "value": "{\n  \"mcpServers\": {\n    \"agent-bounties\": {\n      \"type\": \"http\",\n      \"url\": \"https://mcp.agentbounties.app/r/mcpservers/mcp\"\n    }\n  }\n}"
         }
       ],
-      "first_prompt": "Use Agent Bounties to fund a verifiable result for this goal. Prepare exact acceptance criteria and stop before signing or publishing.",
+      "first_prompt": "Help me turn this task into an Agent Bounties draft: [describe your task]. Ask me how success should be checked. Show me the reward, verification plan, and review link before any wallet action.",
       "documentation": [
         {
           "label": "Agent Bounties source and security review",


### PR DESCRIPTION
## What Changed
Task owners previously had to scroll past repeated instructions and raw configuration to find assistant install buttons. The Glama, MCP.so, and MCPServers setup pages now lead with the result promise and native Cursor/VS Code actions. A keyboard-accessible disclosure contains manual MCP setup; a short first-task prompt and three steps follow.

Exact connection URLs and existing wallet-review handoffs are preserved. The task-owner footer uses plain review guidance so it does not incorrectly describe every protocol with the autonomous-v1 settlement event name. Generic platform installer layout and protocol documentation retain their existing behavior.

## Linked Bounty Or Issue
Closes #1300. No bounty claimed.

## Maintainer Change Notice
Notice: #1300, published before edits. All 86 open PRs were inspected. #1299 merged before this branch was created; its assertions are retained. #1196 touches another checker section; rebase and preserve both sections if needed, then run `python scripts/check-site.py`. No other installer overlap or collaboration branch needed.

## Acceptance Criteria
- [x] Assistant buttons are visible in the first viewport at widths 360, 390, and 1440.
- [x] Cursor, VS Code, manual JSON, failed-manifest fallback, and no-JavaScript fallback retain each exact MCP endpoint.
- [x] Manual disclosure works with Enter; prompt and endpoint copy produce the expected text.
- [x] Generic Cursor installer and nine-platform hub remain functional.
- [x] Payment, settlement, and wallet authority are unchanged.

## SDLC And Recovery
Change class: R1, reversible browser presentation. Source of truth: maintained installer HTML and platform manifest. Failure modes: unavailable manifest or JavaScript; exact endpoint fallbacks remain visible and were checked. No durable writes or replay key. Rollback: revert this change and redeploy Pages. Release signal: site validation and browser checks with analytics disabled; no customer or payment canary is created. No new runtime recovery fixture is needed.

## Local Checks
- `scripts/preflight.ps1 -Mode core` — passed.
- `python scripts/check-site.py` — passed; now also validates native actions and exact manual configuration.
- `node --check site/install/install.js` and `git diff --check` — passed.
- Isolated Chromium browser checks on all three pages at 360/390/1440: decoded native URLs, copy feedback, keyboard disclosure, overflow, first-screen actions, failed manifest, and JavaScript-disabled fallback. Generic installer and hub checked. No uncaught page errors; desktop/mobile screenshots reviewed.

## Discovery Feedback
Maintainer task from a first-party setup review. A clearer first action makes it easier to bring useful work. Contributors can share how they found the project and what would make their first task easier.

## Review Lane
Ready for main after required CI and review. No bounty acceptance or payout claim.
