### PR TITLE
Fix clipped posting actions and wallet dialogs in embedded browsers

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,8 @@ on:
       - "scripts/fixtures/meta-child-plan.json"
       - "scripts/test-competition-proof.js"
       - "scripts/test-phone-wallet.js"
+      - "scripts/test-posting-layout.cjs"
+      - "tools/browser-layout/**"
       - "scripts/configure-phone-wallet.py"
       - "tools/phone-wallet/**"
       - "scripts/github_audience_audit.py"
@@ -40,6 +42,8 @@ on:
       - "scripts/fixtures/meta-child-plan.json"
       - "scripts/test-competition-proof.js"
       - "scripts/test-phone-wallet.js"
+      - "scripts/test-posting-layout.cjs"
+      - "tools/browser-layout/**"
       - "scripts/configure-phone-wallet.py"
       - "tools/phone-wallet/**"
       - "scripts/github_audience_audit.py"
@@ -97,6 +101,12 @@ jobs:
         run: node --test scripts/test-metrics-dashboard.js
       - name: Test unified marketplace readiness, timing, and economics
         run: node --test scripts/test-marketplace-ui.js scripts/test-webmcp.js scripts/test-meta-child.js scripts/test-competition-proof.js scripts/test-phone-wallet.js
+      - name: Test posting and wallet actions in real browser viewports
+        working-directory: tools/browser-layout
+        run: |
+          npm ci --ignore-scripts --no-fund
+          npx playwright install --with-deps chromium
+          npm test
       - name: Verify the privacy-safe GitHub participation aggregate
         run: |
           python scripts/test_github_audience_audit.py -v

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -549,7 +549,7 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
             "data-card-verifier",
             "function renderVerifierTerms",
             "if (!ui.verifierSummary || !ui.verifier) return;",
-            'bounty-composer-v2.js?v=11',
+            'bounty-composer-v2.js?v=12',
             "function verificationReadiness",
             "verificationReadiness(benchmark, state.draft?.evidence_schema)",
             'sourceSnapshotDigest.pattern === "^sha256:[0-9a-f]{64}$"',

