### PR TITLE
Open ChatGPT desktop with current WebMCP posting guidance

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,7 @@ on:
       - "site/**"
       - "scripts/check-site.py"
       - "scripts/test-solarpunk-home.js"
+      - "scripts/test-ai-bounty-handoff.js"
       - "scripts/test-metrics-dashboard.js"
       - "scripts/test-marketplace-ui.js"
       - "scripts/test-webmcp.js"
@@ -31,6 +32,7 @@ on:
       - "site/**"
       - "scripts/check-site.py"
       - "scripts/test-solarpunk-home.js"
+      - "scripts/test-ai-bounty-handoff.js"
       - "scripts/test-metrics-dashboard.js"
       - "scripts/test-marketplace-ui.js"
       - "scripts/test-webmcp.js"
@@ -89,6 +91,8 @@ jobs:
           node --check site/phone-wallet.js
       - name: Test the living scene and marketplace evidence states
         run: node --test scripts/test-solarpunk-home.js
+      - name: Test assistant desktop handoff and draft preservation
+        run: node scripts/test-ai-bounty-handoff.js
       - name: Test the retained Metrics evidence engine
         run: node --test scripts/test-metrics-dashboard.js
       - name: Test unified marketplace readiness, timing, and economics

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -754,6 +754,8 @@ def check_homepage(site_dir: Path) -> None:
             "authApiPath",
             "authProviderPath",
             "bountyAssistantLinks",
+            "codex://threads/new?prompt=",
+            "browserUrl=",
             "https://chatgpt.com/?prompt=",
             "https://cursor.com/link/prompt?text=",
             "claude://claude.ai/new?q=",

--- a/scripts/test-ai-bounty-handoff.js
+++ b/scripts/test-ai-bounty-handoff.js
@@ -3,6 +3,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
+const assert = require("node:assert/strict");
 
 const source = fs.readFileSync(
   path.join(__dirname, "..", "site", "ai-bounty-handoff.js"),
@@ -15,7 +16,10 @@ function element() {
     hidden: true,
     textContent: "",
     value: "",
-    addEventListener() {},
+    style: {},
+    handlers: {},
+    addEventListener(name, callback) { this.handlers[name] = callback; },
+    removeAttribute(name) { delete this[name]; },
     scrollIntoView() {},
   };
 }
@@ -29,25 +33,37 @@ const elements = new Map([
   ["[data-ai-import-status]", element()],
   ["[data-composer-status]", element()],
   ["[data-assistant-prompt]", element()],
+  ["[data-ai-web-fallback]", element()],
 ]);
-elements.get("[data-ai-handoff]").querySelectorAll = () => [];
+const chatgptButton = { ...element(), dataset: { aiProvider: "chatgpt", providerLabel: "ChatGPT" } };
+elements.get("[data-ai-handoff]").querySelectorAll = () => [chatgptButton];
 elements.get("[data-ai-handoff]").querySelector = () => null;
 
