### PR TITLE
Fix phone-wallet network mismatch blocking bounty posting

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ on:
       - "scripts/fixtures/meta-child-plan.json"
       - "scripts/test-competition-proof.js"
       - "scripts/test-phone-wallet.js"
+      - "scripts/test-phone-wallet-network.cjs"
       - "scripts/test-phone-wallet-storage.cjs"
       - "scripts/test-posting-layout.cjs"
       - "tools/browser-layout/**"
@@ -46,6 +47,7 @@ on:
       - "scripts/fixtures/meta-child-plan.json"
       - "scripts/test-competition-proof.js"
       - "scripts/test-phone-wallet.js"
+      - "scripts/test-phone-wallet-network.cjs"
       - "scripts/test-phone-wallet-storage.cjs"
       - "scripts/test-posting-layout.cjs"
       - "tools/browser-layout/**"
@@ -121,7 +123,7 @@ jobs:
       - name: Test the retained Metrics evidence engine
         run: node --test scripts/test-metrics-dashboard.js
       - name: Test unified marketplace readiness, timing, and economics
-        run: node --test scripts/test-marketplace-ui.js scripts/test-webmcp.js scripts/test-meta-child.js scripts/test-competition-proof.js scripts/test-phone-wallet.js
+        run: node --test scripts/test-marketplace-ui.js scripts/test-webmcp.js scripts/test-meta-child.js scripts/test-competition-proof.js scripts/test-phone-wallet.js scripts/test-phone-wallet-network.cjs
       - name: Test posting and wallet actions in real browser viewports
         working-directory: tools/browser-layout
         run: |
@@ -269,7 +271,7 @@ jobs:
           grep -q '<h1>Privacy policy</h1>' /tmp/live-privacy.html
           grep -q '<h1>Terms of use</h1>' /tmp/live-terms.html
           grep -q 'discovery-manifest.v2.json' /tmp/live-discovery.json
-          grep -q 'phone-wallet.js?v=2' /tmp/live-index.html
+          grep -q 'phone-wallet.js?v=3' /tmp/live-index.html
           curl --fail --silent --show-error "https://agentbounties.app/phone-wallet-config.js?verify=${nonce}" -o /tmp/live-phone-wallet-config.js
           grep -Eq 'projectId: "[a-fA-F0-9]{32}"' /tmp/live-phone-wallet-config.js
           python scripts/check-public-handoffs.py --base-url https://agentbounties.app