--- a/scripts/test-posting-layout.cjs
+++ b/scripts/test-posting-layout.cjs
@@ -1,0 +1,185 @@
+"use strict";
+// Real layout/interaction gate. No remote requests, real wallets, or transactions.
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const http = require("node:http");
+const { execFileSync } = require("node:child_process");
+let playwright;
+try { playwright = require("../tools/browser-layout/node_modules/playwright"); }
+catch { playwright = require("playwright"); }
+const root = path.resolve(__dirname, "..");
+const baseline = process.env.POSTING_LAYOUT_BASELINE;
+const mime = { ".html": "text/html", ".css": "text/css", ".js": "text/javascript", ".json": "application/json", ".svg": "image/svg+xml" };
+const server = http.createServer((req, res) => {
+  const relative = decodeURIComponent(new URL(req.url, "http://localhost").pathname).replace(/^\/+/, "");
+  const filename = path.resolve(root, "site", relative);
+  if (!filename.startsWith(path.join(root, "site") + path.sep)) { res.writeHead(403).end(); return; }
+  try {
+    const source = baseline ? execFileSync("git", ["show", baseline + ":site/" + relative], { cwd: root, stdio: ["ignore", "pipe", "ignore"] }) : fs.readFileSync(filename);
+    res.writeHead(200, { "Content-Type": mime[path.extname(filename)] || "application/octet-stream" }).end(source);
+  } catch { res.writeHead(404).end(); }
+});
+const fixture = {
+  title: "An editable product model with assembly instructions",
+  goal: "Create an editable concept model and clear assembly drawings that another person can open, measure, and use.",
+  acceptance_criteria: [
+    "Deliver editable source plus STEP and STL exports that open without errors.",
+    "Include dimensioned drawings, an adjustable adapter, and a list of measurements needed before fabrication.",
+    "Include assembly instructions and a bill of materials with each part clearly identified."
+  ],
+  solver_reward_usdc: "18.00", verifier_reward_usdc: "2.00", task_window_days: 7,
+  review_mode: "creator", delivery_deadline: new Date(Date.now() + 7 * 86400000).toISOString()
+};
+async function hitTarget(page, selector) {
+  const result = await page.locator(selector).evaluate(el => {
+    const r = el.getBoundingClientRect(), x = r.left + r.width / 2, y = r.top + r.height / 2;
+    const hit = document.elementFromPoint(x, y);
+    return { text: el.textContent.trim(), visible: r.width > 0 && r.height >= 43 && r.left >= 0 && r.right <= innerWidth + 1 && r.top >= 0 && r.bottom <= innerHeight + 1, hit: hit === el || el.contains(hit), rect: r.toJSON() };
+  });
+  assert.ok(result.visible && result.hit, selector + " clipped or covered: " + JSON.stringify(result));
+}
+async function noHorizontalOverflow(page) {
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), true, "Page must reflow without horizontal overflow");
+}
+async function wheelToEnd(page, selector = null) {
+  if (selector) {
+    const r = await page.locator(selector).boundingBox();
+    await page.mouse.move(r.x + r.width / 2, r.y + r.height * .7);
+  } else {
+    const v = page.viewportSize(); await page.mouse.move(v.width / 2, v.height / 2);
+  }
+  await page.mouse.wheel(0, 20000);
+  await page.waitForFunction(sel => {
+    const el = sel ? document.querySelector(sel) : document.scrollingElement;
+    return el.scrollHeight - el.clientHeight - el.scrollTop <= 2;
+  }, selector);
+}
+async function modalBounds(page, selector) {
+  const value = await page.locator(selector).evaluate(el => {
+    const r = el.getBoundingClientRect();
+    return { bounded: r.top >= 0 && r.bottom <= innerHeight + 1 && r.left >= 0 && r.right <= innerWidth + 1, noHorizontal: el.scrollWidth <= el.clientWidth + 1, rect: r.toJSON(), viewport: [innerWidth, innerHeight] };
+  });
+  assert.ok(value.bounded && value.noHorizontal, selector + " exceeds the viewport: " + JSON.stringify(value));
+}
+async function main() {
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const origin = "http://127.0.0.1:" + server.address().port;
+  const browser = await playwright.chromium.launch({ headless: true });
+  const sizes = [
+    { width: 1440, height: 900 }, { width: 946, height: 838 },
+    { width: 640, height: 480 }, { width: 390, height: 600 },
+    { width: 320, height: 480 }, { width: 768, height: 320 },
+    // A 960x720 browser at 200% zoom has this 480x360 CSS viewport.
+    { width: 480, height: 360, zoomReflow: true }
+  ];
+  try {
+    for (const size of sizes) {
+      const context = await browser.newContext({ viewport: { width: size.width, height: size.height }, reducedMotion: "reduce" });
+      const page = await context.newPage();
+      const errors = [];
+      page.on("pageerror", error => errors.push(error.message));
+      await context.route("**/*", async route => {
+        const url = new URL(route.request().url());
+        if (url.origin !== origin) return route.abort();
+        if (url.pathname === "/phone-wallet-config.js") return route.fulfill({ contentType: "text/javascript", body: 'window.agentBountiesPhoneWalletConfig={projectId:"00000000000000000000000000000000"};' });
+        // Inert provider renders a synthetic QR image, with no relay connection.
+        if (url.pathname === "/vendor/phone-wallet.bundle.js") return route.fulfill({ contentType: "text/javascript", body: `
+          export async function createProvider() {
+            const listeners = {};
+            return { accounts: [], chainId: 8453, on: (name, fn) => listeners[name] = fn,
+              signer: { cleanupPendingPairings: async () => {} },
+              connect: () => { listeners.display_uri?.("wc:" + "0".repeat(64) + "@2?symKey=" + "0".repeat(64)); return new Promise(() => {}); }
+            };
+          }
+          export async function qrDataUrl() { return "data:image/svg+xml," + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="290" height="290"><rect width="290" height="290" fill="white"/><path d="M20 20h80v80H20zM190 20h80v80h-80zM20 190h80v80H20z" fill="black"/></svg>'); }
+        ` });
+        return route.continue();
+      });
+      await page.addInitScript(() => {
+        window.__walletWrites = [];
+        window.ethereum = { isMetaMask: true, request: async ({ method }) => {
+          if (method === "eth_requestAccounts" || method === "eth_accounts") return ["0x1111111111111111111111111111111111111111"];
+          if (method === "eth_chainId") return "0x2105";
+          if (method === "eth_call") return "0x5f5e100";
+          if (method === "eth_getBalance") return "0x2386f26fc10000";
+          window.__walletWrites.push(method); throw new Error("Layout test prohibits wallet writes: " + method);
+        } };
+      });
+      await page.goto(origin + "/post.html");
+      await page.waitForFunction(() => window.AgentBountiesComposer);
+      await page.evaluate(draft => window.AgentBountiesComposer.stage(draft), fixture);
+      await page.locator("[data-approve-card]").waitFor({ state: "visible" });
+      await noHorizontalOverflow(page);
+      assert.notEqual(await page.evaluate(() => getComputedStyle(document.body).overflowY), "hidden", "Retired chat CSS must not lock the page");
+      // Real wheel input, not scrollIntoView, catches the original silent scroll trap.
+      await page.evaluate(() => scrollTo(0, 0));
+      await page.mouse.move(size.width / 2, size.height / 2);
+      await page.mouse.wheel(0, 400);
+      await page.waitForFunction(() => scrollY > 20);
+      await hitTarget(page, "[data-revise-card]");
+      await hitTarget(page, "[data-approve-card]");
+      if (size.width === 1440) {
+        await page.setViewportSize({ width: 390, height: 320 });
+        await hitTarget(page, "[data-approve-card]");
+        await noHorizontalOverflow(page);
+        await page.setViewportSize(size);
+      }
+      await wheelToEnd(page);
+      const footer = await page.locator("[data-ai-options] > summary").boundingBox();
+      const dock = await page.locator(".bounty-card-actions").boundingBox();
+      assert.ok(footer.y + footer.height < dock.y, "Bottom content must clear the action dock");
+      if (process.env.POSTING_LAYOUT_SCREENSHOTS) {
+        fs.mkdirSync(process.env.POSTING_LAYOUT_SCREENSHOTS, { recursive: true });
+        await page.locator("#bounty-preview").scrollIntoViewIfNeeded();
+        await page.screenshot({ path: path.join(process.env.POSTING_LAYOUT_SCREENSHOTS, "proposal-" + size.width + "x" + size.height + ".png") });
+      }
+      // Only the isolated test fixture is approved. No real site or wallet is touched.
+      await page.locator("[data-approve-card]").click();
+      await page.locator(".wallet-option").first().waitFor();
+      await modalBounds(page, "#funding-dialog");
+      await hitTarget(page, "[data-close-funding]");
+      await wheelToEnd(page, "#funding-dialog");
+      await page.locator("[data-walletless-onramp-link]").focus();
+      assert.equal(await page.locator("[data-walletless-onramp-link]").evaluate(el => {
+        const r = el.getBoundingClientRect(); return r.top >= 0 && r.bottom <= innerHeight;
+      }), true, "Wallet setup link must be keyboard reachable");
+      await page.locator("[data-close-funding]").click();
+      await hitTarget(page, "[data-open-funding]");
+      await page.locator("[data-open-funding]").click();
+      await page.locator(".wallet-option").first().waitFor();
+      if (process.env.POSTING_LAYOUT_SCREENSHOTS) await page.screenshot({ path: path.join(process.env.POSTING_LAYOUT_SCREENSHOTS, "wallet-" + size.width + "x" + size.height + ".png") });
+      await page.getByRole("button", { name: "MetaMask", exact: false }).click();
+      await page.locator("[data-wallet-readiness]").waitFor({ state: "visible" });
+      await page.locator(".funding-help > summary").click();
+      if (size.width === 1440) {
+        await page.setViewportSize({ width: 390, height: 320 });
+        await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+        await modalBounds(page, "#funding-dialog");
+        await hitTarget(page, "[data-close-funding]");
+        await page.setViewportSize(size);
+      }
+      await modalBounds(page, "#funding-dialog");
+      await wheelToEnd(page, "#funding-dialog");
+      await hitTarget(page, "[data-close-funding]");
+      await hitTarget(page, "[data-fund-now]");
+      await page.locator("[data-close-funding]").click();
+      await page.locator(".ab-phone-launcher").click();
+      await page.locator(".ab-phone-qr").waitFor({ state: "visible" });
+      await modalBounds(page, ".ab-phone-dialog");
+      await wheelToEnd(page, ".ab-phone-dialog");
+      await hitTarget(page, ".ab-phone-close");
+      await page.locator(".ab-phone-close").click();
+      await page.keyboard.press("Tab");
+      await page.locator("[data-revise-card]").click();
+      assert.equal(await page.locator("#bounty-composer-input").inputValue(), fixture.goal);
+      assert.equal(await page.locator("#bounty-composer-input").evaluate(el => document.activeElement === el), true);
+      await noHorizontalOverflow(page);
+      assert.deepEqual(await page.evaluate(() => window.__walletWrites), []);
+      assert.deepEqual(errors, [], "No browser runtime errors");
+      console.log("PASS posting, wallet review, QR, keyboard and scrolling at " + size.width + "x" + size.height + (size.zoomReflow ? " (200% browser-zoom reflow equivalent)" : ""));
+      await context.close();
+    }
+  } finally { await browser.close(); }
+}
+main().catch(error => { console.error(error); process.exitCode = 1; }).finally(() => server.close());

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -523,7 +523,7 @@
       kind: "date",
       date: deadline,
       days,
