### PR TITLE
Add Claude Code, Codex, and Antigravity installer choices

### DIFF
--- a/site/install/glama/index.html
+++ b/site/install/glama/index.html
@@ -9,7 +9,7 @@
     <title>Fund work you can verify | Agent Bounties for Glama</title>
     <meta name="description" content="Discover Agent Bounties through Glama. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/glama/">
-    <link rel="stylesheet" href="../install.css?v=2">
+    <link rel="stylesheet" href="../install.css?v=3">
     <script src="../../marketplace-workflow.js?v=1"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
@@ -28,6 +28,6 @@
       <section class="install-detail" data-install-detail aria-label="Glama installation"><noscript><p>Copy <code>https://mcp.agentbounties.app/r/glama-paid/mcp</code> into MCP settings.</p></noscript></section>
       <p class="install-boundary" data-payment-boundary>Review the task, reward, and verification before you fund.</p>
     </main>
-    <script src="../install.js?v=3" defer></script>
+    <script src="../install.js?v=4" defer></script>
   </body>
 </html>

--- a/site/install/install.css
+++ b/site/install/install.css
@@ -345,6 +345,29 @@ button:focus-visible {
   margin-top: 1.25rem;
 }
 
+.install-setup-choice[aria-expanded="true"] {
+  border-color: var(--mint);
+  background: var(--panel-strong);
+  box-shadow: 0 0 0 0.2rem rgba(142, 224, 203, 0.13);
+}
+
+.install-setup {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--line);
+}
+
+.install-setup h3 {
+  margin-bottom: 0.75rem;
+}
+
+.install-setup-docs {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--mint);
+  text-underline-offset: 0.2rem;
+}
+
 .install-manual summary {
   width: fit-content;
   padding: 0.5rem 0;

--- a/site/install/install.js
+++ b/site/install/install.js
@@ -85,6 +85,60 @@
     throw new Error(`Unsupported install action: ${action.kind}`);
   }
 
+  function renderAssistantSetups(actions, panel, platform) {
+    const setups = [
+      {
+        name: "Claude Code",
+        instructions: "Run this in your terminal, then start Claude Code. Use /mcp to check the connection.",
+        label: "Terminal command",
+        value: `claude mcp add --transport http --scope user agent-bounties ${platform.mcp_url}`,
+        docs: "https://code.claude.com/docs/en/mcp",
+      },
+      {
+        name: "Codex",
+        instructions: "Run this in a terminal with Codex CLI installed, then start a new Codex session.",
+        label: "Terminal command",
+        value: `codex mcp add agent-bounties --url ${platform.mcp_url}`,
+        docs: "https://developers.openai.com/codex/mcp",
+      },
+      {
+        name: "Antigravity",
+        instructions: "Open MCP Servers → Manage MCP Servers → View raw config. Add this server to mcp_config.json, keeping any existing servers. Save and refresh.",
+        label: "MCP configuration",
+        value: JSON.stringify({ mcpServers: { "agent-bounties": { serverUrl: platform.mcp_url } } }, null, 2),
+        docs: "https://antigravity.google/docs/mcp",
+      },
+    ];
+    const setupPanel = element("section", "install-setup");
+    setupPanel.id = "install-assistant-setup";
+    setupPanel.hidden = true;
+    setupPanel.setAttribute("aria-labelledby", "install-assistant-setup-title");
+    const buttons = [];
+    setups.forEach((setup) => {
+      const button = element("button", "install-setup-choice", setup.name);
+      button.type = "button";
+      button.setAttribute("aria-controls", setupPanel.id);
+      button.setAttribute("aria-expanded", "false");
+      button.addEventListener("click", () => {
+        const opening = button.getAttribute("aria-expanded") !== "true";
+        buttons.forEach((choice) => choice.setAttribute("aria-expanded", "false"));
+        setupPanel.hidden = !opening;
+        if (!opening) return;
+        button.setAttribute("aria-expanded", "true");
+        const heading = element("h3", "", `Set up ${setup.name}`);
+        heading.id = "install-assistant-setup-title";
+        const docs = element("a", "install-setup-docs", `${setup.name} setup guide`);
+        docs.href = setup.docs;
+        docs.target = "_blank";
+        docs.rel = "noopener noreferrer";
+        setupPanel.replaceChildren(heading, element("p", "", setup.instructions), copyBlock(setup.label, setup.value), docs);
+      });
+      buttons.push(button);
+      actions.appendChild(button);
+    });
+    panel.appendChild(setupPanel);
+  }
+
   function renderPlatform(platform, manifest) {
     status.textContent = platform.status;
     const taskOwner = body.dataset.installAudience === "task-owner";
@@ -119,7 +173,10 @@
       destination.appendChild(renderAction(action, platform));
     });
     actionsPanel.appendChild(actions);
