### PR TITLE
Restore and confirm account wallet linking after Google sign-in

### DIFF
--- a/docs/coinbase-embedded-wallet.md
+++ b/docs/coinbase-embedded-wallet.md
@@ -192,11 +192,17 @@ python scripts/test_configure_wallet_providers.py
 npm run check --prefix tools/coinbase-embedded-wallet
 ```
 
-8. Run `node --test scripts/test-wallet-link.js`, then `npm run test:browser --prefix tools/coinbase-embedded-wallet` with Playwright Chromium installed. The browser regressions exercise both account link labels with and without an injected wallet. They stub the provider and account service; a real account-creation canary remains separate.
+8. Run `node --test scripts/test-wallet-link.js`, then `npm run test:browser --prefix tools/coinbase-embedded-wallet` with Playwright Chromium installed. The browser regressions exercise both account link labels with and without an injected wallet, same-page authentication, a full-page OAuth return, ownership-review cancellation, retry, and an unavailable activity refresh. The redirect tests run the real adapter and React UI against a test CDP boundary and account service; a real account-creation canary remains separate.
 9. Human-test one account for every enabled authentication method. Verify that each intended linked method restores the same wallet and that unlinked methods are clearly distinguished.
 10. Buy a bounded amount of Base USDC through MoonPay to the embedded EOA.
 11. Fund an existing bounty through the gas-only x402 relay.
 12. Confirm the matching indexed `FundingAdded` before calling the bounty funded.
+
+## Account-link completion
+
+Account linking saves a 30-minute, tab-scoped intent before opening embedded-wallet sign-in. After a social-login redirect, the homepage checks the same site account, reloads the CDP adapter, and reopens the account dialog. An expired or different-account intent cannot resume access. The stored intent contains only the site account ID and start time; it is not proof of wallet ownership.
+
+A signed-in wallet appears immediately as **Ready to verify**. The user reviews the exact ownership message and selects **Verify and link wallet** before the adapter signs it. Only a successful server verification changes the row to **Verified** and displays the confirmation. Cancelled or failed verification keeps the address visible with **Finish linking**. A failed activity refresh does not erase an already-confirmed link. Recovery-method management is a separate **Recovery settings** action after linking.
 
 ## Provider incentives and portability
 

--- a/site/index.html
+++ b/site/index.html
@@ -37,10 +37,10 @@
         ]
       }
     </script>
-    <link rel="stylesheet" href="solarpunk.css?v=14">
+    <link rel="stylesheet" href="solarpunk.css?v=15">
     <link rel="stylesheet" href="phone-wallet.css?v=1">
     <link rel="stylesheet" href="wallet-link.css?v=1">
-    <link rel="stylesheet" href="wallet-adapters.css?v=2">
+    <link rel="stylesheet" href="wallet-adapters.css?v=3">
   </head>
   <body>
     <a class="skip-link" href="#hero-title">Skip to the main message</a>
@@ -365,11 +365,11 @@
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=1"></script>
     <script src="wallet-config.js?v=1"></script>
-    <script src="wallet-link.js?v=1"></script>
+    <script src="wallet-link.js?v=2"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=5"></script>
     <script src="posting-prompt.js?v=3"></script>
-    <script src="solarpunk-home.js?v=14"></script>
+    <script src="solarpunk-home.js?v=15"></script>
   </body>
 </html>

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -714,6 +714,8 @@ ${competitionChildBrief(item)}`;
       let providerAvailability = {};
       let currentUser = null;
       let accountLoadId = 0;
+      let verifiedWallets = [];
+      let embeddedAddress = null;
 
       const setStatus = (message) => {
         if (status) status.textContent = message;
@@ -752,13 +754,15 @@ ${competitionChildBrief(item)}`;
 
       const renderWallets = (wallets, loading = false) => {
         if (!walletList) return;
+        if (!loading) verifiedWallets = wallets;
+        const unverifiedEmbedded = embeddedAddress && !wallets.some((wallet) => wallet.address === embeddedAddress);
         walletList.replaceChildren();
-        if (loading) {
+        if (loading && !wallets.length && !unverifiedEmbedded) {
           const item = doc.createElement("li");
           item.className = "wallet-empty";
           item.textContent = "Checking verified wallets…";
           walletList.append(item);
-        } else if (!wallets.length) {
+        } else if (!wallets.length && !unverifiedEmbedded) {
           const item = doc.createElement("li");
           item.className = "wallet-empty";
           item.textContent = "No verified wallet linked.";
@@ -779,10 +783,35 @@ ${competitionChildBrief(item)}`;
             remove.textContent = "Remove";
             remove.setAttribute("aria-label", `Remove linked wallet ${wallet.label}`);
             item.append(address, verified, remove);
+            if (wallet.address === embeddedAddress) {
+              const access = doc.createElement("button");
+              access.type = "button";
+              access.className = "wallet-remove";
+              access.dataset.walletAccess = "true";
+              access.textContent = "Recovery settings";
+              item.append(access);
+            }
             walletList.append(item);
           });
         }
