### PR TITLE
Preserve referral context through assistant posting handoffs

### DIFF
--- a/docs/site-analytics.md
+++ b/docs/site-analytics.md
@@ -38,6 +38,22 @@ GA4 disabled without affecting first-party analytics.
 
 The aggregate endpoint is public and never returns event-level identifiers.
 
+## Assistant return links
+
+The website launcher preserves bounded `utm_source` and `utm_campaign` values
+in its first-party posting return link. The same link appears in the assistant
+prompt, desktop browser destination, copied instructions and web fallback.
+An unexpired first touch wins over a later visit; an explicit destination source
+is kept as one source/campaign pair. Global Privacy Control, Do Not Track and
+the local analytics opt-out carry `analytics=off` to the return page.
+
+This transfer does not include browser or session IDs, full referrers, arbitrary
+query parameters, wallet data or signed MCP acquisitions. A different browser
+still has a different local visitor ID. Forwarded tags describe a referral and
+can be copied or changed; they do not authenticate a customer, prove an ad caused
+a purchase, or establish canonical funding. Operator outcome joins remain
+private and must independently reconcile canonical events and customer identity.
+
 ## External interface usage contract
 
 The `interfaces` array registers external observed requests after deployment:

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -1288,6 +1288,7 @@ def main() -> int:
         path = site_dir / relative
         text = path.read_text(encoding="utf-8")
         prefix = "../" * (len(PurePosixPath(relative).parts) - 1)
+        analytics_version = 5 if relative in {"index.html", "post.html"} else 4
         parser = PageParser()
         parser.feed(text)
         if parser.h1_count != 1:
@@ -1301,10 +1302,10 @@ def main() -> int:
                 f'<link rel="icon" href="{prefix}favicon.svg" type="image/svg+xml">',
                 f'<link rel="canonical" href="{canonical}">',
                 f'<script src="{prefix}analytics-config.js?v=',
-                f'<script src="{prefix}analytics.js?v=4"></script>',
+                f'<script src="{prefix}analytics.js?v={analytics_version}"></script>',
             ],
         )
-        if text.index(f'src="{prefix}analytics-config.js?v=') > text.index(f'src="{prefix}analytics.js?v=4"'):
+        if text.index(f'src="{prefix}analytics-config.js?v=') > text.index(f'src="{prefix}analytics.js?v={analytics_version}"'):
             fail(f"{relative}: analytics config must load before analytics.js")
         if relative not in INDEXABLE_PAGES and '<meta name="robots" content="noindex, nofollow">' not in text:
             fail(f"{relative}: transactional handoffs must remain noindex, nofollow")

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -301,6 +301,7 @@ def main() -> int:
         ["scripts/test-canonical-child-verifier-deployment-console.js"], ["--check", "tools/base-sepolia-sponsor-activation.js"],
         ["scripts/test-base-sepolia-sponsor-activation-console.js"],
         ["--test", "scripts/test-metrics-dashboard.js"],
+        ["--test", "scripts/test-assistant-referrals.js", "scripts/test-solarpunk-home.js", "scripts/test-ai-bounty-handoff.js"],
         ["--test", "scripts/test-phone-wallet.js", "scripts/test-webmcp.js", "scripts/test-meta-child.js", "scripts/test-competition-proof.js"],
         ["--check", "scripts/open-competition-v1-signer.js"],
         ["scripts/test-open-competition-v1-signer-console.js"],

