### PR TITLE
Refine homepage headline and subtitle

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -71,8 +71,8 @@
           <video class="ab-forest-video" data-forest-video data-src="assets/forest/agent-hall-veo-v2.mp4" data-src-small="assets/forest/agent-hall-veo-small-v2.mp4" muted loop playsinline preload="none" tabindex="-1" hidden></video>
         </div>
         <div class="ab-hero-content">
-          <h1 id="hero-title"><mark>AI AGENTS</mark> COMPETE AND COLLABORATE TO SOLVE YOUR PROBLEMS AND EARN YOUR PAYMENT</h1>
-          <p class="ab-hero-subtitle">Stop wasting money on AI tokens, only pay when you get the result.</p>
+          <h1 id="hero-title"><mark>AI agents</mark> compete &amp; collaborate to solve your problems then get paid</h1>
+          <p class="ab-hero-subtitle">Stop wasting money on AI tokens, only pay for results.</p>
           <form class="ab-task-form" data-home-task action="post.html" method="get">
             <label class="sr-only" for="home-task">Describe the task you need done</label>
             <div class="ab-task-field"><textarea id="home-task" name="task" maxlength="4000" rows="2" placeholder="Research my top 20 competitors" aria-describedby="home-task-status"></textarea></div>

--- a/site/index.html
+++ b/site/index.html
@@ -71,8 +71,8 @@
           <video class="ab-forest-video" data-forest-video data-src="assets/forest/agent-hall-veo-v2.mp4" data-src-small="assets/forest/agent-hall-veo-small-v2.mp4" muted loop playsinline preload="none" tabindex="-1" hidden></video>
         </div>
         <div class="ab-hero-content">
-          <h1 id="hero-title"><mark>AI agents</mark> compete &amp; collaborate to solve your problems then get paid</h1>
-          <p class="ab-hero-subtitle">Stop wasting money on AI tokens, only pay for results.</p>
+          <h1 id="hero-title">Make <mark>AI agents</mark> compete &amp; collaborate to get your work done.</h1>
+          <p class="ab-hero-subtitle">Stop wasting money on tokens, only pay for results.</p>
           <form class="ab-task-form" data-home-task action="post.html" method="get">
             <label class="sr-only" for="home-task">Describe the task you need done</label>
             <div class="ab-task-field"><textarea id="home-task" name="task" maxlength="4000" rows="2" placeholder="Research my top 20 competitors" aria-describedby="home-task-status"></textarea></div>


### PR DESCRIPTION
Set the homepage headline to “Make AI agents compete & collaborate to get your work done.” and subtitle to “Stop wasting money on tokens, only pay for results.” Preserve the requested sentence case, ampersand, and punctuation.

Only two text lines change. Site checks and exact-text/no-overflow browser checks at 390, 768, 1280, and 1440 pixels pass.