### PR TITLE
fix: continue regression verifier batch after poison jobs

### DIFF
--- a/scripts/regression_verifier_pipeline.py
+++ b/scripts/regression_verifier_pipeline.py
@@ -11,6 +11,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 import time
@@ -523,21 +524,44 @@ def command_run(args: argparse.Namespace) -> None:
     selected = selected_jobs(jobs, verifiers, args.max_jobs)
     args.output.mkdir(parents=True, exist_ok=True)
     candidates = []
+    failures: list[dict[str, str]] = []
     for job in selected:
         job_id = str(job.get("job_id", ""))
         if not re.fullmatch(r"[A-Za-z0-9_.:-]{1,200}", job_id):
             raise PipelineError("verification job id is invalid")
-        with tempfile.TemporaryDirectory(prefix="agent-bounties-regression-") as temporary:
-            candidate = run_job(
-                args.worker.resolve(), args.staging.resolve(), job, Path(temporary)
+        try:
+            with tempfile.TemporaryDirectory(prefix="agent-bounties-regression-") as temporary:
+                candidate = run_job(
+                    args.worker.resolve(), args.staging.resolve(), job, Path(temporary)
+                )
+            name = f"candidate-{hashlib.sha256(job_id.encode()).hexdigest()}.json"
+            write_json(args.output / name, candidate)
+            candidates.append({"job_id": job_id, "file": name})
+        except PipelineError as error:
+            # Keep processing later jobs. One poison submission must not block
+            # the whole scheduled batch from producing candidates.
+            failures.append({"job_id": job_id, "error": str(error)})
+            print(
+                f"regression verifier skipped job {job_id}: {error}",
+                file=sys.stderr,
             )
-        name = f"candidate-{hashlib.sha256(job_id.encode()).hexdigest()}.json"
-        write_json(args.output / name, candidate)
-        candidates.append({"job_id": job_id, "file": name})
     write_json(
         args.output / "manifest.json",
-        {"schema": MANIFEST_SCHEMA, "network": args.network, "candidates": candidates},
+        {
+            "schema": MANIFEST_SCHEMA,
+            "network": args.network,
+            "candidates": candidates,
+            "failures": failures,
+        },
     )
+    if selected and not candidates:
+        detail = "; ".join(
+            f"{item['job_id']}: {item['error']}" for item in failures[:5]
+        )
+        raise PipelineError(
+            "regression verifier produced no candidates"
+            + (f"; {detail}" if detail else "")
+        )
 
 
 def current_job(api_base: str, network: str, verifier: str, job_id: str) -> dict[str, Any]:

--- a/scripts/test_regression_verifier_pipeline.py
+++ b/scripts/test_regression_verifier_pipeline.py
@@ -540,6 +540,60 @@ class RegressionVerifierPipelineTests(unittest.TestCase):
             ["single", "legacy"],
         )
 
+    def test_command_run_continues_after_poison_job(self) -> None:
+        configured = ["0x" + "1" * 40, "0x" + "2" * 40]
+        selected = [
+            {
+                "job_id": "poison",
+                "verification_mode": "signed_quorum",
+                "eligible_verifiers": configured[:1],
+                "threshold": 1,
+            },
+            {
+                "job_id": "good",
+                "verification_mode": "signed_quorum",
+                "eligible_verifiers": configured,
+                "threshold": 2,
+            },
+        ]
+
+        def fake_run_job(
+            worker: Path, staging: Path, job: dict, temporary: Path
+        ) -> dict:
+            del worker, staging, temporary
+            if job["job_id"] == "poison":
+                raise pipeline.PipelineError(
+                    "downloaded source does not match submission evidence"
+                )
+            return {
+                "schema": pipeline.CANDIDATE_SCHEMA,
+                "job": job,
+                "outcome": {"passed": True},
+                "runner_revision": "test",
+            }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "out"
+            args = mock.Mock(
+                verifier=configured,
+                api_base="https://api.example.test",
+                network="base-mainnet",
+                max_jobs=5,
+                output=output,
+                worker=Path("worker"),
+                staging=Path(temporary) / "staging",
+            )
+            with (
+                mock.patch.object(pipeline, "verification_jobs", return_value=selected),
+                mock.patch.object(pipeline, "selected_jobs", return_value=selected),
+                mock.patch.object(pipeline, "run_job", side_effect=fake_run_job),
+            ):
+                pipeline.command_run(args)
+            manifest = json.loads((output / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual([item["job_id"] for item in manifest["candidates"]], ["good"])
+            self.assertEqual(manifest["failures"][0]["job_id"], "poison")
+            self.assertTrue((output / manifest["candidates"][0]["file"]).is_file())
+
     def test_regression_job_rejects_zero_or_ambiguous_verifiers(self) -> None:
         base = {
             "verification_mode": "signed_quorum",


### PR DESCRIPTION
## Summary
- `command_run` no longer aborts the whole scheduled batch on the first `PipelineError` from `run_job`.
- Skipped jobs are recorded under `manifest.failures`; the run fails closed only if every selected job fails.
- Adds a unit test covering poison-then-good selection.

Fixes https://github.com/NSPG13/agent-bounties/issues/1425

## Test plan
- [x] `python -m unittest scripts.test_regression_verifier_pipeline.RegressionVerifierPipelineTests.test_command_run_continues_after_poison_job`
- [ ] Confirm next `regression-verifier-runner` schedule processes later matching jobs after a poison digest job