### PR TITLE
Restore verified Glama canary funding path

### DIFF
--- a/.github/workflows/regression-verifier-runner.yml
+++ b/.github/workflows/regression-verifier-runner.yml
@@ -45,8 +45,8 @@ jobs:
       - run: |
           python scripts/test_regression_verifier_pipeline.py -v
           python scripts/test_regression_verifier_source_guard.py -v
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
-          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2
+          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc
           python -m py_compile scripts/regression_verifier_pipeline.py
           cargo test -p verifier-sdk -p worker
 
@@ -71,15 +71,15 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
+          --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2
 
       - name: Build isolated regression worker
         run: cargo build --release -p worker
 
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
-          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2
+          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc
 
       - name: Run canonical jobs without signing secrets
         run: >-

--- a/.github/workflows/regression-verifier-signer.yml
+++ b/.github/workflows/regression-verifier-signer.yml
@@ -42,8 +42,8 @@ jobs:
           python-version: "3.12"
       - run: python scripts/test_regression_verifier_pipeline.py -v
       - run: python scripts/test_regression_verifier_source_guard.py -v
-      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
-      - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
+      - run: python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2
+      - run: python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc
 
   authorize-run:
     if: >-
@@ -151,12 +151,12 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
+          --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
-          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2
+          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc
       - name: Revalidate and relay exact quorum
         env:
           BASE_KEEPER_PRIVATE_KEY: ${{ secrets.BASE_KEEPER_PRIVATE_KEY }}

--- a/.github/workflows/regression-verifier-signing-reusable.yml
+++ b/.github/workflows/regression-verifier-signing-reusable.yml
@@ -50,12 +50,12 @@ jobs:
         run: >-
           python scripts/regression_verifier_source_guard.py
           --scope worker-build
-          --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
+          --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2
       - run: cargo build --release -p worker
       - name: Revalidate reviewed runtime after build
         run: |
-          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967
-          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125
+          python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2
+          python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc
       - name: Re-fetch state and sign one exact candidate set
         env:
           REGRESSION_VERIFIER_PRIVATE_KEY: ${{ secrets.verifier_private_key }}

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/check.py
@@ -30,18 +30,18 @@ SCHEMA = "agent-bounties/regression-verifier-watchdog-plan-v1"
 HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 ADDRESS_ONE = "0x" + "11" * 20
 ADDRESS_TWO = "0x" + "22" * 20
-PIPELINE_SHA256 = "23611288dc879bad70ef6966789a5132b136d6e4ca69db7b25ced5c6b581cb2e"
-PIPELINE_TEST_SHA256 = "8b408fc80ff5bf4871ff679f119e6053834b5c9544b1ea0be70e11414cab3be2"
+PIPELINE_SHA256 = "f3e8facba9964fc6206d26fbc6bc2f1147cb50ca6fb3775c847b0acdb392c586"
+PIPELINE_TEST_SHA256 = "78391f62fbafbd6e016303ab06a109da83cc6b3d6b23cb67cbe499d61ff329ff"
 SOURCE_GUARD_SHA256 = "ab8a6491acd5a5b8e93db5ef36d40db6276af8ba658bcd6a52c34d6aeb0be83d"
 SOURCE_GUARD_TEST_SHA256 = "d18ced511f9cd9f266c989dae93ff0088ce38d290f19a6491d6d7b3e6aa108ac"