--- a/scripts/test-phone-wallet-network.cjs
+++ b/scripts/test-phone-wallet-network.cjs
@@ -1,0 +1,106 @@
+"use strict";
+// Use the pinned SDK's real Ethereum/Universal provider chain-ID behavior with
+// a synthetic session and inert signing client. No live relay, RPC or wallet.
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+const { webcrypto } = require("node:crypto");
+const { UniversalProvider } = require("../tools/phone-wallet/node_modules/@walletconnect/universal-provider");
+const { EthereumProvider } = require("../tools/phone-wallet/node_modules/@walletconnect/ethereum-provider");
+const createPhoneWallet = require("../site/phone-wallet.js");
+const { createPostingJournal } = require("../site/marketplace-workflow.js");
+const address = "0x" + "12".repeat(20), other = "0x" + "34".repeat(20);
+const source = fs.readFileSync(require.resolve("../site/bounty-composer-v2.js"), "utf8");
+const start = source.indexOf("  async function fundApprovedBounty()"), end = source.indexOf("  function configureSpeech", start);
+assert.ok(start >= 0 && end > start);
+const fundingFunction = source.slice(start, end) + "; fundApprovedBounty";
+
+async function fixture({ adapted = true, change = null, uncertain = false } = {}) {
+  const storage = new Map(), signing = [], statuses = [], network = [];
+  const store = { getItem: key => storage.get(key) || null, setItem: (key, value) => storage.set(key, value), removeItem: key => storage.delete(key) };
+  store.setItem("agent-bounties-phone-connected-v1", "ab-phone-12345678-1234-1234-1234-123456789012");
+  const namespace = { chains: ["eip155:8453"], accounts: [`eip155:8453:${address}`], methods: ["eth_signTypedData_v4"], events: [], rpcMap: { "eip155:8453": "http://127.0.0.1:1" } };
+  const universal = new UniversalProvider({ logger: "silent", disableProviderPing: true });
+  universal.client = {
+    core: { projectId: "0".repeat(32), storage: { getItem: async key => storage.get(key), setItem: async (key, value) => storage.set(key, value) } },
+    request: async request => {
+      signing.push(request);
+      if (uncertain) throw new Error("Fixture wallet response was lost");
+      throw Object.assign(new Error("Fixture user rejected the wallet request"), { code: 4001 });
+    },
+  };
+  universal.namespaces = { eip155: namespace };
+  universal.session = { topic: "synthetic-session", expiry: Date.now() / 1000 + 3600, namespaces: { eip155: namespace } };
+  universal.createProviders();
+  // Make accidental HTTP reads fail immediately, even if a fixture regresses.
+  universal.rpcProviders.eip155.httpProviders[8453].request = async request => { network.push(request); throw new Error("Unexpected RPC call in offline fixture"); };
+  const sdk = new EthereumProvider(); sdk.signer = universal; sdk.chainId = 8453; sdk.accounts = [address];
+  const win = {
+    document: null, crypto: webcrypto, localStorage: store, sessionStorage: store, location: new URL("https://agentbounties.app/post.html"),
+    agentBountiesPhoneWalletConfig: { projectId: "0".repeat(32) },
+    CustomEvent: class { constructor(type, options) { this.type = type; this.detail = options.detail; } },
+    addEventListener() {}, dispatchEvent() {}, setTimeout, clearTimeout,
+    AgentBountiesLegal: { requireAcceptance: async () => ({ durable: true }) },
+  };
+  const phone = createPhoneWallet(win, { loadVendor: async () => ({ createProvider: async () => sdk }) });
+  await phone.restore();
+  const provider = adapted ? phone.provider : sdk;
+  const journal = createPostingJournal(win);
+  const state = { approved: true, provider, account: address, balances: { usdc: 1000000n, required: 1000000n, eth: 1n }, draft: { title: "Synthetic review" }, fundingUsdc: 1 };
+  const authorization = { domain: { chainId: 8453 }, primaryType: "ReceiveWithAuthorization", message: { value: "1000000" } };
+  const plan = { bounty_id: "0x" + "56".repeat(32), predicted_bounty_contract: "0x" + "78".repeat(20), eip3009_authorization: authorization };
+  const run = vm.runInNewContext(fundingFunction, {
+    postingBusy: false, postingJournal: journal, state, window: win, ui: { form: { querySelectorAll: () => [] }, fundNow: {} },
+    track() {}, setPaymentStatus: value => statuses.push(value), refreshWalletReadiness: async () => {},
+    loadProtocol: async () => ({ api_base_url: "https://api.agentbounties.app", factory: "0x" + "90".repeat(20) }),
+    currentRewardSplit: () => ({ solver: "900000", verifier: "100000", total: "1000000" }),
+    contractTerms: () => ({}), termsDocument: () => ({}), createPayload: () => ({}), validateCreationPlan() {}, formatUsdc: String,
+    requestJson: async url => {
+      if (url.endsWith("/terms")) return {};
+      assert.ok(url.endsWith("/creation-plan"));
+      if (change === "account") { sdk.accounts = [other]; universal.session.namespaces.eip155.accounts = [`eip155:8453:${other}`]; }
+      if (change === "chain") { sdk.chainId = 1; universal.rpcProviders.eip155.chainId = 1; }
+      return plan;
+    },
+    isContractAccount: async () => false,
+    sendTransaction: async () => { throw new Error("No transaction may follow the rejected fixture signature"); },
+  });
+  return { sdk, provider, run, signing, statuses, network, journal, authorization };
+}
+
+test("the real pinned SDK reproduces the false network-change stop before adaptation", async () => {
+  const env = await fixture({ adapted: false });
+  assert.equal(await env.sdk.request({ method: "eth_chainId" }), 8453);
+  await env.run();
+  assert.match(env.statuses.at(-1), /wallet or network changed/);
+  assert.equal(env.signing.length, 0); assert.equal(env.journal.load(), null);
+});
+
+test("the unchanged posting guard reaches one signature request through the adapted SDK", async () => {
+  const env = await fixture();
+  assert.equal(await env.provider.request({ method: "eth_chainId" }), "0x2105");
+  await env.run();
+  assert.equal(env.signing.length, 1);
+  assert.equal(env.signing[0].chainId, "eip155:8453");
+  assert.equal(env.signing[0].request.method, "eth_signTypedData_v4");
+  assert.deepEqual(Array.from(env.signing[0].request.params), [address, JSON.stringify(env.authorization)]);
+  assert.match(env.statuses.at(-1), /Fixture user rejected/);
+  assert.equal(env.network.length, 0);
+  assert.equal(env.journal.load(), null, "An explicit rejection authorizes no payment and leaves the review available");
+});
+
+test("an uncertain signature reply retains the existing journal and cannot dispatch again", async () => {
+  const env = await fixture({ uncertain: true }); await env.run();
+  assert.match(env.statuses.at(-1), /Fixture wallet response was lost/);
+  assert.ok(env.journal.load());
+  await env.run(); assert.equal(env.signing.length, 1);
+});
+
+for (const change of ["account", "chain"]) {
+  test(`a real ${change} change still stops the posting flow before any signature`, async () => {
+    const env = await fixture({ change }); await env.run();
+    assert.match(env.statuses.at(-1), /wallet or network changed/);
+    assert.equal(env.signing.length, 0); assert.equal(env.network.length, 0); assert.equal(env.journal.load(), null);
+  });
+}

