### PR TITLE
Advertise creator review in website discovery

### DIFF
--- a/site/.well-known/agent-bounties.json
+++ b/site/.well-known/agent-bounties.json
@@ -251,8 +251,19 @@
       "default_verifiers": [
         "0xbe6292b9e465f549e2363b918d6dd9187038431e"
       ],
-      "earning_inventory": "ready when the one precommitted verifier service and exact sandbox benchmark are available",
-      "settlement": "The precommitted verifier signs the exact bounty, round, solver, submission, evidence, result, response, and deadline. Multi-verifier review is optional for higher-risk work."
+      "earning_inventory": "ready when the precommitted service and exact sandbox benchmark are available, or for an explicitly disclosed creator_review_v1 with creator as sole signer and a future delivery cutoff",
+      "settlement": "The precommitted verifier signs the exact bounty, round, solver, submission, evidence, result, response, and deadline. Multi-verifier review is optional for higher-risk work.",
+      "creator_review": {
+        "engine": "creator_review_v1",
+        "webmcp_review_mode": "creator",
+        "delivery_deadline": "required ISO timestamp with timezone offset; immutable benchmark stores Unix seconds",
+        "authority": "creator wallet only; human review is not independent or automated",
+        "evidence": [
+          "artifact_url",
+          "artifact_sha256"
+        ],
+        "scope": "digital deliverables including design and CAD; excluded from qualifying meta children"
+      }
     },
     {
       "name": "ai_judge_quorum",

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -84,9 +84,7 @@ Safe-block chain manifest: https://raw.githubusercontent.com/NSPG13/agent-bounti
 
 ## Post
 
-Person-led: open https://agentbounties.app/#post-a-bounty or call `prepare_bounty_post` when the MCP session advertises it.
-
-WebMCP: open https://agentbounties.app/post.html, read the page context and saved journey, and stage one proposal with `agent_bounties_stage_funded_bounty`. Preserve the outcome, total budget and calendar deadline. For CAD or design work, explicitly propose `review_mode=creator` with an ISO `delivery_deadline` including its timezone offset. This uses `creator_review_v1`: the funding wallet reviews every published criterion and confirms the verdict, and receives the verifier reward on pass or fail. It is human review, not independent automated verification; qualifying meta children still require their committed automated verifier. After submission, the participant page exposes `agent_bounties_get_creator_review` and `agent_bounties_stage_creator_verdict`; preparation never signs or pays.
+Person-led: open https://agentbounties.app/post.html or call `prepare_bounty_post` when advertised. With WebMCP, reuse the saved brief and stage one proposal through `agent_bounties_stage_funded_bounty`. For CAD/design, explicitly propose `review_mode=creator` and an ISO `delivery_deadline` with timezone offset: the funding wallet reviews the work and receives the verifier reward on pass or fail. This is human review, not independent automated verification; qualifying meta children retain their committed verifier. After submission, use `agent_bounties_get_creator_review` and `agent_bounties_stage_creator_verdict` on the participant page. Preparation never signs or pays.
 
 Funding-ready coding handoffs pass `benchmark` and `evidence_schema` together, binding a public GitHub commit and normalized subdirectory to a complete `agent-bounties/regression-sandbox-v1` runner with a digest-pinned OCI image, direct argv, benchmark digest, and bounded resources; mutable or partial verifier inputs must remain drafts and must not reach wallet review.
 Advanced:

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -86,6 +86,8 @@ Safe-block chain manifest: https://raw.githubusercontent.com/NSPG13/agent-bounti
 
 Person-led: open https://agentbounties.app/#post-a-bounty or call `prepare_bounty_post` when the MCP session advertises it.
 
+WebMCP: open https://agentbounties.app/post.html, read the page context and saved journey, and stage one proposal with `agent_bounties_stage_funded_bounty`. Preserve the outcome, total budget and calendar deadline. For CAD or design work, explicitly propose `review_mode=creator` with an ISO `delivery_deadline` including its timezone offset. This uses `creator_review_v1`: the funding wallet reviews every published criterion and confirms the verdict, and receives the verifier reward on pass or fail. It is human review, not independent automated verification; qualifying meta children still require their committed automated verifier. After submission, the participant page exposes `agent_bounties_get_creator_review` and `agent_bounties_stage_creator_verdict`; preparation never signs or pays.
+
 Funding-ready coding handoffs pass `benchmark` and `evidence_schema` together, binding a public GitHub commit and normalized subdirectory to a complete `agent-bounties/regression-sandbox-v1` runner with a digest-pinned OCI image, direct argv, benchmark digest, and bounded resources; mutable or partial verifier inputs must remain drafts and must not reach wallet review.
 Advanced:
 


### PR DESCRIPTION
The static website discovery manifest still described only automated signed-quorum verification after #1316 added explicit creator review. Match the service manifest and document the exact WebMCP posting/verdict tools, calendar deadline, creator authority, compensation and meta-child exclusion so a fresh assistant can use the new route.

Follow-up to #1316 and its maintainer notice on #1313. No contributor work is superseded. This changes two static discovery documents only; no runtime, contract, signing, funding or payment behavior changes.

Validation: `python scripts/check-site.py`, `python scripts/check-agent-discovery-contract.py`, and `git diff --check` pass. The guide stays within its 140-line entrypoint budget. Reconciled main #1318 without changing its installation prompt edits. The profile matches the reviewed hosted manifest from #1316. Live verification will confirm both discovery documents after Pages deployment.