--- a/scripts/test-ai-bounty-handoff.js
+++ b/scripts/test-ai-bounty-handoff.js
@@ -216,6 +216,32 @@ async function verifyDesktopHandoff() {
   assert.equal(api.providerLinks("unknown", "draft"), null);
   assert.equal(api.providerLinks("chatgpt", ""), null);
   assert.throws(() => api.providerLinks("chatgpt", "draft", { meta_child: { parent_bounty_contract: "https://evil.example" } }));
+  let optedOut = false;
+  window.agentBountiesAnalytics = {
+    handoffUrl(value) {
+      const url = new URL(value);
+      if (optedOut) url.searchParams.set("analytics", "off");
+      else { url.searchParams.set("utm_source", "example-source"); url.searchParams.set("utm_campaign", "example-campaign"); }
+      return url.href;
+    },
+  };
+  navigator.clipboard.writeText = async text => copies.push(text);
+  api.show("Preserve the parent and review terms.", context);
+  await chatgptButton.handlers.click();
+  const attributed = new URL(desktopLaunches.at(-1));
+  assert.equal(new URL(attributed.searchParams.get("browserUrl")).searchParams.get("parentBounty"), child.meta_child.parent_bounty_contract);
+  assert.ok(attributed.searchParams.get("prompt").includes(attributed.searchParams.get("browserUrl")));
+  assert.match(copies.at(-1), /utm_source=example-source/);
+  optedOut = true;
+  fallback.handlers.click({ preventDefault() { throw new Error("valid fallback must remain usable"); } });
+  assert.match(new URL(fallback.href).searchParams.get("prompt"), /analytics=off/);
+  assert.doesNotMatch(new URL(fallback.href).searchParams.get("prompt"), /utm_source=example-source/);
+  await chatgptButton.handlers.click();
+  const disabled = new URL(desktopLaunches.at(-1));
+  assert.equal(new URL(disabled.searchParams.get("browserUrl")).searchParams.get("analytics"), "off");
+  assert.equal(disabled.searchParams.get("prompt"), copies.at(-1));
+  assert.match(copies.at(-1), /analytics=off/);
+  assert.doesNotMatch(copies.at(-1), /utm_source=example-source/);
   console.log("user-owned AI handoff validates drafts, desktop launch, explicit fallback, preserved context and clipboard recovery");
 }
 verifyDesktopHandoff().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/scripts/test-assistant-referrals.js
