### PR TITLE
Use one end-to-end posting prompt across entry points

### DIFF
--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -93,6 +93,7 @@ REQUIRED_FILES = {
     "blog/posts.json",
     "ai-bounty-handoff.css",
     "ai-bounty-handoff.js",
+    "posting-prompt.js",
     "authorize.html",
     "authorize.js",
     "bounty-chat-controls.css",
@@ -144,6 +145,7 @@ REQUIRED_FILES = {
     "x402-test-vectors.json",
 }
 ALLOWED_UI_CODE = {
+    "posting-prompt.js",
     "meta-child.js",
     "about.css",
     "ai-bounty-handoff.css",
@@ -642,6 +644,12 @@ def check_metrics(site_dir: Path) -> None:
 def check_homepage(site_dir: Path) -> None:
     page = (site_dir / "index.html").read_text(encoding="utf-8")
     javascript = (site_dir / "solarpunk-home.js").read_text(encoding="utf-8")
+    for entry, consumer in (("index.html", "solarpunk-home.js"), ("post.html", "ai-bounty-handoff.js")):
+        entry_source = (site_dir / entry).read_text(encoding="utf-8")
+        shared_script = re.findall(r'<script src="posting-prompt\.js\?v=\d+"></script>', entry_source)
+        consumer_script = re.search(r'<script src="' + re.escape(consumer) + r'\?v=\d+"></script>', entry_source)
+        if len(shared_script) != 1 or not consumer_script or entry_source.index(shared_script[0]) > consumer_script.start():
+            fail(f"{entry} must load the single canonical posting prompt before {consumer}")
     css = (site_dir / "solarpunk.css").read_text(encoding="utf-8")
     require_phrases(
         "index.html",

--- a/scripts/test-ai-bounty-handoff.js
+++ b/scripts/test-ai-bounty-handoff.js
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
 const assert = require("node:assert/strict");
+const postingPrompt = require("../site/posting-prompt.js");
 
 const source = fs.readFileSync(
   path.join(__dirname, "..", "site", "ai-bounty-handoff.js"),
@@ -44,6 +45,7 @@ const webLaunches = [];
 const copies = [];
 const navigator = { clipboard: { async writeText(text) { copies.push(text); } } };
 const window = {
+  AgentBountiesPostingPrompt: postingPrompt,
   AgentBountiesMetaChild: require("../site/meta-child.js"),
   addEventListener() {},
   dispatchEvent() {},
@@ -161,9 +163,8 @@ for (const invalid of [
 }
 
 const prompt = api.promptFor("Build a public climate dashboard");
-for (const marker of ["prepare_bounty_post", api.mcpUrl, "return ONLY one JSON object", "Otherwise omit all three image fields", "exact public sandboxed_regression_v1 benchmark", "Do not claim that anything is posted"]) {
-  if (!prompt.includes(marker)) throw new Error(`AI handoff prompt missing: ${marker}`);
-}
+assert.equal(api.promptFor(), postingPrompt.build(), "both entry points must use the same canonical prompt");
+assert.equal(prompt, postingPrompt.build({ request: "Build a public climate dashboard" }));
 
 async function verifyDesktopHandoff() {
   const context = {
@@ -174,10 +175,14 @@ async function verifyDesktopHandoff() {
     meta_child: child.meta_child,
   };
   const preparedPrompt = api.show('Keep the tests; change the title to "A & B".', context);
-  assert.match(preparedPrompt, /First discover actual access/);
-  assert.match(preparedPrompt, /Preserve my existing answers/);
+  assert.match(preparedPrompt, /Discover WebMCP tools/);
+  assert.match(preparedPrompt, /preserve my answers and draft/);
   assert.match(preparedPrompt, /only for missing business decisions/);
-  assert.match(preparedPrompt, /QUALIFYING META CHILD/);
+  assert.ok(preparedPrompt.startsWith(postingPrompt.build()));
+  assert.match(preparedPrompt, /qualifying_child_constraints/);
+  assert.match(preparedPrompt, /"total_funding_usdc": "1.00"/);
+  assert.match(preparedPrompt, /distinct_intended_child_solver_required/);
+  assert.match(preparedPrompt, /ordinary hosted prepare_bounty_post/);
   assert.ok(preparedPrompt.includes(draft.benchmark.source.commit));
   assert.ok(preparedPrompt.includes(draft.source_url));
   await chatgptButton.handlers.click();

--- a/scripts/test-solarpunk-home.js
+++ b/scripts/test-solarpunk-home.js
@@ -3,6 +3,7 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 const home = require("../site/solarpunk-home.js");
+const postingPrompt = require("../site/posting-prompt.js");
 
 test("scene lighting follows the declared local-time bands", () => {
   assert.equal(home.sceneBlend(0).phase, "night");
@@ -41,15 +42,25 @@ test("OAuth provider routes and callback messages are bounded", () => {
 
 test("bounty assistant handoffs carry one bounded initialization message", () => {
   const prompt = home.BOUNTY_POSTING_PROMPT;
+  assert.equal(prompt, postingPrompt.build());
   assert.match(prompt, /agentbounties\.app\/.well-known\/agent-bounties\.json/i);
   assert.match(prompt, /agentbounties\.app\/llms\.txt/i);
-  assert.match(prompt, /Leave publication consent, funding, payment, legal consent and wallet confirmations to me/i);
-  assert.match(prompt, /discover.*WebMCP site tools/i);
-  assert.match(prompt, /preserve my existing answers/i);
+  assert.match(prompt, /Leave publication, legal, funding and payment consent to me/i);
+  assert.match(prompt, /Leave wallet confirmations to me/i);
+  assert.match(prompt, /discover WebMCP tools/i);
+  assert.match(prompt, /preserve my answers and draft/i);
   assert.match(prompt, /only for missing business decisions/i);
-  assert.match(prompt, /never ask for a seed phrase or private key/i);
+  assert.match(prompt, /Never request private keys or seed phrases/i);
   assert.match(prompt, /confirmed canonical Base USDC evidence/i);
-  assert.ok(prompt.length < 2000);
+  assert.match(prompt, /check funding readiness/);
+  assert.match(prompt, /phone-wallet QR pairing/);
+  assert.match(prompt, /resume automatically/);
+  assert.match(prompt, /never repeat uncertain transactions/);
+  assert.match(prompt, /canonical creation, funding and claimability/);
+  assert.match(prompt, /public ready-to-earn inventory/);
+  assert.match(prompt, /Return its public link/);
+  assert.match(prompt, /posting and funding remain incomplete/);
+  assert.ok(prompt.length < 2500);
 
   const gpt = home.bountyAssistantLinks("GPT");
   const claude = home.bountyAssistantLinks("claude");

--- a/site/ai-bounty-handoff.js
+++ b/site/ai-bounty-handoff.js
@@ -126,45 +126,22 @@
   }
 
   function promptFor(intent, context) {
-    const revision = context?.draft
-      ? `\n\nCURRENT DRAFT TO REVISE:\n${JSON.stringify({
-          title: context.draft.title,
-          goal: context.draft.goal,
-          acceptance_criteria: context.draft.acceptance_criteria,
-          solver_reward_usdc: context.solver_reward_usdc,
-          verifier_reward_usdc: context.verifier_reward_usdc,
-          task_window_days: context.task_window_days,
-          source_url: context.source_url ?? context.draft.source_url,
-          benchmark: context.benchmark ?? context.draft.benchmark,
-          evidence_schema: context.evidence_schema ?? context.draft.evidence_schema,
-          crowdfund: context.crowdfund,
-        }, null, 2)}\n\nREQUESTED CHANGE:\n${intent}`
-      : `\n\nWHAT I WANT DONE:\n${intent}`;
-
-    return `Help me prepare a public Agent Bounties bounty using the context you already have about me and this request.${revision}${context?.meta_child ? `\n\nQUALIFYING META CHILD: Preserve meta_child: ${JSON.stringify(context.meta_child)} in the returned JSON. Use exactly 1 USDC total, ordinarily 0.99 solver plus 0.01 shared between the two committed verifiers. Identify a distinct intended child solver before funding. Use the browser WebMCP stage tool or paste JSON into this review; do not use the ordinary hosted prepare_bounty_post path for this child.` : ""}
-
-First discover actual access. In the desktop app, open Agent Bounties in the built-in browser (@Browser), discover its WebMCP site tools and read the current page context. Tell me whether those tools are actually callable. A web chat alone does not establish WebMCP access. Read https://agentbounties.app/.well-known/agent-bounties.json and https://agentbounties.app/llms.txt before choosing endpoints. If site tools are unavailable, check for connected official Agent Bounties MCP tools; otherwise explain the limitation once and use the portable draft below.
-
-Preserve my existing answers and exact draft fields. Handle navigation, preparation and staging yourself; ask only for missing business decisions such as the outcome, budget and deadline. Propose measurable checks and prepare the reviewed verifier yourself, without asking me for technical hashes or commands. Leave publication consent, funding, payment, legal consent and wallet confirmations to me, and reuse approvals within their agreed scope. Never ask for a seed phrase or private key, invent gas sponsorship, or report an action completed without a confirming tool result. Only confirmed canonical events prove funding or payment.
-
-${context?.meta_child ? "Use the parent-specific browser review described above. Prepare the JSON for review without publishing it." : "Prefer the discovered WebMCP staging tools. If only the Agent Bounties MCP connector is available, show me the complete terms and reuse my approval if already given. After approval, call prepare_bounty_post."} If this AI can generate and attach a unique image, you may show it for approval and call the tool with bounty_image, the exact image_prompt, and accessible image_alt_text. Otherwise omit all three image fields; the Agent Bounties review page will render a deterministic content-derived visual. Agent Bounties does not require or use a platform model key. The MCP endpoint is ${MCP_URL}.
-
-If neither site tools nor the connector are available, resolve only missing business decisions and then return ONLY one JSON object in this exact shape so I can paste the approved terms directly into the Agent Bounties review flow:
-{
-  "title": "concise public title",
-  "goal": "specific public outcome",
-  "acceptance_criteria": ["binary or measurable check"],
-  "solver_reward_usdc": "${context?.meta_child ? "0.99" : "2.00"}",
-  "verifier_reward_usdc": "${context?.meta_child ? "0.01" : "0.10"}",
-  "task_window_days": 30,
-  "source_url": null,
-  "crowdfund": false,
-  "discovery_source": "AI provider and account used",
-  "benchmark": null,
-  "evidence_schema": null
-}
-
-Constraints: title <= 200 characters; goal <= 4000; 1-20 acceptance criteria, each <= 1000; rewards are positive USDC decimals with at most 6 places; task_window_days is 1-30; source_url is HTTPS or null. A funded coding bounty must include an exact public sandboxed_regression_v1 benchmark and matching evidence_schema; never invent a commit, digest, OCI image, command, or resource limit. Do not claim that anything is posted, created, funded, signed, or paid. I must explicitly approve the bounty terms and separately approve any wallet transaction on Agent Bounties.`;
+    const data = {};
+    if (intent) data.request = String(intent);
+    if (context?.draft) {
+      data.draft = {
+        ...context.draft,
+        solver_reward_usdc: context.solver_reward_usdc ?? context.draft.solver_reward_usdc,
+        verifier_reward_usdc: context.verifier_reward_usdc ?? context.draft.verifier_reward_usdc,
+        task_window_days: context.task_window_days ?? context.draft.task_window_days,
+        source_url: context.source_url ?? context.draft.source_url,
+        benchmark: context.benchmark ?? context.draft.benchmark,
+        evidence_schema: context.evidence_schema ?? context.draft.evidence_schema,
+        crowdfund: context.crowdfund ?? context.draft.crowdfund,
+      };
+    }
+    if (context?.meta_child || context?.draft?.meta_child) data.meta_child = context.meta_child || context.draft.meta_child;
+    return window.AgentBountiesPostingPrompt.build(data);
   }
 
   function setImportStatus(message, tone = "") {

--- a/site/index.html
+++ b/site/index.html
@@ -365,6 +365,7 @@
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
-    <script src="solarpunk-home.js?v=11"></script>
+    <script src="posting-prompt.js?v=1"></script>
+    <script src="solarpunk-home.js?v=12"></script>
   </body>
 </html>

--- a/site/post.html
+++ b/site/post.html
@@ -100,7 +100,7 @@
             <div class="ai-handoff-heading">
               <p class="ai-handoff-eyebrow">Your AI, your context</p>
               <h2 id="ai-handoff-title">Continue in the AI account that already knows you</h2>
-              <p>We copy a purpose-built prompt for your account. Agent Bounties does not call a model or need your provider API key.</p>
+              <p>We copy the posting prompt with your request and draft. Agent Bounties does not call a model or need your provider API key.</p>
             </div>
 
             <div class="ai-original" aria-label="Bounty idea to hand off">
@@ -255,7 +255,8 @@
     <script src="evm.js"></script>
     <script src="meta-child.js?v=1"></script>
     <script src="bounty-entry.js?v=1"></script>
-    <script src="ai-bounty-handoff.js?v=7"></script>
+    <script src="posting-prompt.js?v=1"></script>
+    <script src="ai-bounty-handoff.js?v=8"></script>
     <script src="bounty-composer-v2.js?v=10"></script>
     <script src="bounty-chat-ui.js?v=4"></script>
   </body>

--- a/site/posting-prompt.js
+++ b/site/posting-prompt.js
@@ -1,0 +1,41 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.AgentBountiesPostingPrompt = api;
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  const PROMPT = `Help me create, fund and publicly post a bounty on Agent Bounties.
+
+1. Use https://agentbounties.app/post.html in @Browser, preserving existing page context. Discover WebMCP tools and read page context; confirm actual access. Read https://agentbounties.app/.well-known/agent-bounties.json and https://agentbounties.app/llms.txt before choosing endpoints. If needed, use connected official MCP tools. If neither is available, prepare a portable draft and explain that posting and funding remain incomplete; do not request API keys.
+
+2. Save and resume my posting journey; preserve my answers and draft. Ask together only for missing business decisions: outcome, total USDC budget and deadline. Propose deliverables and measurable checks, prepare a supported reviewed verifier, stage the draft and check funding readiness. Resolve blockers or explain unsupported work; never invent verifier details.
+
+3. Show one review of public terms, rewards, fees, total cost and deadline. Leave publication, legal, funding and payment consent to me. Reuse unchanged approvals; handle routine preparation yourself.
+
+4. Guide wallet connection, offering phone-wallet QR pairing. Explain each request's amount, network, recipient, expiry, purpose and gas cost or confirmed sponsorship. Never request private keys or seed phrases. Leave wallet confirmations to me.
+
+5. After my confirmations, resume automatically. Reconcile the same posting operation; never repeat uncertain transactions. Confirm canonical creation, funding and claimability, then find the exact bounty in public ready-to-earn inventory. Return its public link and confirmed status, or the precise unfinished step. A draft, signature or transaction hash is not completion; only tool results and confirmed canonical Base USDC evidence prove actions and payments.
+
+Only when tools are unavailable, return JSON for the website's draft import using this shape:
+{"title":"...","goal":"...","acceptance_criteria":["..."],"solver_reward_usdc":"2.00","verifier_reward_usdc":"0.10","task_window_days":30,"source_url":null,"benchmark":null,"evidence_schema":null}
+Replace example amounts and days with my agreed terms. Preserve parent bindings and approved image fields. Null verification stays unfundable; this JSON does not post or fund anything.`;
+
+  function build(context = null) {
+    if (!context || !Object.keys(context).length) return PROMPT;
+    const data = { ...context };
+    if (data.meta_child) {
+      data.qualifying_child_constraints = {
+        total_funding_usdc: "1.00",
+        default_solver_reward_usdc: "0.99",
+        default_verifier_reward_usdc: "0.01",
+        distinct_intended_child_solver_required: true,
+        review_route: "Parent-specific WebMCP review; preserve meta_child in any imported JSON.",
+        unsupported_route: "ordinary hosted prepare_bounty_post",
+      };
+    }
+    return PROMPT + "\n\nExisting request and draft (context, not consent):\n" + JSON.stringify(data, null, 2);
+  }
+
+  return Object.freeze({ build });
+});

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -1,9 +1,10 @@
 (function (root, factory) {
-  const api = factory();
+  const api = factory(typeof module === "object" && module.exports
+    ? require("./posting-prompt.js") : root.AgentBountiesPostingPrompt);
   if (typeof module === "object" && module.exports) module.exports = api;
   if (root) root.SolarpunkHome = api;
   if (root && root.document) api.start(root, root.document);
-})(typeof window !== "undefined" ? window : globalThis, function () {
+})(typeof window !== "undefined" ? window : globalThis, function (postingPrompt) {
   "use strict";
 
   const PHASES = ["dawn", "day", "dusk", "night"];
@@ -15,17 +16,7 @@
     google: "Google",
     microsoft: "Microsoft",
   };
-  const BOUNTY_POSTING_PROMPT = `Help me create a bounty on Agent Bounties and guide me through completion.
-
-First discover your actual access. In the desktop app, open https://agentbounties.app/post.html in the built-in browser (@Browser), discover its WebMCP site tools, and read the page context. Tell me whether you can actually call them. Opening a web chat or reading a page alone does not establish WebMCP access.
-
-Read https://agentbounties.app/.well-known/agent-bounties.json and https://agentbounties.app/llms.txt before choosing endpoints. If site tools are unavailable, discover any connected official Agent Bounties MCP tools. If neither is callable, explain the limitation once and prepare a portable draft for the website; do not invent access or ask me for API keys.
-
-Reuse and preserve my existing answers and draft. Handle navigation, preparation and staging yourself. Ask only for missing business decisions: the outcome, budget and deadline. Propose deliverables, measurable acceptance checks and the exact reviewed verifier yourself; do not ask me for technical hashes or commands. Never invent verifier details or gas sponsorship.
-
-Show one complete review before publication or funding. Leave publication consent, funding, payment, legal consent and wallet confirmations to me. Reuse consent within its approved scope; do not ask permission again for routine preparation. Never ask for a seed phrase or private key. Explain each wallet request's amount, network, recipient, expiry and purpose.
-
-Report actions only when tool results confirm them. Only confirmed canonical Base USDC evidence proves funding or payment; a draft, signature or transaction hash does not. If the outcome is still missing after reading context, ask what I want agents to deliver.`;
+  const BOUNTY_POSTING_PROMPT = postingPrompt.build();
 
   function clamp(value, minimum = 0, maximum = 1) {
     return Math.min(maximum, Math.max(minimum, value));


### PR DESCRIPTION
## What Changed

The homepage and draft editor previously maintained separate posting instructions and left wallet guidance and the final public-listing check implicit. Both now load one canonical prompt from site/posting-prompt.js. Its five steps discover access, prepare a funding-ready draft, obtain the person's review, guide wallet confirmation, and reconcile canonical funding plus the public ready-to-earn listing. The same instructions preserve business answers and unchanged approvals, offer phone-wallet QR pairing, and prohibit repeating uncertain transactions.

The draft editor only attaches the existing request and draft as context, preserving parent-bound terms. The canonical prompt includes a compact JSON fallback that explicitly remains incomplete. Both entry points and every provider use this same prompt; provider-specific URLs only transport it. The prompt is 2,288 characters including the fallback.

## Linked Bounty Or Issue

Follow-up to #1313 and #1314. No paid bounty is claimed.

## Maintainer Change Notice

- Notice before edits: https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5564178825
- Single-source clarification before consolidation: https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5564236045
- All open PRs checked. No new contributor response on #1268; contributor review lanes are unchanged.
- Older maintainer PRs #1196 and #908 overlap homepage files: retain the current prompt and asset versions when reconciling those branches. No collaboration branch needed.
- Compatibility: tool discovery and the existing consent/payment boundaries remain authoritative; unsupported verification remains a blocker.

## Discovery Feedback

The maintainer's real posting-flow test exposed the missing completion instructions. The linked notice invites feedback about discovery sources and posting friction. After useful work, post your own bounty.

## Acceptance Criteria

- [x] Explicit supported-verifier/readiness check before funding.
- [x] User publication, legal, funding, payment and wallet consent preserved.
- [x] Canonical confirmation and exact public listing required for success.
- [x] Portable fallback reports incomplete posting/funding.

## SDLC And Recovery

- R1: static prompt guidance and existing checks; no API, wallet, verifier or payment logic changes.
- Source of truth: live tool results and confirmed canonical evidence.
- Failure modes: unavailable tools/verifier/wallet or uncertain transaction; explain blockers and reconcile the existing operation.
- Replay: no new wallet authority; do not repeat uncertain transactions.
- Rollback: revert this PR and redeploy Pages.
- Health/readiness: focused prompt/handoff checks, site validation and live asset comparison.
- Recovery fixture: not applicable to prompt-only changes; existing recovery behavior remains unchanged.
- Release: cache versions bumped on both entry pages.

## Local Checks

- Checkout freshness guard passed against current main; core preflight passed.
- node --test scripts/test-solarpunk-home.js: 13 passed.
- node scripts/test-ai-bounty-handoff.js: passed.
- python scripts/check-site.py: passed.
- git diff --check: passed.
- Browser: shared prompt visibly loads in the homepage preview and draft editor; the editor contains exactly one instruction set and preserves the local test request. Existing tests assert the consumers use the same prompt and the shared script loads first.

## Review Lane

- [x] Ready for main.

These checks validate the handoff contract, not a new real-money bounty lifecycle.
