### PR TITLE
Show a wallet chooser and embedded creation when linking accounts

### DIFF
--- a/.github/workflows/coinbase-embedded-wallet.yml
+++ b/.github/workflows/coinbase-embedded-wallet.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Prepare reviewed esbuild binary
         run: npm rebuild --prefix tools/coinbase-embedded-wallet esbuild
 
-      - name: Build the dormant adapter outside the public site
+      - name: Build the adapter in an isolated output directory
         env:
           COINBASE_WALLET_OUTDIR: /tmp/coinbase-wallet
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,9 @@ on:
       - "scripts/test-competition-proof.js"
       - "scripts/test-phone-wallet.js"
       - "scripts/configure-phone-wallet.py"
+      - "scripts/configure-wallet-providers.py"
+      - "scripts/test-wallet-link.js"
+      - "tools/coinbase-embedded-wallet/**"
       - "tools/phone-wallet/**"
       - "scripts/github_audience_audit.py"
       - "scripts/test_github_audience_audit.py"
@@ -41,6 +44,9 @@ on:
       - "scripts/test-competition-proof.js"
       - "scripts/test-phone-wallet.js"
       - "scripts/configure-phone-wallet.py"
+      - "scripts/configure-wallet-providers.py"
+      - "scripts/test-wallet-link.js"
+      - "tools/coinbase-embedded-wallet/**"
       - "tools/phone-wallet/**"
       - "scripts/github_audience_audit.py"
       - "scripts/test_github_audience_audit.py"
@@ -74,8 +80,21 @@ jobs:
         run: |
           npm ci --ignore-scripts --no-fund
           npm run check
+      - name: Build and verify the account embedded wallet
+        env:
+          COINBASE_WALLET_OUTDIR: site/vendor
+        run: |
+          npm ci --prefix tools/coinbase-embedded-wallet --ignore-scripts --no-audit --no-fund
+          npm rebuild --prefix tools/coinbase-embedded-wallet esbuild
+          npm run check --prefix tools/coinbase-embedded-wallet
+          npm run build --prefix tools/coinbase-embedded-wallet
+          python scripts/test_configure_wallet_providers.py
+          node --test scripts/test-wallet-link.js
+          cd tools/coinbase-embedded-wallet
+          npx playwright install --with-deps chromium
+          npm run test:browser
       - name: Validate the reduced public site
-        run: python scripts/check-site.py
+        run: python scripts/check-site.py --require-wallet-bundle
       - name: Check retained browser JavaScript
         run: |
           node --check site/analytics-config.js
