### PR TITLE
Preserve timeout broadcast evidence and repair verifier fixture pins

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
+          --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
+          --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
+          --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 854eabfb8d27f9fca9a6d099b0ef5d6ad7aa36883ca8b8f9feebac63a885fc33
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "d24f17f98066ff9df02389252891b85cfe6cea49816a85db83a13082bafed
 PIPELINE_TEST_SHA256 = "505977c92d852b98d92088b8fc26a31eb754f21d75dc3eb8b1275ec98e76f2be"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"
+WORKER_BUILD_SHA256 = "edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"
 SIGNING_RUNTIME_SHA256 = "ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "7c641a8cda2afb1c7e10be4fdd5431452d217528781d942b46592efa11b1e4d2",
+    ".github/workflows/regression-verifier-runner.yml": "97f8ac3284428118920377efa4fb90e784ef343d32b01e87e1363bbc2611067f",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "146bd0a8bc9035e63c6fbfd2a679c0bb7c152a1edc506cab6bc7b3d2092d1183",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "58ce813cc3e7d453df3ae4a90f9a8251a77d0fd01cfc488a0e60e8fbeee67b6c",
+    ".github/workflows/regression-verifier-signer.yml": "e2bd36b94a501e4faf2ca730c6558d61e7e816e091da8b98cd3de43450f082d5",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "ede99d47e8e1a359c844c1f81b848c828ec7524ac72b2e795bc55e750494a9f3",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 194ff1ce4a8b9e26f41547ceaaa84cdb4d780de730af714a099cc2b4f2dcfd1e"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -13741,7 +13741,9 @@ async fn relay_autonomous_timeout(
         Ok(Err(error)) => return Err(timeout_relay_status(&error)),
         Err(_) => return Err(StatusCode::SERVICE_UNAVAILABLE),
     };