--- a/scripts/test-phone-wallet.js
+++ b/scripts/test-phone-wallet.js
@@ -36,7 +36,7 @@ function fixture({ configured = true, storage = new Map(), restored = false, fai
         approve(account = address, chain = 8453, methods = config.optionalMethods) { this.accounts = [account]; this.session = { expiry: Date.now() / 1000 + 3600, namespaces: { eip155: { accounts: [`eip155:${chain}:${account}`], methods } } }; this.emit("accountsChanged", this.accounts); resolveConnect?.(); },
         reject(wrapped = false) { rejectConnect(wrapped ? new Error("User rejected.") : Object.assign(new Error("User rejected"), { code: 4001 })); },
         async disconnect() { this.disconnects++; this.accounts = []; this.session = null; this.emit("disconnect"); },
-        async request(request) { requests.push(request); if (this.requestError) throw this.requestError; return "confirmed wallet response"; },
+        async request(request) { requests.push(request); if (this.requestError) throw this.requestError; if (request.method === "eth_chainId") return "chainResponse" in this ? this.chainResponse : this.chainId; return "confirmed wallet response"; },
       };
       if (restored) sdk.approve(); providers.push(sdk); return sdk;
     } };
@@ -156,4 +156,21 @@ test("storage failures explain read recovery but never replay or mask a financia
   assert.equal(env.requests[1], request);
   assert.equal(env.api.state().connected, true);
   assert.equal(env.providers.length, 1);
+});
+
+test("phone-wallet chain IDs use canonical hex without disguising a wrong or invalid network", async () => {
+  const env = fixture(); await env.api.openReview(); await flush(); env.providers[0].approve(); await flush();
+  for (const value of [8453, "8453", "0x2105", "0X02105"]) {
+    env.providers[0].chainResponse = value;
+    assert.equal(await env.api.provider.request({ method: "eth_chainId" }), "0x2105");
+  }
+  for (const value of [1, "1", "0x1"]) {
+    env.providers[0].chainResponse = value;
+    assert.equal(await env.api.provider.request({ method: "eth_chainId" }), "0x1");
+  }
+  for (const value of [null, undefined, true, {}, [], "", "0x", "eip155:8453", "8.453e3", "8453.0", 0, -1, 8453.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1]) {
+    env.providers[0].chainResponse = value;
+    await assert.rejects(env.api.provider.request({ method: "eth_chainId" }), { code: 4901 });
+  }
+  assert.ok(env.requests.every(request => request.method === "eth_chainId"));
 });

--- a/site/competition.html
+++ b/site/competition.html
@@ -153,13 +153,13 @@
       <nav aria-label="Footer navigation"><a href="earn.html">Marketplace</a><a href="metrics.html">Metrics</a><a href="privacy.html">Privacy</a><a href="https://github.com/NSPG13/agent-bounties">Source</a></nav>
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=2"></script>
+    <script src="phone-wallet.js?v=3"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="marketplace.js?v=3"></script>
     <script src="competition.js?v=4"></script>
-    <script src="legal-consent.js"></script>
+    <script src="legal-consent.js?v=2"></script>
     <script src="evm.js"></script>
     <script src="competition-proof.js?v=3"></script>
   </body>

