### PR TITLE
Clarify the account guide's internal session routes

### DIFF
--- a/docs/account-setup.md
+++ b/docs/account-setup.md
@@ -6,7 +6,7 @@ The wallet connection is followed by one bounded ownership message. The server v
 
 ## API contract
 
-The website uses `/v1/site-auth/session`, `/v1/site-auth/account`, `/v1/site-auth/wallet/challenge`, `/v1/site-auth/wallet/verify` and `/v1/site-auth/wallet/unlink`. The loopback development server provides equivalent routes below `/auth`.
+The website's internal session, account and wallet-link handlers are defined in [site_auth.rs](../crates/api/src/site_auth.rs). The [loopback development server](../scripts/serve-solarpunk-auth.py) provides equivalent handlers. These browser-session routes are separate from the public marketplace API.
 
 Session, account, successful verification and unlink responses include:
 


### PR DESCRIPTION
The account-setup guide listed internal browser-session endpoints as public API route literals, which the public route contract does not inventory. Link directly to the authoritative production and loopback handlers instead, preserving the completion-field documentation.

This one-line documentation correction unblocks the release from #1339. Application source, wallet behavior and reviewed build fingerprints are unchanged. The prior full gate passed the application tests, source/benchmark rehearsals and database checks before stopping at these five route references. Main CI will revalidate before deployment; the website rollout remains held until the API is ready.