@@ -155,6 +174,20 @@ jobs:
         with:
           python-version: "3.12"
       - uses: actions/configure-pages@v6
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: "22"
+      - name: Build and configure account embedded-wallet creation
+        env:
+          COINBASE_CDP_PROJECT_ID: ${{ vars.COINBASE_CDP_PROJECT_ID }}
+          COINBASE_WALLET_OUTDIR: site/vendor
+        run: |
+          npm ci --prefix tools/coinbase-embedded-wallet --ignore-scripts --no-audit --no-fund
+          npm rebuild --prefix tools/coinbase-embedded-wallet esbuild
+          npm run build --prefix tools/coinbase-embedded-wallet
+          python scripts/configure-wallet-providers.py --verify-origin https://agentbounties.app
+          test -s site/vendor/coinbase-embedded-wallet.bundle.js
+          test -s site/vendor/coinbase-embedded-wallet.bundle.css
       - name: Configure phone-wallet pairing
         env:
           WALLETCONNECT_PROJECT_ID: ${{ vars.WALLETCONNECT_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ contracts/**/cache/
 /cache/
 broadcast/
 /tools/coinbase-embedded-wallet/.build-check
+/site/vendor/coinbase-embedded-wallet.bundle.js
+/site/vendor/coinbase-embedded-wallet.bundle.css

--- a/docs/coinbase-embedded-wallet.md
+++ b/docs/coinbase-embedded-wallet.md
@@ -21,44 +21,52 @@ The EOA is intentional. Agent Bounties' existing claim and funding relays requir
 
 A future smart-account adapter may be added independently, but it must not silently replace the user's EOA or change the address to which an on-ramp delivers assets.
 
-## Preserved adapter design
+## Account wallet linking
 
-The public on-ramp page links to Coinbase's own Base wallet surface as one of
-three external wallet/top-up variations. It does not load the embedded-wallet
-adapter or claim sponsored funding. The adapter source and locked dependencies
-remain available for a future separately reviewed first-party wallet surface.
+The homepage account panel opens a chooser for both **Link wallet** and
+**Link another**, even when MetaMask is the only installed wallet. Discovery
+uses EIP-6963 announcements and legacy injected-provider fallbacks without
+requesting accounts or signatures. Phone pairing remains an explicit choice
+when configured.
 
-The intended embedded-adapter user experience remains:
+**I don’t have a wallet — create one** loads Coinbase's maintained `SignIn`
+components inside a modal. Email, Google, and Apple sign-in create or restore a
+user-controlled EOA without an extension or recovery phrase. The SDK's
+stylesheet and script load only after this choice. Cancelling returns to the
+account panel; load failures allow an explicit retry.
 
-1. A user may browse, draft, and inspect bounties without a wallet.
-2. At the first action requiring an onchain identity, the wallet selector includes **Agent Bounties embedded wallet** beside injected wallets.
-3. Selecting it opens Coinbase's maintained `AuthButton` interface.
-4. The user signs in with an enabled method: email, SMS, Google, Apple, X, or Telegram.
-5. Coinbase creates or restores the user's non-custodial Base-capable EOA. No browser extension or recovery phrase is required.
-6. Agent Bounties receives only the EIP-1193 provider and public wallet address. It does not receive the user's OTP, social password, seed phrase, or private key.
-7. When the wallet lacks Base USDC, MoonPay can deliver Base USDC to that same EOA. The supported funding and claim paths already sponsor gas, so the user is not asked to buy ETH.
-8. For an existing-bounty contribution, the wallet signs the exact EIP-3009 authorization. The Agent Bounties gas-only relayer broadcasts `fundWithAuthorization` and pays ETH gas.
-9. Only confirmed canonical `FundingAdded` changes funded state.
+After the user completes Coinbase authentication, the account handler uses
+that selected provider for the existing ownership-only EIP-191 challenge and
+server verification. Linking never authorizes a transaction, transfer, token
+approval, or delegated action. The linked-wallet list refreshes after server
+verification. The marketplace account login and Coinbase wallet login remain
+separate identities; a matching email alone does not prove wallet ownership.
 
-Authentication never authorizes a transfer. Acquiring Base USDC and committing it to a bounty remain separate, explicit decisions.
+This activation is scoped to account linking. The public on-ramp page still
+uses its existing external wallet/top-up variations. Creating a wallet does
+not imply that every marketplace action supports that provider or sponsors gas.
 
 ## Adapter boundary
 
-The vendor-neutral adapter implementation remains in
-`tools/coinbase-embedded-wallet/src/index.js`. Its build is deliberately written
-to `target/coinbase-embedded-wallet/`, outside `site/`, so validating the dormant
-adapter cannot republish a deleted browser surface. `COINBASE_WALLET_OUTDIR` may
-select another disposable output directory in CI.
+The adapter source is `tools/coinbase-embedded-wallet/src/index.js`. Builds
+still default to `target/coinbase-embedded-wallet/`. The explicit
+`COINBASE_WALLET_OUTDIR=site/vendor` option builds the account assets for Pages;
+relative output paths resolve from the repository root. Generated assets are
+excluded from Git and rebuilt from the locked dependencies for deployment.
 
-The CDP Project ID is public client configuration, not a server secret. The
-configuration helper and its tests are retained so a future reviewed interface
-can restore the adapter without changing custody or exact-origin rules.
+The Pages build supplies the public CDP project ID in `site/wallet-config.js`
+and verifies the exact production origin before publishing. A deployment with
+no configured project shows wallet creation as unavailable and never falls
+back to an installed wallet automatically. `check-site.py --require-wallet-bundle`
+requires both generated assets during the Pages validation job.
 
-Server-side CDP API secrets, wallet secrets, private keys, and seed phrases must never enter a bundle or public configuration. A future public surface must pin the SDK secure iframe to `https://secure-wallet.cdp.coinbase.com` and permit only that frame origin plus the documented CDP API and Base RPC connections.
+Server-side CDP API secrets, wallet secrets, private keys, and seed phrases must
+never enter a bundle or public configuration. The SDK secure iframe is pinned
+to `https://secure-wallet.cdp.coinbase.com`.
 
 ## Authentication and account continuity
 
-When the adapter is reintroduced, its reviewed configuration may enable:
+The provider supports the following methods; the account surface currently enables email, Google, and Apple:
 
 ```text
 email
@@ -93,7 +101,7 @@ SMS is convenient but is more exposed to SIM-swap attacks. The linking screen st
 The restored `authorize.html` review handoff preserves the durable action-intent
 identifier and canonical evidence boundary. The current Coinbase variation
 opens Coinbase's maintained public wallet surface and then returns to the
-provider-neutral on-ramp/posting flow; it does not mount the embedded adapter.
+provider-neutral on-ramp/posting flow; account linking is the separate embedded-wallet entry.
 No wallet credential or signature may enter ChatGPT.
 
 ## Gas sponsorship
@@ -125,7 +133,7 @@ The Coinbase adapter therefore rejects direct transaction methods for now instea
 Two cross-origin boundaries are verified separately:
 
 1. The Agent Bounties API uses Tower HTTP's `CorsLayer::permissive()`, permitting the website to issue x402 requests and read `payment-required` and `payment-response`.
-2. Coinbase must authorize the exact production origin for its locked SDK routes. Before a future production build, check:
+2. Coinbase must authorize the exact production origin for its locked SDK routes. Before a production build, check:
    - `GET https://api.cdp.coinbase.com/platform/v2/embedded-wallet-api/projects/{project}/config`;
    - unauthenticated `POST` preflight for `content-type` and `x-idempotency-key`; and
    - signed-in linking preflight for `content-type` and `x-wallet-auth`.
@@ -174,7 +182,7 @@ COINBASE_CDP_PROJECT_ID=<public project id>
 # Node.js 22 or newer
 npm ci --prefix tools/coinbase-embedded-wallet --ignore-scripts --no-audit --no-fund
 npm rebuild --prefix tools/coinbase-embedded-wallet esbuild
-npm run build --prefix tools/coinbase-embedded-wallet
+COINBASE_WALLET_OUTDIR=site/vendor npm run build --prefix tools/coinbase-embedded-wallet
 ```
 
 7. Run the retained source and configuration gates:
@@ -184,7 +192,7 @@ python scripts/test_configure_wallet_providers.py
 npm run check --prefix tools/coinbase-embedded-wallet
 ```
 
-8. Add a reviewed first-party embedded-wallet surface and its page-specific tests before deploying the adapter. The external Coinbase on-ramp link is not an embedded-wallet live-browser canary.
+8. Run `node --test scripts/test-wallet-link.js`, then `npm run test:browser --prefix tools/coinbase-embedded-wallet` with Playwright Chromium installed. The browser regressions exercise both account link labels with and without an injected wallet. They stub the provider and account service; a real account-creation canary remains separate.
 9. Human-test one account for every enabled authentication method. Verify that each intended linked method restores the same wallet and that unlinked methods are clearly distinguished.
 10. Buy a bounded amount of Base USDC through MoonPay to the embedded EOA.
 11. Fund an existing bounty through the gas-only x402 relay.
@@ -196,7 +204,7 @@ Coinbase benefits when more users authenticate and keep wallets inside its ecosy
 
 ## Rollback
 
-The current public site does not load the adapter, so no runtime rollback is
-required. If a future surface enables it, disabling its provider configuration
-must remove it from EIP-6963 discovery without changing the protocol or other
-wallets. Existing users retain control of their Coinbase-provided wallets.
+Disable the embedded provider in `site/wallet-config.js` to stop new embedded
+connections while preserving the chooser and external-wallet paths. This does
+not change the protocol or existing wallet ownership. Existing users retain
+control of their Coinbase-provided wallets.

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -4,6 +4,7 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 import xml.etree.ElementTree as ET
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
@@ -142,6 +143,9 @@ REQUIRED_FILES = {
     "guild-pages.css",
     "guild-shell.js",
     "wallet-adapters.css",
+    "wallet-link.js",
+    "wallet-link.css",
+    "wallet-config.js",
     "phone-wallet.js",
     "phone-wallet-config.js",
     "phone-wallet.css",
@@ -191,6 +195,9 @@ ALLOWED_UI_CODE = {
     "install/install.css",
     "install/install.js",
     "wallet-adapters.css",
+    "wallet-link.js",
+    "wallet-link.css",
+    "wallet-config.js",
     "phone-wallet.js",
     "phone-wallet-config.js",
     "phone-wallet.css",
@@ -1262,6 +1269,13 @@ def main() -> int:
     if html_files != set(CANONICAL_PAGES):
         fail(f"site HTML inventory does not match canonical page policy; found {sorted(html_files)}")
     ui_code = {path.relative_to(site_dir).as_posix() for pattern in ("*.js", "*.css") for path in site_dir.rglob(pattern)}
+    generated_wallet = {"vendor/coinbase-embedded-wallet.bundle.js", "vendor/coinbase-embedded-wallet.bundle.css"}
+    present_wallet = ui_code & generated_wallet
+    if present_wallet and present_wallet != generated_wallet:
+        fail("embedded wallet build is incomplete")
+    if "--require-wallet-bundle" in sys.argv and present_wallet != generated_wallet:
+        fail("build the embedded wallet bundle before publishing the account chooser")
+    ui_code -= generated_wallet
     if ui_code != ALLOWED_UI_CODE:
         fail(f"orphaned or missing UI code: extra={sorted(ui_code - ALLOWED_UI_CODE)} missing={sorted(ALLOWED_UI_CODE - ui_code)}")
     images = {path.relative_to(site_dir).as_posix() for path in site_dir.rglob("*.webp")}

--- a/scripts/test-wallet-link.js
+++ b/scripts/test-wallet-link.js
@@ -1,0 +1,117 @@
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const createWalletLink = require("../site/wallet-link.js");
+
+class Element extends EventTarget {
+  constructor(tag) { super(); this.tagName = tag; this.children = []; this.nodes = new Map(); this.classList = { add() {} }; }
+  append(...nodes) { this.children.push(...nodes); }
+  replaceChildren(...nodes) { this.children = nodes; }
+  get childElementCount() { return this.children.length; }
+  setAttribute() {}
+  focus() { this.focused = true; }
+  remove() { this.removed = true; }
+  showModal() { this.open = true; }
+  close() { this.open = false; this.dispatchEvent(new Event("close")); }
+  querySelector(key) { if (!this.nodes.has(key)) this.nodes.set(key, new Element("div")); return this.nodes.get(key); }
+  click() { if (!this.disabled) this.dispatchEvent(new Event("click")); }
+}
+function harness(configured = true) {
+  const win = new EventTarget();
+  Object.assign(win, {
+    Event, setTimeout, clearTimeout,
+    document: { baseURI: "https://agentbounties.app/", head: new Element("head"), body: new Element("body"), createElement: (tag) => new Element(tag) },
+    AgentBountiesWalletConfig: { providers: { coinbaseEmbedded: { enabled: configured } } },
+  });
+  const calls = [];
+  win.ethereum = { isMetaMask: true, request: async (request) => { calls.push(request); return []; } };
+  const chooser = createWalletLink(win);
+  const dialog = () => win.document.body.children[0];
+  return { win, calls, chooser, dialog, create: () => dialog().querySelector("[data-wallet-create]").children[0] };
+}
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+test("discovery and opening never wake MetaMask, even as the only wallet", async () => {
+  const h = harness();
+  assert.equal(h.chooser.choices()[0].label, "MetaMask");
+  const selection = h.chooser.select();
+  assert.equal(h.dialog().open, true);
+  assert.equal(h.create().disabled, false);
+  assert.deepEqual(h.calls, []);
+  h.dialog().querySelector(".wallet-link-close").click();
+  await assert.rejects(selection, { code: 4001 });
+  assert.deepEqual(h.calls, []);
+});
+
+test("selecting an announced wallet returns only that provider and deduplicates fallback", async () => {
+  const h = harness();
+  const another = { request() { throw new Error("discovery must not call me"); } };
+  for (const [provider, name] of [[h.win.ethereum, "MetaMask"], [another, "Other wallet"]]) {
+    const event = new Event("eip6963:announceProvider");
+    event.detail = { provider, info: { name } };
+    h.win.dispatchEvent(event);
+  }
+  assert.equal(h.chooser.choices().length, 2);
+  const selection = h.chooser.select();
+  h.dialog().querySelector("[data-wallet-choices]").children[1].click();
+  assert.equal((await selection).provider, another);
+  assert.deepEqual(h.calls, []);
+});
+
+test("new-wallet option loads Coinbase and never uses the installed wallet", async () => {
+  const h = harness();
+  const selection = h.chooser.select();
+  h.create().click();
+  const embedded = { request() {} };
+  h.win.AgentBountiesCoinbaseEmbeddedWallet = { enabled: true, provider: embedded };
+  assert.equal(h.win.document.head.children.length, 1);
+  h.win.document.head.children[0].onload();
+  h.win.document.head.children[1].onload();
+  assert.equal((await selection).provider, embedded);
+  assert.deepEqual(h.calls, []);
+});
+
+test("cancelling a loading wallet cannot resume an old selection or a new chooser", async () => {
+  const h = harness();
+  const selection = h.chooser.select();
+  h.create().click();
+  h.chooser.cancel();
+  await assert.rejects(selection, { code: 4001 });
+  const next = h.chooser.select();
+  h.win.AgentBountiesCoinbaseEmbeddedWallet = { enabled: true, provider: { request() {} } };
+  h.win.document.head.children[0].onload();
+  h.win.document.head.children[1].onload();
+  await tick();
+  assert.equal(h.dialog().open, true);
+  h.chooser.cancel();
+  await assert.rejects(next, { code: 4001 });
+  assert.deepEqual(h.calls, []);
+});
+
+test("a bundle failure stays in the chooser and allows an explicit retry", async () => {
+  const h = harness();
+  const selection = h.chooser.select();
+  h.create().click();
+  h.win.document.head.children[0].onerror();
+  await tick();
+  assert.match(h.dialog().querySelector("[role=status]").textContent, /try again/);
+  assert.equal(h.create().disabled, false);
+  h.create().click();
+  assert.equal(h.win.document.head.children.length, 2);
+  h.win.document.head.children[1].onerror();
+  await tick();
+  h.chooser.cancel();
+  await assert.rejects(selection, { code: 4001 });
+  assert.deepEqual(h.calls, []);
+});
+
+test("no-wallet and unconfigured deployments do not fall through to an injected provider", async () => {
+  const h = harness(false);
+  delete h.win.ethereum;
+  const selection = h.chooser.select();
+  assert.equal(h.create().disabled, true);
+  assert.equal(h.chooser.choices().length, 0);
+  assert.match(h.dialog().querySelector("[role=status]").textContent, /not configured/);
+  h.chooser.cancel();
+  await assert.rejects(selection, { code: 4001 });
+});

--- a/site/index.html
+++ b/site/index.html
@@ -39,6 +39,8 @@
     </script>
     <link rel="stylesheet" href="solarpunk.css?v=14">
     <link rel="stylesheet" href="phone-wallet.css?v=1">
+    <link rel="stylesheet" href="wallet-link.css?v=1">
+    <link rel="stylesheet" href="wallet-adapters.css?v=2">
   </head>
   <body>
     <a class="skip-link" href="#hero-title">Skip to the main message</a>
@@ -362,10 +364,12 @@
     <noscript><p class="noscript-note">JavaScript is required for the living scene and live marketplace metrics.</p></noscript>
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
+    <script src="wallet-config.js?v=1"></script>
+    <script src="wallet-link.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="posting-prompt.js?v=2"></script>
-    <script src="solarpunk-home.js?v=12"></script>
+    <script src="solarpunk-home.js?v=13"></script>
   </body>
 </html>

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -241,6 +241,7 @@ ${competitionChildBrief(item)}`;
       wallet_linked_to_another_account: "That wallet is already linked to another account.",
       wallet_limit_reached: "This account has reached its linked-wallet limit.",
       wallet_signature_invalid: "The signature did not prove control of that wallet.",
+      wallet_selector_unavailable: "The wallet chooser could not load. Reload the page and try again.",
     };
     return messages[reason] || "The wallet could not be linked. Please try again.";
   }
@@ -977,18 +978,19 @@ ${competitionChildBrief(item)}`;
         setStatus("Email and password accounts are not configured yet. Use a connected provider.");
       });
       walletLinkButton?.addEventListener("click", async () => {
-        if (!currentUser) return;
-        const linkProvider = win.AgentBountiesPhoneWallet?.state().connected
-          ? win.AgentBountiesPhoneWallet.provider : win.ethereum || (win.AgentBountiesPhoneWallet?.state().available ? win.AgentBountiesPhoneWallet.provider : null);
-        if (!linkProvider || typeof linkProvider.request !== "function") {
-          setWalletStatus("No browser wallet was detected. Open this page in a browser with an EVM wallet extension.");
-          return;
-        }
+        if (!currentUser || walletLinkButton.disabled) return;
+        const linkingUser = currentUser;
         walletLinkButton.disabled = true;
-        win.agentBountiesAnalytics?.track("wallet_link_started");
-        setWalletStatus("Choose the wallet address you want to link…");
+        setWalletStatus("");
         try {
+          if (!win.AgentBountiesWalletLink) throw { reason: "wallet_selector_unavailable" };
+          const selection = await win.AgentBountiesWalletLink.select();
+          const linkProvider = selection.provider;
+          if (currentUser !== linkingUser) throw { code: 4001 };
+          win.agentBountiesAnalytics?.track("wallet_link_started");
+          setWalletStatus("Choose the wallet address you want to link…");
           const accounts = await linkProvider.request({ method: "eth_requestAccounts" });
+          if (currentUser !== linkingUser) throw { code: 4001 };
           const address = String(Array.isArray(accounts) ? accounts[0] : "").trim();
           if (!/^0x[0-9a-fA-F]{40}$/.test(address)) throw { reason: "invalid_wallet_address" };
           const challenge = await postAccountJson("/wallet/challenge", { address });
@@ -997,6 +999,7 @@ ${competitionChildBrief(item)}`;
             method: "personal_sign",
             params: [utf8Hex(challenge.message), address],
           });
+          if (currentUser !== linkingUser) throw { code: 4001 };
           await postAccountJson("/wallet/verify", {
             challenge_id: challenge.challenge_id,
             address,
@@ -1009,6 +1012,7 @@ ${competitionChildBrief(item)}`;
           setWalletStatus(walletLinkErrorMessage(error));
         } finally {
           walletLinkButton.disabled = false;
+          if (dialog.open) walletLinkButton.focus();
         }
       });
       walletList?.addEventListener("click", async (event) => {

--- a/site/wallet-adapters.css
+++ b/site/wallet-adapters.css
@@ -2,15 +2,25 @@
   position: fixed;
   inset: 0;
   z-index: 10000;
-  display: grid;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  border: 0;
   place-items: center;
   padding: 1rem;
   box-sizing: border-box;
-  background: rgba(0, 0, 0, 0.78);
-  backdrop-filter: blur(4px);
+  background: transparent;
 }
+.wallet-auth-overlay[open] { display: grid; }
+.wallet-auth-overlay::backdrop { background: rgba(0, 0, 0, 0.78); backdrop-filter: blur(4px); }
+.wallet-auth-panel .wallet-auth-signin { gap: 1rem; padding: 1.25rem; border-radius: .75rem; }
+.wallet-auth-panel:focus { outline: none; }
 .wallet-auth-panel {
   width: min(100%, 36rem);
+  max-height: calc(100dvh - 2rem);
+  overflow-y: auto;
   display: grid;
   gap: 1rem;
   box-sizing: border-box;

--- a/site/wallet-config.js
+++ b/site/wallet-config.js
@@ -1,0 +1,18 @@
+/* Public client configuration. The Pages build supplies the CDP project ID. */
+"use strict";
+(function () {
+  const projectId = "__COINBASE_CDP_PROJECT_ID__";
+  window.AgentBountiesWalletConfig = Object.freeze({
+    chain: { rpcUrl: "https://mainnet.base.org" },
+    providers: {
+      coinbaseEmbedded: {
+        enabled: /^[A-Za-z0-9-]{8,128}$/.test(projectId),
+        projectId,
+        disableAnalytics: true,
+        secureIframeBasePath: "https://secure-wallet.cdp.coinbase.com",
+        authMethods: ["email", "oauth:google", "oauth:apple"],
+        transactionPolicy: "agent-bounties-relay-required",
+      },
+    },
+  });
+})();

--- a/site/wallet-link.css
+++ b/site/wallet-link.css
@@ -1,0 +1,32 @@
+.wallet-link-dialog {
+  box-sizing: border-box;
+  width: min(32rem, calc(100% - 2rem));
+  max-height: calc(100dvh - 2rem);
+  overflow: auto;
+  padding: clamp(1.25rem, 4vw, 2rem);
+  color: #edf1e6;
+  background: #08180f;
+  border: 1px solid #526537;
+  border-radius: .3rem 2rem .3rem 2rem;
+  font-family: inherit;
+  box-shadow: 0 2rem 5rem #0008;
+}
+.wallet-link-dialog::backdrop { background: #020803b8; backdrop-filter: blur(5px); }
+.wallet-link-dialog header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.wallet-link-dialog h2 { margin: .4rem 0 0; font: 700 clamp(1.8rem, 5vw, 2.4rem)/1.12 Georgia, serif; }
+.wallet-link-dialog h3 { margin: 1.5rem 0 .75rem; font-size: .95rem; }
+.wallet-link-dialog p { color: #b6c2b2; line-height: 1.5; }
+.wallet-link-dialog .wallet-link-eyebrow { margin: 0; color: #badd6c; font-size: .72rem; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
+.wallet-link-close { flex: 0 0 2.75rem; width: 2.75rem; height: 2.75rem; border: 0; background: transparent; color: #b6c2b2; font-size: 1.8rem; cursor: pointer; }
+.wallet-choice { display: grid; gap: .4rem; box-sizing: border-box; width: 100%; min-height: 3rem; padding: 1rem; text-align: left; color: inherit; background: #ffffff04; border: 1px solid #35452f; border-radius: .25rem 1rem .25rem 1rem; font: inherit; cursor: pointer; transition: border-color 120ms, background 120ms; }
+.wallet-choice span { color: #b6c2b2; font-size: .85rem; line-height: 1.5; }
+.wallet-choice strong { font-size: .98rem; }
+.wallet-choice-create { border-color: #829d4c; background: #badd6c0c; }
+.wallet-choice:hover { background: #badd6c15; border-color: #badd6c; }
+.wallet-choice:disabled { opacity: .6; cursor: wait; }
+.wallet-link-dialog button:focus-visible { outline: 2px solid #c5eb7d; outline-offset: 3px; }
+[data-wallet-choices] { display: grid; gap: .65rem; }
+.wallet-link-dialog .wallet-link-note { padding-top: 1rem; border-top: 1px solid #35452f; margin-bottom: 0; font-size: .75rem; }
+.wallet-link-status { font-size: .85rem; }
+.wallet-link-status:empty { display: none; }
+@media (prefers-reduced-motion: reduce) { .wallet-choice { transition: none; } }

--- a/site/wallet-link.js
+++ b/site/wallet-link.js
@@ -1,0 +1,148 @@
+/* Account wallet selection. Discovery never requests accounts or signatures. */
+"use strict";
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) module.exports = factory;
+  else root.AgentBountiesWalletLink = factory(root);
+})(typeof window === "object" ? window : globalThis, function createWalletLink(win) {
+  const doc = win.document;
+  const discovered = new Map();
+  let chooser, list, status, createButton, pending, bundlePromise;
+  const cancelled = () => Object.assign(new Error("Wallet selection cancelled."), { code: 4001 });
+
+  function remember(detail) {
+    if (!detail?.provider || typeof detail.provider.request !== "function") return;
+    const name = String(detail.info?.name || "Browser wallet").trim().slice(0, 64);
+    discovered.set(detail.provider, { provider: detail.provider, label: name || "Browser wallet", kind: "browser" });
+    if (chooser?.open) render();
+  }
+  win.addEventListener("eip6963:announceProvider", (event) => remember(event.detail));
+  win.dispatchEvent(new win.Event("eip6963:requestProvider"));
+
+  function choices() {
+    const phone = win.AgentBountiesPhoneWallet;
+    const result = [...discovered.values()].filter((item) => item.provider !== phone?.provider);
+    const injected = Array.isArray(win.ethereum?.providers) && win.ethereum.providers.length
+      ? win.ethereum.providers : [win.ethereum];
+    for (const provider of injected) {
+      if (!provider || typeof provider.request !== "function" || result.some((item) => item.provider === provider)) continue;
+      result.push({ provider, kind: "browser", label: provider.isMetaMask ? "MetaMask" : provider.isCoinbaseWallet ? "Coinbase Wallet" : "Browser wallet" });
+    }
+    if (phone?.state().available) result.push({ provider: phone.provider, kind: "phone", label: "Use a phone wallet" });
+    return result;
+  }
+
+  function embeddedConfigured() {
+    return Boolean(win.AgentBountiesWalletConfig?.providers?.coinbaseEmbedded?.enabled);
+  }
+
+  function loadEmbedded() {
+    if (!embeddedConfigured()) return Promise.reject(new Error("Wallet creation is not configured on this site yet."));
+    if (win.AgentBountiesCoinbaseEmbeddedWallet?.enabled) return Promise.resolve(win.AgentBountiesCoinbaseEmbeddedWallet.provider);
+    if (!bundlePromise) {
+      bundlePromise = new Promise((resolve, reject) => {
+        let failed = false;
+        const stylesheet = doc.createElement("link");
+        stylesheet.rel = "stylesheet";
+        stylesheet.href = new URL("vendor/coinbase-embedded-wallet.bundle.css?v=1", doc.baseURI).href;
+        const script = doc.createElement("script");
+        script.src = new URL("vendor/coinbase-embedded-wallet.bundle.js?v=1", doc.baseURI).href;
+        script.async = true;
+        const fail = () => { failed = true; win.clearTimeout(timer); script.remove(); stylesheet.remove(); reject(new Error("Wallet creation could not load. Check your connection and try again.")); };
+        const timer = win.setTimeout(fail, 20000);
+        stylesheet.onerror = fail;
+        stylesheet.onload = () => { if (!failed) doc.head.append(script); };
+        script.onerror = fail;
+        script.onload = () => {
+          if (failed) return;
+          win.clearTimeout(timer);
+          const adapter = win.AgentBountiesCoinbaseEmbeddedWallet;
+          if (!adapter?.enabled || typeof adapter.provider?.request !== "function") fail();
+          else resolve(adapter.provider);
+        };
+        doc.head.append(stylesheet);
+      }).catch((error) => { bundlePromise = null; throw error; });
+    }
+    return bundlePromise;
+  }
+
+  function finish(choice) {
+    const request = pending;
+    if (!request) return;
+    pending = null;
+    chooser.close();
+    if (choice) request.resolve(choice);
+    else request.reject(cancelled());
+  }
+
+  function option(label, description, select) {
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.className = "wallet-choice";
+    const title = doc.createElement("strong");
+    title.textContent = label;
+    const detail = doc.createElement("span");
+    detail.textContent = description;
+    button.append(title, detail);
+    button.addEventListener("click", select);
+    return button;
+  }
+
+  function render() {
+    if (!list) return;
+    list.replaceChildren();
+    for (const choice of choices()) {
+      list.append(option(choice.label, choice.kind === "phone" ? "Scan a QR code with your wallet app." : "Choose an address in this wallet.", () => finish(choice)));
+    }
+    if (!list.childElementCount) {
+      const empty = doc.createElement("p");
+      empty.textContent = "No browser wallet detected. You can create a wallet above.";
+      list.append(empty);
+    }
+  }
+
+  function mount() {
+    if (chooser) return;
+    chooser = doc.createElement("dialog");
+    chooser.className = "wallet-link-dialog";
+    chooser.setAttribute("aria-labelledby", "wallet-link-title");
+    chooser.innerHTML = '<header><div><p class="wallet-link-eyebrow">Linked wallets</p><h2 id="wallet-link-title">Choose a wallet</h2></div><button type="button" class="wallet-link-close" aria-label="Close wallet chooser">×</button></header><p>Create a wallet or connect one you already use.</p><div data-wallet-create></div><h3>I already have a wallet</h3><div data-wallet-choices></div><p class="wallet-link-status" role="status"></p><p class="wallet-link-note">Linking proves ownership only. It cannot move funds or approve payments.</p>';
+    list = chooser.querySelector("[data-wallet-choices]");
+    status = chooser.querySelector("[role=status]");
+    createButton = option("I don’t have a wallet — create one", "Use email or social sign-in. No extension or recovery phrase needed. Powered by Coinbase.", async () => {
+      const request = pending;
+      createButton.disabled = true;
+      status.textContent = "Opening wallet creation…";
+      try {
+        const provider = await loadEmbedded();
+        if (pending === request) finish({ provider, kind: "embedded", label: "Embedded wallet" });
+      } catch (error) {
+        if (pending === request) status.textContent = error.message;
+      } finally {
+        if (pending === request) createButton.disabled = false;
+      }
+    });
+    createButton.classList.add("wallet-choice-create");
+    chooser.querySelector("[data-wallet-create]").append(createButton);
+    chooser.querySelector(".wallet-link-close").addEventListener("click", () => finish());
+    chooser.addEventListener("cancel", (event) => { event.preventDefault(); finish(); });
+    chooser.addEventListener("close", () => { if (pending) finish(); });
+    doc.body.append(chooser);
+  }
+
+  function select() {
+    if (pending) return pending.promise;
+    mount();
+    status.textContent = embeddedConfigured() ? "" : "Wallet creation is not configured on this site yet.";
+    createButton.disabled = !embeddedConfigured();
+    render();
+    const request = {};
+    request.promise = new Promise((resolve, reject) => { request.resolve = resolve; request.reject = reject; });
+    pending = request;
+    chooser.showModal();
+    createButton.focus();
+    win.dispatchEvent(new win.Event("eip6963:requestProvider"));
+    return request.promise;
+  }
+
+  return Object.freeze({ select, choices, cancel: () => finish() });
+});

--- a/tools/coinbase-embedded-wallet/build.mjs
+++ b/tools/coinbase-embedded-wallet/build.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(here, "../..");
 const outdir = process.env.COINBASE_WALLET_OUTDIR
-  ? path.resolve(process.env.COINBASE_WALLET_OUTDIR)
+  ? path.resolve(root, process.env.COINBASE_WALLET_OUTDIR)
   : path.join(root, "target", "coinbase-embedded-wallet");
 const outfile = path.join(outdir, "coinbase-embedded-wallet.bundle.js");
 const cssfile = path.join(outdir, "coinbase-embedded-wallet.bundle.css");

--- a/tools/coinbase-embedded-wallet/package-lock.json
+++ b/tools/coinbase-embedded-wallet/package-lock.json
@@ -2751,6 +2751,20 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3330,6 +3344,21 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.13",

--- a/tools/coinbase-embedded-wallet/package-lock.json
+++ b/tools/coinbase-embedded-wallet/package-lock.json
@@ -16,7 +16,8 @@
         "viem": "2.55.8"
       },
       "devDependencies": {
-        "esbuild": "0.28.1"
+        "esbuild": "0.28.1",
+        "playwright": "1.62.1"
       },
       "engines": {
         "node": ">=22"
@@ -49,6 +50,7 @@
       "version": "0.0.118",
       "resolved": "https://registry.npmjs.org/@coinbase/cdp-core/-/cdp-core-0.0.118.tgz",
       "integrity": "sha512-CEuEHzvNqEUcU56FgR7jcdiUj1LEjV7wqNj0xG2/pOqmWe64IbZ66VDvbxeqPdVWQBVkGbjeNRSOV+7vYkFA5g==",
+      "peer": true,
       "dependencies": {
         "@coinbase/cdp-api-client": "^0.0.118",
         "@solana/kit": "^5.0.0",
@@ -84,6 +86,7 @@
       "version": "0.0.118",
       "resolved": "https://registry.npmjs.org/@coinbase/cdp-hooks/-/cdp-hooks-0.0.118.tgz",
       "integrity": "sha512-u7Hf0qR2jSnDGRTwsc8yM5Acr2XUsW7H5BIaICU8F191j/JHvq25LQPGqmSCVCcBYN2Z0ThHnc7cDr3LuP8QiA==",
+      "peer": true,
       "peerDependencies": {
         "@coinbase/cdp-core": "^0.0.118",
         "react": ">=18.2.0"
@@ -2748,20 +2751,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3105,6 +3094,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3327,21 +3331,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
@@ -3539,6 +3528,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/pngjs": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
@@ -3579,6 +3600,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3588,6 +3610,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4071,6 +4094,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
       "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/tools/coinbase-embedded-wallet/package.json
+++ b/tools/coinbase-embedded-wallet/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "node build.mjs",
+    "test:browser": "node --test test-account-link.mjs",
     "check": "node --check src/index.js && node --check build.mjs && node test-dependency-compat.mjs"
   },
   "dependencies": {
@@ -16,7 +17,8 @@
     "viem": "2.55.8"
   },
   "devDependencies": {
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "playwright": "1.62.1"
   },
   "overrides": {
     "jayson": {

--- a/tools/coinbase-embedded-wallet/src/index.js
+++ b/tools/coinbase-embedded-wallet/src/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
   CDPReactProvider,
@@ -8,7 +8,7 @@ import {
   LinkAuthFlowBackButton,
   LinkAuthTitle,
 } from "@coinbase/cdp-react";
-import { AuthButton } from "@coinbase/cdp-react/components/AuthButton";
+import { SignIn, SignInBackButton, SignInDescription, SignInForm, SignInAuthMethodButtons, SignInFooter } from "@coinbase/cdp-react/components/SignIn";
 import { useCurrentUser, useIsInitialized, useIsSignedIn } from "@coinbase/cdp-hooks";
 import {
   createCDPEmbeddedWallet,
@@ -141,6 +141,7 @@ function AuthBridge() {
   const { isSignedIn: signedIn } = useIsSignedIn();
   const { currentUser } = useCurrentUser();
   const [panel, setPanel] = useState({ visible: false, view: "signin", notice: "" });
+  const dialogRef = useRef(null);
   const address = accountAddress(currentUser);
   const methods = useMemo(() => linkedAuthMethods(currentUser), [currentUser]);
 
@@ -166,10 +167,14 @@ function AuthBridge() {
     setPanel({ visible: true, view: "review", notice: "Wallet connected. Review recovery access before continuing." });
   }, [panel.visible, panel.view, signedIn, address]);
 
+  useEffect(() => {
+    if (panel.visible && dialogRef.current && !dialogRef.current.open) dialogRef.current.showModal();
+  }, [panel.visible]);
+
   if (!panel.visible) return null;
 
   const close = () => {
-    if (authReject) rejectPendingAuth(new Error("Wallet sign-in was cancelled."));
+    if (authReject) rejectPendingAuth(Object.assign(new Error("Wallet sign-in was cancelled."), { code: 4001 }));
     else hidePanel();
   };
   const continueWithWallet = () => {
@@ -193,13 +198,22 @@ function AuthBridge() {
       React.createElement(
         "p",
         null,
-        "Coinbase provides the non-custodial wallet and maintained sign-in interface. Agent Bounties never receives your one-time code, social password, seed phrase, or private key.",
+        "Create a wallet with email or social sign-in. Coinbase secures your wallet; you control it.",
       ),
-      React.createElement(AuthButton, null),
+      React.createElement(SignIn, { className: "wallet-auth-signin" },
+        React.createElement(SignInBackButton, null),
+        React.createElement(SignInForm, null, ({ authMethod, step, Form }) => React.createElement(
+          React.Fragment, null,
+          React.createElement(SignInDescription, { authMethod, step }),
+          Form,
+          step === "credentials" ? React.createElement(SignInAuthMethodButtons, { activeMethod: authMethod }) : null,
+        )),
+        React.createElement(SignInFooter, null),
+      ),
       React.createElement(
         "p",
         { className: "wallet-auth-method-warning" },
-        "Use the same sign-in method you used before. An unlinked email, phone number, or social account can create a separate Coinbase user and a different wallet.",
+        "Returning user? Use the same sign-in method to access your existing wallet.",
       ),
     );
   } else if (panel.view === "link") {
@@ -322,15 +336,12 @@ function AuthBridge() {
   }
 
   return React.createElement(
-    "div",
-    { className: "wallet-auth-overlay", role: "presentation" },
+    "dialog",
+    { ref: dialogRef, className: "wallet-auth-overlay", "aria-labelledby": "coinbase-wallet-auth-title", onCancel: (event) => { event.preventDefault(); close(); } },
     React.createElement(
       "section",
       {
         className: "wallet-auth-panel",
-        role: "dialog",
-        "aria-modal": "true",
-        "aria-labelledby": "coinbase-wallet-auth-title",
       },
       React.createElement(
         "div",
@@ -360,7 +371,7 @@ function AuthBridge() {
       React.createElement(
         "p",
         { className: "wallet-auth-boundary" },
-        "Authentication and linking never authorize a bounty payment. Agent Bounties sponsors gas only for supported, bounded relay actions; canonical events remain the authority.",
+        "Creating or linking a wallet does not authorize a payment. You review any payment separately.",
       ),
     ),
   );

--- a/tools/coinbase-embedded-wallet/test-account-link.mjs
+++ b/tools/coinbase-embedded-wallet/test-account-link.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../site");
+const ADDRESS = "0x" + "11".repeat(20);
+const EMBEDDED = "0x" + "22".repeat(20);
+let browser, server, origin;
+before(async () => {
+  server = createServer(async (request, response) => {
+    const pathname = decodeURIComponent(new URL(request.url, "http://localhost").pathname);
+    const filename = path.resolve(root, `.${pathname === "/" ? "/index.html" : pathname}`);
+    if (!filename.startsWith(root + path.sep)) { response.writeHead(403).end(); return; }
+    try {
+      let body = await readFile(filename);
+      if (pathname === "/wallet-config.js") body = Buffer.from(body.toString().replace("__COINBASE_CDP_PROJECT_ID__", "qa-wallet-project"));
+      response.setHeader("Content-Type", ({ ".html": "text/html", ".js": "text/javascript", ".css": "text/css", ".svg": "image/svg+xml", ".webp": "image/webp" })[path.extname(filename)] || "application/octet-stream");
+      response.end(body);
+    } catch { response.writeHead(404).end(); }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  origin = `http://127.0.0.1:${server.address().port}`;
+  browser = await chromium.launch({ headless: true });
+});
+after(async () => {
+  await browser?.close();
+  if (server) await new Promise((resolve) => server.close(resolve));
+});
+
+async function account({ installed = true, linked = false, mobile = false } = {}) {
+  const context = await browser.newContext({ viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
+  const page = await context.newPage();
+  const proofs = [], errors = [];
+  let wallets = linked ? [{ address: ADDRESS }] : [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.route("https://**/*", (route) => route.fulfill({ json: {} }));
+  await page.route("**/auth/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    let body = {};
+    if (pathname.endsWith("/session")) body = { authenticated: true, user: { id: "qa", name: "Test member", provider: "google" }, providers: { google: true } };
+    if (pathname.endsWith("/account")) body = { wallets, available: false };
+    if (pathname.endsWith("/wallet/challenge")) {
+      const request = route.request().postDataJSON(); proofs.push(request);
+      body = { challenge_id: "ownership-only", message: `Ownership proof for ${request.address}. No payment.` };
+    }
+    if (pathname.endsWith("/wallet/verify")) {
+      const request = route.request().postDataJSON(); proofs.push(request);
+      wallets = [...wallets, { address: request.address }]; body = { wallets };
+    }
+    await route.fulfill({ json: body });
+  });
+  await page.addInitScript(({ installed, address }) => {
+    window.walletTestCalls = [];
+    if (installed) window.ethereum = { isMetaMask: true, request: async (request) => {
+      window.walletTestCalls.push({ wallet: "MetaMask", ...request });
+      return request.method === "eth_requestAccounts" ? [address] : "0x" + "ab".repeat(65);
+    } };
+  }, { installed, address: ADDRESS });
+  // Replace only the external SDK boundary; exercise the real chooser and account handler.
+  await page.route("**/vendor/coinbase-embedded-wallet.bundle.js?*", (route) => route.fulfill({
+    contentType: "text/javascript",
+    body: `window.AgentBountiesCoinbaseEmbeddedWallet = { enabled: true, provider: { request: async (request) => {
+      window.walletTestCalls.push({ wallet: "embedded", ...request });
+      return request.method === "eth_requestAccounts" ? ["${EMBEDDED}"] : "0x" + "cd".repeat(65);
+    } } };`,
+  }));
+  await page.goto(origin);
+  await page.getByRole("button", { name: "Account", exact: true }).click();
+  const link = page.locator("[data-wallet-link]");
+  await page.waitForFunction(() => document.querySelector("[data-wallet-list]").textContent !== "Checking verified wallets…");
+  return { context, page, proofs, errors, link };
+}
+
+for (const installed of [true, false]) {
+  for (const linked of [true, false]) {
+    test(`${linked ? "Link another" : "Link wallet"} offers creation with ${installed ? "MetaMask" : "no wallet"} installed`, async () => {
+      const { context, page, proofs, errors, link } = await account({ installed, linked, mobile: !installed });
+      try {
+        assert.equal(await link.innerText(), linked ? "Link another" : "Link wallet");
+        await link.click();
+        assert.equal(await page.getByRole("dialog", { name: "Choose a wallet" }).isVisible(), true);
+        assert.deepEqual(await page.evaluate(() => window.walletTestCalls), []);
+        await page.getByRole("button", { name: "I don’t have a wallet — create one", exact: false }).click();
+        await page.waitForFunction(() => document.querySelector("[data-wallet-status]").textContent.includes("verified and linked"));
+        const calls = await page.evaluate(() => window.walletTestCalls);
+        assert.deepEqual(calls.map(({ wallet, method }) => [wallet, method]), [["embedded", "eth_requestAccounts"], ["embedded", "personal_sign"]]);
+        assert.equal(calls[1].params[1], EMBEDDED);
+        assert.equal(proofs[1].address, EMBEDDED);
+        assert.equal(proofs[1].challenge_id, "ownership-only");
+        assert.deepEqual(errors, []);
+      } finally { await context.close(); }
+    });
+  }
+}
+
+test("Escape returns to the account without a wallet call; MetaMask works only after selection", async () => {
+  const { context, page, proofs, link } = await account();
+  try {
+    await link.click();
+    await page.keyboard.press("Escape");
+    await page.waitForFunction(() => !document.querySelector("[data-wallet-link]").disabled);
+    assert.deepEqual(await page.evaluate(() => window.walletTestCalls), []);
+    assert.deepEqual(proofs, []);
+    assert.equal(await link.evaluate((element) => element === document.activeElement), true);
+    await link.click();
+    await page.getByRole("button", { name: "MetaMask Choose an address in this wallet." }).click();
+    await page.waitForFunction(() => document.querySelector("[data-wallet-status]").textContent.includes("verified and linked"));
+    assert.deepEqual((await page.evaluate(() => window.walletTestCalls)).map(({ wallet, method }) => [wallet, method]), [["MetaMask", "eth_requestAccounts"], ["MetaMask", "personal_sign"]]);
+    assert.equal(proofs[1].address, ADDRESS);
+  } finally { await context.close(); }
+});


### PR DESCRIPTION
Clicking Link wallet or Link another currently wakes the injected wallet immediately. Both actions now open a chooser with explicit installed-wallet, phone-wallet, and “I don’t have a wallet — create one” options. The creation path lazily loads the retained Coinbase email/Google/Apple sign-in flow and uses the selected provider for the existing ownership-only account challenge.

The account stays open beneath the native wallet dialog; cancellation restores focus and leaves the account usable. Pages builds the locked embedded-wallet assets and verifies the configured production origin before publishing. No payment, delegation, custody, or API contract changes are included.

Validation:
- 33 chooser, homepage, and phone-wallet tests pass.
- Five Chromium account-link regressions pass, covering both link labels with and without MetaMask and explicit cancellation/selection.
- Real Coinbase sign-in UI checked at desktop and mobile sizes; no real account creation or signatures performed.
- Site validation with the required bundle, dependency compatibility, workflow YAML, and the live CDP origin check pass.

Maintainer notice: https://github.com/NSPG13/agent-bounties/issues/1321
Open PRs were inspected before preparation and again before release. #1320 shares Pages and site-inventory files; preserve both browser gates when reconciling. #1196 overlaps account UI and is already conflicting; retain its email-auth functionality when updated. #908 touches homepage links and is already conflicting. No other implementation overlap is known. Rollback disables the embedded provider while retaining the chooser and external-wallet paths.