### PR TITLE
Restore normal readiness for recovered routed API parent

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
+          --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
+          --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
+          --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "d24f17f98066ff9df02389252891b85cfe6cea49816a85db83a13082bafed
 PIPELINE_TEST_SHA256 = "505977c92d852b98d92088b8fc26a31eb754f21d75dc3eb8b1275ec98e76f2be"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"
+WORKER_BUILD_SHA256 = "c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"
 SIGNING_RUNTIME_SHA256 = "ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "97f8ac3284428118920377efa4fb90e784ef343d32b01e87e1363bbc2611067f",
+    ".github/workflows/regression-verifier-runner.yml": "d533f3aefb2fac4f95d9eef1bfdc8837523fd1dee63532b9d162dcc25ec67880",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "e2bd36b94a501e4faf2ca730c6558d61e7e816e091da8b98cd3de43450f082d5",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "ede99d47e8e1a359c844c1f81b848c828ec7524ac72b2e795bc55e750494a9f3",
+    ".github/workflows/regression-verifier-signer.yml": "2e1f408a4d8d1456f447ad921f32a19fa46a940cbb1f5775f5abcf9910b5151a",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "00e765be71ac5e0327a6abe05a082815ac963f054545c78b5a6e1d5766d529f8",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 edd1cf7409cc17023a2485158ac3dc9ffd82ddb4008209ed1c507e4ed646e581"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -3895,7 +3895,7 @@ pub const BUILTIN_STANDING_META_V2_RECOVERY_RESERVED_BOUNTY_CONTRACTS: [&str; 5]
     "0x43b23888d90b36448ee4f4a1919f004c14b6bc53",
 ];
 
-pub const BUILTIN_RECOVERY_RESERVED_BOUNTY_CONTRACTS: [&str; 14] = [
+pub const BUILTIN_RECOVERY_RESERVED_BOUNTY_CONTRACTS: [&str; 13] = [
     "0x680030abf3ffffbc8d0a550b6355a8713c54d3c8",
     "0x3137e6c0f44b940580ea7efc5f8cc6c6c0bda3f1",
     "0xb35b94e1225b66e50644a331feccdab0439e63d7",
@@ -3909,7 +3909,6 @@ pub const BUILTIN_RECOVERY_RESERVED_BOUNTY_CONTRACTS: [&str; 14] = [
     "0xf2e47a253988e98f535ab60f4b9bd7f8975c1263",
     "0x2afb91d160200fac4b91e6134b2cc9d9bff86f42",
     "0xc710d54d192ffb0b84cd6e051754ab70acf1130c",
-    "0xd15306a8cc4274ec46d913817ca4490c4fc41303",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9039,7 +9038,8 @@ mod tests {
     #[test]
     fn recovery_reservations_fail_closed_and_filter_earning_inventory() {
         let reserved_contract = "0x2222222222222222222222222222222222222222";
-        let available_contract = "0x3333333333333333333333333333333333333333";
+        // The recovered routed-V3 API parent is governed by ordinary readiness again.
+        let available_contract = "0xd15306a8cc4274ec46d913817ca4490c4fc41303";
         let reservations = AutonomousBountyRecoveryReservations::parse_csv(Some(&format!(
             " 0x{} , {available_contract} ",
             "22".repeat(20).to_ascii_uppercase()
@@ -9110,6 +9110,26 @@ mod tests {
         only_reserved.exclude_from_verification_jobs(&mut verification_feed);
         assert_eq!(verification_feed.len(), 1);
         assert_eq!(verification_feed[0].bounty_contract, available_contract);
+
+        // Removing a historical hold must not override other readiness failures.
+        let mut unavailable = item(available_contract);
+        unavailable.verification_ready = false;
+        unavailable.verification_readiness_reason = "verifier unavailable".to_string();
+        let mut unready_feed = vec![unavailable];
+        only_reserved.apply(&mut unready_feed, false);
+        assert!(!unready_feed[0].verification_ready);
+        assert_eq!(
+            unready_feed[0].verification_readiness_reason,
+            "verifier unavailable"
+        );
+        only_reserved.apply(&mut unready_feed, true);
+        assert!(unready_feed.is_empty());
+
+        let mut claimed = item(available_contract);
+        claimed.status = "claimed".to_string();
+        let mut claimed_feed = vec![claimed];
+        only_reserved.apply(&mut claimed_feed, true);
+        assert!(claimed_feed.is_empty());
     }
 
     #[test]

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:aa87c5ad336e5b7b03247ec9900168d742083203e8e00ec1f8abadd866df128d",
+    "benchmark_digest": "sha256:a56664a35babe11f5bf9e6c415d3b08e2281cf33abb36afcceaec5ece10f173f",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",


### PR DESCRIPTION
The routed-V3 API parent stayed unavailable after its historical claim expired and its child preparation flow was repaired. Remove that single built-in incident hold so normal canonical readiness and the exact 1 USDC child flow can evaluate it again.

Safe-block reads confirm no active solver/bond, an active immutable routed policy, and the committed child quorum/registries. Keep all V2 migration reservations and explicit operator overrides. Restoring discovery does not compensate the former claimant or close #653, authorize new funding, or prove completion.

Validation: chain-base 85 passed / 2 environment-gated; combined activation, pipeline, source-guard, and watchdog precommit tests 61 passed; known-good/known-bad watchdog rehearsal passed. Exact worker and fixture pins were recomputed from Linux bytes, including the unfunded draft digest. Signing-runtime pin unchanged.

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/1302#issuecomment-5563455977 . No fresh overlapping collaborator PR is displaced.
