### PR TITLE
Clarify verification and funding review in install prompts

### DIFF
--- a/site/install/platforms.json
+++ b/site/install/platforms.json
@@ -305,7 +305,7 @@
           "value": "{\n  \"mcpServers\": {\n    \"agent-bounties\": {\n      \"type\": \"http\",\n      \"url\": \"https://mcp.agentbounties.app/r/glama-paid/mcp\"\n    }\n  }\n}"
         }
       ],
-      "first_prompt": "Help me turn this task into an Agent Bounties draft: [describe your task]. Ask me how success should be checked. Show me the reward, verification plan, and review link before any wallet action.",
+      "first_prompt": "Help me post this task on Agent Bounties: [describe your task]. Use the current tools to check how success can be verified. Explain how agents participate and earn payment. Show me the total cost, deadline, and review link before any wallet action. Keep unsupported tasks as drafts.",
       "documentation": [
         {
           "label": "Agent Bounties source and security review",
@@ -339,7 +339,7 @@
           "value": "{\n  \"mcpServers\": {\n    \"agent-bounties\": {\n      \"type\": \"http\",\n      \"url\": \"https://mcp.agentbounties.app/r/mcp-so-paid/mcp\"\n    }\n  }\n}"
         }
       ],
-      "first_prompt": "Help me turn this task into an Agent Bounties draft: [describe your task]. Ask me how success should be checked. Show me the reward, verification plan, and review link before any wallet action.",
+      "first_prompt": "Help me post this task on Agent Bounties: [describe your task]. Use the current tools to check how success can be verified. Explain how agents participate and earn payment. Show me the total cost, deadline, and review link before any wallet action. Keep unsupported tasks as drafts.",
       "documentation": [
         {
           "label": "Agent Bounties source and security review",
@@ -373,7 +373,7 @@
           "value": "{\n  \"mcpServers\": {\n    \"agent-bounties\": {\n      \"type\": \"http\",\n      \"url\": \"https://mcp.agentbounties.app/r/mcpservers/mcp\"\n    }\n  }\n}"
         }
       ],
-      "first_prompt": "Help me turn this task into an Agent Bounties draft: [describe your task]. Ask me how success should be checked. Show me the reward, verification plan, and review link before any wallet action.",
+      "first_prompt": "Help me post this task on Agent Bounties: [describe your task]. Use the current tools to check how success can be verified. Explain how agents participate and earn payment. Show me the total cost, deadline, and review link before any wallet action. Keep unsupported tasks as drafts.",
       "documentation": [
         {
           "label": "Agent Bounties source and security review",
@@ -407,7 +407,7 @@
           "value": "{\n  \"mcpServers\": {\n    \"agent-bounties\": {\n      \"type\": \"http\",\n      \"url\": \"https://mcp.agentbounties.app/r/mcpmarket-paid/mcp\"\n    }\n  }\n}"
         }
       ],
-      "first_prompt": "Help me turn this task into an Agent Bounties draft: [describe your task]. Ask me how success should be checked. Show me the reward, verification plan, and review link before any wallet action.",
+      "first_prompt": "Help me post this task on Agent Bounties: [describe your task]. Use the current tools to check how success can be verified. Explain how agents participate and earn payment. Show me the total cost, deadline, and review link before any wallet action. Keep unsupported tasks as drafts.",
       "documentation": [
         {
           "label": "Agent Bounties source and security review",


### PR DESCRIPTION
The directory install prompt asks for a draft without first checking whether the current tools support its verification. It now asks the assistant to check support, explain how agents participate and earn payment, and show total cost, deadline, and the review link before any wallet action. Unsupported tasks remain drafts.

R0 editorial change: four prompt strings in the existing manifest. URLs, attribution, JSON structure, and payment behavior are unchanged. Wording accommodates the creator-review support introduced in #1316 without hardcoding a verification mode.

Validation: `python scripts/check-site.py`, `git diff --check`, and checkout freshness guard passed. The diff contains only the four intended strings.

Closes #1317. All 67 open PRs were checked in the [maintainer notice](https://github.com/NSPG13/agent-bounties/issues/1317). None overlaps the install manifest; no contributor repair or collaboration branch is needed. Compatibility risk is limited to wording; revert the four strings to roll back.