-    release_result?;
+    if release_result.is_err() {
+        eprintln!("timeout relay lease release failed after broadcast; preserve transaction for reconciliation");
+    }
 
     let confirmation = wait_for_timeout_confirmation(
         &rpc_url,
@@ -13751,24 +13753,15 @@ async fn relay_autonomous_timeout(
         state.x402_relayer.confirmations,
         state.x402_relayer.wait_seconds,
     )
-    .await?;
-    let response = RelayAutonomousTimeoutResponse {
-        network: network.to_string(),
+    .await;
+    let response = timeout_response_after_broadcast(
+        network,
         bounty_contract,
-        action: request.action,
-        previous_bounty_state: request.action.previous_bounty_state().to_string(),
-        expected_bounty_state: request.action.expected_bounty_state().to_string(),
-        expected_canonical_event: request.action.expected_event_name().to_string(),
-        transaction_hash: transaction.tx_hash,
-        relayer: transaction.relayer,
-        confirmed: confirmation.confirmed,
-        confirmed_block: confirmation.confirmed_block,
-        canonical_event_id: confirmation.canonical_event_id,
-        evidence_boundary: format!(
-            "Only a confirmed {} event proves this timeout transition. It is bond/lifecycle evidence, not bounty payout or BountySettled evidence.",
-            request.action.expected_event_name()
-        ),
-    };
+        request.action,
+        transaction.tx_hash,
+        transaction.relayer,
+        confirmation,
+    );
     Ok((
         if response.confirmed {
             StatusCode::OK
@@ -13778,6 +13771,38 @@ async fn relay_autonomous_timeout(
         Json(response),
     )
         .into_response())
+}
+
+fn timeout_response_after_broadcast(
+    network: &str,
+    bounty_contract: String,
+    action: AutonomousTimeoutAction,
+    transaction_hash: String,
+    relayer: String,
+    observation: Result<TimeoutRelayConfirmation, StatusCode>,
+) -> RelayAutonomousTimeoutResponse {
+    let confirmation = observation.unwrap_or(TimeoutRelayConfirmation {
+        confirmed: false,
+        confirmed_block: None,
+        canonical_event_id: None,
+    });
+    RelayAutonomousTimeoutResponse {
+        network: network.to_string(),
+        bounty_contract,
+        action,
+        previous_bounty_state: action.previous_bounty_state().to_string(),
+        expected_bounty_state: action.expected_bounty_state().to_string(),
+        expected_canonical_event: action.expected_event_name().to_string(),
+        transaction_hash,
+        relayer,
+        confirmed: confirmation.confirmed,
+        confirmed_block: confirmation.confirmed_block,
+        canonical_event_id: confirmation.canonical_event_id,
+        evidence_boundary: format!(
+            "A transaction was broadcast. Reconcile this exact hash before any retry, including after a confirmation-read failure. Only a confirmed {} event proves this timeout transition. It is bond/lifecycle evidence, not bounty payout or BountySettled evidence.",
+            action.expected_event_name()
+        ),
+    }
 }
 
 impl AutonomousTimeoutAction {
@@ -17885,6 +17910,51 @@ mod tests {
             validate_legal_acceptance_request(&request, now),
             Err(StatusCode::BAD_REQUEST)
         );
+    }
+
+    #[test]
+    fn timeout_confirmation_failure_preserves_broadcast_without_claiming_expiry() {
+        let hash = format!("0x{}", "ab".repeat(32));
+        for observation in [
+            Err(StatusCode::SERVICE_UNAVAILABLE),
+            Err(StatusCode::BAD_GATEWAY),
+            Ok(TimeoutRelayConfirmation {
+                confirmed: false,
+                confirmed_block: None,
+                canonical_event_id: None,
+            }),
+        ] {
+            let response = timeout_response_after_broadcast(
+                "base-mainnet",
+                "bounty".into(),
+                AutonomousTimeoutAction::ExpireClaim,
+                hash.clone(),
+                "relayer".into(),
+                observation,
+            );
+            assert_eq!(response.transaction_hash, hash);
+            assert!(!response.confirmed);
+            assert!(response.confirmed_block.is_none());
+            assert!(response.canonical_event_id.is_none());
+            assert_eq!(response.expected_canonical_event, "ClaimExpired");
+            assert!(response.evidence_boundary.contains("before any retry"));
+        }
+        let confirmed = timeout_response_after_broadcast(
+            "base-mainnet",
+            "bounty".into(),
+            AutonomousTimeoutAction::ExpireSubmission,
+            hash.clone(),
+            "relayer".into(),
+            Ok(TimeoutRelayConfirmation {
+                confirmed: true,
+                confirmed_block: Some(42),
+                canonical_event_id: Some("event".into()),
+            }),
+        );
+        assert_eq!(confirmed.transaction_hash, hash);
+        assert!(confirmed.confirmed);
+        assert_eq!(confirmed.confirmed_block, Some(42));
+        assert_eq!(confirmed.canonical_event_id.as_deref(), Some("event"));
     }
 
     #[test]

--- a/docs/webmcp-guided-marketplace.md
+++ b/docs/webmcp-guided-marketplace.md
@@ -202,6 +202,13 @@ Execution needs the person's review, and only a confirmed `ClaimExpired` or
 and recovery reservations remain visible blockers. Cancellation and each
 contributor's `RefundWithdrawn` evidence are separate from solver payment.
 
+The hosted timeout relay preserves a known broadcast hash in a `202` response
+if confirmation reads fail after sending. Lease cleanup failures also preserve
+the transaction and its observed confirmation state. Reconcile that hash
+and the expected canonical event before any retry. A pending response does not
+prove expiry, and a failed receipt is not a reason to repeat a financial action
+without first checking the current round and deadline.
+
 ```powershell
 node --test scripts/test-webmcp.js scripts/test-marketplace-ui.js scripts/test-competition-proof.js
 node scripts/test-ai-bounty-handoff.js


### PR DESCRIPTION
A timeout relay could broadcast successfully and then return an error when confirmation reads or lease cleanup failed. Preserve the known transaction hash and return the observed confirmation state, using 202 while unconfirmed, so clients can reconcile the exact transaction before considering a retry. Confirmed canonical events remain the only proof of expiry; timeout recovery is never bounty payout.

Refresh the exact reviewed worker-build pins in the three verifier workflows and watchdog rehearsal fixtures, including the synthetic workflow hashes. This corrects the full-CI fixture failure after #1303 without relaxing mutation rejection or changing the signing-runtime pin.

Validation: timeout relay regression tests (2 passed); verifier pipeline tests (26 passed); source guard tests (12 passed); Linux-byte source digest verified; watchdog known-good/known-bad rehearsal passed; cargo fmt and diff checks passed. Read-only review of active #1305 found only installer files and no overlap.

Related maintainer notice: #1302.
