### PR TITLE
Preserve prepared bounties through login and wallet setup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,7 @@ on:
       - "scripts/test-phone-wallet-network.cjs"
       - "scripts/test-phone-wallet-storage.cjs"
       - "scripts/test-posting-layout.cjs"
+      - "scripts/test-posting-auth.js"
       - "tools/browser-layout/**"
       - "scripts/configure-phone-wallet.py"
       - "scripts/configure-wallet-providers.py"
@@ -56,6 +57,7 @@ on:
       - "scripts/test-phone-wallet-network.cjs"
       - "scripts/test-phone-wallet-storage.cjs"
       - "scripts/test-posting-layout.cjs"
+      - "scripts/test-posting-auth.js"
       - "tools/browser-layout/**"
       - "scripts/configure-phone-wallet.py"
       - "scripts/configure-wallet-providers.py"
@@ -122,10 +124,13 @@ jobs:
           node --check site/webmcp.js
           node --check site/participate.js
           node --check site/phone-wallet.js
+          node --check site/posting-auth.js
       - name: Test the living scene and marketplace evidence states
         run: node --test scripts/test-solarpunk-home.js
       - name: Test assistant desktop handoff and draft preservation
         run: node scripts/test-ai-bounty-handoff.js
+      - name: Test login and prepared-bounty continuity
+        run: node --test scripts/test-posting-auth.js
       - name: Test the retained Metrics evidence engine
         run: node --test scripts/test-metrics-dashboard.js
       - name: Test unified marketplace readiness, timing, and economics

