### PR TITLE
Fix original OpenHands source validation in verifier pipeline

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -46,7 +46,7 @@ jobs:
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
           python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
-          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
+          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
 
@@ -79,7 +79,7 @@ jobs:
       - name: Revalidate reviewed runtime after build
         run: |
           python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
-          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
+          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
 
       - name: Run canonical jobs without signing secrets
         run: >-

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -43,7 +43,7 @@ jobs:
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
       - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
-      - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
+      - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
 
   authorize-run:
     if: >-
@@ -156,7 +156,7 @@ jobs:
       - name: Revalidate reviewed runtime after build
         run: |
           python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
-          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
+          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
       - name: Revalidate and relay exact quorum
         env:
           BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Revalidate reviewed runtime after build
         run: |
           python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228
-          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066
+          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
       - name: Re-fetch state and sign one exact candidate set
         env:
           REGRESSION_VERIFIER_PRIVATE_KEY: ${{ secrets.verifier_private_key }}

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -30,18 +30,18 @@ SCHEMA = "agent-bounties/regression-verifier-watchdog-plan-v1"
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 ADDRESS_ONE = "0x" + "11" * 20
 ADDRESS_TWO = "0x" + "22" * 20
-PIPELINE_SHA256 = "d24f17f98066ff9df02389252891b85cfe6cea49816a85db83a13082bafed60e"
-PIPELINE_TEST_SHA256 = "505977c92d852b98d92088b8fc26a31eb754f21d75dc3eb8b1275ec98e76f2be"
+PIPELINE_SHA256 = "23611288dc879bad70ef6966789a5132b136d6e4ca69db7b25ced5c6b581cb2e"
+PIPELINE_TEST_SHA256 = "8b408fc80ff5bf4871ff679f119e6053834b5c9544b1ea0be70e11414cab3be2"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
 WORKER_BUILD_SHA256 = "c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"