-      label: prepared.delivery_deadline ? `${deadline.toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone})` : `${days} days after claim`,
+      label: prepared.delivery_deadline ? `${deadline.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })} (${Intl.DateTimeFormat().resolvedOptions().timeZone})` : `${days} days after claim`,
     };
     state.missionPlan = null;
     state.selectedTaskId = null;
@@ -1485,9 +1485,7 @@
     // The card confirmation leads straight to wallet review; no duplicate chat approval.
     openFunding().catch((error) => setPaymentStatus(error.message, "error"));
     setProgress("fund");
-    setStatus(state.bountyImage
-      ? "Card approved with the exact supplied image. Funding still requires a separate wallet review and signature."
-      : "Card approved with a deterministic content-derived visual. Funding still requires a separate wallet review and signature.", "success");
+    setStatus("Proposal approved. Review funding in your wallet before posting.", "success");
   }
 
   function reviseCard() {
@@ -1499,7 +1497,7 @@
     setComposer({ phase:"revise", prompt:"Edit your brief, then continue with your AI in this conversation.", label:"What do you want delivered?", placeholder:"Describe the result you need.", button:"Save brief", hint:"Your AI uses the saved brief to update the proposal." });
     ui.input.value = savedGoal || state.draft?.goal || state.originalRequest;
     ui.form.scrollIntoView({behavior:"smooth",block:"start"});
-    ui.input.focus();
+    ui.input.focus({ preventScroll: true });
     setStatus("Edit the saved brief above and ask your AI to update the proposal in your current conversation.", "pending");
   }
 
