### PR TITLE
Open selected AI apps on mobile with a prefilled WebMCP handoff

### DIFF
--- a/scripts/test-mobile-ai-handoff.js
+++ b/scripts/test-mobile-ai-handoff.js
@@ -139,6 +139,22 @@ assert.match(status.textContent, /Nothing is posted or funded until you approve 
 assert.equal(customActions.hidden, true);
 assert.equal(gptButton.attributes["aria-current"], "true");
 
+let cursorPrevented = false;
+let cursorStopped = false;
+handlers.click.callback({
+  target: cursorButton,
+  preventDefault() { cursorPrevented = true; },
+  stopImmediatePropagation() { cursorStopped = true; },
+});
+assert.equal(cursorPrevented, true);
+assert.equal(cursorStopped, true);
+assert.equal(launches.length, 1, "desktop-only Cursor must not launch a broken mobile deep link");
+assert.equal(customActions.hidden, false);
+assert.equal(webFallback.hidden, true);
+assert.match(status.textContent, /Cursor is desktop-only/);
+assert.match(status.textContent, /copy the instructions/i);
+assert.equal(cursorButton.attributes["aria-current"], "true");
+
 assert.equal(
   mobile.setupMobileAssistantHandoff(
     { navigator: { userAgent: "Mozilla/5.0 (X11; Linux x86_64)", userAgentData: { mobile: false } } },

--- a/scripts/test-mobile-ai-handoff.js
+++ b/scripts/test-mobile-ai-handoff.js
@@ -6,7 +6,8 @@ const mobile = require("../site/forest-home.js");
 
 assert.equal(mobile.isMobileNavigator({ userAgentData: { mobile: true } }), true);
 assert.equal(mobile.isMobileNavigator({ userAgent: "Mozilla/5.0 (Linux; Android 16; Pixel 9a)" }), true);
-assert.equal(mobile.isMobileNavigator({ userAgent: "Mozilla/5.0 (X11; Linux x86_64)" }), false);
+assert.equal(mobile.isMobileNavigator({ userAgentData: { mobile: false }, userAgent: "Mozilla/5.0 (Linux; Android 16; Pixel Tablet)" }), true);
+assert.equal(mobile.isMobileNavigator({ userAgentData: { mobile: false }, userAgent: "Mozilla/5.0 (X11; Linux x86_64)" }), false);
 assert.equal(mobile.isAndroidNavigator({ userAgent: "Android 16" }), true);
 
 const prompt = `${home.BOUNTY_POSTING_PROMPT}\n\nMy task: make the mobile AI handoff work.`;
@@ -118,7 +119,7 @@ let stopped = false;
 handlers.click.callback({
   target: gptButton,
   preventDefault() { prevented = true; },
-  stopImmediatePropagation() { stopped = true; },
+  stopPropagation() { stopped = true; },
 });
 
 assert.equal(prevented, true);
@@ -144,7 +145,7 @@ let cursorStopped = false;
 handlers.click.callback({
   target: cursorButton,
   preventDefault() { cursorPrevented = true; },
-  stopImmediatePropagation() { cursorStopped = true; },
+  stopPropagation() { cursorStopped = true; },
 });
 assert.equal(cursorPrevented, true);
 assert.equal(cursorStopped, true);

--- a/scripts/test-mobile-ai-handoff.js
+++ b/scripts/test-mobile-ai-handoff.js
@@ -1,0 +1,150 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const home = require("../site/solarpunk-home.js");
+const mobile = require("../site/forest-home.js");
+
+assert.equal(mobile.isMobileNavigator({ userAgentData: { mobile: true } }), true);
+assert.equal(mobile.isMobileNavigator({ userAgent: "Mozilla/5.0 (Linux; Android 16; Pixel 9a)" }), true);
+assert.equal(mobile.isMobileNavigator({ userAgent: "Mozilla/5.0 (X11; Linux x86_64)" }), false);
+assert.equal(mobile.isAndroidNavigator({ userAgent: "Android 16" }), true);
+
+const prompt = `${home.BOUNTY_POSTING_PROMPT}\n\nMy task: make the mobile AI handoff work.`;
+const gptLinks = home.bountyAssistantLinks("gpt", prompt, mobile.WEBMCP_RETURN_URL);
+const claudeLinks = home.bountyAssistantLinks("claude", prompt, mobile.WEBMCP_RETURN_URL);
+
+const androidGpt = mobile.mobileLaunchUrl("gpt", gptLinks, { userAgent: "Android 16" });
+assert.match(androidGpt, /^intent:\/\/chatgpt\.com\//);
+assert.match(androidGpt, /package=com\.openai\.chatgpt/);
+assert.doesNotMatch(androidGpt, /codex:/);
+assert.equal(
+  decodeURIComponent(androidGpt.match(/S\.browser_fallback_url=([^;]+);end$/)[1]),
+  gptLinks.webUrl,
+);
+
+const androidClaude = mobile.mobileLaunchUrl("claude", claudeLinks, { userAgent: "Android 16" });
+assert.match(androidClaude, /^intent:\/\/claude\.ai\/new/);
+assert.match(androidClaude, /package=com\.anthropic\.claude/);
+assert.doesNotMatch(androidClaude, /claude:/);
+assert.equal(mobile.mobileLaunchUrl("gpt", gptLinks, { userAgent: "iPhone" }), gptLinks.webUrl);
+assert.equal(
+  mobile.mobileLaunchUrl("gpt", { webUrl: "https://evil.example/?prompt=x" }, { userAgent: "Android" }),
+  null,
+);
+
+let dialog;
+function assistantButton(provider) {
+  const detail = { textContent: "Open a new chat" };
+  return {
+    dataset: { bountyAssistant: provider },
+    attributes: {},
+    detail,
+    querySelector(selector) { return selector === "small" ? detail : null; },
+    closest(selector) {
+      if (selector === "[data-bounty-assistant]") return this;
+      if (selector === "[data-bounty-launcher]") return dialog;
+      return null;
+    },
+    setAttribute(name, value) { this.attributes[name] = value; },
+    removeAttribute(name) { delete this.attributes[name]; },
+  };
+}
+
+const promptPreview = { textContent: prompt };
+const status = { textContent: "" };
+const customActions = { hidden: false };
+const webFallback = { hidden: true, href: "", textContent: "" };
+const connectionHelp = { textContent: "Desktop connection help" };
+const gptButton = assistantButton("gpt");
+const claudeButton = assistantButton("claude");
+const cursorButton = assistantButton("cursor");
+const buttons = [gptButton, claudeButton, cursorButton];
+
+dialog = {
+  dataset: {},
+  querySelectorAll(selector) { return selector === "[data-bounty-assistant]" ? buttons : []; },
+  querySelector(selector) {
+    return new Map([
+      ["[data-bounty-prompt]", promptPreview],
+      ["[data-bounty-launch-status]", status],
+      ["[data-bounty-custom-actions]", customActions],
+      ["[data-bounty-web-fallback]", webFallback],
+      [".bounty-connection-help .bounty-launch-note", connectionHelp],
+    ]).get(selector) || null;
+  },
+};
+
+const handlers = {};
+const launches = [];
+const document = {
+  querySelector(selector) { return selector === "[data-bounty-launcher]" ? dialog : null; },
+  addEventListener(name, callback, options) { handlers[name] = { callback, options }; },
+  createElement(tag) {
+    assert.equal(tag, "a");
+    return {
+      href: "",
+      hidden: false,
+      click() { launches.push(this.href); },
+      remove() {},
+    };
+  },
+  body: { append() {} },
+};
+const window = {
+  navigator: {
+    userAgent: "Mozilla/5.0 (Linux; Android 16; Pixel 9a)",
+    userAgentData: { mobile: true },
+  },
+  SolarpunkHome: home,
+  agentBountiesAnalytics: {
+    handoffUrl(value) {
+      const url = new URL(value);
+      url.searchParams.set("utm_source", "mobile-test");
+      return url.href;
+    },
+  },
+  location: { assign(value) { launches.push(value); } },
+};
+
+assert.equal(mobile.setupMobileAssistantHandoff(window, document), true);
+assert.equal(handlers.click.options, true, "mobile interception must run during capture before the desktop handler");
+assert.equal(gptButton.detail.textContent, "Open the mobile app");
+assert.equal(claudeButton.detail.textContent, "Open the mobile app");
+assert.equal(cursorButton.detail.textContent, "Desktop only");
+assert.match(connectionHelp.textContent, /continue through WebMCP/);
+
+let prevented = false;
+let stopped = false;
+handlers.click.callback({
+  target: gptButton,
+  preventDefault() { prevented = true; },
+  stopImmediatePropagation() { stopped = true; },
+});
+
+assert.equal(prevented, true);
+assert.equal(stopped, true);
+assert.equal(launches.length, 1);
+assert.match(launches[0], /^intent:\/\/chatgpt\.com\//);
+assert.match(launches[0], /package=com\.openai\.chatgpt/);
+assert.doesNotMatch(launches[0], /codex:/);
+assert.equal(webFallback.hidden, false);
+assert.equal(new URL(webFallback.href).origin, "https://chatgpt.com");
+const prefilled = new URL(webFallback.href).searchParams.get("prompt");
+assert.match(prefilled, /post\.html\?from=webmcp/);
+assert.match(prefilled, /Discover WebMCP tools/);
+assert.match(prefilled, /make the mobile AI handoff work/);
+assert.equal(promptPreview.textContent, prefilled);
+assert.match(status.textContent, /continue through WebMCP/);
+assert.match(status.textContent, /Nothing is posted or funded until you approve it/);
+assert.equal(customActions.hidden, true);
+assert.equal(gptButton.attributes["aria-current"], "true");
+
+assert.equal(
+  mobile.setupMobileAssistantHandoff(
+    { navigator: { userAgent: "Mozilla/5.0 (X11; Linux x86_64)", userAgentData: { mobile: false } } },
+    { querySelector() { throw new Error("desktop must not inspect the mobile launcher"); } },
+  ),
+  false,
+);
+
+console.log("mobile AI selection opens the installed app with a prefilled WebMCP handoff and safe web fallback");

--- a/site/forest-home.js
+++ b/site/forest-home.js
@@ -91,9 +91,9 @@ if (typeof document !== "undefined") {
   });
 
   function isMobileNavigator(navigatorLike = {}) {
-    if (typeof navigatorLike.userAgentData?.mobile === "boolean") return navigatorLike.userAgentData.mobile;
     const userAgent = String(navigatorLike.userAgent || "");
-    return /Android|iPhone|iPad|iPod/i.test(userAgent)
+    return navigatorLike.userAgentData?.mobile === true
+      || /Android|iPhone|iPad|iPod/i.test(userAgent)
       || (navigatorLike.platform === "MacIntel" && Number(navigatorLike.maxTouchPoints) > 1);
   }
 
@@ -189,7 +189,7 @@ if (typeof document !== "undefined") {
       if (!prompt || !links) return;
 
       event.preventDefault?.();
-      event.stopImmediatePropagation?.();
+      event.stopPropagation?.();
       assistantButtons.forEach((item) => item.removeAttribute("aria-current"));
       button.setAttribute("aria-current", "true");
 

--- a/site/forest-home.js
+++ b/site/forest-home.js
@@ -1,75 +1,237 @@
 /* Landing-page interactions. No model calls, account writes, or wallet actions. */
-(() => {
-  const form = document.querySelector("[data-home-task]");
-  const input = document.querySelector("#home-task");
-  if (!form || !input) return;
-  const storageKey = "agent-bounties.home-task";
-  try { input.value = sessionStorage.getItem(storageKey) || ""; } catch (_) { /* Input remains usable. */ }
-  input.addEventListener("input", () => {
-    try { sessionStorage.setItem(storageKey, input.value); } catch (_) { /* Submission reports unavailable storage. */ }
-  });
-  form.addEventListener("submit", event => {
-    event.preventDefault();
-    document.querySelector("#post-a-bounty")?.click();
-  });
-  document.querySelectorAll("[data-task-example]").forEach(button => button.addEventListener("click", () => {
-    input.value = button.dataset.taskExample;
-    input.dispatchEvent(new Event("input", { bubbles: true }));
-    input.scrollIntoView({ block: "center", behavior: matchMedia("(prefers-reduced-motion: reduce)").matches ? "instant" : "smooth" });
-    input.focus({ preventScroll: true });
-  }));
-  // A cycling placeholder never replaces user input and stops during editing.
-  const examples = Array.from(new Set(Array.from(document.querySelectorAll("[data-task-example]"), button => button.dataset.taskExample)));
-  let example = 0;
-  const reduced = matchMedia("(prefers-reduced-motion: reduce)");
-  const outcome = document.querySelector("[data-outcome-word]");
-  const outcomes = ["Faster", "Cheaper", "Better"];
-  let outcomeIndex = 0, outcomeAnimation;
-  window.setInterval(() => {
-    if (!outcome || document.hidden || reduced.matches || outcome.getBoundingClientRect().bottom < 0) return;
-    outcomeIndex = (outcomeIndex + 1) % outcomes.length;
-    outcome.textContent = outcomes[outcomeIndex];
-    outcomeAnimation?.cancel();
-    outcomeAnimation = outcome.animate?.([
-      { opacity: 0, transform: "translateY(.3em)" },
-      { opacity: 1, transform: "translateY(0)" },
-    ], { duration: 420, easing: "cubic-bezier(.2,.8,.2,1)" });
-  }, 2800);
-  reduced.addEventListener("change", () => { if (reduced.matches) outcomeAnimation?.cancel(); });
-  if (!reduced.matches && "IntersectionObserver" in window) {
-    const reveal = new IntersectionObserver(entries => entries.forEach(entry => {
-      if (!entry.isIntersecting) return;
-      entry.target.dataset.enter = "visible";
-      reveal.unobserve(entry.target);
-    }), { threshold: .12 });
-    document.querySelectorAll(".ab-process-step").forEach(step => { step.dataset.enter = "waiting"; reveal.observe(step); });
-    reduced.addEventListener("change", () => {
-      if (!reduced.matches) return;
-      reveal.disconnect();
-      document.querySelectorAll("[data-enter]").forEach(step => { step.dataset.enter = "visible"; });
+if (typeof document !== "undefined") {
+  (() => {
+    const form = document.querySelector("[data-home-task]");
+    const input = document.querySelector("#home-task");
+    if (!form || !input) return;
+    const storageKey = "agent-bounties.home-task";
+    try { input.value = sessionStorage.getItem(storageKey) || ""; } catch (_) { /* Input remains usable. */ }
+    input.addEventListener("input", () => {
+      try { sessionStorage.setItem(storageKey, input.value); } catch (_) { /* Submission reports unavailable storage. */ }
     });
-  }
-  window.setInterval(() => {
-    if (!examples.length || document.hidden || reduced.matches || input.value || document.activeElement === input) return;
-    example = (example + 1) % examples.length;
-    input.placeholder = examples[example];
-  }, 5000);
-  const deck = document.querySelector("[data-example-deck]");
-  const cards = Array.from(deck.querySelectorAll(".ab-example-card"));
-  let active = 0, pointerX = null;
-  function show(direction) {
-    active = (active + direction + cards.length) % cards.length;
-    cards.forEach((card, index) => { card.dataset.slot = String((index - active + cards.length) % cards.length); card.setAttribute("aria-hidden", String(index !== active)); });
-    document.querySelector("[data-deck-status]").textContent = `Example ${active + 1} of ${cards.length}`;
-  }
-  document.querySelector("[data-deck-prev]").addEventListener("click", () => show(-1));
-  document.querySelector("[data-deck-next]").addEventListener("click", () => show(1));
-  deck.addEventListener("keydown", event => {
-    if (!["ArrowLeft", "ArrowRight"].includes(event.key)) return;
-    event.preventDefault(); show(event.key === "ArrowRight" ? 1 : -1);
+    form.addEventListener("submit", event => {
+      event.preventDefault();
+      document.querySelector("#post-a-bounty")?.click();
+    });
+    document.querySelectorAll("[data-task-example]").forEach(button => button.addEventListener("click", () => {
+      input.value = button.dataset.taskExample;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.scrollIntoView({ block: "center", behavior: matchMedia("(prefers-reduced-motion: reduce)").matches ? "instant" : "smooth" });
+      input.focus({ preventScroll: true });
+    }));
+    // A cycling placeholder never replaces user input and stops during editing.
+    const examples = Array.from(new Set(Array.from(document.querySelectorAll("[data-task-example]"), button => button.dataset.taskExample)));
+    let example = 0;
+    const reduced = matchMedia("(prefers-reduced-motion: reduce)");
+    const outcome = document.querySelector("[data-outcome-word]");
+    const outcomes = ["Faster", "Cheaper", "Better"];
+    let outcomeIndex = 0, outcomeAnimation;
+    window.setInterval(() => {
+      if (!outcome || document.hidden || reduced.matches || outcome.getBoundingClientRect().bottom < 0) return;
+      outcomeIndex = (outcomeIndex + 1) % outcomes.length;
+      outcome.textContent = outcomes[outcomeIndex];
+      outcomeAnimation?.cancel();
+      outcomeAnimation = outcome.animate?.([
+        { opacity: 0, transform: "translateY(.3em)" },
+        { opacity: 1, transform: "translateY(0)" },
+      ], { duration: 420, easing: "cubic-bezier(.2,.8,.2,1)" });
+    }, 2800);
+    reduced.addEventListener("change", () => { if (reduced.matches) outcomeAnimation?.cancel(); });
+    if (!reduced.matches && "IntersectionObserver" in window) {
+      const reveal = new IntersectionObserver(entries => entries.forEach(entry => {
+        if (!entry.isIntersecting) return;
+        entry.target.dataset.enter = "visible";
+        reveal.unobserve(entry.target);
+      }), { threshold: .12 });
+      document.querySelectorAll(".ab-process-step").forEach(step => { step.dataset.enter = "waiting"; reveal.observe(step); });
+      reduced.addEventListener("change", () => {
+        if (!reduced.matches) return;
+        reveal.disconnect();
+        document.querySelectorAll("[data-enter]").forEach(step => { step.dataset.enter = "visible"; });
+      });
+    }
+    window.setInterval(() => {
+      if (!examples.length || document.hidden || reduced.matches || input.value || document.activeElement === input) return;
+      example = (example + 1) % examples.length;
+      input.placeholder = examples[example];
+    }, 5000);
+    const deck = document.querySelector("[data-example-deck]");
+    const cards = Array.from(deck.querySelectorAll(".ab-example-card"));
+    let active = 0, pointerX = null;
+    function show(direction) {
+      active = (active + direction + cards.length) % cards.length;
+      cards.forEach((card, index) => { card.dataset.slot = String((index - active + cards.length) % cards.length); card.setAttribute("aria-hidden", String(index !== active)); });
+      document.querySelector("[data-deck-status]").textContent = `Example ${active + 1} of ${cards.length}`;
+    }
+    document.querySelector("[data-deck-prev]").addEventListener("click", () => show(-1));
+    document.querySelector("[data-deck-next]").addEventListener("click", () => show(1));
+    deck.addEventListener("keydown", event => {
+      if (!["ArrowLeft", "ArrowRight"].includes(event.key)) return;
+      event.preventDefault(); show(event.key === "ArrowRight" ? 1 : -1);
+    });
+    deck.addEventListener("pointerdown", event => { pointerX = event.clientX; });
+    deck.addEventListener("pointerup", event => { if (pointerX !== null && Math.abs(event.clientX - pointerX) > 45) show(event.clientX < pointerX ? 1 : -1); pointerX = null; });
+    deck.addEventListener("pointercancel", () => { pointerX = null; });
+    show(0);
+  })();
+}
+
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.AgentBountiesMobileAIHandoff = api;
+  if (root && root.document) api.start(root, root.document);
+})(typeof window !== "undefined" ? window : globalThis, function () {
+  "use strict";
+
+  const WEBMCP_RETURN_URL = "https://agentbounties.app/post.html?from=webmcp";
+  const MOBILE_PROVIDERS = Object.freeze({
+    gpt: Object.freeze({ label: "ChatGPT", hostname: "chatgpt.com", androidPackage: "com.openai.chatgpt" }),
+    claude: Object.freeze({ label: "Claude", hostname: "claude.ai", androidPackage: "com.anthropic.claude" }),
   });
-  deck.addEventListener("pointerdown", event => { pointerX = event.clientX; });
-  deck.addEventListener("pointerup", event => { if (pointerX !== null && Math.abs(event.clientX - pointerX) > 45) show(event.clientX < pointerX ? 1 : -1); pointerX = null; });
-  deck.addEventListener("pointercancel", () => { pointerX = null; });
-  show(0);
-})();
+
+  function isMobileNavigator(navigatorLike = {}) {
+    if (typeof navigatorLike.userAgentData?.mobile === "boolean") return navigatorLike.userAgentData.mobile;
+    const userAgent = String(navigatorLike.userAgent || "");
+    return /Android|iPhone|iPad|iPod/i.test(userAgent)
+      || (navigatorLike.platform === "MacIntel" && Number(navigatorLike.maxTouchPoints) > 1);
+  }
+
+  function isAndroidNavigator(navigatorLike = {}) {
+    return /Android/i.test(String(navigatorLike.userAgent || ""));
+  }
+
+  function trustedWebUrl(provider, links) {
+    const config = MOBILE_PROVIDERS[provider];
+    if (!config) return null;
+    try {
+      const url = new URL(String(links?.webUrl || ""));
+      if (url.protocol !== "https:" || url.hostname !== config.hostname || url.username || url.password) return null;
+      return url.href;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function androidIntentUrl(webUrl, packageName) {
+    const url = new URL(webUrl);
+    if (url.protocol !== "https:" || !/^[a-z][a-z0-9_.]*$/i.test(String(packageName || ""))) {
+      throw new Error("A trusted HTTPS app link and Android package are required.");
+    }
+    return `intent://${url.host}${url.pathname}${url.search}#Intent;scheme=https;package=${packageName};S.browser_fallback_url=${encodeURIComponent(url.href)};end`;
+  }
+
+  function mobileLaunchUrl(provider, links, navigatorLike = {}) {
+    const config = MOBILE_PROVIDERS[provider];
+    const webUrl = trustedWebUrl(provider, links);
+    if (!config || !webUrl) return null;
+    return isAndroidNavigator(navigatorLike)
+      ? androidIntentUrl(webUrl, config.androidPackage)
+      : webUrl;
+  }
+
+  function exactPrompt(provider, links, fallback) {
+    const name = provider === "gpt" ? "prompt" : "q";
+    try { return new URL(links.webUrl).searchParams.get(name) || fallback; }
+    catch (_error) { return fallback; }
+  }
+
+  function reviewDestination(win) {
+    try {
+      const candidate = win.agentBountiesAnalytics?.handoffUrl?.(WEBMCP_RETURN_URL) || WEBMCP_RETURN_URL;
+      const url = new URL(candidate);
+      if (url.origin === "https://agentbounties.app" && url.pathname === "/post.html") return url.href;
+    } catch (_error) { /* The canonical first-party handoff remains available. */ }
+    return WEBMCP_RETURN_URL;
+  }
+
+  function updateMobileCopy(dialog) {
+    for (const button of dialog.querySelectorAll("[data-bounty-assistant]")) {
+      const key = String(button.dataset.bountyAssistant || "").toLowerCase();
+      const detail = button.querySelector("small");
+      if (!detail) continue;
+      if (MOBILE_PROVIDERS[key]) detail.textContent = "Open the mobile app";
+      else if (key === "cursor") detail.textContent = "Desktop only";
+    }
+    const help = dialog.querySelector(".bounty-connection-help .bounty-launch-note");
+    if (help) {
+      help.textContent = "ChatGPT and Claude open their mobile app with the posting message ready. Send it so the assistant can open Agent Bounties and continue through WebMCP. If the app is unavailable, the same link opens its web version.";
+    }
+  }
+
+  function setupMobileAssistantHandoff(win, doc) {
+    if (!isMobileNavigator(win.navigator)) return false;
+    const dialog = doc.querySelector("[data-bounty-launcher]");
+    if (!dialog) return false;
+    if (dialog.dataset.mobileAiHandoff === "ready") return true;
+
+    const assistantButtons = Array.from(dialog.querySelectorAll("[data-bounty-assistant]"));
+    const promptPreview = dialog.querySelector("[data-bounty-prompt]");
+    const status = dialog.querySelector("[data-bounty-launch-status]");
+    const customActions = dialog.querySelector("[data-bounty-custom-actions]");
+    const webFallback = dialog.querySelector("[data-bounty-web-fallback]");
+
+    updateMobileCopy(dialog);
+    dialog.dataset.mobileAiHandoff = "ready";
+
+    doc.addEventListener("click", (event) => {
+      const button = event.target?.closest?.("[data-bounty-assistant]");
+      if (!button || button.closest?.("[data-bounty-launcher]") !== dialog) return;
+      const provider = String(button.dataset.bountyAssistant || "").toLowerCase();
+      const config = MOBILE_PROVIDERS[provider];
+      if (!config) return;
+
+      const prompt = String(promptPreview?.textContent || "").trim();
+      const links = win.SolarpunkHome?.bountyAssistantLinks?.(
+        provider,
+        prompt,
+        reviewDestination(win),
+      );
+      const launchUrl = mobileLaunchUrl(provider, links, win.navigator);
+      if (!prompt || !links || !launchUrl) return;
+
+      event.preventDefault?.();
+      event.stopImmediatePropagation?.();
+      assistantButtons.forEach((item) => item.removeAttribute("aria-current"));
+      button.setAttribute("aria-current", "true");
+      if (customActions) customActions.hidden = true;
+      if (promptPreview) promptPreview.textContent = exactPrompt(provider, links, prompt);
+      if (webFallback) {
+        webFallback.href = links.webUrl;
+        webFallback.textContent = `Open ${config.label} web instead`;
+        webFallback.hidden = false;
+      }
+      if (status) {
+        status.textContent = `Opening ${config.label} with your posting message ready. Send it so ${config.label} can open Agent Bounties and continue through WebMCP. Nothing is posted or funded until you approve it.`;
+      }
+
+      try {
+        const anchor = doc.createElement("a");
+        anchor.href = launchUrl;
+        anchor.hidden = true;
+        doc.body.append(anchor);
+        anchor.click();
+        anchor.remove();
+      } catch (_error) {
+        win.location.assign(links.webUrl);
+      }
+    }, true);
+    return true;
+  }
+
+  function start(win, doc) {
+    return setupMobileAssistantHandoff(win, doc);
+  }
+
+  return Object.freeze({
+    WEBMCP_RETURN_URL,
+    androidIntentUrl,
+    isAndroidNavigator,
+    isMobileNavigator,
+    mobileLaunchUrl,
+    reviewDestination,
+    setupMobileAssistantHandoff,
+    start,
+    trustedWebUrl,
+  });
+});

--- a/site/forest-home.js
+++ b/site/forest-home.js
@@ -178,8 +178,7 @@ if (typeof document !== "undefined") {
       const button = event.target?.closest?.("[data-bounty-assistant]");
       if (!button || button.closest?.("[data-bounty-launcher]") !== dialog) return;
       const provider = String(button.dataset.bountyAssistant || "").toLowerCase();
-      const config = MOBILE_PROVIDERS[provider];
-      if (!config) return;
+      if (provider !== "cursor" && !MOBILE_PROVIDERS[provider]) return;
 
       const prompt = String(promptPreview?.textContent || "").trim();
       const links = win.SolarpunkHome?.bountyAssistantLinks?.(
@@ -187,13 +186,26 @@ if (typeof document !== "undefined") {
         prompt,
         reviewDestination(win),
       );
-      const launchUrl = mobileLaunchUrl(provider, links, win.navigator);
-      if (!prompt || !links || !launchUrl) return;
+      if (!prompt || !links) return;
 
       event.preventDefault?.();
       event.stopImmediatePropagation?.();
       assistantButtons.forEach((item) => item.removeAttribute("aria-current"));
       button.setAttribute("aria-current", "true");
+
+      if (provider === "cursor") {
+        if (customActions) customActions.hidden = false;
+        if (webFallback) {
+          webFallback.hidden = true;
+          webFallback.removeAttribute?.("href");
+        }
+        if (status) status.textContent = "Cursor is desktop-only. Choose ChatGPT or Claude on this phone, or copy the instructions to continue later in Cursor.";
+        return;
+      }
+
+      const config = MOBILE_PROVIDERS[provider];
+      const launchUrl = mobileLaunchUrl(provider, links, win.navigator);
+      if (!launchUrl) return;
       if (customActions) customActions.hidden = true;
       if (promptPreview) promptPreview.textContent = exactPrompt(provider, links, prompt);
       if (webFallback) {

--- a/tools/browser-layout/package.json
+++ b/tools/browser-layout/package.json
@@ -2,7 +2,7 @@
   "name": "agent-bounties-browser-layout",
   "version": "0.1.0",
   "private": true,
-  "scripts": { "test": "node ../../scripts/test-forest-ui.cjs && node ../../scripts/test-site-navigation.cjs && node ../../scripts/test-posting-layout.cjs && node ../../scripts/test-marketplace-layout.cjs && node ../../scripts/test-phone-wallet-storage.cjs" },
+  "scripts": { "test": "node ../../scripts/test-mobile-ai-handoff.js && node ../../scripts/test-forest-ui.cjs && node ../../scripts/test-site-navigation.cjs && node ../../scripts/test-posting-layout.cjs && node ../../scripts/test-marketplace-layout.cjs && node ../../scripts/test-phone-wallet-storage.cjs" },
   "devDependencies": { "playwright": "1.62.1" },
   "engines": { "node": ">=22" }
 }


### PR DESCRIPTION
## What changed

- Detect actual mobile browsers before the existing desktop-assistant handoff runs.
- On Android, open the installed ChatGPT or Claude package with the exact provider HTTPS link and a browser fallback.
- On iPhone/iPad, use the provider HTTPS app/universal link with the same prefilled posting message.
- Preserve the current bounty idea, measured return URL, competition context, and WebMCP instructions in the handoff.
- Replace the misleading “Requesting desktop” mobile state with an explicit app-opening state.
- Keep a visible web fallback and preserve manual copy as recovery rather than the primary path.
- Prevent Cursor’s desktop-only scheme from firing on phones; explain the limitation and offer the copy route instead.
- Keep publication, legal acceptance, funding, and wallet confirmation under the person’s explicit control.

## Safety boundaries

The handoff only opens a signed-in assistant with a prepared message. It does not submit the message, create or publish a bounty, move funds, or request a wallet confirmation.

## Tests

- Added focused coverage for Android ChatGPT and Claude package intents, exact prefilled prompts, canonical Agent Bounties WebMCP return context, hostile-host rejection, safe web fallback, mobile event interception, Cursor mobile behavior, and desktop non-interference.
- Added the focused test to the existing browser-layout CI command.
