### PR TITLE
Use the release wallet version in Pages verification

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -271,7 +271,8 @@ jobs:
           grep -q '<h1>Privacy policy</h1>' /tmp/live-privacy.html
           grep -q '<h1>Terms of use</h1>' /tmp/live-terms.html
           grep -q 'discovery-manifest.v2.json' /tmp/live-discovery.json
-          grep -q 'phone-wallet.js?v=3' /tmp/live-index.html
+          phone_wallet_script="$(python -c 'import re; from pathlib import Path; print(re.search(r"phone-wallet\.js\?v=\d+", Path("site/index.html").read_text()).group(0))')"
+          grep -Fq "${phone_wallet_script}" /tmp/live-index.html
           curl --fail --silent --show-error "https://agentbounties.app/phone-wallet-config.js?verify=${nonce}" -o /tmp/live-phone-wallet-config.js
           grep -Eq 'projectId: "[a-fA-F0-9]{32}"' /tmp/live-phone-wallet-config.js
           python scripts/check-public-handoffs.py --base-url https://agentbounties.app


### PR DESCRIPTION
The wallet release in #1332 published successfully, but its final deployment check still expected `phone-wallet.js?v=3` after the site moved to v4. Read the exact script reference from the reviewed release HTML and require that same literal reference in live HTML. This preserves the deployment assertion and removes a duplicated version number.

Follow-up within the asset-version scope of https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5573909247. No application, wallet, consent, transaction, contributor API or storage changes. No active PR impact; no collaboration branches affected.

R1 release verification repair. Source of truth: checked-out release HTML compared with live HTML. Missing source reference or live mismatch still fails. Rollback: revert this two-line change; the old v3 expectation would continue to fail for the current release.

Validation: workflow YAML parsed; exact expected v4 reference matched live HTML and stale v3 reference was absent; all six relevant live wallet/review assets matched #1332 source (allowing only the configured analytics ID substitution); git diff check and freshness guard passed. The preceding wallet release passed 122 targeted tests, seven browser sizes, storage recovery, required CI and container smoke checks before merge.

Discovery: found while verifying a real user-reported wallet repair. No funding or payout is claimed. This small forward repair corrects the release signal without weakening the check.
