### PR TITLE
Refresh unfunded watchdog precommit benchmark digest

### DIFF
--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:2714bc6336ad4a6d72dbe07309a7bc32c8fd156a3c658cfdb68d504b51c0c8cc",
+    "benchmark_digest": "sha256:aa87c5ad336e5b7b03247ec9900168d742083203e8e00ec1f8abadd866df128d",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",


### PR DESCRIPTION
The unfunded watchdog draft still referenced the benchmark digest from before the reviewed fixture updates in #1306. Set that single digest to the recomputed Linux-byte directory hash so the draft matches its current benchmark and main CI can deploy the recovery fixes.

This remains an unfunded precommit. No live terms, existing funded benchmark, funding gates, economic values, or payment authority change.

Validation: the exact 35-test CI activation/watchdog/source-guard group passed against Linux-normalized repository bytes; diff check passed. Related notice: #1302.
