### PR TITLE
Require wallet setup and simplify wallet navigation

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
@@ -71,14 +71,14 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
+          --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
 
       - name: Run canonical jobs without signing secrets

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
       - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
 
   authorize-run:
@@ -151,11 +151,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
+          --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
       - name: Revalidate and relay exact quorum
         env:

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,11 +50,11 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
+          --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
           python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
       - name: Re-fetch state and sign one exact candidate set
         env:

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -34,14 +34,14 @@ PIPELINE_SHA256 = "23611288dc879bad70ef6966789a5132b136d6e4ca69db7b25ced5c6b581c
 PIPELINE_TEST_SHA256 = "8b408fc80ff5bf4871ff679f119e6053834b5c9544b1ea0be70e11414cab3be2"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"
+WORKER_BUILD_SHA256 = "b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"
 SIGNING_RUNTIME_SHA256 = "89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "bead217581bc9218110ed7d366ca7c6151379f0653c9c2871446103c5a1a8f1e",
+    ".github/workflows/regression-verifier-runner.yml": "629cb3b1098a499bf2cdd8304231d393071f29194814f66e3d45980491fea817",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "339105017e6b45c6497cf5c082d7a7d0dd356dfbdb61761e6c48b071c01a18c4",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "a04d096d0092f9c4b08f205c554e4019d3834018de91a9c32bac2ad350d264eb",
+    ".github/workflows/regression-verifier-signer.yml": "90261cfad784c610f40e888b965d2d81fea6d219f2e2c41aa4b221e9de7ef435",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "24d2d8f37fe0d6153db875fa5f0d0f696a3c5fb334f42d3b4f2d8af6d99768fc",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,9 +930,9 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
@@ -1052,9 +1052,9 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
@@ -1095,9 +1095,9 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 4b2191d2babf57a7026ca184fb41de767a882cdf937d4347e47b47ec063c9284"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
         {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}