+++ b/scripts/test-assistant-referrals.js
@@ -1,0 +1,126 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const crypto = require("node:crypto");
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+const home = require("../site/solarpunk-home.js");
+const postingPrompt = require("../site/posting-prompt.js");
+const source = fs.readFileSync(path.join(__dirname, "../site/analytics.js"), "utf8");
+
+function storage() {
+  const values = new Map();
+  return { getItem: key => values.get(key) ?? null, setItem: (key, value) => values.set(key, String(value)), removeItem: key => values.delete(key) };
+}
+
+function page(url, options = {}) {
+  const events = [];
+  const window = {
+    location: new URL(url), localStorage: options.local || storage(), sessionStorage: storage(),
+    crypto: crypto.webcrypto,
+    fetch(endpoint, request) {
+      assert.equal(endpoint, "https://api.agentbounties.app/v1/analytics/events");
+      events.push(JSON.parse(request.body));
+      return Promise.resolve({ ok: true });
+    },
+  };
+  vm.runInNewContext(source, {
+    window, navigator: options.privacy || {}, URL, URLSearchParams, Date, Uint8Array,
+    document: { referrer: "", addEventListener() {} },
+  });
+  return { analytics: window.agentBountiesAnalytics, local: window.localStorage, events };
+}
+
+const landing = "https://agentbounties.app/?utm_source=example-source&utm_campaign=example-campaign&secret=never-forward&gclid=not-collected";
+const review = "https://agentbounties.app/post.html?from=webmcp";
+
+test("a new desktop browser receives referral tags without the original browser identity", () => {
+  const first = page(landing);
+  const destination = first.analytics.handoffUrl(review);
+  const links = home.bountyAssistantLinks("gpt", undefined, destination);
+  const desktop = new URL(links.desktopUrl);
+  assert.equal(desktop.searchParams.get("browserUrl"), destination);
+  assert.equal(desktop.searchParams.get("prompt"), new URL(links.webUrl).searchParams.get("prompt"));
+  assert.match(desktop.searchParams.get("prompt"), /utm_source=example-source/);
+  assert.doesNotMatch(desktop.searchParams.get("prompt"), /utm_source=chatgpt/);
+  const next = page(desktop.searchParams.get("browserUrl"));
+  assert.equal(next.events[0].source, "example-source");
+  assert.equal(next.events[0].campaign, "example-campaign");
+  assert.notEqual(next.events[0].visitor_id, first.events[0].visitor_id);
+  assert.notEqual(next.events[0].session_id, first.events[0].session_id);
+  for (const text of [destination, desktop.searchParams.get("prompt")]) {
+    assert.ok(!text.includes(first.events[0].visitor_id));
+    assert.ok(!text.includes(first.events[0].session_id));
+    assert.doesNotMatch(text, /never-forward|gclid|not-collected/);
+  }
+});
+
+test("web and copied assistant prompts retain the same review destination and task", () => {
+  const first = page(landing);
+  const destination = first.analytics.handoffUrl(review);
+  const task = { request: "Keep retries idempotent.", solver_reward_usdc: "3.00" };
+  const prompt = postingPrompt.build(task, destination);
+  assert.ok(prompt.includes(`Use ${destination} in @Browser`));
+  assert.ok(prompt.includes(JSON.stringify(task, null, 2)));
+  for (const [provider, parameter] of [["claude", "q"], ["cursor", "text"]]) {
+    const links = home.bountyAssistantLinks(provider, postingPrompt.build(task), destination);
+    assert.equal(new URL(links.webUrl).searchParams.get(parameter), prompt);
+  }
+});
+
+test("first touch and explicit destination pairs are preserved independently", () => {
+  const original = page("https://agentbounties.app/?utm_source=github&utm_campaign=readme");
+  const later = page(landing, { local: original.local });
+  const destination = new URL(later.analytics.handoffUrl(review));
+  assert.equal(destination.searchParams.get("utm_source"), "github");
+  assert.equal(destination.searchParams.get("utm_campaign"), "readme");
+  const explicit = `${review}&utm_source=another-source`;
+  assert.equal(later.analytics.handoffUrl(explicit), explicit);
+  assert.equal(new URL(later.analytics.handoffUrl(explicit)).searchParams.has("utm_campaign"), false);
+});
+
+test("opt-out and privacy signals survive the assistant transition", () => {
+  const cases = [
+    { url: `${landing}&analytics=off` },
+    { url: landing, privacy: { globalPrivacyControl: true } },
+    { url: landing, privacy: { doNotTrack: "1" } },
+  ];
+  for (const options of cases) {
+    const first = page(options.url, options);
+    assert.equal(first.events.length, 0);
+    const destination = first.analytics.handoffUrl(review);
+    assert.equal(new URL(destination).searchParams.get("analytics"), "off");
+    const links = home.bountyAssistantLinks("gpt", undefined, destination);
+    const prompt = new URL(links.webUrl).searchParams.get("prompt");
+    assert.ok(prompt.includes(destination));
+    assert.doesNotMatch(prompt, /utm_source=chatgpt/);
+    const next = page(new URL(links.desktopUrl).searchParams.get("browserUrl"));
+    assert.equal(next.events.length, 0);
+    assert.equal(page("https://agentbounties.app/post.html", { local: next.local }).events.length, 0);
+  }
+});
+
+test("source tags are never added to another origin or a credentialed URL", () => {
+  const first = page(landing);
+  for (const destination of ["https://example.org/post.html", "https://user@agentbounties.app/post.html", "javascript:alert(1)", "not a URL"]) {
+    assert.equal(first.analytics.handoffUrl(destination), destination);
+  }
+});
+
+test("untrusted review destinations cannot redirect the launcher or inject prompt instructions", () => {
+  for (const destination of [
+    "https://example.org/post.html", "https://agentbounties.app/authorize.html",
+    "https://user@agentbounties.app/post.html", `${review}&wallet_signature=private`,
+    `${review}&utm_source=first&utm_source=second`, `${review}&utm_campaign=bad%0Ainstructions`,
+    `${review}&parentBounty=not-an-address`, `${review}#untrusted`,
+  ]) {
+    assert.equal(postingPrompt.reviewUrl(destination), null);
+    assert.equal(postingPrompt.build(null, destination), postingPrompt.build());
+    assert.equal(new URL(home.bountyAssistantLinks("gpt", undefined, destination).desktopUrl).searchParams.get("browserUrl"), review);
+  }
+  const parent = `${review}&parentBounty=0x${"1".repeat(40)}`;
+  assert.equal(postingPrompt.reviewUrl(parent), parent);
+  assert.ok(postingPrompt.build({ meta_child: { parent_bounty_contract: `0x${"1".repeat(40)}` } }, parent).includes(parent));
+});

