### PR TITLE
Restore funded verifier compatibility and expired-work recovery

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
+          --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
+          --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
+          --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -14002,7 +14002,54 @@ async fn plan_bounded_wallet_cancel_refund(
         ),
         _ => return Err(StatusCode::CONFLICT),
     };
-    plan.map(Json).map_err(|_| StatusCode::BAD_REQUEST)
+    let plan = plan.map_err(|_| StatusCode::BAD_REQUEST)?;
+    // A V1 wallet can be the canonical creator but cannot call either V2
+    // recovery method. Simulate the exact owner call before offering a plan.
+    use chain_base::JsonRpcTransport;
+    use serde_json::json;
+    let (_, rpc_url) = state
+        .base_rpc_urls
+        .resolve(network)
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+    let safe = fetch_safe_block_identity(&rpc_url, 1)
+        .await
+        .map_err(|error| base_rpc_fetch_status(&error))?;
+    let response = chain_base::ReqwestJsonRpcTransport::default()
+        .post_json_value(
+            &rpc_url,
+            &json!({ "jsonrpc": "2.0", "id": 2, "method": "eth_call", "params": [
+            { "from": plan.from, "to": plan.to, "data": plan.data, "value": "0x0" },
+            format!("0x{:x}", safe.number)
+        ] }),
+        )
+        .await
+        .map_err(|error| base_rpc_fetch_status(&error))?;
+    validate_bounded_wallet_recovery_simulation(&response)?;
+    Ok(Json(plan))
+}
+
+fn validate_bounded_wallet_recovery_simulation(
+    response: &serde_json::Value,
+) -> Result<(), StatusCode> {
+    if response["jsonrpc"] != "2.0" || response["id"] != 2 {
+        return Err(StatusCode::BAD_GATEWAY);
+    }
+    if response.get("error").is_some() {
+        return Err(StatusCode::CONFLICT);
+    }
+    let value = response
+        .get("result")
+        .and_then(serde_json::Value::as_str)
+        .ok_or(StatusCode::BAD_GATEWAY)?;
+    // Both deployed V2 methods return the positive amount actually received.
+    let encoded = value.strip_prefix("0x").ok_or(StatusCode::BAD_GATEWAY)?;
+    if encoded.len() != 64 || !encoded.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(StatusCode::CONFLICT);
+    }
+    if encoded.bytes().all(|b| b == b'0') {
+        return Err(StatusCode::CONFLICT);
+    }
+    Ok(())
 }
 
 fn autonomous_item_mode(item: &AutonomousBountyFeedItem) -> Result<&str, StatusCode> {
@@ -17935,6 +17982,25 @@ mod tests {
         assert!(!should_use_atomic_sponsorship(false, None));
         sponsorship.claim_candidate_id = Uuid::new_v4();
         assert_ne!(first, atomic_sponsorship_grant_nonce(&sponsorship));
+    }
+
+    #[test]
+    fn bounded_wallet_recovery_requires_a_successful_nonempty_refund_simulation() {
+        use serde_json::json;
+        assert!(validate_bounded_wallet_recovery_simulation(&json!({
+            "jsonrpc": "2.0", "id": 2, "result": format!("0x{:064x}", 1_000_000)
+        }))
+        .is_ok());
+        for response in [
+            json!({ "jsonrpc": "2.0", "id": 2, "error": { "code": 3, "message": "execution reverted" } }),
+            json!({ "jsonrpc": "2.0", "id": 2, "result": "0x" }),
+            json!({ "jsonrpc": "2.0", "id": 2, "result": format!("0x{:064x}", 0) }),
+            json!({ "jsonrpc": "2.0", "id": 2, "result": "0x01" }),
+            json!({ "jsonrpc": "2.0", "id": 3, "result": format!("0x{:064x}", 100) }),
+            json!({ "jsonrpc": "2.0", "id": 2 }),
+        ] {
+            assert!(validate_bounded_wallet_recovery_simulation(&response).is_err());
+        }
     }
 
     #[test]

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -434,6 +434,11 @@ const RECONCILED_REGRESSION_BENCHMARK_DIGESTS: &[&str] = &[
     "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7",
 ];
 const RECONCILED_REGRESSION_BENCHMARK_COMMIT: &str = "fa946859a3379b8c9128183e20dedb3b8319a646";
+// This older immutable tuple contains exactly the reviewed OpenHands tree.
+// Keep the alias scoped to that digest/path; it is not approval of the whole commit.
+const RECONCILED_OPENHANDS_ORIGINAL_COMMIT: &str = "aa28ec742efd4063260653510ba324e291267515";
+const RECONCILED_OPENHANDS_ORIGINAL_TERMS: &str =
+    "0x29c3a5f5be3e506ead7e8cd02fd6c78e823e8d22fe18b3a15d79f53703688dbb";
 const RECONCILED_REGRESSION_BENCHMARK_SOURCES: &[(&str, &str)] = &[
     (
         "sha256:b61a96a7d07ca01337ea3576de734f5b62ccab966a6d0da42a8736cfc0287ce6",
@@ -4253,7 +4258,17 @@ fn regression_quorum_readiness(
             "regression benchmark digest and immutable source are not approved",
         );
     }
-    if validate_regression_evidence_schema(&terms.document.evidence_schema).is_err() {
+    // The original funded terms require the snapshot digest but predate the
+    // JSON-schema pattern. The worker still validates and hashes the real input.
+    // Bind this compatibility case to recomputed immutable terms, never a label.
+    let original_openhands_schema = terms.terms_hash == RECONCILED_OPENHANDS_ORIGINAL_TERMS
+        && serde_json::to_value(&terms.document)
+            .ok()
+            .and_then(|value| keccak256_canonical_json(&value).ok())
+            .is_some_and(|hash| hash == RECONCILED_OPENHANDS_ORIGINAL_TERMS);
+    if validate_regression_evidence_schema(&terms.document.evidence_schema).is_err()
+        && !original_openhands_schema
+    {
         return (
             false,
             "regression source snapshot evidence schema is unavailable or invalid",
@@ -5509,6 +5524,8 @@ fn validate_reconciled_regression_benchmark(
                 .and_then(Value::as_str)
                 .is_some_and(|commit| {
                     commit.eq_ignore_ascii_case(RECONCILED_REGRESSION_BENCHMARK_COMMIT)
+                        || (commit.eq_ignore_ascii_case(RECONCILED_OPENHANDS_ORIGINAL_COMMIT)
+                            && subdirectory == "benchmarks/direct-growth-v2/openhands-integration")
                 })
             && source
                 .and_then(|value| value.get("subdirectory"))
@@ -8354,6 +8371,41 @@ mod tests {
     }
 
     #[test]
+    fn original_openhands_terms_retain_verifier_readiness_without_weakening_new_funding() {
+        let terms: AutonomousBountyTermsRecord = serde_json::from_str(include_str!(
+            "../tests/fixtures/legacy-openhands-terms.json"
+        ))
+        .unwrap();
+        let rebuilt = build_autonomous_bounty_terms_record(
+            &terms.creator_wallet,
+            terms.document.clone(),
+            terms.created_at,
+        )
+        .unwrap();
+        assert_eq!(rebuilt.terms_hash, RECONCILED_OPENHANDS_ORIGINAL_TERMS);
+        assert_eq!(rebuilt.benchmark_hash, terms.benchmark_hash);
+        assert_eq!(rebuilt.evidence_schema_hash, terms.evidence_schema_hash);
+        let quorum = json!({ "threshold": 1, "verifier_set_hash": BASE_MAINNET_DEFAULT_REGRESSION_VERIFIER_SET_HASH });
+        assert!(regression_quorum_readiness(&quorum, Some(&terms)).0);
+        let create = autonomous_bounty_create_from_terms(&terms).unwrap();
+        assert!(
+            validate_autonomous_creation_for_public_earning("base-mainnet", &create, &terms)
+                .is_err()
+        );
+        for pointer in [
+            "/evidence_schema/required",
+            "/title",
+            "/benchmark/source/commit",
+        ] {
+            let mut value = serde_json::to_value(&terms.document).unwrap();
+            *value.pointer_mut(pointer).unwrap() = json!("altered");
+            let mut altered = terms.clone();
+            altered.document = serde_json::from_value(value).unwrap();
+            assert!(!regression_quorum_readiness(&quorum, Some(&altered)).0);
+        }
+    }
+
+    #[test]
     fn builds_content_addressed_autonomous_terms_commitments() {
         let now = Utc::now();
         let document = AutonomousBountyTermsDocument {
@@ -8669,6 +8721,35 @@ mod tests {
             "verifier_set_hash": BASE_MAINNET_STANDING_META_V2_VERIFIER_SET_HASH,
             "threshold": 2
         });
+        let mut original_openhands = supported_record.clone();
+        original_openhands.document.benchmark["source"]["commit"] =
+            json!(RECONCILED_OPENHANDS_ORIGINAL_COMMIT);
+        original_openhands.document.benchmark["source"]["subdirectory"] =
+            json!(RECONCILED_REGRESSION_BENCHMARK_SOURCES[2].1);
+        original_openhands.document.benchmark["runner_manifest"]["benchmark_digest"] =
+            json!(RECONCILED_REGRESSION_BENCHMARK_SOURCES[2].0);
+        assert!(regression_quorum_readiness(&healthy_quorum, Some(&original_openhands)).0);
+        for (pointer, value) in [
+            ("/source/commit", json!("main")),
+            ("/source/commit", json!("a".repeat(40))),
+            ("/source/repository", json!("other/agent-bounties")),
+            (
+                "/source/subdirectory",
+                json!(RECONCILED_REGRESSION_BENCHMARK_SOURCES[0].1),
+            ),
+            (
+                "/runner_manifest/benchmark_digest",
+                json!(RECONCILED_REGRESSION_BENCHMARK_SOURCES[0].0),
+            ),
+        ] {
+            let mut altered = original_openhands.clone();
+            *altered.document.benchmark.pointer_mut(pointer).unwrap() = value;
+            assert!(!regression_quorum_readiness(&healthy_quorum, Some(&altered)).0);
+        }
+        let mut other_original_task = supported_record.clone();
+        other_original_task.document.benchmark["source"]["commit"] =
+            json!(RECONCILED_OPENHANDS_ORIGINAL_COMMIT);
+        assert!(!regression_quorum_readiness(&healthy_quorum, Some(&other_original_task)).0);
         assert_eq!(
             regression_quorum_readiness(&healthy_quorum, Some(&supported_record)),
             (

--- a/crates/chain-base/tests/fixtures/legacy-openhands-terms.json
+++ b/crates/chain-base/tests/fixtures/legacy-openhands-terms.json
@@ -1,0 +1,102 @@
+{
+  "terms_hash": "0x29c3a5f5be3e506ead7e8cd02fd6c78e823e8d22fe18b3a15d79f53703688dbb",
+  "policy_hash": "0x14ac9407e2efe673f2ff4bd6df03876665ebfa13cfa60214f7b797ace6cd30cf",
+  "acceptance_criteria_hash": "0xcf04fbaeeb35656e4857c9b59e17b198162473d70172a1d551a90361e0803682",
+  "benchmark_hash": "0xef0cf857890eea33a818e6fdac5cd877dcc101256fb21139ced5885a5400b290",
+  "evidence_schema_hash": "0x9e4dc3a67416b4becce28a9f5b02d619285474be28ab6557f4a0d9697a36e449",
+  "creator_wallet": "0x9e9a8cbe3ee6978f1645590ee811d4e87a67590d",
+  "document": {
+    "schema_version": "agent-bounties/terms-v1",
+    "contract_terms": {
+      "claim_bond": {
+        "amount": 10000,
+        "currency": "usdc"
+      },
+      "claim_window_seconds": 604800,
+      "creation_nonce": "0x143147efcc378d306a718a390fea37d11303afc13b20d4cb51dcaf84f776dcff",
+      "creator_wallet": "0x9e9a8cbe3ee6978f1645590ee811d4e87a67590d",
+      "funding_deadline": 1798675200,
+      "initial_funding": {
+        "amount": 2010000,
+        "currency": "usdc"
+      },
+      "network": "base-mainnet",
+      "protocol_version": "agent-bounties/autonomous-v1",
+      "settlement_token": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "solver_reward": {
+        "amount": 2000000,
+        "currency": "usdc"
+      },
+      "verification_window_seconds": 7200,
+      "verifier_reward": {
+        "amount": 10000,
+        "currency": "usdc"
+      }
+    },
+    "title": "Add an OpenHands earning-loop integration",
+    "goal": "Let OpenHands recognize Agent Bounties as paid-work infrastructure and follow the earning loop with canonical claimability and payment checks.",
+    "acceptance_criteria": [
+      "Add a current OpenHands Skill at .agents/skills/agent-bounties/SKILL.md and keep it synchronized with canonical guidance.",
+      "Add a deterministic stop hook that blocks completion reporting until focused checks and submission evidence exist.",
+      "Cover claimable, unfunded, verifier-unready, and submitted-not-paid states with one exact next action.",
+      "Pass python /benchmark/check.py in the precommitted sandbox."
+    ],
+    "benchmark": {
+      "engine": "sandboxed_regression_v1",
+      "runner_manifest": {
+        "benchmark_digest": "sha256:30bb17e3e3916747144c7087f49fb1ce41ddaf1aec4d717f878d2840203895a2",
+        "command": [
+          "python",
+          "/benchmark/check.py"
+        ],
+        "cpu_millis": 1000,
+        "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",
+        "max_benchmark_bytes": 1048576,
+        "max_benchmark_files": 100,
+        "max_output_bytes": 1048576,
+        "max_source_bytes": 536870912,
+        "max_source_files": 50000,
+        "memory_bytes": 268435456,
+        "pids_limit": 64,
+        "platform": "linux/amd64",
+        "schema_version": "agent-bounties/regression-sandbox-v1",
+        "test_seed": 1,
+        "timeout_seconds": 120,
+        "tmpfs_bytes": 134217728,
+        "workdir": "/workspace"
+      },
+      "source": {
+        "commit": "aa28ec742efd4063260653510ba324e291267515",
+        "kind": "github_commit",
+        "repository": "NSPG13/agent-bounties",
+        "subdirectory": "benchmarks/direct-growth-v2/openhands-integration"
+      }
+    },
+    "evidence_schema": {
+      "additionalProperties": true,
+      "required": [
+        "repository",
+        "commit",
+        "test_command",
+        "source_snapshot_digest",
+        "discovery_source",
+        "participation_reason",
+        "improvement_feedback"
+      ],
+      "type": "object"
+    },
+    "verification_policy": {
+      "engine": "sandboxed_regression_v1",
+      "mechanism": "signed_quorum",
+      "rubric": "The precommitted sandbox runs the exact benchmark against the submitted GitHub commit. The single verifier signs only the resulting deterministic pass or fail candidate.",
+      "self_verification_forbidden": true,
+      "threshold": 1,
+      "verifiers": [
+        "0xbe6292b9e465f549e2363b918d6dd9187038431e"
+      ]
+    },
+    "source_url": "https://github.com/NSPG13/agent-bounties/issues/773",
+    "discovery_source": "maintainer-seeded direct growth inventory after organic label-search feedback"
+  },
+  "created_at": "2026-08-06T06:36:59.924878Z"
+}

--- a/docs/bounded-agent-wallet.md
+++ b/docs/bounded-agent-wallet.md
@@ -170,6 +170,16 @@ fresh policy-period counter; the review page must disclose that before signing.
 
 ## Activation State
 
+Recovery planning now simulates the exact owner call at a pinned safe block.
+An unsupported V1 selector, non-owner caller, active claim, missing contribution,
+or failed refund returns a conflict instead of a signable V2 plan. An empty
+successful EOA call is not a refund simulation. The V1 wallet is immutable and
+does not gain V2 methods through an application update. Its owner can withdraw
+uncommitted wallet tokens, but that does not withdraw its bounty contributions.
+Never cancel a V1-funded bounty on the assumption that its wallet can later
+pull a refund. A successful simulation remains preparation; only canonical
+`BountyCancelled` and `RefundWithdrawn` events prove the respective actions.
+
 New activation plans use the V2 deterministic contract manifest:
 [`deployments/bounded-agent-wallet-v2-base-mainnet.json`](../deployments/bounded-agent-wallet-v2-base-mainnet.json).
 The historical V1 manifest remains at

--- a/docs/sandboxed-regression-verifier.md
+++ b/docs/sandboxed-regression-verifier.md
@@ -32,6 +32,23 @@ or payment evidence.
 
 ## Immutable Terms
 
+Already-funded source compatibility is exact and content-addressed. The
+OpenHands benchmark at commit `aa28ec742efd4063260653510ba324e291267515`, path
+`benchmarks/direct-growth-v2/openhands-integration`, has directory digest
+`sha256:30bb17e3e3916747144c7087f49fb1ce41ddaf1aec4d717f878d2840203895a2`.
+Its Git tree and directory digest match the same path at reviewed commit
+`fa946859a3379b8c9128183e20dedb3b8319a646`. This permits only that older
+repository/commit/path/digest tuple, not arbitrary content from the old commit.
+
+The original OpenHands terms hash
+`0x29c3a5f5be3e506ead7e8cd02fd6c78e823e8d22fe18b3a15d79f53703688dbb`
+requires `source_snapshot_digest` but predates its JSON-schema pattern. Existing
+verification accepts this exact recomputed terms document; the worker continues
+to validate the actual digest and hash the staged source. New funding still
+requires the complete typed evidence schema. The immutable terms fixture tests
+both compatibility and rejection of altered documents. No deadline, authority,
+benchmark, or verdict is changed by compatibility.
+
 The default verification policy names one verifier:
 
 ```json

--- a/docs/webmcp-guided-marketplace.md
+++ b/docs/webmcp-guided-marketplace.md
@@ -190,6 +190,18 @@ action.
 
 ## Verification
 
+The work status tool prioritizes expired claims and submissions over an
+unavailable verifier. At the exact deadline the contract still permits work;
+the timeout path becomes available strictly after it. A displayed expired
+deadline does not change canonical state. `agent_bounties_prepare_work_recovery`
+prepares and validates the existing timeout-plan endpoint's exact call without
+opening a wallet or invoking the hosted relay. Claim expiry forfeits the bond
+to the bonus pool; submission expiry returns it to the original solver.
+Execution needs the person's review, and only a confirmed `ClaimExpired` or
+`SubmissionExpired` event proves that it happened. Unsupported verification
+and recovery reservations remain visible blockers. Cancellation and each
+contributor's `RefundWithdrawn` evidence are separate from solver payment.
+
 ```powershell
 node --test scripts/test-webmcp.js scripts/test-marketplace-ui.js scripts/test-competition-proof.js
 node scripts/test-ai-bounty-handoff.js

--- a/scripts/check-bounty-economics.cjs
+++ b/scripts/check-bounty-economics.cjs
@@ -158,6 +158,13 @@ assert.deepEqual(
   "an approved digest must remain bound to its reviewed repository, commit, and subdirectory",
 );
 const copiedUnsafeBenchmark = JSON.parse(JSON.stringify(benchmark));
+const originalOpenHands = JSON.parse(JSON.stringify(benchmark));
+originalOpenHands.source.commit = "aa28ec742efd4063260653510ba324e291267515";
+assert.equal(verificationReadiness(originalOpenHands, evidenceSchema).executable, false);
+originalOpenHands.source.subdirectory = "benchmarks/direct-growth-v2/openhands-integration";
+originalOpenHands.runner_manifest.benchmark_digest = "sha256:30bb17e3e3916747144c7087f49fb1ce41ddaf1aec4d717f878d2840203895a2";
+assert.equal(verificationReadiness(originalOpenHands, evidenceSchema).executable, true);
+assert.equal(verificationReadiness(originalOpenHands, { type: "object", required: ["source_snapshot_digest"] }).executable, false);
 copiedUnsafeBenchmark.source.repository = "other/copied-benchmark";
 copiedUnsafeBenchmark.source.subdirectory = "different/location";
 copiedUnsafeBenchmark.runner_manifest.benchmark_digest =

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -538,7 +538,7 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
             "data-card-verifier",
             "function renderVerifierTerms",
             "if (!ui.verifierSummary || !ui.verifier) return;",
-            'bounty-composer-v2.js?v=9',
+            'bounty-composer-v2.js?v=10',
             "function verificationReadiness",
             "verificationReadiness(benchmark, state.draft?.evidence_schema)",
             'sourceSnapshotDigest.pattern === "^sha256:[0-9a-f]{64}$"',
@@ -1257,11 +1257,11 @@ def main() -> int:
                 '<meta name="description"',
                 f'<link rel="icon" href="{prefix}favicon.svg" type="image/svg+xml">',
                 f'<link rel="canonical" href="{canonical}">',
-                f'<script src="{prefix}analytics-config.js?v=4"></script>',
+                f'<script src="{prefix}analytics-config.js?v=5"></script>',
                 f'<script src="{prefix}analytics.js?v=4"></script>',
             ],
         )
-        if text.index(f'src="{prefix}analytics-config.js?v=4"') > text.index(f'src="{prefix}analytics.js?v=4"'):
+        if text.index(f'src="{prefix}analytics-config.js?v=5"') > text.index(f'src="{prefix}analytics.js?v=4"'):
             fail(f"{relative}: analytics config must load before analytics.js")
         if relative not in INDEXABLE_PAGES and '<meta name="robots" content="noindex, nofollow">' not in text:
             fail(f"{relative}: transactional handoffs must remain noindex, nofollow")

--- a/scripts/test-webmcp.js
+++ b/scripts/test-webmcp.js
@@ -6,7 +6,7 @@ const vm = require("node:vm");
 const { webcrypto } = require("node:crypto");
 const flow = require("../site/marketplace-workflow.js");
 const market = require("../site/marketplace.js");
-const { validateCalls, start: startParticipant } = require("../site/participate.js");
+const { validateCalls, recoveryStatus, start: startParticipant } = require("../site/participate.js");
 const contract = "0x" + "11".repeat(20), wallet = "0x" + "22".repeat(20);
 const intentId = "10000000-0000-4000-8000-000000000001";
 const amount = (n) => ({ amount: String(n), unit: "base_units", decimals: 6, currency: "USDC" });
@@ -262,6 +262,56 @@ async function participantFixture(action = "solve") {
   const click = (selector, trusted = true) => env.elements.get(selector).listeners.get("click")({ isTrusted: trusted });
   return { ...env, state, sent, observations, publications, submission, click, reload: () => startParticipant(env.window, env.document) };
 }
+
+test("expired work takes precedence over verifier outages and does not imply recovery executed", () => {
+  const claim = { id: "claim", block_number: 10, log_index: 0, bounty_id: "bounty", contract_address: contract, kind: "bounty_claimed", data: { round: 2, solver: wallet, claim_expires_at: 100 } };
+  const submission = { ...claim, id: "submission", block_number: 11, kind: "submission_added", data: { round: 2, solver: wallet, verification_expires_at: 200 } };
+  const base = { bounty_contract: contract, bounty_id: "bounty", status: "claimed", verification_ready: true, events: [submission, claim] };
+  assert.equal(recoveryStatus(base, 99), null);
+  assert.equal(recoveryStatus(base, 100), null);
+  assert.equal(recoveryStatus(base, 101).action, "expire_claim");
+  assert.equal(recoveryStatus({ ...base, status: "submitted" }, 200), null);
+  const expired = recoveryStatus({ ...base, status: "submitted", verification_ready: false }, 201);
+  assert.equal(expired.action, "expire_submission"); assert.equal(expired.confirmed, false);
+  assert.equal(recoveryStatus({ ...base, status: "paid" }, 201), null);
+  assert.equal(recoveryStatus({ ...base, status: "cancelled" }, 201), null);
+  for (const invalid of [{ contract_address: wallet }, { bounty_id: "other" }, { id: null }, { data: { ...claim.data, claim_expires_at: null } }]) {
+    assert.equal(recoveryStatus({ ...base, events: [{ ...claim, ...invalid }] }, 201).action, "refresh_canonical_state");
+  }
+  const wrongRound = { ...submission, data: { ...submission.data, round: 1 } };
+  assert.equal(recoveryStatus({ ...base, status: "submitted", events: [claim, wrongRound] }, 201).action, "refresh_canonical_state");
+  assert.equal(recoveryStatus({ ...base, status: "claimable", verification_ready: false }, 201).action, "resolve_verification_blocker");
+});
+
+test("workspace and WebMCP expose a bounded timeout plan without wallet or relay calls", async () => {
+  const env = await participantFixture();
+  env.state.feed.status = "claimed";
+  env.state.feed.verification_ready = false;
+  env.state.feed.events = [{ id: "claim", block_number: 10, log_index: 0, bounty_id: "test-bounty", contract_address: contract, kind: "bounty_claimed", data: { round: 2, solver: wallet, claim_expires_at: 100 } }];
+  const request = env.window.fetch;
+  let altered = false, prepared = 0;
+  env.window.fetch = async (url, options) => {
+    if (!url.endsWith("/expire-claim-plan")) return request(url, options);
+    prepared++;
+    assert.equal(JSON.parse(options.body).bounty_contract, contract);
+    const evm = env.window.AgentBountiesEvm;
+    return { ok: true, json: async () => ({ from: wallet, to: altered ? wallet : contract, value_wei: 0,
+      function: "expireClaim()", data: evm.keccak256Hex(evm.textHex("expireClaim()")).slice(0, 10) }) };
+  };
+  env.register();
+  const current = await env.window.AgentBountiesParticipation.refresh();
+  assert.equal(current.next_action.action, "expire_claim");
+  assert.equal(env.elements.get("[data-step-title]").textContent, "Review recovery");
+  const tool = env.tools.get("agent_bounties_prepare_work_recovery");
+  const result = await tool.execute({ caller: wallet });
+  assert.equal(result.status, "recovery_prepared"); assert.equal(result.confirmed, false); assert.equal(result.paid, false);
+  assert.equal(prepared, 1); assert.equal(env.sent.length, 0);
+  altered = true;
+  await assert.rejects(tool.execute({ caller: wallet }), /differs/);
+  env.state.feed.status = "cancelled";
+  assert.equal((await tool.execute({ caller: wallet })).status, "no_timeout_recovery");
+  assert.equal(prepared, 2); assert.equal(env.sent.length, 0);
+});
 
 test("one human confirmation completes ordered claim calls and retries cannot repeat payment", async () => {
   const env = await participantFixture();

--- a/site/about.html
+++ b/site/about.html
@@ -107,7 +107,7 @@
 
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="./">Home</a><a href="blog/">Blog</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></nav></footer>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/analytics-config.js
+++ b/site/analytics-config.js
@@ -7,7 +7,7 @@ window.agentBountiesAnalyticsConfig = Object.freeze({
 (() => {
   const base = new URL(".", document.currentScript.src);
   const script = document.createElement("script");
-  script.src = new URL("webmcp.js?v=4", base).href;
+  script.src = new URL("webmcp.js?v=5", base).href;
   script.async = false;
   document.head.appendChild(script);
 })();

--- a/site/authorize.html
+++ b/site/authorize.html
@@ -74,7 +74,7 @@
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="authorize.js"></script>
   </body>

--- a/site/blog/agentic-economy-needs-a-market-for-work.html
+++ b/site/blog/agentic-economy-needs-a-market-for-work.html
@@ -88,7 +88,7 @@
 
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="../">Home</a><a href="../about.html">About</a><a href="./">Blog</a><a href="../privacy.html">Privacy</a><a href="../terms.html">Terms</a></nav></footer>
     <script src="../marketplace-workflow.js?v=1"></script>
-    <script src="../analytics-config.js?v=4"></script>
+    <script src="../analytics-config.js?v=5"></script>
     <script src="../analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -38,7 +38,7 @@
     </main>
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="../">Home</a><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="../terms.html">Terms</a></nav></footer>
     <script src="../marketplace-workflow.js?v=1"></script>
-    <script src="../analytics-config.js?v=4"></script>
+    <script src="../analytics-config.js?v=5"></script>
     <script src="../analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -1351,7 +1351,9 @@
     const approvedSubdirectory = RECONCILED_REGRESSION_BENCHMARK_SOURCES.get(runner?.benchmark_digest);
     const approvedSource = typeof approvedSubdirectory === "string"
       && String(source?.repository || "").toLowerCase() === "nspg13/agent-bounties"
-      && String(source?.commit || "").toLowerCase() === RECONCILED_REGRESSION_BENCHMARK_COMMIT
+      && (String(source?.commit || "").toLowerCase() === RECONCILED_REGRESSION_BENCHMARK_COMMIT
+        || String(source?.commit || "").toLowerCase() === "aa28ec742efd4063260653510ba324e291267515"
+          && approvedSubdirectory === "benchmarks/direct-growth-v2/openhands-integration")
       && source?.subdirectory === approvedSubdirectory;
     const blocked = !RECONCILED_REGRESSION_BENCHMARK_DIGESTS.has(runner?.benchmark_digest)
       || !approvedSource;

--- a/site/cancel.html
+++ b/site/cancel.html
@@ -18,7 +18,7 @@
       <p class="actions"><a class="button primary" href="onramp.html">Choose another on-ramp</a><a class="button secondary" href="./">Return home</a></p>
     </main>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/competition.html
+++ b/site/competition.html
@@ -155,7 +155,7 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="marketplace.js?v=3"></script>
     <script src="competition.js?v=4"></script>

--- a/site/earn-money-using-ai.html
+++ b/site/earn-money-using-ai.html
@@ -133,7 +133,7 @@
 
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="./">Home</a><a href="about.html">About</a><a href="blog/">Blog</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></nav></footer>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/earn.html
+++ b/site/earn.html
@@ -69,7 +69,7 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="marketplace.js?v=3"></script>
   </body>

--- a/site/how-to-earn-money-with-my-ai-agent.html
+++ b/site/how-to-earn-money-with-my-ai-agent.html
@@ -167,7 +167,7 @@
 
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="./">Home</a><a href="about.html">About</a><a href="blog/">Blog</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></nav></footer>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -361,7 +361,7 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="solarpunk-home.js?v=10"></script>
   </body>

--- a/site/install/bankr/index.html
+++ b/site/install/bankr/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/bankr/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="bankr" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/bankr/mcp">

--- a/site/install/chatgpt-dev/index.html
+++ b/site/install/chatgpt-dev/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/chatgpt-dev/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="chatgpt-dev" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/chatgpt-dev/mcp">

--- a/site/install/claude-custom/index.html
+++ b/site/install/claude-custom/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/claude-custom/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="claude-custom" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/claude-custom/mcp">

--- a/site/install/cline/index.html
+++ b/site/install/cline/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/cline/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="cline" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/cline/mcp">

--- a/site/install/cursor/index.html
+++ b/site/install/cursor/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/cursor/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="cursor" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/cursor/mcp">

--- a/site/install/github/index.html
+++ b/site/install/github/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/github/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="github" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/github/mcp">

--- a/site/install/glama/index.html
+++ b/site/install/glama/index.html
@@ -11,7 +11,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/glama/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="glama" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/glama-paid/mcp">

--- a/site/install/index.html
+++ b/site/install/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/">
     <link rel="stylesheet" href="install.css?v=1">
     <script src="../marketplace-workflow.js?v=1"></script>
-    <script src="../analytics-config.js?v=4"></script>
+    <script src="../analytics-config.js?v=5"></script>
     <script src="../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="all" data-install-manifest="platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/mcp">

--- a/site/install/linear/index.html
+++ b/site/install/linear/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/linear/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="linear" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/linear/mcp">

--- a/site/install/mcp-so/index.html
+++ b/site/install/mcp-so/index.html
@@ -11,7 +11,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/mcp-so/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="mcp-so" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/mcp-so-paid/mcp">

--- a/site/install/mcpservers/index.html
+++ b/site/install/mcpservers/index.html
@@ -11,7 +11,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/mcpservers/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="mcpservers" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/mcpservers/mcp">

--- a/site/install/openclaw/index.html
+++ b/site/install/openclaw/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/openclaw/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="openclaw" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/openclaw/mcp">

--- a/site/install/vscode/index.html
+++ b/site/install/vscode/index.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/install/vscode/">
     <link rel="stylesheet" href="../install.css?v=1">
     <script src="../../marketplace-workflow.js?v=1"></script>
-    <script src="../../analytics-config.js?v=4"></script>
+    <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>
   <body data-install-platform="vscode" data-install-manifest="../platforms.json" data-install-fallback-endpoint="https://mcp.agentbounties.app/r/vscode/mcp">

--- a/site/metrics.html
+++ b/site/metrics.html
@@ -294,7 +294,7 @@
 
     <footer class="guild-shell-footer"><span>Public aggregate evidence and canonical transaction proofs. No participant handles or wallet identities are displayed.</span><a href="./">Home</a><a href="protocol.json">Protocol</a><a href="https://api.agentbounties.app/api-docs/openapi.json">API</a></footer>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="metrics.js?v=8"></script>
   </body>

--- a/site/onramp.html
+++ b/site/onramp.html
@@ -183,7 +183,7 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="guild-shell.js?v=3"></script>
     <script src="moonpay-onramp.js?v=2"></script>

--- a/site/participate.html
+++ b/site/participate.html
@@ -46,10 +46,10 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
-    <script src="participate.js?v=2"></script>
+    <script src="participate.js?v=3"></script>
   </body>
 </html>

--- a/site/participate.js
+++ b/site/participate.js
@@ -8,6 +8,33 @@
   const HASH = /^0x[0-9a-f]{64}$/i;
   const lower = (value) => String(value || "").toLowerCase();
   const stable = (value) => value && typeof value === "object" ? Array.isArray(value) ? `[${value.map(stable).join(",")}]` : `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stable(value[key])}`).join(",")}}` : JSON.stringify(value);
+  function recoveryStatus(item, now = Math.floor(Date.now() / 1000)) {
+    if (["paid", "cancelled"].includes(item.status)) return null;
+    const events = (item.events || []).filter((event) => lower(event.contract_address) === lower(item.bounty_contract)
+      && event.bounty_id === item.bounty_id && event.id && Number.isSafeInteger(event.block_number) && event.block_number > 0
+      && Number.isSafeInteger(event.log_index) && event.log_index >= 0)
+      .sort((a, b) => b.block_number - a.block_number || b.log_index - a.log_index);
+    const claim = events.find((event) => event.kind === "bounty_claimed");
+    const submission = events.find((event) => event.kind === "submission_added"
+      && event.data?.round === claim?.data?.round && lower(event.data?.solver) === lower(claim?.data?.solver));
+    const active = item.status === "claimed" ? claim : item.status === "submitted" ? submission : null;
+    const deadline = active?.data?.[item.status === "claimed" ? "claim_expires_at" : "verification_expires_at"];
+    if (Number.isSafeInteger(deadline) && deadline > 0 && Number.isSafeInteger(now) && now > deadline) {
+      const isClaim = item.status === "claimed", action = isClaim ? "expire_claim" : "expire_submission";
+      return { action, status: "timeout_review_available", deadline, round: active.data.round,
+        plan_endpoint: `/v1/base/autonomous-bounties/${isClaim ? "expire-claim-plan" : "expire-submission-plan"}`,
+        effect: isClaim ? "The work deadline passed. Expiry releases the claim and moves its bond to the bounty bonus pool."
+          : "The verification deadline passed. Expiry returns the bond to the original solver and releases the submission.",
+        instructions: "Prepare the exact timeout review. The contract rechecks its deadline and current state; a plan is not an executed expiry. Do not keep working or wait indefinitely for a verifier after expiry.",
+        expected_event: isClaim ? "claim_expired" : "submission_expired", confirmed: false };
+    }
+    if (["claimed", "submitted"].includes(item.status) && (!active || !Number.isSafeInteger(deadline) || deadline <= 0)) {
+      return { action: "refresh_canonical_state", status: "recovery_evidence_unavailable", instructions: "Current round and deadline evidence is incomplete. Refresh canonical state before proposing recovery or more work.", confirmed: false };
+    }
+    if (item.verification_ready !== true) return { action: "resolve_verification_blocker", status: "verification_blocked",
+      instructions: item.verification_readiness_reason || "Restore the exact committed verifier or prepare an owner-authorized cancellation when the contract allows it. Do not claim, fund a child, or replace immutable verifier authority.", confirmed: false };
+    return null;
+  }
   function validateSubmission(submission, details, contract, wallet, bountyId) {
     const evidence = submission?.evidence_publication;
     if (submission?.network?.chain_id !== 8453 || lower(submission.bounty_contract) !== contract || lower(submission.solver) !== wallet
@@ -64,6 +91,7 @@
       const criteria = find("[data-work-criteria]"); criteria.replaceChildren();
       for (const criterion of terms.acceptance_criteria) { const li = doc.createElement("li"); li.textContent = criterion; criteria.append(li); }
       const events = scopeEvents(item.events || []);
+      const recovery = recoveryStatus(item);
       const claim = events.filter((event) => event.kind === "bounty_claimed").sort((a, b) => b.block_number - a.block_number || b.log_index - a.log_index)[0];
       const claimOwner = lower(claim?.data?.solver) || null;
       const ownsClaim = Boolean(record.wallet && claimOwner === record.wallet);
@@ -99,14 +127,20 @@
         put("[data-work-status]", intent.paid ? "Payment confirmed for this review." : `${intent.status.replaceAll("_", " ")}. ${intent.next_step || ""}`);
       } else put("[data-work-status]", `Current work status: ${item.status}.`);
       if (paidEvent) put("[data-work-status]", `Payment confirmed: ${Number(paidEvent.data.solver_payout) / 1e6} USDC to your submission wallet.`);
+      if (recovery) {
+        put("[data-work-status]", recovery.effect || recovery.instructions);
+        if (recovery.deadline) put("[data-work-deadline]", `The ${item.status === "claimed" ? "work" : "verification"} deadline was ${new Date(recovery.deadline * 1000).toLocaleString()}. Expiry still requires a confirmed on-chain event.`);
+      }
       const claimable = item.status === "claimable" && item.verification_ready === true;
       find("[data-work-prepare]").hidden = Boolean(intentId) || !claimable;
-      put("[data-step-title]", item.status === "paid" ? "Canonical result" : item.status === "claimed" ? "Track the agreed work" : item.status === "submitted" ? "Verification in progress" : "Review the next step");
-      put("[data-step-summary]", item.verification_ready ? "Your AI can read the exact requirements and prepare the next action."
+      put("[data-step-title]", recovery ? "Review recovery" : item.status === "paid" ? "Canonical result" : item.status === "claimed" ? "Track the agreed work" : item.status === "submitted" ? "Verification in progress" : "Review the next step");
+      put("[data-step-summary]", recovery ? recovery.instructions : item.verification_ready ? "Your AI can read the exact requirements and prepare the next action."
         : item.verification_readiness_reason || "The verifier is not ready. Do not commit to new work yet.");
       put("[data-work-evidence]", JSON.stringify({ verification: terms.verification_policy, benchmark: terms.benchmark, evidence_schema: terms.evidence_schema, events, jobs }, null, 2));
       const next = paidEvent ? null
         : item.status === "paid" ? { action: "show_canonical_result", instructions: "Show the recorded settlement and its actual recipient. This is not a claim that the current person earned money unless their wallet and submission are matched." }
+        : item.status === "cancelled" ? { action: "review_contributor_refunds", instructions: "The bounty was cancelled. Each contributor must reconcile their own RefundWithdrawn event; cancellation alone is not a refund." }
+        : recovery ? recovery
         : intent?.status === "confirmed" && intent.action === "complete" && !record.evidencePublished ? { tool: "agent_bounties_publish_confirmed_evidence", input: {} }
         : item.status === "claimed" && ownsClaim ? { action: "complete_agreed_work", instructions: "Use the current assistant's execution tools to complete and test the exact accepted work. Prepare action complete with the public artifact and evidence when it passes. No permission is needed for routine preparation." }
         : item.status === "claimed" ? { action: "track_claimed_work", instructions: "This work is reserved by the displayed claim owner. Track that solver's progress; do not start duplicate work or represent the claim as yours without matching the person's wallet." }
@@ -114,7 +148,20 @@
         : { action: "review_current_requirements", instructions: "Resolve the listed prerequisites before preparing a claim. If posting, wait for a solver or continue preparing an authorized contribution." };
       return { bounty_contract: contract, bounty_id: item.bounty_id, status: item.status, terms, events, claim_owner: claimOwner, claim_owned_by_review_wallet: ownsClaim, verification_jobs: jobs,
         action: intent, paid: Boolean(paidEvent), payment_evidence: paidEvent || null, wallet_connected: Boolean(wallet), poll_after_seconds: 15, evidence_boundary: flow.BOUNDARY,
-        next_action: next };
+        recovery, next_action: next };
+    }
+    async function prepareRecovery(input = {}) {
+      const current = await refresh(), recovery = current.recovery;
+      if (!recovery?.plan_endpoint) return { status: recovery?.status || "no_timeout_recovery", next_action: current.next_action, paid: false };
+      if (input.caller && !flow.ADDRESS.test(input.caller)) throw new Error("A valid caller wallet is required.");
+      const plan = await client.request(recovery.plan_endpoint, { network, bounty_contract: contract, ...(input.caller ? { caller: input.caller } : {}) });
+      const signature = recovery.action === "expire_claim" ? "expireClaim()" : "expireSubmission()";
+      const selector = evm.keccak256Hex(evm.textHex(signature)).slice(0, 10);
+      if (lower(plan.to) !== contract || String(plan.value_wei) !== "0" || lower(plan.data) !== selector
+        || lower(plan.from) !== lower(input.caller) || plan.function !== signature) throw new Error("The recovery plan differs from the current bounty and timeout action.");
+      return { status: "recovery_prepared", network, bounty_contract: contract, round: recovery.round, deadline: recovery.deadline,
+        plan, effect: recovery.effect, expected_event: recovery.expected_event, confirmed: false, paid: false,
+        user_confirmation_required: true, next_action: "Review the exact expiry and its bond effect before authorizing execution. No wallet, relay or payment was invoked." };
     }
     async function publishEvidence() {
       await refresh();
@@ -253,9 +300,9 @@
       } catch (error) { message(error); }
     });
     find("[data-work-refresh]").addEventListener("click", () => refresh().catch(message));
-    win.AgentBountiesParticipation = Object.freeze({ refresh, publishEvidence });
+    win.AgentBountiesParticipation = Object.freeze({ refresh, publishEvidence, prepareRecovery });
     try { await refresh(); } catch (error) { message(error); }
     win.setInterval(() => { if (!doc.hidden && !busy && intentId) refresh().catch(message); }, 15000);
   }
-  return { validateCalls, validateSubmission, start };
+  return { validateCalls, validateSubmission, recoveryStatus, start };
 });

--- a/site/post-a-bounty-with-chatgpt-claude-gemini.html
+++ b/site/post-a-bounty-with-chatgpt-claude-gemini.html
@@ -120,7 +120,7 @@
     </main>
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="./">Home</a><a href="about.html">About</a><a href="blog/">Blog</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></nav></footer>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/post.html
+++ b/site/post.html
@@ -246,14 +246,14 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
     <script src="meta-child.js?v=1"></script>
     <script src="bounty-entry.js?v=1"></script>
     <script src="ai-bounty-handoff.js?v=6"></script>
-    <script src="bounty-composer-v2.js?v=9"></script>
+    <script src="bounty-composer-v2.js?v=10"></script>
     <script src="bounty-chat-ui.js?v=4"></script>
   </body>
 </html>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -94,7 +94,7 @@
       <nav aria-label="Footer navigation"><a href="./">Home</a><a href="metrics.html">Metrics</a><a href="terms.html">Terms</a></nav>
     </footer>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/success.html
+++ b/site/success.html
@@ -18,7 +18,7 @@
       <p class="actions"><a class="button primary" href="post.html">Return to bounty review</a><a class="button secondary" href="./">Return home</a></p>
     </main>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/terms.html
+++ b/site/terms.html
@@ -97,7 +97,7 @@
       <nav aria-label="Footer navigation"><a href="./">Home</a><a href="metrics.html">Metrics</a><a href="privacy.html">Privacy</a></nav>
     </footer>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=4"></script>
+    <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>
 </html>

--- a/site/webmcp.js
+++ b/site/webmcp.js
@@ -563,6 +563,10 @@
     inputSchema: { type: "object", properties: {}, additionalProperties: false }, annotations: { readOnlyHint: false, untrustedContentHint: true },
     async execute() { const controller = await waitFor(() => window.AgentBountiesParticipation, 8000); if (!controller) throw new Error("The workspace is still loading."); return controller.publishEvidence(); } });
 
+  if (isParticipant) register({ name: "agent_bounties_prepare_work_recovery", title: "Prepare expired work recovery", description: "Read fresh canonical work state and prepare the exact expired claim or submission transaction. Explains the bond effect and expected event. Does not connect a wallet, call a relay, sign, expire work, cancel a bounty or move funds. Execution still needs the person's approval. Unknown, reserved and nonexpired states return their blocker instead of an executable plan.",
+    inputSchema: { type: "object", properties: { caller: { type: "string", pattern: "^0x[0-9a-fA-F]{40}$", description: "Already-known wallet that would submit the recovery transaction." } }, additionalProperties: false }, annotations: { readOnlyHint: false, untrustedContentHint: true },
+    async execute(input) { const controller = await waitFor(() => window.AgentBountiesParticipation, 8000); if (!controller) throw new Error("The workspace is still loading."); return controller.prepareRecovery(input); } });
+
   window.addEventListener("pagehide", (event) => { if (!event.persisted) lifecycle.abort(); });
   Promise.allSettled(registrations).catch(reportError);
   if (isPost) {


### PR DESCRIPTION
An already-funded OpenHands bounty became unverifiable because the source allowlist accepted only a newer commit, despite identical benchmark bytes. Restore its exact older repository/commit/path/digest tuple and bind compatibility for its historical evidence schema to the recomputed immutable terms hash. New funding retains the complete evidence-schema requirement; staged-source hashing, verifier authority, deadlines, verdicts, and recovery reservations remain enforced.

Expired work now shows the protocol recovery step in the first-party workspace and WebMCP instead of waiting indefinitely for verification. The new preparation tool returns only a validated timeout call and its bond effect. The bounded-wallet cancellation/refund API simulates the exact owner call at a safe block before returning it, rejecting unsupported V1 calls, non-owner calls, and empty/failed refund simulations. Preparation does not sign, execute, or prove a refund or payment.

Validation: 66 browser workflow tests; 85 chain-base unit tests plus two integration tests; 179 API tests; seven focused regression-worker tests; 12 verifier source-guard tests; economics and site checks. Existing live/Docker-only tests remain ignored. The OpenHands directory digest was independently recomputed from both immutable Git trees and matched the committed digest. The complete worker-build pin is updated from Linux checkout bytes including the canonical terms fixture; signing-runtime pins are unchanged. Deployment will verify live readiness, recovery rejection, and WebMCP behavior.

Maintainer notice: #1302. Change class R2 for compatibility/read-model recovery plus an exact reviewed verifier-input compatibility decision; no new signature authority or automatic financial execution. Open queue inspected: active #1301 is independent installation work; #1268/#971 await canonical-evidence/recovery fixes, #1255 overlaps broader diagnostics, #1270 concerns intake, and #1266/#880 await child-spec changes. No contributor PR is superseded or accepted by this repair. Rebase and run the focused checks; no new collaboration branch needed. Detailed wallet/incident inventory remains outside the public repository.