--- a/site/earn.html
+++ b/site/earn.html
@@ -67,7 +67,7 @@
       <nav aria-label="Footer navigation"><a href="./">Home</a><a href="metrics.html">Metrics</a><a href="privacy.html">Privacy</a><a href="https://github.com/NSPG13/agent-bounties">Source</a></nav>
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=2"></script>
+    <script src="phone-wallet.js?v=3"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>

--- a/site/index.html
+++ b/site/index.html
@@ -363,7 +363,7 @@
 
     <noscript><p class="noscript-note">JavaScript is required for the living scene and live marketplace metrics.</p></noscript>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=2"></script>
+    <script src="phone-wallet.js?v=3"></script>
     <script src="wallet-config.js?v=1"></script>
     <script src="wallet-link.js?v=2"></script>
     <script src="marketplace-workflow.js?v=1"></script>

--- a/site/legal-consent.js
+++ b/site/legal-consent.js
@@ -230,8 +230,8 @@
     }
     latestReceipt = receipt;
     status.textContent = receipt.durable
-      ? `Agreement recorded for ${actionLabels[action]}. Review the wallet prompt now.`
-      : `Agreement accepted for ${actionLabels[action]}. Review the wallet prompt now.`;
+      ? `Agreement recorded for ${actionLabels[action]}.`
+      : `Agreement accepted for ${actionLabels[action]}.`;
     status.dataset.tone = "success";
     return receipt;
   }

--- a/site/onramp.html
+++ b/site/onramp.html
@@ -181,7 +181,7 @@
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=2"></script>
+    <script src="phone-wallet.js?v=3"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>

--- a/site/participate.html
+++ b/site/participate.html
@@ -50,11 +50,11 @@
       </section>
     </main>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=2"></script>
+    <script src="phone-wallet.js?v=3"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
-    <script src="legal-consent.js"></script>
+    <script src="legal-consent.js?v=2"></script>
     <script src="evm.js"></script>
     <script src="participate.js?v=4"></script>
     <script src="creator-review-workspace.js?v=1"></script>

--- a/site/phone-wallet.js
+++ b/site/phone-wallet.js
@@ -16,6 +16,13 @@
   const projectId = String(win.agentBountiesPhoneWalletConfig?.projectId || "");
   const configured = PROJECT.test(projectId);
   function error(code, message) { return Object.assign(new Error(message), { code }); }
+  function chainIdHex(value) {
+    // WalletConnect 2.24 returns a number for eth_chainId. EIP-1193 consumers
+    // expect a hexadecimal string; preserve the actual chain, never assume Base.
+    const valid = typeof value === "number" ? Number.isSafeInteger(value) : typeof value === "string" && /^(?:0x[0-9a-f]+|[0-9]+)$/i.test(value);
+    if (!valid || BigInt(value) <= 0n) throw error(4901, "Your phone wallet returned an invalid network. Reconnect it before continuing.");
+    return `0x${BigInt(value).toString(16)}`;
+  }
   function emit(name, value) { for (const listener of listeners.get(name) || []) listener(value); }
   function marker(value) { try { if (value) win.localStorage.setItem(MARKER, activePrefix); else win.localStorage.removeItem(MARKER); } catch (_) { /* Session remains usable in this tab. */ } }
   function remembered() { try { const value = win.localStorage.getItem(MARKER); return /^ab-phone-[a-f0-9-]{36}$/.test(value || "") ? value : null; } catch (_) { return null; } }
@@ -188,7 +195,10 @@
       }
       // Preserve rejection, unsupported-method, and uncertain-response errors.
       // The existing payment journals decide whether a retry is permissible.
