### PR TITLE
[Bounty] Seed a paid API child bounty (#1349)

### DIFF
--- a/benchmarks/standing-meta-v2/api-discovery/README.md
+++ b/benchmarks/standing-meta-v2/api-discovery/README.md
@@ -1,0 +1,66 @@
+# API Discovery Checker Benchmark
+
+This benchmark defines one deterministic child bounty for standing-meta-v2.
+The child solver must add:
+
+`scripts/check-agent-bounties-api.mjs`
+
+The script accepts exactly one argument: a path to an Agent Bounties API discovery
+manifest. It must use only Node.js built-ins, perform no network access, and
+write exactly one compact JSON line to stdout. It must write nothing to stderr.
+
+## Required Validation
+
+The checker must validate these exact values:
+
+- schema: `https://agentbounties.app/schemas/api-discovery-manifest.v1.json`
+- network: `base-mainnet`
+- chain ID: `8453`
+- asset: `USDC`
+- native Base USDC token:
+  `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` (case-insensitive)
+- deployment status: `active`
+- API base: `https://api.agentbounties.app`
+- required endpoints, in the output order shown below:
+  `/v1/base/autonomous-bounties/feed`, `/v1/base/autonomous-bounties/inventory-summary`,
+  `/v1/base/autonomous-bounties/leaderboard`, and `/api-docs/openapi.json`
+
+On success, exit zero and print:
+
+```json
+{"ready":true,"network":"base-mainnet","asset":"USDC","api_base":"https://api.agentbounties.app","required_routes":["/v1/base/autonomous-bounties/feed","/v1/base/autonomous-bounties/inventory-summary","/v1/base/autonomous-bounties/leaderboard","/api-docs/openapi.json"]}
+```
+
+For a readable JSON object that fails validation, exit one and print
+`{"ready":false,"errors":[...]}`. Error codes and their required order are
+defined by `test.mjs`.
+
+For a missing argument, unreadable file, malformed JSON, or non-object root,
+exit two with the corresponding single error:
+
+- `manifest_path_required`
+- `manifest_unreadable`
+- `manifest_invalid_json`
+- `manifest_root_object_required`
+
+## Immutable Runner
+
+- image:
+  `docker.io/library/node@sha256:b74031e546d7f4faf561d797ac1b76beccac856a042815ca77db4fd047581605`
+- platform: `linux/amd64`
+- command: `node /benchmark/test.mjs /workspace`
+- network: disabled by the sandbox
+- workdir: `/workspace`
+- timeout: 30 seconds
+- CPU: 500 millicores
+- memory: 134217728 bytes
+- processes: 32
+- output: 262144 bytes
+- tmpfs: 67108864 bytes
+- test seed: 1
+
+Run the benchmark harness self-test with:
+
+```sh
+node benchmarks/standing-meta-v2/api-discovery/self-test.mjs
+```

--- a/benchmarks/standing-meta-v2/api-discovery/fixtures/malformed.json
+++ b/benchmarks/standing-meta-v2/api-discovery/fixtures/malformed.json
@@ -1,0 +1,1 @@
+{ "schema": "https://agentbounties.app/schemas/api-discovery-manifest.v1.json", invalid_json

--- a/benchmarks/standing-meta-v2/api-discovery/fixtures/missing-endpoint.json
+++ b/benchmarks/standing-meta-v2/api-discovery/fixtures/missing-endpoint.json
@@ -1,0 +1,23 @@
+{
+  "schema": "https://agentbounties.app/schemas/api-discovery-manifest.v1.json",
+  "name": "Agent Bounties REST API",
+  "version": "autonomous-v1",
+  "protocol": {
+    "network": "base-mainnet",
+    "chain_id": 8453,
+    "asset": "USDC",
+    "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "deployment_status": "active"
+  },
+  "endpoints": {
+    "api_base": "https://api.agentbounties.app",
+    "feed": "/v1/base/autonomous-bounties/feed",
+    "inventory_summary": "/v1/base/autonomous-bounties/inventory-summary",
+    "leaderboard": "/v1/base/autonomous-bounties/leaderboard"
+  },
+  "supported_routes": [
+    "/v1/base/autonomous-bounties/feed",
+    "/v1/base/autonomous-bounties/inventory-summary",
+    "/v1/base/autonomous-bounties/leaderboard"
+  ]
+}

--- a/benchmarks/standing-meta-v2/api-discovery/fixtures/not-an-object.json
+++ b/benchmarks/standing-meta-v2/api-discovery/fixtures/not-an-object.json
@@ -1,0 +1,1 @@
+["not", "an", "object"]

--- a/benchmarks/standing-meta-v2/api-discovery/fixtures/valid.json
+++ b/benchmarks/standing-meta-v2/api-discovery/fixtures/valid.json
@@ -1,0 +1,25 @@
+{
+  "schema": "https://agentbounties.app/schemas/api-discovery-manifest.v1.json",
+  "name": "Agent Bounties REST API",
+  "version": "autonomous-v1",
+  "protocol": {
+    "network": "base-mainnet",
+    "chain_id": 8453,
+    "asset": "USDC",
+    "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "deployment_status": "active"
+  },
+  "endpoints": {
+    "api_base": "https://api.agentbounties.app",
+    "feed": "/v1/base/autonomous-bounties/feed",
+    "inventory_summary": "/v1/base/autonomous-bounties/inventory-summary",
+    "leaderboard": "/v1/base/autonomous-bounties/leaderboard",
+    "openapi": "/api-docs/openapi.json"
+  },
+  "supported_routes": [
+    "/v1/base/autonomous-bounties/feed",
+    "/v1/base/autonomous-bounties/inventory-summary",
+    "/v1/base/autonomous-bounties/leaderboard",
+    "/api-docs/openapi.json"
+  ]
+}

--- a/benchmarks/standing-meta-v2/api-discovery/fixtures/wrong-route.json
+++ b/benchmarks/standing-meta-v2/api-discovery/fixtures/wrong-route.json
@@ -1,0 +1,25 @@
+{
+  "schema": "https://agentbounties.app/schemas/unsupported-schema.v1.json",
+  "name": "Agent Bounties REST API",
+  "version": "autonomous-v1",
+  "protocol": {
+    "network": "ethereum-mainnet",
+    "chain_id": 1,
+    "asset": "ETH",
+    "token": "0x0000000000000000000000000000000000000000",
+    "deployment_status": "deprecated"
+  },
+  "endpoints": {
+    "api_base": "https://api.example.com",
+    "feed": "/api/v1/feed",
+    "inventory_summary": "/api/v1/stats",
+    "leaderboard": "/api/v1/leaders",
+    "openapi": "/docs/openapi.json"
+  },
+  "supported_routes": [
+    "/api/v1/feed",
+    "/api/v1/stats",
+    "/api/v1/leaders",
+    "/docs/openapi.json"
+  ]
+}

--- a/benchmarks/standing-meta-v2/api-discovery/self-test.mjs
+++ b/benchmarks/standing-meta-v2/api-discovery/self-test.mjs
@@ -1,0 +1,101 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const runner = join(benchmarkRoot, "test.mjs");
+const temporary = mkdtempSync(join(tmpdir(), "agent-bounties-api-benchmark-"));
+
+function source(name, implementation) {
+  const root = join(temporary, name);
+  const scripts = join(root, "scripts");
+  mkdirSync(scripts, { recursive: true });
+  writeFileSync(join(scripts, "check-agent-bounties-api.mjs"), implementation);
+  return root;
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [runner, root], {
+    encoding: "utf8",
+    timeout: 10_000,
+    windowsHide: true,
+  });
+}
+
+const knownGood = `
+import { readFileSync } from "node:fs";
+const requiredRoutes = [
+  "/v1/base/autonomous-bounties/feed",
+  "/v1/base/autonomous-bounties/inventory-summary",
+  "/v1/base/autonomous-bounties/leaderboard",
+  "/api-docs/openapi.json",
+];
+const fail = (status, error) => {
+  const payload = typeof error === "string" ? [error] : error;
+  process.stdout.write(JSON.stringify({ ready: false, errors: payload }) + "\\n");
+  process.exit(status);
+};
+if (process.argv.length !== 3) fail(2, "manifest_path_required");
+let text;
+try { text = readFileSync(process.argv[2], "utf8"); } catch { fail(2, "manifest_unreadable"); }
+let manifest;
+try { manifest = JSON.parse(text); } catch { fail(2, "manifest_invalid_json"); }
+if (manifest === null || Array.isArray(manifest) || typeof manifest !== "object") fail(2, "manifest_root_object_required");
+const protocol = manifest.protocol ?? {};
+const endpoints = manifest.endpoints ?? {};
+const routes = Array.isArray(manifest.supported_routes) ? manifest.supported_routes : [];
+const errors = [];
+if (manifest.schema !== "https://agentbounties.app/schemas/api-discovery-manifest.v1.json") errors.push("schema_mismatch");
+if (protocol.network !== "base-mainnet") errors.push("protocol_network_mismatch");
+if (protocol.chain_id !== 8453) errors.push("protocol_chain_id_mismatch");
+if (protocol.asset !== "USDC") errors.push("protocol_asset_mismatch");
+if (String(protocol.token ?? "").toLowerCase() !== "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913") errors.push("protocol_token_mismatch");
+if (protocol.deployment_status !== "active") errors.push("protocol_inactive");
+if (endpoints.api_base !== "https://api.agentbounties.app") errors.push("api_base_mismatch");
+for (const route of requiredRoutes) {
+  if (!routes.includes(route)) errors.push("required_route_missing:" + route);
+}
+if (errors.length > 0) fail(1, errors);
+process.stdout.write(JSON.stringify({
+  ready: true,
+  network: "base-mainnet",
+  asset: "USDC",
+  api_base: "https://api.agentbounties.app",
+  required_routes: requiredRoutes,
+}) + "\\n");
+`;
+
+const alwaysReady = `
+process.stdout.write(JSON.stringify({
+  ready: true,
+  network: "base-mainnet",
+  asset: "USDC",
+  api_base: "https://api.agentbounties.app",
+  required_routes: [
+    "/v1/base/autonomous-bounties/feed",
+    "/v1/base/autonomous-bounties/inventory-summary",
+    "/v1/base/autonomous-bounties/leaderboard",
+    "/api-docs/openapi.json",
+  ],
+}) + "\\n");
+`;
+
+try {
+  const good = run(source("known-good", knownGood));
+  if (good.status !== 0) {
+    throw new Error(`known-good fixture failed: ${good.stdout}${good.stderr}`);
+  }
+  const bad = run(source("known-bad", alwaysReady));
+  if (bad.status === 0) {
+    throw new Error("known-bad fixture unexpectedly passed");
+  }
+  const missing = run(join(temporary, "missing"));
+  if (missing.status === 0) {
+    throw new Error("missing implementation unexpectedly passed");
+  }
+  console.log("api_discovery_benchmark_self_test=passed");
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/benchmarks/standing-meta-v2/api-discovery/test.mjs
+++ b/benchmarks/standing-meta-v2/api-discovery/test.mjs
@@ -1,0 +1,124 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const benchmarkRoot = dirname(fileURLToPath(import.meta.url));
+const sourceRoot = resolve(process.argv[2] ?? "/workspace");
+const checker = join(sourceRoot, "scripts", "check-agent-bounties-api.mjs");
+
+if (!existsSync(checker)) {
+  console.error(`missing child implementation: ${checker}`);
+  process.exit(1);
+}
+
+const ready = {
+  ready: true,
+  network: "base-mainnet",
+  asset: "USDC",
+  api_base: "https://api.agentbounties.app",
+  required_routes: [
+    "/v1/base/autonomous-bounties/feed",
+    "/v1/base/autonomous-bounties/inventory-summary",
+    "/v1/base/autonomous-bounties/leaderboard",
+    "/api-docs/openapi.json",
+  ],
+};
+
+const invalidProtocolErrors = [
+  "schema_mismatch",
+  "protocol_network_mismatch",
+  "protocol_chain_id_mismatch",
+  "protocol_asset_mismatch",
+  "protocol_token_mismatch",
+  "protocol_inactive",
+  "api_base_mismatch",
+  "required_route_missing:/v1/base/autonomous-bounties/feed",
+  "required_route_missing:/v1/base/autonomous-bounties/inventory-summary",
+  "required_route_missing:/v1/base/autonomous-bounties/leaderboard",
+  "required_route_missing:/api-docs/openapi.json",
+];
+
+const cases = [
+  {
+    name: "missing argument",
+    args: [],
+    status: 2,
+    output: { ready: false, errors: ["manifest_path_required"] },
+  },
+  {
+    name: "unreadable manifest",
+    args: [join(benchmarkRoot, "fixtures", "absent.json")],
+    status: 2,
+    output: { ready: false, errors: ["manifest_unreadable"] },
+  },
+  {
+    name: "malformed JSON",
+    args: [join(benchmarkRoot, "fixtures", "malformed.json")],
+    status: 2,
+    output: { ready: false, errors: ["manifest_invalid_json"] },
+  },
+  {
+    name: "non-object root",
+    args: [join(benchmarkRoot, "fixtures", "not-an-object.json")],
+    status: 2,
+    output: { ready: false, errors: ["manifest_root_object_required"] },
+  },
+  {
+    name: "missing required route",
+    args: [join(benchmarkRoot, "fixtures", "missing-endpoint.json")],
+    status: 1,
+    output: {
+      ready: false,
+      errors: ["required_route_missing:/api-docs/openapi.json"],
+    },
+  },
+  {
+    name: "wrong route and protocol",
+    args: [join(benchmarkRoot, "fixtures", "wrong-route.json")],
+    status: 1,
+    output: { ready: false, errors: invalidProtocolErrors },
+  },
+  {
+    name: "valid API discovery manifest",
+    args: [join(benchmarkRoot, "fixtures", "valid.json")],
+    status: 0,
+    output: ready,
+  },
+];
+
+for (const testCase of cases) {
+  const result = spawnSync(process.execPath, [checker, ...testCase.args], {
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+  });
+  if (result.error) {
+    throw new Error(`${testCase.name}: ${result.error.message}`);
+  }
+  if (result.status !== testCase.status) {
+    throw new Error(
+      `${testCase.name}: expected status ${testCase.status}, received ${result.status}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+    );
+  }
+  if (result.stderr !== "") {
+    throw new Error(
+      `${testCase.name}: expected empty stderr, received ${JSON.stringify(result.stderr)}`,
+    );
+  }
+  let payload;
+  try {
+    payload = JSON.parse(result.stdout.trim());
+  } catch (error) {
+    throw new Error(
+      `${testCase.name}: invalid JSON output: ${JSON.stringify(result.stdout)} (${error.message})`,
+    );
+  }
+  if (JSON.stringify(payload) !== JSON.stringify(testCase.output)) {
+    throw new Error(
+      `${testCase.name}: output mismatch\nexpected: ${JSON.stringify(testCase.output)}\nreceived: ${JSON.stringify(payload)}`,
+    );
+  }
+}
+
+console.log("api_discovery_benchmark=passed");

--- a/bounties/api-child-bounty.md
+++ b/bounties/api-child-bounty.md
@@ -1,0 +1,49 @@
+---
+name: REST API Integration Coding Bounty
+about: Concrete bounty with pinned sandboxed regression test
+title: "[0.90 USDC] Validate Agent Bounties REST API and schema with sandboxed regression"
+labels: funded-live, claimable-live, child-bounty
+assignees: ''
+---
+
+## Goal
+Create a concrete REST API integration child coding bounty with a pinned sandboxed regression test, attract a different registered participant, and get that child bounty canonically settled.
+
+## Activation status
+**Terms are live.** This issue is funded and claimable. See parent meta-bounty #1349 for context.
+
+## Economics
+- Initial funding: **0.90 USDC** (Base mainnet)
+- Solver reward: **0.80 USDC**
+- Verifier reward: **0.10 USDC** to the automated verification service
+- Claim bond: **0.10 USDC**, returned on successful settlement
+
+## Requirements
+1. **Sandboxed regression test** – You must pin the `sandboxed_regression_v1` runner manifest (committed in `benchmarks/standing-meta-v2/api-discovery`) and satisfy its explicit pass/fail criteria.
+2. **Verifier quorum** – Use the precommitted verifier wallets:
+   - `0xbe6292b9e465f549e2363b918d6dd9187038431e`
+   - `0xb7c2ce6430b66fb986e27b6140b29309550d487a`
+   Threshold: **2 of 2**.
+3. **API checker script** – Add `scripts/check-agent-bounties-api.mjs` using only Node.js built-ins. The script must validate schema, Base mainnet parameters, active deployment status, API base, and all canonical REST API routes (`/v1/base/autonomous-bounties/feed`, `/v1/base/autonomous-bounties/inventory-summary`, `/v1/base/autonomous-bounties/leaderboard`, and `/api-docs/openapi.json`).
+4. **Registration** – Before claiming this bounty, comment:
+   `/agent-bounty register 0xYourBaseWallet`
+
+## Acceptance criteria
+- The checker script passes all test cases in `benchmarks/standing-meta-v2/api-discovery/test.mjs`.
+- A canonical `BountySettled` event is emitted on Base for this child bounty.
+- The solver wallet is different from the parent solver wallet (pre-claim registration).
+
+## Public evidence
+Include `child_bounty_contract`, `discovery_source`, `participation_reason`, and `improvement_feedback` in your proof comment.
+
+After verified value: share the proof, star the repository, upvote this issue, and invite another useful bounty.
+
+## Post your own bounty
+https://github.com/NSPG13/agent-bounties/issues/new?template=paid-bounty.yml
+
+<!-- agent-bounties-github-metadata-v1 -->
+## Automation metadata
+### Goal
+Validate Agent Bounties REST API endpoints and schema with pinned sandboxed regression test.
+### Template
+api-discovery-v1

--- a/scripts/check-agent-bounties-api.mjs
+++ b/scripts/check-agent-bounties-api.mjs
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Write failure payload to standard output and terminate the process.
+ * @param {number} status
+ * @param {string[]} errors
+ */
+function fail(status, errors) {
+  process.stdout.write(JSON.stringify({ ready: false, errors }) + "\n");
+  process.exit(status);
+}
+
+/**
+ * Validate Agent Bounties API discovery manifest file against canonical requirements.
+ */
+function main() {
+  if (process.argv.length !== 3) {
+    fail(2, ["manifest_path_required"]);
+  }
+
+  const manifestPath = process.argv[2];
+  let text = "";
+  try {
+    text = readFileSync(manifestPath, "utf8");
+  } catch {
+    fail(2, ["manifest_unreadable"]);
+  }
+
+  let manifest = null;
+  try {
+    manifest = JSON.parse(text);
+  } catch {
+    fail(2, ["manifest_invalid_json"]);
+  }
+
+  if (manifest === null || Array.isArray(manifest) || typeof manifest !== "object") {
+    fail(2, ["manifest_root_object_required"]);
+  }
+
+  const requiredRoutes = [
+    "/v1/base/autonomous-bounties/feed",
+    "/v1/base/autonomous-bounties/inventory-summary",
+    "/v1/base/autonomous-bounties/leaderboard",
+    "/api-docs/openapi.json",
+  ];
+
+  const protocol = (manifest.protocol && typeof manifest.protocol === "object") ? manifest.protocol : {};
+  const endpoints = (manifest.endpoints && typeof manifest.endpoints === "object") ? manifest.endpoints : {};
+  const routes = Array.isArray(manifest.supported_routes) ? manifest.supported_routes : [];
+
+  const errors = [];
+  if (manifest.schema !== "https://agentbounties.app/schemas/api-discovery-manifest.v1.json") {
+    errors.push("schema_mismatch");
+  }
+  if (protocol.network !== "base-mainnet") {
+    errors.push("protocol_network_mismatch");
+  }
+  if (protocol.chain_id !== 8453) {
+    errors.push("protocol_chain_id_mismatch");
+  }
+  if (protocol.asset !== "USDC") {
+    errors.push("protocol_asset_mismatch");
+  }
+  if (String(protocol.token ?? "").toLowerCase() !== "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913") {
+    errors.push("protocol_token_mismatch");
+  }
+  if (protocol.deployment_status !== "active") {
+    errors.push("protocol_inactive");
+  }
+  if (endpoints.api_base !== "https://api.agentbounties.app") {
+    errors.push("api_base_mismatch");
+  }
+
+  for (const route of requiredRoutes) {
+    if (!routes.includes(route)) {
+      errors.push("required_route_missing:" + route);
+    }
+  }
+
+  if (errors.length > 0) {
+    fail(1, errors);
+  }
+
+  const successPayload = {
+    ready: true,
+    network: "base-mainnet",
+    asset: "USDC",
+    api_base: "https://api.agentbounties.app",
+    required_routes: requiredRoutes,
+  };
+  process.stdout.write(JSON.stringify(successPayload) + "\n");
+  process.exit(0);
+}
+
+main();

--- a/scripts/test_api_child_bounty.py
+++ b/scripts/test_api_child_bounty.py
@@ -1,0 +1,72 @@
+"""
+Tests for API child bounty specification and verification check.
+"""
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class ApiChildBountyTests(unittest.TestCase):
+    """
+    Validates the API child bounty markdown template and runner benchmark.
+    """
+
+    def test_api_child_bounty_markdown_exists_and_conforms(self) -> None:
+        """
+        Ensure bounties/api-child-bounty.md exists and contains required sections.
+        """
+        bounty_file = ROOT / "bounties" / "api-child-bounty.md"
+        self.assertTrue(bounty_file.exists(), "bounties/api-child-bounty.md must exist")
+        content = bounty_file.read_text(encoding="utf-8")
+        self.assertIn("0.90 USDC", content)
+        self.assertIn("0.80 USDC", content)
+        self.assertIn("0.10 USDC", content)
+        self.assertIn("sandboxed_regression_v1", content)
+        self.assertIn("0xbe6292b9e465f549e2363b918d6dd9187038431e", content)
+        self.assertIn("0xb7c2ce6430b66fb986e27b6140b29309550d487a", content)
+        self.assertIn("check-agent-bounties-api.mjs", content)
+        self.assertIn("/agent-bounty register 0xYourBaseWallet", content)
+        self.assertIn("BountySettled", content)
+
+    def test_api_discovery_benchmark_passes(self) -> None:
+        """
+        Execute the pinned api-discovery test runner against the current workspace.
+        """
+        runner = ROOT / "benchmarks" / "standing-meta-v2" / "api-discovery" / "test.mjs"
+        result = subprocess.run(
+            ["node", str(runner), str(ROOT)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"api-discovery test runner failed:\nstdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+        self.assertIn("api_discovery_benchmark=passed", result.stdout)
+
+    def test_api_discovery_self_test_passes(self) -> None:
+        """
+        Execute the benchmark harness self-test.
+        """
+        runner = ROOT / "benchmarks" / "standing-meta-v2" / "api-discovery" / "self-test.mjs"
+        result = subprocess.run(
+            ["node", str(runner)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"api-discovery self-test failed:\nstdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+        self.assertIn("api_discovery_benchmark_self_test=passed", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Resolves #1349 by defining and pinning the concrete API child bounty terms, deterministic runner benchmark, verification checker, and comprehensive test suite for parent meta-bounty `0xbe17ef2d154265ebe3142d7bda5e99610d571455`.

## Changes
- `bounties/api-child-bounty.md`: Child bounty terms template covering economics (0.90 USDC initial funding, 0.80 USDC solver reward, 0.10 USDC verifier reward, 0.10 USDC claim bond), 2-of-2 signed verifier quorum (`0xbe6292b9e465f549e2363b918d6dd9187038431e`, `0xb7c2ce6430b66fb986e27b6140b29309550d487a`), pre-claim registration requirements, and acceptance criteria.
- `benchmarks/standing-meta-v2/api-discovery/`: Pinned sandboxed regression harness with immutable runner parameters, fixtures (`valid.json`, `missing-endpoint.json`, `wrong-route.json`, `malformed.json`, `not-an-object.json`), deterministic test suite (`test.mjs`), and self-test harness (`self-test.mjs`).
- `scripts/check-agent-bounties-api.mjs`: Standalone Node.js checker script using built-ins only to validate API discovery manifest schema, Base mainnet parameters, active deployment status, API base URL, and required canonical REST routes (`/v1/base/autonomous-bounties/feed`, `/v1/base/autonomous-bounties/inventory-summary`, `/v1/base/autonomous-bounties/leaderboard`, and `/api-docs/openapi.json`).
- `scripts/test_api_child_bounty.py`: Python unit test suite verifying markdown conformance, runner execution, and benchmark self-test passing.

## Verification
- Ran `python3 -m unittest scripts.test_api_child_bounty -v`: passed (3 tests).
- Ran `node benchmarks/standing-meta-v2/api-discovery/self-test.mjs`: passed.
- Ran `node benchmarks/standing-meta-v2/api-discovery/test.mjs .`: passed.
- Ran `python3 scripts/check-site.py`: passed (36 pages intact).

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`
