### PR TITLE
Limit lime emphasis in the closing headline

### DIFF
--- a/scripts/sync-site-navigation.py
+++ b/scripts/sync-site-navigation.py
@@ -45,7 +45,7 @@ def sync(check=False):
         # Render shared assets once, last in the head so page-local legacy
         # styles cannot override the shared shell or selected color theme.
         result = re.sub(r'\s*<(?:link\b[^>]*href|script\b[^>]*src)="' + re.escape(prefix) + r'(?:site-navigation\.css|site-navigation\.js|forest-ui\.css|forest-theme\.js|forest-hall\.css)\?v=\d+"[^>]*>(?:</script>)?', '', result)
-        home_atmosphere = '    <link rel="stylesheet" href="forest-hall.css?v=7">\n' if relative.as_posix() == "index.html" else ""
+        home_atmosphere = '    <link rel="stylesheet" href="forest-hall.css?v=8">\n' if relative.as_posix() == "index.html" else ""
         assets = f'''    <link rel="stylesheet" href="{prefix}site-navigation.css?v=4">
     <link rel="stylesheet" href="{prefix}forest-ui.css?v=2">
 {home_atmosphere}    <script src="{prefix}forest-theme.js?v=1"></script>

--- a/site/forest-hall.css
+++ b/site/forest-hall.css
@@ -38,6 +38,8 @@
 .forest-home .ab-metrics { margin-top: 12px; }
 .forest-home .ab-closing { background: linear-gradient(#07110caa, #07110cf0), url("assets/forest/agent-hall-v1.webp") center 58% / cover; }
 .forest-home .ab-closing::before, .forest-home .ab-closing::after { opacity: .2; }
+.forest-home .ab-closing h2 { color: #edf1e8; }
+.forest-home .ab-closing h2 span { color: #c7f542; }
 [data-theme="light"] .ab-forest-backdrop::after { background: linear-gradient(180deg, #07110c70 0%, #07110c99 25%, #07110c80 48%, #07110c00 67%, #07110c00 82%, #f7f8f2 100%), radial-gradient(ellipse at 50% 27%, #07110c99 0%, #07110c20 52%, transparent 75%); }
 @media (max-width: 700px) {
   .forest-home .ab-hero { padding-top: 32px; }

--- a/site/index.html
+++ b/site/index.html
@@ -43,7 +43,7 @@
     <link rel="stylesheet" href="wallet-adapters.css?v=3">
     <link rel="stylesheet" href="site-navigation.css?v=4">
     <link rel="stylesheet" href="forest-ui.css?v=2">
-    <link rel="stylesheet" href="forest-hall.css?v=7">
+    <link rel="stylesheet" href="forest-hall.css?v=8">
     <script src="forest-theme.js?v=1"></script>
     <script src="site-navigation.js?v=4" defer></script>
   </head>
@@ -131,7 +131,7 @@
         <article><span>02</span><h3>Whose agents are they?</h3><p>AI agents from around the world come together to compete and collaborate. Our marketplace is open to everyone.</p></article>
         <article><span>03</span><h3>Why use USDC instead of normal money?</h3><p>USDC is a digital dollar that makes fast, global payments and automated escrow possible. We’re working on letting you pay with regular money too.</p></article>
       </div></section>
-      <section class="ab-closing"><h2>Stop spending without knowing if or when it’s going to work</h2><p>With Agent Bounties, you set the price, you set the terms</p><button class="ab-button ab-button--primary" type="button" data-bounty-open aria-haspopup="dialog" aria-controls="bounty-launcher" aria-expanded="false"><span class="ab-arrow" aria-hidden="true"></span>Post a bounty</button></section>
+      <section class="ab-closing"><h2><span>Stop spending</span> without knowing if or when it’s going to work</h2><p>With Agent Bounties, you set the price, you set the terms</p><button class="ab-button ab-button--primary" type="button" data-bounty-open aria-haspopup="dialog" aria-controls="bounty-launcher" aria-expanded="false"><span class="ab-arrow" aria-hidden="true"></span>Post a bounty</button></section>
       <details class="ab-proof-note"><summary>How payments are verified</summary><p>Only a confirmed canonical <code>BountySettled</code> or <code>CompetitionSettledV2</code> event proves solver payment.</p></details>
     </main>
     <dialog class="auth-dialog" id="auth-dialog" data-auth-dialog aria-labelledby="auth-title" aria-describedby="auth-description">


### PR DESCRIPTION
Make the closing headline warm white, retaining lime only on “Stop spending.” This gives most of the sentence the lighter text requested while preserving the forest palette, wording, and layout.

Validation: core preflight, site/shared-navigation checks, git diff --check, and rendered checks at 390, 1280, and 1920px. Verified the computed text colors and absence of horizontal overflow. Updated the homepage stylesheet cache version.