--- a/crates/api/src/site_auth.rs
+++ b/crates/api/src/site_auth.rs
@@ -257,14 +257,32 @@ async fn healthz(Extension(service): Extension<SiteAuthService>) -> Response {
 
 async fn session(Extension(service): Extension<SiteAuthService>, headers: HeaderMap) -> Response {
     let user = service.current_user(&headers);
-    no_store_json(
-        StatusCode::OK,
+    let account_id = user.as_ref().and_then(|user| service.account_id(user));
+    let wallet_count = match (account_id.as_deref(), service.inner.store.as_ref()) {
+        (Some(id), Some(store)) => store
+            .list_site_auth_wallets(id)
+            .await
+            .ok()
+            .map(|wallets| wallets.len()),
+        _ => None,
+    };
+    let mut browser_user = serde_json::to_value(&user).expect("session user serializes");
+    if let Some(profile) = browser_user.as_object_mut() {
+        profile.insert("id".to_string(), json!(account_id));
+    }
+    let mut payload = with_account_setup(
         json!({
+            // Authentication permits setup/challenge access; it does not complete an account.
             "authenticated": user.is_some(),
-            "user": user,
+            "user": browser_user,
             "providers": service.configured_providers(),
         }),
-    )
+        wallet_count,
+    );
+    if user.is_none() {
+        payload["account_status"] = json!("signed_out");
+    }
+    no_store_json(StatusCode::OK, payload)
 }
 
 async fn account(Extension(service): Extension<SiteAuthService>, headers: HeaderMap) -> Response {
@@ -594,13 +612,19 @@ async fn finish_wallet_link(
         .link_site_auth_wallet(&account_id, &address, BASE_CHAIN_ID)
         .await
     {
-        Ok(wallets) => no_store_json(
-            StatusCode::OK,
-            json!({
-                "linked": true,
-                "wallets": wallets.into_iter().map(browser_wallet).collect::<Vec<_>>(),
-            }),
-        ),
+        Ok(wallets) => {
+            let count = wallets.len();
+            no_store_json(
+                StatusCode::OK,
+                with_account_setup(
+                    json!({
+                        "linked": true,
+                        "wallets": wallets.into_iter().map(browser_wallet).collect::<Vec<_>>(),
+                    }),
+                    Some(count),
+                ),
+            )
+        }
         Err(DbError::SiteAuthConflict(reason)) => error_json(StatusCode::CONFLICT, &reason),
         Err(_) => error_json(
             StatusCode::SERVICE_UNAVAILABLE,
@@ -634,13 +658,19 @@ async fn unlink_wallet(
         );
     };
     match store.unlink_site_auth_wallet(&account_id, &address).await {
-        Ok(wallets) => no_store_json(
-            StatusCode::OK,
-            json!({
-                "unlinked": true,
-                "wallets": wallets.into_iter().map(browser_wallet).collect::<Vec<_>>(),
-            }),
-        ),
+        Ok(wallets) => {
+            let count = wallets.len();
+            no_store_json(
+                StatusCode::OK,
+                with_account_setup(
+                    json!({
+                        "unlinked": true,
+                        "wallets": wallets.into_iter().map(browser_wallet).collect::<Vec<_>>(),
+                    }),
+                    Some(count),
+                ),
+            )
+        }
         Err(_) => error_json(
             StatusCode::SERVICE_UNAVAILABLE,
             "wallet_link_store_unavailable",
@@ -1189,6 +1219,8 @@ fn build_linked_account_dashboard(
         "data_status": "available",
         "reason": null,
         "identity_link_status": "verified",
+        "account_status": "ready",
+        "account_complete": true,
         "wallets": wallets,
         "stats": {
             "participating_bounties": participating_count,
@@ -1206,22 +1238,43 @@ fn build_linked_account_dashboard(
 }
 
 fn unavailable_account_dashboard(reason: &str, wallets: Vec<BrowserWallet>) -> Value {
-    json!({
-        "schema_version": "agent-bounties/account-dashboard-v1",
-        "data_status": "unavailable",
-        "reason": reason,
-        "identity_link_status": if wallets.is_empty() { "unlinked" } else { "verified" },
-        "wallets": wallets,
-        "stats": {
-            "participating_bounties": null,
-            "completed_posted_bounties": null,
-            "earned_usdc": null,
-            "spent_usdc": null,
-            "leaderboard_rank": null,
-        },
-        "activities": { "participating": [], "completed_posts": [] },
-        "evidence_boundary": "OAuth authentication alone does not prove ownership of a marketplace wallet. Personal values are shown only after address control is verified and every required canonical evidence source loads.",
-    })
+    let wallet_count = if !wallets.is_empty() || reason == "marketplace_identity_unlinked" {
+        Some(wallets.len())
+    } else {
+        None
+    };
+    with_account_setup(
+        json!({
+            "schema_version": "agent-bounties/account-dashboard-v1",
+            "data_status": "unavailable",
+            "reason": reason,
+            "identity_link_status": if wallets.is_empty() { "unlinked" } else { "verified" },
+            "wallets": wallets,
+            "stats": {
+                "participating_bounties": null,
+                "completed_posted_bounties": null,
+                "earned_usdc": null,
+                "spent_usdc": null,
+                "leaderboard_rank": null,
+            },
+            "activities": { "participating": [], "completed_posts": [] },
+            "evidence_boundary": "OAuth authentication alone does not prove ownership of a marketplace wallet. Personal values are shown only after address control is verified and every required canonical evidence source loads.",
+        }),
+        wallet_count,
+    )
+}
+
+// The server alone decides completion, using persisted ownership-verified links.
+// A missing store is unknown, never a completed account or an empty wallet list.
+fn with_account_setup(mut payload: Value, verified_wallet_count: Option<usize>) -> Value {
+    let status = match verified_wallet_count {
+        Some(0) => "wallet_required",
+        Some(_) => "ready",
+        None => "unavailable",
+    };
+    payload["account_status"] = json!(status);
+    payload["account_complete"] = json!(status == "ready");
+    payload
 }
 
 fn sign_session(mut user: SessionUser, secret: &[u8], now: DateTime<Utc>) -> String {
@@ -1573,6 +1626,32 @@ mod tests {
     use super::*;
     use alloy::signers::{local::PrivateKeySigner, SignerSync};
     use chrono::TimeZone;
+
+    #[test]
+    fn account_completion_requires_a_verified_link_and_survives_evidence_outage() {
+        let pending = unavailable_account_dashboard("marketplace_identity_unlinked", vec![]);
+        assert_eq!(pending["account_status"], "wallet_required");
+        assert_eq!(pending["account_complete"], false);
+        let unknown = unavailable_account_dashboard("wallet_link_store_unavailable", vec![]);
+        assert_eq!(unknown["account_status"], "unavailable");
+        assert_eq!(unknown["account_complete"], false);
+        let linked = unavailable_account_dashboard(
+            "marketplace_evidence_unavailable",
+            vec![BrowserWallet {
+                address: "0x1111111111111111111111111111111111111111".to_string(),
+                label: "Test wallet".to_string(),
+                chain_id: BASE_CHAIN_ID,
+                linked_at: Utc::now(),
+                proof: "eip191".to_string(),
+            }],
+        );
+        assert_eq!(linked["account_status"], "ready");
+        assert_eq!(linked["account_complete"], true);
+        assert!(linked["stats"]["earned_usdc"].is_null());
+        let removed = with_account_setup(json!({"unlinked": true, "wallets": []}), Some(0));
+        assert_eq!(removed["account_status"], "wallet_required");
+        assert_eq!(removed["account_complete"], false);
+    }
 
     fn test_user() -> SessionUser {
         SessionUser {

--- a/docs/account-setup.md
+++ b/docs/account-setup.md
@@ -1,0 +1,23 @@
+# Website account setup
+
+An account requires sign-in and at least one verified wallet. Users choose **Link wallet** or **Link another** to use a phone wallet (QR), an installed browser wallet, or create a wallet with the configured embedded provider. Phone pairing has no separate floating button. Closing setup saves progress; it does not complete the account.
+
+The wallet connection is followed by one bounded ownership message. The server verifies the signature and stores the link before account setup completes. Pairing, an address, a signature alone, or a successful sign-in does not prove completion. No deposit, token approval or transaction is needed to create an account. Already verified wallets do not need another ownership signature. Removing the final wallet returns the account to unfinished setup.
+
+## API contract
+
+The website uses `/v1/site-auth/session`, `/v1/site-auth/account`, `/v1/site-auth/wallet/challenge`, `/v1/site-auth/wallet/verify` and `/v1/site-auth/wallet/unlink`. The loopback development server provides equivalent routes below `/auth`.
+
+Session, account, successful verification and unlink responses include:
+
+| Field | Meaning |
+| --- | --- |
+| `account_status: signed_out` | No authenticated identity; returned by the session route. |
+| `account_status: wallet_required` | Signed in, with no stored verified wallet. Setup is unfinished. |
+| `account_status: ready` | At least one stored, ownership-verified wallet. |
+| `account_status: unavailable` | Wallet storage could not be checked. Do not report completion. |
+| `account_complete` | True only for `ready`. |
+
+`authenticated` continues to describe the signed-in identity so pending users can request a wallet challenge and finish setup. It is not an account-completion flag. Website clients must use the server's completion fields and verified wallet list before showing a completed account. The session's opaque `user.id` binds resumable setup to the same identity.
+
+An unavailable marketplace activity feed does not revoke a verified link. Account completion and activity availability are separate. Signature and transaction confirmations remain in the user's wallet. These account links grant no authority to spend, fund, publish or settle work.

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:93c7a96f9814b7e3a1f8934077259736a47e11c058f6d8dd13c47fc563ab88a1",
+    "benchmark_digest": "sha256:59742f3b2caf2ec081fc6008e1f41db24112c5903b3dcb91d7d32e7b8faf067a",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -710,7 +710,6 @@ def check_homepage(site_dir: Path) -> None:
         page,
         [
             '<a href="about.html">About us</a>',
-            '<a href="about.html#blog">Blog</a>',
             '<a href="earn.html">Find bounties</a>',
         ],
     )

--- a/scripts/serve-solarpunk-auth.py
+++ b/scripts/serve-solarpunk-auth.py
@@ -265,6 +265,11 @@ class WalletLinkStore:
             return [dict(wallet) for wallet in wallets]
 
 
+def account_setup(wallet_count: int | None) -> dict[str, Any]:
+    status = "unavailable" if wallet_count is None else "ready" if wallet_count else "wallet_required"
+    return {"account_status": status, "account_complete": status == "ready"}
+
+
 def unavailable_account_dashboard(reason: str, wallets: list[dict[str, Any]] | None = None) -> dict[str, Any]:
     linked_wallets = wallets or []
     return {
@@ -272,6 +277,7 @@ def unavailable_account_dashboard(reason: str, wallets: list[dict[str, Any]] | N
         "data_status": "unavailable",
         "reason": reason,
         "identity_link_status": "verified" if linked_wallets else "unlinked",
+        **account_setup(len(linked_wallets) if linked_wallets or reason == "marketplace_identity_unlinked" else None),
         "wallets": linked_wallets,
         "stats": {
             "participating_bounties": None,
@@ -559,6 +565,7 @@ def build_linked_account_dashboard(
         "data_status": "available",
         "reason": None,
         "identity_link_status": "verified",
+        **account_setup(len(wallets)),
         "wallets": wallets,
         "stats": {
             "participating_bounties": len(participating),
@@ -759,12 +766,19 @@ class LocalAuthHandler(SimpleHTTPRequestHandler):
             return
         if parsed.path == "/auth/session":
             user = self.current_user()
+            try:
+                setup = account_setup(len(self.wallet_store.wallets_for(user))) if user else {
+                    "account_status": "signed_out", "account_complete": False,
+                }
+            except (OSError, ValueError, json.JSONDecodeError):
+                setup = account_setup(None)
             self.send_json(
                 HTTPStatus.OK,
                 {
                     "authenticated": bool(user),
                     "user": user if user else None,
                     "providers": configured_providers(self.auth_env),
+                    **setup,
                 },
             )
             return
@@ -915,7 +929,7 @@ class LocalAuthHandler(SimpleHTTPRequestHandler):
         except OSError:
             self.send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": "wallet_link_store_unavailable"})
             return
-        self.send_json(HTTPStatus.OK, {"linked": True, "wallets": wallets})
+        self.send_json(HTTPStatus.OK, {"linked": True, "wallets": wallets, **account_setup(len(wallets))})
 
     def unlink_wallet(self) -> None:
         context = self.wallet_request_context()
@@ -930,7 +944,7 @@ class LocalAuthHandler(SimpleHTTPRequestHandler):
         except OSError:
             self.send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": "wallet_link_store_unavailable"})
             return
-        self.send_json(HTTPStatus.OK, {"unlinked": True, "wallets": wallets})
+        self.send_json(HTTPStatus.OK, {"unlinked": True, "wallets": wallets, **account_setup(len(wallets))})
 
     def begin_oauth(self, provider: str) -> None:
         config = provider_config(self.auth_env, provider)

--- a/scripts/templates/site-navigation.html
+++ b/scripts/templates/site-navigation.html
@@ -6,7 +6,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="{{prefix}}about.html">About us</a>
-    <a href="{{prefix}}about.html#blog">Blog</a>
     <a href="{{prefix}}earn.html">Find bounties</a>
     <a class="ab-site-login" href="{{root}}#login"{{login_attributes}}>Login</a>
   </nav>

--- a/scripts/test-phone-wallet.js
+++ b/scripts/test-phone-wallet.js
@@ -50,6 +50,7 @@ test("discovery and status load no relay or wallet, and advertise an EIP-6963 pr
   env.win.dispatchEvent({ type: "eip6963:requestProvider" });
   assert.equal(announced.provider, env.api.provider); assert.equal(announced.info.name, "Phone wallet (QR)");
   assert.equal(env.api.state().connected, false); assert.equal(env.loads(), 0);
+  assert.equal(env.win.document.body.children.length, 0, "No standalone phone-wallet button");
 });
 test("QR creation is preparation and returns no pairing secrets", async () => {
   const env = fixture(); const opened = await env.api.openReview(); await flush();

--- a/scripts/test-posting-layout.cjs
+++ b/scripts/test-posting-layout.cjs
@@ -166,12 +166,15 @@ async function main() {
       await hitTarget(page, "[data-close-funding]");
       await hitTarget(page, "[data-fund-now]");
       await page.locator("[data-close-funding]").click();
-      await page.locator(".ab-phone-launcher").click();
+      assert.equal(await page.locator(".ab-phone-launcher").count(), 0);
+      await page.locator("[data-open-funding]").click();
+      await page.getByRole("button", { name: "Phone wallet (QR)", exact: false }).click();
       await page.locator(".ab-phone-qr").waitFor({ state: "visible" });
       await modalBounds(page, ".ab-phone-dialog");
       await wheelToEnd(page, ".ab-phone-dialog");
       await hitTarget(page, ".ab-phone-close");
       await page.locator(".ab-phone-close").click();
+      await page.locator("[data-close-funding]").click();
       await page.keyboard.press("Tab");
       await page.locator("[data-revise-card]").click();
       assert.equal(await page.locator("#bounty-composer-input").inputValue(), fixture.goal);

--- a/scripts/test-site-navigation.cjs
+++ b/scripts/test-site-navigation.cjs
@@ -65,7 +65,7 @@ async function main() {
         assert.equal(await page.locator("[data-site-header]").count(), 1, file);
         assert.equal(await page.locator("nav[aria-label='Primary navigation']").count(), 1, file);
         const links = await page.locator(".ab-site-nav a").evaluateAll(els => els.map(el => ({ text: el.textContent.trim(), href: new URL(el.href).pathname + new URL(el.href).hash })));
-        assert.deepEqual(links, [{ text: "About us", href: "/about.html" }, { text: "Blog", href: "/about.html#blog" }, { text: "Find bounties", href: "/earn.html" }, { text: "Login", href: "/#login" }], file);
+        assert.deepEqual(links, [{ text: "About us", href: "/about.html" }, { text: "Find bounties", href: "/earn.html" }, { text: "Login", href: "/#login" }], file);
         const appearance = await page.locator("[data-site-header]").evaluate(el => {
           const css = getComputedStyle(el), brand = getComputedStyle(el.querySelector("strong"));
           return { height: el.getBoundingClientRect().height, background: css.backgroundImage, padding: css.padding, brand: brand.font, color: brand.color };
@@ -75,12 +75,12 @@ async function main() {
         if (width < 701) {
           await assertFits(page, ".ab-site-menu");
           await page.locator(".ab-site-menu").click();
-          for (const n of [1, 2, 3, 4]) await assertFits(page, `.ab-site-nav a:nth-child(${n})`);
+          for (const n of [1, 2, 3]) await assertFits(page, `.ab-site-nav a:nth-child(${n})`);
           await page.keyboard.press("Escape");
           assert.equal(await page.locator(".ab-site-menu").getAttribute("aria-expanded"), "false");
           assert.equal(await page.locator(".ab-site-menu").evaluate(el => el === document.activeElement), true);
         } else {
-          for (const n of [1, 2, 3, 4]) await assertFits(page, `.ab-site-nav a:nth-child(${n})`);
+          for (const n of [1, 2, 3]) await assertFits(page, `.ab-site-nav a:nth-child(${n})`);
         }
       }
       console.log(`Shared homepage header and accessible links passed on ${pages.length} pages at ${width}px`);
@@ -98,7 +98,7 @@ async function main() {
     const fallback = await nojs.newPage();
     for (const file of ["index.html", "about.html", "blog/index.html", "metrics.html", "install/chatgpt-dev/index.html"]) {
       await fallback.goto(`${origin}/${file}`);
-      for (const n of [1, 2, 3, 4]) await assertFits(fallback, `.ab-site-nav a:nth-child(${n})`);
+      for (const n of [1, 2, 3]) await assertFits(fallback, `.ab-site-nav a:nth-child(${n})`);
     }
     await nojs.close();
     for (const [width, height] of [[1440,900],[946,838],[640,480],[390,600],[320,480],[768,320],[480,360]]) {

--- a/scripts/test-wallet-link.js
+++ b/scripts/test-wallet-link.js
@@ -31,6 +31,21 @@ function harness(configured = true) {
 }
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
+test("phone pairing is one contextual choice even when announced and injected", async () => {
+  const h = harness();
+  const phone = { request() { throw new Error("selection must not request a signature"); } };
+  h.win.AgentBountiesPhoneWallet = { provider: phone, state: () => ({ available: true }) };
+  h.win.ethereum.providers = [h.win.ethereum, phone];
+  const event = new Event("eip6963:announceProvider");
+  event.detail = { provider: phone, info: { name: "Phone wallet (QR)" } };
+  h.win.dispatchEvent(event);
+  assert.equal(h.chooser.choices().filter(item => item.provider === phone).length, 1);
+  const selected = h.chooser.select();
+  h.dialog().querySelector("[data-wallet-choices]").children[1].click();
+  assert.equal((await selected).provider, phone);
+  assert.deepEqual(h.calls, []);
+});
+
 test("discovery and opening never wake MetaMask, even as the only wallet", async () => {
   const h = harness();
   assert.equal(h.chooser.choices()[0].label, "MetaMask");

--- a/scripts/test_local_auth_server.py
+++ b/scripts/test_local_auth_server.py
@@ -314,6 +314,8 @@ class LocalAuthTests(unittest.TestCase):
                 session_body = session_response.read().decode("utf-8")
                 self.assertEqual(session_response.status, 200)
                 self.assertIn('"authenticated":true', session_body)
+                self.assertEqual(json.loads(session_body)["account_status"], "wallet_required")
+                self.assertFalse(json.loads(session_body)["account_complete"])
                 self.assertIn('"provider":"google"', session_body)
                 self.assertNotIn("provider-token", session_body)
 
@@ -323,6 +325,7 @@ class LocalAuthTests(unittest.TestCase):
                 self.assertEqual(account_response.status, 200)
                 self.assertEqual(account_payload["data_status"], "unavailable")
                 self.assertEqual(account_payload["reason"], "marketplace_identity_unlinked")
+                self.assertFalse(account_payload["account_complete"])
                 self.assertIsNone(account_payload["stats"]["earned_usdc"])
                 self.assertNotIn("email", account_payload)
                 self.assertNotIn("sub", account_payload)
@@ -371,8 +374,23 @@ class LocalAuthTests(unittest.TestCase):
                 verify_payload = json.loads(verify_response.read().decode("utf-8"))
                 self.assertEqual(verify_response.status, 200)
                 self.assertTrue(verify_payload["linked"])
+                self.assertTrue(verify_payload["account_complete"])
+                self.assertEqual(verify_payload["account_status"], "ready")
                 self.assertEqual(verify_payload["wallets"][0]["address"], wallet_address)
                 self.assertEqual(server.wallet_store.wallets_for(profile)[0]["address"], wallet_address)
+
+                connection.request("GET", "/auth/session", headers={"Cookie": session_cookie})
+                ready_session = json.loads(connection.getresponse().read())
+                self.assertTrue(ready_session["account_complete"])
+                connection.request("POST", "/auth/wallet/unlink", body=challenge_body, headers={
+                    "Content-Type": "application/json", "Cookie": session_cookie, "Origin": origin,
+                })
+                removed = json.loads(connection.getresponse().read())
+                self.assertTrue(removed["unlinked"])
+                self.assertFalse(removed["account_complete"])
+                self.assertEqual(removed["account_status"], "wallet_required")
+                connection.request("GET", "/auth/session", headers={"Cookie": session_cookie})
+                self.assertFalse(json.loads(connection.getresponse().read())["account_complete"])
 
                 connection.request("GET", f"/auth/callback/google?state={state}&code=replayed-code")
                 replay_response = connection.getresponse()

--- a/site/about.html
+++ b/site/about.html
@@ -53,7 +53,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/authorize.html
+++ b/site/authorize.html
@@ -22,7 +22,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/blog/agentic-economy-needs-a-market-for-work.html
+++ b/site/blog/agentic-economy-needs-a-market-for-work.html
@@ -33,7 +33,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../about.html">About us</a>
-    <a href="../about.html#blog">Blog</a>
     <a href="../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../#login">Login</a>
   </nav>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -34,7 +34,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../about.html">About us</a>
-    <a href="../about.html#blog">Blog</a>
     <a href="../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../#login">Login</a>
   </nav>

--- a/site/bug-fix.html
+++ b/site/bug-fix.html
@@ -27,7 +27,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/cancel.html
+++ b/site/cancel.html
@@ -22,7 +22,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/competition.html
+++ b/site/competition.html
@@ -9,7 +9,7 @@
     <meta name="description" content="Contract-specific Open Competition participation instructions, timing, economics, risks, and machine actions.">
     <link rel="canonical" href="https://agentbounties.app/competition.html">
     <link rel="stylesheet" href="marketplace.css?v=2">
-    <link rel="stylesheet" href="phone-wallet.css?v=1">
+    <link rel="stylesheet" href="phone-wallet.css?v=2">
     <link rel="stylesheet" href="site-navigation.css?v=1">
     <script src="site-navigation.js?v=1" defer></script>
   </head>
@@ -24,7 +24,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>
@@ -158,7 +157,7 @@
       <nav aria-label="Footer navigation"><a href="earn.html">Marketplace</a><a href="metrics.html">Metrics</a><a href="privacy.html">Privacy</a><a href="https://github.com/NSPG13/agent-bounties">Source</a></nav>
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=4"></script>
+    <script src="phone-wallet.js?v=5"></script>
     <script src="marketplace-workflow.js?v=3"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>

--- a/site/earn-money-using-ai.html
+++ b/site/earn-money-using-ai.html
@@ -67,7 +67,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/earn.html
+++ b/site/earn.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="https://agentbounties.app/earn.html">
     <link rel="alternate" type="application/json" href="https://api.agentbounties.app/v1/opportunities?network=base-mainnet&amp;view=ready_to_earn&amp;source_type=canonical_base&amp;limit=300">
     <link rel="stylesheet" href="marketplace.css?v=2">
-    <link rel="stylesheet" href="phone-wallet.css?v=1">
+    <link rel="stylesheet" href="phone-wallet.css?v=2">
     <link rel="stylesheet" href="marketplace-theme.css?v=1">
     <link rel="stylesheet" href="site-navigation.css?v=1">
     <script src="site-navigation.js?v=1" defer></script>
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>
@@ -74,7 +73,7 @@
       <nav aria-label="Footer navigation"><a href="./">Home</a><a href="metrics.html">Metrics</a><a href="privacy.html">Privacy</a><a href="https://github.com/NSPG13/agent-bounties">Source</a></nav>
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=4"></script>
+    <script src="phone-wallet.js?v=5"></script>
     <script src="marketplace-workflow.js?v=3"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>

--- a/site/funded.html
+++ b/site/funded.html
@@ -24,7 +24,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/how-to-earn-money-with-my-ai-agent.html
+++ b/site/how-to-earn-money-with-my-ai-agent.html
@@ -55,7 +55,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/index.html
+++ b/site/index.html
@@ -37,8 +37,8 @@
         ]
       }
     </script>
-    <link rel="stylesheet" href="solarpunk.css?v=15">
-    <link rel="stylesheet" href="phone-wallet.css?v=1">
+    <link rel="stylesheet" href="solarpunk.css?v=16">
+    <link rel="stylesheet" href="phone-wallet.css?v=2">
     <link rel="stylesheet" href="wallet-link.css?v=1">
     <link rel="stylesheet" href="wallet-adapters.css?v=3">
     <link rel="stylesheet" href="site-navigation.css?v=1">
@@ -85,7 +85,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login" data-auth-open aria-haspopup="dialog" aria-controls="auth-dialog" aria-expanded="false">Login</a>
   </nav>
@@ -161,8 +160,13 @@
       <header class="auth-heading">
         <p>Agent Bounties access</p>
         <h2 id="auth-title">Sign in</h2>
-        <span id="auth-description">Sign in to manage bounties, evidence, and collaboration.</span>
+        <span id="auth-description">Sign in, then link a wallet to finish creating your account.</span>
       </header>
+
+      <ol class="account-setup-steps" data-account-setup-steps aria-label="Account setup">
+        <li data-setup-signin aria-current="step"><span>1</span> Sign in</li>
+        <li data-setup-wallet><span>2</span> Link a wallet</li>
+      </ol>
 
       <section class="account-dashboard" data-account-dashboard data-auth-session hidden tabindex="-1" aria-label="Account activity">
         <div class="account-identity">
@@ -182,7 +186,7 @@
           <header>
             <div>
               <h3 id="linked-wallets-title">Linked wallets</h3>
-              <p>Verify an EVM address to connect its Base activity to this account.</p>
+              <p>Use a phone wallet, a browser wallet, or create one here.</p>
             </div>
             <button type="button" data-wallet-link>Link wallet</button>
           </header>
@@ -192,6 +196,9 @@
           <p class="wallet-proof-note">Ownership proof only—this signature cannot move funds, approve tokens, or post a bounty.</p>
           <p class="wallet-status" data-wallet-status aria-live="polite"></p>
         </section>
+
+        <p class="account-setup-note" data-account-setup-note aria-live="polite">Checking your account setup…</p>
+        <button class="account-setup-retry" type="button" data-account-setup-retry hidden>Check again</button>
 
         <dl class="account-stats" data-account-stats aria-busy="true">
           <div>
@@ -285,7 +292,7 @@
           </button>
         </div>
 
-        <p class="auth-switch">New to Agent Bounties? <button type="button" data-auth-unavailable>Create an account</button></p>
+        <p class="auth-switch">New to Agent Bounties? <button type="button" data-auth-create>Create an account</button></p>
         <p class="auth-legal">By continuing, you agree to the <a href="terms.html">Terms</a> and acknowledge the <a href="privacy.html">Privacy Policy</a>.</p>
       </form>
       <p class="auth-status" data-auth-status aria-live="polite"></p>
@@ -363,13 +370,13 @@
 
     <noscript><p class="noscript-note">JavaScript is required for the living scene and live marketplace metrics.</p></noscript>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=4"></script>
+    <script src="phone-wallet.js?v=5"></script>
     <script src="wallet-config.js?v=1"></script>
-    <script src="wallet-link.js?v=2"></script>
+    <script src="wallet-link.js?v=3"></script>
     <script src="marketplace-workflow.js?v=3"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=5"></script>
     <script src="posting-prompt.js?v=3"></script>
-    <script src="solarpunk-home.js?v=16"></script>
+    <script src="solarpunk-home.js?v=17"></script>
   </body>
 </html>

--- a/site/install/bankr/index.html
+++ b/site/install/bankr/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/chatgpt-dev/index.html
+++ b/site/install/chatgpt-dev/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/claude-custom/index.html
+++ b/site/install/claude-custom/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/cline/index.html
+++ b/site/install/cline/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/cursor/index.html
+++ b/site/install/cursor/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/github/index.html
+++ b/site/install/github/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/glama/index.html
+++ b/site/install/glama/index.html
@@ -27,7 +27,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/index.html
+++ b/site/install/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../about.html">About us</a>
-    <a href="../about.html#blog">Blog</a>
     <a href="../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../#login">Login</a>
   </nav>

--- a/site/install/linear/index.html
+++ b/site/install/linear/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/mcp-so/index.html
+++ b/site/install/mcp-so/index.html
@@ -27,7 +27,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/mcpmarket/index.html
+++ b/site/install/mcpmarket/index.html
@@ -27,7 +27,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/mcpservers/index.html
+++ b/site/install/mcpservers/index.html
@@ -27,7 +27,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/openclaw/index.html
+++ b/site/install/openclaw/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/install/vscode/index.html
+++ b/site/install/vscode/index.html
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="../../about.html">About us</a>
-    <a href="../../about.html#blog">Blog</a>
     <a href="../../earn.html">Find bounties</a>
     <a class="ab-site-login" href="../../#login">Login</a>
   </nav>

--- a/site/metrics.html
+++ b/site/metrics.html
@@ -29,7 +29,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/onramp.html
+++ b/site/onramp.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="simple-ux.css?v=1">
     <link rel="stylesheet" href="onramp.css?v=1">
     <link rel="stylesheet" href="wallet-adapters.css?v=1">
-    <link rel="stylesheet" href="phone-wallet.css?v=1">
+    <link rel="stylesheet" href="phone-wallet.css?v=2">
     <link rel="stylesheet" href="site-navigation.css?v=1">
     <script src="site-navigation.js?v=1" defer></script>
   </head>
@@ -30,7 +30,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>
@@ -190,7 +189,7 @@
       <a href="https://github.com/NSPG13/agent-bounties/issues">Support</a>
     </footer>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=4"></script>
+    <script src="phone-wallet.js?v=5"></script>
     <script src="marketplace-workflow.js?v=3"></script>
     <script src="analytics-config.js?v=5"></script>
     <script src="analytics.js?v=4"></script>

--- a/site/participate.html
+++ b/site/participate.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="marketplace-theme.css?v=1">
     <meta name="theme-color" content="#07110c">
     <title>Your bounty workspace | Agent Bounties</title>
-    <link rel="stylesheet" href="phone-wallet.css?v=1">
+    <link rel="stylesheet" href="phone-wallet.css?v=2">
     <link rel="stylesheet" href="site-navigation.css?v=1">
     <script src="site-navigation.js?v=1" defer></script>
   </head>
@@ -26,7 +26,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>
@@ -84,7 +83,7 @@
       </div>
     </main>
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=4"></script>
+    <script src="phone-wallet.js?v=5"></script>
     <script src="marketplace-workflow.js?v=3"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=4"></script>

--- a/site/phone-wallet.css
+++ b/site/phone-wallet.css
@@ -1,14 +1,12 @@
-.ab-phone-launcher { position: fixed; right: 1rem; bottom: 1rem; z-index: 45; padding: .75rem 1rem; border: 1px solid #174d43; border-radius: 999px; background: #f5fff7; color: #123c33; box-shadow: 0 2px 12px #123c3326; font: 600 .9rem/1.3 system-ui, sans-serif; cursor: pointer; }
 .ab-phone-dialog { box-sizing: border-box; width: min(94vw, 440px); max-height: 90dvh; overflow: auto; padding: 1.5rem; border: 1px solid #b8d2c6; border-radius: 20px; background: #fcfff9; color: #16382f; font: 1rem/1.5 system-ui, sans-serif; box-shadow: 0 20px 70px #092d3659; }
 .ab-phone-dialog::backdrop { background: #09292299; }
 .ab-phone-dialog h2 { margin: 0 2rem .5rem 0; font: 700 1.45rem/1.25 system-ui, sans-serif; color: inherit; }
 .ab-phone-dialog p { color: inherit; margin: .75rem 0; }
 .ab-phone-dialog button { padding: .65rem 1rem; border: 1px solid #729688; border-radius: 9px; background: #edf8ee; color: #16382f; font: 600 .95rem/1.4 system-ui, sans-serif; cursor: pointer; }
-.ab-phone-dialog button:focus-visible, .ab-phone-launcher:focus-visible { outline: 3px solid #a85613; outline-offset: 3px; }
+.ab-phone-dialog button:focus-visible { outline: 3px solid #a85613; outline-offset: 3px; }
 .ab-phone-dialog button:disabled { opacity: .6; cursor: wait; }
 .ab-phone-close { float: right; }
 .ab-phone-qr { display: block; width: min(100%, 290px); height: auto; margin: 1rem auto; border: 10px solid white; border-radius: 8px; box-sizing: border-box; }
 .ab-phone-qr[hidden], .ab-phone-dialog [hidden] { display: none; }
 .ab-phone-actions { display: flex; gap: .6rem; flex-wrap: wrap; margin-top: 1rem; }
 .ab-phone-note { font-size: .85rem; }
-@media (max-width: 500px) { .ab-phone-launcher { bottom: .6rem; right: .6rem; max-width: calc(100vw - 1.2rem); } }

--- a/site/phone-wallet.js
+++ b/site/phone-wallet.js
@@ -12,7 +12,7 @@
   const listeners = new Map();
   const doc = win.document;
   let sdk, sdkPromise, vendorPromise, attempt, generation = 0, activePrefix, accounts = [], chain = CHAIN;
-  let phase = "disconnected", message = "Scan with your phone wallet. Approve the connection on your phone.", dialog, qr, statusNode, retry, disconnectButton, launcher;
+  let phase = "disconnected", message = "Scan with your phone wallet. Approve the connection on your phone.", dialog, qr, statusNode, retry, disconnectButton;
   const projectId = String(win.agentBountiesPhoneWalletConfig?.projectId || "");
   const configured = PROJECT.test(projectId);
   function error(code, message) { return Object.assign(new Error(message), { code }); }
@@ -57,7 +57,6 @@
   function render() {
     const snapshot = state();
     if (statusNode) statusNode.textContent = message;
-    if (launcher) launcher.textContent = phase === "connected" ? `Phone wallet ${accounts[0].slice(0, 6)}…${accounts[0].slice(-4)}` : "Connect phone wallet";
     if (retry) { retry.hidden = !configured || phase === "connected"; retry.disabled = Boolean(attempt); retry.textContent = phase === "pairing" || phase === "connecting" ? "Waiting for your phone…" : "Show a new QR code"; }
     if (disconnectButton) disconnectButton.hidden = !accounts.length;
     win.dispatchEvent(new win.CustomEvent("agent-bounties:phone-wallet-state", { detail: snapshot }));
@@ -226,10 +225,9 @@
     info: Object.freeze({ uuid: "c1ae1723-39a9-4b06-843c-c4c3ad0967a6", name: "Phone wallet (QR)", rdns: "app.agentbounties.phone", icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 40'><rect x='10' y='3' width='20' height='34' rx='4' fill='%23174d43'/><path d='M16 31h8' stroke='white' stroke-width='2'/></svg>" }), provider,
   }) })); };
   win.addEventListener("eip6963:requestProvider", announce); announce();
-  if (doc?.body) {
-    launcher = doc.createElement("button"); launcher.type = "button"; launcher.className = "ab-phone-launcher"; launcher.hidden = !configured;
-    launcher.addEventListener("click", () => { void openReview(); }); doc.body.append(launcher); render();
-  }
+  // Pairing is opened by the contextual wallet chooser or a WebMCP review.
+  // Publishing discovery/state must never create a competing floating action.
+  render();
   win.addEventListener("pagehide", () => { cancel(); clearQr(); });
   return Object.freeze({ provider, state, openReview, restore, disconnect });
 });

--- a/site/post-a-bounty-with-chatgpt-claude-gemini.html
+++ b/site/post-a-bounty-with-chatgpt-claude-gemini.html
@@ -67,7 +67,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/post.html
+++ b/site/post.html
@@ -17,8 +17,8 @@
     <link rel="stylesheet" href="bounty-composer.css?v=1">
     <link rel="stylesheet" href="bounty-composer-v2.css?v=2">
     <link rel="stylesheet" href="ai-bounty-handoff.css?v=2">
-    <link rel="stylesheet" href="phone-wallet.css?v=1">
-    <link rel="stylesheet" href="posting-workspace.css?v=2">
+    <link rel="stylesheet" href="phone-wallet.css?v=2">
+    <link rel="stylesheet" href="posting-workspace.css?v=3">
     <link rel="stylesheet" href="marketplace-theme.css?v=1">
     <link rel="stylesheet" href="site-navigation.css?v=1">
     <script src="site-navigation.js?v=1" defer></script>
@@ -33,7 +33,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>
@@ -265,7 +264,7 @@
     </main>
 
     <script src="phone-wallet-config.js?v=1"></script>
-    <script src="phone-wallet.js?v=4"></script>
+    <script src="phone-wallet.js?v=5"></script>
     <script src="marketplace-workflow.js?v=3"></script>
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=5"></script>
@@ -277,6 +276,6 @@
     <script src="creator-review.js?v=1"></script>
     <script src="ai-bounty-handoff.js?v=10"></script>
     <script src="bounty-composer-v2.js?v=15"></script>
-    <script src="posting-workspace.js?v=2"></script>
+    <script src="posting-workspace.js?v=3"></script>
   </body>
 </html>

--- a/site/posting-workspace.css
+++ b/site/posting-workspace.css
@@ -20,7 +20,6 @@ html:has(.posting-page)::-webkit-scrollbar-thumb, .posting-page dialog::-webkit-
 .posting-page .chat-app-title { margin: 0 auto 0 12px; font-size: 14px; font-weight: 500; color: #b4c1b8; }
 .posting-page .chat-app-close { display: grid; place-items: center; width: 44px; height: 44px; color: #b4c1b8; text-decoration: none; font-size: 24px; }
 .posting-wallet { min-width: 0; }
-.posting-page .ab-phone-launcher { position: static; max-width: 100%; min-height: 44px; padding: 8px 12px; border: 1px solid #425348; border-radius: 8px; box-shadow: none; background: transparent; color: #dce6df; font: 500 13px/1.4 system-ui, sans-serif; overflow-wrap: anywhere; }
 .posting-workspace { display: block; width: 100%; max-width: 880px; margin: auto; padding: 36px 24px calc(var(--posting-actions-height, 88px) + 48px); }
 .posting-workspace .conversation-panel, .posting-workspace .conversation-log { display: block; overflow: visible; height: auto; padding: 0; }
 .posting-workspace .chat-composer-form { position: static; border: 0; background: none; padding: 0; margin: 0 0 32px; }
@@ -119,7 +118,6 @@ html:has(.posting-page)::-webkit-scrollbar-thumb, .posting-page dialog::-webkit-
   .posting-page .chat-app-title { margin-left: auto; }
   .posting-wallet { order: 4; flex-basis: 100%; }
   .posting-wallet:empty, .posting-wallet:has([hidden]) { display: none; }
-  .posting-page .ab-phone-launcher { width: 100%; }
   .posting-workspace { padding: 24px 16px calc(var(--posting-actions-height, 88px) + 32px); }
   .brief-fields { grid-template-columns: minmax(0, 1fr); }
   .posting-workspace .bounty-card-stats { grid-template-columns: 1fr 1fr; }

--- a/site/posting-workspace.js
+++ b/site/posting-workspace.js
@@ -10,9 +10,6 @@
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   document.querySelector("[data-brief-timezone]").textContent = timezone;
   let restoring = false;
-  // Keep the wallet utility in the header, clear of proposal actions.
-  const launcher = document.querySelector(".ab-phone-launcher");
-  if (launcher) document.querySelector("[data-posting-wallet]").append(launcher);
   const actions = document.querySelector(".bounty-card-actions");
   if (actions) {
     const measureActions = () => document.documentElement.style.setProperty("--posting-actions-height", `${Math.ceil(actions.getBoundingClientRect().height)}px`);

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -22,7 +22,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -703,6 +703,10 @@ ${competitionChildBrief(item)}`;
       const walletLinkButton = dialog.querySelector("[data-wallet-link]");
       const walletList = dialog.querySelector("[data-wallet-list]");
       const walletStatus = dialog.querySelector("[data-wallet-status]");
+      const setupSteps = dialog.querySelector("[data-account-setup-steps]");
+      const setupNote = dialog.querySelector("[data-account-setup-note]");
+      const setupRetry = dialog.querySelector("[data-account-setup-retry]");
+      const accountActivity = dialog.querySelector(".account-activity");
       const heading = dialog.querySelector("#auth-title");
       const description = dialog.querySelector("#auth-description");
       const email = form?.elements.email;
@@ -716,6 +720,7 @@ ${competitionChildBrief(item)}`;
       let accountLoadId = 0;
       let verifiedWallets = [];
       let embeddedAddress = null;
+      let accountStatus = "checking";
 
       const setStatus = (message) => {
         if (status) status.textContent = message;
@@ -729,6 +734,34 @@ ${competitionChildBrief(item)}`;
       };
       const closeDialog = () => {
         if (dialog.open) dialog.close();
+      };
+
+      const renderSetup = (state) => {
+        accountStatus = state;
+        const ready = Boolean(currentUser && state === "ready");
+        dialog.dataset.view = currentUser ? ready ? "account" : "setup" : "login";
+        dialog.dataset.accountStatus = currentUser ? state : "signed_out";
+        if (heading) heading.textContent = currentUser ? ready ? "Your activity" : "Finish your account" : "Sign in";
+        if (description) description.textContent = currentUser
+          ? ready ? "Your bounties and payments, all in one place."
+            : "Link a wallet to finish setup. You can use one you have or create one here."
+          : "Sign in, then link a wallet to finish creating your account.";
+        openButton.textContent = currentUser ? ready ? "Account" : "Finish setup" : "Login";
+        if (setupSteps) {
+          setupSteps.hidden = ready;
+          setupSteps.querySelector("[data-setup-signin]")?.toggleAttribute("data-complete", Boolean(currentUser));
+          setupSteps.querySelector("[data-setup-signin]")?.setAttribute("aria-current", currentUser ? "false" : "step");
+          setupSteps.querySelector("[data-setup-wallet]")?.setAttribute("aria-current", currentUser ? "step" : "false");
+        }
+        [accountStats, accountActivity, accountEvidence].forEach(node => { if (node) node.hidden = !ready; });
+        if (setupNote) {
+          setupNote.hidden = ready;
+          setupNote.textContent = state === "checking" ? "Checking your account setup…"
+            : state === "unavailable" ? "We couldn’t check your linked wallets. Your setup is saved. Check again to continue."
+              : "Your account is not ready yet. Confirm wallet ownership to finish. No payment or deposit is needed.";
+        }
+        if (setupRetry) setupRetry.hidden = state !== "unavailable";
+        if (walletLinkButton) walletLinkButton.hidden = state === "checking" || state === "unavailable";
       };
 
       const replaceActivityList = (list, items, emptyMessage) => {
@@ -817,6 +850,8 @@ ${competitionChildBrief(item)}`;
       const renderAccountDashboard = (payload) => {
         const view = accountDashboardView(payload);
         renderWallets(view.wallets);
+        renderSetup(payload?.account_status === "ready" && payload.account_complete === true && view.wallets.length
+          ? "ready" : payload?.account_status === "wallet_required" && !view.wallets.length ? "wallet_required" : "unavailable");
         if (accountStats) accountStats.setAttribute("aria-busy", "false");
         if (accountParticipating) accountParticipating.textContent = view.participating;
         if (accountCompletedPosts) accountCompletedPosts.textContent = view.completedPosts;
@@ -874,16 +909,9 @@ ${competitionChildBrief(item)}`;
           embeddedAddress = null;
         }
         currentUser = user;
-        dialog.dataset.view = user ? "account" : "login";
         if (form) form.hidden = Boolean(user);
         if (accountDashboard) accountDashboard.hidden = !user;
-        if (heading) heading.textContent = user ? "Your activity" : "Sign in";
-        if (description) {
-          description.textContent = user
-            ? "Your bounties, confirmed money flow, and platform standing in one private view."
-            : "Sign in to manage bounties, evidence, and collaboration.";
-        }
-        openButton.textContent = user ? "Account" : "Login";
+        renderSetup("checking");
         openButton.title = user?.name ? `Signed in as ${user.name}` : "Sign in";
         if (!user) {
           accountLoadId += 1;
@@ -953,10 +981,16 @@ ${competitionChildBrief(item)}`;
           }
           return payload;
         } catch (error) {
-          if (requestId === accountLoadId && currentUser) renderAccountDashboard({ wallets: verifiedWallets });
+          if (requestId === accountLoadId && currentUser) renderAccountDashboard({
+            wallets: verifiedWallets,
+            account_status: ["ready", "wallet_required"].includes(accountStatus) ? accountStatus : "unavailable",
+            account_complete: verifiedWallets.length > 0 && accountStatus === "ready",
+          });
           return null;
         }
       };
+
+      setupRetry?.addEventListener("click", () => loadAccount());
 
       const loadSession = async () => {
         try {
@@ -1045,10 +1079,10 @@ ${competitionChildBrief(item)}`;
             renderWallets(verifiedWallets);
             showDialog();
             setWalletStatus("Your wallet is ready. Confirm ownership to finish linking it to your account.");
-            if (verifiedWallets.some((wallet) => wallet.address === address)) {
-              setWalletStatus(`${shortWalletAddress(address)} is already verified and linked. Your wallet is ready.`);
-              return;
-            }
+          }
+          if (verifiedWallets.some((wallet) => wallet.address === address)) {
+            setWalletStatus(`${shortWalletAddress(address)} is already verified and linked. Your wallet is ready.`);
+            return;
           }
           const challenge = await postAccountJson("/wallet/challenge", { address });
           if (currentUser !== linkingUser) throw { code: 4001 };
@@ -1058,19 +1092,27 @@ ${competitionChildBrief(item)}`;
             params: [utf8Hex(challenge.message), address],
           });
           if (currentUser !== linkingUser) throw { code: 4001 };
-          await postAccountJson("/wallet/verify", {
+          const verification = await postAccountJson("/wallet/verify", {
             challenge_id: challenge.challenge_id,
             address,
             signature,
           });
           if (currentUser !== linkingUser) throw { code: 4001 };
+          const linkedWallets = accountDashboardView(verification).wallets;
+          if (verification.linked !== true || verification.account_complete !== true
+            || verification.account_status !== "ready" || !linkedWallets.some(wallet => wallet.address === address)) {
+            throw { reason: "wallet_link_store_unavailable" };
+          }
           // The successful verify response is authoritative even if activity refresh fails.
-          verifiedWallets = [...verifiedWallets.filter((wallet) => wallet.address !== address), { address, label: shortWalletAddress(address) }];
+          verifiedWallets = linkedWallets;
           renderWallets(verifiedWallets);
+          renderSetup("ready");
           await loadAccount();
           if (currentUser !== linkingUser) return;
           showDialog();
-          setWalletStatus(`${shortWalletAddress(address)} is verified and linked.`);
+          setWalletStatus(accountStatus === "ready" && verifiedWallets.some(wallet => wallet.address === address)
+            ? `${shortWalletAddress(address)} is verified and linked. Your account is ready.`
+            : "Wallet ownership was confirmed. Recheck your account setup to continue.");
           win.agentBountiesAnalytics?.track("wallet_link_confirmed");
         } catch (error) {
           if (currentUser === linkingUser) setWalletStatus(embeddedAddress && !verifiedWallets.some((wallet) => wallet.address === embeddedAddress)
@@ -1092,7 +1134,9 @@ ${competitionChildBrief(item)}`;
         if (button.dataset.confirming !== "true") {
           button.dataset.confirming = "true";
           button.textContent = "Remove?";
-          setWalletStatus("Select Remove? again to unlink this address. No onchain action will occur.");
+          setWalletStatus(verifiedWallets.length === 1
+            ? "Removing your last wallet returns your account to setup. Select Remove? to confirm."
+            : "Select Remove? again to unlink this address. No onchain action will occur.");
           win.setTimeout(() => {
             if (!button.isConnected) return;
             button.dataset.confirming = "false";
@@ -1101,13 +1145,19 @@ ${competitionChildBrief(item)}`;
           return;
         }
         button.disabled = true;
+        const unlinkingUser = currentUser;
         try {
-          await postAccountJson("/wallet/unlink", { address: button.dataset.walletUnlink });
+          const result = await postAccountJson("/wallet/unlink", { address: button.dataset.walletUnlink });
+          if (currentUser !== unlinkingUser) return;
+          if (result.unlinked !== true) throw { reason: "wallet_link_store_unavailable" };
+          renderAccountDashboard(result);
           if (embeddedAddress === button.dataset.walletUnlink) embeddedAddress = null;
           await loadAccount();
-          setWalletStatus("Wallet unlinked from this account. No onchain state changed.");
+          if (currentUser === unlinkingUser) setWalletStatus(verifiedWallets.length
+            ? "Wallet removed from this account."
+            : "Wallet removed. Link a wallet to finish your account setup again.");
         } catch (error) {
-          setWalletStatus(walletLinkErrorMessage(error));
+          if (currentUser === unlinkingUser) setWalletStatus(walletLinkErrorMessage(error));
           button.disabled = false;
         }
       });
@@ -1152,6 +1202,11 @@ ${competitionChildBrief(item)}`;
           setStatus("Account recovery and creation will be connected in a later phase.");
         });
       });
+      dialog.querySelector("[data-auth-create]")?.addEventListener("click", () => {
+        if (heading) heading.textContent = "Create your account";
+        setStatus("Choose a sign-in provider above. Next, link or create a wallet to finish your account.");
+        providerButtons.find(button => button.getAttribute("aria-disabled") !== "true")?.focus();
+      });
 
       renderProviderAvailability();
       // Interior pages use the same real login entry point, without duplicating auth.
@@ -1163,7 +1218,9 @@ ${competitionChildBrief(item)}`;
       loadSession().then(() => {
         if (currentUser && win.AgentBountiesWalletLink?.hasPending(currentUser.id)) void linkWallet(true);
         if (authResult !== "success" && authResult !== "error") return;
-        setStatus(authResultMessage(authResult, authParams.get("provider"), authParams.get("reason")));
+        setStatus(authResult === "success" && accountStatus !== "ready"
+          ? "You’re signed in. Link a wallet to finish your account."
+          : authResultMessage(authResult, authParams.get("provider"), authParams.get("reason")));
         if (authResult === "success") win.agentBountiesAnalytics?.track("auth_completed");
         showDialog();
         authParams.delete("auth");

--- a/site/solarpunk.css
+++ b/site/solarpunk.css
@@ -1235,6 +1235,16 @@ html[data-scene-ready="false"] .scene-plate {
   margin-top: 26px;
 }
 
+.auth-dialog [hidden] { display: none !important; }
+.account-setup-steps { display: flex; flex-wrap: wrap; gap: 12px 24px; list-style: none; padding: 0; margin: 24px 0 8px; font: 600 14px/1.5 system-ui, sans-serif; color: #a9b9ab; }
+.account-setup-steps li { display: flex; align-items: center; gap: 9px; }
+.account-setup-steps li[aria-current="step"] { color: #d8f29c; }
+.account-setup-steps span { display: grid; place-items: center; width: 30px; height: 30px; border: 1px solid #52654a; border-radius: 50%; }
+.account-setup-steps [data-complete] span { background: #234632; color: #bff199; }
+.account-setup-note { color: #c2d1bd; font: 400 14px/1.6 system-ui, sans-serif; margin: 18px 0 0; }
+.account-setup-retry { padding: 10px 16px; margin-top: 12px; border: 1px solid #718958; border-radius: 10px; background: #193b2c; color: #e6f2d1; min-height: 44px; cursor: pointer; }
+.auth-dialog[data-view="setup"] .account-wallets > header > button { min-height: 44px; background: #c7ed8b; color: #122c1d; font-size: 14px; }
+
 .account-identity {
   display: grid;
   grid-template-columns: 52px minmax(0, 1fr) auto;

--- a/site/success.html
+++ b/site/success.html
@@ -22,7 +22,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/terms.html
+++ b/site/terms.html
@@ -22,7 +22,6 @@
   <button class="ab-site-menu" type="button" aria-expanded="false" aria-controls="site-navigation" hidden>Menu <span aria-hidden="true">☰</span></button>
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
-    <a href="about.html#blog">Blog</a>
     <a href="earn.html">Find bounties</a>
     <a class="ab-site-login" href="./#login">Login</a>
   </nav>

--- a/site/wallet-link.js
+++ b/site/wallet-link.js
@@ -24,7 +24,7 @@
     const injected = Array.isArray(win.ethereum?.providers) && win.ethereum.providers.length
       ? win.ethereum.providers : [win.ethereum];
     for (const provider of injected) {
-      if (!provider || typeof provider.request !== "function" || result.some((item) => item.provider === provider)) continue;
+      if (!provider || provider === phone?.provider || typeof provider.request !== "function" || result.some((item) => item.provider === provider)) continue;
       result.push({ provider, kind: "browser", label: provider.isMetaMask ? "MetaMask" : provider.isCoinbaseWallet ? "Coinbase Wallet" : "Browser wallet" });
     }
     if (phone?.state().available) result.push({ provider: phone.provider, kind: "phone", label: "Use a phone wallet" });

--- a/tools/coinbase-embedded-wallet/test-account-link.mjs
+++ b/tools/coinbase-embedded-wallet/test-account-link.mjs
@@ -44,18 +44,19 @@ after(async () => {
 });
 
 async function openAccount(page) {
-  const accountLink = page.getByRole("link", { name: "Account", exact: true });
+  const accountLink = page.getByRole("link", { name: /^(Account|Finish setup)$/, exact: true });
   const menu = page.getByRole("button", { name: "Menu", exact: false });
   if (await menu.isVisible() && await menu.getAttribute("aria-expanded") !== "true") await menu.click();
   await accountLink.click();
 }
 
-async function account({ installed = true, linked = false, mobile = false, adapter = false, pending = null, failVerify = false, failRefresh = false } = {}) {
+async function account({ installed = true, linked = false, mobile = false, adapter = false, pending = null, failVerify = false, failRefresh = false, phone = false, invalidVerify = false, unavailable = false } = {}) {
   const context = await browser.newContext({ viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
   const page = await context.newPage();
   const proofs = [], errors = [];
   let wallets = linked ? [{ address: ADDRESS }] : [];
   let rejectVerification = failVerify;
+  const network = { unavailable };
   page.on("pageerror", (error) => errors.push(error.message));
   await page.route("https://**/*", (route) => route.fulfill({ json: {} }));
   await page.route("**/auth/**", async (route) => {
@@ -63,8 +64,8 @@ async function account({ installed = true, linked = false, mobile = false, adapt
     let body = {};
     if (pathname.endsWith("/session")) body = { authenticated: true, user: { id: "qa", name: "Test member", provider: "google" }, providers: { google: true } };
     if (pathname.endsWith("/account")) {
-      if (failRefresh && wallets.some(wallet => wallet.address === EMBEDDED)) { await route.fulfill({status:503,json:{}}); return; }
-      body = { wallets, available: false };
+      if (network.unavailable || failRefresh && wallets.some(wallet => wallet.address === EMBEDDED)) { await route.fulfill({status:503,json:{}}); return; }
+      body = { wallets, available: false, account_status: wallets.length ? "ready" : "wallet_required", account_complete: wallets.length > 0 };
     }
     if (pathname.endsWith("/wallet/challenge")) {
       const request = route.request().postDataJSON(); proofs.push(request);
@@ -72,8 +73,13 @@ async function account({ installed = true, linked = false, mobile = false, adapt
     }
     if (pathname.endsWith("/wallet/verify")) {
       const request = route.request().postDataJSON(); proofs.push(request);
+      if (invalidVerify) { await route.fulfill({json:{}}); return; }
       if (rejectVerification) { rejectVerification = false; await route.fulfill({status:503,json:{error:'wallet_link_store_unavailable'}}); return; }
-      wallets = [...wallets, { address: request.address }]; body = { wallets };
+      wallets = [...wallets, { address: request.address }]; body = { wallets, linked: true, account_status: "ready", account_complete: true };
+    }
+    if (pathname.endsWith("/wallet/unlink")) {
+      wallets = wallets.filter(wallet => wallet.address !== route.request().postDataJSON().address);
+      body = { wallets, unlinked: true, account_status: wallets.length ? "ready" : "wallet_required", account_complete: wallets.length > 0 };
     }
     await route.fulfill({ json: body });
   });
@@ -84,6 +90,12 @@ async function account({ installed = true, linked = false, mobile = false, adapt
       return request.method === "eth_requestAccounts" ? [address] : "0x" + "ab".repeat(65);
     } };
   }, { installed, address: ADDRESS });
+  if (phone) await page.route("**/phone-wallet.js?*", route => route.fulfill({contentType:"text/javascript",body:`
+    window.AgentBountiesPhoneWallet = { state: () => ({available:true}), provider: {request: async request => {
+      window.walletTestCalls.push({wallet:'phone', ...request});
+      return request.method === 'eth_requestAccounts' ? ['${EMBEDDED}'] : '0x' + 'cd'.repeat(65);
+    }} };
+  `}));
   if (pending) await page.addInitScript((intent) => {
     if (!sessionStorage.getItem('test-intent-seeded')) {
       sessionStorage.setItem('agentbounties:pending-embedded-account-link',JSON.stringify(intent));
@@ -102,8 +114,90 @@ async function account({ installed = true, linked = false, mobile = false, adapt
   await openAccount(page);
   const link = page.locator("[data-wallet-link]");
   await page.waitForFunction(() => document.querySelector("[data-wallet-list]").textContent !== "Checking verified wallets…");
-  return { context, page, proofs, errors, link };
+  return { context, page, proofs, errors, link, network };
 }
+
+test("pending setup is resumable and never shows activity before wallet proof", async () => {
+  const {context,page,link,proofs} = await account();
+  try {
+    assert.equal(await page.locator('#auth-title').innerText(), 'Finish your account');
+    assert.equal(await page.locator('[data-account-stats]').isVisible(), false);
+    await evidence(page, 'setup-desktop');
+    await page.getByRole('button',{name:'Close account dialog'}).click();
+    await openAccount(page);
+    assert.equal(await page.locator('#auth-title').innerText(), 'Finish your account');
+    await link.click();
+    await page.keyboard.press('Escape');
+    assert.deepEqual(proofs, []);
+    await page.reload();
+    await openAccount(page);
+    assert.equal(await page.locator('#auth-title').innerText(), 'Finish your account');
+    assert.deepEqual(await page.evaluate(()=>window.walletTestCalls), []);
+  } finally { await context.close(); }
+});
+
+for (const linked of [false, true]) test(`phone wallet is available through ${linked ? 'Link another' : 'Link wallet'}`, async () => {
+  const {context,page,link,proofs} = await account({phone:true,installed:false,linked,mobile:true});
+  try {
+    assert.equal(await page.locator('.ab-phone-launcher').count(),0);
+    await link.click();
+    const phone = page.getByRole('button',{name:'Use a phone wallet Scan a QR code with your wallet app.'});
+    assert.equal(await phone.count(),1);
+    assert.deepEqual(await page.evaluate(()=>window.walletTestCalls),[]);
+    await evidence(page,'phone-chooser-mobile');
+    await phone.click();
+    await page.waitForFunction(()=>document.querySelector('[data-wallet-status]').textContent.includes('verified and linked'));
+    assert.equal(await page.locator('[data-auth-dialog]').getAttribute('data-account-status'),'ready');
+    assert.deepEqual((await page.evaluate(()=>window.walletTestCalls)).map(call=>call.method),['eth_requestAccounts','personal_sign']);
+    assert.equal(proofs.length,2);
+  } finally { await context.close(); }
+});
+
+test("an HTTP success without verified ownership never completes setup", async () => {
+  const {context,page,link} = await account({invalidVerify:true});
+  try {
+    await link.click();
+    await page.getByRole('button',{name:'MetaMask Choose an address in this wallet.'}).click();
+    await page.waitForFunction(()=>!document.querySelector('[data-wallet-link]').disabled);
+    assert.equal(await page.locator('[data-auth-dialog]').getAttribute('data-account-status'),'wallet_required');
+    assert.equal(await page.locator('.wallet-verified').count(),0);
+    assert.equal(await page.locator('[data-account-stats]').isVisible(),false);
+  } finally { await context.close(); }
+});
+
+test("wallet storage failure has a retry and cannot be mistaken for missing wallets", async () => {
+  const {context,page,network,link} = await account({unavailable:true,mobile:true});
+  try {
+    assert.equal(await page.locator('[data-auth-dialog]').getAttribute('data-account-status'),'unavailable');
+    assert.equal(await link.isVisible(),false);
+    assert.equal(await page.getByRole('button',{name:'Check again',exact:true}).isVisible(),true);
+    network.unavailable=false;
+    await page.getByRole('button',{name:'Check again',exact:true}).click();
+    await link.waitFor({state:'visible'});
+    assert.equal(await page.locator('[data-auth-dialog]').getAttribute('data-account-status'),'wallet_required');
+    await evidence(page,'setup-mobile');
+  } finally { await context.close(); }
+});
+
+test("removing the final wallet revokes completion even if the activity refresh fails", async () => {
+  const {context,page,network} = await account({linked:true});
+  try {
+    assert.equal(await page.locator('[data-auth-dialog]').getAttribute('data-account-status'),'ready');
+    assert.deepEqual(await page.evaluate(()=>window.walletTestCalls),[]);
+    const remove = page.locator('[data-wallet-unlink]');
+    await remove.click();
+    assert.match(await page.locator('[data-wallet-status]').innerText(),/last wallet returns your account to setup/);
+    network.unavailable=true;
+    await remove.click();
+    await page.waitForFunction(()=>document.querySelector('[data-wallet-status]').textContent.includes('Wallet removed.'));
+    assert.equal(await page.locator('.wallet-verified').count(),0);
+    assert.equal(await page.locator('[data-account-stats]').isVisible(),false);
+    assert.notEqual(await page.locator('[data-auth-dialog]').getAttribute('data-account-status'),'ready');
+    network.unavailable=false;
+    await page.reload(); await openAccount(page);
+    assert.equal(await page.locator('[data-auth-dialog]').getAttribute('data-account-status'),'wallet_required');
+  } finally { await context.close(); }
+});
 
 for (const installed of [true, false]) {
   for (const linked of [true, false]) {
@@ -160,7 +254,8 @@ for (const redirect of [false, true]) {
       await page.getByRole('button',{name:redirect?'Continue with Google':'Complete email verification',exact:true}).click();
       const confirm = page.getByRole('dialog',{name:'Confirm wallet ownership',exact:true});
       await confirm.waitFor();
-      assert.equal(await page.getByRole('dialog',{name:'Your activity',exact:true}).isVisible(),true);
+      assert.equal(await page.getByRole('dialog',{name:'Finish your account',exact:true}).isVisible(),true);
+      assert.equal(await page.locator('[data-account-stats]').isVisible(),false);
       assert.match(await page.locator('[data-wallet-list]').textContent(),/Ready to verify/);
       assert.equal((await page.evaluate(()=>window.walletTestCalls)).some(call=>call.method==='personal_sign'),false);
       assert.equal(proofs.length,1);


### PR DESCRIPTION
Remove the duplicate floating phone-wallet button: phone QR pairing stays inside Link wallet / Link another and the transaction wallet chooser. Remove Blog from the shared primary navigation on all 34 pages while keeping the archive, articles and About blog section.

Account setup now requires sign-in plus a server-verified wallet link. Pending users see a resumable two-step setup screen; existing linked users go straight to their account. The auth API returns explicit completion status from stored verified links, independent of activity-feed availability. An empty success response, wallet pairing or cancelled signature cannot complete setup; removing the final link returns the account to setup. No payment or deposit is required.

Validation: 18 account browser scenarios, wallet selection and phone transport tests, local auth HTTP lifecycle tests including signature verification and final-wallet removal, all 34 headers at desktop/mobile widths, account setup/chooser and posting/QR scrolling at seven viewport sizes, site and public-handoff checks. Rust/API compilation and full repository checks run in CI. Documentation covers the additive completion fields and pending identity sessions.

Release review: identity completion is derived from the existing verified-link store. The flow is provider sign-in -> pending identity session -> user-approved ownership signature -> server verification/store -> ready account. No new custody, credentials, persistent schema or spending authority is introduced; account linking has zero payment authority. Malformed success, unavailable storage, cancelled proof and last-wallet removal are covered. Existing linked accounts are preserved. Deploy the API first, then publish the website; the prior website remains compatible with the additive API fields. Roll back the website first if needed.

The reviewed whole-workspace build fingerprint is refreshed in the three regression workflows because crates/api/src/site_auth.rs changed. It matches a committed Linux-byte export; signing-runtime bytes are unchanged. The unfunded #1262 draft benchmark uses the same refreshed source pin, matching known-good workflow fingerprints and recomputed directory digest; its acceptance behavior and funding gates are preserved. All 39 source-guard/pipeline fixtures and the full known-good/known-bad rehearsal pass. No signer/relay job is dispatched by this PR.

Release evidence: application API tests (including the new completion regression), PostgreSQL checks, Pages and Coinbase browser gates passed on the unchanged application code. The full gate initially stopped at the draft benchmark's old source pin; the corrected rehearsal now passes against Linux checkout bytes. The final full gate runs again on the release revision; production rollout waits for successful main CI.

Closes #1338. Contributor repair paths for #1196, #880, #908 and #910 are in the notice. No signing, funding, publication or settlement authority changes.
