### PR TITLE
Fix phone-wallet batch schema and recover rejected posting reviews

### DIFF
--- a/docs/webmcp-guided-marketplace.md
+++ b/docs/webmcp-guided-marketplace.md
@@ -46,6 +46,27 @@ requires a new review. Merely reopening the same review does not.
    for another task can use `start_journey(new_task: true)` after the previous
    posting's funding is confirmed.
 
+### Rejected wallet batches
+
+Posting sends EIP-5792 version 2.0.0 calls with the required
+`atomicRequired: false`: the wallet may execute the reviewed calls sequentially,
+in their supplied order. Only an explicit unsupported-method response permits
+the direct-transaction fallback. A batch ID is not funding evidence.
+
+For an older request rejected with code `-32602` and the exact error
+`atomicRequired - Expected a value of type boolean, but received undefined`,
+use `agent_bounties_recover_rejected_posting_batch` on the posting page. Pass the
+recorded bounty contract and ID plus the person's verbatim wallet error
+(including its original punctuation). The tool requires a matching operation
+without an authorization or submission, checks both canonical events and feed,
+and archives the rejected attempt locally before reopening preparation. It
+preserves the draft and does not grant consent or send a wallet request.
+The person confirms any subsequent request themselves. Network failures,
+changed operations, canonical activity, other parameter errors, and lost or
+pending wallet replies remain blocked; absence of chain activity alone never
+authorizes a retry. New requests also retain the wallet method and this exact
+validation error, so a user report cannot replace an uncertain recorded reply.
+
 ## Earning and contributions
 
 ### Qualifying 1 USDC meta-bounty children

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -556,7 +556,7 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
             "data-card-verifier",
             "function renderVerifierTerms",
             "if (!ui.verifierSummary || !ui.verifier) return;",
-            'bounty-composer-v2.js?v=12',
+            'bounty-composer-v2.js?v=13',
             "function verificationReadiness",
             "verificationReadiness(benchmark, state.draft?.evidence_schema)",
             'sourceSnapshotDigest.pattern === "^sha256:[0-9a-f]{64}$"',

