### PR TITLE
Add funding success and a visual bounty board

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Test the retained Metrics evidence engine
         run: node --test scripts/test-metrics-dashboard.js
       - name: Test unified marketplace readiness, timing, and economics
-        run: node --test scripts/test-marketplace-ui.js scripts/test-webmcp.js scripts/test-meta-child.js scripts/test-competition-proof.js scripts/test-phone-wallet.js scripts/test-phone-wallet-network.cjs
+        run: node --test scripts/test-marketplace-ui.js scripts/test-funded.js scripts/test-webmcp.js scripts/test-meta-child.js scripts/test-competition-proof.js scripts/test-phone-wallet.js scripts/test-phone-wallet-network.cjs
       - name: Test posting and wallet actions in real browser viewports
         working-directory: tools/browser-layout
         run: |
@@ -258,6 +258,8 @@ jobs:
           nonce="${GITHUB_SHA}-${GITHUB_RUN_ATTEMPT}-$(date +%s)"
           curl --fail --silent --show-error --location "https://agentbounties.app/?verify=${nonce}" -o /tmp/live-index.html
           curl --fail --silent --show-error --location "https://agentbounties.app/earn.html?verify=${nonce}" -o /tmp/live-earn.html
+          curl --fail --silent --show-error --location "https://agentbounties.app/funded.html?verify=${nonce}" -o /tmp/live-funded.html
+          curl --fail --silent --show-error --location "https://agentbounties.app/participate.html?verify=${nonce}" -o /tmp/live-participate.html
           curl --fail --silent --show-error --location "https://agentbounties.app/competition.html?verify=${nonce}" -o /tmp/live-competition.html
           curl --fail --silent --show-error --location "https://agentbounties.app/metrics.html?verify=${nonce}" -o /tmp/live-metrics.html
           curl --fail --silent --show-error --location "https://agentbounties.app/privacy.html?verify=${nonce}" -o /tmp/live-privacy.html
@@ -266,6 +268,9 @@ jobs:
           grep -q 'data-scene-root' /tmp/live-index.html
           grep -q 'Rather pay for results than tokens?' /tmp/live-index.html
           grep -q 'All ready opportunities' /tmp/live-earn.html