-WORKER_BUILD_SHA256 = "b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"
-SIGNING_RUNTIME_SHA256 = "89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"
+WORKER_BUILD_SHA256 = "41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2"
+SIGNING_RUNTIME_SHA256 = "469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc"
 SHARED_KEEPER_CONCURRENCY = "agent-bounties-shared-base-keeper"
 CANONICAL_WORKFLOW_SHA256 = {
-    ".github/workflows/regression-verifier-runner.yml": "629cb3b1098a499bf2cdd8304231d393071f29194814f66e3d45980491fea817",
+    ".github/workflows/regression-verifier-runner.yml": "b58f5a9695327ad81a67202cf03e8b0b3edd2c6e123c3162270bf17c8d9b7063",
     ".github/workflows/regression-verifier-watchdog.yml": "2cc7333b9fa5d613c1f84416bfd5593ef6c7416fc916e5157a3e43eac89b0d68",
-    ".github/workflows/regression-verifier-signer.yml": "90261cfad784c610f40e888b965d2d81fea6d219f2e2c41aa4b221e9de7ef435",
-    ".github/workflows/regression-verifier-signing-reusable.yml": "24d2d8f37fe0d6153db875fa5f0d0f696a3c5fb334f42d3b4f2d8af6d99768fc",
+    ".github/workflows/regression-verifier-signer.yml": "f84338ec10a0ca35a1779d47cfeeafcbc60e15fa0089a0a17ce5672995f3e9f8",
+    ".github/workflows/regression-verifier-signing-reusable.yml": "54f5dbe7cdf9233e34ab8d666447db86378e21636bc329b3582906589bdca9a2",
 }
 
 

--- a/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
+++ b/benchmarks/direct-flagship-v1/verifier-settlement-watchdog/rehearse.py
@@ -930,10 +930,10 @@ RUNNER_WORKFLOW = '''{
         {"uses": "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97", "with": {"python-version": "3.12"}},
         {"uses": "dtolnay/rust-toolchain@39b0b3842c7e8bbf6904c0bfc3d9006fdd4dc4e0"},
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2"},
         {"name": "Build isolated regression worker", "run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
-        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2"},
+        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc"},
         {"name": "Run canonical jobs without signing secrets", "run": "python scripts/regression_verifier_pipeline.py run --api-base $API_BASE_URL --network base-mainnet --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --staging $RUNNER_TEMP/regression-staging --output target/regression-candidates --max-jobs 5"},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-candidates-${{ github.run_id }}", "path": "target/regression-candidates", "if-no-files-found": "error", "retention-days": 7}}
       ]
@@ -1052,10 +1052,10 @@ SIGNER_WORKFLOW = '''{
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ github.event.workflow_run.id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ github.event.workflow_run.id }}"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-one-${{ github.event.workflow_run.id }}", "path": "target/attestations-one"}},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-attestations-two-${{ github.event.workflow_run.id }}", "path": "target/attestations-two"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
-        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2"},
+        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc"},
         {"name": "Revalidate and relay exact quorum", "run": "python scripts/regression_verifier_pipeline.py relay --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --attestations target/attestations-one --attestations target/attestations-two --verifier $VERIFIER_ONE --verifier $VERIFIER_TWO --worker target/release/worker --expected-keeper $KEEPER_ADDRESS", "env": {"BASE_KEEPER_PRIVATE_KEY": "${{ secrets.BASE_KEEPER_PRIVATE_KEY }}"}}
       ]
     }