-    if (taskOwner) actionsPanel.appendChild(endpointPanel);
+    if (taskOwner) {
+      renderAssistantSetups(actions, actionsPanel, platform);
+      actionsPanel.appendChild(endpointPanel);
+    }
     grid.appendChild(actionsPanel);
 
     const promptPanel = element("section", taskOwner ? "install-panel" : "install-panel install-panel-wide");

--- a/site/install/mcp-so/index.html
+++ b/site/install/mcp-so/index.html
@@ -9,7 +9,7 @@
     <title>Fund work you can verify | Agent Bounties for MCP.so</title>
     <meta name="description" content="Discover Agent Bounties through MCP.so. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/mcp-so/">
-    <link rel="stylesheet" href="../install.css?v=2">
+    <link rel="stylesheet" href="../install.css?v=3">
     <script src="../../marketplace-workflow.js?v=1"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
@@ -28,6 +28,6 @@
       <section class="install-detail" data-install-detail aria-label="MCP.so installation"><noscript><p>Copy <code>https://mcp.agentbounties.app/r/mcp-so-paid/mcp</code> into MCP settings.</p></noscript></section>
       <p class="install-boundary" data-payment-boundary>Review the task, reward, and verification before you fund.</p>
     </main>
-    <script src="../install.js?v=3" defer></script>
+    <script src="../install.js?v=4" defer></script>
   </body>
 </html>

--- a/site/install/mcpservers/index.html
+++ b/site/install/mcpservers/index.html
@@ -9,7 +9,7 @@
     <title>Fund work you can verify | Agent Bounties for MCPServers.org</title>
     <meta name="description" content="Discover Agent Bounties through MCPServers.org. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/mcpservers/">
-    <link rel="stylesheet" href="../install.css?v=2">
+    <link rel="stylesheet" href="../install.css?v=3">
     <script src="../../marketplace-workflow.js?v=1"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
@@ -28,6 +28,6 @@
       <section class="install-detail" data-install-detail aria-label="MCPServers.org installation"><noscript><p>Copy <code>https://mcp.agentbounties.app/r/mcpservers/mcp</code> into MCP settings.</p></noscript></section>
       <p class="install-boundary" data-payment-boundary>Review the task, reward, and verification before you fund.</p>
     </main>
-    <script src="../install.js?v=3" defer></script>
+    <script src="../install.js?v=4" defer></script>
   </body>
 </html>


### PR DESCRIPTION
The task-owner installer pages previously offered direct choices only for Cursor and VS Code. Add Claude Code, Codex, and Antigravity beside them; selecting a client reveals a copyable terminal command or configuration and its setup guide. Generate every configuration from the page's existing MCP URL so its source survives the handoff.

Keep the existing install manifest compatible and preserve the manual fallback and generic installer layout. Asset versions are updated on the three task-owner pages.

Validation: core preflight, `python scripts/check-site.py`, `node --check site/install/install.js`, and `git diff --check` passed. Browser checks covered all three pages at 360, 390, and 1440px: five visible choices, exact commands and parsed configuration URLs, clipboard output, keyboard switching/collapse, native links, no horizontal overflow, failed-manifest/no-JS fallback, and generic installers. Desktop/mobile screenshots reviewed. Client syntax was checked against official Claude/Antigravity documentation and installed Codex CLI help; this does not claim an authenticated end-to-end session inside every client.

R0 / PUBLIC_REDACTED. Notice: #1304. All 86 open PRs inspected before editing; none touch site/install/. #1196 touches scripts/check-site.py, which this PR does not change. No known affected PR or migration; no collaboration branch needed. Rollback: revert this site-only change. Maintainer owns release verification on the published pages.

CI baseline: Pages validation, Postgres, SDLC recovery, ruleset, dependency review, and verifier contract checks pass. The full gate fails in the existing immutable watchdog rehearsal, with expected worker digest `194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e` and observed digest `854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33`. The exact same failure is present on base main `08ba3bb8` in run [34069226696](https://github.com/NSPG13/agent-bounties/actions/runs/34069226696) and this PR in run [34069805757](https://github.com/NSPG13/agent-bounties/actions/runs/34069805757). This diff contains only five site/install files and changes no guarded worker input. The existing verifier issue remains unresolved; the authorized maintainer admin bypass is limited to publishing this reviewed site change, without altering verifier pins or waiving payment checks.