--- a/scripts/test-phone-wallet-network.cjs
+++ b/scripts/test-phone-wallet-network.cjs
@@ -15,18 +15,25 @@ const source = fs.readFileSync(require.resolve("../site/bounty-composer-v2.js"),
 const start = source.indexOf("  async function fundApprovedBounty()"), end = source.indexOf("  function configureSpeech", start);
 assert.ok(start >= 0 && end > start);
 const fundingFunction = source.slice(start, end) + "; fundApprovedBounty";
+const batchFunction = source.slice(source.indexOf("  async function sendWalletCalls("), source.indexOf("  function contractTerms("));
+const atomicError = { code: -32602, message: "Invalid params\n\n0 > atomicRequired - Expected a value of type `boolean`, but received: `undefined`" };
 
-async function fixture({ adapted = true, change = null, uncertain = false } = {}) {
+async function fixture({ adapted = true, change = null, uncertain = false, batch = false, legacy = false, pending = false } = {}) {
   const storage = new Map(), signing = [], statuses = [], network = [];
   const store = { getItem: key => storage.get(key) || null, setItem: (key, value) => storage.set(key, value), removeItem: key => storage.delete(key) };
   store.setItem("agent-bounties-phone-connected-v1", "ab-phone-12345678-1234-1234-1234-123456789012");
-  const namespace = { chains: ["eip155:8453"], accounts: [`eip155:8453:${address}`], methods: ["eth_signTypedData_v4"], events: [], rpcMap: { "eip155:8453": "http://127.0.0.1:1" } };
+  const namespace = { chains: ["eip155:8453"], accounts: [`eip155:8453:${address}`], methods: ["eth_signTypedData_v4", "wallet_sendCalls"], events: [], rpcMap: { "eip155:8453": "http://127.0.0.1:1" } };
   const universal = new UniversalProvider({ logger: "silent", disableProviderPing: true });
   universal.client = {
     core: { projectId: "0".repeat(32), storage: { getItem: async key => storage.get(key), setItem: async (key, value) => storage.set(key, value) } },
     request: async request => {
       signing.push(request);
       if (uncertain) throw new Error("Fixture wallet response was lost");
+      if (batch) {
+        assert.equal(request.request.method, "wallet_sendCalls");
+        if (typeof request.request.params[0].atomicRequired !== "boolean") throw Object.assign(new Error(atomicError.message), atomicError);
+        return { id: "synthetic-batch-id" };
+      }
       throw Object.assign(new Error("Fixture user rejected the wallet request"), { code: 4001 });
     },
   };
@@ -49,11 +56,12 @@ async function fixture({ adapted = true, change = null, uncertain = false } = {}
   const journal = createPostingJournal(win);
   const state = { approved: true, provider, account: address, balances: { usdc: 1000000n, required: 1000000n, eth: 1n }, draft: { title: "Synthetic review" }, fundingUsdc: 1 };
   const authorization = { domain: { chainId: 8453 }, primaryType: "ReceiveWithAuthorization", message: { value: "1000000" } };
-  const plan = { bounty_id: "0x" + "56".repeat(32), predicted_bounty_contract: "0x" + "78".repeat(20), eip3009_authorization: authorization };
-  const run = vm.runInNewContext(fundingFunction, {
-    postingBusy: false, postingJournal: journal, state, window: win, ui: { form: { querySelectorAll: () => [] }, fundNow: {} },
+  const calls = [{ to: other, data: "0x010203" }, { to: address, data: "0x040506" }];
+  const plan = { bounty_id: "0x" + "56".repeat(32), predicted_bounty_contract: "0x" + "78".repeat(20), eip3009_authorization: authorization, wallet_calls: calls };
+  const run = vm.runInNewContext((legacy ? batchFunction.replace("atomicRequired:false,", "") : batchFunction) + fundingFunction, {
+    postingBusy: false, postingJournal: journal, state, window: win, ui: { form: { querySelectorAll: () => [] }, fundNow: {}, badge: {} }, document: { querySelector: () => null },
     track() {}, setPaymentStatus: value => statuses.push(value), refreshWalletReadiness: async () => {},
-    loadProtocol: async () => ({ api_base_url: "https://api.agentbounties.app", factory: "0x" + "90".repeat(20) }),
+    loadProtocol: async () => ({ api_base_url: "https://api.agentbounties.app", factory: "0x" + "90".repeat(20), chain_id_hex: "0x2105" }),
     currentRewardSplit: () => ({ solver: "900000", verifier: "100000", total: "1000000" }),
     contractTerms: () => ({}), termsDocument: () => ({}), createPayload: () => ({}), validateCreationPlan() {}, formatUsdc: String,
     requestJson: async url => {
@@ -63,11 +71,39 @@ async function fixture({ adapted = true, change = null, uncertain = false } = {}
       if (change === "chain") { sdk.chainId = 1; universal.rpcProviders.eip155.chainId = 1; }
       return plan;
     },
-    isContractAccount: async () => false,
+    isContractAccount: async () => batch,
+    pollCreation: async () => pending ? null : [{ kind: "canonical_bounty_created" }, { kind: "funding_added" }, { kind: "bounty_became_claimable" }],
+    fetchFeedItem: async () => ({ terms_valid: true, verification_ready: true }),
     sendTransaction: async () => { throw new Error("No transaction may follow the rejected fixture signature"); },
   });
-  return { sdk, provider, run, signing, statuses, network, journal, authorization };
+  return { sdk, provider, run, signing, statuses, network, journal, authorization, calls };
 }
+
+test("the old batch reproduces the wallet's exact atomicRequired schema rejection through the pinned SDK", async () => {
+  const env = await fixture({ batch: true, legacy: true }); await env.run();
+  assert.equal(env.signing.length, 1); assert.equal(env.statuses.at(-1), atomicError.message);
+  assert.equal(env.journal.load().wallet_error.code, -32602);
+  assert.equal(env.journal.load().transactions.length, 0);
+  await env.run(); assert.equal(env.signing.length, 1, "no automatic replay or transaction fallback");
+});
+
+for (const pending of [false, true]) test(`a smart-wallet batch passes the real SDK with canonical funding ${pending ? "pending" : "confirmed"}`, async () => {
+  const env = await fixture({ batch: true, pending }); await env.run();
+  assert.equal(env.signing.length, 1); assert.equal(env.network.length, 0);
+  const wire = env.signing[0]; assert.equal(wire.chainId, "eip155:8453");
+  assert.deepEqual(JSON.parse(JSON.stringify(wire.request)), { method: "wallet_sendCalls", params: [{ version: "2.0.0", atomicRequired: false,
+    chainId: "0x2105", from: address, calls: env.calls.map(call => ({ ...call, value: "0x0" })) }] });
+  assert.equal(env.journal.load().transactions[0].id, "synthetic-batch-id");
+  assert.equal(env.journal.load().phase, pending ? "batch_submitted" : "funding_confirmed");
+  await env.run(); assert.equal(env.signing.length, 1, "neither pending nor confirmed funding is repeated");
+});
+
+test("a lost smart-wallet batch reply stays recorded and cannot dispatch a second request", async () => {
+  const env = await fixture({ batch: true, uncertain: true }); await env.run();
+  assert.match(env.statuses.at(-1), /response was lost/); assert.equal(env.journal.load().phase, "sending");
+  assert.equal(env.journal.load().wallet_error, undefined);
+  await env.run(); assert.equal(env.signing.length, 1); assert.equal(env.network.length, 0);
+});
 
 test("the real pinned SDK reproduces the false network-change stop before adaptation", async () => {
   const env = await fixture({ adapted: false });

--- a/scripts/test-webmcp.js
+++ b/scripts/test-webmcp.js
@@ -415,7 +415,7 @@ test("an already open funding review is idempotent", async () => {
 test("posting batch fallback occurs only for explicit unsupported-method errors", async () => {
   const source = fs.readFileSync(require.resolve("../site/bounty-composer-v2.js"), "utf8");
   const fn = source.slice(source.indexOf("  async function sendWalletCalls("), source.indexOf("  function contractTerms("));
-  for (const code of [-32601, 4200, 4001, -32000, undefined]) {
+  for (const code of [-32601, 4200, 4001, -32602, -32000, undefined]) {
     const env = environment(), journal = flow.createPostingJournal(env.window); journal.prepare({ predicted_bounty_contract: contract, bounty_id: "batch" });
     let sends = 0;
     const send = vm.runInNewContext(`${fn}; sendWalletCalls`, { postingJournal: journal,
@@ -426,6 +426,73 @@ test("posting batch fallback occurs only for explicit unsupported-method errors"
     else { await assert.rejects(send(calls, protocol), /wallet error/); assert.equal(sends, 0); assert.equal(journal.load().phase, "sending"); }
   }
 });
+
+function rejectedBatchFixture() {
+  const env = environment("/post.html"), journal = flow.createPostingJournal(env.window);
+  const input = { bounty_contract: contract, bounty_id: "0x" + "ab".repeat(32), wallet_error: {
+    code: -32602, message: "Invalid params\n\n0 > atomicRequired - Expected a value of type `boolean`, but received: `undefined`",
+  } };
+  journal.prepare({ predicted_bounty_contract: contract, bounty_id: input.bounty_id }); journal.checkpoint("sending");
+  const state = { approved: true, draft: { title: "Preserve my draft" } }, statuses = [], field = { disabled: true }, fundNow = { disabled: true };
+  const source = fs.readFileSync(require.resolve("../site/bounty-composer-v2.js"), "utf8");
+  const fn = source.slice(source.indexOf("  async function recoverRejectedBatch("), source.indexOf("  async function fundApprovedBounty("));
+  env.window.fetch = async (url, options) => { env.requests.push({ url, ...options }); return { ok: true, json: async () => [] }; };
+  const context = { postingBusy: false, postingJournal: journal, state, window: env.window,
+    ui: { form: { querySelectorAll: () => [field] }, fundNow }, setPaymentStatus: text => statuses.push(text) };
+  const recoverRejectedBatch = vm.runInNewContext(`${fn}; recoverRejectedBatch`, context);
+  env.window.AgentBountiesComposer = { recoverRejectedBatch }; env.register();
+  return { ...env, journal, input, context, state, statuses, field, fundNow,
+    recover: value => env.tools.get("agent_bounties_recover_rejected_posting_batch").execute(value || input) };
+}
+
+test("WebMCP archives only the explicitly rejected legacy batch, preserves the draft and updates its visible review without wallet access", async () => {
+  const env = rejectedBatchFixture(), draft = env.state.draft;
+  const result = await env.recover();
+  assert.equal(result.status, "rejected_batch_archived"); assert.equal(result.funded, false); assert.equal(result.paid, false);
+  assert.equal(result.user_confirmation_required, true); assert.equal(env.journal.load(), null);
+  assert.equal(result.archived_operation.evidence_source, "user_reported_wallet_response");
+  assert.equal(env.state.draft, draft); assert.equal(env.state.approved, true); assert.equal(env.field.disabled, false); assert.equal(env.fundNow.disabled, false);
+  assert.match(env.statuses.at(-1), /rejected attempt is saved/);
+  assert.equal(JSON.parse(env.storage.get("agent-bounties.posting-operation.v1.rejected")).length, 1);
+  assert.equal(env.requests.length, 2); assert.ok(env.requests.every(r => !r.method || r.method === "GET"));
+  await assert.rejects(env.recover(), /does not match/);
+});
+
+test("recovery does not grant missing card approval", async () => {
+  const env = rejectedBatchFixture(); env.state.approved = false; await env.recover();
+  assert.equal(env.state.approved, false); assert.equal(env.fundNow.disabled, true);
+});
+
+for (const kind of ["wrong code", "different params", "different operation", "authorization", "submitted", "lost reply", "different method"]) {
+  test(`recovery refuses ${kind} without changing the journal or requesting canonical data`, async () => {
+    const env = rejectedBatchFixture(), input = structuredClone(env.input);
+    if (kind === "wrong code") input.wallet_error.code = -32000;
+    if (kind === "different params") input.wallet_error.message = "Invalid params: nonce";
+    if (kind === "different operation") input.bounty_contract = wallet;
+    if (kind === "authorization") { env.journal.checkpoint("authorized"); env.journal.checkpoint("sending"); }
+    if (kind === "submitted") env.journal.checkpoint("batch_submitted", { id: "pending" });
+    if (kind === "lost reply") env.journal.checkpoint("sending", null, "wallet_sendCalls");
+    if (kind === "different method") env.journal.checkpoint("sending", null, "eth_sendTransaction");
+    const before = JSON.stringify(env.journal.load());
+    await assert.rejects(env.recover(input)); assert.equal(JSON.stringify(env.journal.load()), before); assert.equal(env.requests.length, 0);
+  });
+}
+
+for (const kind of ["existing feed item", "existing event", "unavailable feed", "unavailable events", "changed operation", "busy", "archive storage failure"]) {
+  test(`recovery retains the journal on ${kind}`, async () => {
+    const env = rejectedBatchFixture(), fetch = env.window.fetch;
+    env.window.fetch = async (url, options) => {
+      if (kind === "existing feed item" && url.includes("/feed?")) return { ok: true, json: async () => [{ bounty_contract: contract }] };
+      if (kind === "existing event" && url.includes("/events?")) return { ok: true, json: async () => [{ kind: "canonical_bounty_created" }] };
+      if (kind === "unavailable feed" && url.includes("/feed?") || kind === "unavailable events" && url.includes("/events?")) throw new Error("offline");
+      if (kind === "changed operation") env.journal.checkpoint("batch_submitted", { id: "new-result" });
+      if (kind === "busy") env.context.postingBusy = true;
+      return fetch(url, options);
+    };
+    if (kind === "archive storage failure") env.window.sessionStorage.setItem = () => { throw new Error("storage unavailable"); };
+    await assert.rejects(env.recover()); assert.ok(env.journal.load()); assert.equal(env.statuses.length, 0); assert.equal(env.fundNow.disabled, true);
+  });
+}
 test("tracking verification never asks for a new wallet approval", async () => {
   const env = environment("/", [item({ source_status: "submitted", work_state: "in_progress" })]);
   const result = await flow.createClient(env.window).prepareAction({ action: "verify", opportunity_id: item().opportunity_id });

--- a/site/about.html
+++ b/site/about.html
@@ -106,7 +106,7 @@
     </main>
 
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="./">Home</a><a href="blog/">Blog</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></nav></footer>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>

--- a/site/analytics-config.js
+++ b/site/analytics-config.js
@@ -7,7 +7,7 @@ window.agentBountiesAnalyticsConfig = Object.freeze({
 (() => {
   const base = new URL(".", document.currentScript.src);
   const script = document.createElement("script");
-  script.src = new URL("webmcp.js?v=6", base).href;
+  script.src = new URL("webmcp.js?v=7", base).href;
   script.async = false;
   document.head.appendChild(script);
 })();

--- a/site/authorize.html
+++ b/site/authorize.html
@@ -73,7 +73,7 @@
       <a href="privacy.html">Privacy</a>
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="authorize.js"></script>

--- a/site/blog/agentic-economy-needs-a-market-for-work.html
+++ b/site/blog/agentic-economy-needs-a-market-for-work.html
@@ -87,7 +87,7 @@
     </main>
 
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="../">Home</a><a href="../about.html">About</a><a href="./">Blog</a><a href="../privacy.html">Privacy</a><a href="../terms.html">Terms</a></nav></footer>
-    <script src="../marketplace-workflow.js?v=1"></script>
+    <script src="../marketplace-workflow.js?v=2"></script>
     <script src="../analytics-config.js?v=5"></script>
     <script src="../analytics.js?v=4"></script>
   </body>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -37,7 +37,7 @@
       </div><p class="editor-note">Agents and feed readers can monitor <a href="feed.xml">the Atom feed</a> or inspect <a href="posts.json">the compact JSON index</a>.</p></section>
     </main>
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="../">Home</a><a href="../about.html">About</a><a href="../privacy.html">Privacy</a><a href="../terms.html">Terms</a></nav></footer>
-    <script src="../marketplace-workflow.js?v=1"></script>
+    <script src="../marketplace-workflow.js?v=2"></script>
     <script src="../analytics-config.js?v=5"></script>
     <script src="../analytics.js?v=4"></script>
   </body>

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -1592,13 +1592,14 @@
   async function copyUsdcAddress(){const protocol=await loadProtocol();await navigator.clipboard.writeText(protocol.native_usdc);setPaymentStatus("Base USDC contract address copied. Verify the network and address inside your wallet before acquiring tokens.","success");}
 
   function signatureParts(signature){const value=String(signature).replace(/^0x/,"");if(value.length!==130)throw new Error("The wallet returned an invalid signature.");return{r:`0x${value.slice(0,64)}`,s:`0x${value.slice(64,128)}`,v:Number.parseInt(value.slice(128,130),16)};}
-  async function sendTransaction(transaction){if(!transaction||!transaction.to||!transaction.data||Number(transaction.value_wei||0)!==0)throw new Error("The planned transaction is invalid.");postingJournal.checkpoint("sending");const hash=await state.provider.request({method:"eth_sendTransaction",params:[{from:state.account,to:transaction.to,data:transaction.data,value:"0x0"}]});if(!/^0x[0-9a-fA-F]{64}$/.test(hash))throw new Error("The wallet response is uncertain. Check the recorded posting before retrying.");postingJournal.checkpoint("submitted",hash);return hash;}
+  async function sendTransaction(transaction){if(!transaction||!transaction.to||!transaction.data||Number(transaction.value_wei||0)!==0)throw new Error("The planned transaction is invalid.");postingJournal.checkpoint("sending",null,"eth_sendTransaction");const hash=await state.provider.request({method:"eth_sendTransaction",params:[{from:state.account,to:transaction.to,data:transaction.data,value:"0x0"}]});if(!/^0x[0-9a-fA-F]{64}$/.test(hash))throw new Error("The wallet response is uncertain. Check the recorded posting before retrying.");postingJournal.checkpoint("submitted",hash);return hash;}
   async function waitReceipt(hash,timeoutMs=150000){const started=Date.now();while(Date.now()-started<timeoutMs){const receipt=await state.provider.request({method:"eth_getTransactionReceipt",params:[hash]});if(receipt){if(receipt.status!=="0x1")throw new Error(`The Base transaction reverted: ${hash}`);return receipt;}await new Promise((resolve)=>setTimeout(resolve,1600));}throw new Error("The transaction is still pending. Check the wallet or Base explorer before trying again.");}
   async function isContractAccount(){const code=await state.provider.request({method:"eth_getCode",params:[state.account,"latest"]});return code&&code!=="0x"&&code!=="0x0";}
   async function sendWalletCalls(calls,protocol){
-    postingJournal.checkpoint("sending");
+    postingJournal.checkpoint("sending",null,"wallet_sendCalls");
     try {
-      const batch=await state.provider.request({method:"wallet_sendCalls",params:[{version:"2.0.0",chainId:protocol.chain_id_hex,from:state.account,calls:calls.map((call)=>({to:call.to,data:call.data,value:"0x0"}))}]});
+      // EIP-5792 requires this boolean even when sequential execution is allowed.
+      const batch=await state.provider.request({method:"wallet_sendCalls",params:[{version:"2.0.0",atomicRequired:false,chainId:protocol.chain_id_hex,from:state.account,calls:calls.map((call)=>({to:call.to,data:call.data,value:"0x0"}))}]});
       postingJournal.checkpoint("batch_submitted",batch);return batch;
     } catch(error) {
       // Only explicit lack of method support permits a fallback. A lost reply can conceal a submitted batch.
@@ -1619,6 +1620,28 @@
   async function pollCreation(api,bountyId,timeoutMs=100000){const started=Date.now();while(Date.now()-started<timeoutMs){const events=await requestJson(`${api}/v1/base/autonomous-bounties/events?network=base-mainnet&bounty_id=${encodeURIComponent(bountyId)}`,{cache:"no-store"});const created=events.some((event)=>event.kind==="canonical_bounty_created");const funded=events.some((event)=>event.kind==="funding_added");const claimable=events.some((event)=>event.kind==="bounty_became_claimable");if(created&&funded&&claimable)return events;await new Promise((resolve)=>setTimeout(resolve,2500));}return null;}
 
   async function fetchFeedItem(api,contract){try{const items=await requestJson(`${api}/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false`,{cache:"no-store"});return items.find((item)=>String(item.bounty_contract).toLowerCase()===String(contract).toLowerCase())||null;}catch(_error){return null;}}
+
+  async function recoverRejectedBatch(input) {
+    if (postingBusy || state.bountyContract) throw new Error("A posting request is active or returned a wallet result. Check its canonical status.");
+    const snapshot = postingJournal.validateRejectedBatch(input, input.wallet_error);
+    const client = window.AgentBountiesWorkflow.createClient(window);
+    // Absence alone never permits recovery: the exact pre-submission schema
+    // rejection above is required, and both canonical reads must succeed.
+    const [items, events] = await Promise.all([
+      client.request("/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false"),
+      client.request(`/v1/base/autonomous-bounties/events?network=base-mainnet&bounty_id=${encodeURIComponent(snapshot.bounty_id)}`),
+    ]);
+    if (!Array.isArray(items) || !Array.isArray(events)) throw new Error("Canonical posting status is unavailable. Keep the recorded request.");
+    if (events.length || items.some(item => item.bounty_id === snapshot.bounty_id || String(item.bounty_contract).toLowerCase() === snapshot.bounty_contract.toLowerCase()))
+      throw new Error("Canonical activity exists for this posting. Reconcile it before any further wallet request.");
+    if (postingBusy || state.bountyContract) throw new Error("The posting state changed during recovery. Check its status.");
+    const archived = postingJournal.archiveRejectedBatch(input, input.wallet_error, snapshot);
+    for (const field of ui.form.querySelectorAll("input, textarea, button")) field.disabled = false;
+    ui.fundNow.disabled = !state.approved;
+    setPaymentStatus("The wallet rejected the previous batch before accepting it. The rejected attempt is saved. Your draft is unchanged; review it and confirm the new request in your wallet when ready.", "pending");
+    return { status: "rejected_batch_archived", archived_operation: archived, funded: false, paid: false,
+      user_confirmation_required: true, next_action: "Read the preserved bounty review, then open its funding review. The person confirms; recovery sends no wallet request." };
+  }
 
   async function fundApprovedBounty() {
     if (postingBusy) return;
@@ -1886,6 +1909,7 @@
   let stagedFingerprint = null;
   window.AgentBountiesComposer = Object.freeze({
     prepareMetaParent,
+    recoverRejectedBatch,
     invalidate() {
       if (!state.draft || postingBusy || postingJournal.load()) return;
       state.reviewStale = true; state.approved = false; stagedFingerprint = null;

--- a/site/cancel.html
+++ b/site/cancel.html
@@ -17,7 +17,7 @@
       <p>No provider completion was reported, and no bounty funding is credited. A checkout screen, redirect, receipt, or transaction hash is not canonical funding evidence.</p>
       <p class="actions"><a class="button primary" href="onramp.html">Choose another on-ramp</a><a class="button secondary" href="./">Return home</a></p>
     </main>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>

--- a/site/competition.html
+++ b/site/competition.html
@@ -154,7 +154,7 @@
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=3"></script>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="marketplace.js?v=3"></script>

--- a/site/earn-money-using-ai.html
+++ b/site/earn-money-using-ai.html
@@ -132,7 +132,7 @@
     </main>
 
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="./">Home</a><a href="about.html">About</a><a href="blog/">Blog</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></nav></footer>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>

--- a/site/earn.html
+++ b/site/earn.html
@@ -68,7 +68,7 @@
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=3"></script>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="marketplace.js?v=3"></script>

--- a/site/how-to-earn-money-with-my-ai-agent.html
+++ b/site/how-to-earn-money-with-my-ai-agent.html
@@ -166,7 +166,7 @@
     </main>
 
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="./">Home</a><a href="about.html">About</a><a href="blog/">Blog</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></nav></footer>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>

--- a/site/index.html
+++ b/site/index.html
@@ -366,7 +366,7 @@
     <script src="phone-wallet.js?v=3"></script>
     <script src="wallet-config.js?v=1"></script>
     <script src="wallet-link.js?v=2"></script>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=5"></script>
     <script src="posting-prompt.js?v=3"></script>

--- a/site/install/bankr/index.html
+++ b/site/install/bankr/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Connect a wallet-native Bankr agent to Agent Bounties with the portable skill and an attributed remote MCP endpoint.">
     <link rel="canonical" href="https://agentbounties.app/install/bankr/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/chatgpt-dev/index.html
+++ b/site/install/chatgpt-dev/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Test Agent Bounties in ChatGPT developer mode with an attributed MCP endpoint and explicit first-party wallet boundaries.">
     <link rel="canonical" href="https://agentbounties.app/install/chatgpt-dev/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/claude-custom/index.html
+++ b/site/install/claude-custom/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Add Agent Bounties as an attributed Claude custom connector or install its source-controlled Claude Code plugin.">
     <link rel="canonical" href="https://agentbounties.app/install/claude-custom/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/cline/index.html
+++ b/site/install/cline/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Install the Agent Bounties remote MCP server in Cline by CLI or settings JSON with no automatic tool approval.">
     <link rel="canonical" href="https://agentbounties.app/install/cline/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/cursor/index.html
+++ b/site/install/cursor/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Connect Cursor to Agent Bounties with a one-click attributed remote MCP installation and a safe first prompt.">
     <link rel="canonical" href="https://agentbounties.app/install/cursor/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/github/index.html
+++ b/site/install/github/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Configure Agent Bounties for GitHub Copilot cloud agent now and prepare for native GitHub Agent App issue delegation.">
     <link rel="canonical" href="https://agentbounties.app/install/github/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/glama/index.html
+++ b/site/install/glama/index.html
@@ -10,7 +10,7 @@
     <meta name="description" content="Discover Agent Bounties through Glama. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/glama/">
     <link rel="stylesheet" href="../install.css?v=3">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/index.html
+++ b/site/install/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Connect Agent Bounties to Bankr, OpenClaw, VS Code, Cursor, Cline, GitHub, Linear, Claude, or ChatGPT with an attributed MCP endpoint.">
     <link rel="canonical" href="https://agentbounties.app/install/">
     <link rel="stylesheet" href="install.css?v=1">
-    <script src="../marketplace-workflow.js?v=1"></script>
+    <script src="../marketplace-workflow.js?v=2"></script>
     <script src="../analytics-config.js?v=5"></script>
     <script src="../analytics.js?v=4"></script>
   </head>

--- a/site/install/linear/index.html
+++ b/site/install/linear/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Use a Linear issue as Agent Bounties origin context through an attributed MCP endpoint while the native Linear Agent is prepared.">
     <link rel="canonical" href="https://agentbounties.app/install/linear/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/mcp-so/index.html
+++ b/site/install/mcp-so/index.html
@@ -10,7 +10,7 @@
     <meta name="description" content="Discover Agent Bounties through MCP.so. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/mcp-so/">
     <link rel="stylesheet" href="../install.css?v=3">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/mcpmarket/index.html
+++ b/site/install/mcpmarket/index.html
@@ -10,7 +10,7 @@
     <meta name="description" content="Discover Agent Bounties through MCPMarket. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/mcpmarket/">
     <link rel="stylesheet" href="../install.css?v=3">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/mcpservers/index.html
+++ b/site/install/mcpservers/index.html
@@ -10,7 +10,7 @@
     <meta name="description" content="Discover Agent Bounties through MCPServers.org. Turn bugs, tests, integrations, and data checks into funded bounties with clear success criteria.">
     <link rel="canonical" href="https://agentbounties.app/install/mcpservers/">
     <link rel="stylesheet" href="../install.css?v=3">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/openclaw/index.html
+++ b/site/install/openclaw/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Install the portable Agent Bounties skill in OpenClaw and connect its attributed Streamable HTTP MCP endpoint.">
     <link rel="canonical" href="https://agentbounties.app/install/openclaw/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/install/vscode/index.html
+++ b/site/install/vscode/index.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Add Agent Bounties to VS Code with a one-click remote MCP installer or a copy-paste workspace configuration.">
     <link rel="canonical" href="https://agentbounties.app/install/vscode/">
     <link rel="stylesheet" href="../install.css?v=1">
-    <script src="../../marketplace-workflow.js?v=1"></script>
+    <script src="../../marketplace-workflow.js?v=2"></script>
     <script src="../../analytics-config.js?v=5"></script>
     <script src="../../analytics.js?v=4"></script>
   </head>

--- a/site/marketplace-workflow.js
+++ b/site/marketplace-workflow.js
@@ -213,19 +213,46 @@
     const key = "agent-bounties.posting-operation.v1";
     const load = () => JSON.parse(win.sessionStorage.getItem(key) || "null");
     const save = (value) => { win.sessionStorage.setItem(key, JSON.stringify(value)); return value; };
+    const atomicParamsRejected = (error) => error?.code === -32602 && typeof error.message === "string"
+      && error.message.replace(/\s+/g, " ").trim() === "Invalid params 0 > atomicRequired - Expected a value of type `boolean`, but received: `undefined`";
+    function validateRejectedBatch(expected, error) {
+      const current = load();
+      if (!atomicParamsRejected(error)) throw new Error("Only the wallet's exact missing atomicRequired validation error can recover this legacy batch. Keep uncertain requests recorded.");
+      if (!current || !ADDRESS.test(expected?.bounty_contract || "") || !/^0x[0-9a-fA-F]{64}$/.test(expected?.bounty_id || "")
+        || current.bounty_contract.toLowerCase() !== expected.bounty_contract.toLowerCase() || current.bounty_id !== expected.bounty_id)
+        throw new Error("The rejected batch does not match the recorded posting operation.");
+      if (current.phase !== "sending" || current.authorizationIssued || !Array.isArray(current.transactions) || current.transactions.length
+        || current.wallet_method && (current.wallet_method !== "wallet_sendCalls" || !atomicParamsRejected(current.wallet_error)))
+        throw new Error("An authorized, submitted or uncertain posting step cannot be cleared by this recovery.");
+      return current;
+    }
     return {
       load,
+      validateRejectedBatch,
+      archiveRejectedBatch(expected, error, snapshot) {
+        const current = validateRejectedBatch(expected, error);
+        if (JSON.stringify(current) !== JSON.stringify(snapshot)) throw new Error("The posting operation changed during recovery. Check its status again.");
+        const historyKey = `${key}.rejected`;
+        const history = JSON.parse(win.sessionStorage.getItem(historyKey) || "[]");
+        const archived = { ...current, phase: "batch_params_rejected", wallet_error: { code: error.code, message: error.message },
+          evidence_source: current.wallet_error ? "wallet_response" : "user_reported_wallet_response", archived_at: new Date().toISOString() };
+        win.sessionStorage.setItem(historyKey, JSON.stringify([...history, archived]));
+        win.sessionStorage.removeItem(key);
+        return archived;
+      },
       prepare(plan) {
         if (load()) throw new Error("A posting wallet step is already recorded. Check its canonical status before starting another.");
         return save({ bounty_contract: plan.predicted_bounty_contract, bounty_id: plan.bounty_id, phase: "prepared", transactions: [] });
       },
-      checkpoint(phase, hash) {
+      checkpoint(phase, hash, walletMethod) {
         const current = load();
         if (!current) throw new Error("Posting recovery state is unavailable; no new wallet request can be sent.");
-        return save({ ...current, phase, authorizationIssued: current.authorizationIssued || phase === "authorized", transactions: hash ? [...current.transactions, hash] : current.transactions });
+        return save({ ...current, phase, ...(walletMethod ? { wallet_method: walletMethod } : {}), authorizationIssued: current.authorizationIssued || phase === "authorized", transactions: hash ? [...current.transactions, hash] : current.transactions });
       },
       reject(error) {
         const current = load();
+        if (current?.phase === "sending" && current.wallet_method === "wallet_sendCalls" && atomicParamsRejected(error))
+          save({ ...current, wallet_error: { code: error.code, message: error.message } });
         if (current && !current.authorizationIssued && !current.transactions.length
           && (current.phase === "prepared" || ["signing", "sending"].includes(current.phase) && error.code === 4001)) win.sessionStorage.removeItem(key);
       },

--- a/site/metrics.html
+++ b/site/metrics.html
@@ -293,7 +293,7 @@
     </main>
 
     <footer class="guild-shell-footer"><span>Public aggregate evidence and canonical transaction proofs. No participant handles or wallet identities are displayed.</span><a href="./">Home</a><a href="protocol.json">Protocol</a><a href="https://api.agentbounties.app/api-docs/openapi.json">API</a></footer>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="metrics.js?v=8"></script>

--- a/site/onramp.html
+++ b/site/onramp.html
@@ -182,7 +182,7 @@
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=3"></script>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
     <script src="guild-shell.js?v=3"></script>

--- a/site/participate.html
+++ b/site/participate.html
@@ -51,7 +51,7 @@
     </main>
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=3"></script>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
     <script src="legal-consent.js?v=2"></script>

--- a/site/post-a-bounty-with-chatgpt-claude-gemini.html
+++ b/site/post-a-bounty-with-chatgpt-claude-gemini.html
@@ -122,7 +122,7 @@
       </div>
     </main>
     <footer class="about-footer"><span>Open protocol. Verifiable outcomes.</span><nav aria-label="Footer navigation"><a href="./">Home</a><a href="about.html">About</a><a href="blog/">Blog</a><a href="privacy.html">Privacy</a><a href="terms.html">Terms</a></nav></footer>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>

--- a/site/post.html
+++ b/site/post.html
@@ -247,7 +247,7 @@
 
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=3"></script>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=5"></script>
     <script src="legal-consent.js?v=2"></script>
@@ -257,7 +257,7 @@
     <script src="posting-prompt.js?v=3"></script>
     <script src="creator-review.js?v=1"></script>
     <script src="ai-bounty-handoff.js?v=10"></script>
-    <script src="bounty-composer-v2.js?v=12"></script>
+    <script src="bounty-composer-v2.js?v=13"></script>
     <script src="posting-workspace.js?v=2"></script>
   </body>
 </html>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -94,7 +94,7 @@
       <span>Public protocol. Verifiable outcomes.</span>
       <nav aria-label="Footer navigation"><a href="./">Home</a><a href="metrics.html">Metrics</a><a href="terms.html">Terms</a></nav>
     </footer>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>

--- a/site/success.html
+++ b/site/success.html
@@ -17,7 +17,7 @@
       <p>The provider redirected back, but this page does not prove funding. Stripe ledger credit requires a verified webhook. A Base bounty becomes funded only after the matching confirmed <code>FundingAdded</code> event.</p>
       <p class="actions"><a class="button primary" href="post.html">Return to bounty review</a><a class="button secondary" href="./">Return home</a></p>
     </main>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>

--- a/site/terms.html
+++ b/site/terms.html
@@ -96,7 +96,7 @@
       <span>Public protocol. Verifiable outcomes.</span>
       <nav aria-label="Footer navigation"><a href="./">Home</a><a href="metrics.html">Metrics</a><a href="privacy.html">Privacy</a></nav>
     </footer>
-    <script src="marketplace-workflow.js?v=1"></script>
+    <script src="marketplace-workflow.js?v=2"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>
   </body>

--- a/site/webmcp.js
+++ b/site/webmcp.js
@@ -546,6 +546,14 @@
     annotations: { readOnlyHint: false, untrustedContentHint: true }, async execute(input) { const result = await client.prepareAction(input); return { ...result, authorization_url: result.authorization_url ? new URL(`/${result.authorization_url}`, window.location.origin).href : null }; } });
   register({ name: "agent_bounties_check_progress", title: "Check confirmation and continue", description: "Reconcile a prepared action against canonical evidence. Reuse the intent and poll at the returned interval without asking again. Prepared, broadcast and submitted do not mean paid. No signatures or wallet transactions.",
     inputSchema: { type: "object", properties: { intent_id: { type: "string", format: "uuid" } }, required: ["intent_id"], additionalProperties: false }, annotations: { readOnlyHint: true, untrustedContentHint: true }, execute(input) { return client.progress(input.intent_id); } });
+  if (isPost) register({ name: "agent_bounties_recover_rejected_posting_batch", title: "Recover a rejected posting request",
+    description: "Preparation only: archive a legacy batch rejected with the exact missing atomicRequired boolean error the person reported. Requires the recorded bounty address and ID, no authorization or submission, and successful canonical checks. Preserves the attempt and draft, updates the visible review, and sends no wallet request. Never use for a lost reply, pending batch or other error. The person must confirm any subsequent wallet request.",
+    inputSchema: { type: "object", properties: {
+      bounty_contract: { type: "string", pattern: "^0x[0-9a-fA-F]{40}$" }, bounty_id: { type: "string", pattern: "^0x[0-9a-fA-F]{64}$" },
+      wallet_error: { type: "object", properties: { code: { type: "integer", enum: [-32602] }, message: { type: "string", maxLength: 500 } }, required: ["code", "message"], additionalProperties: false },
+    }, required: ["bounty_contract", "bounty_id", "wallet_error"], additionalProperties: false },
+    annotations: { readOnlyHint: false, untrustedContentHint: true },
+    async execute(input) { const composer = await waitFor(() => window.AgentBountiesComposer, 8000); if (!composer) throw new Error("The posting review is still loading."); return composer.recoverRejectedBatch(input); } });
   register({ name: "agent_bounties_get_posting_status", title: "Check the bounty I posted", description: "Resume a recorded posting wallet step after navigation or a lost response. Read canonical creation and funding evidence and save the confirmed checkpoint locally. Never opens a wallet or repeats funding.",
     inputSchema: { type: "object", properties: {}, additionalProperties: false }, annotations: { readOnlyHint: false, untrustedContentHint: true },
     async execute() {


### PR DESCRIPTION
## What Changed

Smart and delegated wallets rejected posting before confirmation because the EIP-5792 v2 batch omitted the required `atomicRequired` boolean. Send `false` explicitly, retaining ordered calls and the existing unsupported-method-only fallback. Exercise the actual pinned EthereumProvider and UniversalProvider with an inert wallet client: the old payload reproduces the reported rejection and the corrected payload reaches canonical funding reconciliation.

Add a posting-page WebMCP preparation tool for that exact legacy validation rejection. It matches the recorded operation, refuses authorizations, submitted steps and uncertain new requests, requires successful canonical event and feed checks, race-checks the journal, archives before clearing, and updates the visible review without granting consent or calling a wallet. Preserve recorded wallet methods and this exact error for future diagnostics. Refresh script versions so existing browsers receive the repair.

## Linked Bounty Or Issue

User-reported posting incident; no bounty acceptance or payout claimed. Follow-up to #1328.

## Maintainer Change Notice

- Published before edits: https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5573446428
- Open PR queue inspected for updates, reviews, checks and mergeability. No new contributor activity since the preceding incident review.
- No competing batch repair found. #880 remains with its contributor; #1196 is separate account UI work. Existing journal and wallet session formats remain compatible. HTML changes are cache versions only.
- No collaboration branch changes.

## Acceptance Criteria

- [x] The pinned SDK integration reproduces missing-boolean rejection and checks exact chain, sender, ordered call data and zero native value.
- [x] A batch ID alone stays pending; confirmed canonical funding is required for success.
- [x] Recovery refuses different errors/operations, authorization, submitted IDs, lost replies, canonical activity, unavailable reads, races and unavailable archive storage.
- [x] Recovery keeps the draft and existing approval state; absent approval stays absent. Neither recovery nor retries auto-send a wallet request.

## SDLC And Recovery

- Change class: R3 wallet request boundary; R2 private local journal preparation. No contract, backend, wallet authority or transfer amount changes.
- Authoritative sources: EIP-5792 request schema; actual pinned WalletConnect providers; confirmed canonical Base events and feed. A legacy rejection supplied by the person is explicitly labeled as user-reported evidence, never a wallet receipt.
- Risk decision: ship the required-field repair with the narrow recovery predicate. Reject generic invalid-parameter reset, ambiguous-response retries and automatic transaction fallback. Native trusted user confirmation remains mandatory.
- Idempotency: existing posting operation contract/ID and journal prevent repeat sends. Recovery compares the whole original snapshot after reads and archives it before removal. No batch retry is automated.
- Failure modes: invalid params, delayed/lost wallet result, canonical data unavailable, journal change or storage failure. Uncertain state remains recorded.
- Forward repair/rollback: revert this commit and redeploy Pages to restore prior assets; preserve active and archived browser journals. No storage migration or on-chain rollback. Reverting also restores the known invalid batch payload, so forward repair is preferred.
- Health signal: no missing-boolean rejection; one wallet batch; pending until canonical creation, funding and claimability evidence.
- Recovery fixtures: real composer and journal through WebMCP with synthetic operations; no credentials, session transport material, mainnet writes or personal data in fixtures.
- Canary: pinned SDK with inert client, seven real-browser viewports, then deployed asset verification and preparation-only recovery in the affected browser. Live wallet confirmation remains with the user.

## Local Checks

- `scripts/preflight.ps1 -Mode core`
- Freshness guard passed before commit and push.
- `node --test scripts/test-marketplace-ui.js scripts/test-webmcp.js scripts/test-meta-child.js scripts/test-competition-proof.js scripts/test-phone-wallet.js scripts/test-phone-wallet-network.cjs` — 113 passed.
- `npm test --prefix tools/browser-layout` — seven viewport checks and phone-wallet storage lifecycle/recovery passed.
- `python scripts/check-site.py` — passed.
- `node scripts/test-ai-bounty-handoff.js` — passed.
- `git diff --check` — passed.

## Discovery Feedback

Found through the user's real posting flow. A wallet rejection needs to preserve the draft and offer bounded recovery instead of stranding the user. Delivery evidence is the regression suite and deployed preparation flow; this is not payment evidence.

## Review Lane

- [x] Ready for main after required checks. Wallet and recovery boundaries reviewed locally.
- [x] No mainnet signatures or transactions are authorized by code review or deployment.