-      try { return await sdk.request(request); }
+      try {
+        const result = await sdk.request(request);
+        return request.method === "eth_chainId" ? chainIdHex(result) : result;
+      }
       catch (failure) {
         // Safe read failures can explain recovery without exposing browser
         // internals. Financial errors stay intact for the payment journal.

--- a/site/post.html
+++ b/site/post.html
@@ -246,11 +246,11 @@
     </main>
 
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=2"></script>
+    <script src="phone-wallet.js?v=3"></script>
     <script src="marketplace-workflow.js?v=1"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=5"></script>
-    <script src="legal-consent.js"></script>
+    <script src="legal-consent.js?v=2"></script>
     <script src="evm.js"></script>
     <script src="meta-child.js?v=1"></script>
     <script src="bounty-entry.js?v=1"></script>

--- a/tools/phone-wallet/README.md
+++ b/tools/phone-wallet/README.md
@@ -4,6 +4,17 @@ Install the pinned dependencies with `npm ci --ignore-scripts --no-fund`, then
 run `npm run build` or `npm run check`. The bundle is lazy-loaded by the shared
 phone-wallet adapter; increment its cache version when changing shipped code.
 
+## Network response compatibility
+
+WalletConnect 2.24.0 returns a number from `eth_chainId`. The shared
+`site/phone-wallet.js` provider converts valid decimal or hexadecimal chain IDs
+to canonical hexadecimal strings for EIP-1193 consumers. It preserves the
+actual network and rejects malformed responses; posting and participation keep
+their existing strict Base/account checks. Run
+`node --test scripts/test-phone-wallet-network.cjs` from the repository root to
+exercise the real pinned SDK against the posting signature boundary with an
+inert client, including actual network/account changes and lost replies.
+
 ## Closed browser storage recovery
 
 The pinned idb-keyval 6.2.1 connection factory caches a database handle forever.


### PR DESCRIPTION
## What Changed

A connected Base phone wallet could stop after legal acceptance with “The wallet or network changed,” without receiving a signature request. WalletConnect 2.24.0 returns numeric `8453` for `eth_chainId`, while the posting guard expects `0x2105`.

Normalize valid chain-ID responses at the shared EIP-1193 provider boundary. Preserve the actual network, reject malformed responses, and retain the existing strict Base/account checks. This also covers participation and creator-review consumers. Legal acceptance now confirms only the agreement, without claiming a wallet prompt is already open. Updated asset versions deliver the fix to cached pages.

## Linked Bounty Or Issue

Posting incident in #1313; no bounty acceptance or payout is requested.

## Maintainer Change Notice

- [Notice before edits](https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5573173838).
- Inspected every open PR's update time, review decision, mergeability and checks. No new contributor activity or known contract overlap since the previous phone-wallet repair. #880 awaits contributor changes; #1196 remains a separate conflicting account UI change.
- No interface migration, session migration, or collaboration branch is needed. SDK response formatting is corrected at the existing adapter boundary.

## Acceptance Criteria

- [x] Reproduce the exact stop with the pinned SDK's real numeric response.
- [x] Reach exactly one signature request through the adapter and unchanged posting guard using an inert client.
- [x] Actual account/network changes still fail before signing.
- [x] Invalid network values fail closed; valid non-Base values remain non-Base.
- [x] Explicit rejection permits a later human retry; an uncertain reply retains the journal and cannot dispatch again.
- [x] Preserve phone storage recovery, QR behavior, and viewport usability.

## SDLC And Recovery

- Change class: R1 response-format compatibility. Financial authority, payment execution and confirmation policy are unchanged.
- Source of truth: the SDK's observed network, existing approved account/terms and canonical payment evidence.
- Failure modes: numeric versus hex IDs, malformed IDs, changed account, wrong chain, user rejection and lost reply. The adapter never substitutes Base for another network or retries a wallet request.
- Replay: existing posting journal is unchanged; the real-SDK fixture proves an uncertain signature cannot be dispatched twice.
- Recovery fixture: `scripts/test-phone-wallet-network.cjs`, with synthetic session data, disabled provider pings, inert signing and blocked RPC. It uses the real pinned Ethereum/Universal providers and the current posting function.
- Release: Pages runs the new integration fixture before deployment. Verify live asset versions and restore the existing phone session read-only; financial confirmation stays with the person.
- Rollback: revert this PR and its asset version references together. No records are cleared or migrated.

## Local Checks

- Fresh checkout guard and core preflight.
- `node --test scripts/test-phone-wallet.js scripts/test-phone-wallet-network.cjs` — 21 passed.
- `node --test scripts/test-marketplace-ui.js scripts/test-webmcp.js scripts/test-meta-child.js scripts/test-competition-proof.js` — 72 passed.
- `node scripts/test-ai-bounty-handoff.js`.
- `npm test --prefix tools/browser-layout` — seven viewport cases and storage recovery passed.
- `python scripts/check-site.py` and `git diff --check`.

## Discovery Feedback

Reported during a first-party WebMCP posting flow. Accurate wallet prompts and reusable preparation make participation easier; no live signing was used for testing.

## Review Lane

- [x] Ready for main after CI.
- [x] Reviewed account/network checks, payment authority, failure/replay behavior and rollback. No automated wallet confirmation or funding is introduced.