--- a/scripts/check-site.py
+++ b/scripts/check-site.py
@@ -113,6 +113,7 @@ REQUIRED_FILES = {
     "ai-bounty-handoff.css",
     "ai-bounty-handoff.js",
     "posting-prompt.js",
+    "posting-auth.js",
     "posting-workspace.js",
     "posting-workspace.css",
     "creator-review.js",
@@ -179,6 +180,7 @@ ALLOWED_UI_CODE = {
     "bug-fix.css",
     "bug-fix.js",
     "posting-prompt.js",
+    "posting-auth.js",
     "posting-workspace.js",
     "posting-workspace.css",
     "creator-review.js",
@@ -581,7 +583,7 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
             "data-card-verifier",
             "function renderVerifierTerms",
             "if (!ui.verifierSummary || !ui.verifier) return;",
-            'bounty-composer-v2.js?v=15',
+            'bounty-composer-v2.js?v=16',
             "function verificationReadiness",
             "verificationReadiness(benchmark, state.draft?.evidence_schema)",
             'sourceSnapshotDigest.pattern === "^sha256:[0-9a-f]{64}$"',
@@ -609,6 +611,27 @@ def check_analytics(site_dir: Path, repo_root: Path) -> None:
     )
     if "const rewards=splitReward(state.fundingUsdc)" in composer:
         fail("funding must preserve an explicitly prepared solver/verifier reward split")
+    posting_auth = (site_dir / "posting-auth.js").read_text(encoding="utf-8")
+    homepage = (site_dir / "index.html").read_text(encoding="utf-8")
+    home_javascript = (site_dir / "solarpunk-home.js").read_text(encoding="utf-8")
+    require_phrases(
+        "posting login and wallet continuity",
+        post + homepage + composer + posting_auth + home_javascript,
+        [
+            'data-post-auth-start',
+            'posting-auth.js?v=1',
+            'solarpunk-home.js?v=19',
+            'bounty-composer-v2.js?v=16',
+            'label: "LOG IN TO POST"',
+            'credentials: "include"',
+            'account_status === "ready" && payload.account_complete === true',
+            'target.pathname !== "/post.html"',
+            'win.sessionStorage.setItem(INTENT_KEY',
+            'win.location.replace(target)',
+            'Returning to the prepared bounty',
+            'approval received. Verifying the account link',
+        ],
+    )
     node = shutil.which("node")
     if not node:
         fail("node is required for the WebMCP reward-handoff behavior check")

--- a/scripts/sync-site-navigation.py
+++ b/scripts/sync-site-navigation.py
@@ -19,8 +19,16 @@ def sync(check=False):
         relative = path.relative_to(ROOT / "site")
         prefix = "../" * (len(relative.parts) - 1)
         markup = template.replace("{{root}}", prefix or "./").replace("{{prefix}}", prefix)
-        login = ' data-auth-open aria-haspopup="dialog" aria-controls="auth-dialog" aria-expanded="false"' if relative.as_posix() == "index.html" else ""
-        markup = markup.replace("{{login_attributes}}", login)
+        if relative.as_posix() == "index.html":
+            login_href = "#login"
+            login_attributes = ' data-auth-open aria-haspopup="dialog" aria-controls="auth-dialog" aria-expanded="false"'
+        elif relative.as_posix() == "post.html":
+            login_href = "?postReturn=1#login"
+            login_attributes = " data-post-auth-start"
+        else:
+            login_href = "#login"
+            login_attributes = ""
+        markup = markup.replace("{{login_href}}", login_href).replace("{{login_attributes}}", login_attributes)
         block = START + "\n" + markup + "\n" + END
         source = path.read_text(encoding="utf-8")
         if PATTERN.search(source):

--- a/scripts/templates/site-navigation.html
+++ b/scripts/templates/site-navigation.html
@@ -7,6 +7,6 @@
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="{{prefix}}about.html">About us</a>
     <a href="{{prefix}}earn.html">Find bounties</a>
-    <a class="ab-site-login" href="{{root}}#login"{{login_attributes}}>Login</a>
+    <a class="ab-site-login" href="{{root}}{{login_href}}"{{login_attributes}}>Login</a>
   </nav>
 </header>

--- a/scripts/test-marketplace-layout.cjs
+++ b/scripts/test-marketplace-layout.cjs
@@ -8,7 +8,10 @@ const mime = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css
 const server = http.createServer((req, res) => {
   const file = path.resolve(site, "." + decodeURIComponent(new URL(req.url, "http://localhost").pathname));
   if (!file.startsWith(site + path.sep)) return res.writeHead(403).end();
-  try { res.writeHead(200, { "Content-Type": mime[path.extname(file)] || "application/octet-stream" }).end(fs.readFileSync(file)); }
+  try {
+    const body = fs.readFileSync(file);
+    res.writeHead(200, { "Content-Type": mime[path.extname(file)] || "application/octet-stream" }).end(body);
+  }
   catch { res.writeHead(404).end(); }
 });
 async function bounds(page, selector) {
@@ -27,7 +30,10 @@ async function layout(page) {
 async function main() {
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
   const origin = `http://127.0.0.1:${server.address().port}`;
-  const browser = await chromium.launch({ headless: true });
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE || undefined,
+  });
   try {
     for (const [width, height] of [[1440,900],[946,838],[640,480],[390,600],[320,480],[768,320],[480,360]]) {
       const context = await browser.newContext({ viewport: { width, height }, reducedMotion: "reduce" });

--- a/scripts/test-phone-wallet-storage.cjs
+++ b/scripts/test-phone-wallet-storage.cjs
@@ -30,7 +30,10 @@ async function main() {
   const deadline = setTimeout(() => { void browser?.close(); }, 45000);
   try {
     const origin = "http://127.0.0.1:" + server.address().port;
-    browser = await chromium.launch({ headless: true });
+    browser = await chromium.launch({
+      headless: true,
+      executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE || undefined,
+    });
     const context = await browser.newContext();
     await context.route("**/*", route => new URL(route.request().url()).origin === origin ? route.continue() : route.abort());
     await context.addInitScript(() => {

--- a/scripts/test-posting-auth.js
+++ b/scripts/test-posting-auth.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const postingAuth = require("../site/posting-auth.js");
+const composer = require("../site/bounty-composer-v2.js");
+
+function storage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.has(key) ? values.get(key) : null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+  };
+}
+
+function browser(href = "https://agentbounties.app/post.html") {
+  const navigations = [];
+  const current = new URL(href);
+  return {
+    sessionStorage: storage(),
+    location: {
+      href: current.href,
+      origin: current.origin,
+      pathname: current.pathname,
+      hostname: current.hostname,
+      assign: (value) => navigations.push({ method: "assign", value }),
+      replace: (value) => navigations.push({ method: "replace", value }),
+    },
+    navigations,
+  };
+}
+
+test("only the exact same-origin post target is accepted", () => {
+  const win = browser();
+  const target = "https://agentbounties.app/post.html?title=Glama&criterion=one&criterion=two&acquisition=opaque#review";
+  assert.equal(postingAuth.safePostTarget(win, target), target);
+  assert.equal(postingAuth.safePostTarget(win, "/post.html?from=webmcp"), "https://agentbounties.app/post.html?from=webmcp");
+  for (const unsafe of [
+    "https://evil.example/post.html",
+    "https://agentbounties.app.evil.example/post.html",
+    "https://user@agentbounties.app/post.html",
+    "https://agentbounties.app/earn.html",
+    "javascript:alert(1)",
+  ]) assert.equal(postingAuth.safePostTarget(win, unsafe), null);
+});
+
+test("login begins without flattening or leaking the prepared URL", () => {
+  const target = "https://agentbounties.app/post.html?title=Audit+Glama&criterion=a%2Fb&benchmark=%7B%22engine%22%3A%22sandboxed_regression_v1%22%7D&acquisition=aba1_opaque&handoff=uuid";
+  const win = browser(target);
+  assert.equal(postingAuth.begin(win, target, 1000), target);
+  assert.deepEqual(win.navigations, [{ method: "assign", value: "https://agentbounties.app/?postReturn=1#login" }]);
+  assert.equal(postingAuth.pending(win), target);
+  assert.doesNotMatch(win.navigations[0].value, /title|criterion|benchmark|acquisition|handoff/);
+});
+
+test("account completion returns once and leaves a bounded public receipt", () => {
+  const now = Date.now();
+  const target = "https://agentbounties.app/post.html?from=ai-app&acquisition=opaque";
+  const win = browser(target);
+  postingAuth.remember(win, target, now);
+  assert.equal(postingAuth.complete(win, { walletKind: "phone", address: "0x" + "AB".repeat(20) }, now + 1000), true);
+  assert.deepEqual(win.navigations, [{ method: "replace", value: target }]);
+  assert.equal(postingAuth.pending(win, now + 1000), null);
+  assert.deepEqual(postingAuth.consumeReceipt(win, now + 1000), {
+    schema: "agent-bounties/post-auth-receipt-v1",
+    completed_at: now + 1000,
+    wallet_kind: "phone",
+    wallet_address: "0x" + "ab".repeat(20),
+  });
+  assert.equal(postingAuth.consumeReceipt(win, now + 1000), null);
+  assert.equal(postingAuth.complete(win, {}, now + 1000), false);
+});
+
+test("expired, malformed, and storage-disabled continuation state fails closed", () => {
+  const now = Date.now();
+  const win = browser();
+  postingAuth.remember(win, win.location.href, now - (5 * 60 * 60 * 1000));
+  assert.equal(postingAuth.pending(win, now), null);
+  win.sessionStorage.setItem(postingAuth.INTENT_KEY, "not-json");
+  assert.equal(postingAuth.pending(win, now), null);
+  const blocked = browser();
+  blocked.sessionStorage.setItem = () => { throw new Error("disabled"); };
+  assert.throws(() => postingAuth.begin(blocked), /could not preserve/i);
+  assert.deepEqual(blocked.navigations, []);
+});
+
+test("posting action is driven by server account state", () => {
+  assert.equal(composer.postingAccountStatus({ authenticated: false, account_status: "signed_out" }), "signed_out");
+  assert.equal(composer.postingAccountStatus({ authenticated: true, account_status: "wallet_required", account_complete: false }), "setup");
+  assert.equal(composer.postingAccountStatus({ authenticated: true, account_status: "ready", account_complete: true }), "ready");
+  assert.equal(composer.postingAccountStatus({ authenticated: true, account_status: "ready", account_complete: false }), "unavailable");
+  assert.deepEqual(composer.postingPrimaryAction("signed_out", true), { action: "login", disabled: false, label: "LOG IN TO POST" });
+  assert.deepEqual(composer.postingPrimaryAction("setup", true), { action: "login", disabled: false, label: "FINISH SETUP TO POST" });
+  assert.deepEqual(composer.postingPrimaryAction("checking", true), { action: "wait", disabled: true, label: "Checking login…" });
+  assert.deepEqual(composer.postingPrimaryAction("unavailable", true), { action: "login", disabled: false, label: "CHECK ACCOUNT TO POST" });
+  assert.deepEqual(composer.postingPrimaryAction("ready", true), { action: "approve", disabled: false, label: "Confirm bounty" });
+});

--- a/scripts/test-posting-layout.cjs
+++ b/scripts/test-posting-layout.cjs
@@ -12,7 +12,7 @@ const root = path.resolve(__dirname, "..");
 const baseline = process.env.POSTING_LAYOUT_BASELINE;
 const mime = { ".html": "text/html", ".css": "text/css", ".js": "text/javascript", ".json": "application/json", ".svg": "image/svg+xml" };
 const server = http.createServer((req, res) => {
-  const relative = decodeURIComponent(new URL(req.url, "http://localhost").pathname).replace(/^\/+/, "");
+  const relative = decodeURIComponent(new URL(req.url, "http://localhost").pathname).replace(/^\/+/, "") || "index.html";
   const filename = path.resolve(root, "site", relative);
   if (!filename.startsWith(path.join(root, "site") + path.sep)) { res.writeHead(403).end(); return; }
   try {
@@ -65,7 +65,10 @@ async function modalBounds(page, selector) {
 async function main() {
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
   const origin = "http://127.0.0.1:" + server.address().port;
-  const browser = await playwright.chromium.launch({ headless: true });
+  const browser = await playwright.chromium.launch({
+    headless: true,
+    executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE || undefined,
+  });
   const sizes = [
     { width: 1440, height: 900 }, { width: 946, height: 838 },
     { width: 640, height: 480 }, { width: 390, height: 600 },
@@ -81,6 +84,7 @@ async function main() {
       page.on("pageerror", error => errors.push(error.message));
       await context.route("**/*", async route => {
         const url = new URL(route.request().url());
+        if (url.pathname === "/auth/session") return route.fulfill({ json: { authenticated: true, account_status: "ready", account_complete: true, user: { id: "layout-qa" } } });
         if (url.origin !== origin) return route.abort();
         if (url.pathname === "/phone-wallet-config.js") return route.fulfill({ contentType: "text/javascript", body: 'window.agentBountiesPhoneWalletConfig={projectId:"00000000000000000000000000000000"};' });
         // Inert provider renders a synthetic QR image, with no relay connection.
@@ -183,6 +187,37 @@ async function main() {
       assert.deepEqual(await page.evaluate(() => window.__walletWrites), []);
       assert.deepEqual(errors, [], "No browser runtime errors");
       console.log("PASS posting, wallet review, QR, keyboard and scrolling at " + size.width + "x" + size.height + (size.zoomReflow ? " (200% browser-zoom reflow equivalent)" : ""));
+      await context.close();
+    }
+    {
+      const context = await browser.newContext({ viewport: { width: 390, height: 844 }, reducedMotion: "reduce" });
+      const page = await context.newPage();
+      await context.route("**/*", async route => {
+        const url = new URL(route.request().url());
+        if (url.pathname === "/auth/session") return route.fulfill({ json: { authenticated: false, account_status: "signed_out", account_complete: false, providers: { github: true } } });
+        if (url.origin !== origin) return route.abort();
+        if (url.pathname === "/phone-wallet-config.js") return route.fulfill({ contentType: "text/javascript", body: "window.agentBountiesPhoneWalletConfig={};" });
+        return route.continue();
+      });
+      await page.addInitScript(() => {
+        window.__walletWrites = [];
+        window.ethereum = { request: async request => { window.__walletWrites.push(request.method); throw new Error("No wallet request is allowed during login."); } };
+      });
+      await page.goto(`${origin}/post.html?from=ai-app&title=Preserve+this+exact+draft&testMarker=opaque`);
+      await page.waitForFunction(() => window.AgentBountiesComposer);
+      await page.evaluate(draft => window.AgentBountiesComposer.stage(draft), fixture);
+      const login = page.getByRole("button", { name: "LOG IN TO POST", exact: true });
+      await login.waitFor();
+      assert.equal(await login.isEnabled(), true);
+      const exactTarget = page.url();
+      await Promise.all([
+        page.waitForURL(`${origin}/?postReturn=1#login`, { waitUntil: "domcontentloaded" }),
+        login.click(),
+      ]);
+      await page.locator("[data-auth-dialog][open]").waitFor();
+      assert.equal(await page.evaluate(() => JSON.parse(sessionStorage.getItem("agentbounties:post-auth-return:v1")).target), exactTarget);
+      assert.deepEqual(await page.evaluate(() => window.__walletWrites), []);
+      console.log("PASS signed-out posting action opens login with the exact draft preserved and no wallet request");
       await context.close();
     }
   } finally { await browser.close(); }

--- a/scripts/test-site-navigation.cjs
+++ b/scripts/test-site-navigation.cjs
@@ -37,7 +37,10 @@ async function assertFits(page, selector) {
 async function main() {
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
   const origin = `http://127.0.0.1:${server.address().port}`;
-  const browser = await chromium.launch({ headless: true });
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE || undefined,
+  });
   let mode = "ready";
   const errors = [];
   async function context(options) {
@@ -64,8 +67,12 @@ async function main() {
         await page.locator(".ab-site-header.is-enhanced").waitFor();
         assert.equal(await page.locator("[data-site-header]").count(), 1, file);
         assert.equal(await page.locator("nav[aria-label='Primary navigation']").count(), 1, file);
-        const links = await page.locator(".ab-site-nav a").evaluateAll(els => els.map(el => ({ text: el.textContent.trim(), href: new URL(el.href).pathname + new URL(el.href).hash })));
-        assert.deepEqual(links, [{ text: "About us", href: "/about.html" }, { text: "Find bounties", href: "/earn.html" }, { text: "Login", href: "/#login" }], file);
+        const links = await page.locator(".ab-site-nav a").evaluateAll(els => els.map(el => {
+          const url = new URL(el.href);
+          return { text: el.textContent.trim(), href: url.pathname + url.search + url.hash };
+        }));
+        const expectedLogin = file === "post.html" ? "/?postReturn=1#login" : "/#login";
+        assert.deepEqual(links, [{ text: "About us", href: "/about.html" }, { text: "Find bounties", href: "/earn.html" }, { text: "Login", href: expectedLogin }], file);
         const appearance = await page.locator("[data-site-header]").evaluate(el => {
           const css = getComputedStyle(el), brand = getComputedStyle(el.querySelector("strong"));
           return { height: el.getBoundingClientRect().height, background: css.backgroundImage, padding: css.padding, brand: brand.font, color: brand.color };

--- a/site/bounty-composer-v2.js
+++ b/site/bounty-composer-v2.js
@@ -68,12 +68,29 @@
     "sun", "road", "lamp", "building", "tree", "water", "screen", "document", "network", "tool", "person", "check", "bridge", "book", "chart",
   ]);
 
+  function postingAccountStatus(payload) {
+    if (!payload?.authenticated) return "signed_out";
+    if (payload.account_status === "ready" && payload.account_complete === true) return "ready";
+    if (payload.account_status === "wallet_required" && payload.account_complete === false) return "setup";
+    return "unavailable";
+  }
+
+  function postingPrimaryAction(accountStatus, handoffReview = false) {
+    if (accountStatus === "ready") return { action: "approve", disabled: false, label: handoffReview ? "Confirm bounty" : "Approve bounty card" };
+    if (accountStatus === "setup") return { action: "login", disabled: false, label: "FINISH SETUP TO POST" };
+    if (accountStatus === "checking") return { action: "wait", disabled: true, label: "Checking login…" };
+    if (accountStatus === "unavailable") return { action: "login", disabled: false, label: "CHECK ACCOUNT TO POST" };
+    return { action: "login", disabled: false, label: "LOG IN TO POST" };
+  }
+
   if (typeof module === "object" && module.exports) {
     module.exports = Object.freeze({
       parseDistributionAttribution,
       parsePreparedRewardSplit,
       rewardSplitForTotal,
       verificationReadiness,
+      postingAccountStatus,
+      postingPrimaryAction,
     });
     return;
   }
@@ -171,6 +188,8 @@
     handoffReview: false,
     distributionAttribution: null,
     observedWalletState: null,
+    postingAccountStatus: "checking",
+    postingAuthReceipt: null,
   };
 
   function track(eventName, details) {
@@ -220,6 +239,72 @@
       item.dataset.active = String(index === activeIndex);
       item.dataset.complete = String(index >= 0 && index < activeIndex);
     });
+  }
+
+  function postingAuthMessage() {
+    if (state.postingAccountStatus === "ready") {
+      return state.postingAuthReceipt
+        ? "Login and account setup are complete. Your prepared bounty is intact. Confirm it, then choose the wallet that will fund it."
+        : "Review the terms, reward, content-derived visual, and verification disclosure. Nothing has been posted or funded.";
+    }
+    if (state.postingAccountStatus === "setup") {
+      return "You are signed in. Finish linking an account wallet, then you will return to this exact prepared bounty. Account setup cannot post or fund it.";
+    }
+    if (state.postingAccountStatus === "checking") {
+      return "Checking your Agent Bounties login. Your prepared bounty remains in this tab.";
+    }
+    if (state.postingAccountStatus === "unavailable") {
+      return "We couldn’t confirm that your account is ready. Check the account screen, then return to this exact prepared bounty. Nothing has been posted or funded.";
+    }
+    return "Log in to continue with this exact prepared bounty. Login cannot connect a funding wallet, sign, post, or pay.";
+  }
+
+  function syncPrimaryAction() {
+    if (!state.draft || !state.imageReady) return;
+    const action = postingPrimaryAction(state.postingAccountStatus, state.handoffReview);
+    if (action.action !== "approve") {
+      ui.approve.dataset.nextAction = action.action;
+      ui.approve.disabled = action.disabled;
+      ui.approve.textContent = action.label;
+      ui.fund.disabled = true;
+      setStatus(postingAuthMessage(), "pending");
+      return;
+    }
+    try { supportedVerificationPolicy(); }
+    catch (error) {
+      ui.approve.disabled = true;
+      ui.fund.disabled = true;
+      ui.approve.dataset.nextAction = "blocked";
+      ui.approve.textContent = "Verification setup needed";
+      ui.confidence.textContent = "Your AI needs to finish the verification setup";
+      setStatus("Your draft is saved. Ask your AI to finish its executable verification setup before you approve funding.", "pending");
+      return;
+    }
+    ui.approve.dataset.nextAction = action.action;
+    ui.approve.disabled = action.disabled;
+    ui.approve.textContent = action.label;
+    ui.fund.disabled = true;
+    setStatus(postingAuthMessage(), state.postingAccountStatus === "ready" && state.postingAuthReceipt ? "success" : "pending");
+  }
+
+  async function loadPostingAccount() {
+    try {
+      const local = ["localhost", "127.0.0.1", "::1", "[::1]"].includes(window.location.hostname);
+      const endpoint = local ? "/auth/session" : `${API}/v1/site-auth/session`;
+      const response = await fetch(endpoint, { cache: "no-store", credentials: "include", headers: { Accept: "application/json" } });
+      if (!response.ok) throw new Error(`session ${response.status}`);
+      state.postingAccountStatus = postingAccountStatus(await response.json());
+    } catch (_) {
+      state.postingAccountStatus = "unavailable";
+    }
+    state.postingAuthReceipt = window.AgentBountiesPostingAuth?.consumeReceipt(window) || null;
+    syncPrimaryAction();
+    return state.postingAccountStatus;
+  }
+
+  function beginPostingLogin() {
+    try { window.AgentBountiesPostingAuth.begin(window); }
+    catch (error) { setStatus(error.message || String(error), "error"); }
   }
 
   function setComposer({ phase, prompt, label, placeholder, button, hint = "" }) {
@@ -984,23 +1069,7 @@
       );
     }
     await renderAiVisualForCurrentDraft();
-    ui.approve.disabled = false;
-    ui.approve.textContent = "Approve bounty card";
-    setStatus("Review the result, completion checks, time window, reward, and creator-verification disclosure. Nothing has been posted or funded.");
-    if (state.handoffReview) {
-      ui.approve.textContent = "Confirm bounty";
-      setStatus(state.bountyImage
-        ? "Review the exact approved image, terms, reward, and verification disclosure. Nothing has been posted or funded."
-        : "Review the terms, reward, content-derived visual, and verification disclosure. Nothing has been posted or funded.");
-    }
-    try { supportedVerificationPolicy(); }
-    catch (error) {
-      ui.approve.disabled = true;
-      ui.fund.disabled = true;
-      ui.approve.textContent = "Verification setup needed";
-      ui.confidence.textContent = "Your AI needs to finish the verification setup";
-      setStatus("Your draft is saved. Ask your AI to finish its executable verification setup before you approve funding.", "pending");
-    }
+    syncPrimaryAction();
   }
 
   function validHex(value) {
@@ -1491,6 +1560,7 @@
 
   function approveCard() {
     if (!state.imageReady) return;
+    if (state.postingAccountStatus !== "ready") { beginPostingLogin(); return; }
     try { supportedVerificationPolicy(); } catch (error) { setStatus(error.message, "error"); return; }
     state.approved = true;
     ui.approve.dataset.approved = "true";
@@ -1906,7 +1976,11 @@
   }
 
   ui.form.addEventListener("submit",handleComposerSubmit);
-  ui.approve.addEventListener("click", (event) => { if (event.isTrusted) approveCard(); });
+  ui.approve.addEventListener("click", (event) => {
+    if (!event.isTrusted) return;
+    if (ui.approve.dataset.nextAction === "login") beginPostingLogin();
+    else if (ui.approve.dataset.nextAction === "approve") approveCard();
+  });
   ui.revise.addEventListener("click",reviseCard);
   ui.share.addEventListener("click",shareBountyCard);
   ui.fund.addEventListener("click",openFunding);
@@ -1972,6 +2046,7 @@
   });
 
   configureSpeech();
+  void loadPostingAccount();
   setProgress("describe");
   const recordedPosting = postingJournal.load();
   if (recordedPosting) {

--- a/site/index.html
+++ b/site/index.html
@@ -369,6 +369,7 @@
     </footer>
 
     <noscript><p class="noscript-note">JavaScript is required for the living scene and live marketplace metrics.</p></noscript>
+    <script src="posting-auth.js?v=1"></script>
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=5"></script>
     <script src="wallet-config.js?v=1"></script>
@@ -377,6 +378,6 @@
     <script src="analytics-config.js?v=6"></script>
     <script src="analytics.js?v=5"></script>
     <script src="posting-prompt.js?v=3"></script>
-    <script src="solarpunk-home.js?v=18"></script>
+    <script src="solarpunk-home.js?v=19"></script>
   </body>
 </html>

--- a/site/post.html
+++ b/site/post.html
@@ -34,7 +34,7 @@
   <nav class="ab-site-nav" id="site-navigation" aria-label="Primary navigation">
     <a href="about.html">About us</a>
     <a href="earn.html">Find bounties</a>
-    <a class="ab-site-login" href="./#login">Login</a>
+    <a class="ab-site-login" href="./?postReturn=1#login" data-post-auth-start>Login</a>
   </nav>
 </header>
 <!-- shared-navigation:end -->
@@ -263,6 +263,7 @@
       </section>
     </main>
 
+    <script src="posting-auth.js?v=1"></script>
     <script src="phone-wallet-config.js?v=1"></script>
     <script src="phone-wallet.js?v=5"></script>
     <script src="marketplace-workflow.js?v=3"></script>
@@ -275,7 +276,7 @@
     <script src="posting-prompt.js?v=3"></script>
     <script src="creator-review.js?v=1"></script>
     <script src="ai-bounty-handoff.js?v=10"></script>
-    <script src="bounty-composer-v2.js?v=15"></script>
+    <script src="bounty-composer-v2.js?v=16"></script>
     <script src="posting-workspace.js?v=3"></script>
   </body>
 </html>

--- a/site/posting-auth.js
+++ b/site/posting-auth.js
@@ -1,0 +1,127 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.AgentBountiesPostingAuth = api;
+  if (root?.document) api.bind(root);
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  const INTENT_KEY = "agentbounties:post-auth-return:v1";
+  const RECEIPT_KEY = "agentbounties:post-auth-receipt:v1";
+  const MAX_TARGET_LENGTH = 65_536;
+  const INTENT_MAX_AGE_MS = 4 * 60 * 60 * 1000;
+  const RECEIPT_MAX_AGE_MS = 5 * 60 * 1000;
+  const WALLET_KINDS = new Set(["browser", "phone", "embedded", "linked"]);
+
+  function safePostTarget(win, candidate) {
+    if (!win?.location?.origin || typeof candidate !== "string" || !candidate || candidate.length > MAX_TARGET_LENGTH) return null;
+    try {
+      const target = new URL(candidate, win.location.href);
+      if (target.origin !== win.location.origin || target.pathname !== "/post.html"
+        || target.username || target.password || target.href.length > MAX_TARGET_LENGTH) return null;
+      return target.href;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function read(win, key) {
+    try { return JSON.parse(win.sessionStorage.getItem(key)); }
+    catch (_) { return null; }
+  }
+
+  function remove(win, key) {
+    try { win.sessionStorage.removeItem(key); }
+    catch (_) { /* A storage-disabled browser can still use the current page. */ }
+  }
+
+  function remember(win, candidate = win?.location?.href, now = Date.now()) {
+    const target = safePostTarget(win, candidate);
+    if (!target) return null;
+    const intent = { schema: "agent-bounties/post-auth-return-v1", target, started_at: now };
+    try { win.sessionStorage.setItem(INTENT_KEY, JSON.stringify(intent)); }
+    catch (_) { return null; }
+    return target;
+  }
+
+  function pending(win, now = Date.now()) {
+    const intent = read(win, INTENT_KEY);
+    const age = Number(intent?.started_at) <= now ? now - Number(intent?.started_at) : -1;
+    const target = intent?.schema === "agent-bounties/post-auth-return-v1"
+      && Number.isFinite(age) && age >= 0 && age < INTENT_MAX_AGE_MS
+      ? safePostTarget(win, intent.target) : null;
+    if (!target) remove(win, INTENT_KEY);
+    return target;
+  }
+
+  function loginUrl(win) {
+    const target = new URL("/", win.location.origin);
+    target.searchParams.set("postReturn", "1");
+    target.hash = "login";
+    return target.href;
+  }
+
+  function begin(win, candidate = win?.location?.href) {
+    const target = remember(win, candidate);
+    if (!target) throw new Error("This browser could not preserve the prepared bounty. Keep this tab open and retry.");
+    win.location.assign(loginUrl(win));
+    return target;
+  }
+
+  function complete(win, details = {}, now = Date.now()) {
+    const target = pending(win, now);
+    if (!target) return false;
+    const rawAddress = String(details.address || "").toLowerCase();
+    const address = /^0x[0-9a-f]{40}$/.test(rawAddress) ? rawAddress : null;
+    const kind = WALLET_KINDS.has(details.walletKind) ? details.walletKind : "linked";
+    try {
+      win.sessionStorage.setItem(RECEIPT_KEY, JSON.stringify({
+        schema: "agent-bounties/post-auth-receipt-v1",
+        completed_at: now,
+        wallet_kind: kind,
+        wallet_address: address,
+      }));
+    } catch (_) { /* The destination still verifies the server session. */ }
+    remove(win, INTENT_KEY);
+    if (typeof win.location.replace === "function") win.location.replace(target);
+    else win.location.assign(target);
+    return true;
+  }
+
+  function consumeReceipt(win, now = Date.now()) {
+    const value = read(win, RECEIPT_KEY);
+    remove(win, RECEIPT_KEY);
+    const age = Number(value?.completed_at) <= now ? now - Number(value?.completed_at) : -1;
+    if (value?.schema !== "agent-bounties/post-auth-receipt-v1"
+      || !Number.isFinite(age) || age < 0 || age >= RECEIPT_MAX_AGE_MS
+      || !WALLET_KINDS.has(value.wallet_kind)
+      || (value.wallet_address !== null && !/^0x[0-9a-f]{40}$/.test(value.wallet_address))) return null;
+    return value;
+  }
+
+  function bind(win) {
+    for (const control of win.document.querySelectorAll("[data-post-auth-start]")) {
+      control.addEventListener("click", (event) => {
+        event.preventDefault();
+        try { begin(win); }
+        catch (error) {
+          const status = win.document.querySelector("[data-composer-status]");
+          if (status) { status.textContent = error.message; status.dataset.tone = "error"; }
+        }
+      });
+    }
+  }
+
+  return Object.freeze({
+    INTENT_KEY,
+    RECEIPT_KEY,
+    safePostTarget,
+    remember,
+    pending,
+    loginUrl,
+    begin,
+    complete,
+    consumeReceipt,
+    bind,
+  });
+});

--- a/site/solarpunk-home.js
+++ b/site/solarpunk-home.js
@@ -1,10 +1,13 @@
 (function (root, factory) {
-  const api = factory(typeof module === "object" && module.exports
-    ? require("./posting-prompt.js") : root.AgentBountiesPostingPrompt);
+  const commonJs = typeof module === "object" && module.exports;
+  const api = factory(
+    commonJs ? require("./posting-prompt.js") : root.AgentBountiesPostingPrompt,
+    commonJs ? require("./posting-auth.js") : root.AgentBountiesPostingAuth,
+  );
   if (typeof module === "object" && module.exports) module.exports = api;
   if (root) root.SolarpunkHome = api;
   if (root && root.document) api.start(root, root.document);
-})(typeof window !== "undefined" ? window : globalThis, function (postingPrompt) {
+})(typeof window !== "undefined" ? window : globalThis, function (postingPrompt, postingAuth) {
   "use strict";
 
   const PHASES = ["dawn", "day", "dusk", "night"];
@@ -736,6 +739,12 @@ ${competitionChildBrief(item)}`;
       let embeddedAddress = null;
       let accountStatus = "checking";
 
+      const returnToPreparedPost = (details = {}) => {
+        if (!currentUser || accountStatus !== "ready" || !postingAuth?.pending(win)) return false;
+        setStatus("Your account is ready. Returning to the prepared bounty…");
+        return postingAuth.complete(win, details);
+      };
+
       const setStatus = (message) => {
         if (status) status.textContent = message;
       };
@@ -1087,6 +1096,9 @@ ${competitionChildBrief(item)}`;
           if (currentUser !== linkingUser) throw { code: 4001 };
           const address = String(Array.isArray(accounts) ? accounts[0] : "").trim().toLowerCase();
           if (!/^0x[0-9a-fA-F]{40}$/.test(address)) throw { reason: "invalid_wallet_address" };
+          const walletLabel = selection.kind === "phone" ? "Phone wallet"
+            : selection.kind === "embedded" ? "Embedded wallet" : selection.label || "Wallet";
+          setWalletStatus(`${walletLabel} ${shortWalletAddress(address)} connected. Preparing the ownership-only confirmation…`);
           if (selection.kind === "embedded") {
             embeddedAddress = address;
             renderWallets(verifiedWallets);
@@ -1095,16 +1107,18 @@ ${competitionChildBrief(item)}`;
           }
           if (verifiedWallets.some((wallet) => wallet.address === address)) {
             setWalletStatus(`${shortWalletAddress(address)} is already verified and linked. Your wallet is ready.`);
+            returnToPreparedPost({ walletKind: selection.kind, address });
             return;
           }
           const challenge = await postAccountJson("/wallet/challenge", { address });
           if (currentUser !== linkingUser) throw { code: 4001 };
-          setWalletStatus("Review the ownership-only message in your wallet. It cannot move funds or approve tokens.");
+          setWalletStatus(`${walletLabel} ${shortWalletAddress(address)} connected. Review the ownership-only message in your wallet; it cannot move funds or approve tokens.`);
           const signature = await linkProvider.request({
             method: "personal_sign",
             params: [utf8Hex(challenge.message), address],
           });
           if (currentUser !== linkingUser) throw { code: 4001 };
+          setWalletStatus(`${walletLabel} approval received. Verifying the account link…`);
           const verification = await postAccountJson("/wallet/verify", {
             challenge_id: challenge.challenge_id,
             address,
@@ -1127,6 +1141,7 @@ ${competitionChildBrief(item)}`;
             ? `${shortWalletAddress(address)} is verified and linked. Your account is ready.`
             : "Wallet ownership was confirmed. Recheck your account setup to continue.");
           win.agentBountiesAnalytics?.track("wallet_link_confirmed");
+          returnToPreparedPost({ walletKind: selection.kind, address });
         } catch (error) {
           if (currentUser === linkingUser) setWalletStatus(embeddedAddress && !verifiedWallets.some((wallet) => wallet.address === embeddedAddress)
             ? `Your wallet is ready, but account linking is not finished. ${walletLinkErrorMessage(error)} Select Finish linking to retry.`
@@ -1139,6 +1154,11 @@ ${competitionChildBrief(item)}`;
         }
       };
       walletLinkButton?.addEventListener("click", () => linkWallet());
+      win.addEventListener("agent-bounties:phone-wallet-state", (event) => {
+        const snapshot = event.detail;
+        if (!currentUser || !walletLinkButton?.disabled || !snapshot?.connected || !/^0x[0-9a-fA-F]{40}$/.test(snapshot.address || "")) return;
+        setWalletStatus(`Phone wallet ${shortWalletAddress(snapshot.address)} connected. Preparing the ownership-only confirmation…`);
+      });
       walletList?.addEventListener("click", async (event) => {
         if (event.target.closest?.("[data-wallet-finish]")) { await linkWallet(true); return; }
         if (event.target.closest?.("[data-wallet-access]")) { await win.AgentBountiesCoinbaseEmbeddedWallet?.manageAccess(); return; }
@@ -1228,8 +1248,9 @@ ${competitionChildBrief(item)}`;
       openLoginHash();
       const authParams = new URLSearchParams(win.location.search);
       const authResult = authParams.get("auth");
-      loadSession().then(() => {
-        if (currentUser && win.AgentBountiesWalletLink?.hasPending(currentUser.id)) void linkWallet(true);
+      loadSession().then(async () => {
+        if (currentUser && win.AgentBountiesWalletLink?.hasPending(currentUser.id)) await linkWallet(true);
+        if (returnToPreparedPost()) return;
         if (authResult !== "success" && authResult !== "error") return;
         setStatus(authResult === "success" && accountStatus !== "ready"
           ? "You’re signed in. Link a wallet to finish your account."

--- a/tools/coinbase-embedded-wallet/test-account-link.mjs
+++ b/tools/coinbase-embedded-wallet/test-account-link.mjs
@@ -36,7 +36,10 @@ before(async () => {
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   origin = `http://127.0.0.1:${server.address().port}`;
-  browser = await chromium.launch({ headless: true });
+  browser = await chromium.launch({
+    headless: true,
+    executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE || undefined,
+  });
 });
 after(async () => {
   await browser?.close();
@@ -50,11 +53,11 @@ async function openAccount(page) {
   await accountLink.click();
 }
 
-async function account({ installed = true, linked = false, mobile = false, adapter = false, pending = null, failVerify = false, failRefresh = false, phone = false, invalidVerify = false, unavailable = false, legacy = false } = {}) {
+async function account({ installed = true, linked = false, linkedAddress = ADDRESS, mobile = false, adapter = false, pending = null, failVerify = false, failRefresh = false, phone = false, invalidVerify = false, unavailable = false, legacy = false, postTarget = null, delayedPhoneSign = false, expectAutoReturn = false } = {}) {
   const context = await browser.newContext({ viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
   const page = await context.newPage();
   const proofs = [], errors = [];
-  let wallets = linked ? [{ address: ADDRESS }] : [];
+  let wallets = linked ? [{ address: linkedAddress }] : [];
   let rejectVerification = failVerify;
   const network = { unavailable };
   page.on("pageerror", (error) => errors.push(error.message));
@@ -62,7 +65,13 @@ async function account({ installed = true, linked = false, mobile = false, adapt
   await page.route("**/auth/**", async (route) => {
     const pathname = new URL(route.request().url()).pathname;
     let body = {};
-    if (pathname.endsWith("/session")) body = { authenticated: true, user: { id: "qa", name: "Test member", provider: "google" }, providers: { google: true } };
+    if (pathname.endsWith("/session")) body = {
+      authenticated: true,
+      user: { id: "qa", name: "Test member", provider: "google" },
+      providers: { google: true },
+      account_status: wallets.length ? "ready" : "wallet_required",
+      account_complete: wallets.length > 0,
+    };
     if (pathname.endsWith("/account")) {
       if (network.unavailable || failRefresh && wallets.some(wallet => wallet.address === EMBEDDED)) { await route.fulfill({status:503,json:{}}); return; }
       body = { wallets, available: false, account_status: wallets.length ? "ready" : "wallet_required", account_complete: wallets.length > 0 };
@@ -100,7 +109,11 @@ async function account({ installed = true, linked = false, mobile = false, adapt
   if (phone) await page.route("**/phone-wallet.js?*", route => route.fulfill({contentType:"text/javascript",body:`
     window.AgentBountiesPhoneWallet = { state: () => ({available:true}), provider: {request: async request => {
       window.walletTestCalls.push({wallet:'phone', ...request});
-      return request.method === 'eth_requestAccounts' ? ['${EMBEDDED}'] : '0x' + 'cd'.repeat(65);
+      if (request.method === 'eth_requestAccounts') return ['${EMBEDDED}'];
+      if (${JSON.stringify(delayedPhoneSign)} && request.method === 'personal_sign') return new Promise(resolve => {
+        window.resolvePhoneOwnership = () => resolve('0x' + 'cd'.repeat(65));
+      });
+      return '0x' + 'cd'.repeat(65);
     }} };
   `}));
   if (pending) await page.addInitScript((intent) => {
@@ -109,15 +122,30 @@ async function account({ installed = true, linked = false, mobile = false, adapt
       sessionStorage.setItem('test-intent-seeded','true');
     }
   }, pending);
+  if (postTarget) await page.addInitScript((target) => {
+    if (!sessionStorage.getItem("test-post-return-seeded")) {
+      sessionStorage.setItem("agentbounties:post-auth-return:v1", JSON.stringify({
+        schema: "agent-bounties/post-auth-return-v1",
+        target,
+        started_at: Date.now(),
+      }));
+      sessionStorage.setItem("test-post-return-seeded", "true");
+    }
+  }, postTarget);
   // Replace only the external SDK boundary; exercise the real chooser and account handler.
   await page.route("**/vendor/coinbase-embedded-wallet.bundle.js?*", (route) => route.fulfill({
     contentType: "text/javascript",
     body: adapter ? testAdapter : `window.AgentBountiesCoinbaseEmbeddedWallet = { enabled: true, provider: { request: async (request) => {
       window.walletTestCalls.push({ wallet: "embedded", ...request });
-      return request.method === "eth_requestAccounts" ? ["${EMBEDDED}"] : "0x" + "cd".repeat(65);
+      sessionStorage.setItem("test-embedded-wallet-methods", JSON.stringify([...(JSON.parse(sessionStorage.getItem("test-embedded-wallet-methods") || "[]")), request.method]));
+      return ["eth_accounts", "eth_requestAccounts"].includes(request.method) ? ["${EMBEDDED}"] : "0x" + "cd".repeat(65);
     } } };`,
   }));
   await page.goto(origin);
+  if (expectAutoReturn) {
+    await page.waitForURL(postTarget);
+    return { context, page, proofs, errors, link: null, network };
+  }
   await openAccount(page);
   const link = page.locator("[data-wallet-link]");
   await page.waitForFunction(() => document.querySelector("[data-wallet-list]").textContent !== "Checking verified wallets…");
@@ -157,6 +185,105 @@ for (const legacy of [false, true]) for (const linked of [false, true]) test(`ph
     assert.equal(await page.locator('[data-auth-dialog]').getAttribute('data-account-status'),'ready');
     assert.deepEqual((await page.evaluate(()=>window.walletTestCalls)).map(call=>call.method),['eth_requestAccounts','personal_sign']);
     assert.equal(proofs.length,2);
+  } finally { await context.close(); }
+});
+
+function preparedPostTarget() {
+  const benchmark = {
+    engine: "sandboxed_regression_v1",
+    runner_manifest: {
+      benchmark_digest: "sha256:eed1340e372c85f87f8718696c03973748fb3fbaec7b4e90041d77d3513f9656",
+      command: ["python", "/benchmark/check.py"],
+      cpu_millis: 1000,
+      image: "docker.io/library/python@sha256:d657ab0ade19f404a6ccc883ab399540de667aff751748ce23c07330c5a89e64",
+      max_benchmark_bytes: 1048576,
+      max_benchmark_files: 100,
+      max_output_bytes: 1048576,
+      max_source_bytes: 67108864,
+      max_source_files: 1000,
+      memory_bytes: 536870912,
+      pids_limit: 128,
+      platform: "linux/amd64",
+      schema_version: "agent-bounties/regression-sandbox-v1",
+      test_seed: 1,
+      timeout_seconds: 120,
+      tmpfs_bytes: 268435456,
+      workdir: "/workspace",
+    },
+    source: {
+      commit: "0fae18cf9be464132cde52dfb9d464d836e8f024",
+      kind: "github_commit",
+      repository: "NSPG13/agent-bounties",
+      subdirectory: "benchmarks/distribution-v1/glama-onboarding-audit",
+    },
+  };
+  const evidenceSchema = {
+    additionalProperties: false,
+    properties: { source_snapshot_digest: { pattern: "^sha256:[0-9a-f]{64}$", type: "string" } },
+    required: ["source_snapshot_digest"],
+    type: "object",
+  };
+  const params = new URLSearchParams({
+    from: "ai-app",
+    title: "Audit the Glama onboarding path",
+    goal: "Verify the attributed MCP path and publish canonical evidence.",
+    solverReward: "2",
+    verifierReward: "0.1",
+    taskWindowDays: "7",
+    crowdfund: "false",
+    discoverySource: "Glama paid-rail mainnet canary",
+    benchmark: JSON.stringify(benchmark),
+    evidenceSchema: JSON.stringify(evidenceSchema),
+    acquisition: `aba1_${"a".repeat(64)}.${"b".repeat(64)}`,
+    handoff: "52b6a4da-4d81-4581-b61e-a3782321cba7",
+  });
+  params.append("criterion", "Connect to the attributed Glama MCP route.");
+  params.append("criterion", "Publish redacted initialize and tools/list evidence.");
+  return `${origin}/post.html?${params}`;
+}
+
+test("phone ownership feedback returns to the exact prepared bounty without a payment request", async () => {
+  const target = preparedPostTarget();
+  const { context, page, link, errors } = await account({
+    installed: false,
+    mobile: true,
+    phone: true,
+    postTarget: target,
+    delayedPhoneSign: true,
+  });
+  try {
+    await link.click();
+    await page.getByRole("button", { name: "Use a phone wallet Scan a QR code with your wallet app." }).click();
+    await page.waitForFunction(() => document.querySelector("[data-wallet-status]").textContent.includes("connected. Review the ownership-only message"));
+    assert.match(await page.locator("[data-wallet-status]").innerText(), /Phone wallet 0x222222…222222 connected/);
+    assert.deepEqual((await page.evaluate(() => window.walletTestCalls)).map(call => call.method), ["eth_requestAccounts", "personal_sign"]);
+    await page.evaluate(() => window.resolvePhoneOwnership());
+    await page.waitForURL(target);
+    await page.getByRole("button", { name: "Confirm bounty", exact: true }).waitFor();
+    assert.equal(page.url(), target);
+    assert.match(await page.locator("[data-composer-status]").innerText(), /prepared bounty is intact/i);
+    assert.equal((await page.evaluate(() => window.walletTestCalls)).some(call => ["eth_sendTransaction", "wallet_sendCalls"].includes(call.method)), false);
+    assert.deepEqual(errors, []);
+  } finally { await context.close(); }
+});
+
+test("an already verified embedded wallet resumes directly into the exact prepared bounty", async () => {
+  const target = preparedPostTarget();
+  const { context, page, errors } = await account({
+    installed: false,
+    linked: true,
+    linkedAddress: EMBEDDED,
+    pending: { userId: "qa", startedAt: Date.now() },
+    postTarget: target,
+    expectAutoReturn: true,
+  });
+  try {
+    await page.getByRole("button", { name: "Confirm bounty", exact: true }).waitFor();
+    assert.equal(page.url(), target);
+    assert.match(await page.locator("[data-composer-status]").innerText(), /prepared bounty is intact/i);
+    assert.deepEqual(await page.evaluate(() => JSON.parse(sessionStorage.getItem("test-embedded-wallet-methods"))), ["eth_accounts"]);
+    assert.equal((await page.evaluate(() => window.walletTestCalls)).some(call => ["personal_sign", "eth_sendTransaction", "wallet_sendCalls"].includes(call.method)), false);
+    assert.deepEqual(errors, []);
   } finally { await context.close(); }
 });
 


### PR DESCRIPTION
## Outcome

A prepared bounty no longer dead-ends when the poster is signed out or still finishing account setup.

- The disabled posting action becomes an enabled **LOG IN TO POST** action for signed-out users.
- The full same-origin `/post.html` URL is kept in tab-scoped session storage, including the prepared verifier, acquisition, and handoff parameters.
- Successful login/account setup returns to that exact draft once, then the poster can confirm it and choose a separate funding wallet.
- Phone-wallet setup now distinguishes **connected**, **ownership approval received**, and **verified and linked**.
- An embedded wallet that was already verified before a redirect resumes the draft without another ownership signature.

## Safety boundaries

- Return targets are bounded, expiring, same-origin, and restricted to `/post.html`; no open redirect and no prepared query is added to OAuth URLs.
- Login and account-wallet setup cannot sign a transaction, fund, publish, or approve a payout.
- Funding remains behind the existing verifier checks, first-party review, and trusted wallet action.
- Tests assert that login/resume issues no `eth_sendTransaction` or `wallet_sendCalls` request.

## Verification

- `node --test scripts/test-posting-auth.js scripts/test-solarpunk-home.js scripts/test-wallet-link.js`
- Full account-wallet browser suite: 22/22 passed
- Posting browser suite across desktop/mobile/narrow/zoom-equivalent viewports, including the real login CTA
- Existing marketplace/WebMCP/wallet suite: 125/125 passed
- Pinned phone-wallet SDK and storage regression suite: 17/17 passed
- `python scripts/check-site.py --require-wallet-bundle`
- Visual inspection of the signed-out draft and login dialog in the in-app browser

## Maintainer protocol / overlapping work

Public notice and migration context: #1361.

I reviewed all open pull requests before editing. #1196 overlaps `site/solarpunk-home.js` and should rebase onto this change, preserving the `postingAuth` dependency and each successful account-completion call to `returnToPreparedPost`. #908 may need a navigation-template rebase if its index links overlap. No other open PR touched this posting/login/wallet continuity path.

Distribution feedback: this removes the conversion dead end encountered while rehearsing the excluded Glama paid-rail canary. The canary remains excluded from GTM metrics; this PR does not alter attribution eligibility or canonical funding/settlement definitions.