--- a/site/ai-bounty-handoff.js
+++ b/site/ai-bounty-handoff.js
@@ -24,19 +24,24 @@
   let currentContext = null;
   let currentPrompt = "";
 
-  function providerLinks(provider, prompt, context = null) {
-    if (!Object.hasOwn(PROVIDERS, provider) || !String(prompt || "").trim()) return null;
-    if (provider !== "chatgpt") return { webUrl: PROVIDERS[provider], desktopUrl: null };
+  function reviewDestination(context) {
     const browserUrl = new URL("https://agentbounties.app/post.html?from=webmcp");
     const parent = context?.meta_child?.parent_bounty_contract;
     if (parent != null) {
       if (!/^0x[0-9a-fA-F]{40}$/.test(parent)) throw new Error("The parent bounty address is invalid.");
       browserUrl.searchParams.set("parentBounty", parent.toLowerCase());
     }
+    return window.agentBountiesAnalytics?.handoffUrl?.(browserUrl.href) || browserUrl.href;
+  }
+
+  function providerLinks(provider, prompt, context = null) {
+    if (!Object.hasOwn(PROVIDERS, provider) || !String(prompt || "").trim()) return null;
+    if (provider !== "chatgpt") return { webUrl: PROVIDERS[provider], desktopUrl: null };
+    const browserUrl = reviewDestination(context);
     // OpenAI Learn uses this registered desktop route for a draft + browser tab.
     const desktop = new URL("codex://threads/new");
     desktop.searchParams.set("prompt", prompt);
-    desktop.searchParams.set("browserUrl", browserUrl.href);
+    desktop.searchParams.set("browserUrl", browserUrl);
     const web = new URL(PROVIDERS.chatgpt);
     web.searchParams.set("prompt", prompt);
     return { desktopUrl: desktop.href, webUrl: web.href };
@@ -144,7 +149,8 @@
       };
     }
     if (context?.meta_child || context?.draft?.meta_child) data.meta_child = context.meta_child || context.draft.meta_child;
-    return window.AgentBountiesPostingPrompt.build(data);
+    return window.AgentBountiesPostingPrompt.build(data,
+      window.agentBountiesAnalytics ? reviewDestination(context) : null);
   }
 
   function setImportStatus(message, tone = "") {
@@ -203,6 +209,8 @@
       const provider = button.dataset.aiProvider;
       let links;
       try {
+        if (currentIntent) currentPrompt = promptFor(currentIntent, currentContext);
+        promptPreview.value = currentPrompt;
         links = providerLinks(provider, currentPrompt, currentContext);
       } catch (error) {
         setImportStatus(error.message || "The desktop handoff could not be prepared.", "error");
@@ -243,8 +251,21 @@
     }
   });
 