-SIGNING_RUNTIME_SHA256 = "ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"
+SIGNING_RUNTIME_SHA256 = "89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "d533f3aefb2fac4f95d9eef1bfdc8837523fd1dee63532b9d162dcc25ec67880",
+    ".github/workflows/regression-verifier-runner.yml": "ee9d35b3d14b79561556c2b895a2d1dc3fbb5a5f1c665d326f0be70ac12f0cf5",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "2e1f408a4d8d1456f447ad921f32a19fa46a940cbb1f5775f5abcf9910b5151a",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "00e765be71ac5e0327a6abe05a082815ac963f054545c78b5a6e1d5766d529f8",
+    ".github/workflows/regression-verifier-signer.yml": "00f8b31984c078dab2bac7ac0b4a677bd74a2dae503c4b6dca2ec120ff592f48",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "4bb572207cf1f259db6a88cc6040acc7e0007e02c61eca4ef553f1434dc615fe",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -933,7 +933,7 @@ RUNNER_WORKFLOW = '''{
         {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
         {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
-        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
+        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
       ]
@@ -1055,7 +1055,7 @@ SIGNER_WORKFLOW = '''{
         {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"run": "cargo build --release -p worker"},
         {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
-        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
+        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
     }
@@ -1098,7 +1098,7 @@ REUSABLE_WORKFLOW = '''{
         {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
         {"run": "cargo build --release -p worker"},
         {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 c4850fc0edf6786462a80a8d51c8e76b5c38cd8c1952192953973424b8ad1228"},
-        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 ada389f13bba3c67199f49299ceb474f75316afdb25a5f5fefe4855f26d44066"},
+        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}
       ]

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:a56664a35babe11f5bf9e6c415d3b08e2281cf33abb36afcceaec5ece10f173f",
+    "benchmark_digest": "sha256:eee6cd35a862c41ddf2db818ca9b971dd3fca613b7793aa0c3facabb4ecf6867",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",

--- a/scripts/regression_verifier_pipeline.py
+++ b/scripts/regression_verifier_pipeline.py
@@ -80,6 +80,16 @@ RECONCILED_REGRESSION_BENCHMARK_SOURCES: dict[str, tuple[str, str, str]] = {
     "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7": ("nspg13/agent-bounties", RECONCILED_REGRESSION_BENCHMARK_COMMIT, "benchmarks/direct-inventory-v1/stalled-work"),
 }
 
+# The original OpenHands publication has byte-identical benchmark contents.
+# Keep this exception bound to all four immutable source fields.
+RECONCILED_REGRESSION_BENCHMARK_SOURCE_ALIASES: dict[str, tuple[str, str, str]] = {
+    "sha256:30bb17e3e3916747144c7087f49fb1ce41ddaf1aec4d717f878d2840203895a2": (
+        "nspg13/agent-bounties",
+        "aa28ec742efd4063260653510ba324e291267515",
+        "benchmarks/direct-growth-v2/openhands-integration",
+    ),
+}
+
 
 class PipelineError(RuntimeError):
     pass
@@ -262,7 +272,11 @@ def require_reconciled_regression_benchmark(job: dict[str, Any]) -> None:
             "sandboxed regression benchmark exact digest must be independently reconciled and approved before verifier signing"
         )
     repository, commit, subdirectory = benchmark_source(job)
-    if (repository.lower(), commit, subdirectory) != RECONCILED_REGRESSION_BENCHMARK_SOURCES.get(digest):
+    source_tuple = (repository.lower(), commit, subdirectory)
+    if source_tuple not in (
+        RECONCILED_REGRESSION_BENCHMARK_SOURCES.get(digest),
+        RECONCILED_REGRESSION_BENCHMARK_SOURCE_ALIASES.get(digest),
+    ):
         raise PipelineError(
             "sandboxed regression benchmark immutable source tuple does not match the independently approved digest"
         )

--- a/scripts/test_regression_verifier_pipeline.py
+++ b/scripts/test_regression_verifier_pipeline.py
@@ -800,6 +800,31 @@ class RegressionVerifierPipelineTests(unittest.TestCase):
             with self.assertRaisesRegex(pipeline.PipelineError, "immutable source tuple"):
                 pipeline.require_reconciled_regression_benchmark(mismatched)
 
+    def test_original_openhands_terms_use_only_the_exact_reconciled_alias(self) -> None:
+        fixture = SCRIPT.parent.parent / "crates/chain-base/tests/fixtures/legacy-openhands-terms.json"
+        job = {"terms": json.loads(fixture.read_text(encoding="utf-8"))}
+        pipeline.require_reconciled_regression_benchmark(job)
+        benchmark = job["terms"]["document"]["benchmark"]
+        self.assertEqual(
+            benchmark["runner_manifest"]["benchmark_digest"],
+            repository_benchmark_digest("benchmarks/direct-growth-v2/openhands-integration"),
+        )
+        for key, value in (
+            ("repository", "relocated/repository"),
+            ("commit", "b" * 40),
+            ("subdirectory", "benchmarks/direct-growth-v2/hermes-integration"),
+        ):
+            changed = json.loads(json.dumps(job))
+            changed["terms"]["document"]["benchmark"]["source"][key] = value
+            with self.assertRaisesRegex(pipeline.PipelineError, "immutable source tuple"):
+                pipeline.require_reconciled_regression_benchmark(changed)
+        changed = json.loads(json.dumps(job))
+        changed["terms"]["document"]["benchmark"]["runner_manifest"]["benchmark_digest"] = (
+            "sha256:b9b0d026347a2922f913e9a8ed3651dd74e7eba930598981a169da3bf42e7c3f"
+        )
+        with self.assertRaisesRegex(pipeline.PipelineError, "immutable source tuple"):
+            pipeline.require_reconciled_regression_benchmark(changed)
+
     def test_runner_pulls_only_the_exact_committed_image(self) -> None:
         manifest = {
             "image": f"docker.io/library/python@sha256:{'a' * 64}",


### PR DESCRIPTION
The scheduled verifier rejected the original OpenHands source commit even though its benchmark bytes match the independently approved digest. Apply the same exact repository/commit/path/digest compatibility tuple to the Python runner and signing validation, preserving all other evidence and payment checks.

Update signing-runtime pins and watchdog fixtures, plus the unfunded watchdog precommit digest. Existing funded terms and verifier thresholds are unchanged.

Validation: 62 targeted tests passed; known-good watchdog accepted and known-bad rejected; worker/signing source guards passed; the actual live round-29 job passes the source check without signing or payment. The regression test rejects changed repository, commit, path, and digest.

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/1302#issuecomment-5563579604
Observed failure: https://github.com/NSPG13/agent-bounties/actions/runs/34071568614

Compatibility and contributor impact: the open PR queue was inspected; no active overlapping collaborator PR is displaced. The fix accepts only the original reconciled OpenHands tuple. No contributor migration is required; all other source tuples and current funding validation retain their existing checks. Full main CI subsequently passed: https://github.com/NSPG13/agent-bounties/actions/runs/34072194684 .