-        if (walletLinkButton) walletLinkButton.textContent = wallets.length ? "Link another" : "Link wallet";
+        if (unverifiedEmbedded) {
+          const item = doc.createElement("li");
+          const address = doc.createElement("code");
+          address.textContent = shortWalletAddress(embeddedAddress);
+          address.title = embeddedAddress;
+          const state = doc.createElement("span");
+          state.className = "wallet-pending";
+          state.textContent = "Ready to verify";
+          const finish = doc.createElement("button");
+          finish.type = "button";
+          finish.className = "wallet-remove";
+          finish.dataset.walletFinish = "true";
+          finish.textContent = "Finish linking";
+          finish.disabled = Boolean(walletLinkButton?.disabled);
+          item.append(address, state, finish);
+          walletList.append(item);
+        }
+        if (walletLinkButton) walletLinkButton.textContent = wallets.length || unverifiedEmbedded ? "Link another" : "Link wallet";
       };
 
       const renderAccountDashboard = (payload) => {
@@ -821,7 +850,7 @@ ${competitionChildBrief(item)}`;
         if (accountCompletedCount) accountCompletedCount.textContent = "— settled";
         replaceActivityList(accountParticipatingList, [], "Checking marketplace activity…");
         replaceActivityList(accountCompletedList, [], "Checking settlement evidence…");
-        renderWallets([], true);
+        renderWallets(verifiedWallets, true);
         if (accountEvidence) accountEvidence.textContent = "Verifying marketplace activity…";
       };
 
@@ -840,6 +869,10 @@ ${competitionChildBrief(item)}`;
       const renderSession = (payload) => {
         providerAvailability = payload?.providers || providerAvailability;
         const user = payload?.authenticated ? payload.user : null;
+        if (currentUser?.id !== user?.id) {
+          verifiedWallets = [];
+          embeddedAddress = null;
+        }
         currentUser = user;
         dialog.dataset.view = user ? "account" : "login";
         if (form) form.hidden = Boolean(user);
@@ -854,6 +887,7 @@ ${competitionChildBrief(item)}`;
         openButton.title = user?.name ? `Signed in as ${user.name}` : "Sign in";
         if (!user) {
           accountLoadId += 1;
+          embeddedAddress = null;
           renderWallets([]);
           setWalletStatus("");
           renderProviderAvailability();
@@ -919,7 +953,7 @@ ${competitionChildBrief(item)}`;
           }
           return payload;
         } catch (error) {
-          if (requestId === accountLoadId && currentUser) renderAccountDashboard(null);
+          if (requestId === accountLoadId && currentUser) renderAccountDashboard({ wallets: verifiedWallets });
           return null;
         }
       };
@@ -979,23 +1013,43 @@ ${competitionChildBrief(item)}`;
         if (!form.reportValidity()) return;
         setStatus("Email and password accounts are not configured yet. Use a connected provider.");
       });
-      walletLinkButton?.addEventListener("click", async () => {
+      const linkWallet = async (resuming = false) => {
         if (!currentUser || walletLinkButton.disabled) return;
         const linkingUser = currentUser;
         walletLinkButton.disabled = true;
         setWalletStatus("");
+        let selection;
         try {
           if (!win.AgentBountiesWalletLink) throw { reason: "wallet_selector_unavailable" };
-          const selection = await win.AgentBountiesWalletLink.select();
+          if (resuming) {
+            showDialog();
+            setWalletStatus("Restoring your wallet after sign-in…");
+            const provider = await win.AgentBountiesWalletLink.loadEmbedded();
+            const accounts = await provider.request({ method: "eth_accounts" });
+            if (!accounts?.length) throw { code: 4001 };
+            selection = { provider, accounts, kind: "embedded" };
+          } else selection = await win.AgentBountiesWalletLink.select();
           const linkProvider = selection.provider;
           if (currentUser !== linkingUser) throw { code: 4001 };
+          if (selection.kind === "embedded") win.AgentBountiesWalletLink.beginPending(linkingUser.id);
           win.agentBountiesAnalytics?.track("wallet_link_started");
           setWalletStatus("Choose the wallet address you want to link…");
-          const accounts = await linkProvider.request({ method: "eth_requestAccounts" });
+          const accounts = selection.accounts || await linkProvider.request({ method: "eth_requestAccounts" });
           if (currentUser !== linkingUser) throw { code: 4001 };
-          const address = String(Array.isArray(accounts) ? accounts[0] : "").trim();
+          const address = String(Array.isArray(accounts) ? accounts[0] : "").trim().toLowerCase();
           if (!/^0x[0-9a-fA-F]{40}$/.test(address)) throw { reason: "invalid_wallet_address" };
+          if (selection.kind === "embedded") {
+            embeddedAddress = address;
+            renderWallets(verifiedWallets);
+            showDialog();
+            setWalletStatus("Your wallet is ready. Confirm ownership to finish linking it to your account.");
+            if (verifiedWallets.some((wallet) => wallet.address === address)) {
+              setWalletStatus(`${shortWalletAddress(address)} is already verified and linked. Your wallet is ready.`);
+              return;
+            }
+          }
           const challenge = await postAccountJson("/wallet/challenge", { address });
+          if (currentUser !== linkingUser) throw { code: 4001 };
           setWalletStatus("Review the ownership-only message in your wallet. It cannot move funds or approve tokens.");
           const signature = await linkProvider.request({
             method: "personal_sign",
@@ -1007,17 +1061,30 @@ ${competitionChildBrief(item)}`;
             address,
             signature,
           });