+  webFallback?.addEventListener("click", (event) => {
+    try {
+      currentPrompt = promptFor(currentIntent, currentContext);
+      promptPreview.value = currentPrompt;
+      webFallback.href = providerLinks("chatgpt", currentPrompt, currentContext).webUrl;
+    } catch (_error) {
+      event.preventDefault();
+      setImportStatus("The handoff could not be refreshed. Reopen AI setup for this draft.", "error");
+    }
+  });
+
   panel.querySelector("[data-copy-ai-prompt]")?.addEventListener("click", async () => {
     try {
+      if (currentIntent) currentPrompt = promptFor(currentIntent, currentContext);
+      promptPreview.value = currentPrompt;
       await copyText(currentPrompt);
       setImportStatus("AI prompt copied.", "success");
     } catch (_error) {

--- a/site/analytics.js
+++ b/site/analytics.js
@@ -289,6 +289,30 @@
     return pattern.test(normalized) ? normalized : null;
   }
 
+  function handoffUrl(value) {
+    try {
+      const url = new URL(value);
+      if (url.origin !== "https://agentbounties.app" || url.username || url.password) return value;
+      if (!enabled()) {
+        if (privacySignalEnabled() || explicitOptOut()) url.searchParams.set("analytics", "off");
+        return url.href;
+      }
+      // Preserve an explicit destination source as one pair, never mix campaigns.
+      if (url.searchParams.has("utm_source") || url.searchParams.has("utm_campaign")) return url.href;
+      const attribution = currentAttribution();
+      const source = safeToken(attribution.source);
+      const campaign = safeToken(attribution.campaign);
+      if (source && (source !== "direct" || campaign)) {
+        url.searchParams.set("utm_source", source);
+        if (campaign) url.searchParams.set("utm_campaign", campaign);
+      }
+      return url.href;
+    } catch (_error) {
+      // A referral helper must not block the person's existing posting flow.
+      return value;
+    }
+  }
+
   function track(eventName, details) {
     if (!enabled() || !EVENTS.has(eventName)) return false;
     const visitorId = browserId();
@@ -366,7 +390,7 @@
     };
   }
 
-  const analytics = { track, optOut, optIn, status };
+  const analytics = { track, optOut, optIn, status, handoffUrl };
   window.agentBountiesAnalytics = analytics;
   window.bountyBoardAnalytics = analytics;
 

--- a/site/index.html
+++ b/site/index.html
@@ -368,8 +368,8 @@
     <script src="wallet-link.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=6"></script>
-    <script src="analytics.js?v=4"></script>
-    <script src="posting-prompt.js?v=2"></script>
-    <script src="solarpunk-home.js?v=13"></script>
+    <script src="analytics.js?v=5"></script>
+    <script src="posting-prompt.js?v=3"></script>
+    <script src="solarpunk-home.js?v=14"></script>
   </body>
 </html>

--- a/site/post.html
+++ b/site/post.html
@@ -249,14 +249,14 @@
     <script src="phone-wallet.js?v=1"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=6"></script>
-    <script src="analytics.js?v=4"></script>
+    <script src="analytics.js?v=5"></script>
     <script src="legal-consent.js"></script>
     <script src="evm.js"></script>
     <script src="meta-child.js?v=1"></script>
     <script src="bounty-entry.js?v=1"></script>
-    <script src="posting-prompt.js?v=2"></script>
+    <script src="posting-prompt.js?v=3"></script>
     <script src="creator-review.js?v=1"></script>
-    <script src="ai-bounty-handoff.js?v=9"></script>
+    <script src="ai-bounty-handoff.js?v=10"></script>
     <script src="bounty-composer-v2.js?v=12"></script>
     <script src="posting-workspace.js?v=2"></script>
   </body>

--- a/site/posting-prompt.js
+++ b/site/posting-prompt.js
@@ -21,8 +21,35 @@ Without tools, return importable JSON:
 {"title":"...","goal":"...","acceptance_criteria":["..."],"solver_reward_usdc":"2.00","verifier_reward_usdc":"0.10","task_window_days":30,"source_url":null,"benchmark":null,"evidence_schema":null}
 Use my agreed amounts and days. For creator review add "review_mode":"creator" and "delivery_deadline" as the agreed ISO timestamp with timezone offset; omit automated benchmark fields. Preserve parent bindings and approved image fields. Missing verification stays unfundable; JSON is not publication or funding.`;
 
-  function build(context = null) {
-    if (!context || !Object.keys(context).length) return PROMPT;
+  function reviewUrl(value) {
+    if (!value) return null;
+    try {
+      const url = new URL(value);
+      if (url.origin !== "https://agentbounties.app" || url.pathname !== "/post.html"
+          || url.username || url.password || url.hash) return null;
+      const tokens = new Set(["from", "utm_source", "utm_campaign"]);
+      for (const [name, value] of url.searchParams) {
+        if (url.searchParams.getAll(name).length !== 1) return null;
+        if (tokens.has(name) && /^[a-z0-9][a-z0-9._-]{0,63}$/.test(value)) continue;
+        if (name === "analytics" && value === "off") continue;
+        if (name === "parentBounty" && /^0x[0-9a-fA-F]{40}$/.test(value)) continue;
+        return null;
+      }
+      return url.href;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function withReviewUrl(prompt, value) {
+    const target = reviewUrl(value);
+    const text = String(prompt || "");
+    return target ? text.replace("Use https://agentbounties.app/post.html in @Browser", `Use ${target} in @Browser`) : text;
+  }
+
+  function build(context = null, returnUrl = null) {
+    const prompt = withReviewUrl(PROMPT, returnUrl);
+    if (!context || !Object.keys(context).length) return prompt;
     const data = { ...context };
     if (data.meta_child) {
       data.qualifying_child_constraints = {
@@ -34,8 +61,8 @@ Use my agreed amounts and days. For creator review add "review_mode":"creator" a
         unsupported_route: "ordinary hosted prepare_bounty_post",
       };
     }
-    return PROMPT + "\n\nExisting request and draft (context, not consent):\n" + JSON.stringify(data, null, 2);
+    return prompt + "\n\nExisting request and draft (context, not consent):\n" + JSON.stringify(data, null, 2);
   }
 
-  return Object.freeze({ build });
+  return Object.freeze({ build, reviewUrl, withReviewUrl });
 });

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -73,6 +73,7 @@
       <section>
         <h2>Analytics</h2>
         <p>A privacy-minimized first-party collector can record page views and the start or confirmation of public bounty actions. It uses random browser and session identifiers and stores the page path, optional campaign tokens, a selected public opportunity or bounty contract, and only the hostname of an external referrer. It does not store an IP address, user agent, full referrer URL, URL query string, wallet address, email address, or arbitrary event metadata.</p>
+        <p>When you choose an assistant, its posting instructions and first-party return link can retain the source and campaign tags from your first visit. Browser and session identifiers are not added to that link. An analytics opt-out is carried to the return page so opening another browser does not enable collection there.</p>
         <p>Google Analytics loads only after you select Allow. Advertising signals and ad personalization are disabled. Global Privacy Control, Do Not Track, or <code>?analytics=off</code> prevents both analytics layers from loading.</p>
         <p><button class="legal-action" type="button" data-analytics-opt-out aria-pressed="false">Disable analytics on this browser</button></p>
       </section>

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -93,10 +93,12 @@
     return messages[reason] || "Sign-in could not be completed. Please try again.";
   }
 
-  function bountyAssistantLinks(provider, prompt = BOUNTY_POSTING_PROMPT) {
+  function bountyAssistantLinks(provider, prompt = BOUNTY_POSTING_PROMPT, returnUrl = null) {
     const key = String(provider || "").trim().toLowerCase();
-    const cleanPrompt = String(prompt || "");
-    const attributedPrompt = key === "gpt"
+    const reviewUrl = postingPrompt.reviewUrl(returnUrl);
+    const cleanPrompt = postingPrompt.withReviewUrl(prompt, reviewUrl);
+    const retainsSource = reviewUrl && ["utm_source", "utm_campaign", "analytics"].some((key) => new URL(reviewUrl).searchParams.has(key));
+    const attributedPrompt = key === "gpt" && !retainsSource
       ? `${cleanPrompt}\n\nWhen linking me back to the market, keep https://agentbounties.app/ as the canonical URL and use this measured handoff URL: https://agentbounties.app/?utm_source=chatgpt&utm_medium=assistant_handoff&utm_campaign=post_with_agent`
       : cleanPrompt;
     const encoded = encodeURIComponent(attributedPrompt);
@@ -104,7 +106,7 @@
       gpt: {
         label: "ChatGPT",
         // Matches OpenAI Learn's desktop composer: prompt + a shared browser tab.
-        desktopUrl: `codex://threads/new?prompt=${encoded}&browserUrl=${encodeURIComponent("https://agentbounties.app/post.html?from=webmcp")}`,
+        desktopUrl: `codex://threads/new?prompt=${encoded}&browserUrl=${encodeURIComponent(reviewUrl || "https://agentbounties.app/post.html?from=webmcp")}`,
         webUrl: `https://chatgpt.com/?prompt=${encoded}`,
         webPrefillsPrompt: true,
       },
@@ -1112,15 +1114,19 @@ ${competitionChildBrief(item)}`;
       const launcherDescription = dialog.querySelector("#bounty-launcher-description");
       const postingRequest = parseCompetitionPostingRequest(win.location.search);
       let launcherPrompt = BOUNTY_POSTING_PROMPT;
+      let fallbackProvider = null;
+      const reviewDestination = () => win.agentBountiesAnalytics?.handoffUrl?.("https://agentbounties.app/post.html?from=webmcp") || null;
+      const currentLauncherPrompt = () => postingPrompt.withReviewUrl(launcherPrompt, reviewDestination());
       let contextReady = !postingRequest.requested;
       let contextStatus = postingRequest.requested ? "Verifying the parent competition and reviewed child-bounty brief…" : "";
 
-      if (promptPreview) promptPreview.textContent = launcherPrompt;
+      if (promptPreview) promptPreview.textContent = currentLauncherPrompt();
 
       const setStatus = (message) => {
         if (status) status.textContent = message;
       };
       const resetLauncher = () => {
+        fallbackProvider = null;
         assistantButtons.forEach((button) => button.removeAttribute("aria-current"));
         if (customActions) customActions.hidden = true;
         if (webFallback) {
@@ -1134,6 +1140,7 @@ ${competitionChildBrief(item)}`;
       };
       const showDialog = () => {
         resetLauncher();
+        if (promptPreview) promptPreview.textContent = currentLauncherPrompt();
         dialog.showModal();
         openButton.setAttribute("aria-expanded", "true");
         win.requestAnimationFrame?.(() => assistantButtons[0]?.focus());
@@ -1142,12 +1149,14 @@ ${competitionChildBrief(item)}`;
         if (dialog.open) dialog.close();
       };
       const copyPrompt = async () => {
+        const prompt = currentLauncherPrompt();
+        if (promptPreview) promptPreview.textContent = prompt;
         try {
-          await win.navigator.clipboard.writeText(launcherPrompt);
+          await win.navigator.clipboard.writeText(prompt);
           return true;
         } catch (error) {
           const textarea = doc.createElement("textarea");
-          textarea.value = launcherPrompt;
+          textarea.value = prompt;
           textarea.setAttribute("readonly", "");
           textarea.style.position = "fixed";
           textarea.style.opacity = "0";
@@ -1180,7 +1189,7 @@ ${competitionChildBrief(item)}`;
       assistantButtons.forEach((button) => {
         button.addEventListener("click", async () => {
           const key = String(button.dataset.bountyAssistant || "").toLowerCase();
-          const links = bountyAssistantLinks(key, launcherPrompt);
+          const links = bountyAssistantLinks(key, launcherPrompt, reviewDestination());
           if (!links) return;
           assistantButtons.forEach((item) => item.removeAttribute("aria-current"));
           button.setAttribute("aria-current", "true");
@@ -1198,6 +1207,7 @@ ${competitionChildBrief(item)}`;
 
           const promptCopy = copyPrompt();
           if (webFallback) {
+            fallbackProvider = key;
             webFallback.href = links.webUrl;
             webFallback.textContent = links.webPrefillsPrompt
               ? `Use ${links.label} web instead`
@@ -1225,6 +1235,11 @@ ${competitionChildBrief(item)}`;
         const copied = await copyPrompt();
         setStatus(copied ? "Initialization message copied." : "Select the message above and copy it manually.");
       });
+      webFallback?.addEventListener("click", () => {
+        const links = bountyAssistantLinks(fallbackProvider, launcherPrompt, reviewDestination());
+        if (links?.webUrl) webFallback.href = links.webUrl;
+        if (promptPreview) promptPreview.textContent = currentLauncherPrompt();
+      });
       if (win.location.hash === "#post-a-bounty") {
         win.requestAnimationFrame?.(showDialog);
       }
@@ -1241,7 +1256,7 @@ ${competitionChildBrief(item)}`;
           contextStatus = `Verified ${shortWalletAddress(item.source_id)}. The selected assistant will receive the exact parent contract, UTC window, and reviewed child brief.`;
           if (launcherTitle) launcherTitle.textContent = "Post a qualifying bounty";
           if (launcherDescription) launcherDescription.textContent = `Bound to ${shortWalletAddress(item.source_id)} · ${item.evidence_requirements.scoring_window.starts_at} → ${item.evidence_requirements.scoring_window.ends_at}`;
-          if (promptPreview) promptPreview.textContent = launcherPrompt;
+          if (promptPreview) promptPreview.textContent = currentLauncherPrompt();
           resetLauncher();
         })().catch(() => {
           contextReady = false;


### PR DESCRIPTION
Opening a posting assistant in another browser dropped the website's referral source and campaign. The homepage and draft-page launchers now carry those bounded tags in the same first-party review URL across desktop browser links, web prompts and copied instructions. Existing first-touch attribution wins, and an analytics opt-out is carried to the return page and refreshed when a fallback is used.

The URL never copies browser/session identifiers or arbitrary source query parameters. Prompt destinations are restricted to the first-party posting page and an allowlist of bounded parameters. Signed MCP acquisitions, canonical funding rules and wallet authority are unchanged. Forwarded tags remain untrusted referral metadata; they are not customer or payment proof.

Notice: #1323. R1 browser change; public interface behavior only. Private acquisition operations and outcome joins remain outside the repository. Rollback is a source revert; there is no migration.

Queue: all 67 open PRs were inspected. #1268's recent activity was a maintainer invitation; its diagnostics/security findings still await contributor changes. This PR adds one Node-test invocation to scripts/check.py, so branches such as #1268/#1255 should retain that invocation alongside their Python checks when rebasing. Older #908, #910 and #1196 must preserve the current launcher/privacy surface if resumed; their existing rebase guidance still applies. No collaboration branch or API migration is needed.

Validation:
- 68 tests passed across assistant referrals, assistant handoff, homepage, WebMCP and meta-child behavior.
- python scripts/check-site.py
- python scripts/check-public-handoffs.py
- python scripts/test_check_public_handoffs.py (3 passed)
- python scripts/check-agent-discovery-contract.py
- git diff --check

The new referral cases exercise a fresh browser, privacy signals and opt-out, preserved source pairs, desktop/web/copied prompt parity, unsafe destinations and identifier isolation. The checks run in the full CI gate. No production analytics requests or funding were used by the local referral tests.