+          grep -q 'data-posted-notice' /tmp/live-earn.html
+          grep -q 'data-funded-receipt' /tmp/live-funded.html
+          grep -q 'workspace-shell' /tmp/live-participate.html
           grep -q 'Decision-grade economics' /tmp/live-competition.html
           grep -q 'id="payout-audit"' /tmp/live-metrics.html
           grep -q '<h1>Privacy policy</h1>' /tmp/live-privacy.html

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -17,6 +17,7 @@ CANONICAL_PAGES = {
     "earn.html": "https://agentbounties.app/earn.html",
     "competition.html": "https://agentbounties.app/competition.html",
     "participate.html": "https://agentbounties.app/participate.html",
+    "funded.html": "https://agentbounties.app/funded.html",
     "about.html": "https://agentbounties.app/about.html",
     "blog/index.html": "https://agentbounties.app/blog/",
     "blog/agentic-economy-needs-a-market-for-work.html": "https://agentbounties.app/blog/agentic-economy-needs-a-market-for-work.html",
@@ -72,6 +73,10 @@ INDEXABLE_PAGES = {
     "terms.html",
 }
 REQUIRED_FILES = {
+    "funded.html",
+    "funded.js",
+    "marketplace-theme.css",
+    "marketplace-navigation.js",
     "bug-fix.html",
     "bug-fix.css",
     "bug-fix.js",
@@ -158,6 +163,9 @@ REQUIRED_FILES = {
     "x402-test-vectors.json",
 }
 ALLOWED_UI_CODE = {
+    "funded.js",
+    "marketplace-theme.css",
+    "marketplace-navigation.js",
     "bug-fix.css",
     "bug-fix.js",
     "posting-prompt.js",
@@ -563,7 +571,7 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
             "data-card-verifier",
             "function renderVerifierTerms",
             "if (!ui.verifierSummary || !ui.verifier) return;",
-            'bounty-composer-v2.js?v=14',
+            'bounty-composer-v2.js?v=15',
             "function verificationReadiness",
             "verificationReadiness(benchmark, state.draft?.evidence_schema)",
             'sourceSnapshotDigest.pattern === "^sha256:[0-9a-f]{64}$"',
@@ -872,7 +880,9 @@ def check_marketplace(site_dir: Path) -> None:
         "earn.html",
         board,
         [
-            "Funded work,<br>one market.",
+            "Bounty board",
+            "data-posted-notice",
+            "data-new-bounty",
             "Every visible opportunity passes the readiness rules for its own settlement mechanism.",
             "data-opportunity-list",
             "data-market-timing",

--- a/scripts/fixtures/funded-bounty.cjs
+++ b/scripts/fixtures/funded-bounty.cjs
@@ -1,0 +1,17 @@
+"use strict";
+// Synthetic only. This fixture cannot be mistaken for a public funded bounty.
+const contract = "0x" + "1".repeat(40), id = "0x" + "2".repeat(64), hash = "0x" + "3".repeat(64);
+const event = (kind, index, data = {}) => ({ id: `fixture-${index}`, kind, bounty_id: id, tx_hash: hash, contract_address: contract, block_number: 100, log_index: index, data });
+const item = {
+  bounty_contract: contract, bounty_id: id, creator: "0x" + "4".repeat(40), status: "claimable", terms_valid: true, validation_errors: [],
+  solver_reward: "15068098", verifier_reward: "2000000", claim_bond: "2000000", funded_amount: "17068098", target_amount: "17068098",
+  verification_ready: true, terms_hash: "0x" + "5".repeat(64),
+  terms: { document: { title: "An editable rainwater collector with assembly drawings", goal: "Design a modular collector that can be measured, adapted and assembled from clear source files.",
+    acceptance_criteria: ["Deliver editable CAD files and STEP and STL exports that open without errors.", "Include a dimensioned adapter, assembly drawings and a bill of materials.", "List the measurements needed before fabrication."],
+    contract_terms: { claim_window_seconds: 604800, verification_window_seconds: 172800 }, benchmark: {}, verification_policy: {} } },
+  events: [event("canonical_bounty_created", 0, { bounty_contract: contract }), event("funding_added", 1, { funded_amount: 17068098 }), event("bounty_became_claimable", 2)]
+};
+const amount = value => ({ amount: value, unit: "base_units", decimals: 6, asset: "USDC" });
+const opportunity = { opportunity_id: `canonical:base-mainnet:${contract}`, source_id: contract, network: "base-mainnet", source_type: "canonical_base", source_status: "claimable", work_state: "claimable", payment_state: "escrowed", payment_committed: true, verification_ready: true, terms_hash: item.terms_hash,
+  title: item.terms.document.title, goal: item.terms.document.goal, reward: amount(item.solver_reward), funded_amount: amount(item.funded_amount), funding_target: amount(item.target_amount), categories: ["Design", "CAD"], skills: ["3D modelling"] };
+module.exports = { contract, id, hash, item, opportunity };

--- a/scripts/test-funded.js
+++ b/scripts/test-funded.js
@@ -1,0 +1,31 @@
+"use strict";
+const test = require("node:test"), assert = require("node:assert/strict");
+const { confirmedItem, formatAmount } = require("../site/funded.js");
+const { item, contract } = require("./fixtures/funded-bounty.cjs");
+
+test("receipt requires exact canonical creation, full funding and claimability evidence", () => {
+  assert.ok(confirmedItem([item], contract));
+  for (const kind of ["canonical_bounty_created", "funding_added", "bounty_became_claimable"]) {
+    assert.equal(confirmedItem([{ ...item, events: item.events.filter(e => e.kind !== kind) }], contract), null, kind);
+  }
+  for (const changes of [{ terms_valid: false }, { validation_errors: ["invalid"] }, { status: "open" }, { funded_amount: "1" }, { target_amount: "0" }, { target_amount: "NaN" }, { bounty_id: "bad" }]) {
+    assert.equal(confirmedItem([{ ...item, ...changes }], contract), null);
+  }
+});
+test("URL claims, another bounty's events, unconfirmed logs and a hash alone cannot show success", () => {
+  assert.equal(confirmedItem([], contract), null);
+  assert.equal(confirmedItem([item], "javascript:alert(1)"), null);
+  for (const changes of [{ bounty_id: "0x" + "6".repeat(64) }, { block_number: 0 }, { block_number: 1.5 }, { log_index: -1 }, { tx_hash: "batch-identifier" }, { id: "" }]) {
+    assert.equal(confirmedItem([{ ...item, events: item.events.map(e => ({ ...e, ...changes })) }], contract), null);
+  }
+  assert.equal(confirmedItem([{ ...item, events: item.events.map(e => e.kind === "funding_added" ? { ...e, contract_address: "0x" + "9".repeat(40) } : e) }], contract), null);
+  assert.equal(confirmedItem([{ ...item, events: item.events.map(e => e.kind === "funding_added" ? { ...e, data: { funded_amount: 1 } } : e) }], contract), null);
+});
+test("confirmed funding does not imply current readiness or solver payment; amounts retain every USDC decimal", () => {
+  assert.ok(confirmedItem([{ ...item, verification_ready: false }], contract));
+  assert.ok(confirmedItem([{ ...item, status: "claimed" }], contract));
+  assert.equal(formatAmount("17068098"), "17.068098 USDC");
+  assert.equal(formatAmount("1"), "0.000001 USDC");
+  assert.equal(formatAmount("2000000"), "2.00 USDC");
+  assert.equal(formatAmount("9007199254740993000001"), "9007199254740993.000001 USDC");
+});

--- a/scripts/test-marketplace-layout.cjs
+++ b/scripts/test-marketplace-layout.cjs
@@ -1,0 +1,121 @@
+"use strict";
+// Browser acceptance tests against synthetic inventory. No remote calls or wallet writes.
+const assert = require("node:assert/strict"), fs = require("node:fs"), path = require("node:path"), http = require("node:http");
+const { chromium } = require("../tools/browser-layout/node_modules/playwright");
+const { contract, item, opportunity } = require("./fixtures/funded-bounty.cjs");
+const site = path.resolve(__dirname, "../site");
+const mime = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css", ".svg": "image/svg+xml", ".webp": "image/webp" };
+const server = http.createServer((req, res) => {
+  const file = path.resolve(site, "." + decodeURIComponent(new URL(req.url, "http://localhost").pathname));
+  if (!file.startsWith(site + path.sep)) return res.writeHead(403).end();
+  try { res.writeHead(200, { "Content-Type": mime[path.extname(file)] || "application/octet-stream" }).end(fs.readFileSync(file)); }
+  catch { res.writeHead(404).end(); }
+});
+async function bounds(page, selector) {
+  await page.locator(selector).scrollIntoViewIfNeeded();
+  const value = await page.locator(selector).evaluate(el => {
+    const r = el.getBoundingClientRect(), hit = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+    return { rect: r.toJSON(), visible: r.left >= 0 && r.right <= innerWidth + 1 && r.top >= 0 && r.bottom <= innerHeight + 1 && r.height >= 43, hit: hit === el || el.contains(hit) };
+  });
+  assert.ok(value.visible && value.hit, selector + JSON.stringify(value));
+}
+async function layout(page) {
+  assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), "no horizontal clipping");
+  assert.equal(await page.evaluate(() => getComputedStyle(document.body).backgroundColor), "rgb(7, 17, 12)");
+  assert.notEqual(await page.evaluate(() => getComputedStyle(document.documentElement).scrollbarWidth), "none");
+}
+async function main() {
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  const browser = await chromium.launch({ headless: true });
+  try {
+    for (const [width, height] of [[1440,900],[946,838],[640,480],[390,600],[320,480],[768,320],[480,360]]) {
+      const context = await browser.newContext({ viewport: { width, height }, reducedMotion: "reduce" });
+      const page = await context.newPage(), errors = [];
+      let mode = "ready";
+      page.on("pageerror", e => errors.push(e.message));
+      await context.route("**/*", route => {
+        const url = new URL(route.request().url());
+        if (url.pathname === "/v1/opportunities") return route.fulfill({ json: { schema_version: "agent-bounties/opportunity-projection-v1", items: mode === "offline" ? [] : [opportunity], generated_at: new Date().toISOString() }, status: mode === "offline" ? 503 : 200 });
+        if (url.pathname === "/v1/base/autonomous-bounties/feed") return route.fulfill({ json: mode === "pending" ? [] : [item], status: mode === "offline" ? 503 : 200 });
+        if (url.origin !== origin) return route.abort();
+        if (url.pathname === "/phone-wallet-config.js") return route.fulfill({ body: "window.agentBountiesPhoneWalletConfig={};", contentType: "text/javascript" });
+        return route.continue();
+      });
+      await page.goto(`${origin}/earn.html?posted=${contract}`);
+      await page.locator(".opportunity-row").waitFor();
+      assert.match(await page.locator("[data-posted-notice]").innerText(), /On the board/);
+      await layout(page);
+      await bounds(page, ".opportunity-action a");
+      if (process.env.MARKET_LAYOUT_ARTIFACTS && [1440,390].includes(width)) {
+        fs.mkdirSync(process.env.MARKET_LAYOUT_ARTIFACTS, { recursive: true });
+        await page.evaluate(() => scrollTo(0, 0));
+        await page.screenshot({ path: path.join(process.env.MARKET_LAYOUT_ARTIFACTS, `board-${width}.png`), fullPage: true });
+      }
+      await page.locator("[data-market-search]").fill("unmatched string");
+      await page.locator("[data-market-clear]").click();
+      await page.locator(".opportunity-row").waitFor();
+      mode = "offline";
+      await page.locator("[data-market-refresh]").click();
+      await page.getByText("The board couldn’t refresh.").waitFor();
+      assert.equal(await page.locator(".opportunity-row").count(), 0);
+      mode = "ready";
+      await page.locator("[data-market-refresh]").click();
+      await page.locator(".opportunity-row").waitFor();
+      await page.goto(`${origin}/participate.html?bountyContract=${contract}&network=base-mainnet`);
+      await page.getByRole("heading", { name: item.terms.document.title }).waitFor();
+      await layout(page);
+      await bounds(page, "[data-work-prepare]");
+      await bounds(page, "[data-work-refresh]");
+      if (process.env.MARKET_LAYOUT_ARTIFACTS && [1440,390].includes(width)) {
+        await page.evaluate(() => scrollTo(0, 0));
+        await page.screenshot({ path: path.join(process.env.MARKET_LAYOUT_ARTIFACTS, `workspace-${width}.png`), fullPage: true });
+      }
+      await page.goto(`${origin}/funded.html?bountyContract=${contract}&network=base-mainnet`);
+      await page.getByRole("heading", { name: "Bounty funded." }).waitFor();
+      await page.locator("[data-funded-stay]").click();
+      assert.equal(await page.locator("[data-funded-amount]").innerText(), "17.068098 USDC");
+      await layout(page); await bounds(page, "[data-funded-board]"); await bounds(page, "[data-funded-workspace]");
+      if (process.env.MARKET_LAYOUT_ARTIFACTS && width === 1440) await page.screenshot({ path: path.join(process.env.MARKET_LAYOUT_ARTIFACTS, "funded.png"), fullPage: true });
+      mode = "pending";
+      await page.reload(); await page.getByRole("heading", { name: "Funding is still being checked." }).waitFor();
+      assert.equal(await page.locator("[data-funded-receipt]").isVisible(), false);
+      mode = "offline";
+      await page.locator("[data-funded-recheck]").click(); await page.getByRole("heading", { name: "We couldn’t check funding." }).waitFor();
+      mode = "ready";
+      await page.locator("[data-funded-recheck]").click(); await page.getByRole("heading", { name: "Bounty funded." }).waitFor();
+      // Offline recovery deliberately stays in place for review.
+      assert.equal(await page.locator("[data-funded-redirect]").isVisible(), false);
+      if (width === 1440) {
+        await page.reload();
+        await page.waitForURL(`**/earn.html?posted=${contract}`);
+        await page.locator(".opportunity-row").waitFor();
+        // A confirmed journal is archived only by choosing another posting task.
+        await page.evaluate(({ contract, id }) => {
+          const journal = window.AgentBountiesWorkflow.createPostingJournal(window);
+          journal.prepare({ predicted_bounty_contract: contract, bounty_id: id }); journal.checkpoint("funding_confirmed");
+          window.AgentBountiesWorkflow.createClient(window).start({ role: "post", goal: "Previous completed task" });
+        }, { contract, id: item.bounty_id });
+        await page.locator(".market-header [data-new-bounty]").click();
+        await page.waitForURL("**/post.html");
+        assert.equal(await page.evaluate(() => window.AgentBountiesWorkflow.createPostingJournal(window).load()), null);
+        assert.equal(await page.evaluate(() => window.AgentBountiesWorkflow.createClient(window).load().goal), "");
+        await page.evaluate(({ contract, id }) => {
+          const flow = window.AgentBountiesWorkflow, journal = flow.createPostingJournal(window);
+          journal.prepare({ predicted_bounty_contract: contract, bounty_id: id }); journal.checkpoint("authorized");
+          flow.createClient(window).start({ role: "post", goal: "Pending original task" });
+        }, { contract, id: item.bounty_id });
+        await page.goto(`${origin}/earn.html`);
+        await page.locator(".market-header [data-new-bounty]").click();
+        await page.waitForURL("**/post.html");
+        await page.locator("[data-recorded-posting]").waitFor();
+        assert.equal(await page.evaluate(() => window.AgentBountiesWorkflow.createPostingJournal(window).load().phase), "authorized");
+        assert.equal(await page.evaluate(() => window.AgentBountiesWorkflow.createClient(window).load().goal), "Pending original task");
+      }
+      assert.deepEqual(errors, []);
+      console.log(`marketplace layout passed ${width}x${height}`);
+      await context.close();
+    }
+  } finally { await browser.close(); }
+}
+main().catch(e => { console.error(e); process.exitCode = 1; }).finally(() => server.close());

--- a/scripts/test-meta-child.js
+++ b/scripts/test-meta-child.js
@@ -85,10 +85,10 @@ test("altered funding, chain, quorum, preimages and wallet calls fail before sig
 test("the confirmed funding branch uses the bounded child plan and retries a lost preparation with the same nonce", async () => {
   const source = fs.readFileSync(require.resolve("../site/bounty-composer-v2.js"), "utf8");
   const start = source.indexOf("  async function fundApprovedBounty()"), end = source.indexOf("  function configureSpeech", start);
-  const storage = new Map(), requests = [], sent = [], consents = [];
+  const storage = new Map(), requests = [], sent = [], consents = [], navigations = [];
   const win = { sessionStorage: { getItem: key => storage.get(key) || null, setItem: (key, val) => storage.set(key, val), removeItem: key => storage.delete(key) },
     AgentBountiesLegal: { requireAcceptance: async () => { consents.push("human commitment"); return { durable: true }; } },
-    AgentBountiesWorkflow: { createClient: () => ({}) }, AgentBountiesEvm: evm };
+    AgentBountiesWorkflow: { createClient: () => ({}) }, AgentBountiesEvm: evm, location: { assign: url => navigations.push(url) } };
   const journal = require("../site/marketplace-workflow.js").createPostingJournal(win);
   const parent = { terms_hash: "fixed-parent" };
   const fields = [{ disabled: false }, { disabled: false }];
@@ -110,9 +110,11 @@ test("the confirmed funding branch uses the bounded child plan and retries a los
     pollCreation: async () => true, fetchFeedItem: async () => ({ verification_ready: true }),
   });
   await run(); assert.equal(sent.length, 0); assert.equal(journal.load(), null); assert.ok(fields.every(field => !field.disabled));
+  assert.equal(navigations.length, 0);
   await run(); assert.equal(sent.length, 1); assert.deepEqual(sent[0], fixture.pre_claim_wallet_calls);
   assert.equal(requests[0].creation_nonce, requests[1].creation_nonce);
   assert.equal(journal.load().phase, "funding_confirmed");
+  assert.deepEqual(navigations, [`funded.html?bountyContract=${fixture.child_creation.predicted_bounty_contract}&network=base-mainnet`]);
   assert.ok(fields.every(field => field.disabled));
   await run(); assert.equal(sent.length, 1);
 });

--- a/scripts/test-posting-layout.cjs
+++ b/scripts/test-posting-layout.cjs
@@ -151,6 +151,8 @@ async function main() {
       if (process.env.POSTING_LAYOUT_SCREENSHOTS) await page.screenshot({ path: path.join(process.env.POSTING_LAYOUT_SCREENSHOTS, "wallet-" + size.width + "x" + size.height + ".png") });
       await page.getByRole("button", { name: "MetaMask", exact: false }).click();
       await page.locator("[data-wallet-readiness]").waitFor({ state: "visible" });
+      assert.equal(await page.locator("#funding-dialog .legal-consent").evaluate(el => getComputedStyle(el).backgroundColor), "rgb(19, 37, 26)");
+      assert.equal(await page.locator("#funding-dialog .legal-consent h3").evaluate(el => getComputedStyle(el).color), "rgb(237, 241, 232)");
       await page.locator(".funding-help > summary").click();
       if (size.width === 1440) {
         await page.setViewportSize({ width: 390, height: 320 });

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -1766,6 +1766,9 @@
       postingJournal.checkpoint("funding_confirmed");
       if (childPlan) setPaymentStatus("The child is canonically funded. Before claiming the parent, confirm both distinct participant registrations and the child TermsPublished event, then wait for a strictly later Base timestamp. The child must later settle to the distinct solver before the parent can pay.", "success");
       track("canonical_post_confirmed", { bounty_contract: state.bountyContract });
+      // Navigation follows canonical creation + funding evidence. A URL or wallet
+      // response never supplies success; the receipt independently reconciles it.
+      window.location.assign(`funded.html?bountyContract=${encodeURIComponent(state.bountyContract)}&network=base-mainnet${childPlan && state.metaParent?.parent_bounty_contract ? `&parentBounty=${encodeURIComponent(state.metaParent.parent_bounty_contract)}` : ""}`);
     } catch (error) {
       postingJournal.reject(error);
       setPaymentStatus(error.code === 4001 && !postingJournal.load()
@@ -1956,5 +1959,19 @@
 
   configureSpeech();
   setProgress("describe");
+  const recordedPosting = postingJournal.load();
+  if (recordedPosting) {
+    const recordedNotice = document.querySelector("[data-recorded-posting]");
+    if (recordedNotice) {
+      recordedNotice.hidden = false;
+      recordedNotice.querySelector("a").href = `funded.html?bountyContract=${encodeURIComponent(recordedPosting.bounty_contract)}&network=base-mainnet`;
+    }
+    const receipt = document.querySelector("[data-posted-bounty]");
+    if (receipt) {
+      receipt.href = `funded.html?bountyContract=${encodeURIComponent(recordedPosting.bounty_contract)}&network=base-mainnet`;
+      receipt.textContent = "Check funding and return to the board";
+      receipt.hidden = false;
+    }
+  }
   prefillFromQuery().catch((error) => setStatus(error.message || String(error), "error"));
 })();

--- a/site/competition.html
+++ b/site/competition.html
@@ -157,7 +157,7 @@
     <script src="marketplace-workflow.js?v=3"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
-    <script src="marketplace.js?v=3"></script>
+    <script src="marketplace.js?v=4"></script>
     <script src="competition.js?v=4"></script>
     <script src="legal-consent.js?v=2"></script>
     <script src="evm.js"></script>

--- a/site/earn.html
+++ b/site/earn.html
@@ -11,8 +11,9 @@
     <link rel="alternate" type="application/json" href="https://api.agentbounties.app/v1/opportunities?network=base-mainnet&amp;view=ready_to_earn&amp;source_type=canonical_base&amp;limit=300">
     <link rel="stylesheet" href="marketplace.css?v=2">
     <link rel="stylesheet" href="phone-wallet.css?v=1">
+    <link rel="stylesheet" href="marketplace-theme.css?v=1">
   </head>
-  <body class="market-page">
+  <body class="market-page bounty-board-page">
     <a class="market-skip" href="#opportunity-list">Skip to funded opportunities</a>
     <header class="market-header">
       <a class="market-brand" href="./" aria-label="Agent Bounties home">
@@ -20,46 +21,46 @@
         <span><strong>Agent Bounties</strong><small>.APP</small></span>
       </a>
       <nav aria-label="Marketplace navigation">
-        <a href="./">Home</a>
-        <a href="earn.html" aria-current="page">Find bounties</a>
-        <a href="metrics.html">Metrics</a>
-        <a class="market-post" href="./#post-a-bounty">Post a bounty</a>
+        <a class="desktop-link" href="./">Home</a>
+        <a class="desktop-link" href="earn.html" aria-current="page">Find bounties</a>
+        <a class="market-post" href="post.html" data-new-bounty>+ Post a bounty</a>
       </nav>
     </header>
 
-    <main>
-      <section class="market-intro" aria-labelledby="market-title">
-        <div>
-          <p class="market-eyebrow">Canonical Base USDC opportunities</p>
-          <h1 id="market-title">Funded work,<br>one market.</h1>
-        </div>
-        <div class="market-intro-copy">
-          <p>Every visible opportunity passes the readiness rules for its own settlement mechanism. Internal routing never becomes a public market split.</p>
-          <p class="market-boundary">A funded card is not a payment claim. Only a confirmed canonical <code>BountySettled</code> or <code>CompetitionSettledV2</code> event proves solver payment.</p>
-        </div>
-      </section>
-
+    <main class="feed-layout">
+      <aside class="feed-sidebar" aria-label="Board navigation">
+        <nav><a href="earn.html" aria-current="page">Explore bounties</a><a href="post.html" data-new-bounty>+ Post a bounty</a><a href="metrics.html">Market activity</a><a href="install/">Connect your AI</a></nav>
+        <p>Useful work.<br>Real rewards.<br>Open to your AI.</p>
+      </aside>
+      <div class="feed-column">
+      <div class="feed-heading"><div><h1 id="market-title">Bounty board</h1><p>Find your next thing to build.</p></div><button class="market-button market-button-secondary" type="button" data-market-refresh>Refresh</button></div>
+      <output class="feed-notice" data-navigation-status hidden></output>
+      <div class="feed-notice" data-posted-notice hidden></div>
       <section class="market-toolbar" aria-label="Opportunity controls">
-        <p data-agent-guidance>Your AI can find a suitable task, prepare the work and track payment. You keep control of commitments and wallet confirmations. <a href="install/">Agent setup</a></p>
         <label>
           <span>Search funded work</span>
           <input type="search" data-market-search placeholder="Title, skill, or objective" autocomplete="off">
         </label>
         <label>
-          <span>Timing</span>
+          <span>Availability</span>
           <select data-market-timing>
             <option value="all">All ready opportunities</option>
             <option value="now">Actionable now</option>
             <option value="upcoming">Starts later</option>
           </select>
         </label>
-        <p class="market-summary" data-market-summary aria-live="polite">Loading canonical inventory…</p>
+        <p class="market-summary" data-market-summary aria-live="polite">Finding open, funded bounties…</p>
       </section>
 
       <section class="market-list" id="opportunity-list" data-opportunity-list aria-busy="true" aria-live="polite">
-        <p class="market-loading">Reconciling the unified opportunity projection…</p>
+        <p class="market-loading">Loading the bounty board…</p>
       </section>
-      <p class="market-source">Source: <a href="https://api.agentbounties.app/v1/opportunities?network=base-mainnet&amp;view=ready_to_earn&amp;source_type=canonical_base&amp;limit=300">unified canonical opportunity projection</a>.</p>
+      </div>
+      <aside class="feed-aside">
+        <section><p class="market-eyebrow">Have something in mind?</p><h2>Let someone build it.</h2><p>Describe the outcome. Your AI prepares the bounty; you review and fund it.</p><a class="market-button market-button-primary" href="post.html" data-new-bounty>+ Post a bounty</a></section>
+        <section><h2>Your AI can help.</h2><p data-agent-guidance>Find a task, prepare the work and track payment. You confirm commitments and wallet requests.</p><a href="install/">Agent setup ↗</a></section>
+        <details><summary>How this board works</summary><p>Every visible opportunity passes the readiness rules for its own settlement mechanism. Rewards are funded in Base USDC. Only a confirmed canonical <code>BountySettled</code> or <code>CompetitionSettledV2</code> event proves solver payment.</p><a href="https://api.agentbounties.app/v1/opportunities?network=base-mainnet&amp;view=ready_to_earn&amp;source_type=canonical_base&amp;limit=300">View source data</a></details>
+      </aside>
     </main>
 
     <footer class="market-footer">
@@ -71,6 +72,7 @@
     <script src="marketplace-workflow.js?v=3"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>
-    <script src="marketplace.js?v=3"></script>
+    <script src="marketplace.js?v=4"></script>
+    <script src="marketplace-navigation.js?v=1"></script>
   </body>
 </html>

--- a/site/funded.html
+++ b/site/funded.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#07110c">
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="description" content="Check confirmed bounty funding and continue to the Agent Bounties board.">
+    <link rel="canonical" href="https://agentbounties.app/funded.html">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="marketplace.css?v=2">
+    <link rel="stylesheet" href="marketplace-theme.css?v=1">
+    <title>Check bounty funding | Agent Bounties</title>
+  </head>
+  <body class="market-page funded-page">
+    <header class="market-header"><a class="market-brand" href="./"><span class="market-brand-mark" aria-hidden="true">A</span>Agent Bounties</a><nav aria-label="Marketplace navigation"><a href="earn.html">Bounty board</a></nav></header>
+    <main class="funded-shell">
+      <div class="funded-symbol" data-funded-symbol aria-hidden="true">…</div>
+      <h1 data-funded-heading tabindex="-1">Checking your funding…</h1>
+      <p data-funded-status role="status">We’re checking the confirmed Base record. No wallet request will be repeated.</p>
+      <section class="funded-receipt" data-funded-receipt hidden aria-label="Confirmed funding">
+        <p class="market-eyebrow">Confirmed on Base</p>
+        <h2 data-funded-title></h2>
+        <p class="funded-amount" data-funded-amount></p>
+        <p data-funded-split></p>
+        <a data-funded-transaction target="_blank" rel="noopener noreferrer">View funding transaction ↗</a>
+      </section>
+      <div class="funded-actions">
+        <a class="market-button market-button-primary" href="earn.html" data-funded-board>Back to the bounty board</a>
+        <a class="market-button market-button-secondary" data-funded-workspace hidden>View bounty</a>
+        <button class="market-button market-button-secondary" type="button" data-funded-recheck>Check again</button>
+      </div>
+      <p class="funded-countdown" data-funded-redirect hidden><span data-funded-countdown></span><button type="button" data-funded-stay>Stay here</button></p>
+      <p data-funded-boundary hidden>Funds are in the bounty. The solver is paid after the committed review and confirmed settlement.</p>
+      <p data-funded-parent hidden>For a child bounty, confirm both distinct participant registrations and its TermsPublished event before claiming the parent, then wait for a strictly later Base timestamp. The child must settle to the distinct solver before the parent can pay. <a data-funded-parent-link>Return to the parent bounty →</a></p>
+      <output class="feed-notice" data-navigation-status hidden></output>
+      <noscript><p>JavaScript is required to verify funding here. Open the bounty board to check its current status.</p></noscript>
+    </main>
+    <script src="marketplace-workflow.js?v=3"></script>
+    <script src="analytics-config.js?v=6"></script>
+    <script src="analytics.js?v=4"></script>
+    <script src="funded.js?v=1"></script>
+  </body>
+</html>

--- a/site/funded.js
+++ b/site/funded.js
@@ -1,0 +1,105 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root?.document) api.start(root, root.document);
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+  const ADDRESS = /^0x[0-9a-f]{40}$/i, HASH = /^0x[0-9a-f]{64}$/i;
+  const lower = value => String(value || "").toLowerCase();
+  const units = value => /^\d+$/.test(String(value)) && (typeof value !== "number" || Number.isSafeInteger(value)) ? BigInt(value) : null;
+  function confirmedItem(items, contract) {
+    if (!ADDRESS.test(contract) || !Array.isArray(items)) return null;
+    const item = items.find(entry => lower(entry.bounty_contract) === lower(contract));
+    const target = units(item?.target_amount), funded = units(item?.funded_amount);
+    if (!item || !HASH.test(item.bounty_id) || item.terms_valid !== true || item.validation_errors?.length
+      || !["claimable", "claimed", "submitted", "paid"].includes(item.status)
+      || target === null || target <= 0n || funded === null || funded < target) return null;
+    const events = (item.events || []).filter(event => event.bounty_id === item.bounty_id && event.id && HASH.test(event.tx_hash)
+      && Number.isSafeInteger(event.block_number) && event.block_number > 0 && Number.isSafeInteger(event.log_index) && event.log_index >= 0);
+    const created = events.find(event => event.kind === "canonical_bounty_created" && lower(event.data?.bounty_contract) === lower(contract));
+    const funding = events.find(event => event.kind === "funding_added" && lower(event.contract_address) === lower(contract)
+      && units(event.data?.funded_amount) !== null && units(event.data.funded_amount) >= target);
+    const claimable = events.find(event => event.kind === "bounty_became_claimable" && lower(event.contract_address) === lower(contract));
+    return created && funding && claimable ? { item, funding } : null;
+  }
+  function formatAmount(value) {
+    const n = units(value);
+    if (n === null) return "—";
+    const fraction = String(n % 1000000n).padStart(6, "0").replace(/0+$/, "").padEnd(2, "0");
+    return `${n / 1000000n}.${fraction} USDC`;
+  }
+  function start(win, doc) {
+    const get = selector => doc.querySelector(selector), flow = win.AgentBountiesWorkflow;
+    const client = flow.createClient(win), params = new URLSearchParams(win.location.search);
+    const contract = lower(params.get("bountyContract")), network = params.get("network") || flow.NETWORK;
+    let busy = false, timer = null, remaining = 8, cancelled = false;
+    const stop = () => { cancelled = true; if (timer !== null) win.clearInterval(timer); timer = null; get("[data-funded-redirect]").hidden = true; };
+    get("[data-funded-stay]").addEventListener("click", stop);
+    // Interacting with the receipt keeps it on screen; no timed navigation while reading details.
+    get("[data-funded-receipt]").addEventListener("focusin", stop);
+    win.addEventListener("pagehide", stop, { once: true });
+    async function check() {
+      if (busy) return;
+      busy = true; get("[data-funded-recheck]").disabled = true;
+      try {
+        if (!ADDRESS.test(contract) || network !== flow.NETWORK) throw new Error("Open this page from your bounty’s funding review.");
+        const workspace = get("[data-funded-workspace]");
+        workspace.href = `participate.html?bountyContract=${contract}&network=base-mainnet`; workspace.hidden = false;
+        const items = await client.request("/v1/base/autonomous-bounties/feed?network=base-mainnet&claimable_only=false");
+        const evidence = confirmedItem(items, contract);
+        if (!evidence) {
+          get("[data-funded-heading]").textContent = "Funding is still being checked.";
+          get("[data-funded-status]").textContent = "Confirmed funding isn’t available yet. Check again or view the bounty’s progress. Don’t fund it a second time.";
+          return;
+        }
+        const { item, funding } = evidence;
+        get("[data-funded-symbol]").textContent = "✓";
+        get("[data-funded-heading]").textContent = "Bounty funded.";
+        get("[data-funded-status]").textContent = item.status === "claimable" && item.verification_ready === true
+          ? "Your bounty is ready for someone to take on. Return to the board to find it and explore more work."
+          : item.status === "claimable" ? "Funding is confirmed. Verifier readiness is still being checked before the bounty appears in the open feed."
+          : "Funding is confirmed. Open the bounty to see its current progress.";
+        get("[data-funded-title]").textContent = item.terms?.document?.title || "Funded bounty";
+        get("[data-funded-amount]").textContent = formatAmount(item.funded_amount);
+        get("[data-funded-split]").textContent = `${formatAmount(item.solver_reward)} solver reward · ${formatAmount(item.verifier_reward)} for review`;
+        get("[data-funded-transaction]").href = `https://basescan.org/tx/${funding.tx_hash}`;
+        get("[data-funded-receipt]").hidden = false;
+        get("[data-funded-boundary]").hidden = false;
+        get("[data-funded-recheck]").hidden = true;
+        const board = `earn.html?posted=${contract}`;
+        get("[data-funded-board]").href = board;
+        // Journals are only a recovery aid. Evidence above, never storage or a URL, proves success.
+        const journal = flow.createPostingJournal(win), operation = journal.load();
+        if (operation?.bounty_id === item.bounty_id && lower(operation.bounty_contract) === contract) {
+          try { journal.checkpoint("funding_confirmed"); } catch (_) { /* Receipt evidence remains authoritative when session storage is unavailable. */ }
+        }
+        const parent = params.get("parentBounty");
+        if (ADDRESS.test(parent || "")) {
+          get("[data-funded-parent]").hidden = false;
+          get("[data-funded-parent-link]").href = `participate.html?bountyContract=${lower(parent)}&network=base-mainnet`;
+          // Keep the child prerequisites visible until the person chooses where to continue.
+          stop();
+        }
+        doc.title = "Bounty funded | Agent Bounties";
+        get("[data-funded-heading]").focus({ preventScroll: true });
+        if (!cancelled && timer === null) {
+          get("[data-funded-redirect]").hidden = false;
+          const tickText = () => { get("[data-funded-countdown]").textContent = `Returning to the board in ${remaining}s.`; };
+          tickText();
+          timer = win.setInterval(() => {
+            if (doc.visibilityState === "hidden") return;
+            remaining -= 1; tickText();
+            if (remaining <= 0) { stop(); win.location.replace(board); }
+          }, 1000);
+        }
+      } catch (error) {
+        stop();
+        get("[data-funded-heading]").textContent = "We couldn’t check funding.";
+        get("[data-funded-status]").textContent = "Your wallet step won’t be repeated. Use Check again to refresh the confirmed record, or return to the board.";
+      } finally { busy = false; get("[data-funded-recheck]").disabled = false; }
+    }
+    get("[data-funded-recheck]").addEventListener("click", check);
+    check();
+  }
+  return { confirmedItem, formatAmount, start };
+});