@@ -1537,7 +1535,7 @@
     onrampUrl.searchParams.set("return", window.location.href);
     for (const link of ui.onramps) link.href = onrampUrl.href;
     ui.dialog.showModal();
-    setPaymentStatus("Choose a detected wallet or open the Base USDC handoff in a separate tab.");
+    setPaymentStatus("");
     ui.walletPanel.hidden = false;
     ui.readiness.hidden = true;
     ui.fundNow.disabled = true;
@@ -1569,7 +1567,7 @@
     ui.walletMessage.textContent="Looking for wallets on this device…";
     const providers=await discoverWallets();
     if(!providers.length){ui.walletMessage.textContent="No compatible browser wallet was detected. Use the Base USDC handoff below to create or fund a wallet, then reopen this review in a browser where that wallet can sign. Never enter a recovery phrase on this website.";track("wallet_missing_detected");return;}
-    ui.walletMessage.textContent=providers.length===1?"One wallet is available.":`${providers.length} wallets are available. Choose which one to use.`;
+    ui.walletMessage.textContent="Choose a wallet to continue.";
     for(const item of providers){const button=document.createElement("button");button.type="button";button.className="wallet-option";const name=document.createElement("strong");name.textContent=providerName(item);const note=document.createElement("small");note.textContent="Connect and check Base USDC";button.append(name,note);button.addEventListener("click",()=>connectWallet(item));ui.walletOptions.append(button);}
   }
 

--- a/site/post.html
+++ b/site/post.html
@@ -16,19 +16,18 @@
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="bounty-composer.css?v=1">
     <link rel="stylesheet" href="bounty-composer-v2.css?v=2">
-    <link rel="stylesheet" href="bounty-chat.css?v=4">
-    <link rel="stylesheet" href="bounty-chat-controls.css?v=1">
     <link rel="stylesheet" href="ai-bounty-handoff.css?v=2">
     <link rel="stylesheet" href="phone-wallet.css?v=1">
-    <link rel="stylesheet" href="posting-workspace.css?v=1">
+    <link rel="stylesheet" href="posting-workspace.css?v=2">
   </head>
-  <body class="composer-page chat-app-page">
+  <body class="composer-page posting-page">
     <header class="chat-app-header">
       <a class="chat-app-brand" href="./" aria-label="Agent Bounties home">
         <span aria-hidden="true">A</span>
         <strong>Agent Bounties</strong>
       </a>
       <h1 class="chat-app-title">New bounty</h1>
+      <div class="posting-wallet" data-posting-wallet></div>
       <a class="chat-app-close" href="./" aria-label="Close and return home">×</a>
     </header>
 
@@ -65,8 +64,8 @@
                 </div>
 
                 <div class="bounty-card-stats" aria-label="Bounty summary">
-                  <div class="bounty-stat"><span>Reward</span><strong data-card-reward>—</strong></div>
-                  <div class="bounty-stat"><span>Time</span><strong data-card-deadline>—</strong></div>
+                  <div class="bounty-stat"><span>Total budget</span><strong data-card-reward>—</strong></div>
+                  <div class="bounty-stat"><span>Delivery</span><strong data-card-deadline>—</strong></div>
                   <div class="bounty-stat"><span>Checks</span><strong data-card-checks>—</strong></div>
                   <strong class="sr-only" data-card-confidence>—</strong>
                 </div>
@@ -96,7 +95,7 @@
                   <p>The named verifier and review method are fixed before funding. Creator review requires your signed verdict; automated review requires a supported benchmark.</p>
                 </details>
 
-                <div class="bounty-card-actions chat-draft-actions">
+                <div class="bounty-card-actions chat-draft-actions" aria-label="Proposal actions">
                   <button class="button secondary" type="button" data-revise-card>Edit brief</button>
                   <button type="button" data-share-card hidden>Share draft</button>
                   <button class="button secondary" type="button" data-approve-card data-approved="false">Approve</button>
@@ -197,7 +196,7 @@
           <section class="wallet-picker-panel" data-wallet-panel hidden>
             <p data-wallet-message>Looking for wallets…</p>
             <div class="wallet-options" data-wallet-options></div>
