### PR TITLE
Make posting preserve the brief and support creator-reviewed design work

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77
+          --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77
+          --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77
+          --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "23611288dc879bad70ef6966789a5132b136d6e4ca69db7b25ced5c6b581c
 PIPELINE_TEST_SHA256 = "8b408fc80ff5bf4871ff679f119e6053834b5c9544b1ea0be70e11414cab3be2"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77"
+WORKER_BUILD_SHA256 = "4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"
 SIGNING_RUNTIME_SHA256 = "89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "a4a8c489d782932f6a087d031016709216ee4501902ea7ed89deb82303aaf6a9",
+    ".github/workflows/regression-verifier-runner.yml": "bead217581bc9218110ed7d366ca7c6151379f0653c9c2871446103c5a1a8f1e",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "d6904534683f36d2b91cda1196212ab1c2d5cd21e28acc83a1a2cd059979f7f6",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "da7d84b51492571c7fafffb3e7e3803907c6b16922bb904e9382a8857ff12720",
+    ".github/workflows/regression-verifier-signer.yml": "339105017e6b45c6497cf5c082d7a7d0dd356dfbdb61761e6c48b071c01a18c4",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "a04d096d0092f9c4b08f205c554e4019d3834018de91a9c32bac2ad350d264eb",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 809361008220ce78e83ee93e5a2cd821ebc186b29960873de857f0ea8e425d77"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/crates/api/src/opportunities.rs
+++ b/crates/api/src/opportunities.rs
@@ -833,12 +833,13 @@ pub fn canonical_opportunity(
         gross_cash_margin_positive: gross_cash_margin > 0,
         scope_disclaimer: "Gross cash margin is solver reward minus required external spend. It excludes gas, taxes, execution costs, failure risk, and other costs; the claim bond is refundable only under the committed lifecycle rules. It is not guaranteed net profit.".to_string(),
     };