@@ -1095,10 +1095,10 @@ REUSABLE_WORKFLOW = '''{
         {"uses": "Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae"},
         {"uses": "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a"},
         {"uses": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", "with": {"name": "regression-candidates-${{ inputs.candidate_run_id }}", "path": "target/regression-candidates", "github-token": "${{ github.token }}", "run-id": "${{ inputs.candidate_run_id }}"}},
-        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
+        {"name": "Verify reviewed worker build inputs", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2"},
         {"run": "cargo build --release -p worker"},
-        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 b9d49927dd79a763cb202210e222b3093bf612856fe706afeed8f4deac851967"},
-        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 89d3a481511c5cc2130673088ed3fd2361eae3a3c7f47d13eb72b6000e341125"},
+        {"name": "Revalidate reviewed sources after build", "run": "python scripts/regression_verifier_source_guard.py --scope worker-build --expected-sha256 41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2"},
+        {"name": "Revalidate reviewed signing runtime", "run": "python scripts/regression_verifier_source_guard.py --scope signing-runtime --expected-sha256 469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc"},
         {"name": "Re-fetch state and sign one exact candidate set", "run": "python scripts/regression_verifier_pipeline.py sign --api-base $API_BASE_URL --network base-mainnet --rpc-url $BASE_MAINNET_RPC_URL --candidates target/regression-candidates --output $ATTESTATION_OUTPUT --worker target/release/worker --private-key-env REGRESSION_VERIFIER_PRIVATE_KEY --expected-signer $EXPECTED_SIGNER", "env": {"REGRESSION_VERIFIER_PRIVATE_KEY": "${{ secrets.verifier_private_key }}"}},
         {"uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a", "with": {"name": "regression-attestations-${{ inputs.signer_slot }}-${{ inputs.candidate_run_id }}", "path": "target/attestations-${{ inputs.signer_slot }}", "if-no-files-found": "error", "retention-days": 7}}
       ]

--- a/crates/chain-base/src/lib.rs
+++ b/crates/chain-base/src/lib.rs
@@ -433,8 +433,13 @@ const RECONCILED_REGRESSION_BENCHMARK_DIGESTS: &[&str] = &[
     "sha256:73fc58dcd45e551344f8889095b7d3a71546170ba7f05fb1876aaf6aa796ac3d",
     "sha256:3bfb647d41539693c9598a01d9f9f7953a285dfb7c1986a190560a8745f64731",
     "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7",
+    "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656",
 ];
 const RECONCILED_REGRESSION_BENCHMARK_COMMIT: &str = "fa946859a3379b8c9128183e20dedb3b8319a646";
+// Keep the paid-rail canary bound to the independently rehearsed historical tree.
+const RECONCILED_GLAMA_CANARY_COMMIT: &str = "0fae18cf9be464132cde52dfb9d464d836e8f024";
+const RECONCILED_GLAMA_CANARY_DIGEST: &str =
+    "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656";
 // This older immutable tuple contains exactly the reviewed OpenHands tree.
 // Keep the alias scoped to that digest/path; it is not approval of the whole commit.
 const RECONCILED_OPENHANDS_ORIGINAL_COMMIT: &str = "aa28ec742efd4063260653510ba324e291267515";
@@ -476,6 +481,10 @@ const RECONCILED_REGRESSION_BENCHMARK_SOURCES: &[(&str, &str)] = &[
     (
         "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7",
         "benchmarks/direct-inventory-v1/stalled-work",
+    ),
+    (
+        RECONCILED_GLAMA_CANARY_DIGEST,
+        "benchmarks/distribution-v1/glama-onboarding-audit",
     ),
 ];
 const PUBLIC_EARNING_MIN_VERIFIER_REWARD_USDC_BASE_UNITS: u128 = 10_000;
@@ -5566,9 +5575,12 @@ fn validate_reconciled_regression_benchmark(
                 .and_then(|value| value.get("commit"))
                 .and_then(Value::as_str)
                 .is_some_and(|commit| {
-                    commit.eq_ignore_ascii_case(RECONCILED_REGRESSION_BENCHMARK_COMMIT)
+                    (commit.eq_ignore_ascii_case(RECONCILED_REGRESSION_BENCHMARK_COMMIT)
+                        && benchmark_digest != Some(RECONCILED_GLAMA_CANARY_DIGEST))
                         || (commit.eq_ignore_ascii_case(RECONCILED_OPENHANDS_ORIGINAL_COMMIT)
                             && subdirectory == "benchmarks/direct-growth-v2/openhands-integration")
+                        || (commit.eq_ignore_ascii_case(RECONCILED_GLAMA_CANARY_COMMIT)
+                            && benchmark_digest == Some(RECONCILED_GLAMA_CANARY_DIGEST))
                 })
             && source
                 .and_then(|value| value.get("subdirectory"))
@@ -8682,6 +8694,30 @@ mod tests {
             Err(ChainBaseError::InvalidTermsDocument(message))
                 if message.contains("independently reconciled")
         ));
+        let mut glama_canary_document = supported_document.clone();
+        glama_canary_document.benchmark["source"]["commit"] = json!(RECONCILED_GLAMA_CANARY_COMMIT);
+        glama_canary_document.benchmark["source"]["subdirectory"] =
+            json!("benchmarks/distribution-v1/glama-onboarding-audit");
+        glama_canary_document.benchmark["runner_manifest"]["benchmark_digest"] =
+            json!(RECONCILED_GLAMA_CANARY_DIGEST);
+        assert!(build_autonomous_bounty_terms_record(
+            &record.creator_wallet,
+            glama_canary_document.clone(),
+            now,
+        )
+        .is_ok());
+        for (field, value) in [
+            ("commit", json!(RECONCILED_REGRESSION_BENCHMARK_COMMIT)),
+            ("subdirectory", json!("benchmarks/copied-location")),
+        ] {
+            let mut altered = glama_canary_document.clone();
+            altered.benchmark["source"][field] = value;
+            assert!(matches!(
+                build_autonomous_bounty_terms_record(&record.creator_wallet, altered, now),
+                Err(ChainBaseError::InvalidTermsDocument(message))
+                    if message.contains("immutable source tuple")
+            ));
+        }
         let supported_record =
             build_autonomous_bounty_terms_record(&record.creator_wallet, supported_document, now)
                 .unwrap();

--- a/crates/mcp-server/src/chatgpt_app.rs
+++ b/crates/mcp-server/src/chatgpt_app.rs
@@ -73,8 +73,13 @@ const RECONCILED_REGRESSION_BENCHMARK_DIGESTS: &[&str] = &[
     "sha256:73fc58dcd45e551344f8889095b7d3a71546170ba7f05fb1876aaf6aa796ac3d",
     "sha256:3bfb647d41539693c9598a01d9f9f7953a285dfb7c1986a190560a8745f64731",
     "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7",
+    "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656",
 ];
 const RECONCILED_REGRESSION_BENCHMARK_COMMIT: &str = "fa946859a3379b8c9128183e20dedb3b8319a646";
+// Keep the paid-rail canary bound to the independently rehearsed historical tree.
+const RECONCILED_GLAMA_CANARY_COMMIT: &str = "0fae18cf9be464132cde52dfb9d464d836e8f024";
+const RECONCILED_GLAMA_CANARY_DIGEST: &str =
+    "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656";
 const RECONCILED_REGRESSION_BENCHMARK_SOURCES: &[(&str, &str)] = &[
     (
         RECONCILED_REGRESSION_BENCHMARK_DIGESTS[0],
@@ -111,6 +116,10 @@ const RECONCILED_REGRESSION_BENCHMARK_SOURCES: &[(&str, &str)] = &[
     (
         RECONCILED_REGRESSION_BENCHMARK_DIGESTS[8],
         "benchmarks/direct-inventory-v1/stalled-work",
+    ),
+    (
+        RECONCILED_GLAMA_CANARY_DIGEST,
+        "benchmarks/distribution-v1/glama-onboarding-audit",
     ),
 ];
 const CHATGPT_ADVERTISED_TOOL_NAMES: &[&str] = &[
@@ -941,8 +950,12 @@ fn validate_prepared_verifier(
             (*digest == benchmark_digest).then_some(*approved_subdirectory)
         },
     );
+    let approved_commit = (commit == RECONCILED_REGRESSION_BENCHMARK_COMMIT
+        && benchmark_digest != RECONCILED_GLAMA_CANARY_DIGEST)
+        || (commit == RECONCILED_GLAMA_CANARY_COMMIT
+            && benchmark_digest == RECONCILED_GLAMA_CANARY_DIGEST);
     if !repository.eq_ignore_ascii_case("NSPG13/agent-bounties")
-        || commit != RECONCILED_REGRESSION_BENCHMARK_COMMIT
+        || !approved_commit
         || approved_subdirectory != Some(subdirectory)
     {
         return Err(
@@ -5467,6 +5480,29 @@ mod tests {
 
     #[test]
     fn verifier_handoff_rejects_incomplete_or_non_executable_inputs() {
+        let mut glama_canary = valid_args();
+        glama_canary.benchmark.as_mut().unwrap()["source"]["commit"] =
+            json!(RECONCILED_GLAMA_CANARY_COMMIT);
+        glama_canary.benchmark.as_mut().unwrap()["source"]["subdirectory"] =
+            json!("benchmarks/distribution-v1/glama-onboarding-audit");
+        glama_canary.benchmark.as_mut().unwrap()["runner_manifest"]["benchmark_digest"] =
+            json!(RECONCILED_GLAMA_CANARY_DIGEST);
+        let glama_image = sandbox_bounty_image_reference(&glama_canary)
+            .unwrap()
+            .unwrap();
+        let glama_result = build_bounty_post_handoff(&glama_canary, Some(&glama_image));
+        assert!(glama_result.is_ok(), "{glama_result:?}");
+        for (field, value) in [
+            ("commit", json!(RECONCILED_REGRESSION_BENCHMARK_COMMIT)),
+            ("subdirectory", json!("benchmarks/copied-location")),
+        ] {
+            let mut altered = glama_canary.clone();
+            altered.benchmark.as_mut().unwrap()["source"][field] = value;
+            assert!(build_bounty_post_handoff(&altered, None)
+                .unwrap_err()
+                .contains("immutable source tuple"));
+        }
+
         let mut args = valid_args();
         args.evidence_schema = None;
         assert!(build_bounty_post_handoff(&args, None)

--- a/ops/direct-flagship-verifier-settlement-watchdog-v1.json
+++ b/ops/direct-flagship-verifier-settlement-watchdog-v1.json
@@ -48,7 +48,7 @@
     ],
     "threshold": 1,
     "benchmark_subdirectory": "benchmarks/direct-flagship-v1/verifier-settlement-watchdog",
-    "benchmark_digest": "sha256:59742f3b2caf2ec081fc6008e1f41db24112c5903b3dcb91d7d32e7b8faf067a",
+    "benchmark_digest": "sha256:250a62f546a538350ce6f7d00040286b260e7361270fd5fe3ee35a628997a18f",
     "runner_manifest": {
       "schema_version": "agent-bounties/regression-sandbox-v1",
       "image": "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",

--- a/scripts/check-bounty-economics.cjs
+++ b/scripts/check-bounty-economics.cjs
@@ -165,6 +165,27 @@ originalOpenHands.source.subdirectory = "benchmarks/direct-growth-v2/openhands-i
 originalOpenHands.runner_manifest.benchmark_digest = "sha256:30bb17e3e3916747144c7087f49fb1ce41ddaf1aec4d717f878d2840203895a2";
 assert.equal(verificationReadiness(originalOpenHands, evidenceSchema).executable, true);
 assert.equal(verificationReadiness(originalOpenHands, { type: "object", required: ["source_snapshot_digest"] }).executable, false);
+const glamaCanary = JSON.parse(JSON.stringify(benchmark));
+glamaCanary.source.commit = "0fae18cf9be464132cde52dfb9d464d836e8f024";
+glamaCanary.source.subdirectory = "benchmarks/distribution-v1/glama-onboarding-audit";
+glamaCanary.runner_manifest.benchmark_digest = "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656";
+assert.deepEqual(
+  verificationReadiness(glamaCanary, evidenceSchema),
+  { blocked: false, executable: true },
+  "the independently rehearsed Glama canary tuple must reach wallet review",
+);
+for (const mutate of [
+  (value) => { value.source.commit = "fa946859a3379b8c9128183e20dedb3b8319a646"; },
+  (value) => { value.source.subdirectory = "benchmarks/copied-location"; },
+]) {
+  const alteredGlamaCanary = JSON.parse(JSON.stringify(glamaCanary));
+  mutate(alteredGlamaCanary);
+  assert.deepEqual(
+    verificationReadiness(alteredGlamaCanary, evidenceSchema),
+    { blocked: true, executable: false },
+    "Glama canary approval must remain bound to its exact historical source tuple",
+  );
+}
 copiedUnsafeBenchmark.source.repository = "other/copied-benchmark";
 copiedUnsafeBenchmark.source.subdirectory = "different/location";
 copiedUnsafeBenchmark.runner_manifest.benchmark_digest =

--- a/scripts/regression_verifier_pipeline.py
+++ b/scripts/regression_verifier_pipeline.py
@@ -52,8 +52,9 @@ CANONICAL_BOUNTY_RUNTIME = (
 )
 # Every digest accepted by the trusted signer must have a separately reviewed
 # semantic benchmark. These entries are the checked-in direct inventory and
-# direct growth benchmarks; a relocated or modified copy has a different digest
-# and remains ineligible until that exact content is reviewed.
+# direct growth benchmarks plus the pinned historical Glama canary; a relocated
+# or modified copy has a different digest and remains ineligible until that
+# exact content is reviewed.
 RECONCILED_REGRESSION_BENCHMARK_DIGESTS: frozenset[str] = frozenset(
     {
         "sha256:b61a96a7d07ca01337ea3576de734f5b62ccab966a6d0da42a8736cfc0287ce6",
@@ -65,6 +66,7 @@ RECONCILED_REGRESSION_BENCHMARK_DIGESTS: frozenset[str] = frozenset(
         "sha256:73fc58dcd45e551344f8889095b7d3a71546170ba7f05fb1876aaf6aa796ac3d",
         "sha256:3bfb647d41539693c9598a01d9f9f7953a285dfb7c1986a190560a8745f64731",
         "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7",
+        "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656",
     }
 )
 RECONCILED_REGRESSION_BENCHMARK_COMMIT = "fa946859a3379b8c9128183e20dedb3b8319a646"
@@ -78,6 +80,7 @@ RECONCILED_REGRESSION_BENCHMARK_SOURCES: dict[str, tuple[str, str, str]] = {
     "sha256:73fc58dcd45e551344f8889095b7d3a71546170ba7f05fb1876aaf6aa796ac3d": ("nspg13/agent-bounties", RECONCILED_REGRESSION_BENCHMARK_COMMIT, "benchmarks/direct-inventory-v1/wallet-liquidity"),
     "sha256:3bfb647d41539693c9598a01d9f9f7953a285dfb7c1986a190560a8745f64731": ("nspg13/agent-bounties", RECONCILED_REGRESSION_BENCHMARK_COMMIT, "benchmarks/direct-inventory-v1/replenishment-plan"),
     "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7": ("nspg13/agent-bounties", RECONCILED_REGRESSION_BENCHMARK_COMMIT, "benchmarks/direct-inventory-v1/stalled-work"),
+    "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656": ("nspg13/agent-bounties", "0fae18cf9be464132cde52dfb9d464d836e8f024", "benchmarks/distribution-v1/glama-onboarding-audit"),
 }
 
 # The original OpenHands publication has byte-identical benchmark contents.

--- a/scripts/test_regression_verifier_pipeline.py
+++ b/scripts/test_regression_verifier_pipeline.py
@@ -825,6 +825,36 @@ class RegressionVerifierPipelineTests(unittest.TestCase):
         with self.assertRaisesRegex(pipeline.PipelineError, "immutable source tuple"):
             pipeline.require_reconciled_regression_benchmark(changed)
 
+    def test_glama_canary_uses_only_the_rehearsed_historical_tuple(self) -> None:
+        digest = "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656"
+        repository, commit, subdirectory = pipeline.RECONCILED_REGRESSION_BENCHMARK_SOURCES[digest]
+        job = {
+            "terms": {
+                "document": {
+                    "benchmark": {
+                        "engine": "sandboxed_regression_v1",
+                        "source": {
+                            "kind": "github_commit",
+                            "repository": repository,
+                            "commit": commit,
+                            "subdirectory": subdirectory,
+                        },
+                        "runner_manifest": {"benchmark_digest": digest},
+                    }
+                }
+            }
+        }
+        pipeline.require_reconciled_regression_benchmark(job)
+        for key, value in (
+            ("repository", "relocated/repository"),
+            ("commit", pipeline.RECONCILED_REGRESSION_BENCHMARK_COMMIT),
+            ("subdirectory", "benchmarks/copied-location"),
+        ):
+            changed = json.loads(json.dumps(job))
+            changed["terms"]["document"]["benchmark"]["source"][key] = value
+            with self.assertRaisesRegex(pipeline.PipelineError, "immutable source tuple"):
+                pipeline.require_reconciled_regression_benchmark(changed)
+
     def test_runner_pulls_only_the_exact_committed_image(self) -> None:
         manifest = {
             "image": f"docker.io/library/python@sha256:{'a' * 64}",

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -23,8 +23,12 @@
     "sha256:73fc58dcd45e551344f8889095b7d3a71546170ba7f05fb1876aaf6aa796ac3d",
     "sha256:3bfb647d41539693c9598a01d9f9f7953a285dfb7c1986a190560a8745f64731",
     "sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7",
+    "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656",
   ]);
   const RECONCILED_REGRESSION_BENCHMARK_COMMIT = "fa946859a3379b8c9128183e20dedb3b8319a646";
+  // The paid-rail canary is pinned to the independently rehearsed historical tree.
+  const RECONCILED_GLAMA_CANARY_COMMIT = "0fae18cf9be464132cde52dfb9d464d836e8f024";
+  const RECONCILED_GLAMA_CANARY_DIGEST = "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656";
   const RECONCILED_REGRESSION_BENCHMARK_SOURCES = new Map([
     ["sha256:b61a96a7d07ca01337ea3576de734f5b62ccab966a6d0da42a8736cfc0287ce6", "benchmarks/direct-growth-v2/a2a-agent-card"],
     ["sha256:b9b0d026347a2922f913e9a8ed3651dd74e7eba930598981a169da3bf42e7c3f", "benchmarks/direct-growth-v2/hermes-integration"],
@@ -35,6 +39,7 @@
     ["sha256:73fc58dcd45e551344f8889095b7d3a71546170ba7f05fb1876aaf6aa796ac3d", "benchmarks/direct-inventory-v1/wallet-liquidity"],
     ["sha256:3bfb647d41539693c9598a01d9f9f7953a285dfb7c1986a190560a8745f64731", "benchmarks/direct-inventory-v1/replenishment-plan"],
     ["sha256:a14e53feada2f49b646d340a494c822ec3112a2a6c468ce1cdb21fd7ee23a3d7", "benchmarks/direct-inventory-v1/stalled-work"],
+    [RECONCILED_GLAMA_CANARY_DIGEST, "benchmarks/distribution-v1/glama-onboarding-audit"],
   ]);
   const RUNNER_MANIFEST_FIELDS = [
     "schema_version", "image", "command", "workdir", "benchmark_digest",
@@ -1364,11 +1369,20 @@
       && runner.tmpfs_bytes <= runner.memory_bytes
       && new Set(["linux/amd64", "linux/arm64"]).has(runner.platform);
     const approvedSubdirectory = RECONCILED_REGRESSION_BENCHMARK_SOURCES.get(runner?.benchmark_digest);
+    const sourceCommit = String(source?.commit || "").toLowerCase();
+    const approvedCommit = (
+      sourceCommit === RECONCILED_REGRESSION_BENCHMARK_COMMIT
+        && runner?.benchmark_digest !== RECONCILED_GLAMA_CANARY_DIGEST
+    ) || (
+      sourceCommit === "aa28ec742efd4063260653510ba324e291267515"
+        && approvedSubdirectory === "benchmarks/direct-growth-v2/openhands-integration"
+    ) || (
+      sourceCommit === RECONCILED_GLAMA_CANARY_COMMIT
+        && runner?.benchmark_digest === RECONCILED_GLAMA_CANARY_DIGEST
+    );
     const approvedSource = typeof approvedSubdirectory === "string"
       && String(source?.repository || "").toLowerCase() === "nspg13/agent-bounties"
-      && (String(source?.commit || "").toLowerCase() === RECONCILED_REGRESSION_BENCHMARK_COMMIT
-        || String(source?.commit || "").toLowerCase() === "aa28ec742efd4063260653510ba324e291267515"
-          && approvedSubdirectory === "benchmarks/direct-growth-v2/openhands-integration")
+      && approvedCommit
       && source?.subdirectory === approvedSubdirectory;
     const blocked = !RECONCILED_REGRESSION_BENCHMARK_DIGESTS.has(runner?.benchmark_digest)
       || !approvedSource;


### PR DESCRIPTION
## Why

The attributed Glama mainnet canary is pinned to an independently rehearsed benchmark at commit `0fae18cf9be464132cde52dfb9d464d836e8f024`, but a later fail-closed verifier allowlist omitted that historical tuple. WebMCP can stage the draft, yet the first-party wallet review correctly blocks funding as unreconciled.

This restores only the exact immutable tuple:

- digest: `sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656`
- repository: `NSPG13/agent-bounties`
- commit: `0fae18cf9be464132cde52dfb9d464d836e8f024`
- path: `benchmarks/distribution-v1/glama-onboarding-audit`

The current modified directory digest and any changed repository, commit, or path remain blocked.

Public maintainer notice and distribution context: #1274.

## What changed

- Restored the tuple in the browser wallet-review gate, MCP handoff validator, canonical terms validator, and trusted sandbox signer.
- Added positive coverage for the exact historical tuple.
- Added negative coverage for current-commit substitution, copied paths, and repository changes.
- Rotated the reviewed worker/signing source digests in all three production workflows.
- Updated the verifier-settlement watchdog's byte-level executable pins and exact workflow fixtures; its unsafe-mutation matrix still fails closed.
- Rotated that watchdog benchmark's own precommitted content digest to match the reviewed files.
- Kept agent/MCP infrastructure outside wallet authority.

## Conflict audit

- Rebased onto current `main` commit `822ae715f78f39cf28af9af5d24d9828a72cf5d2`.
- Published tree `881659916856f1a387307d1b88d0adc752cd00df` exactly matches the locally tested tree.
- Synthetic merge against current `main`: clean.
- Inspected all 68 other open PR refs across all 12 changed files. Five touch an overlapping path.
- PR #662 merges cleanly.
- PRs #663 and #934 auto-merge in the overlapping file; their existing conflicts are elsewhere.
- Older PRs #906 and #910 carry stale overlapping changes and would need a normal rebase if resumed. Neither blocks current production main; this PR does not silently resolve or overwrite them.

## Verification

- Historical Glama benchmark self-test at the pinned commit: 1 positive and 5 negative fixtures passed.
- `cargo test -p mcp-server`: 83 passed.
- `cargo test -p chain-base`: 90 tests, 88 passed and 2 environment-gated tests ignored; both integration fixtures passed.
- Verifier pipeline + source-guard suites: 40 passed.
- Direct flagship precommit + verifier suites: 44 passed after rotating the watchdog benchmark digest to `sha256:250a62f546a538350ce6f7d00040286b260e7361270fd5fe3ee35a628997a18f`.
- Verifier-settlement watchdog rehearsal: known-good accepted; every known-bad/unsafe mutation rejected.
- Reviewed source digests recomputed exactly:
  - worker build: `41c015895864373c73125be5ba1fc87576270128ebde84f7a93bf7898754f9d2`
  - signing runtime: `469bf155b1bbc5f19ee91ee41172e113cd5baea6f9d1f2d574d88672b1999ddc`
- `node scripts/check-bounty-economics.cjs`: passed.
- `python3 scripts/check-site.py`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.

No wallet transaction, funding, or signing is performed by this change.