### PR TITLE
Keep funding receipts accurate after settlement

### DIFF
--- a/site/funded.html
+++ b/site/funded.html
@@ -31,7 +31,7 @@
         <button class="market-button market-button-secondary" type="button" data-funded-recheck>Check again</button>
       </div>
       <p class="funded-countdown" data-funded-redirect hidden><span data-funded-countdown></span><button type="button" data-funded-stay>Stay here</button></p>
-      <p data-funded-boundary hidden>Funds are in the bounty. The solver is paid after the committed review and confirmed settlement.</p>
+      <p data-funded-boundary hidden>This receipt confirms funding. Open the bounty to track work, review and payment. Only confirmed settlement proves the solver was paid.</p>
       <p data-funded-parent hidden>For a child bounty, confirm both distinct participant registrations and its TermsPublished event before claiming the parent, then wait for a strictly later Base timestamp. The child must settle to the distinct solver before the parent can pay. <a data-funded-parent-link>Return to the parent bounty →</a></p>
       <output class="feed-notice" data-navigation-status hidden></output>
       <noscript><p>JavaScript is required to verify funding here. Open the bounty board to check its current status.</p></noscript>


### PR DESCRIPTION
The funding receipt can be revisited after settlement. Replace its present-tense escrow-balance claim with wording that confirms funding history and directs users to current work/payment status. This remains accurate after the funds have been paid out.

R0 copy correction following #1334 and its notice: https://github.com/NSPG13/agent-bounties/issues/1313#issuecomment-5574308493. No wallet or evidence logic changes; no known open-PR impact. Verified with the receipt evidence tests and site checks. Rollback is a one-line revert.