-    let verification_method =
-        if item.verification_mode == "signed_quorum" && item.verifier_threshold == Some(1) {
-            "single_verifier".to_string()
-        } else {
-            item.verification_mode.clone()
-        };
+    let verification_method = if item.runner_identifier.as_deref() == Some("creator_review_v1") {
+        "creator_review (human verdict)".to_string()
+    } else if item.verification_mode == "signed_quorum" && item.verifier_threshold == Some(1) {
+        "single_verifier".to_string()
+    } else {
+        item.verification_mode.clone()
+    };
     Some(OpportunityItem {
         opportunity_id: opportunity_id.clone(),
         source_type: "canonical_base".to_string(),

--- a/crates/chain-base/src/creator_review.rs
+++ b/crates/chain-base/src/creator_review.rs
@@ -1,0 +1,138 @@
+use super::*;
+
+pub(crate) const ENGINE: &str = "creator_review_v1";
+
+// A supported human review path, not an assertion that an automated service is live.
+pub(crate) fn validate(document: &AutonomousBountyTermsDocument) -> Result<(), ChainBaseError> {
+    let policy = &document.verification_policy;
+    let benchmark = &document.benchmark;
+    let contract = &document.contract_terms;
+    let schema = &document.evidence_schema;
+    let creator = contract["creator_wallet"].as_str().unwrap_or_default();
+    let cutoff = benchmark["delivery_deadline"].as_u64().unwrap_or(0);
+    let signers = policy["verifiers"].as_array();
+    let exact_creator = signers.is_some_and(|values| {
+        values.len() == 1
+            && values[0]
+                .as_str()
+                .is_some_and(|value| value.eq_ignore_ascii_case(creator))
+    });
+    let evidence = schema["required"].as_array().is_some_and(|required| {
+        ["artifact_url", "artifact_sha256"]
+            .iter()
+            .all(|field| required.contains(&json!(field)))
+    });
+    if benchmark["engine"] != ENGINE
+        || policy["engine"] != ENGINE
+        || policy["mechanism"] != "signed_quorum"
+        || policy["threshold"] != 1
+        || normalize_evm_address(creator).is_err()
+        || !exact_creator
+        || benchmark["reviewer"] != "creator"
+        || benchmark["acceptance"] != "all_published_criteria"
+        || cutoff == 0
+        || contract["funding_deadline"].as_u64() != Some(cutoff)
+        || document.acceptance_criteria.is_empty()
+        || policy["public_disclosure"]
+            .as_str()
+            .is_none_or(|text| text.trim().is_empty())
+        || schema["type"] != "object"
+        || !evidence
+        || schema["properties"]["artifact_url"]["type"] != "string"
+        || schema["properties"]["artifact_url"]["pattern"] != "^https://"
+        || schema["properties"]["artifact_sha256"]["type"] != "string"
+        || schema["properties"]["artifact_sha256"]["pattern"] != "^sha256:[0-9a-f]{64}$"
+    {
+        return Err(ChainBaseError::InvalidVerificationConfiguration(
+            "creator review must bind the creator as sole signer, all published criteria, an exact delivery/funding cutoff, disclosure and public artifact evidence".to_string()));
+    }
+    Ok(())
+}
+
+pub(crate) fn submission_on_time(
+    document: &AutonomousBountyTermsDocument,
+    verification_expires_at: u64,
+) -> bool {
+    // AgentBounty._submit emits block.timestamp + the immutable verification window.
+    document.contract_terms["verification_window_seconds"]
+        .as_u64()
+        .and_then(|window| verification_expires_at.checked_sub(window))
+        .zip(document.benchmark["delivery_deadline"].as_u64())
+        .is_some_and(|(submitted_at, cutoff)| submitted_at <= cutoff)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn document() -> AutonomousBountyTermsDocument {
+        serde_json::from_value(json!({
+            "schema_version":"agent-bounties/terms-v1", "contract_terms":{
+                "creator_wallet":"0x1111111111111111111111111111111111111111", "funding_deadline":2000, "verification_window_seconds":100},
+            "title":"Design deliverable", "goal":"Deliver the specified model", "acceptance_criteria":["All specified files open and meet the dimensioned brief"],
+            "benchmark":{"engine":ENGINE,"reviewer":"creator","acceptance":"all_published_criteria","delivery_deadline":2000},
+            "verification_policy":{"engine":ENGINE,"mechanism":"signed_quorum","threshold":1,"verifiers":["0x1111111111111111111111111111111111111111"],"public_disclosure":"Creator signs the human review verdict."},
+            "evidence_schema":{"type":"object","required":["artifact_url","artifact_sha256"],"properties":{"artifact_url":{"type":"string","pattern":"^https://"},"artifact_sha256":{"type":"string","pattern":"^sha256:[0-9a-f]{64}$"}}}, "source_url":null,"discovery_source":null
+        })).unwrap()
+    }
+    #[test]
+    fn creator_review_binds_authority_and_evidence() {
+        let doc = document();
+        validate(&doc).unwrap();
+        for (field, value) in [
+            ("threshold", json!(2)),
+            ("engine", json!("sandboxed_regression_v1")),
+            (
+                "verifiers",
+                json!(["0x2222222222222222222222222222222222222222"]),
+            ),
+        ] {
+            let mut invalid = doc.clone();
+            invalid.verification_policy[field] = value;
+            assert!(validate(&invalid).is_err());
+        }
+        let mut invalid = doc.clone();
+        invalid.contract_terms["funding_deadline"] = json!(2001);
+        assert!(validate(&invalid).is_err());
+        let mut invalid = doc;
+        invalid.evidence_schema["required"] = json!([]);
+        assert!(validate(&invalid).is_err());
+    }
+    #[test]
+    fn delivery_cutoff_uses_canonical_submission_not_review_time() {
+        let doc = document();
+        assert!(submission_on_time(&doc, 2100));
+        assert!(!submission_on_time(&doc, 2101));
+        assert!(!submission_on_time(&doc, 99));
+    }
+
+    #[test]
+    fn creator_review_can_prepare_fully_funded_public_creation_with_exact_terms() {
+        let now = Utc::now();
+        let cutoff = now.timestamp() + 86400;
+        let mut doc = document();
+        doc.benchmark["delivery_deadline"] = json!(cutoff);
+        doc.contract_terms = json!({
+            "protocol_version":"agent-bounties/autonomous-v1", "creator_wallet":"0x1111111111111111111111111111111111111111",
+            "network":"base-mainnet", "settlement_token":BASE_MAINNET_USDC_TOKEN_ADDRESS,
+            "solver_reward":{"amount":18_000_000,"currency":"usdc"}, "verifier_reward":{"amount":2_000_000,"currency":"usdc"},
+            "claim_bond":{"amount":2_000_000,"currency":"usdc"}, "initial_funding":{"amount":20_000_000,"currency":"usdc"},
+            "funding_deadline":cutoff,"claim_window_seconds":86400,"verification_window_seconds":172800,"creation_nonce":format!("0x{}","12".repeat(32))
+        });
+        let record = build_autonomous_bounty_terms_record(
+            "0x1111111111111111111111111111111111111111",
+            doc,
+            now,
+        )
+        .unwrap();
+        let create = autonomous_bounty_create_from_terms(&record).unwrap();
+        validate_autonomous_creation_for_public_earning("base-mainnet", &create, &record).unwrap();
+        assert_eq!(create.verifiers, vec![record.creator_wallet.clone()]);
+        assert_eq!(create.threshold, 1);
+        let mut altered = create;
+        altered.verifiers[0] = "0x2222222222222222222222222222222222222222".to_string();
+        assert!(
+            validate_autonomous_creation_for_public_earning("base-mainnet", &altered, &record)
+                .is_err()
+        );
+    }
+}

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 use verifier_sdk::RegressionSandboxPolicy;
 
 mod agent_wallet_readiness;
+mod creator_review;
 mod open_competition;
 mod open_competition_v2;
 mod open_competition_v2_planner;
@@ -3996,7 +3997,15 @@ impl AutonomousBountyRecoveryReservations {
 }
 
 pub fn autonomous_bounty_is_earning_ready(item: &AutonomousBountyFeedItem) -> bool {
-    item.status == "claimable" && item.terms_valid && item.verification_ready
+    item.status == "claimable"
+        && item.terms_valid
+        && item.verification_ready
+        && !item.terms.as_ref().is_some_and(|terms| {
+            terms.document.benchmark["engine"] == creator_review::ENGINE
+                && terms.document.benchmark["delivery_deadline"]
+                    .as_u64()
+                    .is_none_or(|deadline| deadline <= Utc::now().timestamp().max(0) as u64)
+        })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -4445,6 +4454,15 @@ pub fn validate_attestation_request_against_feed(
                 "submission verification deadline is missing".to_string(),
             )
         })?;
+    if request.passed
+        && terms.document.benchmark["engine"] == creator_review::ENGINE
+        && (creator_review::validate(&terms.document).is_err()
+            || !creator_review::submission_on_time(&terms.document, verification_expires_at))
+    {
+        return Err(ChainBaseError::InvalidAttestationScope(
+            "creator review cannot pass an invalid policy or late canonical submission".to_string(),
+        ));
+    }
     if !matches_round || !matches_submission || !matches_evidence {
         return Err(ChainBaseError::InvalidAttestationScope(
             "attestation does not match the current submission round and hashes".to_string(),
@@ -5387,6 +5405,32 @@ pub fn build_autonomous_bounty_feed(
         let gross_cash_margin = i128::from(solver_reward) - i128::from(required_external_spend);
         let (verification_ready, verification_readiness_reason) = if !terms_valid {
             (false, "content-addressed terms are invalid or unavailable")
+        } else if verification_mode == "signed_quorum"
+            && terms_record
+                .as_ref()
+                .is_some_and(|terms| terms.document.benchmark["engine"] == creator_review::ENGINE)
+        {
+            if terms_record
+                .as_ref()
+                .is_some_and(|terms| creator_review::validate(&terms.document).is_ok())
+            {
+                if status == "claimable"
+                    && terms_record.as_ref().is_some_and(|terms| {
+                        terms.document.benchmark["delivery_deadline"]
+                            .as_u64()
+                            .is_none_or(|cutoff| cutoff <= Utc::now().timestamp().max(0) as u64)
+                    })
+                {
+                    (false, "the creator-review delivery deadline passed; cancel and recover unclaimed funds")
+                } else {
+                    (true, "creator-signed human review is supported; completion requires the creator's verdict")
+                }
+            } else {
+                (
+                    false,
+                    "creator review authority, deadline or evidence terms are invalid",
+                )
+            }
         } else if verification_mode == "signed_quorum" {
             regression_quorum_readiness(&creation_data, terms_record.as_ref())
         } else if verification_mode != "deterministic_module" {
@@ -5611,6 +5655,11 @@ pub fn build_autonomous_bounty_terms_record(
     }
     validate_reconciled_regression_benchmark(&document)?;
     validate_contract_terms_document(&normalized_creator, &document.contract_terms, created_at)?;
+    if document.benchmark["engine"] == creator_review::ENGINE
+        || document.verification_policy["engine"] == creator_review::ENGINE
+    {
+        creator_review::validate(&document)?;
+    }
     validate_known_deterministic_module_semantics(&document)?;
     validate_claim_metadata(&mut document)?;
     let document_value = serde_json::to_value(&document)
@@ -6642,6 +6691,10 @@ pub fn validate_autonomous_creation_for_public_earning(
             }
         }
         AutonomousVerificationMode::SignedQuorum => {
+            if terms.document.benchmark["engine"] == creator_review::ENGINE {
+                creator_review::validate(&terms.document)?;
+                return Ok(());
+            }
             validate_regression_evidence_schema(&terms.document.evidence_schema)?;
             let threshold = usize::from(create.threshold);
             let exact_verifiers = (1..=BASE_MAINNET_STANDING_META_V2_VERIFIERS.len())

--- a/crates/web-public/src/lib.rs
+++ b/crates/web-public/src/lib.rs
@@ -1035,7 +1035,8 @@ pub fn discovery_manifest(api_base_url: &str, mcp_base_url: &str) -> DiscoveryMa
                 "default_for_new_bounties": true,
                 "default_threshold": 1,
                 "default_verifiers": ["0xbe6292b9e465f549e2363b918d6dd9187038431e"],
-                "earning_inventory": "ready when the one precommitted verifier service and exact sandbox benchmark are available",
+                "earning_inventory": "ready when the precommitted service and exact sandbox benchmark are available, or for an explicitly disclosed creator_review_v1 with creator as sole signer and a future delivery cutoff",
+                "creator_review": {"engine":"creator_review_v1", "webmcp_review_mode":"creator", "delivery_deadline":"required ISO timestamp with timezone offset; immutable benchmark stores Unix seconds", "authority":"creator wallet only; human review is not independent or automated", "evidence":["artifact_url","artifact_sha256"], "scope":"digital deliverables including design and CAD; excluded from qualifying meta children"},
                 "settlement": "The precommitted verifier signs the exact round, solver, submission, evidence, result, response, and deadline. Multi-verifier review is optional for higher-risk work."
             }),
             serde_json::json!({

--- a/docs/autonomous-protocol.md
+++ b/docs/autonomous-protocol.md
@@ -363,6 +363,37 @@ parent claim timestamp. Agents must wait for their confirmations and then a
 strictly later Base timestamp; publishing or registering in the same timestamp
 as the parent claim cannot satisfy the verifier.
 
+### Creator review for digital deliverables
+
+Design and CAD bounties may explicitly commit `creator_review_v1` under
+`signed_quorum` with the creator as the sole verifier, threshold one. This is
+human review, not an automated or independent verifier service. The creator
+signs the verdict after reviewing every published acceptance criterion; an AI
+may prepare the assessment but cannot approve it. The positive verifier reward
+is paid to the creator on either verdict. Rejection uses the solver bond and
+leaves the bounty fully funded; verification timeout returns the bond.
+
+The benchmark commits `reviewer: "creator"`,
+`acceptance: "all_published_criteria"`, and `delivery_deadline` in Unix seconds,
+matching the immutable funding deadline. The evidence schema requires an HTTPS
+`artifact_url` and `artifact_sha256` with the exact SHA-256 pattern. WebMCP accepts
+`review_mode: "creator"` and an ISO `delivery_deadline` with timezone offset,
+then derives these technical fields. This option is excluded from qualifying
+meta children, which retain their committed automated verifier requirements.
+
+The delivery cutoff is enforced by the signed reviewer against canonical
+submission time (the emitted verification expiry minus the immutable review
+window). The contract's relative claim timeout is separate; it does not become
+a calendar deadline. After the delivery cutoff, unclaimed work leaves earning
+inventory and may be cancelled for contributor refunds. An on-time submission
+may still be reviewed within its original verification window.
+
+The participation workspace exposes `agent_bounties_get_creator_review` and
+`agent_bounties_stage_creator_verdict`. The creator confirms the exact verdict
+in the page and wallet; a signature or broadcast is not a completed payment.
+Only the matching canonical `BountySettled` proves payout. Existing signature
+and settlement planner APIs and MCP tools also support this committed policy.
+
 ### AI Judge Quorum
 
 AI judging uses the signed-quorum path and requires threshold two or greater.

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:3a2acb106fddae5200e338a7db567ea5fbc881807b2ebc08a1b00b0fbc799de2",
+    "benchmark_digest": "sha256:93c7a96f9814b7e3a1f8934077259736a47e11c058f6d8dd13c47fc563ab88a1",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -94,6 +94,10 @@ REQUIRED_FILES = {
     "ai-bounty-handoff.css",
     "ai-bounty-handoff.js",
     "posting-prompt.js",
+    "posting-workspace.js",
+    "posting-workspace.css",
+    "creator-review.js",
+    "creator-review-workspace.js",
     "authorize.html",
     "authorize.js",
     "bounty-chat-controls.css",
@@ -146,6 +150,10 @@ REQUIRED_FILES = {
 }
 ALLOWED_UI_CODE = {
     "posting-prompt.js",
+    "posting-workspace.js",
+    "posting-workspace.css",
+    "creator-review.js",
+    "creator-review-workspace.js",
     "meta-child.js",
     "about.css",
     "ai-bounty-handoff.css",
@@ -541,7 +549,7 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
             "data-card-verifier",
             "function renderVerifierTerms",
             "if (!ui.verifierSummary || !ui.verifier) return;",
-            'bounty-composer-v2.js?v=10',
+            'bounty-composer-v2.js?v=11',
             "function verificationReadiness",
             "verificationReadiness(benchmark, state.draft?.evidence_schema)",
             'sourceSnapshotDigest.pattern === "^sha256:[0-9a-f]{64}$"',
@@ -1278,11 +1286,11 @@ def main() -> int:
                 '<meta name="description"',
                 f'<link rel="icon" href="{prefix}favicon.svg" type="image/svg+xml">',
                 f'<link rel="canonical" href="{canonical}">',
-                f'<script src="{prefix}analytics-config.js?v=5"></script>',
+                f'<script src="{prefix}analytics-config.js?v=',
                 f'<script src="{prefix}analytics.js?v=4"></script>',
             ],
         )
-        if text.index(f'src="{prefix}analytics-config.js?v=5"') > text.index(f'src="{prefix}analytics.js?v=4"'):
+        if text.index(f'src="{prefix}analytics-config.js?v=') > text.index(f'src="{prefix}analytics.js?v=4"'):
             fail(f"{relative}: analytics config must load before analytics.js")
         if relative not in INDEXABLE_PAGES and '<meta name="robots" content="noindex, nofollow">' not in text:
             fail(f"{relative}: transactional handoffs must remain noindex, nofollow")

--- a/scripts/test-ai-bounty-handoff.js
+++ b/scripts/test-ai-bounty-handoff.js
@@ -46,6 +46,7 @@ const copies = [];
 const navigator = { clipboard: { async writeText(text) { copies.push(text); } } };
 const window = {
   AgentBountiesPostingPrompt: postingPrompt,
+  AgentBountiesCreatorReview: require("../site/creator-review.js"),
   AgentBountiesMetaChild: require("../site/meta-child.js"),
   addEventListener() {},
   dispatchEvent() {},

--- a/scripts/test-creator-review.js
+++ b/scripts/test-creator-review.js
@@ -1,0 +1,104 @@
+"use strict";
+const { test } = require("node:test"), assert = require("node:assert/strict"), vm = require("node:vm"), fs = require("node:fs");
+const review = require("../site/creator-review.js"), workspace = require("../site/creator-review-workspace.js");
+const contract = "0x" + "22".repeat(20), creator = "0x" + "11".repeat(20), solver = "0x" + "33".repeat(20);
+const hash = (byte) => "0x" + byte.repeat(32);
+function environment(options = {}) {
+  const elements = new Map(), records = new Map(), requests = [];
+  const element = () => ({ hidden: true, disabled: true, textContent: "", children: [], handlers: {}, addEventListener(name, fn) { this.handlers[name] = fn; }, replaceChildren() { this.children = []; }, append(child) { this.children.push(child); } });
+  const root = element(); root.querySelector = (name) => { if (!elements.has(name)) elements.set(name, element()); return elements.get(name); };
+  const win = { location: { search: `?bountyContract=${contract}` }, document: { querySelector: () => root, createElement: element }, sessionStorage: { getItem: (key) => records.get(key) || null, setItem: (key, value) => records.set(key, value), removeItem: (key) => records.delete(key) } };
+  vm.runInNewContext(fs.readFileSync(require.resolve("../site/evm.js"), "utf8"), { window: win, TextEncoder, BigInt, Uint8Array });
+  const now = Math.floor(Date.now() / 1000), terms = { terms_hash: hash("aa"), policy_hash: hash("bb"), document: { acceptance_criteria: ["Files open", "Dimensions match"], contract_terms: { verification_window_seconds: 3600 }, benchmark: { engine: review.ENGINE, delivery_deadline: now + 1000 } } };
+  const job = { bounty_contract: contract, bounty_id: hash("cc"), round: 1, solver_wallet: solver, threshold: 1, eligible_verifiers: [creator], terms, verifier_reward: "2000000", current_solver_payout: "20000000", verification_expires_at: now + 3600, submission_evidence: { artifact_hash: hash("dd"), evidence_hash: hash("ee") } };
+  const submitted = { kind: "submission_added", id: "submission", contract_address: contract, bounty_id: job.bounty_id, block_number: 1, log_index: 0, data: { round: 1, solver, submission_hash: hash("dd"), evidence_hash: hash("ee") } };
+  const item = { status: "submitted", bounty_contract: contract, bounty_id: job.bounty_id, creator, terms_valid: true, terms_hash: terms.terms_hash, terms, events: [submitted] };
+  win.AgentBountiesWorkflow = { createClient: () => ({ async request(path, body) {
+    if (path.includes("/feed?")) return [item];
+    if (path.includes("/verification-jobs?")) return [job];
+    if (path.endsWith("verification-attestation-plan")) { const plan = workspace.typedData(body.attestation); if (options.alteredSignature) plan.message.verifier = solver; return plan; }
+    if (path.endsWith("attestation-settlement-plan")) return { from: creator, to: options.alteredTransaction ? solver : contract, value_wei: "0", data: workspace.settlementData(body.attestations[0], win.AgentBountiesEvm) };
+    throw new Error(`Unexpected endpoint ${path}`);
+  } }) };
+  let rejected = false;
+  win.ethereum = { async request({ method }) {
+    requests.push(method);
+    if (method === "eth_accounts" || method === "eth_requestAccounts") return [options.foreignWallet ? solver : creator];
+    if (method === "eth_chainId") return "0x2105";
+    if (method === "eth_signTypedData_v4") return "0x" + "ab".repeat(65);
+    if (method === "eth_sendTransaction") {
+      if (options.rejectOnce && !rejected) { rejected = true; throw Object.assign(new Error("Rejected"), { code: 4001 }); }
+      if (options.lostResponse) throw new Error("Connection lost after sending");
+      return hash("ff");
+    }
+    throw new Error(method);
+  } };
+  workspace.start(win);
+  const checks = terms.document.acceptance_criteria.map((criterion) => ({ criterion, passed: true, reason: "Verified in the supplied artifact" }));
+  return { win, item, job, checks, requests, records, elements, stage: () => win.AgentBountiesCreatorReviewWorkspace.stage({ checks }), click: () => elements.get("button").handlers.click({ isTrusted: true }), refresh: () => win.AgentBountiesCreatorReviewWorkspace.refresh() };
+}
+test("creator review is explicit, binds a calendar deadline, and cannot replace meta verification", () => {
+  const draft = { review_mode: "creator", delivery_deadline: new Date(Date.now() + 7 * 86400000).toISOString() };
+  const prepared = review.prepare(draft);
+  assert.equal(prepared.delivery_deadline, draft.delivery_deadline);
+  assert.equal(review.deadline("2099-09-13T18:00:00-06:00"), "2099-09-14T00:00:00.000Z");
+  assert.equal(review.ready(prepared.benchmark, prepared.evidence_schema), true);
+  assert.equal(review.prepare({ benchmark: null }).benchmark, null);
+  assert.throws(() => review.prepare({ ...draft, meta_child: {} }), /meta/);
+  assert.throws(() => review.prepare({ ...draft, benchmark: { engine: "sandboxed_regression_v1" } }), /replace/);
+  assert.throws(() => review.prepare({ ...draft, delivery_deadline: "Sunday 6pm" }), /timestamp/);
+  assert.throws(() => review.prepare({ ...draft, delivery_deadline: "2000-01-01T00:00:00Z" }), /future/);
+});
+test("the assessment must cover exact criteria and cannot pass a late submission", () => {
+  const env = environment();
+  assert.equal(workspace.assessment(env.job, { checks: env.checks }).passed, true);
+  assert.throws(() => workspace.assessment(env.job, { checks: [...env.checks].reverse() }), /match/);
+  env.job.verification_expires_at += 1001;
+  assert.equal(workspace.assessment(env.job, { checks: env.checks }).passed, false);
+});
+test("staging cannot sign and changed signature or transaction scopes cannot reach settlement", async () => {
+  for (const option of ["alteredSignature", "alteredTransaction", "foreignWallet"]) {
+    const env = environment({ [option]: true }); await env.stage(); assert.equal(env.requests.length, 0);
+    await env.click(); assert.equal(env.requests.includes("eth_sendTransaction"), false);
+    if (option !== "alteredTransaction") assert.equal(env.requests.includes("eth_signTypedData_v4"), false);
+  }
+});
+test("a lost send response is not payment and cannot send again", async () => {
+  const env = environment({ lostResponse: true }); await env.stage(); await env.click(); await env.click();
+  assert.equal(env.requests.filter((method) => method === "eth_sendTransaction").length, 1);
+  assert.equal((await env.refresh()).paid, false);
+  await assert.rejects(env.stage(), /recorded verdict/);
+  const event = { ...env.item.events[0], kind: "bounty_settled", id: "settled", block_number: 2, data: { ...env.item.events[0].data, round: 2 } };
+  env.item.events.push(event); assert.equal((await env.refresh()).paid, false);
+  event.data.round = 1; assert.equal((await env.refresh()).paid, true);
+});
+test("explicitly rejected transaction resumes the same signed verdict", async () => {
+  const env = environment({ rejectOnce: true }); await env.stage(); await env.click(); await env.click();
+  assert.equal(env.requests.filter((method) => method === "eth_signTypedData_v4").length, 1);
+  assert.equal(env.requests.filter((method) => method === "eth_sendTransaction").length, 2);
+  assert.equal((await env.refresh()).status, "pending_confirmation");
+});
+
+test("saved brief edits reach the shared journey and invalidate an older funding proposal", () => {
+  const flow = require("../site/marketplace-workflow.js"), records = new Map(), listeners = new Map(), elements = new Map();
+  const element = () => ({ value: "", textContent: "", open: false, handlers: {}, addEventListener(name, fn) { this.handlers[name] = fn; } });
+  for (const name of ["#bounty-composer-form", "#bounty-composer-input", "[data-brief-budget]", "[data-brief-deadline]", "[data-brief-status]", "[data-brief-timezone]", "[data-ai-options]", "[data-export-draft]"]) elements.set(name, element());
+  const document = { activeElement: null, documentElement: { dataset: {} }, querySelector: (name) => elements.get(name) };
+  let invalidations = 0;
+  const win = { AgentBountiesWorkflow: flow, AgentBountiesComposer: { invalidate() { invalidations++; } }, document,
+    crypto: require("node:crypto").webcrypto, location: new URL("https://agentbounties.app/post.html"),
+    sessionStorage: { getItem: (key) => records.get(key) || null, setItem: (key, value) => records.set(key, value) },
+    CustomEvent: class { constructor(type, options) { this.type = type; this.detail = options.detail; } },
+    addEventListener(name, fn) { listeners.set(name, fn); }, dispatchEvent(event) { listeners.get(event.type)?.(event); } };
+  vm.runInNewContext(fs.readFileSync(require.resolve("../site/posting-workspace.js"), "utf8"), { window: win, document, Intl, Date, URL, Blob });
+  const goal = elements.get("#bounty-composer-input"), budget = elements.get("[data-brief-budget]"), deadline = elements.get("[data-brief-deadline]");
+  goal.value = "Make a dimensioned CAD model"; document.activeElement = goal; goal.handlers.input();
+  const client = flow.createClient(win); assert.equal(client.load().goal, goal.value);
+  document.activeElement = budget; budget.value = "20"; budget.handlers.input();
+  const cutoff = new Date(Date.now() + 7 * 86400000).toISOString();
+  client.save({ ...client.load(), draft: { goal: goal.value, solver_reward_usdc: "18", verifier_reward_usdc: "2" }, brief: { ...client.load().brief, deadline_at: cutoff } });
+  assert.notEqual(deadline.value, "", "AI staging updates the deadline even while another field has focus");
+  budget.value = "25"; budget.handlers.input();
+  assert.equal(client.load().brief.budget_usdc, "25"); assert.equal(client.load().draft_stale, true); assert.equal(invalidations, 1);
+  assert.ok(client.load().brief.deadline_at, "editing the budget must not erase the deadline");
+});

--- a/scripts/test-meta-child.js
+++ b/scripts/test-meta-child.js
@@ -91,11 +91,12 @@ test("the confirmed funding branch uses the bounded child plan and retries a los
     AgentBountiesWorkflow: { createClient: () => ({}) }, AgentBountiesEvm: evm };
   const journal = require("../site/marketplace-workflow.js").createPostingJournal(win);
   const parent = { terms_hash: "fixed-parent" };
-  const state = { approved: true, provider: { request: async () => "0x2105" }, account: fixture.parent_solver,
+  const fields = [{ disabled: false }, { disabled: false }];
+  const state = { approved: true, provider: { request: async ({ method }) => method === "eth_accounts" ? [fixture.parent_solver] : "0x2105" }, account: fixture.parent_solver,
     balances: { usdc: 1000000n, required: 1000000n, eth: 1n }, draft: fixture.terms.document, metaParent: parent, fundingUsdc: 1, taskWindowDays: 3 };
   let fail = true, nonces = 0;
   const run = vm.runInNewContext(source.slice(start, end) + "; fundApprovedBounty", {
-    postingBusy: false, postingJournal: journal, state, window: win, ui: { fundNow: {}, badge: {} },
+    postingBusy: false, postingJournal: journal, state, window: win, ui: { form: { querySelectorAll: () => fields }, fundNow: {}, badge: {} },
     track() {}, setPaymentStatus() {}, refreshWalletReadiness: async () => {}, loadProtocol: async () => ({ api_base_url: "https://api.agentbounties.app", factory: fixture.child_creation.factory_contract, chain_id: 8453 }),
     currentRewardSplit: () => split, randomBytes32: () => nonces++ ? "0x" + "77".repeat(32) : fixture.child_create.creation_nonce,
     metaChild: { ...helper, resolve: async () => parent, request: (_draft, _parent, _wallet, _split, _days, nonce) => ({ ...inputFor(), creation_nonce: nonce }), validatePlan: fixedHelper.validatePlan },
@@ -108,9 +109,10 @@ test("the confirmed funding branch uses the bounded child plan and retries a los
     sendWalletCalls: async calls => { sent.push(calls); journal.checkpoint("batch_submitted", { id: "test-only" }); },
     pollCreation: async () => true, fetchFeedItem: async () => ({ verification_ready: true }),
   });
-  await run(); assert.equal(sent.length, 0); assert.equal(journal.load(), null);
+  await run(); assert.equal(sent.length, 0); assert.equal(journal.load(), null); assert.ok(fields.every(field => !field.disabled));
   await run(); assert.equal(sent.length, 1); assert.deepEqual(sent[0], fixture.pre_claim_wallet_calls);
   assert.equal(requests[0].creation_nonce, requests[1].creation_nonce);
   assert.equal(journal.load().phase, "funding_confirmed");
+  assert.ok(fields.every(field => field.disabled));
   await run(); assert.equal(sent.length, 1);
 });

--- a/scripts/test-webmcp.js
+++ b/scripts/test-webmcp.js
@@ -1,4 +1,5 @@
 "use strict";
+require("./test-creator-review.js");
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");

--- a/site/ai-bounty-handoff.js
+++ b/site/ai-bounty-handoff.js
@@ -106,6 +106,8 @@
       solver_reward_usdc: solver,
       verifier_reward_usdc: verifier,
       task_window_days: days,
+      review_mode: raw.review_mode === "creator" ? "creator" : "automated",
+      delivery_deadline: window.AgentBountiesCreatorReview.deadline(raw.delivery_deadline),
       source_url: sourceUrl,
       crowdfund: Boolean(raw.crowdfund),
       discovery_source: boundedText(raw.discovery_source || "User-owned AI assistant", "Discovery source", 500),
@@ -128,6 +130,7 @@
   function promptFor(intent, context) {
     const data = {};
     if (intent) data.request = String(intent);
+    if (context?.brief) data.brief = context.brief;
     if (context?.draft) {
       data.draft = {
         ...context.draft,
@@ -180,7 +183,7 @@
       webFallback.removeAttribute("href");
     }
     panel.hidden = false;
-    log.append(panel);
+    // Keep AI setup in its optional disclosure; never create a second chat.
     requestAnimationFrame(() => {
       const previousScrollBehavior = log.style.scrollBehavior;
       log.style.scrollBehavior = "auto";
@@ -189,7 +192,7 @@
     });
     document.documentElement.dataset.aiInterface = "user-owned";
     if (composerStatus) {
-      composerStatus.textContent = "No Agent Bounties model key is being used. Continue in your AI account, then return with its prepared draft.";
+      composerStatus.textContent = "Brief saved. Your current AI can continue here; setup and import are optional.";
       composerStatus.dataset.tone = "success";
     }
     return currentPrompt;
@@ -249,12 +252,13 @@
     }
   });
 
-  panel.querySelector("[data-import-ai-draft]")?.addEventListener("click", () => {
+  panel.querySelector("[data-import-ai-draft]")?.addEventListener("click", async () => {
     try {
       const draft = parseDraft(importInput.value);
+      if (!window.AgentBountiesComposer) throw new Error("The draft controller is still loading. Retry the same import.");
+      await window.AgentBountiesComposer.stage(draft);
       setImportStatus("Draft imported locally. Review every field before approving it.", "success");
       panel.hidden = true;
-      window.dispatchEvent(new CustomEvent("agent-bounties:prepared-draft", { detail: draft }));
     } catch (error) {
       setImportStatus(error.message || String(error), "error");
     }

--- a/site/analytics-config.js
+++ b/site/analytics-config.js
@@ -7,7 +7,7 @@ window.agentBountiesAnalyticsConfig = Object.freeze({
 (() => {
   const base = new URL(".", document.currentScript.src);
   const script = document.createElement("script");
-  script.src = new URL("webmcp.js?v=5", base).href;
+  script.src = new URL("webmcp.js?v=6", base).href;
   script.async = false;
   document.head.appendChild(script);
 })();

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -481,11 +481,12 @@
   }
 
   async function importPreparedDraft(value) {
-    const prepared = window.AgentBountyAI?.parseDraft
+    let prepared = window.AgentBountyAI?.parseDraft
       ? window.AgentBountyAI.parseDraft(value)
       : value;
     if (!prepared || typeof prepared !== "object") throw new Error("The prepared bounty draft is invalid.");
 
+    prepared = window.AgentBountiesCreatorReview.prepare(prepared);
     const days = Number(prepared.task_window_days || MAX_TASK_DAYS);
     const parentContext = prepared.meta_child || (new URLSearchParams(window.location.search).has("parentBounty") ? state.metaParent : null);
     const metaParent = parentContext ? await metaChild.resolve(parentContext, window.AgentBountiesWorkflow.createClient(window)) : null;
@@ -497,9 +498,11 @@
       throw new Error("The prepared bounty must include the exact image generated and approved in ChatGPT.");
     }
 
-    const deadline = new Date(Date.now() + days * 86_400_000);
+    const deadline = prepared.delivery_deadline ? new Date(prepared.delivery_deadline) : new Date(Date.now() + days * 86_400_000);
+    state.deliveryDeadline = prepared.delivery_deadline || null;
     state.phase = "review";
     state.originalRequest = prepared.goal;
+    state.reviewStale = false;
     state.context = [];
     state.initialDraft = normalizeDraft({
       title: prepared.title,
@@ -520,7 +523,7 @@
       kind: "date",
       date: deadline,
       days,
-      label: `${days} day${days === 1 ? "" : "s"}`,
+      label: prepared.delivery_deadline ? `${deadline.toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone})` : `${days} days after claim`,
     };
     state.missionPlan = null;
     state.selectedTaskId = null;
@@ -530,13 +533,16 @@
     state.metaParent = metaParent;
     state.bountyImage = bountyImage;
     state.approved = false;
-    ui.input.value = "";
+    ui.input.value = prepared.goal;
     ui.prompt.textContent = state.handoffReview
       ? (state.bountyImage
           ? "Review the exact image and bounty terms you approved in your AI conversation. Agent Bounties cannot edit or replace them."
           : "Review the exact bounty terms you approved in your AI conversation. This card uses a deterministic content-derived visual.")
       : "Review the bounty card your AI prepared. You can approve it or ask your AI for a revision.";
     await renderPreview();
+    const client = window.AgentBountiesWorkflow.createClient(window);
+    const journey = client.load() || client.start({ role: "post" });
+    client.save({ ...journey, role: "post", goal: prepared.goal, draft: prepared, draft_stale: false, brief: { ...journey.brief, goal: prepared.goal, budget_usdc: String(total), deadline_at: prepared.delivery_deadline || journey.brief?.deadline_at || null } });
   }
 
   function queueQuestions(questions) {
@@ -852,7 +858,7 @@
 
   function riskSummary() {
     const risks = state.draft.risk_flags || [];
-    return risks.length ? `${risks.length} item${risks.length === 1 ? "" : "s"} to review` : "No AI blocker flagged";
+    return risks.length ? `${risks.length} item${risks.length === 1 ? "" : "s"} to review` : "Review required";
   }
 
   function renderCardText() {
@@ -892,6 +898,15 @@
   function renderVerifierTerms() {
     if (!ui.verifierSummary || !ui.verifier) return;
     const benchmark = missionBenchmark(state.draft?.benchmark || {});
+    if (benchmark.engine === "creator_review_v1") {
+      const reward = currentRewardSplit();
+      ui.verifierSummary.textContent = `You review the delivered files and confirm the verdict in your wallet. The ${formatUsdc(Number(reward.verifier) / 1_000_000)} USDC verifier reward is paid to you on pass or fail. This is your review; no independent automated verifier is involved.`;
+      ui.verifier.replaceChildren();
+      for (const [label, value] of [["Reviewer", "You, using the wallet that funds this bounty"], ["Due", state.horizon.label], ["Evidence", "Public deliverable URL and SHA-256 digest"], ["Review window", "48 hours after submission"], ["Wallet cost", "Base gas is additional; this route does not promise sponsorship"]]) {
+        const dt = document.createElement("dt"), dd = document.createElement("dd"); dt.textContent = label; dd.textContent = value; ui.verifier.append(dt, dd);
+      }
+      return;
+    }
     const source = benchmark.source || {};
     const runner = benchmark.runner_manifest || {};
     const requiredEvidence = state.draft?.evidence_schema?.required || [];
@@ -1375,7 +1390,13 @@
   }
 
   function supportedVerificationPolicy() {
+    if (state.reviewStale) throw new Error("The saved brief changed. Update the proposal from its current outcome, budget and deadline before approval.");
     const benchmark = missionBenchmark(state.draft?.benchmark || {});
+    if (benchmark.engine === "creator_review_v1") {
+      if (state.metaParent || !window.AgentBountiesCreatorReview.ready(benchmark, state.draft?.evidence_schema)) throw new Error("Creator review needs a future agreed deadline and public artifact evidence. It cannot be used for a qualifying meta child.");
+      return window.AgentBountiesCreatorReview.policy(state.account);
+    }
+    if (state.deliveryDeadline) throw new Error("This automated benchmark does not enforce the requested calendar deadline. Propose creator review or agree a relative work window; do not silently change the deadline.");
     const readiness = verificationReadiness(benchmark, state.draft?.evidence_schema);
     if (readiness.blocked) {
       throw new Error(
@@ -1475,7 +1496,10 @@
     ui.approve.textContent = "Approve bounty card";
     ui.fund.disabled = true;
     setComposer({ phase:"revise", prompt:"What should the AI change about this bounty or mission plan?", label:"Revision request", placeholder:"Example: Split the research into its own task and extend the mission horizon to one year.", button:"Update card", hint:"Changing the card removes approval until you review it again." });
-    document.querySelector(".composer-shell")?.scrollIntoView({behavior:"smooth",block:"center"});
+    ui.input.value = state.draft?.goal || state.originalRequest;
+    ui.form.scrollIntoView({behavior:"smooth",block:"start"});
+    ui.input.focus();
+    setStatus("Edit the saved brief above and ask your AI to update the proposal in your current conversation.", "pending");
   }
 
   async function openFunding() {
@@ -1585,11 +1609,11 @@
     }
   }
 
-  function contractTerms(protocol,rewards){const now=Math.floor(Date.now()/1000);return{protocol_version:protocol.protocol_version,creator_wallet:state.account,network:protocol.network,settlement_token:protocol.native_usdc,solver_reward:{amount:Number(rewards.solver),currency:"usdc"},verifier_reward:{amount:Number(rewards.verifier),currency:"usdc"},claim_bond:{amount:Number(rewards.verifier),currency:"usdc"},initial_funding:{amount:Number(rewards.total),currency:"usdc"},funding_deadline:now+30*86400,claim_window_seconds:state.taskWindowDays*86400,verification_window_seconds:48*3600,creation_nonce:randomBytes32()};}
+  function contractTerms(protocol,rewards){const now=Math.floor(Date.now()/1000);return{protocol_version:protocol.protocol_version,creator_wallet:state.account,network:protocol.network,settlement_token:protocol.native_usdc,solver_reward:{amount:Number(rewards.solver),currency:"usdc"},verifier_reward:{amount:Number(rewards.verifier),currency:"usdc"},claim_bond:{amount:Number(rewards.verifier),currency:"usdc"},initial_funding:{amount:Number(rewards.total),currency:"usdc"},funding_deadline:state.deliveryDeadline?Math.floor(Date.parse(state.deliveryDeadline)/1000):now+30*86400,claim_window_seconds:state.taskWindowDays*86400,verification_window_seconds:48*3600,creation_nonce:randomBytes32()};}
 
   function termsDocument(committed){const document={schema_version:"agent-bounties/terms-v1",contract_terms:committed,title:state.draft.title,goal:state.draft.goal,acceptance_criteria:state.draft.acceptance_criteria,benchmark:canonicalJsonValue(missionBenchmark(state.draft.benchmark||{})),evidence_schema:canonicalJsonValue(stripVisualExtension(state.draft.evidence_schema)),verification_policy:supportedVerificationPolicy(),source_url:null,discovery_source:state.bountyImage?"ai_assistant_approved_image_handoff":"ai_assistant_terms_handoff"};if(state.bountyImage)document.image=canonicalJsonValue(state.bountyImage);return document;}
 
-  function createPayload(terms,committed){return{creator:state.account,solver_reward:committed.solver_reward,verifier_reward:committed.verifier_reward,terms_hash:terms.terms_hash,policy_hash:terms.policy_hash,acceptance_criteria_hash:terms.acceptance_criteria_hash,benchmark_hash:terms.benchmark_hash,evidence_schema_hash:terms.evidence_schema_hash,funding_deadline:committed.funding_deadline,claim_window_seconds:committed.claim_window_seconds,verification_window_seconds:committed.verification_window_seconds,verification_mode:"signed_quorum",verifier_module:null,verifier_reward_recipient:null,verifiers:REGRESSION_VERIFIERS,threshold:REGRESSION_VERIFIERS.length,initial_funding:committed.initial_funding,creation_nonce:committed.creation_nonce};}
+  function createPayload(terms,committed){return{creator:state.account,solver_reward:committed.solver_reward,verifier_reward:committed.verifier_reward,terms_hash:terms.terms_hash,policy_hash:terms.policy_hash,acceptance_criteria_hash:terms.acceptance_criteria_hash,benchmark_hash:terms.benchmark_hash,evidence_schema_hash:terms.evidence_schema_hash,funding_deadline:committed.funding_deadline,claim_window_seconds:committed.claim_window_seconds,verification_window_seconds:committed.verification_window_seconds,verification_mode:"signed_quorum",verifier_module:null,verifier_reward_recipient:null,verifiers:supportedVerificationPolicy().verifiers,threshold:supportedVerificationPolicy().threshold,initial_funding:committed.initial_funding,creation_nonce:committed.creation_nonce};}
 
   function validateCreationPlan(plan,protocol,create){if(!plan||!/^0x[0-9a-fA-F]{40}$/.test(plan.predicted_bounty_contract||""))throw new Error("The creation plan did not return a valid bounty address.");if(Number(plan.network&&plan.network.chain_id)!==Number(protocol.chain_id))throw new Error("The creation plan targets the wrong network.");if(String(plan.factory_contract||"").toLowerCase()!==String(protocol.factory).toLowerCase())throw new Error("The creation plan does not use the canonical factory.");const target=Number(create.solver_reward.amount)+Number(create.verifier_reward.amount);if(Number(create.initial_funding.amount)!==target)throw new Error("The creation plan is not fully funded.");}
 
@@ -1605,6 +1629,7 @@
     }
     if (!state.approved || !state.provider || !state.account || !state.balances) return;
     postingBusy = true;
+    for (const field of ui.form.querySelectorAll("input, textarea, button")) field.disabled = true;
     const approvedDraft = state.draft;
     const approvedAccount = state.account;
     track("canonical_post_started");
@@ -1656,7 +1681,7 @@
       }
       validateCreationPlan(plan, protocol, create);
       if (!state.approved || state.draft !== approvedDraft) throw new Error("The bounty changed during preparation. Review the revised commitment before funding.");
-      if (childPlan && (state.account !== approvedAccount || String(await state.provider.request({ method: "eth_chainId" })).toLowerCase() !== "0x2105")) throw new Error("The wallet or network changed. Reopen the child review before funding.");
+      if (state.account !== approvedAccount || String((await state.provider.request({ method: "eth_accounts" }))[0]).toLowerCase() !== String(approvedAccount).toLowerCase() || String(await state.provider.request({ method: "eth_chainId" })).toLowerCase() !== "0x2105") throw new Error("The wallet or network changed. Reopen the same review before funding.");
       postingJournal.prepare(plan);
       setPaymentStatus([
         "Review the wallet request carefully.",
@@ -1697,6 +1722,10 @@
         return;
       }
       const item = await fetchFeedItem(api, state.bountyContract);
+      if (item?.terms_valid && item.verification_ready) {
+        const link = document.querySelector("[data-posted-bounty]");
+        if (link) { link.href = `participate.html?bountyContract=${encodeURIComponent(state.bountyContract)}&network=base-mainnet`; link.hidden = false; }
+      }
       ui.badge.textContent = item?.verification_ready ? "Funded · ready to earn" : "Funded · verifier readiness pending";
       setPaymentStatus([
         item?.verification_ready ? "Bounty funded and ready for public earning." : "Canonical funding is confirmed. The committed verifier must be ready before this bounty appears in ready-to-earn inventory.",
@@ -1714,6 +1743,7 @@
       ui.fundNow.disabled = Boolean(postingJournal.load());
     } finally {
       postingBusy = false;
+      if (!postingJournal.load()) for (const field of ui.form.querySelectorAll("input, textarea, button")) field.disabled = false;
     }
   }
 
@@ -1857,6 +1887,11 @@
   let stagedFingerprint = null;
   window.AgentBountiesComposer = Object.freeze({
     prepareMetaParent,
+    invalidate() {
+      if (!state.draft || postingBusy || postingJournal.load()) return;
+      state.reviewStale = true; state.approved = false; stagedFingerprint = null;
+      ui.approve.dataset.approved = "false"; ui.approve.disabled = true; ui.fund.disabled = true; ui.fundNow.disabled = true;
+    },
     stage(value) {
       staging = staging.catch(() => {}).then(() => {
         if (postingBusy || state.bountyContract || postingJournal.load()) throw new Error("A posting operation is in progress or recorded. Check its canonical status before preparing another draft.");
@@ -1868,7 +1903,7 @@
     },
     review() {
       let blocker = null;
-      try { supportedVerificationPolicy(); } catch (error) { blocker = error.message; }
+      if (state.draft) { try { supportedVerificationPolicy(); } catch (error) { blocker = error.message; } }
       return {
         status: state.bountyContract ? "created_check_canonical_funding" : state.draft ? "staged" : "no_staged_bounty",
         explicitly_approved: state.approved === true,
@@ -1877,7 +1912,11 @@
         bounty_contract: state.bountyContract || postingJournal.load()?.bounty_contract || null,
         posting_operation: postingJournal.load(),
         meta_child: state.metaParent ? { parent_bounty_contract: state.metaParent.parent_bounty_contract, total_usdc: "1.00", intended_child_solver: state.metaParent.intended_child_solver, verifier_threshold: 2, terms_before_parent_claim: true, gas_sponsored: false } : null,
-        next_action: blocker ? "The agent should prepare the missing executable verifier and restage the draft; do not ask the person for technical fields or funding yet."
+        review_mode: state.draft?.benchmark?.engine === "creator_review_v1" ? "creator" : "automated",
+        delivery_deadline: state.deliveryDeadline || null,
+        saved_brief: window.AgentBountiesWorkflow.createClient(window).load()?.brief || null,
+        next_action: !state.draft || state.reviewStale ? "Prepare or update the proposal using saved_brief. Preserve its outcome, budget and deadline. Ask only for missing business decisions."
+          : blocker ? "For non-software work, propose review_mode=creator with the agreed delivery_deadline and no automated benchmark, then stage it for the person’s review. Meta children still require their automated verifier. Never invent benchmark details."
           : "The person reviews the terms once, then uses the wallet confirmation. No separate approval in chat is needed.",
       };
     },

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -1495,8 +1495,9 @@
     ui.approve.dataset.approved = "false";
     ui.approve.textContent = "Approve bounty card";
     ui.fund.disabled = true;
-    setComposer({ phase:"revise", prompt:"What should the AI change about this bounty or mission plan?", label:"Revision request", placeholder:"Example: Split the research into its own task and extend the mission horizon to one year.", button:"Update card", hint:"Changing the card removes approval until you review it again." });
-    ui.input.value = state.draft?.goal || state.originalRequest;
+    const savedGoal = ui.input.value;
+    setComposer({ phase:"revise", prompt:"Edit your brief, then continue with your AI in this conversation.", label:"What do you want delivered?", placeholder:"Describe the result you need.", button:"Save brief", hint:"Your AI uses the saved brief to update the proposal." });
+    ui.input.value = savedGoal || state.draft?.goal || state.originalRequest;
     ui.form.scrollIntoView({behavior:"smooth",block:"start"});
     ui.input.focus();
     setStatus("Edit the saved brief above and ask your AI to update the proposal in your current conversation.", "pending");

--- a/site/competition.html
+++ b/site/competition.html
@@ -155,7 +155,7 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=5"></script>
+    <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="marketplace.js?v=3"></script>
     <script src="competition.js?v=4"></script>

--- a/site/creator-review-workspace.js
+++ b/site/creator-review-workspace.js
@@ -1,0 +1,134 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root?.document) api.start(root);
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+  const lower = (value) => String(value || "").toLowerCase();
+  const stable = (value) => value && typeof value === "object" ? Array.isArray(value) ? `[${value.map(stable).join(",")}]` : `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stable(value[key])}`).join(",")}}` : JSON.stringify(value);
+  function typedData(request) {
+    const fields = (entries) => entries.map(([name, type]) => ({ name, type }));
+    return { domain: { name: "Agent Bounties", version: "1", chainId: 8453, verifyingContract: request.bounty_contract }, primaryType: "VerificationAttestation",
+      types: { EIP712Domain: fields([["name", "string"], ["version", "string"], ["chainId", "uint256"], ["verifyingContract", "address"]]),
+        VerificationAttestation: fields([["bounty", "address"], ["bountyId", "bytes32"], ["round", "uint64"], ["verifier", "address"], ["submissionHash", "bytes32"], ["evidenceHash", "bytes32"], ["policyHash", "bytes32"], ["passed", "bool"], ["responseHash", "bytes32"], ["deadline", "uint256"]]) },
+      message: { bounty: request.bounty_contract, bountyId: request.bounty_id, round: String(request.round), verifier: request.verifier, submissionHash: request.submission_hash, evidenceHash: request.evidence_hash, policyHash: request.policy_hash, passed: request.passed, responseHash: request.response_hash, deadline: String(request.deadline) } };
+  }
+  function settlementData(attestation, evm) {
+    if (!/^0x(?:[0-9a-f]{2}){1,4096}$/i.test(attestation.signature)) throw new Error("A bounded verifier signature is required.");
+    const word = evm.uint256Word;
+    const length = (attestation.signature.length - 2) / 2;
+    return evm.keccak256Hex(evm.textHex("settleWithAttestations((address,bool,bytes32,uint256,bytes)[])")).slice(0, 10)
+      + word(32) + word(1) + word(32) + evm.addressWord(attestation.verifier) + word(attestation.passed ? 1 : 0)
+      + evm.bytes32Word(attestation.response_hash) + word(attestation.deadline) + word(160) + word(length) + attestation.signature.slice(2).padEnd(Math.ceil(length / 32) * 64, "0");
+  }
+  function assessment(job, input) {
+    const criteria = job.terms.document.acceptance_criteria;
+    if (!Array.isArray(input.checks) || input.checks.length !== criteria.length) throw new Error("Assess every published acceptance criterion, in its published order.");
+    const checks = input.checks.map((check, index) => {
+      if (check.criterion !== criteria[index] || typeof check.passed !== "boolean" || typeof check.reason !== "string" || !check.reason.trim() || check.reason.length > 1000) throw new Error("Every check must match the published criterion and include a bounded reason.");
+      return { criterion: criteria[index], passed: check.passed, reason: check.reason.trim() };
+    });
+    const terms = job.terms.document;
+    const submittedAt = job.verification_expires_at - terms.contract_terms.verification_window_seconds;
+    const onTime = Number.isSafeInteger(submittedAt) && submittedAt > 0 && submittedAt <= terms.benchmark.delivery_deadline;
+    return { checks, on_time: onTime, passed: onTime && checks.every((check) => check.passed), round: job.round, submission_hash: job.submission_evidence.artifact_hash, evidence_hash: job.submission_evidence.evidence_hash };
+  }
+  function start(win) {
+    const doc = win.document, root = doc.querySelector("[data-creator-review]");
+    if (!root) return;
+    const client = win.AgentBountiesWorkflow.createClient(win), evm = win.AgentBountiesEvm;
+    const contract = lower(new URLSearchParams(win.location.search).get("bountyContract"));
+    const key = `agent-bounties.creator-review.v1:${contract}`;
+    const output = root.querySelector("output"), confirm = root.querySelector("button");
+    let job = null, staged = null, busy = false;
+    const load = () => JSON.parse(win.sessionStorage.getItem(key) || "null");
+    const save = (record) => win.sessionStorage.setItem(key, JSON.stringify(record));
+    async function refresh() {
+      const feed = await client.request("/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false");
+      const item = feed.find((entry) => lower(entry.bounty_contract) === contract);
+      if (!item?.terms_valid || item.terms.document.benchmark?.engine !== "creator_review_v1") return { status: "not_creator_review" };
+      root.hidden = false;
+      const operation = load();
+      const submitted = operation && item.events.find((entry) => entry.kind === "submission_added" && lower(entry.contract_address) === contract && entry.bounty_id === item.bounty_id && entry.data.round === operation.request.round
+        && lower(entry.data.submission_hash) === lower(operation.request.submission_hash) && lower(entry.data.evidence_hash) === lower(operation.request.evidence_hash));
+      const event = submitted && item.events.find((entry) => entry.kind === (operation.request.passed ? "bounty_settled" : "submission_rejected") && lower(entry.contract_address) === contract && entry.bounty_id === item.bounty_id
+        && entry.data.round === operation.request.round && lower(entry.data.solver) === lower(submitted.data.solver) && entry.id && entry.block_number > 0
+        && (entry.block_number > submitted.block_number || entry.block_number === submitted.block_number && entry.log_index > submitted.log_index)
+        && (entry.kind === "submission_rejected" || lower(entry.data.submission_hash) === lower(operation.request.submission_hash) && lower(entry.data.evidence_hash) === lower(operation.request.evidence_hash)));
+      if (event) { output.textContent = event.kind === "bounty_settled" ? "Payment confirmed by canonical settlement." : "Rejection confirmed; the bounty is available again."; confirm.disabled = true; return { status: "confirmed", paid: event.kind === "bounty_settled", event }; }
+      const jobs = item.status === "submitted" ? await client.request("/v1/base/autonomous-bounties/verification-jobs?network=base-mainnet") : [];
+      job = jobs.find((entry) => lower(entry.bounty_contract) === contract && entry.bounty_id === item.bounty_id && entry.terms.terms_hash === item.terms_hash && entry.threshold === 1
+        && entry.eligible_verifiers.length === 1 && lower(entry.eligible_verifiers[0]) === lower(item.creator)) || null;
+      if (operation?.phase === "signed" && operation.request.deadline <= Date.now() / 1000) {
+        // This phase proves no broadcast was attempted. An expired signature cannot settle.
+        win.sessionStorage.setItem(`${key}.previous`, JSON.stringify(operation)); win.sessionStorage.removeItem(key);
+        staged = null; return refresh();
+      }
+      if (operation?.phase === "signed") {
+        staged = operation.assessment; if (job && staged) renderAssessment(); confirm.disabled = !job || !staged;
+        output.textContent = "Your verdict is already signed. Confirm in wallet to submit this same verdict without signing it again.";
+      } else if (operation) output.textContent = "A verdict wallet step is recorded. Check its canonical status; do not repeat it.";
+      else if (!staged) output.textContent = job ? "A submission is ready. Your AI can check every criterion and prepare your verdict here." : "The creator will confirm the verdict here after a submission arrives.";
+      return { status: operation ? "pending_confirmation" : job ? "review_available" : "waiting_for_submission", paid: false, job, operation: operation ? { phase: operation.phase, transaction_hash: operation.hash || null } : null, user_confirmation_required: false };
+    }
+    function renderAssessment() {
+      const list = root.querySelector("ol"); list.replaceChildren();
+      for (const check of staged.checks) { const li = doc.createElement("li"); li.textContent = `${check.passed ? "Pass" : "Fail"}: ${check.criterion} — ${check.reason}`; list.append(li); }
+      output.textContent = `${staged.passed ? "Proposed pass" : "Proposed rejection"}. ${staged.on_time ? "Submitted by the delivery deadline." : "The submission missed the delivery deadline."} Review every check before confirming.`;
+      root.querySelector("[data-review-cost]").textContent = `On Base: a pass pays ${Number(job.current_solver_payout) / 1e6} USDC to solver ${job.solver_wallet}; either verdict pays ${Number(job.verifier_reward) / 1e6} USDC to reviewer ${job.eligible_verifiers[0]}. A rejection forfeits the solver bond. Review expires ${new Date(job.verification_expires_at * 1000).toLocaleString()}. Your wallet will show the additional gas fee.`;
+    }
+    async function stage(input) {
+      if (busy || load()) throw new Error("Reconcile the recorded verdict before preparing another.");
+      await refresh(); if (!job) throw new Error("No current creator-review submission is available.");
+      staged = assessment(job, input);
+      renderAssessment();
+      confirm.disabled = false;
+      return { status: "verdict_staged", assessment: staged, paid: false, user_confirmation_required: true, next_action: "The creator reviews these checks and confirms the verdict in the page and wallet. Do not click their confirmation." };
+    }
+    confirm.addEventListener("click", async (event) => {
+      if (!event.isTrusted || busy || !staged || (load() && load().phase !== "signed")) return;
+      busy = true; confirm.disabled = true;
+      try {
+        const priorJob = job, existing = load(); await refresh();
+        if (!job || job.round !== priorJob.round || job.submission_evidence.evidence_hash !== priorJob.submission_evidence.evidence_hash || job.submission_evidence.artifact_hash !== priorJob.submission_evidence.artifact_hash) throw new Error("The submission changed. Ask your AI to refresh its review.");
+        await win.AgentBountiesPhoneWallet?.restore();
+        const provider = win.AgentBountiesPhoneWallet?.state().connected ? win.AgentBountiesPhoneWallet.provider : win.ethereum;
+        if (!provider) throw new Error("Connect your phone wallet using the QR button, then confirm this review.");
+        let accounts = await provider.request({ method: "eth_accounts" });
+        if (!accounts.length) accounts = await provider.request({ method: "eth_requestAccounts" });
+        const wallet = lower(accounts[0]);
+        if (wallet !== lower(job.eligible_verifiers[0])) throw new Error("Connect the creator wallet named in this bounty.");
+        if (lower(await provider.request({ method: "eth_chainId" })) !== "0x2105") await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: "0x2105" }] });
+        const request = existing?.request || { bounty_contract: contract, bounty_id: job.bounty_id, round: job.round, verifier: wallet, submission_hash: staged.submission_hash, evidence_hash: staged.evidence_hash, policy_hash: job.terms.policy_hash, passed: staged.passed,
+          response_hash: evm.keccak256Hex(evm.textHex(stable(staged))), deadline: Math.min(job.verification_expires_at, Math.floor(Date.now() / 1000) + 600) };
+        if (request.round !== job.round || request.submission_hash !== job.submission_evidence.artifact_hash || request.evidence_hash !== job.submission_evidence.evidence_hash || request.deadline <= Date.now() / 1000) throw new Error("The signed review is stale; check its canonical status.");
+        let attestation = existing?.attestation;
+        if (!attestation) {
+          const plan = await client.request("/v1/base/autonomous-bounties/verification-attestation-plan", { network: "base-mainnet", attestation: request });
+          if (stable(plan) !== stable(typedData(request))) throw new Error("The requested signature differs from your reviewed verdict.");
+          save({ phase: "signing", request, assessment: staged });
+          const signature = await provider.request({ method: "eth_signTypedData_v4", params: [wallet, JSON.stringify(plan)] });
+          attestation = { verifier: wallet, passed: request.passed, response_hash: request.response_hash, deadline: request.deadline, signature };
+          save({ phase: "signed", request, attestation, assessment: staged });
+        }
+        const tx = await client.request("/v1/base/autonomous-bounties/attestation-settlement-plan", { network: "base-mainnet", bounty_contract: contract, caller: wallet, attestations: [attestation] });
+        if (lower(tx.from) !== wallet || lower(tx.to) !== contract || String(tx.value_wei) !== "0" || lower(tx.data) !== lower(settlementData(attestation, evm))) throw new Error("The settlement transaction differs from the signed verdict.");
+        if (lower((await provider.request({ method: "eth_accounts" }))[0]) !== wallet || lower(await provider.request({ method: "eth_chainId" })) !== "0x2105") throw new Error("Wallet or chain changed; no transaction was sent.");
+        save({ phase: "sending", request, attestation, assessment: staged });
+        const hash = await provider.request({ method: "eth_sendTransaction", params: [{ from: wallet, to: contract, data: tx.data, value: "0x0" }] });
+        if (!/^0x[0-9a-f]{64}$/i.test(hash)) throw new Error("The transaction response is uncertain. Check status before retrying.");
+        save({ phase: "submitted", request, hash });
+        output.textContent = "Verdict submitted. Your AI can check canonical confirmation; payment is not confirmed yet.";
+      } catch (error) {
+        const record = load();
+        if (error.code === 4001 && record?.phase === "signing") win.sessionStorage.removeItem(key);
+        if (error.code === 4001 && record?.phase === "sending") save({ ...record, phase: "signed" });
+        output.textContent = error.message || String(error);
+        confirm.disabled = Boolean(load() && load().phase !== "signed");
+      } finally { busy = false; }
+    });
+    win.AgentBountiesCreatorReviewWorkspace = Object.freeze({ refresh, stage });
+    refresh().catch((error) => { output.textContent = error.message; });
+  }
+  return { typedData, settlementData, assessment, start };
+});

--- a/site/creator-review.js
+++ b/site/creator-review.js
@@ -1,0 +1,33 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.AgentBountiesCreatorReview = api;
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+  const ENGINE = "creator_review_v1";
+  const DISCLOSURE = "The creator reviews every published acceptance check and signs the verdict. This is human review, not independent or automated verification. The verifier reward is paid to the creator on pass or fail; a missed review deadline returns the solver bond. The delivery cutoff is checked against the canonical submission time; the contract's claim timeout remains a separate relative window.";
+  const evidenceSchema = () => ({ type: "object", required: ["artifact_url", "artifact_sha256"], properties: { artifact_url: { type: "string", pattern: "^https://" }, artifact_sha256: { type: "string", pattern: "^sha256:[0-9a-f]{64}$" } } });
+  function deadline(value) {
+    if (value == null || value === "") return null;
+    if (typeof value !== "string" || !/^\d{4}-\d\d-\d\dT\d\d:\d\d(?::\d\d(?:\.\d{1,3})?)?(?:Z|[+-]\d\d:\d\d)$/.test(value) || !Number.isFinite(Date.parse(value))) throw new Error("Supply the agreed delivery deadline as an ISO timestamp including its time-zone offset.");
+    return new Date(value).toISOString();
+  }
+  function prepare(draft) {
+    if (draft.review_mode !== "creator") return draft;
+    if (draft.meta_child) throw new Error("Qualifying meta-bounty children require their existing automated verifier.");
+    const cutoff = deadline(draft.delivery_deadline);
+    if (!cutoff || Date.parse(cutoff) <= Date.now()) throw new Error("Creator review requires a future delivery deadline.");
+    if (Date.parse(cutoff) > Date.now() + 366 * 86400000) throw new Error("The delivery deadline must be within 366 days; prepare a nearer milestone for longer work.");
+    if (draft.benchmark && draft.benchmark.engine !== ENGINE) throw new Error("Do not replace an automated benchmark with creator review. Explicitly restage the selected policy without that benchmark.");
+    return { ...draft, delivery_deadline: cutoff, benchmark: { engine: ENGINE, delivery_deadline: Math.floor(Date.parse(cutoff) / 1000), acceptance: "all_published_criteria", reviewer: "creator" }, evidence_schema: evidenceSchema() };
+  }
+  function ready(benchmark, schema) {
+    return benchmark?.engine === ENGINE && benchmark.reviewer === "creator" && benchmark.acceptance === "all_published_criteria"
+      && Number.isSafeInteger(benchmark.delivery_deadline) && benchmark.delivery_deadline > Date.now() / 1000
+      && benchmark.delivery_deadline <= Date.now() / 1000 + 366 * 86400
+      && schema?.type === "object" && ["artifact_url", "artifact_sha256"].every((key) => schema.required?.includes(key))
+      && schema.properties?.artifact_url?.pattern === "^https://" && schema.properties?.artifact_sha256?.pattern === "^sha256:[0-9a-f]{64}$";
+  }
+  function policy(wallet) { return { mechanism: "signed_quorum", engine: ENGINE, verifiers: wallet ? [wallet.toLowerCase()] : [], threshold: 1, rubric: "Pass only when every published acceptance criterion is satisfied and canonical submission time is no later than the committed delivery deadline.", public_disclosure: DISCLOSURE }; }
+  return { ENGINE, DISCLOSURE, deadline, prepare, ready, policy, evidenceSchema };
+});

--- a/site/earn.html
+++ b/site/earn.html
@@ -69,7 +69,7 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=5"></script>
+    <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="marketplace.js?v=3"></script>
   </body>

--- a/site/index.html
+++ b/site/index.html
@@ -363,9 +363,9 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=5"></script>
+    <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
-    <script src="posting-prompt.js?v=1"></script>
+    <script src="posting-prompt.js?v=2"></script>
     <script src="solarpunk-home.js?v=12"></script>
   </body>
 </html>

--- a/site/participate.html
+++ b/site/participate.html
@@ -38,6 +38,12 @@
           <details><summary>Exact prepared details</summary><pre data-action-details class="machine-block"></pre></details>
           <button class="market-button market-button-primary" type="button" data-wallet-confirm disabled>Confirm in wallet</button>
         </section>
+        <section data-creator-review hidden aria-label="Creator completion review">
+          <h2>Review the submitted work</h2>
+          <p>Your AI can prepare the checks. You decide the verdict and confirm it in your wallet.</p>
+          <ol></ol><p data-review-cost></p><output aria-live="polite"></output>
+          <button class="market-button market-button-primary" type="button" disabled>Confirm verdict in wallet</button>
+        </section>
         <button class="market-button" type="button" data-work-refresh>Refresh progress</button>
         <p>After you confirm, your AI can continue without asking again. Only confirmed canonical <code>BountySettled</code> or <code>CompetitionSettledV2</code> events prove payment.</p>
         <details><summary>Evidence and verifier details</summary><pre data-work-evidence class="machine-block"></pre></details>
@@ -46,10 +52,11 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=5"></script>
+    <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
-    <script src="participate.js?v=3"></script>
+    <script src="participate.js?v=4"></script>
+    <script src="creator-review-workspace.js?v=1"></script>
   </body>
 </html>

--- a/site/participate.js
+++ b/site/participate.js
@@ -95,7 +95,7 @@
       const claim = events.filter((event) => event.kind === "bounty_claimed").sort((a, b) => b.block_number - a.block_number || b.log_index - a.log_index)[0];
       const claimOwner = lower(claim?.data?.solver) || null;
       const ownsClaim = Boolean(record.wallet && claimOwner === record.wallet);
-      put("[data-work-deadline]", item.status === "claimed" && claim?.data?.claim_expires_at
+      put("[data-work-deadline]", terms.benchmark?.engine === "creator_review_v1" ? `Deliver by ${new Date(terms.benchmark.delivery_deadline * 1000).toLocaleString()}. Creator review is due within ${terms.contract_terms.verification_window_seconds / 3600} hours after submission. The claim timeout is a separate relative window.` : item.status === "claimed" && claim?.data?.claim_expires_at
         ? `Work is due ${new Date(claim.data.claim_expires_at * 1000).toLocaleString()}.`
         : terms.contract_terms?.claim_window_seconds ? `After claiming, complete the work within ${terms.contract_terms.claim_window_seconds / 86400} days.` : "Read the committed terms for the work deadline.");
       const paidEvent = record.submission && events.find((event) => event.kind === "bounty_settled" && event.id && event.block_number != null
@@ -144,6 +144,7 @@
         : intent?.status === "confirmed" && intent.action === "complete" && !record.evidencePublished ? { tool: "agent_bounties_publish_confirmed_evidence", input: {} }
         : item.status === "claimed" && ownsClaim ? { action: "complete_agreed_work", instructions: "Use the current assistant's execution tools to complete and test the exact accepted work. Prepare action complete with the public artifact and evidence when it passes. No permission is needed for routine preparation." }
         : item.status === "claimed" ? { action: "track_claimed_work", instructions: "This work is reserved by the displayed claim owner. Track that solver's progress; do not start duplicate work or represent the claim as yours without matching the person's wallet." }
+        : item.status === "submitted" && terms.benchmark?.engine === "creator_review_v1" ? { tool: "agent_bounties_get_creator_review", input: {}, instructions: "The creator signs the verdict. Prepare their assessment only after examining the exact submitted artifacts; a solver cannot approve their own payment." }
         : item.status === "submitted" ? { action: "continue_committed_verification", instructions: "Read the returned verification job. Execute its exact committed flow through an available interface, or wait for the committed verifier. Do not ask for a new approval just to check status." }
         : { action: "review_current_requirements", instructions: "Resolve the listed prerequisites before preparing a claim. If posting, wait for a solver or continue preparing an authorized contribution." };
       return { bounty_contract: contract, bounty_id: item.bounty_id, status: item.status, terms, events, claim_owner: claimOwner, claim_owned_by_review_wallet: ownsClaim, verification_jobs: jobs,

--- a/site/post.html
+++ b/site/post.html
@@ -20,6 +20,7 @@
     <link rel="stylesheet" href="bounty-chat-controls.css?v=1">
     <link rel="stylesheet" href="ai-bounty-handoff.css?v=2">
     <link rel="stylesheet" href="phone-wallet.css?v=1">
+    <link rel="stylesheet" href="posting-workspace.css?v=1">
   </head>
   <body class="composer-page chat-app-page">
     <header class="chat-app-header">
@@ -31,14 +32,23 @@
       <a class="chat-app-close" href="./" aria-label="Close and return home">×</a>
     </header>
 
-    <main class="chat-app" data-bounty-chat aria-label="Bounty creation chat">
+    <main class="posting-workspace" aria-label="Bounty draft and review">
       <section class="conversation-panel">
-        <div class="conversation-log" data-conversation-log aria-live="polite" aria-label="Conversation messages">
-          <section class="ai-safety-note" aria-label="Your AI can prepare the bounty" data-agent-guidance>
-            <strong>Describe the result you want. Your AI can handle the setup.</strong>
-            It prepares the work, budget, deadline and completion checks. You review the finished proposal and confirm funding in your wallet.
-            <a href="install/">Agent setup</a>
-          </section>
+        <form id="bounty-composer-form" class="chat-composer-form">
+          <h2 class="brief-heading">Your bounty brief</h2>
+          <p class="brief-help" data-agent-guidance>Work with your AI in your current conversation. This page keeps the brief and displays the proposal for your review.</p>
+          <label for="bounty-composer-input" data-composer-label>What do you want delivered?</label>
+          <textarea id="bounty-composer-input" maxlength="4000" rows="4" required placeholder="Describe the result you need."></textarea>
+          <div class="brief-fields">
+            <div><label for="brief-budget">Total budget (USDC)</label><input id="brief-budget" data-brief-budget type="number" min="0.01" step="0.01" placeholder="20.00"></div>
+            <div><label for="brief-deadline">Delivery deadline</label><input id="brief-deadline" data-brief-deadline type="datetime-local"><small data-brief-timezone></small></div>
+          </div>
+          <div class="brief-actions"><button class="button secondary" type="submit" data-composer-submit>Save brief</button><button class="button secondary" type="button" data-export-draft>Download draft</button></div>
+          <output class="brief-status" data-brief-status aria-live="polite">Your brief is saved as you type. Nothing is published yet.</output>
+          <output class="composer-status" data-composer-status aria-live="polite"></output>
+          <span data-composer-hint hidden></span><button data-dictate type="button" hidden>Dictate</button>
+        </form>
+        <div class="conversation-log" data-conversation-log aria-live="polite" aria-label="Bounty proposal">
           <section id="bounty-preview" class="bounty-preview conversation-draft" hidden aria-labelledby="bounty-card-title">
             <article id="bounty-card" class="bounty-card">
               <div class="bounty-card-visual">
@@ -74,7 +84,7 @@
                 </section>
 
                 <section class="bounty-card-section verifier-terms" aria-labelledby="verifier-terms-title">
-                  <h3 id="verifier-terms-title">Executable verifier</h3>
+                  <h3 id="verifier-terms-title">How completion is reviewed</h3>
                   <p data-card-verifier-summary></p>
                   <dl data-card-verifier></dl>
                 </section>
@@ -83,23 +93,25 @@
                   <summary>Details to review</summary>
                   <ul data-card-risks></ul>
                   <p><strong>Publish only a complete paid loop.</strong> The artifact, binary checks, live verifier, positive solver net value, and full funding are fixed before signing.</p>
-                  <p>The verifier named in the immutable terms executes the published checks. Unsupported review-only drafts cannot be funded or listed as ready to earn.</p>
+                  <p>The named verifier and review method are fixed before funding. Creator review requires your signed verdict; automated review requires a supported benchmark.</p>
                 </details>
 
                 <div class="bounty-card-actions chat-draft-actions">
-                  <button class="button secondary" type="button" data-revise-card>Edit in chat</button>
+                  <button class="button secondary" type="button" data-revise-card>Edit brief</button>
                   <button type="button" data-share-card hidden>Share draft</button>
                   <button class="button secondary" type="button" data-approve-card data-approved="false">Approve</button>
                   <button class="button primary" type="button" data-open-funding disabled>Connect wallet</button>
+                  <a class="button primary" data-posted-bounty hidden>Open your bounty</a>
                 </div>
               </div>
             </article>
           </section>
 
-          <section class="ai-handoff" data-ai-handoff hidden aria-labelledby="ai-handoff-title">
+          <details data-ai-options><summary>AI setup or import a prepared draft</summary>
+          <section class="ai-handoff" data-ai-handoff aria-labelledby="ai-handoff-title">
             <div class="ai-handoff-heading">
               <p class="ai-handoff-eyebrow">Your AI, your context</p>
-              <h2 id="ai-handoff-title">Continue in the AI account that already knows you</h2>
+              <h2 id="ai-handoff-title">Prepare this brief with your AI</h2>
               <p>We copy the posting prompt with your request and draft. Agent Bounties does not call a model or need your provider API key.</p>
             </div>
 
@@ -152,6 +164,7 @@
 
             <p class="ai-safety-note">Nothing is posted, funded, or signed until you review the card and explicitly approve the wallet transaction.</p>
           </section>
+          </details>
         </div>
 
         <div class="conversation-thinking" data-assistant-thinking hidden aria-label="AI is thinking">
@@ -166,20 +179,7 @@
           <li data-progress-step="fund">Connect</li>
         </ol>
 
-        <form id="bounty-composer-form" class="chat-composer-form">
-          <label class="sr-only" for="bounty-composer-input" data-composer-label>Your message</label>
-          <div class="chat-composer-input-wrap">
-            <textarea id="bounty-composer-input" maxlength="12000" rows="1" required placeholder="Message Agent Bounties"></textarea>
-            <button class="composer-mic" type="button" data-dictate aria-label="Dictate your message" title="Dictate your message">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="8" y="3" width="8" height="12" rx="4"/><path d="M5 11a7 7 0 0 0 14 0M12 18v3M9 21h6"/></svg>
-            </button>
-            <button class="chat-send" type="submit" data-composer-submit aria-label="Send message">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m5 12 14-7-4 14-3-6-7-1Z"/><path d="m12 13 7-8"/></svg>
-            </button>
-          </div>
-          <p class="sr-only" data-composer-hint>You can keep revising the draft by continuing the conversation.</p>
-          <output class="composer-status" data-composer-status aria-live="polite"></output>
-        </form>
+
       </section>
 
       <dialog id="funding-dialog" class="payment-dialog chat-wallet-dialog" aria-labelledby="funding-dialog-title">
@@ -249,15 +249,16 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
-    <script src="analytics-config.js?v=5"></script>
+    <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
     <script src="meta-child.js?v=1"></script>
     <script src="bounty-entry.js?v=1"></script>
-    <script src="posting-prompt.js?v=1"></script>
-    <script src="ai-bounty-handoff.js?v=8"></script>
-    <script src="bounty-composer-v2.js?v=10"></script>
-    <script src="bounty-chat-ui.js?v=4"></script>
+    <script src="posting-prompt.js?v=2"></script>
+    <script src="creator-review.js?v=1"></script>
+    <script src="ai-bounty-handoff.js?v=9"></script>
+    <script src="bounty-composer-v2.js?v=11"></script>
+    <script src="posting-workspace.js?v=1"></script>
   </body>
 </html>

--- a/site/posting-prompt.js
+++ b/site/posting-prompt.js
@@ -7,9 +7,9 @@
 
   const PROMPT = `Help me create, fund and publicly post a bounty on Agent Bounties.
 
-1. Use https://agentbounties.app/post.html in @Browser, preserving existing page context. Discover WebMCP tools and read page context; confirm actual access. Read https://agentbounties.app/.well-known/agent-bounties.json and https://agentbounties.app/llms.txt before choosing endpoints. If needed, use connected official MCP tools. If neither is available, prepare a portable draft and explain that posting and funding remain incomplete; do not request API keys.
+1. Use https://agentbounties.app/post.html in @Browser, preserving existing page context. Discover WebMCP tools and read page context; confirm actual access. Read https://agentbounties.app/.well-known/agent-bounties.json and https://agentbounties.app/llms.txt before choosing endpoints. Fallback to connected official MCP tools; otherwise prepare a portable draft and say posting and funding remain incomplete. Never request API keys.
 
-2. Save and resume my posting journey; preserve my answers and draft. Ask together only for missing business decisions: outcome, total USDC budget and deadline. Propose deliverables and measurable checks, prepare a supported reviewed verifier, stage the draft and check funding readiness. Resolve blockers or explain unsupported work; never invent verifier details.
+2. Save and resume my posting journey; preserve my answers and draft. Ask together only for missing business decisions: outcome, total USDC budget and deadline. Propose deliverables and measurable checks. Use a supported reviewed verifier; for design work, propose creator review with my exact calendar deadline and explain that I confirm the verdict. Stage the draft and check funding readiness. Never invent verifier details or replace a calendar deadline with days after claim.
 
 3. Show one review of public terms, rewards, fees, total cost and deadline. Leave publication, legal, funding and payment consent to me. Reuse unchanged approvals; handle routine preparation yourself.
 
@@ -17,9 +17,9 @@
 
 5. After my confirmations, resume automatically. Reconcile the same posting operation; never repeat uncertain transactions. Confirm canonical creation, funding and claimability, then find the exact bounty in public ready-to-earn inventory. Return its public link and confirmed status, or the precise unfinished step. A draft, signature or transaction hash is not completion; only tool results and confirmed canonical Base USDC evidence prove actions and payments.
 
-Only when tools are unavailable, return JSON for the website's draft import using this shape:
+Without tools, return importable JSON:
 {"title":"...","goal":"...","acceptance_criteria":["..."],"solver_reward_usdc":"2.00","verifier_reward_usdc":"0.10","task_window_days":30,"source_url":null,"benchmark":null,"evidence_schema":null}
-Replace example amounts and days with my agreed terms. Preserve parent bindings and approved image fields. Null verification stays unfundable; this JSON does not post or fund anything.`;
+Use my agreed amounts and days. For creator review add "review_mode":"creator" and "delivery_deadline" as the agreed ISO timestamp with timezone offset; omit automated benchmark fields. Preserve parent bindings and approved image fields. Missing verification stays unfundable; JSON is not publication or funding.`;
 
   function build(context = null) {
     if (!context || !Object.keys(context).length) return PROMPT;

--- a/site/posting-workspace.css
+++ b/site/posting-workspace.css
@@ -24,3 +24,7 @@
 .posting-workspace .bounty-preview { scroll-margin-top: 90px; }
 .posting-workspace .verifier-terms { border: 0; border-top: 1px solid #354238; background: transparent; border-radius: 0; padding: 22px 0 0; }
 .posting-workspace .bounty-stat { border: 0; border-radius: 0; background: transparent; padding: 0 16px 0 0; }
+
+.posting-workspace #bounty-composer-form { scroll-margin-top: 88px; }
+.posting-workspace #bounty-composer-input { border: 1px solid #405044; background: #101f16; border-radius: 8px; min-height: 130px; max-height: none; padding: 12px; }
+.posting-workspace #bounty-composer-input:focus { outline: 2px solid #c4f43b; outline-offset: 2px; }

--- a/site/posting-workspace.css
+++ b/site/posting-workspace.css
@@ -1,0 +1,26 @@
+.composer-page { overflow: auto; height: auto; min-height: 100vh; }
+.posting-workspace { display: block; max-width: 960px; margin: auto; padding: 32px 24px 100px; }
+.posting-workspace .conversation-panel, .posting-workspace .conversation-log { display: block; overflow: visible; height: auto; padding: 0; }
+.posting-workspace .chat-composer-form { position: static; border: 0; background: none; padding: 0; margin-bottom: 36px; }
+.brief-heading { font-size: 28px; letter-spacing: -.03em; margin: 0 0 8px; }
+.brief-help, .brief-status { color: #aab8ad; line-height: 1.5; }
+.brief-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin: 20px 0; }
+.posting-workspace label { display: block; font-weight: 650; margin-bottom: 8px; }
+.posting-workspace textarea, .posting-workspace input { box-sizing: border-box; width: 100%; color: #eff5ee; background: #101f16; border: 1px solid #405044; border-radius: 8px; padding: 12px; font: inherit; }
+.posting-workspace textarea:focus, .posting-workspace input:focus { outline: 2px solid #c4f43b; outline-offset: 2px; }
+.brief-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; }
+.brief-status { display: block; margin-top: 16px; min-height: 24px; }
+.posting-workspace .bounty-card-visual { display: none; }
+.posting-workspace .bounty-card { border-radius: 10px; box-shadow: none; background: #0b1710; }
+.posting-workspace .bounty-card-body { padding: 28px; }
+.posting-workspace .bounty-card-stats { margin: 24px 0; }
+.posting-workspace .ai-handoff { background: none; box-shadow: none; padding: 16px 0; border: 0; }
+.posting-workspace .ai-handoff h2 { font-size: 22px; }
+.posting-workspace .ai-original { display: none; }
+.posting-workspace details[data-ai-options] { border-top: 1px solid #354238; padding-top: 18px; margin-top: 28px; }
+.posting-workspace summary { cursor: pointer; }
+@media(max-width: 600px) { .posting-workspace { padding: 24px 16px 90px; } .brief-fields { grid-template-columns: 1fr; } .posting-workspace .bounty-card-body { padding: 18px; } }
+
+.posting-workspace .bounty-preview { scroll-margin-top: 90px; }
+.posting-workspace .verifier-terms { border: 0; border-top: 1px solid #354238; background: transparent; border-radius: 0; padding: 22px 0 0; }
+.posting-workspace .bounty-stat { border: 0; border-radius: 0; background: transparent; padding: 0 16px 0 0; }

--- a/site/posting-workspace.js
+++ b/site/posting-workspace.js
@@ -1,0 +1,70 @@
+(() => {
+  "use strict";
+  const flow = window.AgentBountiesWorkflow;
+  const client = flow.createClient(window);
+  const form = document.querySelector("#bounty-composer-form");
+  const goal = document.querySelector("#bounty-composer-input");
+  const budget = document.querySelector("[data-brief-budget]");
+  const deadline = document.querySelector("[data-brief-deadline]");
+  const status = document.querySelector("[data-brief-status]");
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  document.querySelector("[data-brief-timezone]").textContent = timezone;
+  let restoring = false;
+  function localDate(value) {
+    const date = new Date(value);
+    return Number.isFinite(date.getTime()) ? new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString().slice(0, 16) : "";
+  }
+  function restore(journey) {
+    if (!journey || journey.role !== "post") return;
+    restoring = true;
+    const brief = journey.brief || {};
+    if (document.activeElement !== goal) goal.value = brief.goal || journey.draft?.goal || journey.goal || "";
+    if (document.activeElement !== budget) budget.value = brief.budget_usdc || (journey.draft ? String(Number(journey.draft.solver_reward_usdc) + Number(journey.draft.verifier_reward_usdc)) : "");
+    if (document.activeElement !== deadline) deadline.value = localDate(brief.deadline_at || journey.draft?.delivery_deadline || "");
+    status.textContent = journey.draft ? "Draft saved in this browser. Review it below; it has not been posted." : "Brief saved. Your connected AI can use these answers.";
+    restoring = false;
+  }
+  function save() {
+    if (restoring) return;
+    const current = client.load() || client.start({ role: "post" });
+    const brief = { goal: goal.value.trim(), budget_usdc: budget.value, deadline_at: deadline.value ? new Date(deadline.value).toISOString() : null, timezone };
+    const changed = JSON.stringify(brief) !== JSON.stringify(current.brief);
+    if (changed && current.draft) window.AgentBountiesComposer?.invalidate();
+    client.save({ ...current, role: "post", goal: brief.goal, brief, draft_stale: current.draft_stale || Boolean(changed && current.draft), updated_at: new Date().toISOString() });
+    status.textContent = changed && current.draft ? "Brief updated. Your AI must update the proposal before you can approve funding." : "Brief saved. Continue with your AI in the same conversation.";
+  }
+  for (const input of [goal, budget, deadline]) input.addEventListener("input", save);
+  form.addEventListener("submit", (event) => {
+    event.preventDefault(); event.stopImmediatePropagation(); save();
+    const journey = client.load();
+    window.AgentBountyAI.show(goal.value.trim(), { draft: journey?.draft, brief: journey?.brief });
+    document.querySelector("[data-ai-options]").open = !document.documentElement.dataset.agentConnected;
+  }, true);
+  window.addEventListener("agent-bounties:journey", (event) => {
+    restore(event.detail);
+  });
+  window.addEventListener("agent-bounties:site-tool-used", () => {
+    document.documentElement.dataset.agentConnected = "true";
+    document.querySelector("[data-ai-options]").open = false;
+    status.textContent = "Your AI is connected to this workspace. Continue in your current conversation.";
+  });
+  window.addEventListener("agent-bounties:request-ai-handoff", () => { document.querySelector("[data-ai-options]").open = !document.documentElement.dataset.agentConnected; });
+  document.querySelector("[data-export-draft]").addEventListener("click", () => {
+    const journey = client.load();
+    const blob = new Blob([JSON.stringify(journey?.draft || journey?.brief || {}, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob), link = document.createElement("a");
+    link.href = url; link.download = "agent-bounties-draft.json"; link.click(); URL.revokeObjectURL(url);
+  });
+  restore(client.load());
+  const operation = flow.createPostingJournal(window).load();
+  if (operation?.bounty_contract) {
+    client.request("/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false").then((feed) => {
+      const item = feed.find((entry) => entry.bounty_id === operation.bounty_id && entry.bounty_contract.toLowerCase() === operation.bounty_contract.toLowerCase());
+      if (!item?.terms_valid || !["claimable", "claimed", "submitted", "paid"].includes(item.status) || BigInt(item.funded_amount) < BigInt(item.target_amount)) {
+        status.textContent = "A posting step is recorded; canonical funding is not confirmed. Ask your AI to check it before trying again."; return;
+      }
+      status.textContent = `Your bounty is funded. Current state: ${item.status}. `;
+      const link = document.createElement("a"); link.href = `participate.html?bountyContract=${encodeURIComponent(item.bounty_contract)}&network=base-mainnet`; link.textContent = "Open your bounty"; status.append(link);
+    }).catch(() => { status.textContent = "A posting step is recorded. Funding status is temporarily unavailable; keep the same operation."; });
+  }
+})();

--- a/site/webmcp.js
+++ b/site/webmcp.js
@@ -50,6 +50,8 @@
     if (["agent_bounties_get_bounty_review", "agent_bounties_open_funding_review"].includes(tool.name) && !isPost) return;
     if (["agent_bounties_get_competition_manifest", "agent_bounties_start_competition_child_bounty"].includes(tool.name) && !isCompetition) return;
     try {
+      const execute = tool.execute;
+      tool.execute = (...args) => { window.dispatchEvent(new CustomEvent("agent-bounties:site-tool-used")); return execute(...args); };
       const registered = context.registerTool(tool, { signal: lifecycle.signal });
       names.push(tool.name);
       registrations.push(
@@ -102,6 +104,8 @@
       solver_reward_usdc: positiveUsdc(input?.solver_reward_usdc, "Solver reward"),
       verifier_reward_usdc: positiveUsdc(input?.verifier_reward_usdc, "Verifier reward"),
       task_window_days: days,
+      review_mode: input.review_mode === "creator" ? "creator" : "automated",
+      delivery_deadline: input.delivery_deadline || null,
       source_url: sourceUrl,
       crowdfund: false,
       discovery_source: "WebMCP on agentbounties.app",
@@ -200,9 +204,11 @@
         window.sessionStorage.removeItem(PENDING_DRAFT_KEY);
         draft = JSON.parse(raw);
       } else {
-        const saved = client.load()?.draft;
+        const journey = client.load();
+        if (journey?.draft_stale) return;
+        const saved = journey?.draft;
         const parent = params.get("parentBounty");
-        if (!saved?.meta_child || !parent || saved.meta_child.parent_bounty_contract !== parent.toLowerCase() || flow.createPostingJournal(window).load()) return;
+        if (!saved || (parent && saved.meta_child?.parent_bounty_contract !== parent.toLowerCase()) || flow.createPostingJournal(window).load()) return;
         draft = saved;
       }
     } catch (_error) {
@@ -233,6 +239,7 @@
         available_tools: names.slice(),
         guidance: flow.GUIDANCE,
         journey: client.load(),
+        posting: window.AgentBountiesComposer?.review?.() || null,
         phone_wallet: window.AgentBountiesPhoneWallet?.state() || { available: false },
         next_action: { tool: "agent_bounties_get_journey", input: {} },
       };
@@ -307,6 +314,18 @@
     },
   });
 
+  if (isParticipant) {
+    register({ name: "agent_bounties_get_creator_review", title: "Read creator review and payment status",
+      description: "Read the current creator-review submission, its exact terms, artifact evidence and any recorded verdict transaction. No signature or payment is made. Use canonical status after the person confirms; do not repeat a pending wallet request.",
+      inputSchema: { type: "object", properties: {}, additionalProperties: false }, annotations: { readOnlyHint: true, untrustedContentHint: true },
+      async execute() { await waitFor(() => window.AgentBountiesCreatorReviewWorkspace, 8000); return window.AgentBountiesCreatorReviewWorkspace.refresh(); } });
+    register({ name: "agent_bounties_stage_creator_verdict", title: "Prepare the creator's completion review",
+      description: "After inspecting the exact submitted artifacts, assess every published criterion in order with evidence-based reasons. This stages a proposed verdict for the creator, never signs it or authorizes payment. The page also checks the committed calendar delivery cutoff against canonical submission time. The person confirms the verdict and payment in their wallet.",
+      inputSchema: { type: "object", properties: { checks: { type: "array", minItems: 1, maxItems: 20, items: { type: "object", properties: { criterion: { type: "string", maxLength: 1000 }, passed: { type: "boolean" }, reason: { type: "string", minLength: 1, maxLength: 1000 } }, required: ["criterion", "passed", "reason"], additionalProperties: false } } }, required: ["checks"], additionalProperties: false },
+      annotations: { readOnlyHint: false, untrustedContentHint: true },
+      async execute(input) { await waitFor(() => window.AgentBountiesCreatorReviewWorkspace, 8000); return window.AgentBountiesCreatorReviewWorkspace.stage(input); } });
+  }
+
   register({
     name: "agent_bounties_stage_funded_bounty",
     title: "Stage a funded bounty for review",
@@ -320,6 +339,8 @@
         solver_reward_usdc: { type: "string", pattern: "^\\d+(?:\\.\\d{1,6})?$" },
         verifier_reward_usdc: { type: "string", pattern: "^\\d+(?:\\.\\d{1,6})?$" },
         task_window_days: { type: "integer", minimum: 1, maximum: 30 },
+        review_mode: { type: "string", enum: ["automated", "creator"], description: "For design work without a supported automated benchmark, explicitly propose creator review: the poster signs the completion verdict. It is not automatic or independent verification. Meta children still require automated review." },
+        delivery_deadline: { type: "string", description: "Exact agreed ISO timestamp with timezone offset. Required for creator review; preserve the person’s calendar deadline." },
         source_url: { type: ["string", "null"], maxLength: 2048 },
         benchmark: { type: "object", description: "Exact executable verifier with pinned public source and runner. Prepare this for the person; do not ask them for technical fields." },
         evidence_schema: { type: "object", description: "Evidence schema paired with the benchmark. Supply both verifier fields or neither; absent verifier stays an unfundable draft." },
@@ -339,10 +360,10 @@
       const journey = client.load() || client.start({ role: "post" });
       if (isPost) {
         const result = await stageOnPostPage(draft);
-        client.save({ ...journey, draft, meta_child: draft.meta_child, role: "post" });
+        client.save({ ...journey, draft, draft_stale: false, goal: draft.goal, brief: { ...journey.brief, goal: draft.goal, budget_usdc: String(Number(draft.solver_reward_usdc) + Number(draft.verifier_reward_usdc)), deadline_at: draft.delivery_deadline || journey.brief?.deadline_at || null }, meta_child: draft.meta_child, role: "post" });
         return result;
       }
-      client.save({ ...journey, draft, meta_child: draft.meta_child, role: "post" });
+      client.save({ ...journey, draft, draft_stale: false, goal: draft.goal, brief: { ...journey.brief, goal: draft.goal, budget_usdc: String(Number(draft.solver_reward_usdc) + Number(draft.verifier_reward_usdc)), deadline_at: draft.delivery_deadline || journey.brief?.deadline_at || null }, meta_child: draft.meta_child, role: "post" });
       if (!persistPendingDraft(draft)) throw new Error("This browser cannot preserve the draft across navigation. Open /post.html and call this tool again.");
       const target = new URL("/post.html?from=webmcp", window.location.origin).href;
       window.setTimeout(() => window.location.assign(target), 0);
@@ -505,13 +526,14 @@
       : isParticipant ? { tool: "agent_bounties_get_work_status", input: {} }
       : posting ? { tool: "agent_bounties_get_posting_status", input: {} }
       : !journey ? { tool: "agent_bounties_start_journey", missing: "Does the person want work done, or want to earn? Infer this from their request when possible." }
+      : journey.draft_stale ? { tool: "agent_bounties_stage_funded_bounty", missing: "The brief changed. Update the existing proposal from journey.brief and restage it; do not reuse the old draft amounts or deadline." }
       : journey.draft && isPost ? { tool: "agent_bounties_get_bounty_review", input: {} }
       : journey.meta_child && isPost ? { tool: "agent_bounties_stage_funded_bounty", missing: "Prepare the parent's qualifying 1 USDC child, executable benchmark and distinct child solver before claiming the parent.", meta_child: journey.meta_child }
       : journey.current_intent ? { tool: "agent_bounties_check_progress", input: { intent_id: journey.current_intent } }
       : journey.draft ? { tool: "agent_bounties_stage_funded_bounty", input: journey.draft }
       : journey.selected ? { tool: "agent_bounties_inspect_opportunity", input: { opportunity_id: journey.selected } }
       : journey.role === "earn" ? { tool: "agent_bounties_list_ready_work", input: { limit: 5, timing: "now" } }
-      : { tool: "agent_bounties_stage_funded_bounty", missing: "Draft the outcome, measurable checks, total budget and work window. Prepare an executable benchmark and evidence schema before wallet review. Ask only for missing business decisions." };
+      : { tool: "agent_bounties_stage_funded_bounty", missing: "Use the saved brief to prepare deliverables and checks. For design work, propose explicit creator review and the agreed calendar delivery deadline; for automated work, prepare a supported benchmark. Ask only for missing business decisions." };
     return { journey, next_action: next, guidance: flow.GUIDANCE, user_confirmation_required: false, storage: "this browser session; no wallet authority" };
   }
   register({ name: "agent_bounties_get_journey", title: "Continue my marketplace task", description: "Resume the current posting or earning journey. Returns the saved outcome and one next action; do not restart the interview or repeat earlier approvals.",


### PR DESCRIPTION
## What Changed

The posting page looked like a second AI chat, lost text entered on the site when WebMCP read the journey, and rejected design work because it only offered selected software benchmarks. It now presents a saved brief and a single proposal review. Outcome, budget and calendar deadline are shared with WebMCP, restored after reload, and edits invalidate stale funding approval. AI setup/import stays optional and the posting prompt remains one shared source.

Add an explicit `creator_review_v1` option for public digital deliverables such as CAD. It binds the creator as sole signed-quorum reviewer, full atomic funding, positive verifier reward/bond, exact public artifact evidence and a calendar cutoff. Human review is disclosed in the card and marketplace. WebMCP can inspect a submission and stage criterion-by-criterion assessments; only the creator's page/wallet confirmation signs and submits the verdict. Exact scope/calldata validation and a recovery journal prevent replay after uncertain wallet replies. Existing automated and qualifying meta-child verification stays strict.

## Linked Issue / Maintainer Notice

No bounty claim. Owner-reported posting defects, tracked in #1313.
Notice: https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5564335675

All open PRs were inspected before edits. No new collaborator response required intervention. #934 (changes requested), #906 and #910 overlap chain-base; #908/#1196 overlap site surfaces. Reconcile current main and rerun the affected protocol/site checks; none are superseded. No collaboration branch is needed.

## Acceptance / Validation

- `cargo test -p chain-base --lib`: 88 passed, 2 live-environment tests ignored.
- `cargo check -p api -p mcp-server`: passed.
- Marketplace UI, WebMCP, meta-child, competition proof and phone-wallet tests: 86 passed, including six creator/workspace tests. Funding tests check wallet identity and field locking.
- Verifier source guard (12 tests), pipeline (27 tests), and unfunded watchdog precommit (4 tests) pass. The exact LF archive reproduces CI worker-build digest `4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284`; signing runtime is unchanged. Updated production workflow pins and the unfunded watchdog fixture/digest after reviewing the source boundary. Its full known-good/known-bad rehearsal passes.
- Homepage prompt tests: 13 passed; user-owned AI handoff test passed.
- `python scripts/check-site.py`, JS syntax, formatting and diff checks passed.
- Actual browser WebMCP: typed brief visible in page context; CAD proposal staged at 20 USDC with exact calendar deadline and no approval; reload restores the same proposal and deadline. No live bounty publication, funding, verdict or payment occurred.

## SDLC And Recovery

R3. Existing immutable contract and canonical indexed events remain authoritative; no contract deployment, new signer service, database migration or custody rail. Design/risk review covers creator authority, artifact and deadline commitments, signature/transaction scope, uncertain responses and containment.

The creator is a trusted human reviewer, not an independent or automated service. The calendar cutoff is checked against canonical submission time; the contract's relative claim timeout remains separate and is disclosed. Expired unclaimed design work leaves earning inventory and retains existing cancellation/refund paths. Gas is not represented as sponsored.

Recovery keys bind contract, round and exact submission/evidence. Never-broadcast signed requests resume without re-signing; uncertain sends remain blocked until canonical reconciliation. Only a matching canonical settlement proves payment. Forward repair must preserve already funded creator-review reconciliation; hide new creation if necessary rather than blindly rolling back support for existing funds.

## Discovery Feedback

Found through the owner's ChatGPT/WebMCP screenshots. Completing an ordinary design posting flow motivated the change. The primary improvement is preserving the brief and giving it a usable, clearly disclosed review path. Post your own bounty after reviewing its actual terms and funding requirements.