-            <a class="button secondary" href="onramp.html?purpose=post" target="_blank" rel="noopener noreferrer" data-onramp-link data-walletless-onramp-link>Create or fund a wallet with Base USDC</a>
+            <p class="wallet-alternative">Need a wallet or USDC? <a href="onramp.html?purpose=post" target="_blank" rel="noopener noreferrer" data-onramp-link data-walletless-onramp-link>View setup options ↗</a></p>
           </section>
 
           <section class="wallet-readiness" data-wallet-readiness hidden aria-label="Wallet readiness">
@@ -258,7 +257,7 @@
     <script src="posting-prompt.js?v=2"></script>
     <script src="creator-review.js?v=1"></script>
     <script src="ai-bounty-handoff.js?v=9"></script>
-    <script src="bounty-composer-v2.js?v=11"></script>
-    <script src="posting-workspace.js?v=1"></script>
+    <script src="bounty-composer-v2.js?v=12"></script>
+    <script src="posting-workspace.js?v=2"></script>
   </body>
 </html>

--- a/site/posting-workspace.css
+++ b/site/posting-workspace.css
@@ -1,30 +1,137 @@
-.composer-page { overflow: auto; height: auto; min-height: 100vh; }
-.posting-workspace { display: block; max-width: 960px; margin: auto; padding: 32px 24px 100px; }
+/* Posting owns its viewport; the retired chat layout locks document scrolling. */
+html:has(.posting-page) {
+  height: auto;
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
+  scroll-padding-block: 24px calc(var(--posting-actions-height, 88px) + 24px);
+  color-scheme: dark;
+  scrollbar-color: #738379 #101b15;
+}
+.posting-page { margin: 0; min-width: 0; height: auto; min-height: 100vh; overflow: visible; background: #0b1410; color: #edf2ee; font: 400 16px/1.55 system-ui, sans-serif; }
+html:has(.posting-page)::-webkit-scrollbar, .posting-page dialog::-webkit-scrollbar { width: 12px; }
+html:has(.posting-page)::-webkit-scrollbar-track, .posting-page dialog::-webkit-scrollbar-track { background: #101b15; }
+html:has(.posting-page)::-webkit-scrollbar-thumb, .posting-page dialog::-webkit-scrollbar-thumb { background: #738379; border: 3px solid #101b15; border-radius: 8px; }
+.posting-page *, .posting-page *::before, .posting-page *::after { box-sizing: border-box; }
+.posting-page :is(button, a, input, textarea, summary):focus-visible { outline: 2px solid #c4f43b; outline-offset: 3px; }
+.posting-page .chat-app-header { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; padding: 12px clamp(16px, 3vw, 32px); border-bottom: 1px solid #2a382f; background: #0b1410; }
+.posting-page .chat-app-brand { display: flex; align-items: center; gap: 10px; color: inherit; text-decoration: none; }
+.posting-page .chat-app-brand span { display: grid; place-items: center; width: 32px; height: 32px; border: 1px solid #586b32; border-radius: 8px; color: #c4f43b; font-weight: 700; }
+.posting-page .chat-app-brand strong { font-size: 14px; font-weight: 600; }
+.posting-page .chat-app-title { margin: 0 auto 0 12px; font-size: 14px; font-weight: 500; color: #b4c1b8; }
+.posting-page .chat-app-close { display: grid; place-items: center; width: 44px; height: 44px; color: #b4c1b8; text-decoration: none; font-size: 24px; }
+.posting-wallet { min-width: 0; }
+.posting-page .ab-phone-launcher { position: static; max-width: 100%; min-height: 44px; padding: 8px 12px; border: 1px solid #425348; border-radius: 8px; box-shadow: none; background: transparent; color: #dce6df; font: 500 13px/1.4 system-ui, sans-serif; overflow-wrap: anywhere; }
+.posting-workspace { display: block; width: 100%; max-width: 880px; margin: auto; padding: 36px 24px calc(var(--posting-actions-height, 88px) + 48px); }
 .posting-workspace .conversation-panel, .posting-workspace .conversation-log { display: block; overflow: visible; height: auto; padding: 0; }
-.posting-workspace .chat-composer-form { position: static; border: 0; background: none; padding: 0; margin-bottom: 36px; }
-.brief-heading { font-size: 28px; letter-spacing: -.03em; margin: 0 0 8px; }
-.brief-help, .brief-status { color: #aab8ad; line-height: 1.5; }
-.brief-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin: 20px 0; }
-.posting-workspace label { display: block; font-weight: 650; margin-bottom: 8px; }
-.posting-workspace textarea, .posting-workspace input { box-sizing: border-box; width: 100%; color: #eff5ee; background: #101f16; border: 1px solid #405044; border-radius: 8px; padding: 12px; font: inherit; }
-.posting-workspace textarea:focus, .posting-workspace input:focus { outline: 2px solid #c4f43b; outline-offset: 2px; }
-.brief-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; }
-.brief-status { display: block; margin-top: 16px; min-height: 24px; }
+.posting-workspace .chat-composer-form { position: static; border: 0; background: none; padding: 0; margin: 0 0 32px; }
+.brief-heading { font-size: 26px; line-height: 1.25; letter-spacing: -.025em; margin: 0 0 8px; }
+.brief-help, .brief-status { color: #aebbb2; line-height: 1.5; }
+.brief-help { margin: 0 0 24px; }
+.brief-fields { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 20px; margin: 20px 0; }
+.posting-workspace label { display: block; font-size: 14px; font-weight: 600; margin-bottom: 8px; }
+.posting-workspace textarea, .posting-workspace input { width: 100%; min-width: 0; color: #edf2ee; background: #132019; border: 1px solid #405044; border-radius: 8px; padding: 12px; font: inherit; }
+.posting-workspace #bounty-composer-input { min-height: 130px; max-height: none; resize: vertical; }
+.brief-fields small { display: block; color: #aebbb2; margin-top: 6px; overflow-wrap: anywhere; }
+.posting-page .button { min-height: 44px; padding: 10px 16px; border-radius: 8px; font: 600 14px/1.45 system-ui, sans-serif; white-space: normal; text-align: center; }
+.posting-page .button.secondary { color: #e1e9e3; border: 1px solid #4a5b4f; background: transparent; }
+.posting-page .button.primary { color: #152006; border: 1px solid #c4f43b; background: #c4f43b; }
+.brief-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; }
+.brief-status, .posting-page .composer-status { display: block; margin-top: 16px; font-size: 14px; }
+.posting-page .composer-status:empty { display: none; }
+.posting-workspace .bounty-preview { width: 100%; margin: 0; scroll-margin-top: 24px; }
 .posting-workspace .bounty-card-visual { display: none; }
-.posting-workspace .bounty-card { border-radius: 10px; box-shadow: none; background: #0b1710; }
-.posting-workspace .bounty-card-body { padding: 28px; }
-.posting-workspace .bounty-card-stats { margin: 24px 0; }
+.posting-workspace .bounty-card { overflow: visible; border: 0; border-top: 1px solid #354238; border-radius: 0; box-shadow: none; background: transparent; }
+.posting-workspace .bounty-card-body { padding: 28px 0 0; }
+.draft-state { display: block; color: #b9ce8c; font-size: 13px; font-weight: 600; margin-bottom: 12px; }
+.posting-workspace .bounty-card h2 { font-size: clamp(24px, 3vw, 30px); line-height: 1.2; letter-spacing: -.025em; overflow-wrap: anywhere; }
+.posting-workspace .bounty-card-goal { font-size: 16px; line-height: 1.6; margin: 12px 0 24px; }
+.posting-workspace .bounty-card-stats { grid-template-columns: 1.1fr 1.2fr .5fr; gap: 20px; margin: 24px 0 28px; }
+.posting-workspace .bounty-stat { border: 0; border-radius: 0; background: transparent; padding: 0; }
+.posting-workspace .bounty-stat span { font-size: 12px; font-weight: 500; letter-spacing: 0; text-transform: none; color: #aebbb2; }
+.posting-workspace .bounty-stat strong { font-size: 14px; font-weight: 600; line-height: 1.5; }
+.posting-workspace .bounty-card-section h3 { font-size: 16px; font-weight: 600; }
+.posting-workspace .bounty-card-section ol { color: #d0dad3; line-height: 1.6; }
+.posting-workspace .verifier-terms { border: 0; border-top: 1px solid #354238; background: transparent; border-radius: 0; margin-top: 28px; padding: 24px 0 0; font-size: 14px; }
+.posting-workspace .verifier-terms p { color: #d0dad3; line-height: 1.6; }
+.posting-workspace .verifier-terms dl { grid-template-columns: minmax(100px, .3fr) 1fr; gap: 8px 20px; }
+.posting-workspace .verifier-terms dt { font-weight: 500; }
+.posting-workspace .verifier-terms dd { overflow-wrap: anywhere; }
+.posting-workspace .bounty-review-details { margin-top: 24px; border-top: 1px solid #354238; padding-top: 16px; font-size: 14px; }
+.posting-page summary { cursor: pointer; padding-block: 8px; }
+.posting-workspace .bounty-card-actions {
+  position: fixed;
+  z-index: 40;
+  inset: auto 0 0;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin: 0;
+  padding: 12px 24px max(12px, env(safe-area-inset-bottom));
+  border-top: 1px solid #405044;
+  background: #101c15;
+}
+.posting-workspace .bounty-card-actions .button { flex: 0 1 240px; min-width: 0; }
+.posting-workspace .bounty-card-actions:has([data-approve-card][data-approved="false"]) [data-open-funding],
+.posting-workspace .bounty-card-actions [data-approve-card][data-approved="true"] { display: none; }
+.posting-workspace .bounty-card-actions [data-approve-card] { color: #152006; border-color: #c4f43b; background: #c4f43b; }
 .posting-workspace .ai-handoff { background: none; box-shadow: none; padding: 16px 0; border: 0; }
 .posting-workspace .ai-handoff h2 { font-size: 22px; }
 .posting-workspace .ai-original { display: none; }
-.posting-workspace details[data-ai-options] { border-top: 1px solid #354238; padding-top: 18px; margin-top: 28px; }
-.posting-workspace summary { cursor: pointer; }
-@media(max-width: 600px) { .posting-workspace { padding: 24px 16px 90px; } .brief-fields { grid-template-columns: 1fr; } .posting-workspace .bounty-card-body { padding: 18px; } }
-
-.posting-workspace .bounty-preview { scroll-margin-top: 90px; }
-.posting-workspace .verifier-terms { border: 0; border-top: 1px solid #354238; background: transparent; border-radius: 0; padding: 22px 0 0; }
-.posting-workspace .bounty-stat { border: 0; border-radius: 0; background: transparent; padding: 0 16px 0 0; }
-
-.posting-workspace #bounty-composer-form { scroll-margin-top: 88px; }
-.posting-workspace #bounty-composer-input { border: 1px solid #405044; background: #101f16; border-radius: 8px; min-height: 130px; max-height: none; padding: 12px; }
-.posting-workspace #bounty-composer-input:focus { outline: 2px solid #c4f43b; outline-offset: 2px; }
+.posting-workspace details[data-ai-options] { border-top: 1px solid #354238; padding-top: 12px; margin-top: 28px; }
+.posting-page .payment-dialog {
+  width: min(520px, calc(100% - 24px));
+  max-height: calc(100vh - 24px);
+  max-height: calc(100dvh - 24px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scrollbar-color: #738379 #101b15;
+  border: 1px solid #425348;
+  border-radius: 12px;
+  padding: 0;
+  background: #101c15;
+}
+.posting-page .payment-dialog-inner { padding: 0 24px 24px; }
+.posting-page .payment-dialog-head { position: sticky; top: 0; z-index: 1; align-items: flex-start; gap: 12px; margin: 0 -24px; padding: 20px 24px 16px; background: #101c15; border-bottom: 1px solid #354238; }
+.posting-page .payment-dialog h2 { font-size: 24px; line-height: 1.25; letter-spacing: -.025em; }
+.posting-page .payment-dialog-head p { margin: 8px 0 0; color: #aebbb2; font-size: 13px; }
+.posting-page .dialog-close { flex-shrink: 0; width: 44px; height: 44px; border-radius: 8px; }
+.posting-page .wallet-picker-panel { margin: 0; padding: 20px 0 0; border: 0; }
+.posting-page .wallet-picker-panel > p:first-child { font-size: 14px; color: #b6c3ba; margin: 0 0 12px; }
+.posting-page .wallet-option { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; min-height: 72px; padding: 14px 16px; border: 1px solid #596b49; border-radius: 8px; background: #1b2a1b; text-align: left; }
+.posting-page .wallet-option strong { font: 600 16px/1.4 system-ui, sans-serif; }
+.posting-page .wallet-option small { font: 400 13px/1.4 system-ui, sans-serif; color: #b6c3ba; }
+.posting-page .wallet-alternative { margin: 20px 0 0; font-size: 13px; color: #b6c3ba; }
+.posting-page .wallet-alternative a { display: inline-block; padding-block: 8px; color: #d7e5c4; text-underline-offset: 3px; }
+.posting-page .wallet-readiness { border: 0; background: none; padding: 20px 0 0; }
+.posting-page .wallet-readiness-grid { gap: 12px; }
+.posting-page .wallet-readiness-grid > div { min-width: 0; border: 0; background: #16241b; padding: 12px; }
+.posting-page .wallet-readiness-grid strong { overflow-wrap: anywhere; }
+.posting-page .wallet-tools { gap: 8px; }
+.posting-page .wallet-tools .button { flex: 1 1 140px; font-size: 13px; }
+.posting-page [data-fund-now] { width: 100%; margin-top: 20px; }
+.posting-page .payment-status { display: block; margin-top: 16px; color: #b6c3ba; font-size: 13px; line-height: 1.5; overflow-wrap: anywhere; }
+.posting-page .payment-status:empty { display: none; }
+.posting-page .ab-phone-dialog { max-height: calc(100dvh - 24px); scrollbar-gutter: stable; }
+.posting-page .ab-phone-close { position: sticky; top: 0; z-index: 1; min-height: 44px; }
+@media (max-width: 600px) {
+  .posting-page .chat-app-header { gap: 8px; padding: 8px 16px; }
+  .posting-page .chat-app-title { margin-left: auto; }
+  .posting-wallet { order: 4; flex-basis: 100%; }
+  .posting-wallet:empty, .posting-wallet:has([hidden]) { display: none; }
+  .posting-page .ab-phone-launcher { width: 100%; }
+  .posting-workspace { padding: 24px 16px calc(var(--posting-actions-height, 88px) + 32px); }
+  .brief-fields { grid-template-columns: minmax(0, 1fr); }
+  .posting-workspace .bounty-card-stats { grid-template-columns: 1fr 1fr; }
+  .posting-workspace .verifier-terms dl { grid-template-columns: 1fr; gap: 4px; }
+  .posting-workspace .verifier-terms dd { margin-bottom: 8px; }
+  .posting-workspace .bounty-card-actions { flex-wrap: nowrap; gap: 8px; padding-inline: 12px; }
+  .posting-workspace .bounty-card-actions .button { flex: 1 1 0; padding-inline: 10px; }
+  .posting-page .payment-dialog-inner { padding: 0 16px 16px; }
+  .posting-page .payment-dialog-head { margin-inline: -16px; padding: 16px; }
+}
+@media (max-height: 420px) {
+  .posting-page .payment-dialog-head { padding-block: 12px; }
+  .posting-page .payment-dialog-head p { display: none; }
+}
+@media (prefers-reduced-motion: reduce) { .posting-page * { scroll-behavior: auto; } }

--- a/site/posting-workspace.js
+++ b/site/posting-workspace.js
@@ -10,6 +10,16 @@
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   document.querySelector("[data-brief-timezone]").textContent = timezone;
   let restoring = false;
+  // Keep the wallet utility in the header, clear of proposal actions.
+  const launcher = document.querySelector(".ab-phone-launcher");
+  if (launcher) document.querySelector("[data-posting-wallet]").append(launcher);
+  const actions = document.querySelector(".bounty-card-actions");
+  if (actions) {
+    const measureActions = () => document.documentElement.style.setProperty("--posting-actions-height", `${Math.ceil(actions.getBoundingClientRect().height)}px`);
+    if (typeof ResizeObserver === "function") new ResizeObserver(measureActions).observe(actions);
+    window.addEventListener("resize", measureActions);
+    measureActions();
+  }
   function localDate(value) {
     const date = new Date(value);
     return Number.isFinite(date.getTime()) ? new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString().slice(0, 16) : "";

--- a/tools/browser-layout/README.md
+++ b/tools/browser-layout/README.md
@@ -1,0 +1,23 @@
+# Browser layout gate
+
+Run from this directory:
+
+```sh
+npm ci --ignore-scripts --no-fund
+npx playwright install chromium
+npm test
+```
+
+The Pages validation gate runs the same Chromium check before deployment.
+It serves production posting assets locally, stages a synthetic draft through
+the composer, and tests wheel scrolling, keyboard focus, unobscured proposal
+actions, wallet review, and phone QR dialogs at seven viewport sizes.
+The 480x360 CSS viewport models the reflow of a 960x720 browser at 200% zoom;
+it is not a test of browser chrome or operating-system scrollbar preferences.
+External network requests are blocked and wallet providers are inert fixtures.
+The harness never contacts a relay, signs, or sends a transaction.
+
+Set `POSTING_LAYOUT_SCREENSHOTS` to a private absolute output directory to
+inspect screenshots. To check that the harness catches a historical regression,
+set `POSTING_LAYOUT_BASELINE` to a local Git revision; the server then reads
+that revision's site assets without altering the checkout.

--- a/tools/browser-layout/package-lock.json
+++ b/tools/browser-layout/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "agent-bounties-browser-layout",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-bounties-browser-layout",
+      "version": "0.1.0",
+      "devDependencies": {
+        "playwright": "1.62.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tools/browser-layout/package.json
+++ b/tools/browser-layout/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "agent-bounties-browser-layout",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": { "test": "node ../../scripts/test-posting-layout.cjs" },
+  "devDependencies": { "playwright": "1.62.1" },
+  "engines": { "node": ">=22" }
+}


### PR DESCRIPTION
The posting page inherited the retired chat layout's fixed height and hidden overflow. In short embedded browser panes, users could not scroll to the proposal buttons, and the floating phone-wallet control covered them.

Give posting its own normal document layout and visible scroll track, keep proposal actions in a bottom bar with measured content clearance, and move wallet status into the header. Simplify the proposal typography and wallet picker; constrain scrolling dialogs to the available viewport with reachable close controls. Existing approval, wallet, funding, and canonical evidence behavior is retained.

Validation:
- Real Chromium checks pass at seven sizes, including 946×838, 320×480, 768×320, and a 480×360 reflow equivalent of 200% browser zoom. Checks cover wheel input, action hit targets, keyboard focus, resize while a dialog is open, funding review, and synthetic phone QR pairing.
- The same harness fails on the previous main revision with the original hidden-overflow defect.
- 86 marketplace, WebMCP, creator-review, proof, meta-child and phone-wallet tests pass; site validation and AI handoff checks pass.
- Pages now runs the pinned browser gate before deploying.

The test wallets are inert and external requests are blocked. No real wallet signatures, payments, or bounty publication were performed. The gate tests page behavior; operating-system scrollbar preferences and host browser chrome remain outside site control.

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5564997878
