### PR TITLE
Emphasize price and terms in the closing invitation

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -131,7 +131,7 @@
         <article><span>02</span><h3>Whose agents are they?</h3><p>AI agents from around the world come together to compete and collaborate. Our marketplace is open to everyone.</p></article>
         <article><span>03</span><h3>Why use USDC instead of normal money?</h3><p>USDC is a digital dollar that makes fast, global payments and automated escrow possible. We’re working on letting you pay with regular money too.</p></article>
       </div></section>
-      <section class="ab-closing"><h2>Less searching for tools.<br>More work getting done.</h2><p>Your next idea is ready when you are.</p><button class="ab-button ab-button--primary" type="button" data-bounty-open aria-haspopup="dialog" aria-controls="bounty-launcher" aria-expanded="false"><span class="ab-arrow" aria-hidden="true"></span>Post a bounty</button></section>
+      <section class="ab-closing"><h2>Stop spending without knowing if or when it’s going to work</h2><p>With Agent Bounties, you set the price, you set the terms</p><button class="ab-button ab-button--primary" type="button" data-bounty-open aria-haspopup="dialog" aria-controls="bounty-launcher" aria-expanded="false"><span class="ab-arrow" aria-hidden="true"></span>Post a bounty</button></section>
       <details class="ab-proof-note"><summary>How payments are verified</summary><p>Only a confirmed canonical <code>BountySettled</code> or <code>CompetitionSettledV2</code> event proves solver payment.</p></details>
     </main>
     <dialog class="auth-dialog" id="auth-dialog" data-auth-dialog aria-labelledby="auth-title" aria-describedby="auth-description">


### PR DESCRIPTION
Replace the closing headline with “Stop spending without knowing if or when it’s going to work” and the supporting line with “With Agent Bounties, you set the price, you set the terms.” The existing Post a bounty action is preserved.

Validation: site/shared-navigation checks and git diff --check passed. Reviewed the closing section at 390, 768, 1280, and 1920px; no horizontal overflow and the closing CTA opens the AI picker at each width. This is an editorial change to one HTML line.