+          if (currentUser !== linkingUser) throw { code: 4001 };
+          // The successful verify response is authoritative even if activity refresh fails.
+          verifiedWallets = [...verifiedWallets.filter((wallet) => wallet.address !== address), { address, label: shortWalletAddress(address) }];
+          renderWallets(verifiedWallets);
           await loadAccount();
+          if (currentUser !== linkingUser) return;
+          showDialog();
           setWalletStatus(`${shortWalletAddress(address)} is verified and linked.`);
           win.agentBountiesAnalytics?.track("wallet_link_confirmed");
         } catch (error) {
-          setWalletStatus(walletLinkErrorMessage(error));
+          if (currentUser === linkingUser) setWalletStatus(embeddedAddress && !verifiedWallets.some((wallet) => wallet.address === embeddedAddress)
+            ? `Your wallet is ready, but account linking is not finished. ${walletLinkErrorMessage(error)} Select Finish linking to retry.`
+            : walletLinkErrorMessage(error));
         } finally {
+          win.AgentBountiesWalletLink?.clearPending();
           walletLinkButton.disabled = false;
+          if (currentUser === linkingUser) renderWallets(verifiedWallets);
           if (dialog.open) walletLinkButton.focus();
         }
-      });
+      };
+      walletLinkButton?.addEventListener("click", () => linkWallet());
       walletList?.addEventListener("click", async (event) => {
+        if (event.target.closest?.("[data-wallet-finish]")) { await linkWallet(true); return; }
+        if (event.target.closest?.("[data-wallet-access]")) { await win.AgentBountiesCoinbaseEmbeddedWallet?.manageAccess(); return; }
         const button = event.target.closest?.("[data-wallet-unlink]");
         if (!button || button.disabled || !currentUser) return;
         if (button.dataset.confirming !== "true") {
@@ -1034,6 +1101,7 @@ ${competitionChildBrief(item)}`;
         button.disabled = true;
         try {
           await postAccountJson("/wallet/unlink", { address: button.dataset.walletUnlink });
+          if (embeddedAddress === button.dataset.walletUnlink) embeddedAddress = null;
           await loadAccount();
           setWalletStatus("Wallet unlinked from this account. No onchain state changed.");
         } catch (error) {
@@ -1069,6 +1137,7 @@ ${competitionChildBrief(item)}`;
           });
           if (!response.ok) throw new Error(`logout ${response.status}`);
           renderSession({ authenticated: false, user: null, providers: providerAvailability });
+          win.AgentBountiesWalletLink?.clearPending();
           setStatus("Signed out from this session.");
         } catch (error) {
           setStatus("The session could not be signed out. Please try again.");
@@ -1086,6 +1155,7 @@ ${competitionChildBrief(item)}`;
       const authParams = new URLSearchParams(win.location.search);
       const authResult = authParams.get("auth");
       loadSession().then(() => {
+        if (currentUser && win.AgentBountiesWalletLink?.hasPending(currentUser.id)) void linkWallet(true);
         if (authResult !== "success" && authResult !== "error") return;
         setStatus(authResultMessage(authResult, authParams.get("provider"), authParams.get("reason")));
         if (authResult === "success") win.agentBountiesAnalytics?.track("auth_completed");

--- a/site/solarpunk.css
+++ b/site/solarpunk.css
@@ -1407,6 +1407,9 @@ html[data-scene-ready="false"] .scene-plate {
   text-transform: uppercase;
 }
 
+.wallet-pending { color: #dbca91; font-size: .65rem; }
+.account-wallets [data-wallet-access] { grid-column: 1 / -1; justify-self: start; }
+
 .account-wallets .wallet-remove {
   padding: 4px 6px;
   border: 0;

--- a/site/wallet-adapters.css
+++ b/site/wallet-adapters.css
@@ -127,6 +127,20 @@
   flex: 1 1 12rem;
 }
 
+.wallet-auth-actions > button {
+  min-height: 2.75rem;
+  padding: .65rem 1rem;
+  border: 1px solid rgba(201, 245, 72, .4);
+  border-radius: .5rem;
+  font: inherit;
+  color: #f4f6ef;
+  background: #18321f;
+  cursor: pointer;
+}
+.wallet-auth-actions > button.primary { color: #102015; background: #c3e66a; }
+.wallet-auth-actions > button:disabled { opacity: .5; cursor: default; }
+.wallet-auth-message { white-space: pre-wrap; overflow-wrap: anywhere; max-height: 12rem; overflow: auto; font-size: .8rem; }
+
 .wallet-auth-back,
 .wallet-auth-signout {
   justify-self: start;

--- a/site/wallet-link.js
+++ b/site/wallet-link.js
@@ -43,9 +43,9 @@
         let failed = false;
         const stylesheet = doc.createElement("link");
         stylesheet.rel = "stylesheet";
-        stylesheet.href = new URL("vendor/coinbase-embedded-wallet.bundle.css?v=1", doc.baseURI).href;
+        stylesheet.href = new URL("vendor/coinbase-embedded-wallet.bundle.css?v=2", doc.baseURI).href;
         const script = doc.createElement("script");
-        script.src = new URL("vendor/coinbase-embedded-wallet.bundle.js?v=1", doc.baseURI).href;
+        script.src = new URL("vendor/coinbase-embedded-wallet.bundle.js?v=2", doc.baseURI).href;
         script.async = true;
         const fail = () => { failed = true; win.clearTimeout(timer); script.remove(); stylesheet.remove(); reject(new Error("Wallet creation could not load. Check your connection and try again.")); };
         const timer = win.setTimeout(fail, 20000);
@@ -144,5 +144,22 @@
     return request.promise;
   }
 
-  return Object.freeze({ select, choices, cancel: () => finish() });
+  // This tab-scoped intent only resumes the UI; it is never ownership evidence.
+  const intentKey = "agentbounties:pending-embedded-account-link";
+  function clearPending() {
+    try { win.sessionStorage.removeItem(intentKey); } catch (_) { /* Storage may be disabled. */ }
+  }
+  function beginPending(userId) {
+    try { win.sessionStorage.setItem(intentKey, JSON.stringify({ userId: String(userId), startedAt: Date.now() })); } catch (_) { /* Same-page linking still works. */ }
+  }
+  function hasPending(userId) {
+    try {
+      const intent = JSON.parse(win.sessionStorage.getItem(intentKey));
+      if (intent && intent.userId === String(userId) && Date.now() - intent.startedAt >= 0 && Date.now() - intent.startedAt < 30 * 60 * 1000) return true;
+    } catch (_) { /* Ignore expired or malformed intent. */ }
+    clearPending();
+    return false;
+  }
+
+  return Object.freeze({ select, choices, loadEmbedded, beginPending, hasPending, clearPending, cancel: () => finish() });
 });

--- a/tools/coinbase-embedded-wallet/src/index.js
+++ b/tools/coinbase-embedded-wallet/src/index.js
@@ -50,6 +50,8 @@ let registered = false;
 let authRequest = null;
 let authResolve = null;
 let authReject = null;
+let authReview = null;
+let authReviewMessage = "";
 let panelControl = null;
 let sdkReadyResolve = null;
 let sdkReadyReject = null;
@@ -118,6 +120,7 @@ function rejectPendingAuth(error) {
   authRequest = null;
   authResolve = null;
   authReject = null;
+  authReview = null;
   hidePanel();
   if (rejecter) rejecter(error instanceof Error ? error : new Error(String(error)));
 }
@@ -127,6 +130,7 @@ function resolvePendingAuth(address) {
   authRequest = null;
   authResolve = null;
   authReject = null;
+  authReview = null;
   hidePanel();
   emit("coinbase-embedded-authenticated", { address });
   if (resolver) resolver(address);
@@ -149,6 +153,7 @@ function AuthBridge() {
     panelControl = Object.freeze({
       showSignIn: () => setPanel({ visible: true, view: "signin", notice: "" }),
       showReview: () => setPanel({ visible: true, view: "review", notice: "" }),
+      showOwnership: () => setPanel({ visible: true, view: "ownership", notice: "" }),
       showLink: () => setPanel({ visible: true, view: "link", notice: "" }),
       hide: () => setPanel((value) => ({ ...value, visible: false, notice: "" })),
     });
@@ -164,7 +169,8 @@ function AuthBridge() {
 
   useEffect(() => {
     if (!panel.visible || !signedIn || !address || panel.view !== "signin") return;
-    setPanel({ visible: true, view: "review", notice: "Wallet connected. Review recovery access before continuing." });
+    if (!authReview) resolvePendingAuth(address);
+    else setPanel({ visible: true, view: authReview, notice: "Wallet ready." });
   }, [panel.visible, panel.view, signedIn, address]);
 
   useEffect(() => {
@@ -214,6 +220,20 @@ function AuthBridge() {
         "p",
         { className: "wallet-auth-method-warning" },
         "Returning user? Use the same sign-in method to access your existing wallet.",
+      ),
+    );
+  } else if (panel.view === "ownership") {
+    body = React.createElement(React.Fragment, null,
+      React.createElement("p", { className: "wallet-auth-notice", role: "status" }, "Your wallet is ready. Confirm ownership to finish linking it to your Agent Bounties account."),
+      React.createElement("div", { className: "wallet-auth-account" },
+        React.createElement("span", null, "Wallet"),
+        React.createElement("strong", null, address),
+      ),
+      React.createElement("p", null, "Review the message below. Signing proves you own this address; it does not authorize a payment."),
+      React.createElement("pre", { className: "wallet-auth-message" }, authReviewMessage),
+      React.createElement("div", { className: "wallet-auth-actions" },
+        React.createElement("button", { type: "button", className: "button secondary", onClick: close }, "Not now"),
+        React.createElement("button", { type: "button", className: "button primary", disabled: !address, onClick: continueWithWallet }, "Verify and link wallet"),
       ),
     );
   } else if (panel.view === "link") {
@@ -349,11 +369,11 @@ function AuthBridge() {
         React.createElement(
           "div",
           null,
-          React.createElement("p", { className: "eyebrow" }, panel.view === "review" ? "Your wallet, your recovery paths" : "No extension or recovery phrase"),
+          React.createElement("p", { className: "eyebrow" }, panel.view === "ownership" ? "Wallet ready" : panel.view === "review" ? "Your wallet, your recovery paths" : "No extension or recovery phrase"),
           React.createElement(
             "h2",
             { id: "coinbase-wallet-auth-title" },
-            panel.view === "link" ? "Link another way to sign in" : panel.view === "review" ? "Protect access to this wallet" : "Create or access your wallet",
+            panel.view === "ownership" ? "Confirm wallet ownership" : panel.view === "link" ? "Link another way to sign in" : panel.view === "review" ? "Protect access to this wallet" : "Create or access your wallet",
           ),
         ),
         React.createElement(
@@ -452,21 +472,31 @@ async function accessMethods() {
   return linkedAuthMethods(await getCurrentUser());
 }
 
-async function ensureAuthenticated() {
+async function ensureAuthenticated({ review = "review", message = "" } = {}) {
   await waitForSdk();
-  if (authRequest) return authRequest;
+  const pendingRequest = () => {
+    if (review) throw Object.assign(new Error("Finish the current wallet request before reviewing another message."), { code: -32002 });
+    return authRequest;
+  };
+  if (authRequest) return pendingRequest();
   const existing = await currentAddress();
+  if (authRequest) return pendingRequest();
+  if (existing && !review) return existing;
+  authReview = review;
+  authReviewMessage = message;
   authRequest = new Promise((resolve, reject) => {
     authResolve = resolve;
     authReject = reject;
   });
+  const request = authRequest;
   if (!panelControl) {
     rejectPendingAuth(new Error("Coinbase wallet authentication UI is not ready. Reload and try again."));
-    return authRequest;
+    return request;
   }
-  if (existing) panelControl.showReview();
+  if (existing && review === "ownership") panelControl.showOwnership();
+  else if (existing) panelControl.showReview();
   else panelControl.showSignIn();
-  return authRequest;
+  return request;
 }
 
 async function manageAccess() {
@@ -497,7 +527,16 @@ const provider = {
       return (await innerProvider()).request(args);
     }
     if (method === "eth_requestAccounts") {
-      await ensureAuthenticated();
+      await ensureAuthenticated({ review: null });
+      return (await innerProvider()).request(args);
+    }
+    if (method === "personal_sign") {
+      const raw = String(args?.params?.[0] || "");
+      let message = raw;
+      if (/^0x(?:[0-9a-fA-F]{2})*$/.test(raw)) {
+        message = new TextDecoder().decode(Uint8Array.from(raw.slice(2).match(/../g) || [], (byte) => parseInt(byte, 16)));
+      }
+      await ensureAuthenticated({ review: message.startsWith("Agent Bounties wallet ownership verification\n\n") ? "ownership" : "review", message });
       return (await innerProvider()).request(args);
     }
     if (method === "wallet_addEthereumChain") {

--- a/tools/coinbase-embedded-wallet/test-account-link.mjs
+++ b/tools/coinbase-embedded-wallet/test-account-link.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { after, before, test } from "node:test";
-import { readFile } from "node:fs/promises";
+import { readFile, mkdir } from "node:fs/promises";
+import { build } from "esbuild";
+import { fakeSdk } from "./test-auth-sdk.mjs";
 import { createServer } from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,8 +11,18 @@ import { chromium } from "playwright";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../site");
 const ADDRESS = "0x" + "11".repeat(20);
 const EMBEDDED = "0x" + "22".repeat(20);
-let browser, server, origin;
+let browser, server, origin, testAdapter;
 before(async () => {
+  const built = await build({
+    entryPoints: [path.resolve(root, '../tools/coinbase-embedded-wallet/src/index.js')],
+    bundle: true, write: false, format: 'iife', platform: 'browser',
+    define: { 'process.env.NODE_ENV': '"production"' },
+    plugins: [{ name: 'test-cdp-boundary', setup(build) {
+      build.onResolve({ filter: /^@coinbase\/cdp-/ }, () => ({ path: 'fake-cdp', namespace: 'test-sdk' }));
+      build.onLoad({ filter: /.*/, namespace: 'test-sdk' }, () => ({ contents: fakeSdk, loader: 'js', resolveDir: path.resolve(root, '../tools/coinbase-embedded-wallet') }));
+    } }],
+  });
+  testAdapter = built.outputFiles[0].text;
   server = createServer(async (request, response) => {
     const pathname = decodeURIComponent(new URL(request.url, "http://localhost").pathname);
     const filename = path.resolve(root, `.${pathname === "/" ? "/index.html" : pathname}`);
@@ -31,24 +43,29 @@ after(async () => {
   if (server) await new Promise((resolve) => server.close(resolve));
 });
 
-async function account({ installed = true, linked = false, mobile = false } = {}) {
+async function account({ installed = true, linked = false, mobile = false, adapter = false, pending = null, failVerify = false, failRefresh = false } = {}) {
   const context = await browser.newContext({ viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
   const page = await context.newPage();
   const proofs = [], errors = [];
   let wallets = linked ? [{ address: ADDRESS }] : [];
+  let rejectVerification = failVerify;
   page.on("pageerror", (error) => errors.push(error.message));
   await page.route("https://**/*", (route) => route.fulfill({ json: {} }));
   await page.route("**/auth/**", async (route) => {
     const pathname = new URL(route.request().url()).pathname;
     let body = {};
     if (pathname.endsWith("/session")) body = { authenticated: true, user: { id: "qa", name: "Test member", provider: "google" }, providers: { google: true } };
-    if (pathname.endsWith("/account")) body = { wallets, available: false };
+    if (pathname.endsWith("/account")) {
+      if (failRefresh && wallets.some(wallet => wallet.address === EMBEDDED)) { await route.fulfill({status:503,json:{}}); return; }
+      body = { wallets, available: false };
+    }
     if (pathname.endsWith("/wallet/challenge")) {
       const request = route.request().postDataJSON(); proofs.push(request);
-      body = { challenge_id: "ownership-only", message: `Ownership proof for ${request.address}. No payment.` };
+      body = { challenge_id: "ownership-only", message: `Agent Bounties wallet ownership verification\n\nSign this message to link the wallet to your signed-in Agent Bounties account.\nThis proves address control only. It does not authorize a transaction, token approval, or payment.\nWallet: ${request.address}` };
     }
     if (pathname.endsWith("/wallet/verify")) {
       const request = route.request().postDataJSON(); proofs.push(request);
+      if (rejectVerification) { rejectVerification = false; await route.fulfill({status:503,json:{error:'wallet_link_store_unavailable'}}); return; }
       wallets = [...wallets, { address: request.address }]; body = { wallets };
     }
     await route.fulfill({ json: body });
@@ -60,10 +77,16 @@ async function account({ installed = true, linked = false, mobile = false } = {}
       return request.method === "eth_requestAccounts" ? [address] : "0x" + "ab".repeat(65);
     } };
   }, { installed, address: ADDRESS });
+  if (pending) await page.addInitScript((intent) => {
+    if (!sessionStorage.getItem('test-intent-seeded')) {
+      sessionStorage.setItem('agentbounties:pending-embedded-account-link',JSON.stringify(intent));
+      sessionStorage.setItem('test-intent-seeded','true');
+    }
+  }, pending);
   // Replace only the external SDK boundary; exercise the real chooser and account handler.
   await page.route("**/vendor/coinbase-embedded-wallet.bundle.js?*", (route) => route.fulfill({
     contentType: "text/javascript",
-    body: `window.AgentBountiesCoinbaseEmbeddedWallet = { enabled: true, provider: { request: async (request) => {
+    body: adapter ? testAdapter : `window.AgentBountiesCoinbaseEmbeddedWallet = { enabled: true, provider: { request: async (request) => {
       window.walletTestCalls.push({ wallet: "embedded", ...request });
       return request.method === "eth_requestAccounts" ? ["${EMBEDDED}"] : "0x" + "cd".repeat(65);
     } } };`,
@@ -113,3 +136,107 @@ test("Escape returns to the account without a wallet call; MetaMask works only a
     assert.equal(proofs[1].address, ADDRESS);
   } finally { await context.close(); }
 });
+
+async function evidence(page, name) {
+  const directory = process.env.WALLET_QA_EVIDENCE_DIR;
+  if (!directory) return;
+  await mkdir(directory, {recursive:true});
+  await page.screenshot({path:path.join(directory, name + '.png')});
+}
+
+for (const redirect of [false, true]) {
+  test(`${redirect ? 'Google redirect' : 'Email completion'} returns to a visible wallet and one ownership confirmation`, async () => {
+    const {context,page,link,proofs,errors} = await account({adapter:true,mobile:redirect});
+    try {
+      await link.click();
+      await page.getByRole('button',{name:'I don’t have a wallet — create one',exact:false}).click();
+      await page.getByRole('button',{name:redirect?'Continue with Google':'Complete email verification',exact:true}).click();
+      const confirm = page.getByRole('dialog',{name:'Confirm wallet ownership',exact:true});
+      await confirm.waitFor();
+      assert.equal(await page.getByRole('dialog',{name:'Your activity',exact:true}).isVisible(),true);
+      assert.match(await page.locator('[data-wallet-list]').textContent(),/Ready to verify/);
+      assert.equal((await page.evaluate(()=>window.walletTestCalls)).some(call=>call.method==='personal_sign'),false);
+      assert.equal(proofs.length,1);
+      assert.equal(await page.evaluate(async () => {
+        try { await window.AgentBountiesCoinbaseEmbeddedWallet.provider.request({method:'personal_sign',params:['second message','0x'+'22'.repeat(20)]}); }
+        catch (error) { return error.code; }
+      }),-32002);
+      await evidence(page,redirect?'oauth-return-mobile':'email-ready-desktop');
+      await page.getByRole('button',{name:'Verify and link wallet',exact:true}).click();
+      await page.waitForFunction(()=>document.querySelector('[data-wallet-status]').textContent.includes('verified and linked'));
+      assert.equal(await page.getByRole('dialog',{name:'Your activity',exact:true}).isVisible(),true);
+      assert.match(await page.locator('[data-wallet-list]').textContent(),/Verified/);
+      assert.equal(await page.locator('[data-wallet-list] code').getAttribute('title'),EMBEDDED);
+      assert.equal((await page.evaluate(()=>window.walletTestCalls)).filter(call=>call.method==='personal_sign').length,1);
+      assert.equal(await page.evaluate(()=>sessionStorage.getItem('agentbounties:pending-embedded-account-link')),null);
+      await evidence(page,redirect?'linked-mobile':'linked-desktop');
+      await link.click();
+      await page.getByRole('button',{name:'I don’t have a wallet — create one',exact:false}).click();
+      await page.waitForFunction(()=>document.querySelector('[data-wallet-status]').textContent.includes('already verified and linked'));
+      assert.equal(proofs.length,2);
+      await page.reload();
+      await page.getByRole('button',{name:'Account',exact:true}).click();
+      await page.waitForFunction(()=>document.querySelector('[data-wallet-list]').textContent.includes('Verified'));
+      assert.equal(proofs.length,2);
+      assert.deepEqual(errors,[]);
+    } finally { await context.close(); }
+  });
+}
+
+test('cancelled ownership review retains the wallet and retries without another sign-in', async () => {
+  const {context,page,link,proofs,errors} = await account({adapter:true});
+  try {
+    await link.click();
+    await page.getByRole('button',{name:'I don’t have a wallet — create one',exact:false}).click();
+    await page.getByRole('button',{name:'Complete email verification'}).click();
+    await page.getByRole('button',{name:'Not now',exact:true}).click();
+    await page.getByRole('button',{name:'Finish linking',exact:true}).click();
+    await page.getByRole('dialog',{name:'Confirm wallet ownership'}).waitFor();
+    assert.equal((await page.evaluate(()=>window.walletTestCalls)).some(call=>call.method==='personal_sign'),false);
+    await page.getByRole('button',{name:'Verify and link wallet',exact:true}).click();
+    await page.waitForFunction(()=>document.querySelector('[data-wallet-status]').textContent.includes('verified and linked'));
+    assert.equal(proofs.length,3);
+    await page.getByRole('button',{name:'Recovery settings',exact:true}).click();
+    await page.getByRole('dialog',{name:'Protect access to this wallet'}).waitFor();
+    assert.deepEqual(errors,[]);
+  } finally { await context.close(); }
+});
+
+test('verification failure never marks the wallet verified and can be retried', async () => {
+  const {context,page,link,errors} = await account({adapter:true,failVerify:true});
+  try {
+    await link.click();
+    await page.getByRole('button',{name:'I don’t have a wallet — create one',exact:false}).click();
+    await page.getByRole('button',{name:'Complete email verification'}).click();
+    await page.getByRole('button',{name:'Verify and link wallet',exact:true}).click();
+    await page.waitForFunction(()=>document.querySelector('[data-wallet-status]').textContent.includes('not finished'));
+    assert.equal(await page.locator('.wallet-verified').count(),0);
+    await page.getByRole('button',{name:'Finish linking',exact:true}).click();
+    await page.getByRole('button',{name:'Verify and link wallet',exact:true}).click();
+    await page.waitForFunction(()=>document.querySelector('[data-wallet-status]').textContent.includes('verified and linked'));
+    assert.deepEqual(errors,[]);
+  } finally { await context.close(); }
+});
+
+test('confirmed wallet remains visible when activity refresh fails', async () => {
+  const {context,page,link} = await account({failRefresh:true});
+  try {
+    await link.click();
+    await page.getByRole('button',{name:'I don’t have a wallet — create one',exact:false}).click();
+    await page.waitForFunction(()=>document.querySelector('[data-wallet-status]').textContent.includes('verified and linked'));
+    assert.equal(await page.locator('[data-wallet-list] code').getAttribute('title'),EMBEDDED);
+    assert.match(await page.locator('[data-wallet-list]').textContent(),/Verified/);
+  } finally { await context.close(); }
+});
+
+for (const pending of [{userId:'another-member',startedAt:Date.now()},{userId:'qa',startedAt:Date.now()-31*60*1000}]) {
+  test(`stale or different-account intent cannot resume wallet access (${pending.userId})`,async()=>{
+    const {context,page,proofs} = await account({adapter:true,pending});
+    try {
+      assert.equal(await page.evaluate(()=>window.AgentBountiesCoinbaseEmbeddedWallet),undefined);
+      assert.deepEqual(await page.evaluate(()=>window.walletTestCalls),[]);
+      assert.deepEqual(proofs,[]);
+      assert.equal(await page.evaluate(()=>sessionStorage.getItem('agentbounties:pending-embedded-account-link')),null);
+    } finally { await context.close(); }
+  });
+}

--- a/tools/coinbase-embedded-wallet/test-auth-sdk.mjs
+++ b/tools/coinbase-embedded-wallet/test-auth-sdk.mjs
@@ -1,0 +1,39 @@
+// Test-only CDP boundary. The adapter, React UI, redirect, and account linker remain real.
+export const fakeSdk = `
+import React, { useSyncExternalStore } from 'react';
+const listeners = new Set();
+const signedIn = () => sessionStorage.getItem('test-cdp-signed-in') === 'true';
+const user = () => signedIn() ? { evmAccountObjects: [{address:'0x'+'22'.repeat(20)}], authenticationMethods: {oauth:{google:true}} } : null;
+const subscribe = callback => { listeners.add(callback); return () => listeners.delete(callback); };
+const login = redirect => {
+  sessionStorage.setItem('test-cdp-signed-in','true');
+  if (redirect) location.assign('/?test-oauth-return=1');
+  else listeners.forEach(callback => callback());
+};
+export const CDPReactProvider = ({children}) => children;
+export const useIsInitialized = () => ({isInitialized:true});
+export const useIsSignedIn = () => ({isSignedIn:useSyncExternalStore(subscribe,signedIn)});
+const testUser = { evmAccountObjects: [{address:'0x'+'22'.repeat(20)}], authenticationMethods: {oauth:{google:true}} };
+export const useCurrentUser = () => ({currentUser:useSyncExternalStore(subscribe,()=>signedIn()?testUser:null)});
+export const getCurrentUser = async () => user();
+export const isSignedIn = async () => signedIn();
+export const signOut = async () => { sessionStorage.removeItem('test-cdp-signed-in'); listeners.forEach(callback=>callback()); };
+export const createCDPEmbeddedWallet = () => ({provider:{request:async request=>{
+  window.walletTestCalls.push({wallet:'embedded',...request});
+  return ['eth_accounts','eth_requestAccounts'].includes(request.method) ? (signedIn() ? ['0x'+'22'.repeat(20)] : []) : '0x'+'cd'.repeat(65);
+}}});
+export const SignIn = () => React.createElement('div',null,
+  React.createElement('button',{onClick:()=>login(true)},'Continue with Google'),
+  React.createElement('button',{onClick:()=>login(false)},'Complete email verification')
+);
+export const SignInBackButton = () => null;
+export const SignInDescription = () => null;
+export const SignInForm = () => null;
+export const SignInAuthMethodButtons = () => null;
+export const SignInFooter = () => null;
+export const LinkAuth = () => null;
+export const LinkAuthError = () => null;
+export const LinkAuthFlow = () => null;
+export const LinkAuthFlowBackButton = () => null;
+export const LinkAuthTitle = () => null;
+`;


### PR DESCRIPTION
Google wallet sign-in reloads the page, which previously discarded the pending account-link request and left the lazy-loaded CDP callback unprocessed until another chooser click. The homepage now resumes the same account’s tab-scoped intent, initializes the wallet, and reopens Account with the address marked Ready to verify. A dedicated ownership-message review leads to Verified and an explicit confirmation after server verification.

Cancellation and verification failures retain the address with Finish linking. Confirmed links remain visible if activity refresh fails. Recovery settings remain separate, and selecting an already-linked embedded wallet reports its existing link without another signature. The adapter rejects overlapping message reviews. External-wallet selection and payment/transaction restrictions are preserved.

Validation: 33 focused Node tests; 12 browser regressions covering real adapter/React UI with mocked CDP and account boundaries, full-page OAuth return, same-page email completion, cancellation, retry, cross-account/expired intent, repeated selection, concurrent signature rejection, and failed activity refresh. Desktop and mobile screenshots inspected. Adapter dependency check, production bundle build, site validator, and diff checks passed. No real signup, ownership signature, or transfer was performed.

Maintainer notice: #1325. Open PR queue checked; #1196 overlaps the account handler and should retain redirect recovery when reconciling. No other active adapter overlap or collaboration branch needed. No API schema, custody, or payment authority change. UI intent expires after 30 minutes and cannot prove ownership. Rollback: revert this change or disable embedded connections using the existing provider configuration.