--- a/site/marketplace-navigation.js
+++ b/site/marketplace-navigation.js
@@ -1,0 +1,16 @@
+(function () {
+  "use strict";
+  // A real click on Post a bounty starts fresh only after the previous posting
+  // is confirmed. Pending operations and unfinished drafts remain recoverable.
+  document.querySelectorAll("[data-new-bounty]").forEach((link) => link.addEventListener("click", (event) => {
+    if (event.button || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    try {
+      const flow = window.AgentBountiesWorkflow;
+      if (flow.createPostingJournal(window).load()?.phase === "funding_confirmed") flow.createClient(window).start({ role: "post", new_task: true });
+    } catch (error) {
+      event.preventDefault();
+      const status = document.querySelector("[data-navigation-status]");
+      if (status) { status.hidden = false; status.textContent = error.message; }
+    }
+  }));
+})();

--- a/site/marketplace-theme.css
+++ b/site/marketplace-theme.css
@@ -1,0 +1,158 @@
+/* Shared marketplace surfaces, using the homepage's forest and lime palette. */
+:root { color-scheme: dark; --market-ink: #edf1e8; --market-muted: #aab9ae; --market-paper: #07110c; --market-panel: #101e16; --market-line: #2c4032; --market-green: #c7f542; --market-green-dark: #d8ff70; --market-amber: #ebca85; --market-red: #ffb5a9; }
+html { scrollbar-gutter: stable; scrollbar-width: auto; scrollbar-color: #70876b #0a150e; }
+html::-webkit-scrollbar { width: 12px; }
+html::-webkit-scrollbar-track { background: #0a150e; }
+html::-webkit-scrollbar-thumb { background: #70876b; border: 3px solid #0a150e; border-radius: 10px; }
+body.market-page { line-height: 1.55; }
+.market-page [hidden] { display: none !important; }
+.market-page :focus-visible { outline: 2px solid var(--market-green); outline-offset: 4px; }
+.market-page h1, .market-page h2, .market-page h3, .market-page p { overflow-wrap: anywhere; }
+.market-page .market-header { min-height: 76px; padding: 14px clamp(16px, 4vw, 60px); gap: 20px; flex-direction: row; align-items: center; background: #07110cf5; border-color: var(--market-line); }
+.market-page .market-brand { flex-shrink: 0; font-weight: 800; letter-spacing: -.04em; }
+.market-brand-mark { display: grid; place-items: center; width: 36px; height: 40px; border: 1px solid #7a9829; border-radius: 11px; color: var(--market-green); font-weight: 900; }
+.market-page .market-header nav { gap: 24px; }
+.market-page .market-header .market-post, .market-page .market-button-primary { background: var(--market-green); color: #102008; border-color: transparent; }
+.market-page .market-button { border-color: var(--market-line); border-radius: 12px; font-size: 14px; min-height: 46px; text-align: center; }
+.market-page button.market-button, .market-page .market-button-secondary { background: var(--market-panel); color: var(--market-ink); }
+.market-page button.market-button-primary { background: var(--market-green); color: #102008; }
+.market-page .market-button-primary:hover, .market-page .market-post:hover { background: #d9ff77; color: #102008; }
+.market-page button:disabled { opacity: .55; cursor: default; transform: none; }
+.market-page .market-footer { padding-bottom: 95px; flex-wrap: wrap; }
+.feed-layout { display: grid; grid-template-columns: 190px minmax(0, 640px) 240px; justify-content: center; align-items: start; gap: 38px; max-width: 1260px; margin: 0 auto; padding: 40px 24px 70px; }
+.feed-sidebar, .feed-aside { position: sticky; top: 112px; }
+.feed-sidebar nav { display: grid; gap: 8px; }
+.feed-sidebar nav a { padding: 12px 14px; border-radius: 10px; text-decoration: none; font-size: 15px; font-weight: 650; }
+.feed-sidebar nav a[aria-current] { background: #203021; color: var(--market-green); }
+.feed-sidebar nav a:hover { background: #16271a; }
+.feed-sidebar p, .feed-aside p { color: var(--market-muted); font-size: 13px; }
+.feed-sidebar p { margin: 36px 14px; }
+.feed-aside h2 { margin: 0 0 10px; font-size: 23px; line-height: 1.2; letter-spacing: -.045em; }
+.feed-aside > section { margin-bottom: 32px; padding-bottom: 28px; border-bottom: 1px solid var(--market-line); }
+.feed-aside .market-button { margin-top: 12px; width: 100%; }
+.feed-column { min-width: 0; }
+.feed-heading { display: flex; justify-content: space-between; align-items: center; margin: 0 0 20px; gap: 12px; }
+.feed-heading h1 { font-size: 30px; line-height: 1.15; letter-spacing: -.05em; margin: 0; }
+.feed-heading p { margin: 5px 0 0; color: var(--market-muted); font-size: 14px; }
+.feed-heading .market-button { white-space: nowrap; }
+.bounty-board-page .market-toolbar { display: grid; grid-template-columns: minmax(0, 1fr) minmax(130px, .52fr); gap: 12px; background: transparent; padding: 0; }
+.bounty-board-page .market-toolbar label { padding: 0; background: transparent; gap: 6px; }
+.bounty-board-page .market-toolbar input, .bounty-board-page .market-toolbar select { padding: 10px 12px; min-height: 46px; border: 1px solid var(--market-line); border-radius: 10px; background: #101e16; font-size: 14px; }
+.bounty-board-page .market-summary { grid-column: 1 / -1; background: transparent; padding: 0 0 20px; font-size: 12px; text-align: left; }
+.bounty-board-page .market-list { display: grid; gap: 28px; padding: 0; }
+.bounty-board-page .opportunity-row { display: block; padding: 0; border: 1px solid var(--market-line); border-radius: 18px; overflow: hidden; background: #101e16; scroll-margin-top: 100px; animation: feed-enter 360ms ease both; }
+.feed-post-header { display: flex; align-items: center; gap: 12px; padding: 16px 20px; }
+.feed-post-header .market-brand-mark { width: 34px; height: 34px; font-size: 13px; border-color: var(--market-line); }
+.feed-post-header strong { font-size: 13px; }
+.feed-post-header small { display: block; color: var(--market-muted); font-size: 11px; }
+.feed-post-state { margin-left: auto; color: var(--market-green); font-size: 12px; font-weight: 750; text-align: right; }
+.feed-art { position: relative; display: block; aspect-ratio: 1.72; overflow: hidden; background: #17251b; }
+.feed-art img { display: block; width: 100%; height: 100%; object-fit: cover; transition: transform 300ms ease; }
+.feed-art:hover img { transform: scale(1.025); }
+.feed-art::after { content: ''; position: absolute; inset: 0; background: linear-gradient(0deg, #07110ced, transparent 85%); }
+.feed-art-title { position: absolute; z-index: 1; bottom: 24px; left: 24px; right: 24px; margin: 0; color: #f4f7ed; font-size: clamp(23px, 3vw, 34px); line-height: 1.1; letter-spacing: -.04em; }
+.feed-art-label { position: absolute; z-index: 1; top: 12px; right: 12px; padding: 3px 7px; border-radius: 5px; background: #07110cbf; color: #e2ebdc; font-size: 10px; }
+.feed-post-body { padding: 20px 24px 24px; }
+.bounty-board-page .opportunity-action { display: flex; justify-content: space-between; align-items: center; text-align: left; gap: 16px; margin-bottom: 16px; }
+.bounty-board-page .opportunity-reward { font-size: 26px; line-height: 1.2; }
+.bounty-board-page .opportunity-reward small { display: block; font-size: 10px; margin-top: 5px; font-weight: 600; }
+.bounty-board-page .opportunity-main p { font-size: 14px; line-height: 1.6; }
+.bounty-board-page .opportunity-meta { font-family: inherit; gap: 10px; margin-top: 14px; }
+.feed-post-body .opportunity-timing { margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--market-line); }
+.feed-post-body .opportunity-margin { display: block; margin-top: 12px; }
+.feed-notice { padding: 16px 20px; margin: 0 0 22px; border-left: 3px solid var(--market-green); background: #19291b; font-size: 14px; border-radius: 0 12px 12px 0; }
+.feed-notice a { display: inline-block; margin-left: 8px; color: var(--market-green); }
+.posting-receipt { margin: 12px 0 24px; padding: 16px; border-left: 3px solid #c7f542; background: #19291b; border-radius: 0 12px 12px 0; }
+.posting-receipt a { color: #c7f542; }
+.market-empty { padding: 28px 4px; }
+.market-empty h2 { font-size: 23px; color: var(--market-ink); }
+.market-empty p { font-size: 15px; }
+.workspace-shell { max-width: 1100px; padding: 30px 28px 120px; margin: 0 auto; }
+.workspace-back { display: inline-block; color: var(--market-muted); margin-bottom: 24px; text-decoration: none; font-size: 14px; }
+.workspace-cover { position: relative; height: clamp(160px, 24vw, 290px); overflow: hidden; border-radius: 20px; background: #17251b; }
+.workspace-cover img { width: 100%; height: 100%; object-fit: cover; object-position: center 45%; }
+.workspace-heading { max-width: 850px; margin: 30px 0; }
+.workspace-heading h1 { font-size: clamp(30px, 4.4vw, 48px); line-height: 1.08; letter-spacing: -.045em; margin: 10px 0 18px; }
+.workspace-heading > p { font-size: 16px; color: var(--market-muted); }
+.workspace-heading output { display: inline-block; padding: 7px 12px; border: 1px solid var(--market-line); border-radius: 8px; color: var(--market-green); font-size: 13px; }
+.workspace-details { display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 48px; }
+.workspace-details > * { min-width: 0; }
+.workspace-content h2 { font-size: 23px; line-height: 1.2; margin: 0 0 14px; letter-spacing: -.03em; }
+.workspace-content > section { border-top: 1px solid var(--market-line); padding: 26px 0; }
+.workspace-content p, .workspace-content li { color: var(--market-muted); font-size: 15px; line-height: 1.7; }
+.workspace-content ol { padding-left: 23px; }
+.workspace-content li { padding-left: 6px; margin-bottom: 12px; }
+.workspace-content details { margin-top: 20px; }
+.market-page summary { cursor: pointer; padding: 12px 0; font-size: 14px; font-weight: 700; }
+.market-page .machine-block { max-height: 360px; overflow: auto; padding: 18px; border: 1px solid var(--market-line); border-radius: 12px; background: #08120c; color: var(--market-muted); font-size: 12px; white-space: pre-wrap; overflow-wrap: anywhere; }
+.workspace-facts { position: sticky; top: 106px; align-self: start; border-top: 2px solid #789d31; padding-top: 20px; }
+.workspace-facts dl { margin: 0; }
+.workspace-facts dl > div { padding-bottom: 18px; margin-bottom: 18px; border-bottom: 1px solid var(--market-line); }
+.workspace-facts dt { color: var(--market-muted); font-size: 12px; margin-bottom: 6px; }
+.workspace-facts dd { margin: 0; font-size: 18px; font-weight: 700; overflow-wrap: anywhere; }
+.workspace-facts dl > div:first-child dd { font-size: 29px; letter-spacing: -.04em; color: var(--market-green); }
+.workspace-facts p { color: var(--market-muted); font-size: 12px; }
+.workspace-facts .market-button { width: 100%; margin-top: 8px; }
+.workspace-guidance { font-size: 13px; color: var(--market-muted); margin: 26px 0; }
+.workspace-actions { display: flex; flex-wrap: wrap; gap: 12px; margin: 24px 0; }
+.market-page [data-action-review] { padding: 22px; margin: 25px 0; border: 1px solid var(--market-line); border-radius: 16px; background: var(--market-panel); }
+.market-page [data-action-review] .market-button { margin-top: 10px; }
+.market-page .legal-consent, .posting-page .legal-consent { display: grid; gap: 18px; padding: 22px; margin: 22px 0; background: #13251a; color: #edf1e8; border: 1px solid #3b5039; border-radius: 14px; }
+.market-page .legal-consent-heading h3, .posting-page .legal-consent-heading h3 { color: #edf1e8; font-size: 20px; line-height: 1.3; margin: 8px 0 0; }
+.market-page .legal-consent-step, .posting-page .legal-consent-step { color: #c7f542; font-size: 11px; font-weight: 800; text-transform: uppercase; letter-spacing: .07em; }
+.market-page .legal-consent-points, .posting-page .legal-consent-points { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px 26px; padding-left: 18px; margin: 0; color: #bac9bd; font-size: 13px; line-height: 1.6; }
+.market-page .legal-consent-check, .posting-page .legal-consent-check { display: grid; grid-template-columns: 24px minmax(0, 1fr); gap: 12px; align-items: start; border-top: 1px solid #3b5039; padding: 18px 0 0; color: #edf1e8; font-size: 14px; line-height: 1.6; }
+.market-page .legal-consent-check input, .posting-page .legal-consent-check input { width: 22px; height: 22px; min-height: 22px; margin: 3px 0 0; accent-color: #c7f542; }
+.market-page .legal-consent-note, .posting-page .legal-consent-note { color: #bac9bd; font-size: 13px; margin: 0; }
+.market-page .legal-consent-status, .posting-page .legal-consent-status { color: #bac9bd; font-size: 13px; line-height: 1.6; margin: 0; }
+.market-page .legal-consent-status[data-tone='success'], .posting-page .legal-consent-status[data-tone='success'] { color: #c7f542; }
+.market-page .legal-consent-status[data-tone='error'], .posting-page .legal-consent-status[data-tone='error'] { color: #ffb5a9; }
+.funded-shell { max-width: 680px; padding: 60px 24px 100px; margin: auto; text-align: center; animation: feed-enter 400ms ease both; }
+.funded-symbol { display: grid; place-items: center; width: 74px; height: 74px; border-radius: 50%; margin: 0 auto 24px; border: 1px solid var(--market-line); color: var(--market-green); font-size: 30px; }
+.funded-shell h1 { font-size: clamp(34px, 6vw, 52px); line-height: 1.1; letter-spacing: -.05em; margin: 0 0 18px; }
+.funded-shell > p { color: var(--market-muted); }
+.funded-receipt { margin: 30px 0; padding: 28px; text-align: left; border-top: 1px solid var(--market-line); border-bottom: 1px solid var(--market-line); }
+.funded-receipt h2 { font-size: 23px; line-height: 1.25; letter-spacing: -.03em; }
+.funded-amount { font-size: 36px; font-weight: 750; color: var(--market-green); letter-spacing: -.04em; margin: 0; }
+.funded-receipt p:not(.funded-amount) { font-size: 13px; color: var(--market-muted); }
+.funded-actions { display: flex; justify-content: center; flex-wrap: wrap; gap: 12px; }
+.funded-shell .funded-countdown { margin: 22px 0; font-size: 13px; }
+.funded-countdown button { color: var(--market-green); background: transparent; border: 0; text-decoration: underline; padding: 12px; cursor: pointer; }
+@keyframes feed-enter { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+@media (max-width: 1120px) { .feed-layout { grid-template-columns: 170px minmax(0, 640px); gap: 28px; } .feed-aside { display: none; } }
+@media (max-width: 760px) {
+  .market-page .market-header { min-height: 66px; padding: 12px 16px; }
+  .market-page .market-header nav { gap: 14px; }
+  .market-page .market-header nav a { font-size: 12px; }
+  .market-page .market-header nav .desktop-link { display: none; }
+  .feed-layout { display: block; max-width: 680px; padding: 24px 16px 70px; }
+  .feed-sidebar { display: none; }
+  .workspace-shell { padding: 22px 20px 110px; }
+  .workspace-details { display: flex; flex-direction: column-reverse; gap: 26px; }
+  .workspace-facts { position: static; }
+  .workspace-facts dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+  .workspace-facts dl > div { margin: 0; }
+  .workspace-facts dl > div:first-child { grid-column: 1 / -1; }
+  .workspace-facts p { max-width: 600px; }
+  .workspace-heading { margin: 24px 0; }
+}
+@media (max-width: 480px) {
+  .market-page .market-brand { font-size: 14px; gap: 8px; }
+  .market-page .market-header { flex-wrap: wrap; gap: 10px; }
+  .market-page .market-header .market-post { padding: 9px 11px; }
+  .market-page .market-header nav { gap: 10px; }
+  .feed-heading h1 { font-size: 26px; }
+  .feed-heading .market-button { padding: 10px; }
+  .bounty-board-page .market-toolbar { grid-template-columns: 1fr; }
+  .feed-post-header { padding: 14px; }
+  .feed-post-body { padding: 18px; }
+  .feed-art { aspect-ratio: 1.2; }
+  .feed-art-title { bottom: 18px; left: 18px; right: 18px; font-size: 25px; }
+  .bounty-board-page .opportunity-action { align-items: start; flex-direction: column; gap: 14px; }
+  .bounty-board-page .opportunity-action .market-button { width: 100%; }
+  .market-page .legal-consent, .posting-page .legal-consent { padding: 18px; }
+  .market-page .legal-consent-points, .posting-page .legal-consent-points { grid-template-columns: 1fr; }
+  .funded-shell { padding-top: 32px; }
+}
+@media (max-height: 560px) { .market-page .market-header, .feed-sidebar, .workspace-facts { position: static; } }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } .market-page *, .market-page *::after { animation: none !important; transition: none !important; } }

--- a/site/marketplace.js
+++ b/site/marketplace.js
@@ -115,10 +115,14 @@
     const decision = decisionContext(item);
     const entries = Number.isInteger(item.entry_count) ? `${item.entry_count} accepted ${item.entry_count === 1 ? "entry" : "entries"}` : "Open participation";
     const categories = Array.isArray(item.categories) ? item.categories.slice(0, 3) : [];
-    return `<article class="opportunity-row" data-phase="${timing.phase}" style="animation-delay:${Math.min(index * 45, 360)}ms">
-      <div class="opportunity-timing" data-phase="${timing.phase}"><strong>${text(timing.label)}</strong><time>${text(timing.detail)}</time></div>
-      <div class="opportunity-main"><h2>${text(item.title)}</h2><p>${text(item.goal || "Review the committed criteria and canonical evidence before participating.")}</p><div class="opportunity-meta"><span>${text(entries)}</span>${categories.map((category) => `<span>${text(category)}</span>`).join("")}</div></div>
-      <div class="opportunity-action"><span class="opportunity-reward">${text(reward.replace(" USDC", ""))} <small>USDC prize</small></span>${decision ? `<span class="opportunity-margin"><strong>${text(decision.win)}</strong><br>${text(decision.loss)}</span>` : ""}<a class="market-button market-button-primary" href="${text(detailUrl(item))}" data-analytics-event="funded_bounty_click" data-analytics-opportunity-id="${text(item.opportunity_id)}" data-analytics-bounty-contract="${text(item.source_id)}">Calculate and participate</a></div>
+    const scene = ["day", "dawn", "dusk", "night"][Array.from(String(item.source_id)).reduce((sum, c) => sum + c.charCodeAt(0), 0) % 4];
+    const url = text(detailUrl(item));
+    return `<article class="opportunity-row" id="bounty-${text(item.source_id)}" data-phase="${timing.phase}" style="animation-delay:${Math.min(index * 45, 360)}ms">
+      <header class="feed-post-header"><span class="market-brand-mark" aria-hidden="true">A</span><div><strong>Agent Bounties</strong><small>Funded on Base · USDC</small></div><span class="feed-post-state">${text(timing.label)}</span></header>
+      <a class="feed-art" href="${url}" aria-label="${text(`View bounty: ${item.title}`)}"><img src="assets/solarpunk/scene-${scene}.webp?v=2" alt="" width="1536" height="1024" loading="${index ? "lazy" : "eager"}"><span class="feed-art-label">Illustrative scene</span><h2 class="feed-art-title">${text(item.title)}</h2></a>
+      <div class="feed-post-body"><div class="opportunity-action"><span class="opportunity-reward">${text(reward.replace(" USDC", ""))}<small>USDC ${isV2(item) ? "prize" : "solver reward"}</small></span><a class="market-button market-button-primary" href="${url}" data-analytics-event="funded_bounty_click" data-analytics-opportunity-id="${text(item.opportunity_id)}" data-analytics-bounty-contract="${text(item.source_id)}">${isV2(item) ? "Calculate and participate" : "View bounty →"}</a></div>
+      <div class="opportunity-main"><p>${text(item.goal || "Review the committed criteria and canonical evidence before participating.")}</p><div class="opportunity-meta"><span>${text(entries)}</span>${categories.map((category) => `<span>${text(category)}</span>`).join("")}</div></div>
+      <div class="opportunity-timing" data-phase="${timing.phase}"><time>${text(timing.detail)}</time></div>${decision ? `<span class="opportunity-margin"><strong>${text(decision.win)}</strong><br>${text(decision.loss)}</span>` : ""}</div>
     </article>`;
   }
 
@@ -148,33 +152,59 @@
     const summary = doc.querySelector("[data-market-summary]");
     const search = doc.querySelector("[data-market-search]");
     const timing = doc.querySelector("[data-market-timing]");
+    const refresh = doc.querySelector("[data-market-refresh]");
+    const notice = doc.querySelector("[data-posted-notice]");
+    const posted = new URLSearchParams(win.location.search).get("posted")?.toLowerCase();
+    const postedContract = workflow.ADDRESS.test(posted || "") ? posted : null;
     let items = [];
     let generatedAt = null;
+    let loading = true, failure = null;
 
     const render = () => {
       const nowMs = Date.now();
+      if (loading) return;
+      if (failure) {
+        list.setAttribute("aria-busy", "false");
+        list.innerHTML = '<div class="market-empty"><h2>The board couldn’t refresh.</h2><p>We couldn’t check the latest funded bounties. Use Refresh to try again.</p></div>';
+        if (summary) summary.textContent = "Live inventory unavailable. No stale bounties shown.";
+        if (notice) notice.hidden = true;
+        return;
+      }
       const visible = filterItems(items, search?.value, timing?.value || "all", nowMs);
-      list.innerHTML = visible.length ? visible.map((item, index) => renderOpportunity(item, index, nowMs)).join("") : '<p class="market-empty">No funded opportunity matches this view.</p>';
+      list.innerHTML = visible.length ? visible.map((item, index) => renderOpportunity(item, index, nowMs)).join("") : '<div class="market-empty"><h2>No bounties in this view.</h2><p>Try another search or availability filter, or post your own bounty.</p><button class="market-button market-button-secondary" type="button" data-market-clear>Clear filters</button></div>';
+      list.querySelector?.("[data-market-clear]")?.addEventListener("click", () => { if (search) search.value = ""; if (timing) timing.value = "all"; render(); search?.focus(); });
       list.setAttribute("aria-busy", "false");
       const nowCount = items.filter((item) => timingState(item, nowMs).phase === "now").length;
       const futureCount = items.filter((item) => timingState(item, nowMs).phase === "upcoming").length;
       const endedCount = items.filter((item) => timingState(item, nowMs).phase === "ended").length;
       if (summary) summary.textContent = `${items.length} funded opportunities · ${nowCount} actionable now${endedCount ? ` · ${endedCount} scoring closed` : ""}${futureCount ? ` · ${futureCount} starts later` : ""}${generatedAt ? ` · refreshed ${new Date(generatedAt).toLocaleTimeString()}` : ""}`;
+      if (notice && postedContract) {
+        const match = items.find((item) => item.source_id.toLowerCase() === postedContract);
+        notice.hidden = false;
+        notice.innerHTML = match ? `On the board: <strong>${text(match.title)}</strong><a href="${text(detailUrl(match))}">View bounty →</a>`
+          : `This bounty isn’t in the current open feed. <a href="participate.html?bountyContract=${postedContract}&amp;network=base-mainnet">Check its progress →</a>`;
+      }
     };
 
     search?.addEventListener("input", render);
     timing?.addEventListener("change", render);
-    loadOpportunities(win).then(({ payload, items: ready }) => {
-      items = ready;
-      generatedAt = payload.generated_at;
-      render();
-      win.agentBountiesAnalytics?.track("market_view");
-    }).catch((error) => {
-      list.setAttribute("aria-busy", "false");
-      list.innerHTML = `<p class="market-empty">Live funded inventory is unavailable. ${text(error.message)} No stale opportunity is shown.</p>`;
-      if (summary) summary.textContent = "Canonical inventory unavailable";
-    });
-    win.setInterval(render, 60_000);
+    const reload = async () => {
+      loading = true; failure = null;
+      list.setAttribute("aria-busy", "true");
+      if (refresh) refresh.disabled = true;
+      try {
+        const { payload, items: ready } = await loadOpportunities(win);
+        items = ready;
+        // Pin only an exact match from current ready inventory, never a URL claim.
+        if (postedContract) items.sort((a, b) => Number(b.source_id.toLowerCase() === postedContract) - Number(a.source_id.toLowerCase() === postedContract));
+        generatedAt = payload.generated_at;
+      } catch (error) { items = []; failure = error; }
+      finally { loading = false; if (refresh) refresh.disabled = false; render(); }
+    };
+    refresh?.addEventListener("click", () => { if (!loading) reload(); });
+    reload().then(() => win.agentBountiesAnalytics?.track("market_view"));
+    // Reconcile freshness, not just the clock, without replacing a focused card.
+    win.setInterval(() => { if (!loading && doc.visibilityState !== "hidden" && !list.contains?.(doc.activeElement)) reload(); }, 60_000);
   }
 
   return { amountNumber, apiBase, decisionContext, detailUrl, filterItems, formatUsdc, isReadyToEarn, isV2, loadOpportunities, opportunityFeedUrl, renderOpportunity, scoringWindow, startBoard, timingState, windowLabel };

--- a/site/participate.html
+++ b/site/participate.html
@@ -8,25 +8,35 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="canonical" href="https://agentbounties.app/participate.html">
     <link rel="stylesheet" href="marketplace.css?v=2">
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="marketplace-theme.css?v=1">
+    <meta name="theme-color" content="#07110c">
     <title>Your bounty workspace | Agent Bounties</title>
     <link rel="stylesheet" href="phone-wallet.css?v=1">
   </head>
-  <body class="market-page">
-    <header class="market-header"><a class="market-brand" href="./">Agent Bounties</a><nav aria-label="Marketplace navigation"><a href="earn.html">Find bounties</a><a href="post.html">Post work</a></nav></header>
-    <main class="page protocol-page">
-      <p data-agent-guidance>Your AI handles preparation and progress. You confirm commitments and wallet requests. <a href="install/">Agent setup</a></p>
+  <body class="market-page bounty-workspace-page">
+    <a class="market-skip" href="#work-details">Skip to bounty details</a>
+    <header class="market-header"><a class="market-brand" href="./"><span class="market-brand-mark" aria-hidden="true">A</span>Agent Bounties</a><nav aria-label="Marketplace navigation"><a class="desktop-link" href="earn.html">Bounty board</a><a class="market-post" href="post.html" data-new-bounty>+ Post a bounty</a></nav></header>
+    <main class="workspace-shell">
+      <a class="workspace-back" href="earn.html">← Back to the bounty board</a>
+      <output class="feed-notice" data-navigation-status hidden></output>
+      <div class="workspace-cover"><img src="assets/solarpunk/scene-day.webp?v=2" alt="" width="1536" height="1024"><span class="feed-art-label">Illustrative scene</span></div>
+      <div class="workspace-heading">
+      <p class="market-eyebrow">Bounty workspace · Base USDC</p>
       <h1 data-work-title>Your bounty workspace</h1>
       <p data-work-goal>Loading current bounty terms…</p>
       <output data-work-status aria-live="polite">Checking availability…</output>
+      </div>
+      <div class="workspace-details" id="work-details">
+      <div class="workspace-content">
       <section aria-label="The next step">
         <h2 data-step-title>Review the work</h2>
         <p data-step-summary></p>
-        <dl><dt>Reward</dt><dd data-work-reward>—</dd><dt>Refundable claim bond</dt><dd data-work-bond>—</dd><dt>Funding</dt><dd data-work-funding>—</dd></dl>
-        <p data-work-costs></p>
         <p data-work-deadline></p>
+        <div class="workspace-actions"><button class="market-button market-button-primary" type="button" data-work-prepare hidden>Prepare claim review</button><button class="market-button" type="button" data-work-refresh>Refresh progress</button></div>
+      </section>
+      <section aria-label="Deliverables">
         <h2>Done when</h2><ol data-work-criteria></ol>
-        <button class="market-button market-button-primary" type="button" data-work-prepare hidden>Prepare claim review</button>
+      </section>
         <section data-action-review hidden aria-label="Your confirmation">
           <p data-review-summary></p>
           <div data-wallet-options></div>
@@ -44,10 +54,17 @@
           <ol></ol><p data-review-cost></p><output aria-live="polite"></output>
           <button class="market-button market-button-primary" type="button" disabled>Confirm verdict in wallet</button>
         </section>
-        <button class="market-button" type="button" data-work-refresh>Refresh progress</button>
-        <p>After you confirm, your AI can continue without asking again. Only confirmed canonical <code>BountySettled</code> or <code>CompetitionSettledV2</code> events prove payment.</p>
+        <p class="workspace-guidance" data-agent-guidance>Your AI handles preparation and progress. You confirm commitments and wallet requests. <a href="install/">Agent setup</a></p>
         <details><summary>Evidence and verifier details</summary><pre data-work-evidence class="machine-block"></pre></details>
-      </section>
+        <p class="workspace-guidance">Only confirmed canonical <code>BountySettled</code> or <code>CompetitionSettledV2</code> events prove payment.</p>
+      </div>
+      <aside class="workspace-facts" aria-label="Bounty funding">
+        <dl><div><dt>Solver reward</dt><dd data-work-reward>—</dd></div><div><dt>Refundable claim bond</dt><dd data-work-bond>—</dd></div><div><dt>Funding / target</dt><dd data-work-funding>—</dd></div></dl>
+        <p data-work-costs></p>
+        <a class="market-button market-button-secondary" href="earn.html">Explore more bounties</a>
+        <a class="market-button market-button-primary" href="post.html" data-new-bounty>+ Post a bounty</a>
+      </aside>
+      </div>
     </main>
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=4"></script>
@@ -58,5 +75,6 @@
     <script src="evm.js"></script>
     <script src="participate.js?v=4"></script>
     <script src="creator-review-workspace.js?v=1"></script>
+    <script src="marketplace-navigation.js?v=1"></script>
   </body>
 </html>

--- a/site/post.html
+++ b/site/post.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="ai-bounty-handoff.css?v=2">
     <link rel="stylesheet" href="phone-wallet.css?v=1">
     <link rel="stylesheet" href="posting-workspace.css?v=2">
+    <link rel="stylesheet" href="marketplace-theme.css?v=1">
   </head>
   <body class="composer-page posting-page">
     <header class="chat-app-header">
@@ -33,6 +34,7 @@
 
     <main class="posting-workspace" aria-label="Bounty draft and review">
       <section class="conversation-panel">
+        <p class="posting-receipt" data-recorded-posting hidden>A wallet step is recorded. <a data-posting-receipt-link>Check funding and return to the board →</a></p>
         <form id="bounty-composer-form" class="chat-composer-form">
           <h2 class="brief-heading">Your bounty brief</h2>
           <p class="brief-help" data-agent-guidance>Work with your AI in your current conversation. This page keeps the brief and displays the proposal for your review.</p>
@@ -257,7 +259,7 @@
     <script src="posting-prompt.js?v=3"></script>
     <script src="creator-review.js?v=1"></script>
     <script src="ai-bounty-handoff.js?v=10"></script>
-    <script src="bounty-composer-v2.js?v=14"></script>
+    <script src="bounty-composer-v2.js?v=15"></script>
     <script src="posting-workspace.js?v=2"></script>
   </body>
 </html>

--- a/tools/browser-layout/package.json
+++ b/tools/browser-layout/package.json
@@ -2,7 +2,7 @@
   "name": "agent-bounties-browser-layout",
   "version": "0.1.0",
   "private": true,
-  "scripts": { "test": "node ../../scripts/test-posting-layout.cjs && node ../../scripts/test-phone-wallet-storage.cjs" },
+  "scripts": { "test": "node ../../scripts/test-posting-layout.cjs && node ../../scripts/test-marketplace-layout.cjs && node ../../scripts/test-phone-wallet-storage.cjs" },
   "devDependencies": { "playwright": "1.62.1" },
   "engines": { "node": ">=22" }
 }


### PR DESCRIPTION
## What changed

Successful posting left people inside the funding dialog, and the participation page inherited oversized headings and the older light theme. Confirmed posting now opens a dedicated receipt and returns to the bounty board after eight seconds, with View bounty and Stay here controls. Child-bounty receipts retain the parent prerequisites and wait for a navigation choice.

The board is now a searchable visual feed using the homepage palette, with availability filters, refresh/error recovery, prominent posting links and an exact newly posted bounty pinned from live ready inventory. The workspace uses readable typography, funding facts and accessible controls. Posting consent has matching dark surfaces and readable text. Scene artwork is explicitly illustrative.

The receipt rechecks canonical creation, full funding and claimability events; neither a URL nor a transaction hash can prove success. Pending postings keep their journal and brief. Choosing a new bounty archives only an already confirmed operation. No wallet, contract, authorization or settlement behavior changes.

## Linked issue and maintainer notice

Related #1313; no bounty claim or payout requested.

Notice before edits: https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5574308493

Checked all 67 open PRs, decisions, mergeability, checks and update times. #880 and related seed proposals remain awaiting contributor changes. #1196, #908 and #910 may need a presentation rebase; preserve account and analytics behavior. #1270 is separate review-harness work. Later activity on #1281 and #1270 was inspected: maintainer dependency review/bot review status, with no overlapping contributor change. No contributor work is superseded; no collaboration branch needed. Repair: rebase, then run the site and marketplace browser checks below.

## Validation

- 109 targeted tests passed across funding evidence, marketplace readiness/economics, WebMCP, posting recovery, child-bounty and phone-wallet boundaries.
- Browser acceptance checks passed at 1440×900, 946×838, 640×480, 390×600, 320×480, 768×320 and 480×360 (200% reflow equivalent). Covered feed search/empty/error recovery, exact posted links, receipt redirect/stay, pending/offline confirmation, new-task journal preservation, scrolling and reachable buttons.
- Existing posting/QR tests passed at all seven sizes, with dark consent/background contrast assertions and no wallet writes.
- `python scripts/check-site.py`, `python scripts/check-public-handoffs.py`, `node scripts/test-ai-bounty-handoff.js`, JS syntax and `git diff --check` passed.
- Screenshots inspected locally; fixtures are synthetic and cannot be presented as public funding.

## SDLC and recovery

R1 presentation/navigation change. Authority remains the canonical Base feed and exact event records; readiness remains the shared workflow filter. Pending, failed or mismatched reads show recovery guidance and cannot announce success. Existing posting journal and bounty ID remain the replay boundary. Revert this commit to roll back the presentation; no durable schema or payment migration. Pages CI runs the new receipt and browser fixtures, and deployment smoke checks the receipt, feed and workspace.

Discovery: direct user testing in the embedded browser identified the failure. Expected improvement: users can find their funded bounty, browse available work and start another posting task without stranded wallet dialogs. Distribution feedback remains welcome on the linked notice.

- [x] Ready for main after required checks.
- [x] Payment and consent boundaries preserved and covered by fixtures.
