### PR TITLE
Keep wallet signup working across API rollout versions

### DIFF
--- a/docs/account-setup.md
+++ b/docs/account-setup.md
@@ -21,3 +21,5 @@ Session, account, successful verification and unlink responses include:
 `authenticated` continues to describe the signed-in identity so pending users can request a wallet challenge and finish setup. It is not an account-completion flag. Website clients must use the server's completion fields and verified wallet list before showing a completed account. The session's opaque `user.id` binds resumable setup to the same identity.
 
 An unavailable marketplace activity feed does not revoke a verified link. Account completion and activity availability are separate. Signature and transaction confirmations remain in the user's wallet. These account links grant no authority to spend, fund, publish or settle work.
+
+During a rolling deployment, the website also understands the previous API's explicit verified-identity and wallet-link receipts. New completion fields take precedence when present. A wallet address or empty successful response alone never completes setup.

--- a/scripts/test-solarpunk-home.js
+++ b/scripts/test-solarpunk-home.js
@@ -5,6 +5,19 @@ const test = require("node:test");
 const home = require("../site/solarpunk-home.js");
 const postingPrompt = require("../site/posting-prompt.js");
 
+test("rolling auth deployments still require explicit server wallet proof", () => {
+  const wallets = [{address:"0x" + "11".repeat(20)}];
+  assert.equal(home.accountSetupStatus({identity_link_status:"verified"},wallets),"ready");
+  assert.equal(home.accountSetupStatus({linked:true},wallets),"ready");
+  assert.equal(home.accountSetupStatus({unlinked:true},[]),"wallet_required");
+  assert.equal(home.accountSetupStatus({reason:"marketplace_identity_unlinked"},[]),"wallet_required");
+  assert.equal(home.accountSetupStatus({},wallets),"unavailable");
+  assert.equal(home.accountSetupStatus({linked:true},[]),"unavailable");
+  assert.equal(home.accountSetupStatus({identity_link_status:"verified",account_status:"unavailable",account_complete:false},wallets),"unavailable");
+  assert.equal(home.accountSetupStatus({linked:true,account_complete:false},wallets),"unavailable");
+  assert.equal(home.accountSetupStatus({account_status:"wallet_required",account_complete:true},[]),"unavailable");
+});
+
 test("scene lighting follows the declared local-time bands", () => {
   assert.equal(home.sceneBlend(0).phase, "night");
   assert.equal(home.sceneBlend(330).phase, "dawn");

--- a/site/index.html
+++ b/site/index.html
@@ -377,6 +377,6 @@
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=5"></script>
     <script src="posting-prompt.js?v=3"></script>
-    <script src="solarpunk-home.js?v=17"></script>
+    <script src="solarpunk-home.js?v=18"></script>
   </body>
 </html>

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -248,6 +248,20 @@ ${competitionChildBrief(item)}`;
     return messages[reason] || "The wallet could not be linked. Please try again.";
   }
 
+  function accountSetupStatus(payload, wallets) {
+    const count = wallets.length;
+    // During a rolling release, the prior API still provides authoritative
+    // ownership receipts. Never turn a bare address or an empty 200 into proof.
+    if (payload && (Object.hasOwn(payload, "account_status") || Object.hasOwn(payload, "account_complete"))) {
+      if (payload.account_status === "ready" && payload.account_complete === true && count) return "ready";
+      if (payload.account_status === "wallet_required" && payload.account_complete === false && !count) return "wallet_required";
+      return "unavailable";
+    }
+    if (count && (payload?.identity_link_status === "verified" || payload?.linked === true || payload?.unlinked === true)) return "ready";
+    if (!count && (payload?.unlinked === true || payload?.reason === "marketplace_identity_unlinked")) return "wallet_required";
+    return "unavailable";
+  }
+
   function accountDashboardView(payload) {
     const normalizeWallets = (items) => {
       if (!Array.isArray(items)) return [];
@@ -850,8 +864,7 @@ ${competitionChildBrief(item)}`;
       const renderAccountDashboard = (payload) => {
         const view = accountDashboardView(payload);
         renderWallets(view.wallets);
-        renderSetup(payload?.account_status === "ready" && payload.account_complete === true && view.wallets.length
-          ? "ready" : payload?.account_status === "wallet_required" && !view.wallets.length ? "wallet_required" : "unavailable");
+        renderSetup(accountSetupStatus(payload, view.wallets));
         if (accountStats) accountStats.setAttribute("aria-busy", "false");
         if (accountParticipating) accountParticipating.textContent = view.participating;
         if (accountCompletedPosts) accountCompletedPosts.textContent = view.completedPosts;
@@ -1099,8 +1112,8 @@ ${competitionChildBrief(item)}`;
           });
           if (currentUser !== linkingUser) throw { code: 4001 };
           const linkedWallets = accountDashboardView(verification).wallets;
-          if (verification.linked !== true || verification.account_complete !== true
-            || verification.account_status !== "ready" || !linkedWallets.some(wallet => wallet.address === address)) {
+          if (verification.linked !== true || accountSetupStatus(verification, linkedWallets) !== "ready"
+            || !linkedWallets.some(wallet => wallet.address === address)) {
             throw { reason: "wallet_link_store_unavailable" };
           }
           // The successful verify response is authoritative even if activity refresh fails.
@@ -1443,6 +1456,7 @@ ${competitionChildBrief(item)}`;
   return {
     BOUNTY_POSTING_PROMPT,
     accountDashboardView,
+    accountSetupStatus,
     authApiPath,
     authProviderPath,
     authResultMessage,

--- a/tools/coinbase-embedded-wallet/test-account-link.mjs
+++ b/tools/coinbase-embedded-wallet/test-account-link.mjs
@@ -50,7 +50,7 @@ async function openAccount(page) {
   await accountLink.click();
 }
 
-async function account({ installed = true, linked = false, mobile = false, adapter = false, pending = null, failVerify = false, failRefresh = false, phone = false, invalidVerify = false, unavailable = false } = {}) {
+async function account({ installed = true, linked = false, mobile = false, adapter = false, pending = null, failVerify = false, failRefresh = false, phone = false, invalidVerify = false, unavailable = false, legacy = false } = {}) {
   const context = await browser.newContext({ viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
   const page = await context.newPage();
   const proofs = [], errors = [];
@@ -80,6 +80,13 @@ async function account({ installed = true, linked = false, mobile = false, adapt
     if (pathname.endsWith("/wallet/unlink")) {
       wallets = wallets.filter(wallet => wallet.address !== route.request().postDataJSON().address);
       body = { wallets, unlinked: true, account_status: wallets.length ? "ready" : "wallet_required", account_complete: wallets.length > 0 };
+    }
+    if (legacy) {
+      delete body.account_status; delete body.account_complete;
+      if (pathname.endsWith('/account')) {
+        body.identity_link_status = wallets.length ? 'verified' : 'unlinked';
+        body.reason = wallets.length ? 'marketplace_evidence_unavailable' : 'marketplace_identity_unlinked';
+      }
     }
     await route.fulfill({ json: body });
   });
@@ -136,8 +143,8 @@ test("pending setup is resumable and never shows activity before wallet proof", 
   } finally { await context.close(); }
 });
 
-for (const linked of [false, true]) test(`phone wallet is available through ${linked ? 'Link another' : 'Link wallet'}`, async () => {
-  const {context,page,link,proofs} = await account({phone:true,installed:false,linked,mobile:true});
+for (const legacy of [false, true]) for (const linked of [false, true]) test(`phone wallet is available through ${linked ? 'Link another' : 'Link wallet'} (${legacy ? 'prior' : 'current'} API)`, async () => {
+  const {context,page,link,proofs} = await account({phone:true,installed:false,linked,mobile:true,legacy});
   try {
     assert.equal(await page.locator('.ab-phone-launcher').count(),0);
     await link.click();


### PR DESCRIPTION
During a rolling release, an hourly Pages publish can reach users before the account API update. Accept the prior API's explicit verified-identity or wallet-link receipt with stored wallets as account-setup proof. Explicit new completion fields remain authoritative, including unavailable or incomplete states; bare addresses and empty HTTP success still cannot complete setup.

This preserves mandatory wallet ownership while preventing a version mismatch from stranding signup. Tested both old and new API responses through Link wallet and Link another, plus cancellation, failed proof, final-wallet removal and existing-wallet reuse. The ownership message, API, database and payment authority are unchanged. Main release checks for #1339/#1343 have passed and the updated API is live; this frontend compatibility repair is covered by the rollout follow-up on #1338.