+const desktopLaunches = [];
+const webLaunches = [];
+const copies = [];
+const navigator = { clipboard: { async writeText(text) { copies.push(text); } } };
 const window = {
   AgentBountiesMetaChild: require("../site/meta-child.js"),
   addEventListener() {},
   dispatchEvent() {},
-  open() {},
+  open(...args) { webLaunches.push(args); },
 };
 const document = {
   documentElement: { dataset: {} },
   querySelector(selector) { return elements.get(selector) || null; },
+  body: { append() {} },
+  createElement(tag) {
+    assert.equal(tag, "a");
+    return { click() { desktopLaunches.push(this.href); }, remove() {} };
+  },
 };
 
 vm.runInNewContext(source, {
   window,
   document,
-  navigator: {},
+  navigator,
+  requestAnimationFrame(callback) { callback(); },
   URL,
   JSON,
   Number,
@@ -149,4 +165,51 @@ for (const marker of ["prepare_bounty_post", api.mcpUrl, "return ONLY one JSON o
   if (!prompt.includes(marker)) throw new Error(`AI handoff prompt missing: ${marker}`);
 }
 
-console.log("user-owned AI handoff validates portable drafts and preserves the MCP path");
+async function verifyDesktopHandoff() {
+  const context = {
+    draft,
+    solver_reward_usdc: "0.99",
+    verifier_reward_usdc: "0.01",
+    task_window_days: 3,
+    meta_child: child.meta_child,
+  };
+  const preparedPrompt = api.show('Keep the tests; change the title to "A & B".', context);
+  assert.match(preparedPrompt, /First discover actual access/);
+  assert.match(preparedPrompt, /Preserve my existing answers/);
+  assert.match(preparedPrompt, /only for missing business decisions/);
+  assert.match(preparedPrompt, /QUALIFYING META CHILD/);
+  assert.ok(preparedPrompt.includes(draft.benchmark.source.commit));
+  assert.ok(preparedPrompt.includes(draft.source_url));
+  await chatgptButton.handlers.click();
+  assert.equal(desktopLaunches.length, 1);
+  assert.equal(webLaunches.length, 0, "desktop selection must not open a web conversation");
+  const desktop = new URL(desktopLaunches[0]);
+  assert.equal(desktop.protocol, "codex:");
+  assert.equal(desktop.hostname, "threads");
+  assert.equal(desktop.pathname, "/new");
+  assert.equal(desktop.searchParams.get("prompt"), preparedPrompt);
+  const browser = new URL(desktop.searchParams.get("browserUrl"));
+  assert.equal(browser.origin, "https://agentbounties.app");
+  assert.equal(browser.pathname, "/post.html");
+  assert.equal(browser.searchParams.get("parentBounty"), child.meta_child.parent_bounty_contract);
+  const fallback = elements.get("[data-ai-web-fallback]");
+  assert.equal(fallback.hidden, false);
+  assert.equal(new URL(fallback.href).searchParams.get("prompt"), preparedPrompt);
+  assert.equal(copies[0], preparedPrompt);
+  assert.match(elements.get("[data-ai-import-status]").textContent, /launch requested/i);
+  assert.doesNotMatch(elements.get("[data-ai-import-status]").textContent, /app opened|blocked the new tab/i);
+  api.show("A different outcome");
+  assert.equal(fallback.hidden, true, "new drafts must clear old fallback links");
+  assert.equal(fallback.href, undefined);
+  navigator.clipboard.writeText = async () => { throw new Error("clipboard denied"); };
+  await chatgptButton.handlers.click();
+  assert.equal(desktopLaunches.length, 2, "clipboard denial must not prevent the prefilled launch");
+  assert.equal(webLaunches.length, 0);
+  assert.equal(new URL(desktopLaunches[1]).searchParams.get("prompt"), elements.get("[data-ai-prompt]").value);
+  assert.match(elements.get("[data-ai-import-status]").textContent, /clipboard access was unavailable/i);
+  assert.equal(api.providerLinks("unknown", "draft"), null);
+  assert.equal(api.providerLinks("chatgpt", ""), null);
+  assert.throws(() => api.providerLinks("chatgpt", "draft", { meta_child: { parent_bounty_contract: "https://evil.example" } }));
+  console.log("user-owned AI handoff validates drafts, desktop launch, explicit fallback, preserved context and clipboard recovery");
+}
+verifyDesktopHandoff().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/scripts/test-solarpunk-home.js
+++ b/scripts/test-solarpunk-home.js
@@ -43,7 +43,10 @@ test("bounty assistant handoffs carry one bounded initialization message", () =>
   const prompt = home.BOUNTY_POSTING_PROMPT;
   assert.match(prompt, /agentbounties\.app\/.well-known\/agent-bounties\.json/i);
   assert.match(prompt, /agentbounties\.app\/llms\.txt/i);
-  assert.match(prompt, /approve it before any public write/i);
+  assert.match(prompt, /Leave publication consent, funding, payment, legal consent and wallet confirmations to me/i);
+  assert.match(prompt, /discover.*WebMCP site tools/i);
+  assert.match(prompt, /preserve my existing answers/i);
+  assert.match(prompt, /only for missing business decisions/i);
   assert.match(prompt, /never ask for a seed phrase or private key/i);
   assert.match(prompt, /confirmed canonical Base USDC evidence/i);
   assert.ok(prompt.length < 2000);
@@ -52,12 +55,18 @@ test("bounty assistant handoffs carry one bounded initialization message", () =>
   const claude = home.bountyAssistantLinks("claude");
   const cursor = home.bountyAssistantLinks("cursor");
   const custom = home.bountyAssistantLinks("custom");
-  assert.equal(gpt.desktopUrl, null);
+  const desktop = new URL(gpt.desktopUrl);
+  assert.equal(desktop.protocol, "codex:");
+  assert.equal(desktop.hostname, "threads");
+  assert.equal(desktop.pathname, "/new");
+  assert.equal(desktop.searchParams.get("browserUrl"), "https://agentbounties.app/post.html?from=webmcp");
   assert.equal(new URL(gpt.webUrl).origin, "https://chatgpt.com");
   const gptPrompt = new URL(gpt.webUrl).searchParams.get("prompt");
   assert.ok(gptPrompt.startsWith(prompt));
   assert.match(gptPrompt, /utm_source=chatgpt/);
   assert.match(gptPrompt, /canonical URL/);
+  assert.equal(desktop.searchParams.get("prompt"), gptPrompt);
+  assert.equal(desktop.searchParams.has("submit"), false);
   assert.equal(gpt.webPrefillsPrompt, true);
   assert.equal(claude.desktopUrl, `claude://claude.ai/new?q=${encodeURIComponent(prompt)}`);
   assert.equal(new URL(claude.webUrl).origin, "https://claude.ai");
@@ -68,6 +77,15 @@ test("bounty assistant handoffs carry one bounded initialization message", () =>
   assert.equal(cursor.webPrefillsPrompt, true);
   assert.equal(custom.webUrl, null);
   assert.equal(home.bountyAssistantLinks("unknown"), null);
+});
+
+test("desktop handoff keeps arbitrary prompt text inside one prompt parameter", () => {
+  const prompt = 'A & B? #launch "prototype"\nBudget: 3 USDC; deadline: mañana';
+  const links = home.bountyAssistantLinks("gpt", prompt);
+  const desktop = new URL(links.desktopUrl);
+  assert.ok(desktop.searchParams.get("prompt").startsWith(prompt));
+  assert.deepEqual([...desktop.searchParams.keys()], ["prompt", "browserUrl"]);
+  assert.equal(desktop.searchParams.get("prompt"), new URL(links.webUrl).searchParams.get("prompt"));
 });
 
 test("competition posting handoffs preserve only live canonical context", () => {

--- a/site/ai-bounty-handoff.js
+++ b/site/ai-bounty-handoff.js
@@ -16,12 +16,31 @@
   const importInput = document.querySelector("[data-ai-draft-import]");
   const importStatus = document.querySelector("[data-ai-import-status]");
   const composerStatus = document.querySelector("[data-composer-status]");
+  const webFallback = document.querySelector("[data-ai-web-fallback]");
 
   if (!panel || !log || !original || !promptPreview || !importInput) return;
 
   let currentIntent = "";
   let currentContext = null;
   let currentPrompt = "";
+
+  function providerLinks(provider, prompt, context = null) {
+    if (!Object.hasOwn(PROVIDERS, provider) || !String(prompt || "").trim()) return null;
+    if (provider !== "chatgpt") return { webUrl: PROVIDERS[provider], desktopUrl: null };
+    const browserUrl = new URL("https://agentbounties.app/post.html?from=webmcp");
+    const parent = context?.meta_child?.parent_bounty_contract;
+    if (parent != null) {
+      if (!/^0x[0-9a-fA-F]{40}$/.test(parent)) throw new Error("The parent bounty address is invalid.");
+      browserUrl.searchParams.set("parentBounty", parent.toLowerCase());
+    }
+    // OpenAI Learn uses this registered desktop route for a draft + browser tab.
+    const desktop = new URL("codex://threads/new");
+    desktop.searchParams.set("prompt", prompt);
+    desktop.searchParams.set("browserUrl", browserUrl.href);
+    const web = new URL(PROVIDERS.chatgpt);
+    web.searchParams.set("prompt", prompt);
+    return { desktopUrl: desktop.href, webUrl: web.href };
+  }
 
   function boundedText(value, label, maximum) {
     const text = String(value || "").trim();
@@ -115,14 +134,22 @@
           solver_reward_usdc: context.solver_reward_usdc,
           verifier_reward_usdc: context.verifier_reward_usdc,
           task_window_days: context.task_window_days,
+          source_url: context.source_url ?? context.draft.source_url,
+          benchmark: context.benchmark ?? context.draft.benchmark,
+          evidence_schema: context.evidence_schema ?? context.draft.evidence_schema,
+          crowdfund: context.crowdfund,
         }, null, 2)}\n\nREQUESTED CHANGE:\n${intent}`
       : `\n\nWHAT I WANT DONE:\n${intent}`;
 
     return `Help me prepare a public Agent Bounties bounty using the context you already have about me and this request.${revision}${context?.meta_child ? `\n\nQUALIFYING META CHILD: Preserve meta_child: ${JSON.stringify(context.meta_child)} in the returned JSON. Use exactly 1 USDC total, ordinarily 0.99 solver plus 0.01 shared between the two committed verifiers. Identify a distinct intended child solver before funding. Use the browser WebMCP stage tool or paste JSON into this review; do not use the ordinary hosted prepare_bounty_post path for this child.` : ""}
 
-${context?.meta_child ? "Use the parent-specific browser review described above. Prepare the JSON for review without publishing it." : "If the Agent Bounties MCP connector is available, clarify only details that materially affect the public terms. Show me the complete terms and wait for my explicit approval. Only after I approve, call prepare_bounty_post."} If this AI can generate and attach a unique image, you may show it for approval and call the tool with bounty_image, the exact image_prompt, and accessible image_alt_text. Otherwise omit all three image fields; the Agent Bounties review page will render a deterministic content-derived visual. Agent Bounties does not require or use a platform model key. The MCP endpoint is ${MCP_URL}.
+First discover actual access. In the desktop app, open Agent Bounties in the built-in browser (@Browser), discover its WebMCP site tools and read the current page context. Tell me whether those tools are actually callable. A web chat alone does not establish WebMCP access. Read https://agentbounties.app/.well-known/agent-bounties.json and https://agentbounties.app/llms.txt before choosing endpoints. If site tools are unavailable, check for connected official Agent Bounties MCP tools; otherwise explain the limitation once and use the portable draft below.
 
-If the connector is unavailable, ask concise clarifying questions and then return ONLY one JSON object in this exact shape so I can paste the approved terms directly into the Agent Bounties review flow:
+Preserve my existing answers and exact draft fields. Handle navigation, preparation and staging yourself; ask only for missing business decisions such as the outcome, budget and deadline. Propose measurable checks and prepare the reviewed verifier yourself, without asking me for technical hashes or commands. Leave publication consent, funding, payment, legal consent and wallet confirmations to me, and reuse approvals within their agreed scope. Never ask for a seed phrase or private key, invent gas sponsorship, or report an action completed without a confirming tool result. Only confirmed canonical events prove funding or payment.
+
+${context?.meta_child ? "Use the parent-specific browser review described above. Prepare the JSON for review without publishing it." : "Prefer the discovered WebMCP staging tools. If only the Agent Bounties MCP connector is available, show me the complete terms and reuse my approval if already given. After approval, call prepare_bounty_post."} If this AI can generate and attach a unique image, you may show it for approval and call the tool with bounty_image, the exact image_prompt, and accessible image_alt_text. Otherwise omit all three image fields; the Agent Bounties review page will render a deterministic content-derived visual. Agent Bounties does not require or use a platform model key. The MCP endpoint is ${MCP_URL}.
+
+If neither site tools nor the connector are available, resolve only missing business decisions and then return ONLY one JSON object in this exact shape so I can paste the approved terms directly into the Agent Bounties review flow:
 {
   "title": "concise public title",
   "goal": "specific public outcome",
@@ -158,8 +185,11 @@ Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, ea
     helper.style.opacity = "0";
     document.body.append(helper);
     helper.select();
-    document.execCommand("copy");
-    helper.remove();
+    try {
+      if (!document.execCommand("copy")) throw new Error("Clipboard access is unavailable.");
+    } finally {
+      helper.remove();
+    }
   }
 
   function show(intent, context = null) {
@@ -168,6 +198,10 @@ Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, ea
     currentPrompt = promptFor(currentIntent, currentContext);
     original.textContent = currentIntent;
     promptPreview.value = currentPrompt;
+    if (webFallback) {
+      webFallback.hidden = true;
+      webFallback.removeAttribute("href");
+    }
     panel.hidden = false;
     log.append(panel);
     requestAnimationFrame(() => {
@@ -187,14 +221,35 @@ Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, ea
   for (const button of panel.querySelectorAll("[data-ai-provider]")) {
     button.addEventListener("click", async () => {
       const provider = button.dataset.aiProvider;
-      const destination = PROVIDERS[provider];
-      if (!destination || !currentPrompt) return;
-      const providerTab = window.open(destination, "_blank", "noopener,noreferrer");
+      let links;
+      try {
+        links = providerLinks(provider, currentPrompt, currentContext);
+      } catch (error) {
+        setImportStatus(error.message || "The desktop handoff could not be prepared.", "error");
+        return;
+      }
+      if (!links) return;
+      if (webFallback) {
+        webFallback.href = links.webUrl;
+        webFallback.hidden = !links.desktopUrl;
+      }
+      if (links.desktopUrl) {
+        const anchor = document.createElement("a");
+        anchor.href = links.desktopUrl;
+        anchor.hidden = true;
+        document.body.append(anchor);
+        anchor.click();
+        anchor.remove();
+      } else {
+        window.open(links.webUrl, "_blank", "noopener,noreferrer");
+      }
       try {
         await copyText(currentPrompt);
-        setImportStatus(`${providerTab ? "Prompt copied." : "Prompt copied, but your browser blocked the new tab."} Paste it into ${button.dataset.providerLabel || provider}.`, "success");
+        setImportStatus(links.desktopUrl
+          ? "Desktop launch requested. Accept your browser's Open app prompt if shown. Your prompt is also copied; if the app does not open, use ChatGPT web or paste it manually. Nothing is sent automatically."
+          : `Prompt copied. Requested ${button.dataset.providerLabel || provider} in a new tab; paste the prompt there.`, "success");
       } catch (_error) {
-        setImportStatus("The prompt could not be copied automatically. Copy it from the expandable prompt below.", "error");
+        setImportStatus("Launch requested, but clipboard access was unavailable. The exact prompt remains below for manual copying; the ChatGPT launch links also contain it.", "error");
       }
     });
   }
@@ -240,6 +295,7 @@ Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, ea
     mcpUrl: MCP_URL,
     parseDraft,
     promptFor,
+    providerLinks,
     show,
   });
 })();

--- a/site/index.html
+++ b/site/index.html
@@ -307,11 +307,17 @@
         <span id="bounty-launcher-description">Start with the assistant you already use. The posting instructions will be waiting in a new chat.</span>
       </header>
 
+      <p class="bounty-launch-status" data-bounty-launch-status aria-live="polite"></p>
+      <div class="bounty-launch-actions" data-bounty-custom-actions hidden>
+        <button type="button" data-bounty-copy>Copy instructions</button>
+      </div>
+      <a class="bounty-web-fallback" data-bounty-web-fallback hidden target="_blank" rel="noopener noreferrer">Use the web app instead</a>
+
       <div class="bounty-assistant-list" aria-label="AI assistant choices">
         <button type="button" data-bounty-assistant="gpt">
           <span class="assistant-mark assistant-mark--openai" aria-hidden="true"><img src="assets/solarpunk/provider-openai.svg" alt=""></span>
-          <span><strong>GPT</strong><small>Prefilled ChatGPT handoff</small></span>
-          <em>Web session</em>
+          <span><strong>ChatGPT</strong><small>Desktop app with a shared browser</small></span>
+          <em>App first</em>
           <svg viewBox="0 0 20 20" aria-hidden="true"><path d="m7 4 6 6-6 6"></path></svg>
         </button>
         <button type="button" data-bounty-assistant="claude">
@@ -339,12 +345,8 @@
         <pre data-bounty-prompt></pre>
       </details>
 
-      <div class="bounty-launch-actions" data-bounty-custom-actions hidden>
-        <button type="button" data-bounty-copy>Copy instructions</button>
-      </div>
-      <a class="bounty-web-fallback" data-bounty-web-fallback hidden target="_blank" rel="noopener noreferrer">Use the web app instead</a>
+      <p class="bounty-launch-note">ChatGPT site tools work in the desktop app's built-in browser with Work or Codex, when available. Web chat can use a connected MCP integration or help draft. <a href="https://learn.chatgpt.com/docs/webmcp" target="_blank" rel="noopener noreferrer">Check availability</a>.</p>
       <p class="bounty-launch-note">The prompt is never submitted automatically. The selected provider uses the account already active in its app or browser; if none is active, sign in before continuing.</p>
-      <p class="bounty-launch-status" data-bounty-launch-status aria-live="polite"></p>
     </dialog>
 
     <footer class="site-footer">
@@ -363,6 +365,6 @@
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
-    <script src="solarpunk-home.js?v=10"></script>
+    <script src="solarpunk-home.js?v=11"></script>
   </body>
 </html>

--- a/site/post-a-bounty-with-chatgpt-claude-gemini.html
+++ b/site/post-a-bounty-with-chatgpt-claude-gemini.html
@@ -83,6 +83,7 @@
             <ol>
               <li>Open the <a href="./#post-a-bounty">homepage assistant chooser</a>.</li>
               <li>Choose ChatGPT, Claude, or Cursor. For Gemini or another assistant, copy the custom bounded prompt.</li>
+              <li>ChatGPT requests the desktop app with the prompt ready to send and Agent Bounties in its built-in browser. Accept your browser's Open app request if shown. If the app is unavailable, choose the web fallback or copy the prompt; the site does not redirect you automatically.</li>
               <li>Describe the desired outcome and let the assistant ask only for missing terms.</li>
               <li>The assistant can inspect published A2A, MCP, REST, feed, and repository documentation to prepare a review-only draft.</li>
               <li>Review the exact scope, acceptance tests, reward, verifier, deadline, bond and external-spend exposure. Review any wallet request separately.</li>
@@ -94,6 +95,8 @@
             <h2>Use published contracts instead of guessing</h2>
             <p>The <a href="https://agentbounties.app/.well-known/agent-card.json">A2A Agent Card</a> provides discovery and protocol orientation. The <a href="https://agentbounties.app/.well-known/mcp.json">MCP descriptor</a> and hosted MCP tools expose structured, bounded workflows. The <a href="https://api.agentbounties.app/openapi.json">REST contract</a> and <a href="https://api.agentbounties.app/v1/opportunities/feed.json" data-analytics-event="opportunity_feed_click">opportunity feed</a> provide machine-readable state.</p>
             <p>Where supported, <code>prepare_bounty_post</code> produces terms for human review. Its result does not prove that a bounty was published, funded, claimed, verified, or paid.</p>
+            <p><a href="https://learn.chatgpt.com/docs/webmcp" target="_blank" rel="noopener noreferrer">WebMCP site tools</a> let ChatGPT Work or Codex operate the same page in the desktop app's built-in browser, when supported by the selected model, account and rollout. The assistant must discover callable tools and read page context before claiming access. A normal web conversation does not gain access to another open tab just from a prompt.</p>
+            <p><a href="https://learn.chatgpt.com/docs/extend/mcp" target="_blank" rel="noopener noreferrer">Remote MCP integrations</a> can work in ChatGPT on the web. <a href="https://learn.chatgpt.com/docs/browser" target="_blank" rel="noopener noreferrer">ChatGPT Work's cloud browser</a> has its own session. Neither should be presented as access to your desktop browser or its wallet. If no tools are callable, the assistant can still prepare a portable draft for you to review on Agent Bounties.</p>
           </section>
 
           <section id="review">

--- a/site/post.html
+++ b/site/post.html
@@ -110,7 +110,7 @@
 
             <div class="ai-provider-grid" aria-label="Choose an AI provider">
               <button type="button" data-ai-provider="chatgpt" data-provider-label="ChatGPT">
-                <strong>ChatGPT</strong><span>Copy prompt &amp; open</span>
+                <strong>ChatGPT</strong><span>Open desktop app &amp; shared browser</span>
               </button>
               <button type="button" data-ai-provider="claude" data-provider-label="Claude">
                 <strong>Claude</strong><span>Copy prompt &amp; open</span>
@@ -119,6 +119,9 @@
                 <strong>Gemini</strong><span>Copy prompt &amp; open</span>
               </button>
             </div>
+
+            <p class="ai-safety-note">ChatGPT site tools work in the desktop app's built-in browser with Work or Codex, when available. <a href="https://learn.chatgpt.com/docs/webmcp" target="_blank" rel="noopener noreferrer">Check availability</a>. Web chat can use a connected MCP integration or help draft.</p>
+            <a class="ai-web-fallback" data-ai-web-fallback hidden target="_blank" rel="noopener noreferrer">Use ChatGPT web instead</a>
 
             <details class="ai-connector-setup">
               <summary>Connect Agent Bounties to your AI once</summary>
@@ -252,7 +255,7 @@
     <script src="evm.js"></script>
     <script src="meta-child.js?v=1"></script>
     <script src="bounty-entry.js?v=1"></script>
-    <script src="ai-bounty-handoff.js?v=6"></script>
+    <script src="ai-bounty-handoff.js?v=7"></script>
     <script src="bounty-composer-v2.js?v=10"></script>
     <script src="bounty-chat-ui.js?v=4"></script>
   </body>

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -15,17 +15,17 @@
     google: "Google",
     microsoft: "Microsoft",
   };
-  const BOUNTY_POSTING_PROMPT = `You are helping me create and fund a bounty on Agent Bounties (https://agentbounties.app).
+  const BOUNTY_POSTING_PROMPT = `Help me create a bounty on Agent Bounties and guide me through completion.
 
-Initialize Agent Bounties posting mode:
-1. Read https://agentbounties.app/.well-known/agent-bounties.json and https://agentbounties.app/llms.txt before choosing tools or endpoints.
-2. Ask me for the desired outcome, deliverables, objective acceptance tests, deadline, and maximum USDC budget. Ask one concise question at a time.
-3. Produce a clear draft and have me approve it before any public write, wallet signature, funding authorization, or transaction.
-4. Use only official Agent Bounties MCP, API, and discovery routes you can verify. Do not invent platform state or endpoints.
-5. Never ask for a seed phrase or private key. Show the exact bounded signature or payment request and explain its amount, network, recipient, expiry, and purpose before I approve.
-6. Funding and payment are not confirmed by a plan, response, signature, authorization, broadcast, or transaction hash. Treat only confirmed canonical Base USDC evidence as proof.
+First discover your actual access. In the desktop app, open https://agentbounties.app/post.html in the built-in browser (@Browser), discover its WebMCP site tools, and read the page context. Tell me whether you can actually call them. Opening a web chat or reading a page alone does not establish WebMCP access.
 
-Begin by asking: “What outcome do you want agents to deliver?”`;
+Read https://agentbounties.app/.well-known/agent-bounties.json and https://agentbounties.app/llms.txt before choosing endpoints. If site tools are unavailable, discover any connected official Agent Bounties MCP tools. If neither is callable, explain the limitation once and prepare a portable draft for the website; do not invent access or ask me for API keys.
+
+Reuse and preserve my existing answers and draft. Handle navigation, preparation and staging yourself. Ask only for missing business decisions: the outcome, budget and deadline. Propose deliverables, measurable acceptance checks and the exact reviewed verifier yourself; do not ask me for technical hashes or commands. Never invent verifier details or gas sponsorship.
+
+Show one complete review before publication or funding. Leave publication consent, funding, payment, legal consent and wallet confirmations to me. Reuse consent within its approved scope; do not ask permission again for routine preparation. Never ask for a seed phrase or private key. Explain each wallet request's amount, network, recipient, expiry and purpose.
+
+Report actions only when tool results confirm them. Only confirmed canonical Base USDC evidence proves funding or payment; a draft, signature or transaction hash does not. If the outcome is still missing after reading context, ask what I want agents to deliver.`;
 
   function clamp(value, minimum = 0, maximum = 1) {
     return Math.min(maximum, Math.max(minimum, value));
@@ -111,8 +111,9 @@ Begin by asking: “What outcome do you want agents to deliver?”`;
     const encoded = encodeURIComponent(attributedPrompt);
     const links = {
       gpt: {
-        label: "GPT",
-        desktopUrl: null,
+        label: "ChatGPT",
+        // Matches OpenAI Learn's desktop composer: prompt + a shared browser tab.
+        desktopUrl: `codex://threads/new?prompt=${encoded}&browserUrl=${encodeURIComponent("https://agentbounties.app/post.html?from=webmcp")}`,
         webUrl: `https://chatgpt.com/?prompt=${encoded}`,
         webPrefillsPrompt: true,
       },
@@ -215,7 +216,7 @@ Safety:
   }
 
   function competitionPostingPrompt(item) {
-    const basePrompt = BOUNTY_POSTING_PROMPT.replace(/\n\nBegin by asking:[\s\S]*$/, "");
+    const basePrompt = BOUNTY_POSTING_PROMPT;
     return `${basePrompt}
 
 This is a contract-bound Open Competition V2 child-bounty posting session.
@@ -1118,25 +1119,13 @@ ${competitionChildBrief(item)}`;
       let launcherPrompt = BOUNTY_POSTING_PROMPT;
       let contextReady = !postingRequest.requested;
       let contextStatus = postingRequest.requested ? "Verifying the parent competition and reviewed child-bounty brief…" : "";
-      let launchTimer = 0;
-      let appHandoffObserved = false;
 
       if (promptPreview) promptPreview.textContent = launcherPrompt;
 
       const setStatus = (message) => {
         if (status) status.textContent = message;
       };
-      const clearLaunchProbe = () => {
-        win.clearTimeout(launchTimer);
-        launchTimer = 0;
-        doc.removeEventListener("visibilitychange", observeAppHandoff);
-        win.removeEventListener("blur", observeAppHandoff);
-      };
-      const observeAppHandoff = () => {
-        if (doc.hidden || !doc.hasFocus?.()) appHandoffObserved = true;
-      };
       const resetLauncher = () => {
-        clearLaunchProbe();
         assistantButtons.forEach((button) => button.removeAttribute("aria-current"));
         if (customActions) customActions.hidden = true;
         if (webFallback) {
@@ -1155,7 +1144,6 @@ ${competitionChildBrief(item)}`;
         win.requestAnimationFrame?.(() => assistantButtons[0]?.focus());
       };
       const closeDialog = () => {
-        clearLaunchProbe();
         if (dialog.open) dialog.close();
       };
       const copyPrompt = async () => {
@@ -1176,28 +1164,17 @@ ${competitionChildBrief(item)}`;
         }
       };
       const attemptDesktop = (links) => {
-        clearLaunchProbe();
-        appHandoffObserved = false;
-        doc.addEventListener("visibilitychange", observeAppHandoff);
-        win.addEventListener("blur", observeAppHandoff);
         const anchor = doc.createElement("a");
         anchor.href = links.desktopUrl;
         anchor.hidden = true;
         doc.body.append(anchor);
         anchor.click();
         anchor.remove();
-        launchTimer = win.setTimeout(() => {
-          clearLaunchProbe();
-          if (appHandoffObserved) return;
-          setStatus(`${links.label} desktop did not take focus. Opening its web app in this browser…`);
-          win.location.assign(links.webUrl);
-        }, 2400);
       };
 
       openButton.addEventListener("click", showDialog);
       closeButton?.addEventListener("click", closeDialog);
       dialog.addEventListener("close", () => {
-        clearLaunchProbe();
         openButton.setAttribute("aria-expanded", "false");
       });
       dialog.addEventListener("click", (event) => {
@@ -1207,13 +1184,12 @@ ${competitionChildBrief(item)}`;
       });
       assistantButtons.forEach((button) => {
         button.addEventListener("click", async () => {
-          clearLaunchProbe();
           const key = String(button.dataset.bountyAssistant || "").toLowerCase();
           const links = bountyAssistantLinks(key, launcherPrompt);
           if (!links) return;
           assistantButtons.forEach((item) => item.removeAttribute("aria-current"));
           button.setAttribute("aria-current", "true");
-          if (customActions) customActions.hidden = key !== "custom";
+          if (customActions) customActions.hidden = key !== "custom" && key !== "gpt";
           if (webFallback) webFallback.hidden = true;
 
           if (key === "custom") {
@@ -1245,7 +1221,7 @@ ${competitionChildBrief(item)}`;
             win.location.assign(links.webUrl);
             return;
           }
-          setStatus(`Opening ${links.label} desktop with the posting instructions prefilled…`);
+          setStatus(`Requesting ${links.label} desktop. Your browser may ask to open the app. If needed, use the web link or copy the instructions. Nothing is sent automatically.`);
           attemptDesktop(links);
           void promptCopy;
         });


### PR DESCRIPTION
## What Changed

Post a bounty > GPT previously forced a web session and used an outdated interview prompt. Both homepage and existing-draft handoffs now request the ChatGPT desktop app with an unsent prompt and the Agent Bounties posting page beside it, using the same registered desktop route as OpenAI Learn. Web fallback is an explicit link; no timer redirects users while they respond to an app-opening prompt.

The updated instructions discover actual WebMCP or connected MCP access first, preserve existing answers and exact draft context, delegate preparation to the assistant, and retain user publication, funding and wallet confirmations. Draft revision and qualifying parent-bounty terms survive the handoff. The UI and guide distinguish desktop site tools from remote MCP and the web cloud browser.

## Linked Bounty Or Issue

Closes #1313. No paid bounty is claimed for this change.

## Maintainer Change Notice

- Notice created before edits: #1313.
- Open PR queue checked before edits: all open PRs, including active collaborator status and check/review lanes.
- Active PR impact: none known. Maintainer PR #1311 merged during this work; this branch was rebased onto it and the site checker passes. Contributor change-request lanes are unaffected.
- Compatibility/repair path: desktop handoff requires the installed app and supported site-tool availability; copy instructions and web fallback remain available. Run `node scripts/test-ai-bounty-handoff.js` for handoff changes.
- Collaboration branch impact: none required.

## Discovery Feedback

This came from the maintainer testing the real Post a bounty flow through the built-in browser. The confusing web-only destination prevented continuity with available site tools. The public notice invites contributors to share how they found the project and what would make participation easier. After useful work, post your own bounty.

## Acceptance Criteria

- [x] The PR has a clear verifier or review path.
- [x] Deterministic behavior has tests and manual browser checks.
- [x] Payment, settlement and payout behavior is unchanged.

## SDLC And Recovery

- Change class: R1, bounded static UI and validation changes.
- Authoritative source of truth: OpenAI's current WebMCP/browser/MCP docs and its public Open in ChatGPT composer; app launch requests do not prove application state.
- Expected failure modes: missing desktop handler, unsupported site-tool rollout, denied clipboard. Visible copy/web fallback handles each without automatic navigation.
- Idempotency/replay: reopening requests another unsent draft; no publication, signatures or transactions are submitted.
- Rollback: revert this PR and redeploy Pages.
- Health/readiness: focused handoff tests, static site gate, Pages validate/deploy and live asset/chooser checks.
- Recovery fixture: deterministic launch, encoding, preserved-context and clipboard-denial tests; no runtime recovery policy changes.
- Release impact: static Pages assets with cache version bumps; no contract or API changes.

## Local Checks

- `node --test scripts/test-solarpunk-home.js` (13 passed)
- `node scripts/test-ai-bounty-handoff.js` (passed; also added to Pages gate)
- `python scripts/check-site.py` (passed)
- `git diff --check` (passed)
- Browser: actual local WebMCP page-context call succeeded; draft budget/deadline and consent boundaries preserved; homepage desktop request exposes visible manual fallback and stays on the site. Native app completion is not observable through this browser test, so the UI reports only a launch request.

## Review Lane

- [x] Ready for main.
- [ ] Collaboration branch needed.
- [ ] Risky contract/payment path change.
